### PR TITLE
[onton-completeness-pt-5] Patch 9: TUI detail view with activity and scroll

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -431,7 +431,6 @@ let tui_fiber ~runtime ~clock ~stdout ~selected ~view_mode =
             snap.Runtime.gameplan,
             snap.Runtime.activity_log ))
     in
-    let views = Tui.views_of_orchestrator ~orchestrator:orch ~gameplan:gp in
     let size = Term.get_size () in
     let width = match size with Some s -> s.Term.cols | None -> 80 in
     let height = match size with Some s -> s.Term.rows | None -> 24 in
@@ -442,6 +441,9 @@ let tui_fiber ~runtime ~clock ~stdout ~selected ~view_mode =
       | Tui.List_view -> 10
     in
     let activity = activity_entries_of_log ~limit log in
+    let views =
+      Tui.views_of_orchestrator ~orchestrator:orch ~gameplan:gp ~activity
+    in
     let frame =
       Tui.render_frame ~width ~height ~selected:!selected ~view_mode:!view_mode
         ~activity ~project_name:gp.Gameplan.project_name views
@@ -733,7 +735,22 @@ let input_fiber ~runtime ~selected ~view_mode ~pr_registry ~repo_root =
                   in
                   selected :=
                     Tui_input.apply_move ~count ~selected:!selected cmd
-              | Tui.Detail_view _ -> ());
+              | Tui.Detail_view _ ->
+                  (* Scroll detail view — selected doubles as scroll offset *)
+                  let delta =
+                    match cmd with
+                    | Tui_input.Move_up -> -1
+                    | Tui_input.Move_down -> 1
+                    | Tui_input.Page_up -> -10
+                    | Tui_input.Page_down -> 10
+                    | Tui_input.Quit | Tui_input.Refresh | Tui_input.Help
+                    | Tui_input.Select | Tui_input.Back | Tui_input.Timeline
+                    | Tui_input.Noop | Tui_input.Send_message _
+                    | Tui_input.Add_pr _ | Tui_input.Add_worktree _
+                    | Tui_input.Remove_patch ->
+                        0
+                  in
+                  selected := Base.Int.max 0 (!selected + delta));
               loop ()
           | Tui_input.Select -> (
               match !view_mode with
@@ -747,9 +764,10 @@ let input_fiber ~runtime ~selected ~view_mode ~pr_registry ~repo_root =
                     let idx =
                       Base.Int.max 0 (Base.Int.min !selected (count - 1))
                     in
-                    selected := idx;
+                    saved_list_selected := idx;
                     let agent = Base.List.nth_exn agents idx in
-                    view_mode := Tui.Detail_view agent.Patch_agent.patch_id);
+                    view_mode := Tui.Detail_view agent.Patch_agent.patch_id;
+                    selected := 0);
                   loop ()
               | Tui.Detail_view _ ->
                   text_mode := true;
@@ -759,6 +777,7 @@ let input_fiber ~runtime ~selected ~view_mode ~pr_registry ~repo_root =
               match !view_mode with
               | Tui.Detail_view _ ->
                   view_mode := Tui.List_view;
+                  selected := !saved_list_selected;
                   loop ()
               | Tui.Timeline_view ->
                   view_mode := Tui.List_view;

--- a/lib/tui.ml
+++ b/lib/tui.ml
@@ -324,6 +324,7 @@ type patch_view = {
   pending_comments : int;
   ci_checks : Ci_check.t list;
   recent_stream : activity_entry list;
+  pr_number : Pr_number.t option;
 }
 [@@warning "-69"]
 
@@ -372,6 +373,7 @@ let patch_view_of_agent (agent : Patch_agent.t)
     pending_comments = List.length agent.pending_comments;
     ci_checks = agent.ci_checks;
     recent_stream = [];
+    pr_number = agent.pr_number;
   }
 
 (** {1 Render helpers} *)
@@ -541,7 +543,10 @@ let render_detail (pv : patch_view) ~width =
       Printf.sprintf "  Status:      %s" badge;
       fit_value "  Patch ID:    " (Patch_id.to_string pv.patch_id);
       fit_value "  Branch:      " (Branch.to_string pv.branch);
-      Printf.sprintf "  PR:          %s" (if pv.has_pr then "yes" else "no");
+      Printf.sprintf "  PR:          %s"
+        (match pv.pr_number with
+        | Some n -> Printf.sprintf "#%d" (Pr_number.to_int n)
+        | None -> if pv.has_pr then "yes" else "no");
       Printf.sprintf "  Dependencies: %d" pv.dep_count;
       Printf.sprintf "  CI failures: %d" pv.ci_failures;
       Printf.sprintf "  Queue depth: %d" pv.queue_len;
@@ -672,7 +677,7 @@ let render_footer ~width ~view_mode =
 (** {1 Public API} *)
 
 let views_of_orchestrator ~(orchestrator : Orchestrator.t)
-    ~(gameplan : Gameplan.t) =
+    ~(gameplan : Gameplan.t) ~(activity : activity_entry list) =
   let agents = Orchestrator.all_agents orchestrator in
   let graph = Orchestrator.graph orchestrator in
   let patches_by_id =
@@ -681,7 +686,16 @@ let views_of_orchestrator ~(orchestrator : Orchestrator.t)
       ~f:(fun acc (p : Patch.t) -> Map.set acc ~key:p.Patch.id ~data:p)
   in
   List.map agents ~f:(fun agent ->
-      patch_view_of_agent agent ~patches_by_id ~graph)
+      let pv = patch_view_of_agent agent ~patches_by_id ~graph in
+      let pid_str = Patch_id.to_string agent.patch_id in
+      let filtered =
+        List.filter activity ~f:(fun entry ->
+            match entry with
+            | Transition { patch_id = pid; _ } -> String.equal pid pid_str
+            | Event { patch_id = Some pid; _ } -> String.equal pid pid_str
+            | Event { patch_id = None; _ } -> false)
+      in
+      { pv with recent_stream = List.take filtered 10 })
 
 let render_frame ~width ~height ~selected ~view_mode
     ~(activity : activity_entry list) ~project_name (views : patch_view list) =
@@ -694,27 +708,20 @@ let render_frame ~width ~height ~selected ~view_mode
         match
           List.find views ~f:(fun pv -> Patch_id.equal pv.patch_id patch_id)
         with
-        | Some pv ->
-            let patch_id_str = Patch_id.to_string patch_id in
-            let filtered_activity =
-              List.filter activity ~f:(fun entry ->
-                  match entry with
-                  | Transition { patch_id = pid; _ } ->
-                      String.equal pid patch_id_str
-                  | Event { patch_id = Some pid; _ } ->
-                      String.equal pid patch_id_str
-                  | Event { patch_id = None; _ } -> false)
-            in
-            let pv =
-              { pv with recent_stream = List.take filtered_activity 10 }
-            in
-            render_detail pv ~width
+        | Some pv -> render_detail pv ~width
         | None -> [ " (patch not found)" ]
       in
       (* Chrome: header(2) + blank + summary(1) + blank + blank before footer
          + footer(2) = 7 fixed lines *)
       let max_detail = Int.max 0 (height - 7) in
-      let detail = List.take detail max_detail in
+      let total_detail = List.length detail in
+      let scroll_offset =
+        Int.min selected (Int.max 0 (total_detail - max_detail))
+      in
+      let detail =
+        List.sub detail ~pos:scroll_offset
+          ~len:(Int.min max_detail (total_detail - scroll_offset))
+      in
       let lines =
         header @ [ "" ] @ summary @ [ "" ] @ detail @ [ "" ] @ footer
       in

--- a/lib/tui.mli
+++ b/lib/tui.mli
@@ -66,6 +66,7 @@ type patch_view = {
   pending_comments : int;
   ci_checks : Ci_check.t list;
   recent_stream : activity_entry list;
+  pr_number : Pr_number.t option;
 }
 
 (** {2 Frame rendering} *)
@@ -73,7 +74,10 @@ type patch_view = {
 type frame
 
 val views_of_orchestrator :
-  orchestrator:Orchestrator.t -> gameplan:Gameplan.t -> patch_view list
+  orchestrator:Orchestrator.t ->
+  gameplan:Gameplan.t ->
+  activity:activity_entry list ->
+  patch_view list
 
 val render_frame :
   width:int ->


### PR DESCRIPTION
## Summary
- Add `pr_number : Pr_number.t option` to `patch_view`, displayed as `#N` in detail view
- Move per-patch activity filtering into `views_of_orchestrator` so each `patch_view` carries its own `recent_stream` (last 10 entries)
- Add scroll support in detail view: up/down/pgup/pgdn adjust scroll offset; `saved_list_selected` restores list position on back

## Test plan
- [x] `dune build` passes
- [x] `dune runtest` — all tests pass
- [ ] Manual: open TUI, enter detail view, verify PR number shows as `#N`
- [ ] Manual: verify activity entries appear filtered to the selected patch
- [ ] Manual: verify up/down scrolls detail view content

🤖 Generated with [Claude Code](https://claude.com/claude-code)