### PR TITLE
Auto-detect default branch, fix retry loop and stale snapshot

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -2550,12 +2550,14 @@ let with_snapshot_load ~project_name config gameplan =
       project name.
     - [PROJECT] only: load stored config + gameplan. CLI flags override stored
       values. *)
+let normalize_repo_root rr =
+  if Filename.is_relative rr then Filename.concat (Stdlib.Sys.getcwd ()) rr
+  else rr
+
 let resolve_config ~project ~gameplan_path ~github_token ~backend ~main_branch
-    ~poll_interval ~repo_root ~max_concurrency ~headless =
-  let repo_root =
-    if Filename.is_relative repo_root then
-      Filename.concat (Stdlib.Sys.getcwd ()) repo_root
-    else repo_root
+    ~poll_interval ~(repo_root : string option) ~max_concurrency ~headless =
+  let repo_root_for_fresh =
+    normalize_repo_root (Base.Option.value repo_root ~default:".")
   in
   let resolve_branch ~repo_root mb_opt =
     match mb_opt with
@@ -2564,6 +2566,7 @@ let resolve_config ~project ~gameplan_path ~github_token ~backend ~main_branch
   in
   match (project, gameplan_path) with
   | None, None ->
+      let repo_root = repo_root_for_fresh in
       let token, owner, repo =
         resolve_github_credentials ~github_token ~repo_root
       in
@@ -2619,6 +2622,7 @@ let resolve_config ~project ~gameplan_path ~github_token ~backend ~main_branch
             | Some p -> p
             | None -> gameplan.Gameplan.project_name
           in
+          let repo_root = repo_root_for_fresh in
           let token, owner, repo =
             resolve_github_credentials ~github_token ~repo_root
           in
@@ -2684,9 +2688,14 @@ let resolve_config ~project ~gameplan_path ~github_token ~backend ~main_branch
                     merge_cli_stored github_token
                       stored.Project_store.github_token
                   in
+                  let repo_root =
+                    match repo_root with
+                    | Some rr -> normalize_repo_root rr
+                    | None -> stored.Project_store.repo_root
+                  in
                   let token, inferred_owner, inferred_repo =
                     resolve_github_credentials ~github_token:token_from_stored
-                      ~repo_root:stored.Project_store.repo_root
+                      ~repo_root
                   in
                   let owner =
                     let s =
@@ -2710,8 +2719,7 @@ let resolve_config ~project ~gameplan_path ~github_token ~backend ~main_branch
                   Project_store.save_config ~project_name:proj
                     ~github_token:token ~github_owner:owner ~github_repo:repo
                     ~backend ~main_branch:(Branch.to_string branch)
-                    ~poll_interval:stored.Project_store.poll_interval
-                    ~repo_root:stored.Project_store.repo_root
+                    ~poll_interval:stored.Project_store.poll_interval ~repo_root
                     ~max_concurrency:stored.Project_store.max_concurrency;
                   let config =
                     {
@@ -2722,7 +2730,7 @@ let resolve_config ~project ~gameplan_path ~github_token ~backend ~main_branch
                       github_repo = repo;
                       main_branch = branch;
                       poll_interval = stored.Project_store.poll_interval;
-                      repo_root = stored.Project_store.repo_root;
+                      repo_root;
                       max_concurrency = stored.Project_store.max_concurrency;
                       headless;
                       user_config =
@@ -2932,8 +2940,8 @@ let run_with_config (config : config) gameplan existing_snapshot =
             with Quit_tui -> ())
 
 let run ~project ~gameplan_path ~github_token ~backend
-    ~(main_branch : Branch.t option) ~poll_interval ~repo_root ~max_concurrency
-    ~headless =
+    ~(main_branch : Branch.t option) ~poll_interval ~(repo_root : string option)
+    ~max_concurrency ~headless =
   match
     resolve_config ~project ~gameplan_path ~github_token ~backend ~main_branch
       ~poll_interval ~repo_root ~max_concurrency ~headless
@@ -2980,7 +2988,8 @@ let backend_arg =
 let repo_arg =
   let open Cmdliner in
   Arg.(
-    value & opt string "."
+    value
+    & opt (some string) None
     & info [ "repo" ] ~docv:"PATH"
         ~doc:"Path to the git repository (default: current directory).")
 

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -67,6 +67,43 @@ let infer_github_token () =
         if Base.String.is_empty t then "" else t
       with _ -> "")
 
+(** Detect the default branch of a git repository. Tries: 1.
+    [git symbolic-ref refs/remotes/origin/HEAD] (fast, local) 2.
+    [git rev-parse --verify refs/heads/main] → "main" 3.
+    [git rev-parse --verify refs/heads/master] → "master" 4. Fallback: "main" *)
+let infer_default_branch ~repo_root =
+  let run_git cmd =
+    let buf = Buffer.create 128 in
+    try
+      let ic =
+        Unix.open_process_in
+          (Printf.sprintf "git -C %s %s 2>/dev/null" (Filename.quote repo_root)
+             cmd)
+      in
+      (try
+         while true do
+           Buffer.add_char buf (input_char ic)
+         done
+       with End_of_file -> ());
+      match Unix.close_process_in ic with
+      | Unix.WEXITED 0 -> Some (Base.String.strip (Buffer.contents buf))
+      | Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> None
+    with _ -> None
+  in
+  match run_git "symbolic-ref refs/remotes/origin/HEAD" with
+  | Some ref_path ->
+      let prefix = "refs/remotes/origin/" in
+      if Base.String.is_prefix ref_path ~prefix then
+        Base.String.chop_prefix_exn ref_path ~prefix
+      else ref_path
+  | None -> (
+      match run_git "rev-parse --verify refs/heads/main" with
+      | Some _ -> "main"
+      | None -> (
+          match run_git "rev-parse --verify refs/heads/master" with
+          | Some _ -> "master"
+          | None -> "main"))
+
 let validate_resolved_config ~backend ~github_token ~github_owner ~github_repo
     ~main_branch ~poll_interval ~max_concurrency =
   let errors =
@@ -2515,6 +2552,16 @@ let with_snapshot_load ~project_name config gameplan =
       values. *)
 let resolve_config ~project ~gameplan_path ~github_token ~backend ~main_branch
     ~poll_interval ~repo_root ~max_concurrency ~headless =
+  let repo_root =
+    if Filename.is_relative repo_root then
+      Filename.concat (Stdlib.Sys.getcwd ()) repo_root
+    else repo_root
+  in
+  let resolve_branch ~repo_root mb_opt =
+    match mb_opt with
+    | Some b -> b
+    | None -> Branch.of_string (infer_default_branch ~repo_root)
+  in
   match (project, gameplan_path) with
   | None, None ->
       let token, owner, repo =
@@ -2541,6 +2588,7 @@ let resolve_config ~project ~gameplan_path ~github_token ~backend ~main_branch
       let backend =
         if Base.String.is_empty backend then "claude" else backend
       in
+      let main_branch = resolve_branch ~repo_root main_branch in
       Project_store.save_config ~project_name ~github_token:token
         ~github_owner:owner ~github_repo:repo ~backend
         ~main_branch:(Branch.to_string main_branch)
@@ -2577,6 +2625,7 @@ let resolve_config ~project ~gameplan_path ~github_token ~backend ~main_branch
           let backend =
             if Base.String.is_empty backend then "claude" else backend
           in
+          let main_branch = resolve_branch ~repo_root main_branch in
           Project_store.save_config ~project_name ~github_token:token
             ~github_owner:owner ~github_repo:repo ~backend
             ~main_branch:(Branch.to_string main_branch)
@@ -2652,9 +2701,9 @@ let resolve_config ~project ~gameplan_path ~github_token ~backend ~main_branch
                     if Base.String.is_empty s then inferred_repo else s
                   in
                   let branch =
-                    if Base.String.equal (Branch.to_string main_branch) "main"
-                    then Branch.of_string stored.Project_store.main_branch
-                    else main_branch
+                    match main_branch with
+                    | Some b -> b
+                    | None -> Branch.of_string stored.Project_store.main_branch
                   in
                   let config =
                     {
@@ -2874,8 +2923,9 @@ let run_with_config (config : config) gameplan existing_snapshot =
                 :: common_fibers)
             with Quit_tui -> ())
 
-let run ~project ~gameplan_path ~github_token ~backend ~main_branch
-    ~poll_interval ~repo_root ~max_concurrency ~headless =
+let run ~project ~gameplan_path ~github_token ~backend
+    ~(main_branch : Branch.t option) ~poll_interval ~repo_root ~max_concurrency
+    ~headless =
   match
     resolve_config ~project ~gameplan_path ~github_token ~backend ~main_branch
       ~poll_interval ~repo_root ~max_concurrency ~headless
@@ -2929,9 +2979,10 @@ let repo_arg =
 let main_branch_arg =
   let open Cmdliner in
   Arg.(
-    value & opt string "main"
+    value
+    & opt (some string) None
     & info [ "main-branch" ] ~docv:"BRANCH"
-        ~doc:"Main branch name (default: main).")
+        ~doc:"Main branch name. Auto-detected from the git remote when omitted.")
 
 let poll_interval_arg =
   let open Cmdliner in
@@ -2958,10 +3009,13 @@ let main_cmd =
   let open Cmdliner in
   let run_cmd project gameplan_path github_token backend main_branch
       poll_interval repo_root max_concurrency headless =
+    let main_branch =
+      Base.Option.map main_branch ~f:(fun s ->
+          Branch.of_string (Base.String.strip s))
+    in
     run ~project ~gameplan_path ~github_token
       ~backend:(Base.String.strip backend)
-      ~main_branch:(Branch.of_string (Base.String.strip main_branch))
-      ~poll_interval ~repo_root ~max_concurrency ~headless
+      ~main_branch ~poll_interval ~repo_root ~max_concurrency ~headless
   in
   let term =
     Term.(

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -2705,6 +2705,14 @@ let resolve_config ~project ~gameplan_path ~github_token ~backend ~main_branch
                     | Some b -> b
                     | None -> Branch.of_string stored.Project_store.main_branch
                   in
+                  (* Persist the resolved config so the next launch without
+                     CLI overrides picks up the current values. *)
+                  Project_store.save_config ~project_name:proj
+                    ~github_token:token ~github_owner:owner ~github_repo:repo
+                    ~backend ~main_branch:(Branch.to_string branch)
+                    ~poll_interval:stored.Project_store.poll_interval
+                    ~repo_root:stored.Project_store.repo_root
+                    ~max_concurrency:stored.Project_store.max_concurrency;
                   let config =
                     {
                       project = Some proj;

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -374,6 +374,7 @@ let restore ~graph ~agents ~outbox ~main_branch =
   { graph; agents; outbox; main_branch }
 
 let main_branch t = t.main_branch
+let set_main_branch t branch = { t with main_branch = branch }
 let agents_map t = t.agents
 
 let add_agent t ~patch_id ~branch ~pr_number =
@@ -493,6 +494,7 @@ let apply_session_result t patch_id result =
   | Session_ok -> clear_session_fallback t patch_id
   | Session_process_error { is_fresh } ->
       let t = on_session_failure t patch_id ~is_fresh in
+      let t = update_agent t patch_id ~f:Patch_agent.on_pre_session_failure in
       complete_failed t patch_id
   | Session_no_resume ->
       let t = on_session_failure t patch_id ~is_fresh:false in
@@ -504,4 +506,6 @@ let apply_session_result t patch_id result =
       let t = set_session_failed t patch_id in
       let t = set_tried_fresh t patch_id in
       complete_failed t patch_id
-  | Session_worktree_missing -> complete_failed t patch_id
+  | Session_worktree_missing ->
+      let t = update_agent t patch_id ~f:Patch_agent.on_pre_session_failure in
+      complete_failed t patch_id

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -107,6 +107,7 @@ val find_agent : t -> Patch_id.t -> Patch_agent.t option
 val all_agents : t -> Patch_agent.t list
 val graph : t -> Graph.t
 val main_branch : t -> Branch.t
+val set_main_branch : t -> Branch.t -> t
 val agents_map : t -> Patch_agent.t Map.M(Patch_id).t
 
 val add_agent :
@@ -128,11 +129,12 @@ type session_result =
 
 val apply_session_result : t -> Patch_id.t -> session_result -> t
 (** Apply a Claude session outcome to the orchestrator. Pure function.
-    [Session_ok] -> clear_session_fallback. [Session_process_error] /
-    [Session_failed] -> on_session_failure + complete. [Session_no_resume] ->
-    on_session_failure (not fresh) + complete. [Session_give_up] ->
-    set_session_failed + set_tried_fresh + complete. [Session_worktree_missing]
-    -> complete. *)
+    [Session_ok] -> clear_session_fallback. [Session_process_error] ->
+    on_session_failure + on_pre_session_failure + complete. [Session_failed] ->
+    on_session_failure + complete. [Session_no_resume] -> on_session_failure
+    (not fresh) + complete. [Session_give_up] -> set_session_failed +
+    set_tried_fresh + complete. [Session_worktree_missing] ->
+    on_pre_session_failure + complete. *)
 
 (** Side effects emitted by rebase result application. The runner is responsible
     for executing these (e.g. force-pushing the branch to the remote). Modeled

--- a/lib/patch_agent.ml
+++ b/lib/patch_agent.ml
@@ -165,6 +165,9 @@ let increment_start_attempts_without_pr t =
     durable attempt. The controller derives intervention from this fact. *)
 let on_pr_discovery_failure t = increment_start_attempts_without_pr t
 
+let on_pre_session_failure t =
+  if has_pr t then t else increment_start_attempts_without_pr t
+
 let set_checks_passing t v = { t with checks_passing = v }
 let set_worktree_path t path = { t with worktree_path = Some path }
 let set_head_branch t branch = { t with head_branch = Some branch }

--- a/lib/patch_agent.mli
+++ b/lib/patch_agent.mli
@@ -126,6 +126,12 @@ val on_pr_discovery_failure : t -> t
 (** Handle a successful Claude run where PR discovery failed. Resets fallback so
     the patch retries from scratch. *)
 
+val on_pre_session_failure : t -> t
+(** Handle a failure that occurs before a Claude session starts (worktree
+    creation, process spawn error). Increments [start_attempts_without_pr] for
+    no-PR agents so they hit [needs_intervention] after 2 failures instead of
+    retrying indefinitely. No-op for agents that already have a PR. *)
+
 val set_has_conflict : t -> t
 (** Mark the patch as having a merge conflict. *)
 

--- a/lib/runtime.ml
+++ b/lib/runtime.ml
@@ -12,7 +12,11 @@ type t = { mutex : Eio.Mutex.t; mutable snap : snapshot }
 let create ~gameplan ~(main_branch : Branch.t) ?snapshot () =
   let snap =
     match snapshot with
-    | Some s -> s
+    | Some s ->
+        let orchestrator =
+          Orchestrator.set_main_branch s.orchestrator main_branch
+        in
+        { s with orchestrator }
     | None ->
         let orchestrator =
           Orchestrator.create ~patches:gameplan.Gameplan.patches ~main_branch

--- a/lib/runtime.ml
+++ b/lib/runtime.ml
@@ -16,7 +16,7 @@ let create ~gameplan ~(main_branch : Branch.t) ?snapshot () =
         let orchestrator =
           Orchestrator.set_main_branch s.orchestrator main_branch
         in
-        { s with orchestrator }
+        { s with orchestrator; gameplan }
     | None ->
         let orchestrator =
           Orchestrator.create ~patches:gameplan.Gameplan.patches ~main_branch

--- a/test/test_interleaving_properties.ml
+++ b/test/test_interleaving_properties.ml
@@ -57,6 +57,10 @@ type session_result_kind =
   | Sess_failed_fresh
   | Sess_failed_resume
   | Sess_give_up
+  | Sess_worktree_missing
+  | Sess_process_error_fresh
+  | Sess_process_error_resume
+  | Sess_no_resume
 
 type rebase_result_kind =
   | Rebase_ok
@@ -92,6 +96,10 @@ let show_session_result_kind = function
   | Sess_failed_fresh -> "Failed_fresh"
   | Sess_failed_resume -> "Failed_resume"
   | Sess_give_up -> "Give_up"
+  | Sess_worktree_missing -> "Worktree_missing"
+  | Sess_process_error_fresh -> "Process_error_fresh"
+  | Sess_process_error_resume -> "Process_error_resume"
+  | Sess_no_resume -> "No_resume"
 
 let show_rebase_result_kind = function
   | Rebase_ok -> "Ok"
@@ -135,7 +143,16 @@ let gen_poll_kind =
 
 let gen_session_result_kind =
   QCheck2.Gen.oneof_list
-    [ Sess_ok; Sess_failed_fresh; Sess_failed_resume; Sess_give_up ]
+    [
+      Sess_ok;
+      Sess_failed_fresh;
+      Sess_failed_resume;
+      Sess_give_up;
+      Sess_worktree_missing;
+      Sess_process_error_fresh;
+      Sess_process_error_resume;
+      Sess_no_resume;
+    ]
 
 let gen_rebase_result_kind =
   QCheck2.Gen.oneof_list
@@ -238,6 +255,12 @@ let to_session_result = function
   | Sess_failed_fresh -> Orchestrator.Session_failed { is_fresh = true }
   | Sess_failed_resume -> Orchestrator.Session_failed { is_fresh = false }
   | Sess_give_up -> Orchestrator.Session_give_up
+  | Sess_worktree_missing -> Orchestrator.Session_worktree_missing
+  | Sess_process_error_fresh ->
+      Orchestrator.Session_process_error { is_fresh = true }
+  | Sess_process_error_resume ->
+      Orchestrator.Session_process_error { is_fresh = false }
+  | Sess_no_resume -> Orchestrator.Session_no_resume
 
 let to_worktree_result = function
   | Rebase_ok -> Worktree.Ok
@@ -729,3 +752,91 @@ let () =
   in
   QCheck2.Test.check_exn prop_pi2;
   Stdlib.print_endline "PI-2 passed"
+
+(** PI-3: Fresh-start interleavings — agents begin without PRs, exercising the
+    Start path and its failure modes. Safety invariants must hold throughout. *)
+let () =
+  let n = 3 in
+  let patches = mk_patches n in
+  let prop_pi3 =
+    QCheck2.Test.make
+      ~name:"PI-3: fresh-start interleavings preserve scheduling invariants"
+      ~count:1000 (gen_command_seq ~n ~len:50) (fun cmds ->
+        (safe_verbose cmds patches) (fun () ->
+            let orch = Orchestrator.create ~patches ~main_branch:main in
+            run_sequence orch patches cmds;
+            true))
+  in
+  QCheck2.Test.check_exn prop_pi3;
+  Stdlib.print_endline "PI-3 passed"
+
+(* ========== Liveness / convergence properties ========== *)
+
+(** Helper: create a single-patch orchestrator with no PR, start the agent, and
+    return (orch, patch_id). The agent is busy after this call. *)
+let mk_started_no_pr () =
+  let patches = mk_patches 1 in
+  let orch = Orchestrator.create ~patches ~main_branch:main in
+  let pid = pid_of_idx patches 0 in
+  let orch = Orchestrator.fire orch (Orchestrator.Start (pid, main)) in
+  (orch, pid)
+
+(** PI-4: Repeated worktree failure on a no-PR agent converges to
+    needs_intervention. After 2 worktree failures (each producing
+    complete_failed + on_worktree_failure), the agent must require intervention.
+*)
+let () =
+  let prop_pi4 =
+    QCheck2.Test.make
+      ~name:"PI-4: repeated worktree failure converges to needs_intervention"
+      (QCheck2.Gen.return ()) (fun () ->
+        let orch, pid = mk_started_no_pr () in
+        (* First worktree failure *)
+        let orch =
+          Orchestrator.apply_session_result orch pid
+            Orchestrator.Session_worktree_missing
+        in
+        let a = Orchestrator.agent orch pid in
+        if Patch_agent.needs_intervention a then
+          failwith "needs_intervention too early after 1 failure";
+        (* Re-start and fail again *)
+        let orch = Orchestrator.fire orch (Orchestrator.Start (pid, main)) in
+        let orch =
+          Orchestrator.apply_session_result orch pid
+            Orchestrator.Session_worktree_missing
+        in
+        let a = Orchestrator.agent orch pid in
+        Patch_agent.needs_intervention a)
+  in
+  QCheck2.Test.check_exn prop_pi4;
+  Stdlib.print_endline "PI-4 passed"
+
+(** PI-5: Repeated Session_process_error { is_fresh = true } on a no-PR agent
+    converges to needs_intervention. This tests the same liveness guarantee as
+    PI-4 but for the process-error path. *)
+let () =
+  let prop_pi5 =
+    QCheck2.Test.make
+      ~name:
+        "PI-5: repeated process error (fresh) on no-PR converges to \
+         needs_intervention" (QCheck2.Gen.return ()) (fun () ->
+        let orch, pid = mk_started_no_pr () in
+        let apply_and_restart orch =
+          let orch =
+            Orchestrator.apply_session_result orch pid
+              (Orchestrator.Session_process_error { is_fresh = true })
+          in
+          Orchestrator.fire orch (Orchestrator.Start (pid, main))
+        in
+        (* Apply 3 process errors — should be enough to converge *)
+        let orch = apply_and_restart orch in
+        let orch = apply_and_restart orch in
+        let orch =
+          Orchestrator.apply_session_result orch pid
+            (Orchestrator.Session_process_error { is_fresh = true })
+        in
+        let a = Orchestrator.agent orch pid in
+        Patch_agent.needs_intervention a)
+  in
+  QCheck2.Test.check_exn prop_pi5;
+  Stdlib.print_endline "PI-5 passed"

--- a/test/test_interleaving_properties.ml
+++ b/test/test_interleaving_properties.ml
@@ -821,16 +821,16 @@ let () =
         "PI-5: repeated process error (fresh) on no-PR converges to \
          needs_intervention" (QCheck2.Gen.return ()) (fun () ->
         let orch, pid = mk_started_no_pr () in
-        let apply_and_restart orch =
-          let orch =
-            Orchestrator.apply_session_result orch pid
-              (Orchestrator.Session_process_error { is_fresh = true })
-          in
-          Orchestrator.fire orch (Orchestrator.Start (pid, main))
+        (* First process error *)
+        let orch =
+          Orchestrator.apply_session_result orch pid
+            (Orchestrator.Session_process_error { is_fresh = true })
         in
-        (* Apply 3 process errors — should be enough to converge *)
-        let orch = apply_and_restart orch in
-        let orch = apply_and_restart orch in
+        let a = Orchestrator.agent orch pid in
+        if Patch_agent.needs_intervention a then
+          failwith "needs_intervention too early after 1 failure";
+        (* Re-start and fail again *)
+        let orch = Orchestrator.fire orch (Orchestrator.Start (pid, main)) in
         let orch =
           Orchestrator.apply_session_result orch pid
             (Orchestrator.Session_process_error { is_fresh = true })

--- a/test/test_runtime_create.ml
+++ b/test/test_runtime_create.ml
@@ -30,3 +30,42 @@ let () =
   in
   let _rt = Onton.Runtime.create ~gameplan ~main_branch ~snapshot () in
   Printf.printf "PASS: Runtime.create with snapshot outside Eio\n"
+
+(* Regression test: Runtime.create must override the snapshot's main_branch
+   with the config-provided value, so stale snapshots don't silently use the
+   wrong branch. *)
+let () =
+  let open Onton.Types in
+  let old_branch = Branch.of_string "old-branch" in
+  let new_branch = Branch.of_string "new-branch" in
+  let gameplan =
+    {
+      Gameplan.project_name = "test";
+      problem_statement = "";
+      solution_summary = "";
+      final_state_spec = "";
+      patches = [];
+      current_state_analysis = "";
+      explicit_opinions = "";
+      acceptance_criteria = [];
+      open_questions = [];
+    }
+  in
+  let snapshot =
+    {
+      Onton.Runtime.orchestrator =
+        Onton.Orchestrator.create ~patches:[] ~main_branch:old_branch;
+      activity_log = Onton.Activity_log.empty;
+      gameplan;
+      transcripts = Base.Hashtbl.create (module Onton.Types.Patch_id);
+    }
+  in
+  let rt =
+    Onton.Runtime.create ~gameplan ~main_branch:new_branch ~snapshot ()
+  in
+  let actual =
+    Onton.Runtime.read rt (fun s ->
+        Onton.Orchestrator.main_branch s.Onton.Runtime.orchestrator)
+  in
+  assert (Branch.equal actual new_branch);
+  Printf.printf "PASS: Runtime.create overrides snapshot main_branch\n"


### PR DESCRIPTION
## Summary

- **Auto-detect default branch**: `--main-branch` is now optional. When omitted, onton infers the default branch via `git symbolic-ref refs/remotes/origin/HEAD`, falling back to checking local `main`/`master` refs. Eliminates the most common misconfiguration when running against `master`-default repos.
- **Fix infinite worktree retry loop**: `Session_worktree_missing` and `Session_process_error` now increment `start_attempts_without_pr` for no-PR agents via `on_pre_session_failure`. After 2 failures, `needs_intervention` fires and stops the loop.
- **Override stale snapshot `main_branch`**: `Runtime.create` now calls `Orchestrator.set_main_branch` when restoring from a snapshot, so the config/CLI value is always authoritative. Fixes `Blocked_by_dep` display and `merge-base --is-ancestor` errors when snapshot had a stale `main_branch`.
- **Canonicalize `repo_root`**: Relative `repo_root` values are resolved to absolute paths at config save time, preventing breakage when onton is launched from a different CWD.

## Test plan

- [x] `dune build` compiles cleanly
- [x] `dune runtest` — all existing tests pass
- [x] PI-1/PI-2 now exercise all 8 session result variants (was 4)
- [x] PI-3: fresh-start interleavings exercise the no-PR Start path
- [x] PI-4: liveness — repeated worktree failure converges to `needs_intervention`
- [x] PI-5: liveness — repeated process error converges to `needs_intervention` (caught a latent bug)
- [x] Runtime.create main_branch override regression test
- [ ] Manual: run `onton --gameplan <file>` in a `master`-default repo without `--main-branch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `--main-branch` and `--repo` are now optional; the tool auto-detects the repo default (when omitted) and accepts/normalizes relative repo paths. Resolved branch is persisted.

* **Bug Fixes**
  * CLI main-branch overrides reliably take precedence when creating or resuming runs and are saved to config.
  * Improved pre-session failure handling so repeated init failures trigger intervention only for agents without PRs.

* **Tests**
  * Added/expanded tests covering main-branch override, pre-session failures, and interleavings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->