### PR TITLE
[onton-port] Patch 7: GitHub API client

### DIFF
--- a/lib/github.ml
+++ b/lib/github.ml
@@ -1,0 +1,176 @@
+open Base
+
+module Pr_state = struct
+  type merge_state = Mergeable | Conflicting | Unknown [@@deriving show, eq]
+  type check_status = Passing | Failing | Pending [@@deriving show, eq]
+
+  type t = {
+    merged : bool;
+    merge_state : merge_state;
+    check_status : check_status;
+    comments : Types.Comment.t list;
+    unresolved_comment_count : int;
+  }
+  [@@deriving show, eq]
+end
+
+type error =
+  | Http_error of int * string
+  | Json_parse_error of string
+  | Graphql_error of string list
+[@@deriving show, eq]
+
+type t = { token : string; owner : string; repo : string }
+
+let create ~token ~owner ~repo = { token; owner; repo }
+
+let graphql_query =
+  {|query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
+      merged
+      mergeable
+      commits(last: 1) {
+        nodes {
+          commit {
+            statusCheckRollup {
+              state
+            }
+          }
+        }
+      }
+      reviewThreads(first: 100) {
+        nodes {
+          isResolved
+          comments(first: 1) {
+            nodes {
+              body
+              path
+              line
+            }
+          }
+        }
+      }
+    }
+  }
+}|}
+
+let build_request_body t (pr : Types.Pr_number.t) =
+  let variables =
+    `Assoc
+      [
+        ("owner", `String t.owner);
+        ("repo", `String t.repo);
+        ("number", `Int (Types.Pr_number.to_int pr));
+      ]
+  in
+  `Assoc [ ("query", `String graphql_query); ("variables", variables) ]
+  |> Yojson.Safe.to_string
+
+let parse_merge_state = function
+  | "MERGEABLE" -> Pr_state.Mergeable
+  | "CONFLICTING" -> Pr_state.Conflicting
+  | _ -> Pr_state.Unknown
+
+let parse_check_status = function
+  | "SUCCESS" -> Pr_state.Passing
+  | "FAILURE" | "ERROR" -> Pr_state.Failing
+  | _ -> Pr_state.Pending
+
+let parse_comment_node node =
+  let open Yojson.Safe.Util in
+  let body = node |> member "body" |> to_string in
+  let path = node |> member "path" |> to_string_option in
+  let line = node |> member "line" |> to_int_option in
+  Types.Comment.{ body; path; line }
+
+let parse_response body =
+  let open Yojson.Safe.Util in
+  try
+    let json = Yojson.Safe.from_string body in
+    let errors = json |> member "errors" in
+    match errors with
+    | `Null -> (
+        let pr =
+          json |> member "data" |> member "repository" |> member "pullRequest"
+        in
+        match pr with
+        | `Null -> Error (Json_parse_error "pullRequest not found")
+        | pr ->
+            let merged = pr |> member "merged" |> to_bool in
+            let merge_state =
+              pr |> member "mergeable" |> to_string |> parse_merge_state
+            in
+            let check_status =
+              let commits = pr |> member "commits" |> member "nodes" in
+              match commits |> to_list with
+              | [] -> Pr_state.Pending
+              | node :: _ -> (
+                  let rollup =
+                    node |> member "commit" |> member "statusCheckRollup"
+                  in
+                  match rollup with
+                  | `Null -> Pr_state.Pending
+                  | rollup ->
+                      rollup |> member "state" |> to_string
+                      |> parse_check_status)
+            in
+            let review_threads =
+              pr |> member "reviewThreads" |> member "nodes" |> to_list
+            in
+            let unresolved_comment_count =
+              List.count review_threads ~f:(fun thread ->
+                  not (thread |> member "isResolved" |> to_bool))
+            in
+            let comments =
+              List.concat_map review_threads ~f:(fun thread ->
+                  thread |> member "comments" |> member "nodes" |> to_list
+                  |> List.map ~f:parse_comment_node)
+            in
+            Ok
+              Pr_state.
+                {
+                  merged;
+                  merge_state;
+                  check_status;
+                  comments;
+                  unresolved_comment_count;
+                })
+    | errors ->
+        let msgs =
+          errors |> to_list
+          |> List.map ~f:(fun e -> e |> member "message" |> to_string)
+        in
+        Error (Graphql_error msgs)
+  with
+  | Yojson.Safe.Util.Type_error (msg, _) -> Error (Json_parse_error msg)
+  | Yojson.Json_error msg -> Error (Json_parse_error msg)
+
+let pr_state t pr =
+  let body = build_request_body t pr in
+  ignore (t.token, body, parse_response);
+  (* TODO: Wire up cohttp-eio HTTP call in orchestration patch *)
+  Error (Http_error (0, "not yet wired to HTTP client"))
+
+(* WorldCtx predicate accessors *)
+
+let merged (st : Pr_state.t) = st.Pr_state.merged
+
+let mergeable (st : Pr_state.t) =
+  let open Pr_state in
+  (not st.merged) && equal_merge_state st.merge_state Mergeable
+
+let checks_passing (st : Pr_state.t) =
+  let open Pr_state in
+  equal_check_status st.check_status Passing
+
+let no_unresolved_comments (st : Pr_state.t) =
+  st.Pr_state.unresolved_comment_count = 0
+
+let has_conflict (st : Pr_state.t) =
+  let open Pr_state in
+  equal_merge_state st.merge_state Conflicting
+
+let ci_failed (st : Pr_state.t) =
+  let open Pr_state in
+  equal_check_status st.check_status Failing

--- a/lib/github.mli
+++ b/lib/github.mli
@@ -1,0 +1,43 @@
+open Types
+
+(** GitHub API client for querying PR/world state.
+
+    Provides the data source for WorldCtx predicates from the spec: merged,
+    mergeable, checks-passing, no-unresolved-comments, world-has-comment,
+    world-has-conflict, world-ci-failed. *)
+
+module Pr_state : sig
+  type merge_state = Mergeable | Conflicting | Unknown [@@deriving show, eq]
+  type check_status = Passing | Failing | Pending [@@deriving show, eq]
+
+  type t = {
+    merged : bool;
+    merge_state : merge_state;
+    check_status : check_status;
+    comments : Comment.t list;
+    unresolved_comment_count : int;
+  }
+  [@@deriving show, eq]
+end
+
+type error =
+  | Http_error of int * string
+  | Json_parse_error of string
+  | Graphql_error of string list
+[@@deriving show, eq]
+
+type t
+
+val create : token:string -> owner:string -> repo:string -> t
+(** [create ~token ~owner ~repo] creates a GitHub API client. *)
+
+val pr_state : t -> Pr_number.t -> (Pr_state.t, error) Result.t
+(** [pr_state client pr] fetches the current state of a pull request. This is
+    the primary data source for WorldCtx predicates. *)
+
+val merged : Pr_state.t -> bool
+val mergeable : Pr_state.t -> bool
+val checks_passing : Pr_state.t -> bool
+val no_unresolved_comments : Pr_state.t -> bool
+val has_conflict : Pr_state.t -> bool
+val ci_failed : Pr_state.t -> bool


### PR DESCRIPTION
## Summary
- Add `Github` module (`lib/github.ml` + `lib/github.mli`) implementing the WorldCtx data source from the Pantagruel spec
- GraphQL query fetches PR state: merged status, mergeability, CI check status, and review thread comments
- Pure predicate accessors (`merged`, `mergeable`, `checks_passing`, `no_unresolved_comments`, `has_conflict`, `ci_failed`) match spec's WorldCtx fragment
- HTTP transport stubbed — will be wired via cohttp-eio in the orchestration patch

## Test plan
- [x] `dune build` passes with no warnings
- [x] `dune runtest` passes
- [x] `dune fmt` produces no diff
- [ ] Integration test with live GitHub API (deferred to orchestration patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GitHub pull request state fetching capability to retrieve and query PR status information.
  * Introduced status checks for: merged state, mergeable status, CI passing status, unresolved comments, merge conflicts, and CI failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->