### PR TITLE
[onton-completeness] Patch 12: Headless mode

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -402,9 +402,11 @@ let headless_fiber ~runtime ~clock ~stdout =
       Base.List.filter entries ~f:(fun (ts, _) ->
           Float.compare ts !last_seen_ts > 0)
     in
-    Base.List.iter new_entries ~f:(fun (ts, msg) ->
-        Eio.Flow.copy_string (msg ^ "\n") stdout;
-        if Float.compare ts !last_seen_ts > 0 then last_seen_ts := ts);
+    Base.List.iter new_entries ~f:(fun (_ts, msg) ->
+        Eio.Flow.copy_string (msg ^ "\n") stdout);
+    (match Base.List.last new_entries with
+    | Some (ts, _) -> last_seen_ts := ts
+    | None -> ());
     Eio.Time.sleep clock 1.0;
     loop ()
   in


### PR DESCRIPTION
## Summary
- Add `--headless` CLI flag that runs onton without the TUI
- In headless mode, activity log entries are printed as plain text to stdout instead of using terminal escape codes and raw mode
- Useful for CI environments, background execution, and piping output to files

## Test plan
- [x] `dune build` passes
- [x] `dune runtest` passes
- [ ] Manual: run with `--headless` flag and verify plain text output
- [ ] Manual: run without `--headless` and verify TUI still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)