### PR TITLE
[onton-completeness-pt-2] Patch 10: QCheck2 properties for comment dedup

### DIFF
--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -581,7 +581,10 @@ let () =
                (List.exists result.new_comments ~f:(fun (c : Types.Comment.t) ->
                     Types.Comment_id.equal c.id first.id)))
             && List.length result.new_comments
-               >= List.length pr.Github.Pr_state.comments - 1)
+               = List.length pr.Github.Pr_state.comments
+                 - List.count pr.Github.Pr_state.comments
+                     ~f:(fun (c : Types.Comment.t) ->
+                       Types.Comment_id.equal c.id first.id))
   in
   List.iter
     ~f:(fun t -> QCheck2.Test.check_exn t)


### PR DESCRIPTION
## Summary
- Add 6 QCheck2 property tests for comment deduplication in `test/test_properties.ml`
- Tests cover poller addressed-ID filtering, review queue suppression, unaddressed comment preservation, `add_pending_comment` idempotency, synthetic-to-real ID migration, and partial addressed-set correctness

## Test plan
- [x] `dune build` passes
- [x] `dune runtest` passes — all 6 new properties pass
- [x] Format check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)