### PR TITLE
[onton-port] Patch 11: GitHub poller

### DIFF
--- a/lib/poller.ml
+++ b/lib/poller.ml
@@ -1,0 +1,39 @@
+open Base
+open Types
+
+type t = {
+  queue : Operation_kind.t list;
+  merged : bool;
+  has_conflict : bool;
+  mergeable : bool;
+  checks_passing : bool;
+}
+[@@deriving show, eq]
+
+let poll ~was_merged (pr : Github.Pr_state.t) =
+  let unresolved =
+    let open Github.Pr_state in
+    pr.unresolved_comment_count > 0
+  in
+  let queue =
+    let acc = [] in
+    (* world-has-comment c p and ~resolved c -> queue' p review-comments *)
+    let acc =
+      if unresolved then Operation_kind.Review_comments :: acc else acc
+    in
+    (* world-has-conflict p -> queue' p merge-conflict *)
+    let acc =
+      if Github.has_conflict pr then Operation_kind.Merge_conflict :: acc
+      else acc
+    in
+    (* world-ci-failed p -> queue' p ci *)
+    let acc = if Github.ci_failed pr then Operation_kind.Ci :: acc else acc in
+    List.rev acc
+  in
+  {
+    queue;
+    merged = was_merged || Github.merged pr;
+    has_conflict = Github.has_conflict pr;
+    mergeable = Github.mergeable pr;
+    checks_passing = Github.checks_passing pr;
+  }

--- a/lib/poller.mli
+++ b/lib/poller.mli
@@ -1,0 +1,35 @@
+open Types
+
+(** GitHub poller: translates PR world state into patch state updates.
+
+    Implements the Poll action from the Pantagruel spec:
+    {v
+    PatchCtx, WorldCtx ~> Poll.
+    ---
+    all c: Comment, p: Patch |
+        world-has-comment c p and ~resolved c -> queue' p review-comments.
+    all p: Patch | world-has-conflict p -> queue' p merge-conflict.
+    all p: Patch | world-has-conflict p -> has-conflict' p.
+    all p: Patch | world-ci-failed p -> queue' p ci.
+    all p: Patch | world-merged p -> merged' p.
+    all p: Patch | merged p -> merged' p.
+    all p: Patch | mergeable' p = world-mergeable p.
+    all p: Patch | checks-passing' p = world-checks-passing p.
+    v} *)
+
+type t = {
+  queue : Operation_kind.t list;  (** Operations to enqueue for this patch. *)
+  merged : bool;  (** [true] if the patch is now merged (absorbing). *)
+  has_conflict : bool;  (** [true] if the PR has a merge conflict. *)
+  mergeable : bool;  (** [true] if the PR is currently mergeable. *)
+  checks_passing : bool;  (** [true] if CI checks are currently passing. *)
+}
+[@@deriving show, eq]
+(** The result of polling a single patch's PR state. *)
+
+val poll : was_merged:bool -> Github.Pr_state.t -> t
+(** [poll ~was_merged pr_state] computes the patch state updates from the
+    current GitHub PR state.
+
+    [was_merged] is the patch's current merged status (from PatchCtx). Once
+    merged, a patch stays merged regardless of what the world reports. *)


### PR DESCRIPTION
## Summary
- Add `Poller` module (`lib/poller.ml`, `lib/poller.mli`) implementing the Poll action from the Pantagruel spec
- Pure function that translates `Github.Pr_state.t` into a result record containing queue operations (review-comments, merge-conflict, ci) and boolean state flags (merged, has-conflict, mergeable, checks-passing)
- Merged status is absorbing: once a patch is merged, it stays merged regardless of world state

## Spec fragment implemented
```
PatchCtx, WorldCtx ~> Poll.
---
all c: Comment, p: Patch | world-has-comment c p and ~resolved c -> queue' p review-comments.
all p: Patch | world-has-conflict p -> queue' p merge-conflict.
all p: Patch | world-has-conflict p -> has-conflict' p.
all p: Patch | world-ci-failed p -> queue' p ci.
all p: Patch | world-merged p -> merged' p.
all p: Patch | merged p -> merged' p.
all p: Patch | mergeable' p = world-mergeable p.
all p: Patch | checks-passing' p = world-checks-passing p.
```

## Test plan
- [x] `dune build` passes with no warnings
- [x] `dune runtest` passes
- [x] `dune fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pull request polling and analysis capability. The system automatically evaluates the state of each pull request by tracking merge status, detecting merge conflicts, assessing mergeability, monitoring CI check results, and identifying unresolved review comments. Results are compiled into a comprehensive action queue and status report for pull request management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->