### PR TITLE
Enable Claude review for fork PRs with manual approval

### DIFF
--- a/.github/workflows/pr-claude-review.yml
+++ b/.github/workflows/pr-claude-review.yml
@@ -3,6 +3,8 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
+  pull_request_target:
+    types: [opened, synchronize, ready_for_review, reopened]
 
 jobs:
   review:
@@ -13,6 +15,7 @@ jobs:
       group: claude-review-pr-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     if: >-
+      github.event_name == 'pull_request' &&
       !github.event.pull_request.draft &&
       github.actor != 'dependabot[bot]' &&
       !github.event.pull_request.head.repo.fork
@@ -38,6 +41,120 @@ jobs:
       # Pre-fetch so they can be injected into the prompt. This avoids
       # Claude needing to call gh api itself (saves tokens + tool calls)
       # and ensures it never reads other bots' comments.
+      - name: Fetch prior Claude comments
+        id: prior
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const comments = await github.paginate(
+              github.rest.pulls.listReviewComments,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: ${{ github.event.pull_request.number }},
+                per_page: 100,
+              }
+            )
+            const mine = comments
+              .filter(c => c.user?.login === 'claude[bot]')
+              .map(c => `- **${c.path}** (line ${c.line ?? c.original_line ?? '?'}): ${c.body.slice(0, 300)}`)
+            if (mine.length === 0) {
+              core.setOutput('comments', 'No prior Claude comments on this PR.')
+            } else {
+              core.setOutput('comments', mine.join('\n'))
+            }
+
+      - name: Claude Code Review
+        uses: anthropics/claude-code-action@cd77b50d2b0808657f8e6774085c8bf54484351c # v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+            EVENT: ${{ github.event.action }}
+            BEFORE_SHA: ${{ github.event.before }}
+            AFTER_SHA: ${{ github.event.after }}
+            BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
+
+            You are a pragmatic senior engineer reviewing this PR. Your job is to catch
+            things a human reviewer would miss — not to be exhaustive.
+
+            **Diff strategy:** If EVENT is "synchronize", this is a follow-up push — focus
+            your review on the incremental changes by running `git diff BEFORE_SHA..AFTER_SHA`
+            (using the actual SHAs above). You may also look at surrounding context in the
+            full PR diff, but only comment on issues introduced by the new commits.
+            For "opened", "reopened", or "ready_for_review", review the full PR diff
+            (`git diff origin/BASE_BRANCH...HEAD`).
+
+            **Comment budget: aim for 3–7 comments total.** If you find fewer issues, that's
+            fine — "LGTM" with zero comments is a valid outcome. Only exceed the budget if
+            you find genuine bugs or security issues.
+
+            **Only comment when you are confident the issue is real.** If you're unsure
+            whether something is intentional, skip it. Assume the author made deliberate
+            choices unless there is clear evidence of a mistake.
+
+            What to flag (in priority order):
+            1. Bugs, logic errors, or broken behavior
+            2. Security vulnerabilities
+            3. Performance problems that would matter at scale
+            4. Missing error handling that could cause silent failures
+            5. Incorrect OCaml patterns (missing exhaustive matches, unsafe casts, exception-heavy control flow)
+            6. Spec violations (check .pant spec if referenced in commit messages or PR description)
+
+            What to skip:
+            - Style, formatting, naming (ocamlformat handles this)
+            - Missing docs, comments, or tests
+            - Nitpicks, suggestions, or "nice to have" improvements
+            - Issues in non-executable files (docs, configs, planning documents) unless they
+              would cause a downstream tool to break
+            - Anything you're less than ~80% sure is actually wrong
+
+            **Incremental review:** Your prior comments on this PR are listed below. Do NOT
+            re-raise issues you have already commented on. If a previous comment was addressed
+            by a subsequent commit, don't comment on it again. Focus on new or unaddressed
+            issues only.
+
+            YOUR PRIOR COMMENTS:
+            ${{ steps.prior.outputs.comments }}
+
+            When you do comment:
+            - Be concrete — suggest the fix, not just the problem
+            - One comment per distinct issue (don't repeat yourself across files)
+            - Use inline comments pinned to the relevant line
+
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*),Bash(git diff:*),Bash(git log:*)"
+
+  # ── Fork PRs: requires manual approval via the claude-review-fork environment ──
+  review-fork:
+    name: Claude Review (fork)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: claude-review-fork
+    concurrency:
+      group: claude-review-pr-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    if: >-
+      github.event_name == 'pull_request_target' &&
+      github.event.pull_request.head.repo.fork &&
+      !github.event.pull_request.draft &&
+      github.actor != 'dependabot[bot]'
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+
+    steps:
+      - name: Debounce (120s)
+        run: sleep 120
+
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
       - name: Fetch prior Claude comments
         id: prior
         uses: actions/github-script@v7


### PR DESCRIPTION
## Summary
- Fork PRs were skipped by the Claude Code Review workflow because `pull_request` events from forks can't access repo secrets
- Adds a `pull_request_target`-triggered job (`Claude Review (fork)`) gated behind the `claude-review-fork` environment, requiring a maintainer to approve before the review runs
- Non-fork PRs continue to run automatically via the existing `pull_request` job

## Setup
Requires a GitHub environment named `claude-review-fork` with required reviewers (already created).

## Test plan
- [ ] Verify non-fork PRs still trigger the regular `Claude Review` job automatically
- [ ] Re-trigger PR #138 (fork PR) and confirm `Claude Review (fork)` shows a pending approval button
- [ ] Approve and confirm the review runs to completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced automated code review workflow to support forked pull requests with separate handling and environment-based gating.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->