### PR TITLE
[onton-completeness] Patch 11: Scrollable and selectable TUI with detail view

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -184,8 +184,11 @@ let run_claude_and_handle ~runtime ~process_mgr ~fs ~repo_root ~patch_id ~prompt
 exception Quit_tui
 (** Raised by the input fiber to signal a clean exit. *)
 
-(** TUI rendering fiber — redraws the terminal at ~10 fps. *)
-let tui_fiber ~runtime ~clock ~stdout =
+(** TUI rendering fiber — redraws the terminal at ~10 fps.
+
+    [selected] and [view_mode] are shared mutable refs updated by the input
+    fiber. *)
+let tui_fiber ~runtime ~clock ~stdout ~selected ~view_mode =
   Eio.Flow.copy_string (Tui.enter_tui ()) stdout;
   let rec loop () =
     let orch, gp, log =
@@ -195,13 +198,13 @@ let tui_fiber ~runtime ~clock ~stdout =
             snap.Runtime.activity_log ))
     in
     let views = Tui.views_of_orchestrator ~orchestrator:orch ~gameplan:gp in
-    let width =
-      match Term.get_size () with Some size -> size.Term.cols | None -> 80
-    in
+    let size = Term.get_size () in
+    let width = match size with Some s -> s.Term.cols | None -> 80 in
+    let height = match size with Some s -> s.Term.rows | None -> 24 in
     let activity = activity_entries_of_log log in
     let frame =
-      Tui.render_frame ~width ~activity ~project_name:gp.Gameplan.project_name
-        views
+      Tui.render_frame ~width ~height ~selected:!selected ~view_mode:!view_mode
+        ~activity ~project_name:gp.Gameplan.project_name views
     in
     Eio.Flow.copy_string (Tui.paint_frame frame) stdout;
     Eio.Time.sleep clock 0.1;
@@ -210,7 +213,7 @@ let tui_fiber ~runtime ~clock ~stdout =
   loop ()
 
 (** Input fiber — reads keypresses and dispatches TUI commands. *)
-let input_fiber ~runtime ~selected =
+let input_fiber ~runtime ~selected ~view_mode =
   let rec loop () =
     match Term.Key.read () with
     | None -> log_event runtime "input fiber: stdin closed (EOF or I/O error)"
@@ -218,16 +221,34 @@ let input_fiber ~runtime ~selected =
         let cmd = Tui_input.of_key key in
         match cmd with
         | Tui_input.Quit -> raise Quit_tui
-        | Tui_input.Refresh | Tui_input.Help | Tui_input.Select | Tui_input.Back
-        | Tui_input.Noop | Tui_input.Move_up | Tui_input.Move_down
-        | Tui_input.Page_up | Tui_input.Page_down ->
+        | Tui_input.Move_up | Tui_input.Move_down | Tui_input.Page_up
+        | Tui_input.Page_down ->
             let count =
               Runtime.read runtime (fun snap ->
                   Base.List.length
                     (Orchestrator.all_agents snap.Runtime.orchestrator))
             in
             selected := Tui_input.apply_move ~count ~selected:!selected cmd;
-            loop ())
+            loop ()
+        | Tui_input.Select -> (
+            match !view_mode with
+            | Tui.List_view ->
+                let agents =
+                  Runtime.read runtime (fun snap ->
+                      Orchestrator.all_agents snap.Runtime.orchestrator)
+                in
+                (if !selected < Base.List.length agents then
+                   let agent = Base.List.nth_exn agents !selected in
+                   view_mode := Tui.Detail_view agent.Patch_agent.patch_id);
+                loop ()
+            | Tui.Detail_view _ -> loop ())
+        | Tui_input.Back -> (
+            match !view_mode with
+            | Tui.Detail_view _ ->
+                view_mode := Tui.List_view;
+                loop ()
+            | Tui.List_view -> loop ())
+        | Tui_input.Refresh | Tui_input.Help | Tui_input.Noop -> loop ())
   in
   loop ()
 
@@ -492,6 +513,7 @@ let run config =
           let net = Eio.Stdenv.net env in
           let stdout = Eio.Stdenv.stdout env in
           let selected = ref 0 in
+          let view_mode = ref Tui.List_view in
           Term.Raw.with_raw (fun () ->
               Fun.protect
                 ~finally:(fun () ->
@@ -500,8 +522,9 @@ let run config =
                   try
                     Eio.Fiber.all
                       [
-                        (fun () -> tui_fiber ~runtime ~clock ~stdout);
-                        (fun () -> input_fiber ~runtime ~selected);
+                        (fun () ->
+                          tui_fiber ~runtime ~clock ~stdout ~selected ~view_mode);
+                        (fun () -> input_fiber ~runtime ~selected ~view_mode);
                         (fun () ->
                           poller_fiber ~runtime ~clock ~net ~github ~config
                             ~pr_registry ~branch_of);

--- a/lib/tui.ml
+++ b/lib/tui.ml
@@ -290,26 +290,43 @@ let status_indicator = function
   | Awaiting_ci | Awaiting_review -> "◎"
   | Pending -> "·"
 
+(** {1 View mode — list vs detail} *)
+
+type view_mode = List_view | Detail_view of Patch_id.t [@@deriving show, eq]
+
 (** {1 Patch view — derived per-patch rendering data} *)
 
 type patch_view = {
   patch_id : Patch_id.t;
   title : string;
+  branch : Branch.t;
   status : display_status;
   queue_len : int;
   current_op : Operation_kind.t option;
   ci_failures : int;
   dep_count : int;
+  has_pr : bool;
+  has_conflict : bool;
+  needs_intervention : bool;
+  pending_comments : int;
 }
 [@@warning "-69"]
 
 let patch_view_of_agent (agent : Patch_agent.t) ~(patches : Patch.t list)
     ~(graph : Graph.t) =
   let patch_id = agent.patch_id in
+  let patch_opt =
+    List.find patches ~f:(fun p -> Patch_id.equal p.id patch_id)
+  in
   let title =
-    match List.find patches ~f:(fun p -> Patch_id.equal p.id patch_id) with
+    match patch_opt with
     | Some p -> p.Patch.title
     | None -> Patch_id.to_string patch_id
+  in
+  let branch =
+    match patch_opt with
+    | Some p -> p.Patch.branch
+    | None -> Branch.of_string (Patch_id.to_string patch_id)
   in
   let current_op = Patch_agent.highest_priority agent in
   let ctx =
@@ -330,11 +347,16 @@ let patch_view_of_agent (agent : Patch_agent.t) ~(patches : Patch.t list)
   {
     patch_id;
     title;
+    branch;
     status;
     queue_len = List.length agent.queue;
     current_op;
     ci_failures = agent.ci_failure_count;
     dep_count;
+    has_pr = agent.has_pr;
+    has_conflict = agent.has_conflict;
+    needs_intervention = agent.needs_intervention;
+    pending_comments = List.length agent.pending_comments;
   }
 
 (** {1 Render helpers} *)
@@ -371,7 +393,7 @@ let render_header ~project_name ~width =
   let rule = Term.hrule width in
   [ title; rule ]
 
-let render_patch_row ~width (pv : patch_view) =
+let render_patch_row ~width ~selected (pv : patch_view) =
   let badge = render_status_badge pv.status in
   let title_max = width - 30 in
   let title_display = Term.fit_width (max title_max 10) pv.title in
@@ -392,12 +414,47 @@ let render_patch_row ~width (pv : patch_view) =
           (Printf.sprintf " [%s]" (Operation_kind.show op))
     | None -> ""
   in
-  Printf.sprintf " %s  %s%s%s%s" badge title_display queue_info ci_info op_info
+  let cursor = if selected then "▸" else " " in
+  let row =
+    Printf.sprintf "%s%s  %s%s%s%s" cursor badge title_display queue_info
+      ci_info op_info
+  in
+  if selected then Term.styled [ Term.Sgr.bold; Term.Sgr.bg_256 236 ] row
+  else row
 
-let render_patches ~width (views : patch_view list) =
+(** Compute visible window: returns (offset, count) for scrolling. *)
+let visible_window ~selected ~total ~max_visible =
+  if total <= max_visible then (0, total)
+  else
+    let half = max_visible / 2 in
+    let offset =
+      if selected < half then 0
+      else if selected > total - max_visible + half then total - max_visible
+      else selected - half
+    in
+    (offset, max_visible)
+
+let render_patches ~width ~selected ~max_visible (views : patch_view list) =
+  let total = List.length views in
+  let offset, count = visible_window ~selected ~total ~max_visible in
   let section_header = Term.styled [ Term.Sgr.bold ] " Patches" in
-  let rows = List.map views ~f:(render_patch_row ~width) in
-  section_header :: rows
+  let visible = List.sub views ~pos:offset ~len:(min count (total - offset)) in
+  let rows =
+    List.mapi visible ~f:(fun i pv ->
+        render_patch_row ~width ~selected:(offset + i = selected) pv)
+  in
+  let scroll_up =
+    if offset > 0 then
+      [ Term.styled [ Term.Sgr.dim ] (Printf.sprintf " ↑ %d more" offset) ]
+    else []
+  in
+  let remaining = total - offset - count in
+  let scroll_down =
+    if remaining > 0 then
+      [ Term.styled [ Term.Sgr.dim ] (Printf.sprintf " ↓ %d more" remaining) ]
+    else []
+  in
+  (section_header :: scroll_up) @ rows @ scroll_down
 
 let render_summary (views : patch_view list) =
   let count status =
@@ -453,8 +510,52 @@ let render_activity (entries : activity_entry list) =
     in
     header :: lines
 
-let render_footer ~width =
-  let help = Term.styled [ Term.Sgr.dim ] " q:quit  r:refresh  h:help" in
+let render_detail (pv : patch_view) ~width =
+  let header = Term.styled [ Term.Sgr.bold ] (Printf.sprintf " %s" pv.title) in
+  let rule = Term.hrule width in
+  let badge = render_status_badge pv.status in
+  let lines =
+    [
+      header;
+      rule;
+      Printf.sprintf "  Status:      %s" badge;
+      Printf.sprintf "  Patch ID:    %s" (Patch_id.to_string pv.patch_id);
+      Printf.sprintf "  Branch:      %s" (Branch.to_string pv.branch);
+      Printf.sprintf "  PR:          %s" (if pv.has_pr then "yes" else "no");
+      Printf.sprintf "  Dependencies: %d" pv.dep_count;
+      Printf.sprintf "  CI failures: %d" pv.ci_failures;
+      Printf.sprintf "  Queue depth: %d" pv.queue_len;
+      Printf.sprintf "  Conflict:    %s"
+        (if pv.has_conflict then "yes" else "no");
+      Printf.sprintf "  Comments:    %d pending" pv.pending_comments;
+    ]
+  in
+  let op_line =
+    match pv.current_op with
+    | Some op -> [ Printf.sprintf "  Current op:  %s" (Operation_kind.show op) ]
+    | None -> []
+  in
+  let intervention =
+    if pv.needs_intervention then
+      [
+        "";
+        Term.styled
+          [ Term.Sgr.fg_red; Term.Sgr.bold ]
+          "  ⚠ Needs manual intervention";
+      ]
+    else []
+  in
+  lines @ op_line @ intervention
+
+let render_footer ~width ~view_mode =
+  let help =
+    match view_mode with
+    | List_view ->
+        Term.styled [ Term.Sgr.dim ]
+          " q:quit  r:refresh  ↑/↓:navigate  enter:detail  h:help"
+    | Detail_view _ ->
+        Term.styled [ Term.Sgr.dim ] " q:quit  esc:back  r:refresh  h:help"
+  in
   [ Term.hrule width; help ]
 
 (** {1 Public API} *)
@@ -466,19 +567,38 @@ let views_of_orchestrator ~(orchestrator : Orchestrator.t)
   List.map agents ~f:(fun agent ->
       patch_view_of_agent agent ~patches:gameplan.patches ~graph)
 
-let render_frame ~width ~(activity : activity_entry list) ~project_name
-    (views : patch_view list) =
+let render_frame ~width ~height ~selected ~view_mode
+    ~(activity : activity_entry list) ~project_name (views : patch_view list) =
   let header = render_header ~project_name ~width in
   let summary = [ render_summary views ] in
-  let patches = render_patches ~width views in
-  let activity_lines = render_activity activity in
-  let footer = render_footer ~width in
-  let lines =
-    header @ [ "" ] @ summary @ [ "" ] @ patches
-    @ (if List.is_empty activity_lines then [] else "" :: activity_lines)
-    @ [ "" ] @ footer
-  in
-  { lines; width }
+  let footer = render_footer ~width ~view_mode in
+  (* Reserve lines for header(2) + blank + summary(1) + blank + footer(2) +
+     blank = 8 fixed lines *)
+  let max_patch_rows = max 3 (height - 8) in
+  match view_mode with
+  | Detail_view patch_id ->
+      let detail =
+        match
+          List.find views ~f:(fun pv -> Patch_id.equal pv.patch_id patch_id)
+        with
+        | Some pv -> render_detail pv ~width
+        | None -> [ " (patch not found)" ]
+      in
+      let lines =
+        header @ [ "" ] @ summary @ [ "" ] @ detail @ [ "" ] @ footer
+      in
+      { lines; width }
+  | List_view ->
+      let patches =
+        render_patches ~width ~selected ~max_visible:max_patch_rows views
+      in
+      let activity_lines = render_activity activity in
+      let lines =
+        header @ [ "" ] @ summary @ [ "" ] @ patches
+        @ (if List.is_empty activity_lines then [] else "" :: activity_lines)
+        @ [ "" ] @ footer
+      in
+      { lines; width }
 
 let frame_to_string (frame : frame) = String.concat ~sep:"\n" frame.lines ^ "\n"
 

--- a/lib/tui.mli
+++ b/lib/tui.mli
@@ -32,16 +32,25 @@ val derive_display_status :
   current_op:Operation_kind.t option ->
   display_status
 
+(** {2 View mode} *)
+
+type view_mode = List_view | Detail_view of Patch_id.t [@@deriving show, eq]
+
 (** {2 Patch view} *)
 
 type patch_view = {
   patch_id : Patch_id.t;
   title : string;
+  branch : Branch.t;
   status : display_status;
   queue_len : int;
   current_op : Operation_kind.t option;
   ci_failures : int;
   dep_count : int;
+  has_pr : bool;
+  has_conflict : bool;
+  needs_intervention : bool;
+  pending_comments : int;
 }
 
 (** {2 Frame rendering} *)
@@ -63,6 +72,9 @@ val views_of_orchestrator :
 
 val render_frame :
   width:int ->
+  height:int ->
+  selected:int ->
+  view_mode:view_mode ->
   activity:activity_entry list ->
   project_name:string ->
   patch_view list ->


### PR DESCRIPTION
## Summary
- Add `view_mode` type (`List_view` / `Detail_view`) to TUI for navigating between patch list and individual patch details
- Implement selection highlighting with `▸` cursor indicator and background color on the selected row
- Add automatic scroll windowing with "↑ N more" / "↓ N more" indicators when the patch list exceeds terminal height
- Add detail panel (Enter) showing full patch state: status, branch, PR, dependencies, CI failures, queue, conflicts, pending comments
- Wire up Select (Enter) and Back (Escape/Backspace) commands in the input fiber to toggle between views
- Update footer keybind hints to reflect available actions per view mode
- Enrich `patch_view` with `branch`, `has_pr`, `has_conflict`, `needs_intervention`, `pending_comments` fields

## Test plan
- [x] `dune build` passes with no warnings
- [x] `dune runtest` — all existing tests pass (no new test stubs for this patch)
- [ ] Manual: run TUI, verify ↑/↓/j/k navigate with visible cursor
- [ ] Manual: verify scroll indicators appear with many patches
- [ ] Manual: press Enter on a patch → detail view; Escape → back to list

🤖 Generated with [Claude Code](https://claude.com/claude-code)