### PR TITLE
Fix human messages silently dropped on session failure

### DIFF
--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -437,20 +437,40 @@ type session_result =
   | Session_worktree_missing
 [@@deriving show, eq, sexp_of]
 
+(** Complete a failed session, preserving human messages. When
+    [current_op = Human], [complete] clears [human_messages] because it assumes
+    the messages were delivered. On failure they were NOT delivered, so we save
+    them before [complete] and restore + re-enqueue afterwards. *)
+let complete_failed t patch_id =
+  let agent = agent t patch_id in
+  let was_human =
+    Option.equal Operation_kind.equal agent.Patch_agent.current_op
+      (Some Operation_kind.Human)
+  in
+  let saved_messages = agent.Patch_agent.human_messages in
+  let t = complete t patch_id in
+  if was_human && not (List.is_empty saved_messages) then
+    let t =
+      update_agent t patch_id ~f:(fun a ->
+          Patch_agent.restore_human_messages a saved_messages)
+    in
+    enqueue t patch_id Operation_kind.Human
+  else t
+
 let apply_session_result t patch_id result =
   match result with
   | Session_ok -> clear_session_fallback t patch_id
   | Session_process_error { is_fresh } ->
       let t = on_session_failure t patch_id ~is_fresh in
-      complete t patch_id
+      complete_failed t patch_id
   | Session_no_resume ->
       let t = on_session_failure t patch_id ~is_fresh:false in
-      complete t patch_id
+      complete_failed t patch_id
   | Session_failed { is_fresh } ->
       let t = on_session_failure t patch_id ~is_fresh in
-      complete t patch_id
+      complete_failed t patch_id
   | Session_give_up ->
       let t = set_session_failed t patch_id in
       let t = set_tried_fresh t patch_id in
-      complete t patch_id
-  | Session_worktree_missing -> complete t patch_id
+      complete_failed t patch_id
+  | Session_worktree_missing -> complete_failed t patch_id

--- a/lib/patch_agent.ml
+++ b/lib/patch_agent.ml
@@ -121,6 +121,8 @@ let mark_merged t = { t with merged = true }
 let add_human_message t msg =
   { t with human_messages = msg :: t.human_messages }
 
+let restore_human_messages t msgs = { t with human_messages = msgs }
+
 let set_session_failed t =
   match t.session_fallback with
   | Fresh_available -> { t with session_fallback = Tried_fresh }

--- a/lib/patch_agent.mli
+++ b/lib/patch_agent.mli
@@ -101,6 +101,11 @@ val mark_merged : t -> t
 val add_human_message : t -> string -> t
 (** Add a human message to the pending list. *)
 
+val restore_human_messages : t -> string list -> t
+(** Replace [human_messages] wholesale. Used to preserve messages across a
+    failed Human session — [complete] clears them assuming delivery succeeded,
+    but on failure they must be restored for the retry. *)
+
 val set_session_failed : t -> t
 (** Mark session fallback as [Given_up]. *)
 

--- a/test/test_patch_controller_state_machine.ml
+++ b/test/test_patch_controller_state_machine.ml
@@ -114,6 +114,203 @@ let () =
         with _ -> false
         end)
   in
+  let prop_human_after_review_completes =
+    Test.make
+      ~name:
+        "patch_controller_state_machine: human message queued during \
+         review_comments is delivered after review completes"
+      ~count:300
+      Gen.(pair gen_patch_id gen_branch)
+      (fun (pid, branch) ->
+        begin try
+          let patch = make_patch pid branch in
+          let gameplan = make_gameplan patch in
+          let orch = Orchestrator.create ~patches:[ patch ] ~main_branch:main in
+          (* Step 1: Start → get PR *)
+          let orch, _eff, msgs =
+            Patch_controller.plan_tick_messages orch
+              ~project_name:"test-project" ~gameplan
+          in
+          let orch = accept_all_messages orch msgs in
+          (* Simulate start completing and PR being discovered *)
+          let orch = Orchestrator.complete orch pid in
+          let orch = Orchestrator.set_pr_number orch pid (Pr_number.of_int 1) in
+          (* Step 2: Enqueue Review_comments via poller *)
+          let orch =
+            Orchestrator.enqueue orch pid Operation_kind.Review_comments
+          in
+          (* Step 3: Plan + accept Review_comments *)
+          let orch, _eff, msgs =
+            Patch_controller.plan_tick_messages orch
+              ~project_name:"test-project" ~gameplan
+          in
+          let orch = accept_all_messages orch msgs in
+          (* Agent should now be busy with Review_comments *)
+          let agent = Orchestrator.agent orch pid in
+          assert agent.Patch_agent.busy;
+          (* Step 4: Human sends a message while agent is busy *)
+          let orch = Orchestrator.send_human_message orch pid "fix the typo" in
+          (* Step 5: Review_comments session completes *)
+          let orch = Orchestrator.complete orch pid in
+          (* Step 6: Next tick should plan Human Respond *)
+          let _orch2, _eff2, msgs2 =
+            Patch_controller.plan_tick_messages orch
+              ~project_name:"test-project" ~gameplan
+          in
+          List.exists msgs2 ~f:(fun msg ->
+              let is_human_respond =
+                match Orchestrator.message_action msg with
+                | Orchestrator.Respond (p, kind) ->
+                    Patch_id.equal p pid
+                    && Operation_kind.equal kind Operation_kind.Human
+                | Orchestrator.Start _ | Orchestrator.Rebase _ -> false
+              in
+              is_human_respond)
+        with _ -> false
+        end)
+  in
+  (* Comprehensive scenario: a PRIOR Human delivery exists (Completed in outbox),
+     then Review_comments runs, human sends another message during it, and
+     after review completes the NEW human message should still be planned.
+     Tests that message ID collision with the Completed message does not block. *)
+  let prop_second_human_after_review =
+    Test.make
+      ~name:
+        "patch_controller_state_machine: second human message after prior \
+         human delivery + review_comments"
+      ~count:300
+      Gen.(pair gen_patch_id gen_branch)
+      (fun (pid, branch) ->
+        begin try
+          let patch = make_patch pid branch in
+          let gameplan = make_gameplan patch in
+          let orch = Orchestrator.create ~patches:[ patch ] ~main_branch:main in
+          (* Start → get PR *)
+          let orch, _eff, msgs =
+            Patch_controller.plan_tick_messages orch
+              ~project_name:"test-project" ~gameplan
+          in
+          let orch = accept_all_messages orch msgs in
+          let orch = Orchestrator.complete orch pid in
+          let orch = Orchestrator.set_pr_number orch pid (Pr_number.of_int 1) in
+          (* First Human message: send, plan, accept, complete *)
+          let orch = Orchestrator.send_human_message orch pid "first message" in
+          let orch, _eff, msgs =
+            Patch_controller.plan_tick_messages orch
+              ~project_name:"test-project" ~gameplan
+          in
+          let orch = accept_all_messages orch msgs in
+          let orch = Orchestrator.complete orch pid in
+          (* Now outbox has a Completed Human Respond message *)
+          (* Enqueue Review_comments via poller *)
+          let orch =
+            Orchestrator.enqueue orch pid Operation_kind.Review_comments
+          in
+          let orch, _eff, msgs =
+            Patch_controller.plan_tick_messages orch
+              ~project_name:"test-project" ~gameplan
+          in
+          let orch = accept_all_messages orch msgs in
+          (* Agent busy with Review_comments *)
+          (* Send second human message while busy *)
+          let orch =
+            Orchestrator.send_human_message orch pid "second message"
+          in
+          (* Complete Review_comments *)
+          let orch = Orchestrator.complete orch pid in
+          (* Next tick should plan Human Respond for second message *)
+          let _orch2, _eff2, msgs2 =
+            Patch_controller.plan_tick_messages orch
+              ~project_name:"test-project" ~gameplan
+          in
+          List.exists msgs2 ~f:(fun msg ->
+              let is_human_respond =
+                match Orchestrator.message_action msg with
+                | Orchestrator.Respond (p, kind) ->
+                    Patch_id.equal p pid
+                    && Operation_kind.equal kind Operation_kind.Human
+                | Orchestrator.Start _ | Orchestrator.Rebase _ -> false
+              in
+              is_human_respond)
+        with _ -> false
+        end)
+  in
+  (* Regression: when a Human session fails, the human_messages must be
+     preserved and Human re-enqueued so the retry delivers them. *)
+  let prop_human_messages_survive_session_failure =
+    Test.make
+      ~name:
+        "patch_controller_state_machine: human messages survive session \
+         failure and are re-delivered"
+      ~count:300
+      Gen.(pair gen_patch_id gen_branch)
+      (fun (pid, branch) ->
+        begin try
+          let patch = make_patch pid branch in
+          let gameplan = make_gameplan patch in
+          let orch = Orchestrator.create ~patches:[ patch ] ~main_branch:main in
+          (* Start → get PR *)
+          let orch, _eff, msgs =
+            Patch_controller.plan_tick_messages orch
+              ~project_name:"test-project" ~gameplan
+          in
+          let orch = accept_all_messages orch msgs in
+          let orch = Orchestrator.complete orch pid in
+          let orch = Orchestrator.set_pr_number orch pid (Pr_number.of_int 1) in
+          (* Send a human message *)
+          let orch = Orchestrator.send_human_message orch pid "fix the typo" in
+          (* Plan + accept the Human Respond *)
+          let orch, _eff, msgs =
+            Patch_controller.plan_tick_messages orch
+              ~project_name:"test-project" ~gameplan
+          in
+          let orch = accept_all_messages orch msgs in
+          let agent = Orchestrator.agent orch pid in
+          assert agent.Patch_agent.busy;
+          assert (
+            Option.equal Operation_kind.equal agent.Patch_agent.current_op
+              (Some Operation_kind.Human));
+          (* Simulate session failure (e.g. No_session_to_resume) *)
+          let orch =
+            Orchestrator.apply_session_result orch pid
+              Orchestrator.Session_no_resume
+          in
+          (* After failure: human_messages must still exist and Human
+             must be re-enqueued so the retry delivers them *)
+          let agent = Orchestrator.agent orch pid in
+          let messages_preserved =
+            not (List.is_empty agent.Patch_agent.human_messages)
+          in
+          let human_requeued =
+            List.mem agent.Patch_agent.queue Operation_kind.Human
+              ~equal:Operation_kind.equal
+          in
+          (* The retry tick should plan Human Respond again *)
+          let _orch2, _eff2, msgs2 =
+            Patch_controller.plan_tick_messages orch
+              ~project_name:"test-project" ~gameplan
+          in
+          let replanned =
+            List.exists msgs2 ~f:(fun msg ->
+                let is_human_respond =
+                  match Orchestrator.message_action msg with
+                  | Orchestrator.Respond (p, kind) ->
+                      Patch_id.equal p pid
+                      && Operation_kind.equal kind Operation_kind.Human
+                  | Orchestrator.Start _ | Orchestrator.Rebase _ -> false
+                in
+                is_human_respond)
+          in
+          messages_preserved && human_requeued && replanned
+        with _ -> false
+        end)
+  in
   QCheck_base_runner.run_tests ~verbose:true
-    [ prop_replay_deterministic; prop_resume_keeps_same_message_id ]
+    [
+      prop_replay_deterministic;
+      prop_resume_keeps_same_message_id;
+      prop_human_after_review_completes;
+      prop_second_human_after_review;
+      prop_human_messages_survive_session_failure;
+    ]
   |> Stdlib.exit


### PR DESCRIPTION
## Summary
- When a `Respond(Human)` session fails (e.g. `No_session_to_resume` from `--continue` finding no previous session), `apply_session_result` called `complete` which cleared `human_messages` because `current_op = Some Human`. But `respond(Human)` had already dequeued `Human` from the queue, so both the queue and messages were silently lost — the user had to re-enter their message.
- Added `complete_failed` helper that saves `human_messages` before `complete` and restores them + re-enqueues `Human` on failure, so the retry session still has the messages to deliver.
- Added 3 new property tests covering human message delivery after review completion, message ID collision resistance, and the regression case (human messages survive session failure).

## Test plan
- [x] All existing tests pass (inline, property, state machine, interleaving)
- [x] New regression test: `human messages survive session failure and are re-delivered`
- [x] New test: `human message queued during review_comments is delivered after review completes`
- [x] New test: `second human message after prior human delivery + review_comments`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced patch workflow reliability: human feedback messages are now preserved during failed operations and automatically re-queued for retry, preventing loss of user input during reviews and corrections.

* **Tests**
  * Added comprehensive test coverage for human message preservation, ensuring feedback is retained and re-delivered across failed patch sessions, retries, and concurrent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->