### PR TITLE
[onton-completeness] Patch 14: Cross-patch timeline view in TUI

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -138,6 +138,40 @@ let activity_entries_of_log (log : Activity_log.t) =
         })
   |> Base.List.map ~f:snd
 
+let timeline_entries_of_log (log : Activity_log.t) =
+  merged_log_entries ~log ~limit:100
+    ~compare:(fun (t1, _) (t2, _) -> Base.Float.descending t1 t2)
+    ~map_event:(fun (e : Activity_log.Event.t) ->
+      Tui.
+        {
+          timestamp = e.Activity_log.Event.timestamp;
+          entry =
+            Event
+              {
+                patch_id =
+                  Base.Option.map e.Activity_log.Event.patch_id
+                    ~f:Patch_id.to_string;
+                message = e.Activity_log.Event.message;
+              };
+        })
+    ~map_transition:(fun (t : Activity_log.Transition_entry.t) ->
+      Tui.
+        {
+          timestamp = t.Activity_log.Transition_entry.timestamp;
+          entry =
+            Transition
+              {
+                patch_id =
+                  Patch_id.to_string t.Activity_log.Transition_entry.patch_id;
+                from_label =
+                  Tui.label t.Activity_log.Transition_entry.from_status;
+                to_status = t.Activity_log.Transition_entry.to_status;
+                to_label = Tui.label t.Activity_log.Transition_entry.to_status;
+                action = t.Activity_log.Transition_entry.action;
+              };
+        })
+  |> Base.List.map ~f:snd
+
 (** {1 Branch lookup map}
 
     Built once at startup to avoid O(n) linear scans per [branch_of] call. *)
@@ -211,9 +245,11 @@ let tui_fiber ~runtime ~clock ~stdout ~selected ~view_mode =
     let width = match size with Some s -> s.Term.cols | None -> 80 in
     let height = match size with Some s -> s.Term.rows | None -> 24 in
     let activity = activity_entries_of_log log in
+    let timeline = timeline_entries_of_log log in
+    let now = Unix.gettimeofday () in
     let frame =
       Tui.render_frame ~width ~height ~selected:!selected ~view_mode:!view_mode
-        ~activity ~project_name:gp.Gameplan.project_name views
+        ~activity ~timeline ~now ~project_name:gp.Gameplan.project_name views
     in
     Eio.Flow.copy_string (Tui.paint_frame frame) stdout;
     Eio.Time.sleep clock 0.1;
@@ -296,7 +332,7 @@ let input_fiber ~runtime ~selected ~view_mode ~pr_registry =
                   ( Tui_input.Quit | Tui_input.Refresh | Tui_input.Help
                   | Tui_input.Move_up | Tui_input.Move_down | Tui_input.Page_up
                   | Tui_input.Page_down | Tui_input.Select | Tui_input.Back
-                  | Tui_input.Noop )
+                  | Tui_input.Noop | Tui_input.Timeline )
               | None ->
                   log_event runtime
                     (Printf.sprintf "Unrecognised input: %s" line));
@@ -331,6 +367,17 @@ let input_fiber ~runtime ~selected ~view_mode ~pr_registry =
                   in
                   selected :=
                     Tui_input.apply_move ~count ~selected:!selected cmd
+              | Tui.Timeline_view ->
+                  let count =
+                    Runtime.read runtime (fun snap ->
+                        let log = snap.Runtime.activity_log in
+                        Base.List.length
+                          (Activity_log.recent_events log ~limit:100)
+                        + Base.List.length
+                            (Activity_log.recent_transitions log ~limit:100))
+                  in
+                  selected :=
+                    Tui_input.apply_move ~count ~selected:!selected cmd
               | Tui.Detail_view _ -> ());
               loop ()
           | Tui_input.Select -> (
@@ -351,10 +398,16 @@ let input_fiber ~runtime ~selected ~view_mode ~pr_registry =
                   loop ()
               | Tui.Detail_view _ ->
                   text_mode := true;
-                  loop ())
+                  loop ()
+              | Tui.Timeline_view -> loop ())
+          | Tui_input.Timeline ->
+              selected := 0;
+              view_mode := Tui.Timeline_view;
+              loop ()
           | Tui_input.Back -> (
               match !view_mode with
-              | Tui.Detail_view _ ->
+              | Tui.Detail_view _ | Tui.Timeline_view ->
+                  selected := 0;
                   view_mode := Tui.List_view;
                   loop ()
               | Tui.List_view -> loop ())

--- a/lib/tui.ml
+++ b/lib/tui.ml
@@ -292,7 +292,8 @@ let status_indicator = function
 
 (** {1 View mode — list vs detail} *)
 
-type view_mode = List_view | Detail_view of Patch_id.t [@@deriving show, eq]
+type view_mode = List_view | Detail_view of Patch_id.t | Timeline_view
+[@@deriving show, eq]
 
 (** {1 Patch view — derived per-patch rendering data} *)
 
@@ -381,6 +382,11 @@ type activity_entry =
     }
   | Event of { patch_id : string option; message : string }
 [@@warning "-37"]
+
+type timeline_entry = { timestamp : float; entry : activity_entry }
+[@@warning "-69"]
+(** Timeline entry: an activity entry with a timestamp for chronological display
+    across all patches. *)
 
 let render_header ~project_name ~width =
   let title =
@@ -551,15 +557,80 @@ let render_detail (pv : patch_view) ~width =
   in
   lines @ op_line @ intervention
 
+let format_relative_time (timestamp : float) ~(now : float) =
+  let delta = now -. timestamp in
+  if Float.( < ) delta 60.0 then Printf.sprintf "%ds ago" (Float.to_int delta)
+  else if Float.( < ) delta 3600.0 then
+    Printf.sprintf "%dm ago" (Float.to_int (delta /. 60.0))
+  else if Float.( < ) delta 86400.0 then
+    Printf.sprintf "%dh ago" (Float.to_int (delta /. 3600.0))
+  else Printf.sprintf "%dd ago" (Float.to_int (delta /. 86400.0))
+
+let render_timeline_entry ~now (te : timeline_entry) =
+  let time_str =
+    Term.styled [ Term.Sgr.dim ]
+      (Printf.sprintf "%-8s" (format_relative_time te.timestamp ~now))
+  in
+  match te.entry with
+  | Transition { patch_id; from_label; to_status; to_label; action } ->
+      Printf.sprintf "  %s %s  %s → %s  %s" time_str
+        (Term.styled [ Term.Sgr.fg_cyan ] (Printf.sprintf "%-6s" patch_id))
+        (Term.styled [ Term.Sgr.dim ] from_label)
+        (styled_status to_status to_label)
+        (Term.styled [ Term.Sgr.dim ] action)
+  | Event { patch_id; message } ->
+      let pid_str =
+        match patch_id with
+        | Some pid ->
+            Term.styled [ Term.Sgr.fg_cyan ] (Printf.sprintf "%-6s" pid)
+        | None -> Term.styled [ Term.Sgr.dim ] "      "
+      in
+      Printf.sprintf "  %s %s  %s" time_str pid_str
+        (Term.styled [ Term.Sgr.dim ] message)
+
+let render_timeline ~width ~selected ~max_visible ~now
+    (entries : timeline_entry list) =
+  let total = List.length entries in
+  let offset, count = visible_window ~selected ~total ~max_visible in
+  let header = Term.styled [ Term.Sgr.bold ] " Timeline (newest first)" in
+  let col_header =
+    Term.styled [ Term.Sgr.dim ]
+      (Term.fit_width (Int.max 1 width) "  Time     Patch   Status change")
+  in
+  let visible =
+    List.sub entries ~pos:offset ~len:(min count (total - offset))
+  in
+  let rows = List.map visible ~f:(render_timeline_entry ~now) in
+  let scroll_up =
+    if offset > 0 then
+      [ Term.styled [ Term.Sgr.dim ] (Printf.sprintf " ↑ %d more" offset) ]
+    else []
+  in
+  let remaining = total - offset - count in
+  let scroll_down =
+    if remaining > 0 then
+      [ Term.styled [ Term.Sgr.dim ] (Printf.sprintf " ↓ %d more" remaining) ]
+    else []
+  in
+  let empty =
+    if List.is_empty entries then
+      [ Term.styled [ Term.Sgr.dim ] "  (no activity yet)" ]
+    else []
+  in
+  (header :: col_header :: scroll_up) @ rows @ scroll_down @ empty
+
 let render_footer ~width ~view_mode =
   let help =
     match view_mode with
     | List_view ->
         Term.styled [ Term.Sgr.dim ]
-          " q:quit  r:refresh  ↑/↓:navigate  enter:detail  h:help"
+          " q:quit  r:refresh  ↑/↓:navigate  enter:detail  t:timeline  h:help"
     | Detail_view _ ->
         Term.styled [ Term.Sgr.dim ]
-          " q:quit  esc/backspace:back  r:refresh  h:help"
+          " q:quit  esc/backspace:back  r:refresh  t:timeline  h:help"
+    | Timeline_view ->
+        Term.styled [ Term.Sgr.dim ]
+          " q:quit  esc/backspace:back  r:refresh  ↑/↓:scroll  h:help"
   in
   [ Term.hrule width; help ]
 
@@ -578,7 +649,8 @@ let views_of_orchestrator ~(orchestrator : Orchestrator.t)
       patch_view_of_agent agent ~patches_by_id ~graph)
 
 let render_frame ~width ~height ~selected ~view_mode
-    ~(activity : activity_entry list) ~project_name (views : patch_view list) =
+    ~(activity : activity_entry list) ~(timeline : timeline_entry list) ~now
+    ~project_name (views : patch_view list) =
   let header = render_header ~project_name ~width in
   let summary = [ render_summary views ] in
   let footer = render_footer ~width ~view_mode in
@@ -597,6 +669,16 @@ let render_frame ~width ~height ~selected ~view_mode
       let detail = List.take detail max_detail in
       let lines =
         header @ [ "" ] @ summary @ [ "" ] @ detail @ [ "" ] @ footer
+      in
+      { lines; width }
+  | Timeline_view ->
+      let reserved = 2 + 1 + 1 + 1 + 2 + 1 + 2 in
+      let max_rows = Int.max 0 (height - reserved) in
+      let timeline_lines =
+        render_timeline ~width ~selected ~max_visible:max_rows ~now timeline
+      in
+      let lines =
+        header @ [ "" ] @ summary @ [ "" ] @ timeline_lines @ [ "" ] @ footer
       in
       { lines; width }
   | List_view ->

--- a/lib/tui.mli
+++ b/lib/tui.mli
@@ -34,7 +34,8 @@ val derive_display_status :
 
 (** {2 View mode} *)
 
-type view_mode = List_view | Detail_view of Patch_id.t [@@deriving show, eq]
+type view_mode = List_view | Detail_view of Patch_id.t | Timeline_view
+[@@deriving show, eq]
 
 (** {2 Patch view} *)
 
@@ -67,6 +68,8 @@ type activity_entry =
     }
   | Event of { patch_id : string option; message : string }
 
+type timeline_entry = { timestamp : float; entry : activity_entry }
+
 val views_of_orchestrator :
   orchestrator:Orchestrator.t -> gameplan:Gameplan.t -> patch_view list
 
@@ -76,6 +79,8 @@ val render_frame :
   selected:int ->
   view_mode:view_mode ->
   activity:activity_entry list ->
+  timeline:timeline_entry list ->
+  now:float ->
   project_name:string ->
   patch_view list ->
   frame

--- a/lib/tui_input.ml
+++ b/lib/tui_input.ml
@@ -16,6 +16,7 @@ type command =
   | Select
   | Back
   | Noop
+  | Timeline
   | Send_message of Types.Patch_id.t * string
   | Add_pr of Types.Pr_number.t
 [@@deriving show, eq]
@@ -24,6 +25,7 @@ let of_key (key : Term.Key.t) : command =
   match key with
   | Char 'q' | Ctrl 'c' -> Quit
   | Char 'r' -> Refresh
+  | Char 't' -> Timeline
   | Char 'h' | Char '?' -> Help
   | Up | Char 'k' -> Move_up
   | Down | Char 'j' -> Move_down
@@ -46,8 +48,8 @@ let apply_move ~count ~selected (cmd : command) =
       | Move_down -> selected + 1
       | Page_up -> selected - 5
       | Page_down -> selected + 5
-      | Quit | Refresh | Help | Select | Back | Noop | Send_message _ | Add_pr _
-        ->
+      | Quit | Refresh | Help | Select | Back | Noop | Timeline | Send_message _
+      | Add_pr _ ->
           selected
     in
     clamp next
@@ -122,6 +124,7 @@ let%test "page_down maps to Page_down" =
 let%test "enter maps to Select" = equal_command (of_key Enter) Select
 let%test "escape maps to Back" = equal_command (of_key Escape) Back
 let%test "backspace maps to Back" = equal_command (of_key Backspace) Back
+let%test "t maps to Timeline" = equal_command (of_key (Char 't')) Timeline
 let%test "unknown key maps to Noop" = equal_command (of_key (Char 'z')) Noop
 let%test "tab maps to Noop" = equal_command (of_key Tab) Noop
 

--- a/lib/tui_input.mli
+++ b/lib/tui_input.mli
@@ -14,6 +14,7 @@ type command =
   | Select
   | Back
   | Noop
+  | Timeline
   | Send_message of Types.Patch_id.t * string
   | Add_pr of Types.Pr_number.t
 [@@deriving show, eq]


### PR DESCRIPTION
## Summary
- Adds a new `Timeline_view` mode to the TUI that shows all activity entries (transitions and events) across all patches in reverse chronological order with relative timestamps
- Accessible via `t` key from list or detail view, returns to list view via esc/backspace
- Supports scrolling with arrow keys/j/k and page up/down

## Test plan
- [x] All existing tests pass (`dune runtest`)
- [x] New test for `t` key mapping to `Timeline` command
- [x] Build succeeds with no warnings
- [x] Format check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)