### PR TITLE
Extract Pr_state and Forge interface from Github

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1429,7 +1429,7 @@ let poller_fiber ~runtime ~clock ~net ~process_mgr ~github ~config ~project_name
                         (Printf.sprintf "PR re-discovery failed: %s" msg))
                 else
                   let branch_in_root =
-                    match pr_state.Github.Pr_state.head_branch with
+                    match pr_state.Pr_state.head_branch with
                     | Some b ->
                         Worktree.is_checked_out_in_repo_root ~process_mgr
                           ~repo_root:config.repo_root b
@@ -1492,7 +1492,7 @@ let poller_fiber ~runtime ~clock ~net ~process_mgr ~github ~config ~project_name
                             in
                             (* head_branch and intervention management *)
                             let orch, newly_blocked =
-                              match pr_state.Github.Pr_state.head_branch with
+                              match pr_state.Pr_state.head_branch with
                               | Some b ->
                                   let orch =
                                     Orchestrator.set_head_branch orch patch_id b
@@ -1526,7 +1526,7 @@ let poller_fiber ~runtime ~clock ~net ~process_mgr ~github ~config ~project_name
                               let agent = Orchestrator.agent orch patch_id in
                               match
                                 ( agent.Patch_agent.base_branch,
-                                  pr_state.Github.Pr_state.base_branch )
+                                  pr_state.Pr_state.base_branch )
                               with
                               | None, Some b ->
                                   Orchestrator.set_base_branch orch patch_id b
@@ -1566,7 +1566,7 @@ let poller_fiber ~runtime ~clock ~net ~process_mgr ~github ~config ~project_name
                       log_event runtime ~patch_id:entry.Poll_applicator.patch_id
                         entry.Poll_applicator.message);
                   (if newly_blocked then
-                     match pr_state.Github.Pr_state.head_branch with
+                     match pr_state.Pr_state.head_branch with
                      | Some b ->
                          let main_root =
                            Worktree.resolve_main_root ~process_mgr
@@ -1580,7 +1580,7 @@ let poller_fiber ~runtime ~clock ~net ~process_mgr ~github ~config ~project_name
                                work on this patch"
                               (Branch.to_string b) main_root main_root)
                      | None -> ());
-                  if pr_state.Github.Pr_state.ci_checks_truncated then
+                  if pr_state.Pr_state.ci_checks_truncated then
                     log_event runtime ~patch_id
                       "warning: CI check list was truncated (>100 checks); \
                        some failures may not appear in the prompt"));
@@ -1925,7 +1925,7 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry
                           log_event runtime ~patch_id
                             "fetching fresh review comments from GitHub";
                           match Github.pr_state ~net github pr_num with
-                          | Ok pr_state -> pr_state.Github.Pr_state.comments
+                          | Ok pr_state -> pr_state.Pr_state.comments
                           | Error _err ->
                               log_event runtime ~patch_id
                                 "failed to fetch fresh comments";

--- a/lib/forge.ml
+++ b/lib/forge.ml
@@ -1,0 +1,14 @@
+(** Forge interface: abstract source of pull request / merge request state.
+
+    Each forge implementation (GitHub, GitLab, etc.) satisfies this signature.
+    Constructor functions are forge-specific and not part of the interface. *)
+
+module type S = sig
+  type t
+  type error
+
+  val show_error : error -> string
+
+  val pr_state :
+    net:_ Eio.Net.t -> t -> Types.Pr_number.t -> (Pr_state.t, error) Result.t
+end

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -1,25 +1,5 @@
 open Base
 
-module Pr_state = struct
-  type merge_state = Mergeable | Conflicting | Unknown [@@deriving show, eq]
-  type check_status = Passing | Failing | Pending [@@deriving show, eq]
-  type pr_status = Open | Merged | Closed [@@deriving show, eq]
-
-  type t = {
-    status : pr_status;
-    merge_state : merge_state;
-    merge_ready : bool;
-    check_status : check_status;
-    ci_checks : Types.Ci_check.t list;
-    ci_checks_truncated : bool;
-    comments : Types.Comment.t list;
-    unresolved_comment_count : int;
-    head_branch : Types.Branch.t option;
-    base_branch : Types.Branch.t option;
-  }
-  [@@deriving show, eq]
-end
-
 type error =
   | Http_error of int * string
   | Json_parse_error of string
@@ -237,19 +217,18 @@ let parse_response_json json =
               |> Option.map ~f:Types.Branch.of_string
             in
             Ok
-              Pr_state.
-                {
-                  status;
-                  merge_state;
-                  merge_ready;
-                  check_status;
-                  ci_checks;
-                  ci_checks_truncated;
-                  comments;
-                  unresolved_comment_count;
-                  head_branch;
-                  base_branch;
-                })
+              {
+                Pr_state.status;
+                merge_state;
+                merge_ready;
+                check_status;
+                ci_checks;
+                ci_checks_truncated;
+                comments;
+                unresolved_comment_count;
+                head_branch;
+                base_branch;
+              })
     | errors ->
         let msgs =
           errors |> to_list
@@ -312,32 +291,12 @@ let pr_state ~net t pr =
         else Error (Http_error (status, resp_str)))
   with exn -> Error (Transport_error (Exn.to_string exn))
 
-(* WorldCtx predicate accessors *)
+(* Static assertion: Github satisfies Forge.S *)
+let (_ : (module Forge.S)) =
+  (module struct
+    type nonrec t = t
+    type nonrec error = error
 
-let merged (st : Pr_state.t) =
-  Pr_state.equal_pr_status st.Pr_state.status Pr_state.Merged
-
-let closed (st : Pr_state.t) =
-  Pr_state.equal_pr_status st.Pr_state.status Pr_state.Closed
-
-let mergeable (st : Pr_state.t) =
-  let open Pr_state in
-  equal_pr_status st.status Open && equal_merge_state st.merge_state Mergeable
-
-let merge_ready (st : Pr_state.t) =
-  Pr_state.equal_pr_status st.status Open && st.merge_ready
-
-let checks_passing (st : Pr_state.t) =
-  let open Pr_state in
-  equal_check_status st.check_status Passing
-
-let no_unresolved_comments (st : Pr_state.t) =
-  st.Pr_state.unresolved_comment_count = 0
-
-let has_conflict (st : Pr_state.t) =
-  let open Pr_state in
-  equal_merge_state st.merge_state Conflicting
-
-let ci_failed (st : Pr_state.t) =
-  let open Pr_state in
-  equal_check_status st.check_status Failing
+    let show_error = show_error
+    let pr_state = pr_state
+  end)

--- a/lib/github.mli
+++ b/lib/github.mli
@@ -1,30 +1,6 @@
-open Types
+(** GitHub forge implementation.
 
-(** GitHub API client for querying PR/world state.
-
-    Provides the data source for WorldCtx predicates from the spec: merged,
-    mergeable, checks-passing, no-unresolved-comments, world-has-comment,
-    world-has-conflict, world-ci-failed. *)
-
-module Pr_state : sig
-  type merge_state = Mergeable | Conflicting | Unknown [@@deriving show, eq]
-  type check_status = Passing | Failing | Pending [@@deriving show, eq]
-  type pr_status = Open | Merged | Closed [@@deriving show, eq]
-
-  type t = {
-    status : pr_status;
-    merge_state : merge_state;
-    merge_ready : bool;
-    check_status : check_status;
-    ci_checks : Ci_check.t list;
-    ci_checks_truncated : bool;
-    comments : Comment.t list;
-    unresolved_comment_count : int;
-    head_branch : Branch.t option;
-    base_branch : Branch.t option;
-  }
-  [@@deriving show, eq]
-end
+    Queries the GitHub GraphQL API for PR/world state. Satisfies {!Forge.S}. *)
 
 type error =
   | Http_error of int * string
@@ -46,16 +22,6 @@ val parse_response : string -> (Pr_state.t, error) Result.t
 (** Parse a GitHub GraphQL response body string into a [Pr_state.t]. *)
 
 val pr_state :
-  net:_ Eio.Net.t -> t -> Pr_number.t -> (Pr_state.t, error) Result.t
+  net:_ Eio.Net.t -> t -> Types.Pr_number.t -> (Pr_state.t, error) Result.t
 (** [pr_state ~net client pr] fetches the current state of a pull request via
-    the GitHub GraphQL API over HTTPS. This is the primary data source for
-    WorldCtx predicates. *)
-
-val merged : Pr_state.t -> bool
-val closed : Pr_state.t -> bool
-val mergeable : Pr_state.t -> bool
-val merge_ready : Pr_state.t -> bool
-val checks_passing : Pr_state.t -> bool
-val no_unresolved_comments : Pr_state.t -> bool
-val has_conflict : Pr_state.t -> bool
-val ci_failed : Pr_state.t -> bool
+    the GitHub GraphQL API over HTTPS. *)

--- a/lib/markdown_render.ml
+++ b/lib/markdown_render.ml
@@ -124,16 +124,15 @@ let render s =
   let lines = render_block (Cmarkit.Doc.block doc) in
   String.concat ~sep:"\n" lines
 
-(** Test whether a raw line is a tool marker (e.g. [[tool: Read] /path]).
-    These are structural elements we inject — they should not be parsed as
-    CommonMark, which would collapse them into adjacent paragraphs. *)
+(** Test whether a raw line is a tool marker (e.g. [[tool: Read] /path]). These
+    are structural elements we inject — they should not be parsed as CommonMark,
+    which would collapse them into adjacent paragraphs. *)
 let is_tool_marker line =
   let s = String.strip line in
   String.is_prefix s ~prefix:"[tool: "
 
 (** Style a tool-marker line directly (no CommonMark parsing). *)
-let style_tool_marker line =
-  Term.styled [ Term.Sgr.dim ] line
+let style_tool_marker line = Term.styled [ Term.Sgr.dim ] line
 
 (** Render a full markdown string to a list of styled lines. Consecutive blank
     lines are collapsed to at most one.
@@ -230,9 +229,7 @@ let%expect_test "render hrule" =
     |}]
 
 let%expect_test "tool markers rendered as separate lines" =
-  let s =
-    "[tool: Edit] /some/file.ml\nFix the stale comment on taskResults:"
-  in
+  let s = "[tool: Edit] /some/file.ml\nFix the stale comment on taskResults:" in
   let lines = render_to_lines s in
   let stripped = List.map lines ~f:Term.strip_ansi in
   List.iter stripped ~f:Stdio.print_endline;
@@ -244,9 +241,7 @@ let%expect_test "tool markers rendered as separate lines" =
     |}]
 
 let%expect_test "consecutive tool markers" =
-  let s =
-    "[tool: Read] /a.ml\n[tool: Edit] /b.ml\nSome agent text."
-  in
+  let s = "[tool: Read] /a.ml\n[tool: Edit] /b.ml\nSome agent text." in
   let lines = render_to_lines s in
   let stripped = List.map lines ~f:Term.strip_ansi in
   List.iter stripped ~f:Stdio.print_endline;

--- a/lib/poller.ml
+++ b/lib/poller.ml
@@ -13,7 +13,7 @@ type t = {
 }
 [@@deriving show, eq]
 
-let poll ~was_merged (pr : Github.Pr_state.t) =
+let poll ~was_merged (pr : Pr_state.t) =
   let unresolved = not (List.is_empty pr.comments) in
   let queue =
     let acc = [] in
@@ -23,20 +23,20 @@ let poll ~was_merged (pr : Github.Pr_state.t) =
     in
     (* world-has-conflict p -> queue' p merge-conflict *)
     let acc =
-      if Github.has_conflict pr then Operation_kind.Merge_conflict :: acc
+      if Pr_state.has_conflict pr then Operation_kind.Merge_conflict :: acc
       else acc
     in
     (* world-ci-failed p -> queue' p ci *)
-    let acc = if Github.ci_failed pr then Operation_kind.Ci :: acc else acc in
+    let acc = if Pr_state.ci_failed pr then Operation_kind.Ci :: acc else acc in
     List.rev acc
   in
   {
     queue;
-    merged = was_merged || Github.merged pr;
-    closed = Github.closed pr;
-    has_conflict = Github.has_conflict pr;
-    mergeable = Github.mergeable pr;
-    merge_ready = Github.merge_ready pr;
-    checks_passing = Github.checks_passing pr;
-    ci_checks = pr.Github.Pr_state.ci_checks;
+    merged = was_merged || Pr_state.merged pr;
+    closed = Pr_state.closed pr;
+    has_conflict = Pr_state.has_conflict pr;
+    mergeable = Pr_state.mergeable pr;
+    merge_ready = Pr_state.merge_ready pr;
+    checks_passing = Pr_state.checks_passing pr;
+    ci_checks = pr.Pr_state.ci_checks;
   }

--- a/lib/poller.mli
+++ b/lib/poller.mli
@@ -36,9 +36,9 @@ type t = {
 [@@deriving show, eq]
 (** The result of polling a single patch's PR state. *)
 
-val poll : was_merged:bool -> Github.Pr_state.t -> t
+val poll : was_merged:bool -> Pr_state.t -> t
 (** [poll ~was_merged pr_state] computes the patch state updates from the
-    current GitHub PR state.
+    current PR state.
 
     [was_merged] is the patch's current merged status (from PatchCtx). Once
     merged, a patch stays merged regardless of what the world reports.

--- a/lib/pr_state.ml
+++ b/lib/pr_state.ml
@@ -1,0 +1,31 @@
+open Base
+
+type merge_state = Mergeable | Conflicting | Unknown [@@deriving show, eq]
+type check_status = Passing | Failing | Pending [@@deriving show, eq]
+type pr_status = Open | Merged | Closed [@@deriving show, eq]
+
+type t = {
+  status : pr_status;
+  merge_state : merge_state;
+  merge_ready : bool;
+  check_status : check_status;
+  ci_checks : Types.Ci_check.t list;
+  ci_checks_truncated : bool;
+  comments : Types.Comment.t list;
+  unresolved_comment_count : int;
+  head_branch : Types.Branch.t option;
+  base_branch : Types.Branch.t option;
+}
+[@@deriving show, eq]
+
+let merged (st : t) = equal_pr_status st.status Merged
+let closed (st : t) = equal_pr_status st.status Closed
+
+let mergeable (st : t) =
+  equal_pr_status st.status Open && equal_merge_state st.merge_state Mergeable
+
+let merge_ready (st : t) = equal_pr_status st.status Open && st.merge_ready
+let checks_passing (st : t) = equal_check_status st.check_status Passing
+let no_unresolved_comments (st : t) = st.unresolved_comment_count = 0
+let has_conflict (st : t) = equal_merge_state st.merge_state Conflicting
+let ci_failed (st : t) = equal_check_status st.check_status Failing

--- a/lib/pr_state.mli
+++ b/lib/pr_state.mli
@@ -1,0 +1,36 @@
+open Types
+
+(** Forge-agnostic pull request state.
+
+    Contains the data model and predicates for WorldCtx from the spec: merged,
+    mergeable, checks-passing, no-unresolved-comments, world-has-comment,
+    world-has-conflict, world-ci-failed. *)
+
+type merge_state = Mergeable | Conflicting | Unknown [@@deriving show, eq]
+type check_status = Passing | Failing | Pending [@@deriving show, eq]
+type pr_status = Open | Merged | Closed [@@deriving show, eq]
+
+type t = {
+  status : pr_status;
+  merge_state : merge_state;
+  merge_ready : bool;
+  check_status : check_status;
+  ci_checks : Ci_check.t list;
+  ci_checks_truncated : bool;
+  comments : Comment.t list;
+  unresolved_comment_count : int;
+  head_branch : Branch.t option;
+  base_branch : Branch.t option;
+}
+[@@deriving show, eq]
+
+(** {2 WorldCtx predicates} *)
+
+val merged : t -> bool
+val closed : t -> bool
+val mergeable : t -> bool
+val merge_ready : t -> bool
+val checks_passing : t -> bool
+val no_unresolved_comments : t -> bool
+val has_conflict : t -> bool
+val ci_failed : t -> bool

--- a/lib_test/test_generators.ml
+++ b/lib_test/test_generators.ml
@@ -138,21 +138,20 @@ let gen_gameplan =
 
 let gen_graph = QCheck2.Gen.(map Onton.Graph.of_patches gen_patch_list_unique)
 
-(* -- Github types -- *)
+(* -- Pr_state types -- *)
 
 let gen_pr_status =
-  QCheck2.Gen.oneof_list Onton.Github.Pr_state.[ Open; Merged; Closed ]
+  QCheck2.Gen.oneof_list Onton.Pr_state.[ Open; Merged; Closed ]
 
 let gen_merge_state =
-  QCheck2.Gen.oneof_list
-    Onton.Github.Pr_state.[ Mergeable; Conflicting; Unknown ]
+  QCheck2.Gen.oneof_list Onton.Pr_state.[ Mergeable; Conflicting; Unknown ]
 
 let gen_check_status =
-  QCheck2.Gen.oneof_list Onton.Github.Pr_state.[ Passing; Failing; Pending ]
+  QCheck2.Gen.oneof_list Onton.Pr_state.[ Passing; Failing; Pending ]
 
 let gen_pr_state =
   QCheck2.Gen.(
-    let open Onton.Github.Pr_state in
+    let open Onton.Pr_state in
     map5
       (fun (status, merge_state) merge_ready (check_status, ci_checks_truncated)
            ci_checks (comments, unresolved_comment_count) ->
@@ -507,5 +506,5 @@ let print_ci_check = Ci_check.show
 let print_gameplan = Gameplan.show
 let print_patch_agent = Onton.Patch_agent.show
 let print_poller = Onton.Poller.show
-let print_pr_state = Onton.Github.Pr_state.show
+let print_pr_state = Onton.Pr_state.show
 let print_github_error = Onton.Github.show_error

--- a/test/test_poller_properties.ml
+++ b/test/test_poller_properties.ml
@@ -9,25 +9,25 @@ let () =
       Test.make ~name:"mergeable passed through" ~count:500
         Onton_test_support.Test_generators.gen_pr_state (fun pr ->
           let result = Onton.Poller.poll ~was_merged:false pr in
-          Bool.equal result.Onton.Poller.mergeable (Onton.Github.mergeable pr));
+          Bool.equal result.Onton.Poller.mergeable (Onton.Pr_state.mergeable pr));
       (* merge_ready is passed through from PR state *)
       Test.make ~name:"merge_ready passed through" ~count:500
         Onton_test_support.Test_generators.gen_pr_state (fun pr ->
           let result = Onton.Poller.poll ~was_merged:false pr in
           Bool.equal result.Onton.Poller.merge_ready
-            (Onton.Github.merge_ready pr));
+            (Onton.Pr_state.merge_ready pr));
       (* checks_passing is passed through from PR state *)
       Test.make ~name:"checks_passing passed through" ~count:500
         Onton_test_support.Test_generators.gen_pr_state (fun pr ->
           let result = Onton.Poller.poll ~was_merged:false pr in
           Bool.equal result.Onton.Poller.checks_passing
-            (Onton.Github.checks_passing pr));
+            (Onton.Pr_state.checks_passing pr));
       (* ci_checks are passed through from PR state *)
       Test.make ~name:"ci_checks passed through" ~count:500
         Onton_test_support.Test_generators.gen_pr_state (fun pr ->
           let result = Onton.Poller.poll ~was_merged:false pr in
           List.equal Ci_check.equal result.Onton.Poller.ci_checks
-            pr.Onton.Github.Pr_state.ci_checks);
+            pr.Onton.Pr_state.ci_checks);
     ]
   in
   List.iter tests ~f:(fun t -> QCheck2.Test.check_exn t)

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -136,7 +136,7 @@ let () =
     Test.make ~name:"poller: merged reflects pr state"
       Onton_test_support.Test_generators.gen_pr_state (fun pr ->
         let result = Poller.poll ~was_merged:false pr in
-        Bool.equal result.merged (Github.merged pr))
+        Bool.equal result.merged (Pr_state.merged pr))
   in
   let prop_conflict_queue =
     Test.make ~name:"poller: conflict in queue iff has_conflict"
@@ -156,7 +156,7 @@ let () =
           List.mem result.queue Types.Operation_kind.Ci
             ~equal:Types.Operation_kind.equal
         in
-        Bool.equal in_queue (Github.ci_failed pr))
+        Bool.equal in_queue (Pr_state.ci_failed pr))
   in
   let prop_review_queue =
     Test.make ~name:"poller: review in queue iff unresolved comments"
@@ -166,7 +166,7 @@ let () =
           List.mem result.queue Types.Operation_kind.Review_comments
             ~equal:Types.Operation_kind.equal
         in
-        Bool.equal in_queue (not (List.is_empty pr.Github.Pr_state.comments)))
+        Bool.equal in_queue (not (List.is_empty pr.Pr_state.comments)))
   in
   let prop_no_rebase =
     Test.make ~name:"poller: rebase never in poll queue"


### PR DESCRIPTION
## Summary
- Extracts forge-agnostic `Pr_state` module (types + WorldCtx predicates) from `Github`, so `Poller` and core orchestration no longer depend on a specific forge
- Introduces `Forge.S` module type — the minimal interface any forge backend must satisfy (`pr_state`, `error`, `show_error`)
- `Github` satisfies `Forge.S` with a static assertion; its `create`, `parse_response`, and error types remain GitHub-specific
- No behavioral changes — pure structural refactor

## Test plan
- [x] `dune build` compiles cleanly
- [x] `dune runtest` — all existing property tests pass
- [x] `dune fmt` — formatting clean
- [x] `Poller` has zero references to `Github` (grep verified)
- [x] `Github` satisfies `Forge.S` (static module assertion in `github.ml`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured pull request state handling for improved code organization and maintainability.
  * Consolidated PR state utilities and checks into a dedicated, reusable module.

* **Tests**
  * Updated automated tests to reflect internal code reorganization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->