### PR TITLE
Replace flow section with SVG diagram

### DIFF
--- a/docs/assets/app.js
+++ b/docs/assets/app.js
@@ -1,4 +1,5 @@
 document.addEventListener("DOMContentLoaded", () => {
+  /* ── Copy buttons ── */
   document.querySelectorAll(".copy-button").forEach((button) => {
     const defaultLabel = button.textContent || "Copy";
     let resetTimer = null;

--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -363,97 +363,47 @@ h3 {
   align-items: center;
 }
 
-.flow-layout {
+/* ── Flow diagram ── */
+
+.flow-grid {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(16rem, var(--layout-rail-width));
-  gap: var(--layout-column-gap);
+  grid-template-columns: 1fr;
+  gap: 2rem;
   align-items: start;
 }
 
-.flow-side {
-  grid-column: 2;
-  grid-row: 3;
+.flow-diagram svg {
+  display: block;
+  width: 100%;
+  max-width: 780px;
+  height: auto;
+  margin: 0 auto;
 }
 
-.flow-workstream {
-  grid-column: 1;
-  grid-row: 1;
-}
-
-.flow-connector-block {
-  grid-column: 1;
-  justify-self: center;
-}
-
-.flow-connector-step-1 {
-  grid-row: 2;
-}
-
-.flow-connector-step-2 {
-  grid-row: 4;
-}
-
-.flow-optional {
-  grid-column: 1;
-  grid-row: 3;
-}
-
-.flow-loop {
-  grid-column: 1;
-  grid-row: 5;
-}
-
-.flow-loop {
+.flow-annotations {
   display: grid;
-  gap: 1rem;
-  padding: 1rem;
-  background: color-mix(in oklab, var(--card-muted) 72%, var(--secondary));
-  border: 1px dashed color-mix(in oklab, var(--brand) 38%, var(--border));
-  border-radius: var(--radius-xl);
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.25rem;
+  align-content: start;
 }
 
-.flow-optional {
-  background:
-    linear-gradient(135deg, color-mix(in oklab, var(--secondary) 70%, white), color-mix(in oklab, var(--card) 92%, white));
-  border-style: dashed;
-  border-color: color-mix(in oklab, var(--brand) 26%, var(--border));
-  box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--brand) 10%, transparent);
-}
-
-.flow-optional-header {
-  display: flex;
-  align-items: center;
-  margin-bottom: 0.65rem;
-}
-
-.flow-loop-header {
+.flow-annotation {
   display: grid;
   grid-template-columns: auto 1fr;
-  gap: 0.85rem;
+  gap: 0.75rem;
   align-items: start;
 }
 
-.flow-loop-header h3 {
-  margin-bottom: 0.15rem;
+.flow-annotation .workflow-kicker {
+  margin-bottom: 0;
 }
 
-.flow-loop-header p {
-  margin: 0;
+.flow-annotation h3 {
+  margin-bottom: 0.2rem;
 }
 
-.flow-loop-steps {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
-  gap: 1rem;
-  align-items: center;
-}
-
-.workflow-step {
-  background: var(--card-muted);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-xl);
-  padding: 1rem;
-  min-height: 100%;
+.flow-annotation p {
+  margin: 0 0 0.3rem;
 }
 
 .workflow-kicker {
@@ -466,24 +416,22 @@ h3 {
   background: var(--secondary);
   color: var(--secondary-foreground);
   font-weight: 700;
+  font-family: var(--font-sans);
   margin-bottom: 0.9rem;
+}
+
+.workflow-step {
+  background: var(--card-muted);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  padding: 1rem;
+  min-height: 100%;
 }
 
 .workflow-arrow {
   font-size: 2rem;
   text-align: center;
   color: var(--brand);
-}
-
-.flow-connector {
-  justify-self: center;
-  font-size: 2rem;
-  line-height: 1;
-  color: var(--brand);
-}
-
-.flow-connector-inline {
-  align-self: center;
 }
 
 .key-points,
@@ -651,7 +599,7 @@ code {
     grid-template-columns: 1fr;
   }
 
-  .flow-layout {
+  .flow-annotations {
     grid-template-columns: 1fr;
   }
 
@@ -661,25 +609,6 @@ code {
   }
 
   .workflow-arrow {
-    transform: rotate(90deg);
-  }
-
-  .flow-loop-header {
-    grid-template-columns: 1fr;
-  }
-
-  .flow-side {
-    grid-column: 1;
-    grid-row: 4;
-  }
-}
-
-@media (max-width: 720px) {
-  .flow-loop-steps {
-    grid-template-columns: 1fr;
-  }
-
-  .flow-connector-inline {
     transform: rotate(90deg);
   }
 }

--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -363,6 +363,36 @@ h3 {
   align-items: center;
 }
 
+/* ── Legacy flow selectors (used by execution.html, workstream.html) ── */
+
+.flow-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(16rem, var(--layout-rail-width));
+  gap: var(--layout-column-gap);
+  align-items: start;
+}
+
+.flow-side {
+  grid-column: 2;
+  grid-row: 3;
+}
+
+.flow-optional {
+  grid-column: 1;
+  grid-row: 3;
+  background:
+    linear-gradient(135deg, color-mix(in oklab, var(--secondary) 70%, white), color-mix(in oklab, var(--card) 92%, white));
+  border-style: dashed;
+  border-color: color-mix(in oklab, var(--brand) 26%, var(--border));
+  box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--brand) 10%, transparent);
+}
+
+.flow-optional-header {
+  display: flex;
+  align-items: center;
+  margin-bottom: 0.65rem;
+}
+
 /* ── Flow diagram ── */
 
 .flow-grid {
@@ -601,6 +631,15 @@ code {
 
   .flow-annotations {
     grid-template-columns: 1fr;
+  }
+
+  .flow-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .flow-side {
+    grid-column: 1;
+    grid-row: 4;
   }
 
   .hero-copy,

--- a/docs/index.html
+++ b/docs/index.html
@@ -117,7 +117,7 @@
                   <text class="fc-label--mono" x="254" y="345">g = /write-gameplan m</text>
 
                   <!-- Edge 3a→3b -->
-                  <path class="fc-edge" d="M 384 345 L 420 345" />
+                  <path class="fc-edge" d="M 384 345 L 413 345" />
 
                   <!-- Step 3b: onton -->
                   <rect class="fc-node" x="420" y="314" width="216" height="62" rx="10" />
@@ -126,7 +126,7 @@
                   <!-- Loop-back: exits right side of loop box, curves down, goes left, curves up into left side -->
                   <path class="fc-edge fc-edge--loop"
                         d="M 660 345 L 694 345 Q 714 345 714 365 L 714 420 Q 714 440 694 440 L 66 440 Q 46 440 46 420 L 46 365 Q 46 345 66 345 L 100 345"
-                        marker-end="url(#fc-ah)" marker-start="" />
+                        marker-end="url(#fc-ah)" />
                 </svg>
               </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -63,97 +63,140 @@
 
           <section class="index-section index-flow-section">
             <p class="section-label">flow</p>
-            <div class="flow-layout section-block">
-              <div class="panel workflow-step flow-workstream">
-                <span class="workflow-kicker">1</span>
-                <h3>write a workstream <code>w</code></h3>
-                <p>
-                  Define the vision, current state, key challenges, and
-                  milestones. The output is a workstream whose milestones
-                  become the unit of iteration.
-                </p>
-                <a href="workstream.html">Read the workstream guide</a>
+            <div class="flow-grid section-block">
+              <div class="flow-diagram">
+                <svg viewBox="0 0 760 464" role="img"
+                     aria-label="Flowchart: write a workstream, optionally write a spec, then loop through milestones running write-gameplan and onton.">
+                  <style>
+                    .fc-node { fill: var(--card-muted); stroke: var(--border); stroke-width: 1.5; }
+                    .fc-node--opt { stroke-dasharray: 7 5; fill: var(--secondary); stroke: var(--brand); stroke-opacity: 0.4; }
+                    .fc-loop-bg { fill: var(--secondary); stroke: var(--border); stroke-width: 1.5; }
+                    .fc-edge { fill: none; stroke: var(--brand); stroke-width: 2.5; stroke-linecap: round; marker-end: url(#fc-ah); }
+                    .fc-edge--dash { stroke-dasharray: 8 5; }
+                    .fc-edge--loop { stroke-width: 2; stroke-opacity: 0.55; stroke-dasharray: 6 4; }
+                    .fc-label--mono { font-family: var(--font-mono); font-size: 15px; fill: var(--foreground); font-weight: 500; text-anchor: middle; dominant-baseline: central; }
+                    .fc-label--loop { font-family: var(--font-mono); font-size: 15px; fill: var(--muted-foreground); font-weight: 500; }
+                    .fc-label--opt { font-family: var(--font-sans); font-size: 11px; fill: var(--muted-foreground); font-weight: 600; text-transform: uppercase; letter-spacing: 0.12em; }
+                    .fc-kicker { fill: var(--secondary); stroke: var(--border); stroke-width: 1.5; }
+                    .fc-kicker-text { font-family: var(--font-sans); font-size: 15px; fill: var(--foreground); font-weight: 700; text-anchor: middle; dominant-baseline: central; }
+                  </style>
+                  <defs>
+                    <marker id="fc-ah" viewBox="0 0 10 7" refX="9" refY="3.5"
+                            markerWidth="9" markerHeight="7" orient="auto-start-reverse">
+                      <polygon points="0 0, 10 3.5, 0 7" fill="var(--brand)" />
+                    </marker>
+                  </defs>
+
+                  <!-- Step 1: write workstream -->
+                  <rect class="fc-node" x="170" y="20" width="340" height="64" rx="12" />
+                  <circle class="fc-kicker" cx="194" cy="38" r="14" />
+                  <text class="fc-kicker-text" x="194" y="38">1</text>
+                  <text class="fc-label--mono" x="340" y="52">w = /write-workstream</text>
+
+                  <!-- Edge 1→2 -->
+                  <path class="fc-edge" d="M 340 84 L 340 130" />
+
+                  <!-- Step 2: write spec (optional) -->
+                  <rect class="fc-node--opt" x="220" y="130" width="240" height="64" rx="12" />
+                  <circle class="fc-kicker" cx="244" cy="148" r="14" />
+                  <text class="fc-kicker-text" x="244" y="148">2</text>
+                  <text class="fc-label--mono" x="340" y="162">/write-spec</text>
+                  <text class="fc-label--opt" x="340" y="180" text-anchor="middle">optional</text>
+
+                  <!-- Edge 2→loop -->
+                  <path class="fc-edge fc-edge--dash" d="M 340 194 L 340 260" />
+
+                  <!-- Loop container -->
+                  <rect class="fc-loop-bg" x="100" y="260" width="560" height="140" rx="14" />
+                  <circle class="fc-kicker" cx="128" cy="286" r="14" />
+                  <text class="fc-kicker-text" x="128" y="286">3</text>
+                  <text class="fc-label--loop" x="150" y="291">for m in w.milestones:</text>
+
+                  <!-- Step 3a: write-gameplan -->
+                  <rect class="fc-node" x="124" y="314" width="260" height="62" rx="10" />
+                  <text class="fc-label--mono" x="254" y="345">g = /write-gameplan m</text>
+
+                  <!-- Edge 3a→3b -->
+                  <path class="fc-edge" d="M 384 345 L 420 345" />
+
+                  <!-- Step 3b: onton -->
+                  <rect class="fc-node" x="420" y="314" width="216" height="62" rx="10" />
+                  <text class="fc-label--mono" x="528" y="345">onton --gameplan g</text>
+
+                  <!-- Loop-back: exits right side of loop box, curves down, goes left, curves up into left side -->
+                  <path class="fc-edge fc-edge--loop"
+                        d="M 660 345 L 694 345 Q 714 345 714 365 L 714 420 Q 714 440 694 440 L 66 440 Q 46 440 46 420 L 46 365 Q 46 345 66 345 L 100 345"
+                        marker-end="url(#fc-ah)" marker-start="" />
+                </svg>
               </div>
 
-              <div class="flow-connector flow-connector-block flow-connector-step-1" aria-hidden="true">↓</div>
-
-              <div class="panel workflow-step flow-optional">
-                <div class="flow-optional-header">
-                  <span class="workflow-kicker">2</span>
+              <div class="flow-annotations">
+                <div class="flow-annotation">
+                  <span class="workflow-kicker">1</span>
+                  <div>
+                    <h3>write a workstream</h3>
+                    <p>
+                      Define the vision, current state, key challenges, and
+                      milestones. The output is a workstream whose milestones
+                      become the unit of iteration.
+                    </p>
+                    <a href="workstream.html">Read the workstream guide</a>
+                  </div>
                 </div>
-                <h3>write a spec</h3>
-                <p>
-                  Optionally: formally specify invariants that should hold
-                  when the feature is complete.
-                </p>
-                <a href="https://pantagruel-language.com/"
-                  >Read about the Pantagruel specification language</a
-                >
-              </div>
-
-              <aside class="flow-side" aria-label="Flow sidenote">
-                <section class="sidenote-card">
-                  <p class="section-label">sidenote</p>
-                  <h2>Theory is the artifact</h2>
-                  <p class="sidenote-intro">
-                    Formal specifications do at least two important kinds of
-                    work in this process:
-                  </p>
-                  <ol class="sidenote-list">
-                    <li>
-                      They give the coding agent an unambiguous change to
-                      implement, with some ambiguity and contradiction removed
-                      from the natural language description.
-                    </li>
-                    <li>
-                      They force the engineer to order the domain conceptually,
-                      making the system’s entities, rules, and consequences
-                      concrete before the implementation phase starts.
-                    </li>
-                  </ol>
-                </section>
-              </aside>
-
-              <div class="flow-connector flow-connector-block flow-connector-step-2" aria-hidden="true">↓</div>
-
-              <div class="flow-loop">
-                <div class="flow-loop-header">
+                <div class="flow-annotation">
+                  <span class="workflow-kicker">2</span>
+                  <div>
+                    <h3>write a spec</h3>
+                    <p>
+                      Optionally: formally specify invariants that should hold
+                      when the feature is complete.
+                    </p>
+                    <a href="https://pantagruel-language.com/"
+                      >Read about the Pantagruel specification language</a
+                    >
+                  </div>
+                </div>
+                <div class="flow-annotation">
                   <span class="workflow-kicker">3</span>
                   <div>
-                    <h3>for <code>m</code> in <code>w.milestones</code>:</h3>
-                    <p>
-                      Turn one milestone into a gameplan, then execute that
-                      milestone with onton.
-                    </p>
+                    <h3>write and execute gameplans</h3>
+                    <ol>
+                      <li>Turn a milestone into a concrete gameplan.</li>
+                      <li>Execute the gameplan with the
+                        <code>onton</code> supervisor.</li>
+                    </ol>
+                    <p>Repeat for the next milestone in the workstream.</p>
+                    <a href="gameplan.html">Gameplan guide</a> &middot;
+                    <a href="execution.html">Execution guide</a>
                   </div>
                 </div>
-                <div class="flow-loop-steps">
-                  <div class="workflow-step">
-                    <h3><code>/write-gameplan m</code></h3>
-                    <p>
-                      Convert milestone <code>m</code> into typed patches,
-                      classifications, tests, specs, and a dependency DAG.
-                    </p>
-                    <a href="gameplan.html">Read the gameplan guide</a>
-                  </div>
-                  <div
-                    class="flow-connector flow-connector-inline"
-                    aria-hidden="true"
-                  >
-                    →
-                  </div>
-                  <div class="workflow-step">
-                    <h3><code>onton --gameplan m</code></h3>
-                    <p>
-                      Parse <code>gameplan(m)</code>, derive runnable patch
-                      work, and supervise execution in isolated worktrees.
-                    </p>
-                    <a href="execution.html">Read the execution guide</a>
-                  </div>
-                </div>
+
               </div>
             </div>
           </section>
+
+          <aside class="index-section" aria-label="Flow sidenote">
+            <section class="sidenote-card">
+              <p class="section-label">sidenote</p>
+              <h2>Theory is the artifact</h2>
+              <p class="sidenote-intro">
+                Formal specifications do at least two important kinds of
+                work in this process:
+              </p>
+              <ol class="sidenote-list">
+                <li>
+                  They give the coding agent an unambiguous change to
+                  implement, with some ambiguity and contradiction removed
+                  from the natural language description.
+                </li>
+                <li>
+                  They force the engineer to order the domain conceptually,
+                  making the system’s entities, rules, and consequences
+                  concrete before the implementation phase starts.
+                </li>
+              </ol>
+            </section>
+          </aside>
 
           <section class="panel index-section main-column-section">
             <div class="section-stack">


### PR DESCRIPTION
## Summary
- Replace the text-div flowchart on the docs index page with a hand-crafted inline SVG diagram
- Geometric nodes with arrows and a loop-back path visually show the 3-step workflow
- Text annotations sit below the diagram in a 3-column grid
- Remove old `.flow-*` CSS and JS connector script; the SVG is fully static

## Test plan
- [ ] Open `docs/index.html` in browser — verify diagram renders with correct shapes, arrows, and loop-back
- [ ] Resize to narrow viewport — annotations stack to single column
- [ ] Verify other docs pages (workstream, gameplan, execution) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added click-to-copy behavior for code/example copy buttons in the docs.

* **Style**
  * Redesigned workflow diagram into an inline SVG flowchart with refreshed annotation cards and updated responsive behavior.
  * Simplified diagram visuals and typography for clearer presentation.

* **Refactor**
  * Reorganized documentation markup and CSS for the flow/annotation system for easier maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->