### PR TITLE
[onton-completeness] Patch 15: TUI input history

### DIFF
--- a/lib/tui_input.ml
+++ b/lib/tui_input.ml
@@ -146,3 +146,102 @@ let%test "apply_move noop preserves" = apply_move ~count:5 ~selected:3 Noop = 3
 
 let%test "apply_move noop clamps stale selection" =
   apply_move ~count:3 ~selected:9 Noop = 2
+
+(** Input history — a pure zipper over previously entered lines.
+
+    [prev] is older entries (most recent first), [next] is newer entries (oldest
+    first), and [draft] holds the in-progress line the user was typing before
+    navigating history. *)
+module History = struct
+  type t = {
+    prev : string list;
+    next : string list;
+    draft : string;
+    max_size : int;
+  }
+  [@@deriving show, eq]
+
+  let create ?(max_size = 100) () =
+    { prev = []; next = []; draft = ""; max_size }
+
+  let add entry t =
+    (* Skip duplicates of the most recent entry and empty strings *)
+    if String.is_empty entry then t
+    else
+      let prev =
+        match t.prev @ List.rev t.next with
+        | top :: _ when String.equal top entry -> t.prev @ List.rev t.next
+        | _ -> (entry :: t.prev) @ List.rev t.next
+      in
+      (* Flatten and truncate to max_size *)
+      let prev = List.take prev t.max_size in
+      { prev; next = []; draft = ""; max_size = t.max_size }
+
+  let up ~current t =
+    match t.prev with
+    | [] -> (current, t)
+    | top :: rest ->
+        let draft = if List.is_empty t.next then current else t.draft in
+        (top, { t with prev = rest; next = top :: t.next; draft })
+
+  let down ~current:_ t =
+    match t.next with
+    | [] -> (t.draft, t)
+    | [ only ] ->
+        (t.draft, { t with next = []; prev = only :: t.prev; draft = "" })
+    | top :: next_entry :: rest ->
+        (next_entry, { t with next = next_entry :: rest; prev = top :: t.prev })
+
+  let reset t =
+    { t with prev = t.prev @ List.rev t.next; next = []; draft = "" }
+
+  let entries t = List.rev t.prev @ t.next
+
+  let%test "empty history up returns current" =
+    let h = create () in
+    let line, h' = up ~current:"foo" h in
+    String.equal line "foo" && equal h h'
+
+  let%test "add then up recalls entry" =
+    let h = create () |> add "hello" in
+    let line, _ = up ~current:"" h in
+    String.equal line "hello"
+
+  let%test "up then down restores draft" =
+    let h = create () |> add "hello" in
+    let _, h = up ~current:"typing" h in
+    let line, _ = down ~current:"hello" h in
+    String.equal line "typing"
+
+  let%test "duplicate suppression" =
+    let h = create () |> add "hello" |> add "hello" in
+    equal_list String.equal (entries h) [ "hello" ]
+
+  let%test "empty string not added" =
+    let h = create () |> add "" in
+    equal_list String.equal (entries h) []
+
+  let%test "max_size truncation" =
+    let h = create ~max_size:3 () in
+    let h = h |> add "a" |> add "b" |> add "c" |> add "d" in
+    List.length (entries h) = 3
+
+  let%test "multiple entries in order" =
+    let h = create () |> add "first" |> add "second" |> add "third" in
+    let line1, h = up ~current:"" h in
+    let line2, h = up ~current:line1 h in
+    let line3, _ = up ~current:line2 h in
+    String.equal line1 "third"
+    && String.equal line2 "second"
+    && String.equal line3 "first"
+
+  let%test "reset flattens navigation" =
+    let h = create () |> add "a" |> add "b" in
+    let _, h = up ~current:"" h in
+    let h = reset h in
+    List.is_empty h.next
+
+  let%test "entries returns chronological order" =
+    let h = create () |> add "first" |> add "second" in
+    equal_list String.equal (entries h) [ "first"; "second" ]
+end

--- a/lib/tui_input.mli
+++ b/lib/tui_input.mli
@@ -34,3 +34,34 @@ val parse_line : string -> command option
     Supported formats:
     - ["N> message"] — send a human message to patch N
     - ["+123"] — register ad-hoc PR for the currently selected patch *)
+
+(** Pure input history with zipper-based navigation.
+
+    Maintains a bounded list of previously entered lines. Navigating up/down
+    moves through history while preserving the in-progress draft. *)
+module History : sig
+  type t [@@deriving show, eq]
+
+  val create : ?max_size:int -> unit -> t
+  (** Create an empty history. [max_size] defaults to 100. *)
+
+  val add : string -> t -> t
+  (** Record a submitted line. Empty strings and consecutive duplicates are
+      ignored. Oldest entries are dropped when [max_size] is exceeded. *)
+
+  val up : current:string -> t -> string * t
+  (** Move to the previous (older) entry. Returns the recalled line and updated
+      history. On the first [up], [current] is saved as the draft. Returns
+      [current] unchanged if already at the oldest entry. *)
+
+  val down : current:string -> t -> string * t
+  (** Move to the next (newer) entry. Returns the draft when past the newest
+      entry. *)
+
+  val reset : t -> t
+  (** Flatten navigation state, keeping all entries but clearing the position
+      cursor. Call this after submitting a line. *)
+
+  val entries : t -> string list
+  (** All entries in chronological order (oldest first). *)
+end


### PR DESCRIPTION
## Summary
- Add `Tui_input.History` module: a pure zipper-based input history with bounded size, duplicate suppression, and draft preservation during up/down navigation
- Fully tested with inline tests covering navigation, draft restore, dedup, truncation, and chronological ordering

## Test plan
- [x] `dune build` passes
- [x] `dune runtest` passes (all 42 tests + property tests)
- [x] Format check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)