### PR TITLE
[onton-complete] Patch 5: Activity log types

### DIFF
--- a/lib/activity_log.ml
+++ b/lib/activity_log.ml
@@ -33,3 +33,6 @@ let add_transition t entry = { t with transitions = entry :: t.transitions }
 let add_event t event = { t with events = event :: t.events }
 let recent_transitions t ~limit = List.take t.transitions limit
 let recent_events t ~limit = List.take t.events limit
+
+let trim t ~max =
+  { transitions = List.take t.transitions max; events = List.take t.events max }

--- a/lib/activity_log.mli
+++ b/lib/activity_log.mli
@@ -47,7 +47,15 @@ val add_event : t -> Event.t -> t
 (** Prepend an event to the log. *)
 
 val recent_transitions : t -> limit:int -> Transition_entry.t list
-(** Return the most recent [limit] transitions (newest first). *)
+(** Return the most recent [limit] transitions (newest first). Returns an empty
+    list if [limit <= 0]. Returns all transitions if [limit] exceeds the number
+    of entries. *)
 
 val recent_events : t -> limit:int -> Event.t list
-(** Return the most recent [limit] events (newest first). *)
+(** Return the most recent [limit] events (newest first). Returns an empty list
+    if [limit <= 0]. Returns all events if [limit] exceeds the number of
+    entries. *)
+
+val trim : t -> max:int -> t
+(** Truncate both transitions and events to at most [max] entries, keeping the
+    most recent. Use periodically to bound memory in long-running sessions. *)


### PR DESCRIPTION
## Summary
- Adds `Activity_log` module with `Transition_entry` and `Event` types for tracking patch state transitions and general system events
- Provides a simple prepend-list log with `add_transition`, `add_event`, and `recent_*` query helpers
- Record types are private in the `.mli` with smart constructors to enforce construction through `create` functions

## Test plan
- [x] `dune build` passes
- [x] `dune runtest` passes
- [x] Format check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)