### PR TITLE
[onton-completeness-pt-5] Patch 6: Add Comments enumeration for invariant checking

### DIFF
--- a/lib/invariants.ml
+++ b/lib/invariants.ml
@@ -24,17 +24,23 @@ let check_ci_failure_count_non_negative (state : State.t) =
       else None)
 
 let check_resolved_not_pending (state : State.t) =
-  (* A resolved comment should not be pending for any patch *)
-  let patch_ids = State.Patch_ctx.known_patch_ids (patch_ctx state) in
-  (* We can only check comments we know about via pending entries.
-     If a comment is resolved, it must not be pending for any patch. *)
-  (* This is a structural invariant — enforced by callers, checked here. *)
-  (* Without iterating all comments (no iterator on Comments.t), we rely
-     on the invariant being checked when mutations happen. For now,
-     we return an empty list as we cannot enumerate comments from the
-     opaque Comments.t type. A future patch will add comment enumeration. *)
-  ignore (patch_ids : Patch_id.t list);
-  []
+  let comments = state.State.comments in
+  let resolved =
+    State.Comments.all_resolved comments |> Set.of_list (module Comment)
+  in
+  State.Comments.all_pending comments
+  |> List.filter_map ~f:(fun (comment, patch_id) ->
+      if Set.mem resolved comment then
+        Some
+          {
+            invariant = "resolved_not_pending";
+            details =
+              Printf.sprintf
+                "comment %s is both resolved and pending for patch %s"
+                (Comment.show comment)
+                (Patch_id.to_string patch_id);
+          }
+      else None)
 
 let check_busy_implies_has_session (state : State.t) =
   State.Patch_ctx.known_patch_ids (patch_ctx state)

--- a/lib/state.ml
+++ b/lib/state.ml
@@ -155,6 +155,14 @@ module Comments = struct
 
   let set_pending t ~comment ~patch_id ~value =
     { t with pending = Map.set t.pending ~key:(comment, patch_id) ~data:value }
+
+  let all_resolved t =
+    Map.fold t.resolved ~init:[] ~f:(fun ~key ~data acc ->
+        if data then key :: acc else acc)
+
+  let all_pending t =
+    Map.fold t.pending ~init:[] ~f:(fun ~key ~data acc ->
+        if data then key :: acc else acc)
 end
 
 type t = { patch_ctx : Patch_ctx.t; comments : Comments.t } [@@deriving sexp_of]

--- a/lib/state.mli
+++ b/lib/state.mli
@@ -55,6 +55,9 @@ module Comments : sig
 
   val set_pending :
     t -> comment:Comment.t -> patch_id:Patch_id.t -> value:bool -> t
+
+  val all_resolved : t -> Comment.t list
+  val all_pending : t -> (Comment.t * Patch_id.t) list
 end
 
 type t = { patch_ctx : Patch_ctx.t; comments : Comments.t } [@@deriving sexp_of]


### PR DESCRIPTION
## Summary
- Add `all_resolved` and `all_pending` enumeration functions to `Comments` module
- Implement `check_resolved_not_pending` invariant using the new enumerators to verify no comment is simultaneously resolved and pending

## Test plan
- [x] `dune build` passes
- [x] `dune runtest` — all tests pass
- [x] Format check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)