### PR TITLE
Fix worktree creation to use remote branch when no local exists

### DIFF
--- a/lib/worktree.ml
+++ b/lib/worktree.ml
@@ -46,24 +46,23 @@ let clean_git_env () =
       && not (String.is_prefix s ~prefix:"GIT_INDEX_FILE="))
   |> Array.of_list
 
-let branch_exists ~process_mgr ~repo_root branch_str =
+let ref_exists ~process_mgr ~repo_root ref_path =
   let buf = Buffer.create 16 in
   match
     Eio.Process.run process_mgr ~env:(clean_git_env ())
       ~stdout:(Eio.Flow.buffer_sink buf)
       ~stderr:(Eio.Flow.buffer_sink (Buffer.create 16))
-      [
-        "git";
-        "-C";
-        repo_root;
-        "rev-parse";
-        "--verify";
-        "refs/heads/" ^ branch_str;
-      ]
+      [ "git"; "-C"; repo_root; "rev-parse"; "--verify"; ref_path ]
   with
   | () -> true
   | exception e when has_cancellation e -> raise e
   | exception _ -> false
+
+let branch_exists ~process_mgr ~repo_root branch_str =
+  ref_exists ~process_mgr ~repo_root ("refs/heads/" ^ branch_str)
+
+let remote_branch_exists ~process_mgr ~repo_root branch_str =
+  ref_exists ~process_mgr ~repo_root ("refs/remotes/origin/" ^ branch_str)
 
 let resolve_main_root ~process_mgr ~repo_root =
   let buf = Buffer.create 128 in
@@ -112,6 +111,21 @@ let create ~process_mgr ~repo_root ~project_name ~patch_id ~branch ~base_ref =
   else if branch_exists ~process_mgr ~repo_root branch_str then (
     Eio.Process.run process_mgr ~env:(clean_git_env ())
       [ "git"; "-C"; repo_root; "worktree"; "add"; path; branch_str ];
+    { patch_id; branch; path })
+  else if remote_branch_exists ~process_mgr ~repo_root branch_str then (
+    (* Branch exists on remote but not locally — create local branch from remote *)
+    Eio.Process.run process_mgr ~env:(clean_git_env ())
+      [
+        "git";
+        "-C";
+        repo_root;
+        "worktree";
+        "add";
+        "-b";
+        branch_str;
+        path;
+        "origin/" ^ branch_str;
+      ];
     { patch_id; branch; path })
   else (
     Eio.Process.run process_mgr ~env:(clean_git_env ())

--- a/lib/worktree.mli
+++ b/lib/worktree.mli
@@ -21,6 +21,10 @@ val is_checked_out_in_repo_root :
     (resolved via the git common dir, not necessarily [repo_root] itself). A
     worktree cannot be created for a branch that is checked out there. *)
 
+val remote_branch_exists :
+  process_mgr:_ Eio.Process.mgr -> repo_root:string -> string -> bool
+(** Returns [true] if [origin/<branch>] exists as a remote tracking ref. *)
+
 val create :
   process_mgr:_ Eio.Process.mgr ->
   repo_root:string ->


### PR DESCRIPTION
## Summary

- When creating a worktree for a PR whose branch exists only on the remote (no local tracking branch), the code created a new branch from `base_ref` (typically `main`/`HEAD`), leaving the worktree at the wrong commit
- Now checks for `origin/<branch>` before falling back to `base_ref`, so the worktree starts at the correct remote commit
- Extracted a generic `ref_exists` helper and added `remote_branch_exists` to `Worktree`

## Test plan

- [x] `dune build` passes
- [x] `dune runtest` — all existing tests pass
- [ ] Manual: create a scenario where a branch exists only on remote, verify worktree gets the remote content

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added capability to check whether branches exist on remote repositories.
  * Enhanced worktree creation workflow: when creating a new worktree where the local branch doesn't exist, the system now automatically checks if the branch exists on the remote repository and creates the local branch accordingly, streamlining the initialization process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->