### PR TITLE
[onton-port] Patch 10: Patch agent state machine

### DIFF
--- a/lib/patch_agent.ml
+++ b/lib/patch_agent.ml
@@ -1,0 +1,131 @@
+open Base
+open Types
+open Operation_kind
+
+type pending_comment = { comment : Comment.t; valid : bool }
+[@@deriving show, eq, sexp_of, compare]
+
+type t = {
+  patch_id : Patch_id.t;
+  has_pr : bool;
+  has_session : bool;
+  busy : bool;
+  merged : bool;
+  needs_intervention : bool;
+  queue : Operation_kind.t list;
+  satisfies : bool;
+  changed : bool;
+  has_conflict : bool;
+  base_branch : Branch.t option;
+  ci_failure_count : int;
+  session_failed : bool;
+  pending_comments : pending_comment list;
+}
+[@@deriving show, eq, sexp_of, compare]
+
+let create patch_id =
+  {
+    patch_id;
+    has_pr = false;
+    has_session = false;
+    busy = false;
+    merged = false;
+    needs_intervention = false;
+    queue = [];
+    satisfies = false;
+    changed = false;
+    has_conflict = false;
+    base_branch = None;
+    ci_failure_count = 0;
+    session_failed = false;
+    pending_comments = [];
+  }
+
+let priority = function
+  | Human -> 5
+  | Merge_conflict -> 4
+  | Ci -> 3
+  | Review_comments -> 2
+  | Rebase -> 1
+
+let highest_priority t =
+  List.max_elt t.queue ~compare:(fun a b ->
+      Int.compare (priority a) (priority b))
+
+let is_feedback _ = true
+
+let enqueue t k =
+  if List.mem t.queue k ~equal:Operation_kind.equal then t
+  else { t with queue = k :: t.queue }
+
+let mark_merged t = { t with merged = true }
+
+let add_pending_comment t comment ~valid =
+  { t with pending_comments = { comment; valid } :: t.pending_comments }
+
+let set_session_failed t = { t with session_failed = true }
+let set_has_conflict t = { t with has_conflict = true }
+
+let increment_ci_failure_count t =
+  { t with ci_failure_count = t.ci_failure_count + 1 }
+
+let clear_needs_intervention t = { t with needs_intervention = false }
+
+let start t ~base_branch =
+  if t.has_pr then invalid_arg "Patch_agent.start: patch already has a PR";
+  {
+    t with
+    has_pr = true;
+    has_session = true;
+    busy = true;
+    satisfies = true;
+    base_branch = Some base_branch;
+  }
+
+let respond t k =
+  if not t.has_pr then invalid_arg "Patch_agent.respond: patch has no PR";
+  if t.merged then invalid_arg "Patch_agent.respond: patch is merged";
+  if t.busy then invalid_arg "Patch_agent.respond: patch is busy";
+  if t.needs_intervention then
+    invalid_arg "Patch_agent.respond: patch needs intervention";
+  if not (List.mem t.queue k ~equal:Operation_kind.equal) then
+    invalid_arg "Patch_agent.respond: operation not in queue";
+  (match highest_priority t with
+  | Some hp when Operation_kind.equal hp k -> ()
+  | _ -> invalid_arg "Patch_agent.respond: not highest priority");
+  let queue =
+    List.filter t.queue ~f:(fun j -> not (Operation_kind.equal j k))
+  in
+  let equal_k = Operation_kind.equal k in
+  let is_human = equal_k Human in
+  let is_ci = equal_k Ci in
+  let is_review = equal_k Review_comments in
+  let is_merge_conflict = equal_k Merge_conflict in
+  let satisfies = if is_human then false else t.satisfies in
+  let changed =
+    if is_ci then true
+    else if is_review then
+      t.changed || List.exists t.pending_comments ~f:(fun c -> c.valid)
+    else t.changed
+  in
+  let has_conflict = if is_merge_conflict then false else t.has_conflict in
+  let pending_comments = if is_review then [] else t.pending_comments in
+  {
+    t with
+    has_session = true;
+    busy = true;
+    queue;
+    satisfies;
+    changed;
+    has_conflict;
+    pending_comments;
+  }
+
+let complete t =
+  if not t.busy then invalid_arg "Patch_agent.complete: patch is not busy";
+  let needs_intervention =
+    if List.mem t.queue Operation_kind.Human ~equal:Operation_kind.equal then
+      false
+    else t.ci_failure_count >= 3 || t.session_failed
+  in
+  { t with busy = false; needs_intervention }

--- a/lib/patch_agent.mli
+++ b/lib/patch_agent.mli
@@ -1,0 +1,85 @@
+open Base
+
+(** Per-patch agent state machine.
+
+    Encodes the spec fragment for actions: Start, Respond, Complete. The type
+    [t] is private — external code can inspect fields but must use smart
+    constructors that enforce spec preconditions. *)
+
+type pending_comment = private { comment : Types.Comment.t; valid : bool }
+[@@deriving show, eq, sexp_of, compare]
+
+type t = private {
+  patch_id : Types.Patch_id.t;
+  has_pr : bool;
+  has_session : bool;
+  busy : bool;
+  merged : bool;
+  needs_intervention : bool;
+  queue : Types.Operation_kind.t list;
+  satisfies : bool;
+  changed : bool;
+  has_conflict : bool;
+  base_branch : Types.Branch.t option;
+  ci_failure_count : int;
+  session_failed : bool;
+  pending_comments : pending_comment list;
+}
+[@@deriving show, eq, sexp_of, compare]
+
+val create : Types.Patch_id.t -> t
+(** Initial state for a patch: no PR, not busy, empty queue. *)
+
+(** {2 Spec actions} *)
+
+val start : t -> base_branch:Types.Branch.t -> t
+(** [PatchCtx ~> Start] — begin work on a patch. Preconditions (checked):
+    [~has_pr]. Caller must verify [in_gameplan] and [deps_satisfied] externally.
+    Postconditions: [has_pr], [has_session], [busy], [satisfies],
+    [base_branch = Some base_branch]. *)
+
+val respond : t -> Types.Operation_kind.t -> t
+(** [PatchCtx, Comments ~> Respond] — respond to queued feedback. Preconditions
+    (checked): [has_pr], [~merged], [~busy], [~needs_intervention], [k] in
+    [queue], [k] is [highest_priority]. Postconditions per spec: sets
+    [has_session], [busy]; dequeues [k]; conditionally updates [satisfies],
+    [changed], [has_conflict], and resolves [pending_comments]. *)
+
+val complete : t -> t
+(** [PatchCtx ~> Complete] — session finished. Preconditions (checked): [busy].
+    Postconditions: [~busy]; recalculates [needs_intervention] from
+    [ci_failure_count], [session_failed], and [Human] in queue. *)
+
+(** {2 State mutation helpers} *)
+
+val enqueue : t -> Types.Operation_kind.t -> t
+(** Add an operation to the queue (idempotent). *)
+
+val mark_merged : t -> t
+(** Mark the patch as merged. *)
+
+val add_pending_comment : t -> Types.Comment.t -> valid:bool -> t
+(** Add a pending review comment. *)
+
+val set_session_failed : t -> t
+(** Mark the current session as failed. *)
+
+val set_has_conflict : t -> t
+(** Mark the patch as having a merge conflict. *)
+
+val increment_ci_failure_count : t -> t
+(** Increment the CI failure counter. *)
+
+val clear_needs_intervention : t -> t
+(** Clear the needs-intervention flag (e.g., after manual resolution). *)
+
+(** {2 Queries} *)
+
+val priority : Types.Operation_kind.t -> int
+(** Priority ordering for operation kinds. Higher is more urgent. *)
+
+val highest_priority : t -> Types.Operation_kind.t option
+(** The highest-priority operation in the queue, or [None] if empty. *)
+
+val is_feedback : Types.Operation_kind.t -> bool
+(** All operation kinds are feedback kinds. *)


### PR DESCRIPTION
## Summary
- Add `Patch_agent` module implementing the per-patch state machine with three spec actions: `Start`, `Respond`, and `Complete`
- State is a private record type — external code can read fields but must use smart constructors that enforce spec preconditions (e.g., `respond` validates `has_pr`, `~merged`, `~busy`, `~needs_intervention`, queue membership, and priority ordering)
- `Respond` handles all feedback kinds (CI, review comments, merge conflicts, human, rebase) with correct post-state updates: queue management, comment resolution, `satisfies`/`changed`/`has_conflict` transitions
- `Complete` recalculates `needs_intervention` from `ci_failure_count`, `session_failed`, and presence of `Human` in queue

## Test plan
- [x] `dune build` passes with no warnings
- [x] `dune runtest` passes
- [ ] QCheck2 state machine tests (future patch) will verify invariants

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new patch state management system with priority-based operation queuing. Patches now follow a formal state machine for handling multiple concurrent operations, including PR management, CI processes, and review comments. The system intelligently prioritizes operations and tracks patch status throughout the workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->