### PR TITLE
[onton-tui-ux-polish] Patch P7: Mouse integration — click to select, scroll wheel navigation

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -532,7 +532,8 @@ exception Quit_tui
     shared mutable refs updated by the input fiber. *)
 let tui_fiber ~runtime ~clock ~stdout ~list_selected ~detail_scroll
     ~detail_follow ~timeline_scroll ~view_mode ~show_help ~transcripts
-    ~sorted_patch_ids ~input_line ~completion_hint =
+    ~sorted_patch_ids ~input_line ~completion_hint ~patches_start_row
+    ~patches_scroll_offset ~patches_visible_count =
   Eio.Flow.copy_string (Tui.enter_tui ()) stdout;
   let first = ref true in
   let prev_output = ref "" in
@@ -584,6 +585,9 @@ let tui_fiber ~runtime ~clock ~stdout ~list_selected ~detail_scroll
     (* Write back the clamped scroll offset so delta-based input in
        input_fiber works from a real value, not a sentinel like max_value. *)
     detail_scroll := Tui.detail_scroll_offset frame;
+    patches_start_row := Tui.patches_start_row frame;
+    patches_scroll_offset := Tui.patches_scroll_offset frame;
+    patches_visible_count := Tui.patch_count frame;
     let output = Tui.paint_frame frame in
     if not (String.equal output !prev_output) then (
       Eio.Flow.copy_string output stdout;
@@ -606,7 +610,8 @@ let tui_fiber ~runtime ~clock ~stdout ~list_selected ~detail_scroll
     - ["-"] — remove the selected patch from orchestration *)
 let input_fiber ~runtime ~list_selected ~detail_scroll ~detail_follow
     ~timeline_scroll ~detail_scrolls ~view_mode ~pr_registry ~project_name
-    ~show_help ~sorted_patch_ids ~input_line ~completion_hint =
+    ~show_help ~sorted_patch_ids ~input_line ~completion_hint ~patches_start_row
+    ~patches_scroll_offset ~patches_visible_count =
   let buf = Buffer.create 64 in
   let text_mode = ref false in
   let current_completions = ref [] in
@@ -633,6 +638,8 @@ let input_fiber ~runtime ~list_selected ~detail_scroll ~detail_follow
   let history = Tui_input.History.create () in
   let saved_draft = ref "" in
   let eof_count = ref 0 in
+  let last_click_time = ref 0.0 in
+  let last_click_row = ref (-1) in
   let rec loop () =
     sync_input ();
     match Term.Key.read () with
@@ -945,11 +952,72 @@ let input_fiber ~runtime ~list_selected ~detail_scroll ~detail_follow
                   text_mode := true;
                   loop ()
               | Tui.List_view | Tui.Timeline_view -> loop ())
+          | Term.Key.Mouse ev -> (
+              match (ev, !view_mode) with
+              | ( Term.Click { button = Term.Left; row; press = true; _ },
+                  Tui.List_view ) ->
+                  let start = !patches_start_row in
+                  let count = !patches_visible_count in
+                  let screen_idx = row - start in
+                  let abs_idx = !patches_scroll_offset + screen_idx in
+                  if start > 0 && screen_idx >= 0 && screen_idx < count then (
+                    let now = Unix.gettimeofday () in
+                    let is_double =
+                      Float.compare (now -. !last_click_time) 0.3 <= 0
+                      && !last_click_row = abs_idx
+                    in
+                    last_click_time := now;
+                    last_click_row := abs_idx;
+                    if is_double then (
+                      let pids = !sorted_patch_ids in
+                      let pid_count = Base.List.length pids in
+                      if abs_idx < pid_count then (
+                        list_selected := abs_idx;
+                        let pid = Base.List.nth_exn pids abs_idx in
+                        view_mode := Tui.Detail_view pid;
+                        match Hashtbl.find_opt detail_scrolls pid with
+                        | Some (offset, follow) ->
+                            detail_scroll := offset;
+                            detail_follow := follow
+                        | None ->
+                            detail_scroll := 0;
+                            detail_follow := true))
+                    else list_selected := abs_idx);
+                  loop ()
+              | ( Term.Click { button = Term.Left; row; press = true; _ },
+                  Tui.Detail_view pid ) ->
+                  let size = Term.get_size () in
+                  let height =
+                    match size with Some s -> s.Term.rows | None -> 24
+                  in
+                  if row >= height - 1 then (
+                    Hashtbl.replace detail_scrolls pid
+                      (!detail_scroll, !detail_follow);
+                    view_mode := Tui.List_view);
+                  loop ()
+              | Term.Scroll { dir; _ }, Tui.List_view ->
+                  let count = Base.List.length !sorted_patch_ids in
+                  let delta = match dir with Term.Up -> -1 | Term.Down -> 1 in
+                  list_selected :=
+                    Base.Int.max 0
+                      (Base.Int.min (count - 1) (!list_selected + delta));
+                  loop ()
+              | Term.Scroll { dir; _ }, Tui.Detail_view _ ->
+                  let delta = match dir with Term.Up -> -3 | Term.Down -> 3 in
+                  detail_scroll := Base.Int.max 0 (!detail_scroll + delta);
+                  loop ()
+              | Term.Scroll { dir; _ }, Tui.Timeline_view ->
+                  let delta = match dir with Term.Up -> -3 | Term.Down -> 3 in
+                  timeline_scroll := Base.Int.max 0 (!timeline_scroll + delta);
+                  loop ()
+              | ( Term.Click { button = Term.Left | Term.Middle | Term.Right; _ },
+                  (Tui.List_view | Tui.Detail_view _ | Tui.Timeline_view) ) ->
+                  loop ())
           | Term.Key.Char _ | Term.Key.Enter | Term.Key.Tab | Term.Key.Backspace
           | Term.Key.Escape | Term.Key.Up | Term.Key.Down | Term.Key.Left
           | Term.Key.Right | Term.Key.Home | Term.Key.End | Term.Key.Page_up
           | Term.Key.Page_down | Term.Key.Delete | Term.Key.F _
-          | Term.Key.Ctrl _ | Term.Key.Mouse _ | Term.Key.Unknown _ -> (
+          | Term.Key.Ctrl _ | Term.Key.Unknown _ -> (
               let cmd = Tui_input.of_key key in
               match cmd with
               | Tui_input.Quit -> raise Quit_tui
@@ -2017,6 +2085,9 @@ let run_with_config (config : config) gameplan existing_snapshot =
         let input_line = ref None in
         let completion_hint = ref None in
         let show_help = ref false in
+        let patches_start_row = ref 0 in
+        let patches_scroll_offset = ref 0 in
+        let patches_visible_count = ref 0 in
         let raw_state = Term.Raw.enter () in
         Fun.protect
           ~finally:(fun () ->
@@ -2036,12 +2107,14 @@ let run_with_config (config : config) gameplan existing_snapshot =
                    tui_fiber ~runtime ~clock ~stdout ~list_selected
                      ~detail_scroll ~detail_follow ~timeline_scroll ~view_mode
                      ~show_help ~transcripts ~sorted_patch_ids ~input_line
-                     ~completion_hint)
+                     ~completion_hint ~patches_start_row ~patches_scroll_offset
+                     ~patches_visible_count)
                 :: (fun () ->
                   input_fiber ~runtime ~list_selected ~detail_scroll
                     ~detail_follow ~timeline_scroll ~detail_scrolls ~view_mode
                     ~pr_registry ~project_name ~show_help ~sorted_patch_ids
-                    ~input_line ~completion_hint)
+                    ~input_line ~completion_hint ~patches_start_row
+                    ~patches_scroll_offset ~patches_visible_count)
                 :: common_fibers)
             with Quit_tui -> ())
 

--- a/lib/tui.ml
+++ b/lib/tui.ml
@@ -546,6 +546,9 @@ type frame = {
   width : int;
   detail_at_bottom : bool;
   detail_scroll_offset : int;
+  patches_start_row : int;
+  patches_scroll_offset : int;
+  patch_count : int;
 }
 [@@warning "-69"]
 
@@ -607,19 +610,21 @@ let visible_window ~selected ~total ~max_visible =
 let render_patches ~width ~selected ~max_visible (views : patch_view list) =
   let total = List.length views in
   if total = 0 then
-    [
-      Term.styled [ Term.Sgr.bold ] " Patches";
-      Term.styled [ Term.Sgr.dim ]
-        (Term.fit_width
-           (Int.max 1 (width - 2))
-           "  No patches. Press : then +N to add a PR (e.g. +123)");
-    ]
+    ( [
+        Term.styled [ Term.Sgr.bold ] " Patches";
+        Term.styled [ Term.Sgr.dim ]
+          (Term.fit_width
+             (Int.max 1 (width - 2))
+             "  No patches. Press : then +N to add a PR (e.g. +123)");
+      ],
+      0,
+      0,
+      0 )
   else
     let offset, count = visible_window ~selected ~total ~max_visible in
     let section_header = Term.styled [ Term.Sgr.bold ] " Patches" in
-    let visible =
-      List.sub views ~pos:offset ~len:(min count (total - offset))
-    in
+    let vis_count = min count (total - offset) in
+    let visible = List.sub views ~pos:offset ~len:vis_count in
     let rows =
       List.mapi visible ~f:(fun i pv ->
           render_patch_row ~width ~selected:(offset + i = selected) pv)
@@ -634,7 +639,11 @@ let render_patches ~width ~selected ~max_visible (views : patch_view list) =
       if String.is_empty bottom then []
       else [ Term.styled [ Term.Sgr.dim ] (" " ^ bottom) ]
     in
-    (section_header :: scroll_up) @ rows @ scroll_down
+    let header_lines = 1 + List.length scroll_up in
+    ( (section_header :: scroll_up) @ rows @ scroll_down,
+      header_lines,
+      offset,
+      vis_count )
 
 let render_summary (views : patch_view list) =
   let count status =
@@ -1037,14 +1046,20 @@ let render_frame ~width ~height ~selected ~scroll_offset ~view_mode
     ~(activity : activity_entry list) ~project_name ~show_help
     ?(transcript = "") ?input_line ?completion_hint ?status_msg
     (views : patch_view list) =
-  if show_help then
-    let overlay = render_help_overlay ~width ~height in
+  let no_patches =
     {
-      lines = overlay;
+      lines = [];
       width;
       detail_at_bottom = false;
       detail_scroll_offset = 0;
+      patches_start_row = 0;
+      patches_scroll_offset = 0;
+      patch_count = 0;
     }
+  in
+  if show_help then
+    let overlay = render_help_overlay ~width ~height in
+    { no_patches with lines = overlay }
   else
     let header = render_header ~project_name ~width in
     let summary = [ render_summary views ] in
@@ -1079,8 +1094,8 @@ let render_frame ~width ~height ~selected ~scroll_offset ~view_mode
               @ [ "" ] @ status_line @ footer
             in
             {
+              no_patches with
               lines;
-              width;
               detail_at_bottom = at_bottom;
               detail_scroll_offset = clamped_offset;
             }
@@ -1089,8 +1104,7 @@ let render_frame ~width ~height ~selected ~scroll_offset ~view_mode
               header @ [ "" ] @ summary @ [ "" ] @ [ " (patch not found)" ]
               @ [ "" ] @ status_line @ footer
             in
-            { lines; width; detail_at_bottom = false; detail_scroll_offset = 0 }
-        )
+            { no_patches with lines })
     | Timeline_view ->
         (* Budget: header(2) + blank + summary(1) + blank + "Timeline" header(1)
          + scroll indicators(2) + blank before footer + footer(2) = 11 *)
@@ -1106,7 +1120,7 @@ let render_frame ~width ~height ~selected ~scroll_offset ~view_mode
           header @ [ "" ] @ summary @ [ "" ] @ timeline @ [ "" ] @ status_line
           @ footer
         in
-        { lines; width; detail_at_bottom = false; detail_scroll_offset = 0 }
+        { no_patches with lines }
     | List_view ->
         let activity_lines = render_activity activity in
         let activity_height =
@@ -1121,19 +1135,29 @@ let render_frame ~width ~height ~selected ~scroll_offset ~view_mode
           + activity_height
         in
         let max_patch_rows = Int.max 0 (height - reserved) in
-        let patches =
+        let patches, patch_header_lines, scroll_off, visible_rows =
           render_patches ~width ~selected ~max_visible:max_patch_rows views
         in
+        let patches_start_row = 5 + patch_header_lines + 1 in
         let lines =
           header @ [ "" ] @ summary @ [ "" ] @ patches
           @ (if List.is_empty activity_lines then [] else "" :: activity_lines)
           @ [ "" ] @ status_line @ footer
         in
-        { lines; width; detail_at_bottom = false; detail_scroll_offset = 0 }
+        {
+          no_patches with
+          lines;
+          patches_start_row;
+          patches_scroll_offset = scroll_off;
+          patch_count = visible_rows;
+        }
 
 let frame_to_string (frame : frame) = String.concat ~sep:"\n" frame.lines ^ "\n"
 let detail_at_bottom frame = frame.detail_at_bottom
 let detail_scroll_offset frame = frame.detail_scroll_offset
+let patches_start_row frame = frame.patches_start_row
+let patches_scroll_offset frame = frame.patches_scroll_offset
+let patch_count frame = frame.patch_count
 
 let paint_frame (frame : frame) =
   let buf = Buffer.create 4096 in
@@ -1148,9 +1172,10 @@ let paint_frame (frame : frame) =
 let enter_tui () =
   Term.Cursor.hide ^ Term.Clear.screen
   ^ Term.Cursor.move_to ~row:1 ~col:1
-  ^ "\027[?2004h" (* enable bracketed paste *)
+  ^ "\027[?2004h" (* enable bracketed paste *) ^ Term.enable_mouse
 
 let exit_tui () =
-  "\027[?2004l" (* disable bracketed paste *) ^ Term.Clear.screen
+  Term.disable_mouse ^ "\027[?2004l" (* disable bracketed paste *)
+  ^ Term.Clear.screen
   ^ Term.Cursor.move_to ~row:1 ~col:1
   ^ Term.Cursor.show

--- a/lib/tui.mli
+++ b/lib/tui.mli
@@ -107,6 +107,18 @@ val detail_scroll_offset : frame -> int
 (** The actual clamped scroll offset used for the detail view. Written back to
     the detail_scroll ref so delta-based input produces sensible values. *)
 
+val patches_start_row : frame -> int
+(** 1-indexed terminal row where the first patch line is rendered in list view.
+    Returns 0 for non-list views. *)
+
+val patches_scroll_offset : frame -> int
+(** Scroll offset of the visible patch window in list view. The first visible
+    patch row corresponds to patch index [patches_scroll_offset], not 0. *)
+
+val patch_count : frame -> int
+(** Number of actually rendered patch rows in the visible window (not total
+    patches). Only meaningful in list view; 0 otherwise. *)
+
 val views_of_orchestrator :
   orchestrator:Orchestrator.t ->
   gameplan:Gameplan.t ->


### PR DESCRIPTION
## Summary
- Enable SGR mouse mode (1000h + 1006h) on `enter_tui`, disable on `exit_tui`
- Left-click on a patch row in list view selects it; double-click (within 300ms) opens detail view
- Scroll wheel moves selection in list view, scrolls by 3 lines in detail/timeline views
- Left-click on footer area in detail view returns to list
- Expose `patches_start_row` and `patch_count` from `Tui.frame` for click-to-patch-index hit-testing
- Merges P1 (Term.Mouse types and SGR protocol parsing) as a dependency

## Test plan
- [x] `dune build` clean (no warnings)
- [x] `dune runtest` all tests pass
- [x] `dune fmt` formatted
- [ ] Manual: verify mouse enable/disable escape sequences in terminal output
- [ ] Manual: click patch rows to select, double-click to open detail
- [ ] Manual: scroll wheel navigates list/detail/timeline views
- [ ] Manual: clicking outside patch area does not crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mouse interaction support for patch lists: click to navigate, double-click to switch between list and detail views
  * Enabled mouse support in the terminal UI

* **Enhancements**
  * Improved patch list state management for better scroll position tracking and view persistence across navigation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->