### PR TITLE
[onton-tui-ux-polish] Patch P4: Status_msg — flash message type and render support

### DIFF
--- a/lib/term.ml
+++ b/lib/term.ml
@@ -103,6 +103,21 @@ let utf8_char_width b =
   else if b land 0xF8 = 0xF0 then 4
   else 1
 
+(** Validated UTF-8 sequence width: returns [utf8_char_width] if continuation
+    bytes are present and valid, otherwise [1] to avoid over-skipping. *)
+let utf8_seq_width s i len =
+  let w = utf8_char_width (String.get s i) in
+  if w = 1 then 1
+  else
+    let rec valid k =
+      if k >= w then true
+      else if i + k >= len then false
+      else
+        let b = Char.to_int (String.get s (i + k)) in
+        if b land 0xC0 = 0x80 then valid (k + 1) else false
+    in
+    if valid 1 then w else 1
+
 (** Visible character width of a string (strips ANSI codes, counts UTF-8
     codepoints rather than bytes). *)
 let visible_length s =
@@ -110,7 +125,9 @@ let visible_length s =
   let len = String.length raw in
   let rec loop i count =
     if i >= len then count
-    else loop (i + utf8_char_width (String.get raw i)) (count + 1)
+    else
+      let w = utf8_seq_width raw i len in
+      loop (i + w) (count + 1)
   in
   loop 0 0
 
@@ -128,7 +145,7 @@ let fit_width width s =
       else if Char.equal (String.get s i) '\027' then
         copy_escape (i + 1) visible
       else
-        let w = utf8_char_width (String.get s i) in
+        let w = utf8_seq_width s i len in
         let () =
           for j = 0 to w - 1 do
             if i + j < len then Buffer.add_char buf (String.get s (i + j))

--- a/lib/tui.ml
+++ b/lib/tui.ml
@@ -309,7 +309,9 @@ let msg_expired ~now msg =
 
 let sanitize_text s =
   let s = Term.strip_ansi s in
-  String.map s ~f:(fun c -> if Char.to_int c < 0x20 then ' ' else c)
+  String.map s ~f:(fun c ->
+      let code = Char.to_int c in
+      if code < 0x20 || code = 0x7F then ' ' else c)
 
 let render_status_msg ~width = function
   | None -> ""


### PR DESCRIPTION
## Summary
- Add `msg_level` type (`Info | Warning | Error`) and `status_msg` record with optional TTL via `expires_at`
- Add `render_status_msg` helper that produces styled one-line output (dim for Info, yellow ⚠ for Warning, red bold ✗ for Error)
- Add `msg_expired` function for TTL-based auto-clearing
- Inline tests cover all acceptance criteria (None→empty, ANSI codes, expiry logic)

## Test plan
- [x] `render_status_msg ~width:80 None` = `""`
- [x] `render_status_msg` with Error contains "oops" and red ANSI codes
- [x] `msg_expired ~now:100.0 {expires_at=Some 50.0; ...}` = `true`
- [x] `msg_expired ~now:100.0 {expires_at=None; ...}` = `false`
- [x] `dune build` clean
- [x] `dune runtest` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)