### PR TITLE
Replace gh CLI with direct HTTP, add LLM timeout, harden process management

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -157,8 +157,10 @@ let execute_github_effects ~runtime ~net ~github effects =
                 Patch_controller.apply_github_effect_success orch github_effect)
         | Error err ->
             Printf.eprintf "%s failed: %s\n%!" label (Github.show_error err)
-      with exn ->
-        Printf.eprintf "%s crashed: %s\n%!" label (Printexc.to_string exn))
+      with
+      | Eio.Cancel.Cancelled _ as exn -> raise exn
+      | exn ->
+          Printf.eprintf "%s crashed: %s\n%!" label (Printexc.to_string exn))
 
 (** {1 Activity log helpers} *)
 

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -18,14 +18,13 @@ type config = {
 }
 
 (** Infer GitHub owner/repo from [git remote get-url origin] in [repo_root].
-    Parses both HTTPS and SSH remote URLs. *)
+    Parses both HTTPS and SSH remote URLs. Uses argv (no shell). *)
 let infer_owner_repo ~repo_root =
   let buf = Buffer.create 128 in
   try
     let ic =
-      Unix.open_process_in
-        (Printf.sprintf "git -C %s remote get-url origin 2>/dev/null"
-           (Filename.quote repo_root))
+      Unix.open_process_args_in "git"
+        [| "git"; "-C"; repo_root; "remote"; "get-url"; "origin" |]
     in
     (try
        while true do
@@ -46,7 +45,7 @@ let infer_owner_repo ~repo_root =
   with _ -> None
 
 (** Resolve GitHub token: check GITHUB_TOKEN env var, then try [gh auth token].
-*)
+    Uses argv (no shell). *)
 let infer_github_token () =
   match Stdlib.Sys.getenv_opt "GITHUB_TOKEN" with
   | Some t when not (Base.String.is_empty (Base.String.strip t)) ->
@@ -54,7 +53,7 @@ let infer_github_token () =
   | _ -> (
       let buf = Buffer.create 128 in
       try
-        let ic = Unix.open_process_in "gh auth token 2>/dev/null" in
+        let ic = Unix.open_process_args_in "gh" [| "gh"; "auth"; "token" |] in
         (try
            while true do
              Buffer.add_char buf (input_char ic)
@@ -119,111 +118,44 @@ module Pr_registry = struct
         Hashtbl.remove t.table patch_id)
 end
 
-(** Discover PR number for a branch by calling [gh pr list]. Returns [Ok] with
-    the PR number or [Error] with a diagnostic message. *)
-let discover_pr_number ~process_mgr ~token ~owner ~repo ~branch ~base_branch =
-  let args =
-    [
-      "gh";
-      "pr";
-      "list";
-      "--repo";
-      Printf.sprintf "%s/%s" owner repo;
-      "--head";
-      Branch.to_string branch;
-      "--base";
-      Branch.to_string base_branch;
-      "--json";
-      "number";
-      "--limit";
-      "1";
-    ]
-  in
-  let base_env = Unix.environment () in
-  let env = Array.append [| Printf.sprintf "GH_TOKEN=%s" token |] base_env in
-  try
-    let buf = Buffer.create 256 in
-    Eio.Process.run ~stdout:(Eio.Flow.buffer_sink buf) ~env process_mgr args;
-    let output = Buffer.contents buf in
-    match Yojson.Basic.from_string output with
-    | `List (`Assoc fields :: _) -> (
-        match Base.List.Assoc.find fields ~equal:String.equal "number" with
-        | Some (`Int n) -> Ok (Pr_number.of_int n)
-        | _ -> Error (Printf.sprintf "unexpected JSON shape: %s" output))
-    | `List [] -> Error "no PRs found for branch"
-    | _ -> Error (Printf.sprintf "unexpected JSON: %s" output)
+(** Discover PR number for a branch via GitHub REST API. Returns [Ok] with the
+    PR number or [Error] with a diagnostic message. *)
+let discover_pr_number ~net ~github ~branch ~base_branch =
+  match
+    Github.list_prs ~net github ~branch ~base:(Some base_branch) ~state:`Open ()
   with
-  | Eio.Exn.Io _ as e ->
-      Error (Printf.sprintf "gh command failed: %s" (Printexc.to_string e))
-  | Yojson.Json_error msg -> Error (Printf.sprintf "JSON parse error: %s" msg)
-  | exn ->
-      Error (Printf.sprintf "unexpected error: %s" (Printexc.to_string exn))
-
-(** Set or unset draft status on a PR. [draft:true] converts to draft,
-    [draft:false] marks ready for review. Errors are logged but not fatal. *)
-let set_pr_draft ~process_mgr ~token ~owner ~repo ~pr_number ~draft =
-  let pr_str = Int.to_string (Pr_number.to_int pr_number) in
-  let args =
-    [ "gh"; "pr"; "ready"; pr_str; "--repo"; Printf.sprintf "%s/%s" owner repo ]
-    @ if draft then [ "--undo" ] else []
-  in
-  let env =
-    Array.append [| Printf.sprintf "GH_TOKEN=%s" token |] (Unix.environment ())
-  in
-  try
-    Eio.Process.run ~env process_mgr args;
-    true
-  with
-  | Eio.Cancel.Cancelled _ as exn -> raise exn
-  | exn ->
-      Printf.eprintf "set_pr_draft failed (PR #%s, draft=%b): %s\n%!" pr_str
-        draft (Printexc.to_string exn);
-      false
-
-(** Set the PR body to a rendered description. Errors are logged but not fatal —
-    the PR already exists; a missing description is cosmetic. *)
-let set_pr_description ~process_mgr ~token ~owner ~repo ~pr_number ~body =
-  let pr_str = Int.to_string (Pr_number.to_int pr_number) in
-  let args =
-    [
-      "gh";
-      "pr";
-      "edit";
-      pr_str;
-      "--repo";
-      Printf.sprintf "%s/%s" owner repo;
-      "--body";
-      body;
-    ]
-  in
-  let env =
-    Array.append [| Printf.sprintf "GH_TOKEN=%s" token |] (Unix.environment ())
-  in
-  try
-    Eio.Process.run ~env process_mgr args;
-    true
-  with
-  | Eio.Cancel.Cancelled _ as exn -> raise exn
-  | exn ->
-      Printf.eprintf "set_pr_description failed (PR #%s): %s\n%!" pr_str
-        (Printexc.to_string exn);
-      false
+  | Ok ((pr_number, _, _) :: _) -> Ok pr_number
+  | Ok [] -> Error "no PRs found for branch"
+  | Error e -> Error (Github.show_error e)
 
 (** Execute declarative GitHub effects and record successful observations back
     into durable state. *)
-let execute_github_effects ~runtime ~process_mgr ~token ~owner ~repo effects =
+let execute_github_effects ~runtime ~net ~github effects =
   Base.List.iter effects ~f:(fun github_effect ->
-      let success =
+      let result =
         match github_effect with
         | Patch_controller.Set_pr_description { patch_id = _; pr_number; body }
           ->
-            set_pr_description ~process_mgr ~token ~owner ~repo ~pr_number ~body
+            Github.update_pr_body ~net github ~pr_number ~body
         | Patch_controller.Set_pr_draft { patch_id = _; pr_number; draft } ->
-            set_pr_draft ~process_mgr ~token ~owner ~repo ~pr_number ~draft
+            Github.set_draft ~net github ~pr_number ~draft
       in
-      if success then
-        Runtime.update_orchestrator runtime (fun orch ->
-            Patch_controller.apply_github_effect_success orch github_effect))
+      match result with
+      | Ok () ->
+          Runtime.update_orchestrator runtime (fun orch ->
+              Patch_controller.apply_github_effect_success orch github_effect)
+      | Error err ->
+          let label =
+            match github_effect with
+            | Patch_controller.Set_pr_description { pr_number; _ } ->
+                Printf.sprintf "set_pr_description (PR #%d)"
+                  (Pr_number.to_int pr_number)
+            | Patch_controller.Set_pr_draft { pr_number; draft; _ } ->
+                Printf.sprintf "set_pr_draft (PR #%d, draft=%b)"
+                  (Pr_number.to_int pr_number)
+                  draft
+          in
+          Printf.eprintf "%s failed: %s\n%!" label (Github.show_error err))
 
 (** {1 Activity log helpers} *)
 
@@ -656,6 +588,7 @@ let run_claude_and_handle ~runtime ~process_mgr ~fs ~project_name ~patch_id
                   got_events = r.Llm_backend.got_events;
                   stderr = r.Llm_backend.stderr;
                   stream_errors = String.trim (Buffer.contents error_buf);
+                  timed_out = r.Llm_backend.timed_out;
                 })
               result
           in
@@ -671,6 +604,11 @@ let run_claude_and_handle ~runtime ~process_mgr ~fs ~project_name ~patch_id
                   "--continue produced no events (no session to resume), will \
                    retry fresh";
                 (Orchestrator.Session_no_resume, `Failed)
+            | Timed_out ->
+                log_event runtime ~patch_id
+                  (Printf.sprintf "%s session timed out, marking failed"
+                     backend.Llm_backend.name);
+                (Orchestrator.Session_failed { is_fresh }, `Failed)
             | Success { stream_errors } ->
                 if String.length stream_errors > 0 then
                   log_event runtime ~patch_id
@@ -1542,9 +1480,7 @@ let poller_fiber ~runtime ~clock ~net ~process_mgr ~github ~config ~project_name
                               | None -> branch_of patch_id)
                     in
                     (match
-                       Startup_reconciler.discover_pr ~process_mgr
-                         ~token:config.github_token ~owner:config.github_owner
-                         ~repo:config.github_repo ~branch
+                       Startup_reconciler.discover_pr ~net ~github ~branch
                      with
                     | Ok (Some (new_pr, base_branch, merged)) ->
                         log_event runtime ~patch_id
@@ -1752,17 +1688,23 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry
     ~ci_checks_cache ~transcripts ~github ~net ~event_log ?status_msg () =
   let main = config.main_branch in
   let process_mgr = Eio.Stdenv.process_mgr env in
+  let clock = Eio.Stdenv.clock env in
   let fs = Eio.Stdenv.fs env in
+  let session_timeout =
+    1800.0
+    (* 30 minutes *)
+  in
   let backend =
     match config.backend with
-    | "claude" -> Claude_backend.create ~process_mgr
-    | "codex" -> Codex_backend.create ~process_mgr
+    | "claude" ->
+        Claude_backend.create ~process_mgr ~clock ~timeout:session_timeout
+    | "codex" ->
+        Codex_backend.create ~process_mgr ~clock ~timeout:session_timeout
     | other ->
         invalid_arg
           (Printf.sprintf
              "Unsupported --backend=%S (expected \"claude\" or \"codex\")" other)
   in
-  let clock = Eio.Stdenv.clock env in
   let set_status ~level ~text ?expires_at () =
     match status_msg with
     | Some r -> r := Some { Tui.level; text; expires_at }
@@ -1854,8 +1796,7 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry
           in
           (orch, (effects, List.rev dispatched, pre_fire_agents)))
     in
-    execute_github_effects ~runtime ~process_mgr ~token:config.github_token
-      ~owner:config.github_owner ~repo:config.github_repo lifecycle_effects;
+    execute_github_effects ~runtime ~net ~github lifecycle_effects;
     (* Log dispatched actions to event log *)
     Base.List.iter messages ~f:(fun (msg : Orchestrator.patch_agent_message) ->
         let action = Orchestrator.message_action msg in
@@ -1966,13 +1907,10 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry
                                        (Patch_id.to_string patch_id))
                                   ()
                           | `Ok ->
-                              (* Always confirm via gh pr list *)
+                              (* Always confirm via REST API *)
                               let rec discover remaining =
                                 match
-                                  discover_pr_number ~process_mgr
-                                    ~token:config.github_token
-                                    ~owner:config.github_owner
-                                    ~repo:config.github_repo
+                                  discover_pr_number ~net ~github
                                     ~branch:patch.Patch.branch ~base_branch
                                 with
                                 | Ok pr_number ->
@@ -2743,10 +2681,10 @@ let run_with_config (config : config) gameplan existing_snapshot =
       in
       let reconciliation_fiber () =
         let startup =
-          Startup_reconciler.reconcile ~process_mgr ~token:config.github_token
-            ~owner:config.github_owner ~repo:config.github_repo
+          Startup_reconciler.reconcile ~net ~github
             ~patches:gameplan.Gameplan.patches ~repo_root:config.repo_root
-            ~agents:pre_agents ~pre_recovered_worktrees:pre_worktrees ()
+            ~process_mgr ~agents:pre_agents
+            ~pre_recovered_worktrees:pre_worktrees ()
         in
         let errored_ids =
           Base.List.map startup.Startup_reconciler.errors

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -132,30 +132,33 @@ let discover_pr_number ~net ~github ~branch ~base_branch =
     into durable state. *)
 let execute_github_effects ~runtime ~net ~github effects =
   Base.List.iter effects ~f:(fun github_effect ->
-      let result =
+      let label =
         match github_effect with
-        | Patch_controller.Set_pr_description { patch_id = _; pr_number; body }
-          ->
-            Github.update_pr_body ~net github ~pr_number ~body
-        | Patch_controller.Set_pr_draft { patch_id = _; pr_number; draft } ->
-            Github.set_draft ~net github ~pr_number ~draft
+        | Patch_controller.Set_pr_description { pr_number; _ } ->
+            Printf.sprintf "set_pr_description (PR #%d)"
+              (Pr_number.to_int pr_number)
+        | Patch_controller.Set_pr_draft { pr_number; draft; _ } ->
+            Printf.sprintf "set_pr_draft (PR #%d, draft=%b)"
+              (Pr_number.to_int pr_number)
+              draft
       in
-      match result with
-      | Ok () ->
-          Runtime.update_orchestrator runtime (fun orch ->
-              Patch_controller.apply_github_effect_success orch github_effect)
-      | Error err ->
-          let label =
-            match github_effect with
-            | Patch_controller.Set_pr_description { pr_number; _ } ->
-                Printf.sprintf "set_pr_description (PR #%d)"
-                  (Pr_number.to_int pr_number)
-            | Patch_controller.Set_pr_draft { pr_number; draft; _ } ->
-                Printf.sprintf "set_pr_draft (PR #%d, draft=%b)"
-                  (Pr_number.to_int pr_number)
-                  draft
-          in
-          Printf.eprintf "%s failed: %s\n%!" label (Github.show_error err))
+      try
+        let result =
+          match github_effect with
+          | Patch_controller.Set_pr_description
+              { patch_id = _; pr_number; body } ->
+              Github.update_pr_body ~net github ~pr_number ~body
+          | Patch_controller.Set_pr_draft { patch_id = _; pr_number; draft } ->
+              Github.set_draft ~net github ~pr_number ~draft
+        in
+        match result with
+        | Ok () ->
+            Runtime.update_orchestrator runtime (fun orch ->
+                Patch_controller.apply_github_effect_success orch github_effect)
+        | Error err ->
+            Printf.eprintf "%s failed: %s\n%!" label (Github.show_error err)
+      with exn ->
+        Printf.eprintf "%s crashed: %s\n%!" label (Printexc.to_string exn))
 
 (** {1 Activity log helpers} *)
 

--- a/lib/claude_backend.ml
+++ b/lib/claude_backend.ml
@@ -1,8 +1,8 @@
-let create ~process_mgr : Llm_backend.t =
+let create ~process_mgr ~clock ~timeout : Llm_backend.t =
   {
     name = "Claude";
     run_streaming =
       (fun ~cwd ~patch_id ~prompt ~continue ~on_event ->
-        Claude_runner.run_streaming ~process_mgr ~cwd ~patch_id ~prompt
-          ~continue ~on_event);
+        Claude_runner.run_streaming ~process_mgr ~clock ~timeout ~cwd ~patch_id
+          ~prompt ~continue ~on_event);
   }

--- a/lib/claude_backend.mli
+++ b/lib/claude_backend.mli
@@ -1,2 +1,7 @@
-val create : process_mgr:_ Eio.Process.mgr -> Llm_backend.t
-(** Create an LLM backend that uses the Claude CLI. *)
+val create :
+  process_mgr:_ Eio.Process.mgr ->
+  clock:_ Eio.Time.clock ->
+  timeout:float ->
+  Llm_backend.t
+(** Create an LLM backend that uses the Claude CLI. [timeout] is the maximum
+    session duration in seconds before the process is killed. *)

--- a/lib/claude_runner.ml
+++ b/lib/claude_runner.ml
@@ -23,14 +23,21 @@ let ansi_re =
 (** Strip ANSI escape sequences injected by the PTY wrapper. *)
 let strip_ansi s = Re.replace_string ansi_re ~by:"" s
 
+(** Detect Linux (vs macOS) by the presence of [/proc/version]. *)
+let is_linux = Stdlib.Sys.file_exists "/proc/version"
+
 (** Wrap a command in a pseudo-TTY via [script].
 
     Claude CLI requires a TTY to produce stream-json output when not in
-    [--print] mode. We use [script -q /dev/null] on macOS to allocate a PTY
-    without writing a transcript file. *)
+    [--print] mode. On macOS we use [script -q /dev/null <cmd> <args...>]. On
+    Linux the syntax is [script -qc "<cmd>" /dev/null]. *)
 let pty_wrap args =
-  (* macOS: script -q /dev/null <cmd> <args...> *)
-  "/usr/bin/script" :: "-q" :: "/dev/null" :: args
+  if is_linux then
+    let cmd =
+      List.map args ~f:Stdlib.Filename.quote |> String.concat ~sep:" "
+    in
+    [ "/usr/bin/script"; "-qc"; cmd; "/dev/null" ]
+  else "/usr/bin/script" :: "-q" :: "/dev/null" :: args
 
 let build_args ~prompt ~continue =
   let base = [ "claude"; "-p"; prompt; "--output-format"; "text" ] in
@@ -190,16 +197,19 @@ let run ~process_mgr ~cwd ~patch_id ~prompt ~continue =
     stdout = strip_ansi stdout_content;
     stderr = stderr_content;
     got_events = true;
+    timed_out = false;
   }
 
-let run_streaming ~process_mgr ~cwd ~patch_id ~prompt ~continue ~on_event =
+let run_streaming ~process_mgr ~clock ~timeout ~cwd ~patch_id ~prompt ~continue
+    ~on_event =
   ignore (patch_id : Types.Patch_id.t);
   let args = pty_wrap (build_stream_args ~prompt ~continue) in
   let process_line line =
     let trimmed = strip_ansi (String.strip line) in
     if String.is_empty trimmed then [] else parse_stream_events trimmed
   in
-  Llm_backend.spawn_and_stream ~process_mgr ~cwd ~args ~process_line ~on_event
+  Llm_backend.spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~args
+    ~process_line ~on_event
 
 let%test "build_args without continue" =
   let args = build_args ~prompt:"do stuff" ~continue:false in
@@ -269,8 +279,12 @@ let%test "strip_ansi passes clean text through" =
 
 let%test "pty_wrap prepends script command" =
   let args = pty_wrap [ "claude"; "-p"; "hello" ] in
-  List.equal String.equal args
-    [ "/usr/bin/script"; "-q"; "/dev/null"; "claude"; "-p"; "hello" ]
+  if is_linux then
+    List.equal String.equal args
+      [ "/usr/bin/script"; "-qc"; "'claude' '-p' 'hello'"; "/dev/null" ]
+  else
+    List.equal String.equal args
+      [ "/usr/bin/script"; "-q"; "/dev/null"; "claude"; "-p"; "hello" ]
 
 let%test "parse_stream_event text_delta" =
   let line =

--- a/lib/claude_runner.mli
+++ b/lib/claude_runner.mli
@@ -30,6 +30,8 @@ val run :
 
 val run_streaming :
   process_mgr:_ Eio.Process.mgr ->
+  clock:_ Eio.Time.clock ->
+  timeout:float ->
   cwd:Eio.Fs.dir_ty Eio.Path.t ->
   patch_id:Types.Patch_id.t ->
   prompt:string ->

--- a/lib/codex_backend.ml
+++ b/lib/codex_backend.ml
@@ -65,7 +65,8 @@ let parse_event (line : string) : Types.Stream_event.t list =
   | exception Yojson.Json_error _ -> []
   | exception Yojson.Safe.Util.Type_error _ -> []
 
-let run_streaming ~process_mgr ~cwd ~patch_id ~prompt ~continue ~on_event =
+let run_streaming ~process_mgr ~clock ~timeout ~cwd ~patch_id ~prompt ~continue
+    ~on_event =
   ignore (patch_id : Types.Patch_id.t);
   let cwd_path = snd cwd in
   let args = build_args ~cwd_path ~prompt ~continue in
@@ -73,14 +74,16 @@ let run_streaming ~process_mgr ~cwd ~patch_id ~prompt ~continue ~on_event =
     let trimmed = String.strip line in
     if String.is_empty trimmed then [] else parse_event trimmed
   in
-  Llm_backend.spawn_and_stream ~process_mgr ~cwd ~args ~process_line ~on_event
+  Llm_backend.spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~args
+    ~process_line ~on_event
 
-let create ~process_mgr : Llm_backend.t =
+let create ~process_mgr ~clock ~timeout : Llm_backend.t =
   {
     name = "Codex";
     run_streaming =
       (fun ~cwd ~patch_id ~prompt ~continue ~on_event ->
-        run_streaming ~process_mgr ~cwd ~patch_id ~prompt ~continue ~on_event);
+        run_streaming ~process_mgr ~clock ~timeout ~cwd ~patch_id ~prompt
+          ~continue ~on_event);
   }
 
 let%test "build_args without continue" =

--- a/lib/codex_backend.mli
+++ b/lib/codex_backend.mli
@@ -1,2 +1,7 @@
-val create : process_mgr:_ Eio.Process.mgr -> Llm_backend.t
-(** Create an LLM backend that uses the Codex CLI. *)
+val create :
+  process_mgr:_ Eio.Process.mgr ->
+  clock:_ Eio.Time.clock ->
+  timeout:float ->
+  Llm_backend.t
+(** Create an LLM backend that uses the Codex CLI. [timeout] is the maximum
+    session duration in seconds before the process is killed. *)

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -264,7 +264,9 @@ let https_fun tls_config uri flow =
 
 let max_response_size = 1_000_000
 
-let pr_state ~net t pr =
+(** Internal: execute an HTTP request against api.github.com. Returns the raw
+    response body on 2xx, [Http_error] otherwise. *)
+let request ~net t ~meth ~path ?(query = []) ?body () =
   try
     Mirage_crypto_rng_unix.use_default ();
     Result.bind
@@ -273,29 +275,216 @@ let pr_state ~net t pr =
         let client =
           Cohttp_eio.Client.make ~https:(Some (https_fun tls_config)) net
         in
-        let request_body = build_request_body t pr in
-        let uri = Uri.of_string "https://api.github.com/graphql" in
+        let uri =
+          Uri.of_string ("https://api.github.com" ^ path) |> fun u ->
+          Uri.add_query_params u query
+        in
         let headers =
           Http.Header.of_list
             [
               ("Authorization", "Bearer " ^ t.token);
               ("Content-Type", "application/json");
+              ("Accept", "application/vnd.github+json");
               ("User-Agent", "onton/0.1.0");
+              ("X-GitHub-Api-Version", "2022-11-28");
             ]
         in
-        let body = Cohttp_eio.Body.of_string request_body in
         Eio.Switch.run @@ fun sw ->
         let resp, resp_body =
-          Cohttp_eio.Client.post client ~sw ~headers ~body uri
+          match meth with
+          | `GET -> Cohttp_eio.Client.get client ~sw ~headers uri
+          | `POST ->
+              let body =
+                Cohttp_eio.Body.of_string (Option.value body ~default:"{}")
+              in
+              Cohttp_eio.Client.post client ~sw ~headers ~body uri
+          | `PATCH ->
+              let body =
+                Cohttp_eio.Body.of_string (Option.value body ~default:"{}")
+              in
+              Cohttp_eio.Client.patch client ~sw ~headers ~body uri
         in
         let status = Http.Response.status resp |> Http.Status.to_int in
         let resp_str =
           Eio.Buf_read.(
             of_flow ~max_size:max_response_size resp_body |> take_all)
         in
-        if status >= 200 && status < 300 then parse_response resp_str
+        if status >= 200 && status < 300 then Ok resp_str
         else Error (Http_error (status, resp_str)))
   with exn -> Error (Transport_error (Exn.to_string exn))
+
+let pr_state ~net t pr =
+  let body = build_request_body t pr in
+  match request ~net t ~meth:`POST ~path:"/graphql" ~body () with
+  | Ok resp_str -> parse_response resp_str
+  | Error _ as e -> e
+
+(** Parse the REST response from [GET /repos/:owner/:repo/pulls]. Returns a list
+    of [(pr_number, base_branch, merged)] for non-CLOSED PRs, newest first. Pure
+    function — no I/O. *)
+let parse_rest_pr_list body =
+  try
+    match Yojson.Safe.from_string body with
+    | `List entries ->
+        let prs =
+          List.filter_map entries ~f:(fun entry ->
+              let open Yojson.Safe.Util in
+              let number = entry |> member "number" |> to_int in
+              let state =
+                entry |> member "state" |> to_string |> String.lowercase
+              in
+              let merged_at = entry |> member "merged_at" in
+              let base_ref =
+                entry |> member "base" |> member "ref" |> to_string
+              in
+              match (state, merged_at) with
+              | "closed", `Null -> None (* truly closed, not merged *)
+              | _ ->
+                  let merged =
+                    match merged_at with `Null -> false | _ -> true
+                  in
+                  Some
+                    ( Types.Pr_number.of_int number,
+                      Types.Branch.of_string base_ref,
+                      merged ))
+        in
+        Ok prs
+    | _ -> Error (Json_parse_error "expected JSON array from REST PR list")
+  with
+  | Yojson.Json_error msg -> Error (Json_parse_error msg)
+  | Yojson.Safe.Util.Type_error (msg, _) -> Error (Json_parse_error msg)
+
+(** List PRs for a branch via REST API. Returns non-CLOSED PRs. *)
+let list_prs ~net t ~branch ?(base = None) ~state () =
+  let state_str = match state with `Open -> "open" | `All -> "all" in
+  let query =
+    [
+      ("head", [ t.owner ^ ":" ^ Types.Branch.to_string branch ]);
+      ("state", [ state_str ]);
+      ("per_page", [ "10" ]);
+    ]
+    @
+    match base with
+    | Some b -> [ ("base", [ Types.Branch.to_string b ]) ]
+    | None -> []
+  in
+  let path = Printf.sprintf "/repos/%s/%s/pulls" t.owner t.repo in
+  match request ~net t ~meth:`GET ~path ~query () with
+  | Ok body -> parse_rest_pr_list body
+  | Error _ as e -> e
+
+(** Update the body (description) of a PR via REST API. *)
+let update_pr_body ~net t ~pr_number ~body =
+  let path =
+    Printf.sprintf "/repos/%s/%s/pulls/%d" t.owner t.repo
+      (Types.Pr_number.to_int pr_number)
+  in
+  let req_body = `Assoc [ ("body", `String body) ] |> Yojson.Safe.to_string in
+  match request ~net t ~meth:`PATCH ~path ~body:req_body () with
+  | Ok _ -> Ok ()
+  | Error _ as e -> e
+
+(** Fetch the GraphQL node ID for a PR via REST API. *)
+let pr_node_id ~net t ~pr_number =
+  let path =
+    Printf.sprintf "/repos/%s/%s/pulls/%d" t.owner t.repo
+      (Types.Pr_number.to_int pr_number)
+  in
+  match request ~net t ~meth:`GET ~path () with
+  | Error _ as e -> e
+  | Ok body -> (
+      try
+        let json = Yojson.Safe.from_string body in
+        let node_id =
+          Yojson.Safe.Util.(json |> member "node_id" |> to_string)
+        in
+        Ok node_id
+      with
+      | Yojson.Json_error msg -> Error (Json_parse_error msg)
+      | Yojson.Safe.Util.Type_error (msg, _) -> Error (Json_parse_error msg))
+
+(** Set or unset draft status on a PR via GraphQL mutation. REST API does not
+    support changing the draft field. *)
+let set_draft ~net t ~pr_number ~draft =
+  Result.bind (pr_node_id ~net t ~pr_number) ~f:(fun node_id ->
+      let mutation =
+        if draft then "convertPullRequestToDraft"
+        else "markPullRequestReadyForReview"
+      in
+      let query =
+        Printf.sprintf
+          {|mutation($id: ID!) { %s(input: {pullRequestId: $id}) { pullRequest { isDraft } } }|}
+          mutation
+      in
+      let req_body =
+        `Assoc
+          [
+            ("query", `String query);
+            ("variables", `Assoc [ ("id", `String node_id) ]);
+          ]
+        |> Yojson.Safe.to_string
+      in
+      match request ~net t ~meth:`POST ~path:"/graphql" ~body:req_body () with
+      | Ok resp -> (
+          try
+            let json = Yojson.Safe.from_string resp in
+            let open Yojson.Safe.Util in
+            match json |> member "errors" with
+            | `Null | `List [] -> Ok ()
+            | errors ->
+                let msgs =
+                  errors |> to_list
+                  |> List.map ~f:(fun e -> e |> member "message" |> to_string)
+                in
+                Error (Graphql_error msgs)
+          with
+          | Yojson.Json_error msg -> Error (Json_parse_error msg)
+          | Yojson.Safe.Util.Type_error (msg, _) -> Error (Json_parse_error msg)
+          )
+      | Error _ as e -> e)
+
+let owner t = t.owner
+
+(* ── Inline tests ── *)
+
+let%test "parse_rest_pr_list open PR" =
+  let body =
+    {|[{"number":42,"state":"open","merged_at":null,"base":{"ref":"main"},"node_id":"PR_1"}]|}
+  in
+  match parse_rest_pr_list body with
+  | Ok [ (n, b, merged) ] ->
+      Types.Pr_number.to_int n = 42
+      && String.equal (Types.Branch.to_string b) "main"
+      && not merged
+  | Ok _ | Error _ -> false
+
+let%test "parse_rest_pr_list merged PR" =
+  let body =
+    {|[{"number":10,"state":"closed","merged_at":"2024-01-01T00:00:00Z","base":{"ref":"develop"},"node_id":"PR_2"}]|}
+  in
+  match parse_rest_pr_list body with
+  | Ok [ (n, b, merged) ] ->
+      Types.Pr_number.to_int n = 10
+      && String.equal (Types.Branch.to_string b) "develop"
+      && merged
+  | Ok _ | Error _ -> false
+
+let%test "parse_rest_pr_list filters truly closed" =
+  let body =
+    {|[{"number":1,"state":"closed","merged_at":null,"base":{"ref":"main"},"node_id":"PR_3"}]|}
+  in
+  match parse_rest_pr_list body with Ok [] -> true | Ok _ | Error _ -> false
+
+let%test "parse_rest_pr_list mixed" =
+  let body =
+    {|[{"number":5,"state":"open","merged_at":null,"base":{"ref":"main"},"node_id":"PR_4"},{"number":3,"state":"closed","merged_at":null,"base":{"ref":"main"},"node_id":"PR_5"},{"number":2,"state":"closed","merged_at":"2024-01-01T00:00:00Z","base":{"ref":"main"},"node_id":"PR_6"}]|}
+  in
+  match parse_rest_pr_list body with
+  | Ok prs -> List.length prs = 2 (* open + merged, not the truly closed *)
+  | Error _ -> false
+
+let%test "parse_rest_pr_list invalid json" =
+  match parse_rest_pr_list "not json" with Error _ -> true | Ok _ -> false
 
 (* Static assertion: Github satisfies Forge.S *)
 let (_ : (module Forge.S)) =

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -361,7 +361,7 @@ let list_prs ~net t ~branch ?(base = None) ~state () =
     [
       ("head", [ t.owner ^ ":" ^ Types.Branch.to_string branch ]);
       ("state", [ state_str ]);
-      ("per_page", [ "10" ]);
+      ("per_page", [ "100" ]);
     ]
     @
     match base with

--- a/lib/github.mli
+++ b/lib/github.mli
@@ -25,3 +25,40 @@ val pr_state :
   net:_ Eio.Net.t -> t -> Types.Pr_number.t -> (Pr_state.t, error) Result.t
 (** [pr_state ~net client pr] fetches the current state of a pull request via
     the GitHub GraphQL API over HTTPS. *)
+
+val parse_rest_pr_list :
+  string -> ((Types.Pr_number.t * Types.Branch.t * bool) list, error) Result.t
+(** Parse the REST response from [GET /repos/:owner/:repo/pulls]. Returns
+    non-CLOSED PRs as [(pr_number, base_branch, merged)]. Pure function. *)
+
+val list_prs :
+  net:_ Eio.Net.t ->
+  t ->
+  branch:Types.Branch.t ->
+  ?base:Types.Branch.t option ->
+  state:[ `Open | `All ] ->
+  unit ->
+  ((Types.Pr_number.t * Types.Branch.t * bool) list, error) Result.t
+(** [list_prs ~net t ~branch ~state ()] lists PRs matching [branch] via the
+    GitHub REST API. Returns non-CLOSED PRs as [(number, base, merged)]. *)
+
+val update_pr_body :
+  net:_ Eio.Net.t ->
+  t ->
+  pr_number:Types.Pr_number.t ->
+  body:string ->
+  (unit, error) Result.t
+(** [update_pr_body ~net t ~pr_number ~body] updates the PR description via
+    [PATCH /repos/:owner/:repo/pulls/:number]. *)
+
+val set_draft :
+  net:_ Eio.Net.t ->
+  t ->
+  pr_number:Types.Pr_number.t ->
+  draft:bool ->
+  (unit, error) Result.t
+(** [set_draft ~net t ~pr_number ~draft] sets draft status via GraphQL mutation.
+    REST API does not support changing the draft field. *)
+
+val owner : t -> string
+(** [owner t] returns the repository owner. *)

--- a/lib/llm_backend.ml
+++ b/lib/llm_backend.ml
@@ -21,6 +21,8 @@ let spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~args
         Eio.Process.spawn ~sw process_mgr ~cwd ~stdin:stdin_r ~stdout:stdout_w
           ~stderr:stderr_w args
       in
+      Eio.Switch.on_release sw (fun () ->
+          try Eio.Process.signal child Stdlib.Sys.sigterm with _ -> ());
       Eio.Flow.close stdin_r;
       Eio.Flow.close stdin_w;
       Eio.Flow.close stdout_w;
@@ -62,7 +64,7 @@ let spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~args
   | Ok result -> result
   | Error `Timeout ->
       {
-        exit_code = 128 + 15 (* SIGTERM *);
+        exit_code = 128 + 15 (* SIGTERM — sent via on_release hook *);
         stdout = "";
         stderr = "process timed out";
         got_events = false;

--- a/lib/llm_backend.ml
+++ b/lib/llm_backend.ml
@@ -5,46 +5,69 @@ type result = {
   stdout : string;
   stderr : string;
   got_events : bool;
+  timed_out : bool;
 }
 [@@deriving show, eq, sexp_of, compare]
 
-let spawn_and_stream ~process_mgr ~cwd ~args
+let spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~args
     ~(process_line : string -> Types.Stream_event.t list) ~on_event =
-  let stderr_content, exit_code, got_events =
-    Eio.Switch.run @@ fun sw ->
-    let stdin_r, stdin_w = Eio.Process.pipe ~sw process_mgr in
-    let stdout_r, stdout_w = Eio.Process.pipe ~sw process_mgr in
-    let stderr_r, stderr_w = Eio.Process.pipe ~sw process_mgr in
-    let child =
-      Eio.Process.spawn ~sw process_mgr ~cwd ~stdin:stdin_r ~stdout:stdout_w
-        ~stderr:stderr_w args
+  let run () =
+    let stderr_content, exit_code, got_events =
+      Eio.Switch.run @@ fun sw ->
+      let stdin_r, stdin_w = Eio.Process.pipe ~sw process_mgr in
+      let stdout_r, stdout_w = Eio.Process.pipe ~sw process_mgr in
+      let stderr_r, stderr_w = Eio.Process.pipe ~sw process_mgr in
+      let child =
+        Eio.Process.spawn ~sw process_mgr ~cwd ~stdin:stdin_r ~stdout:stdout_w
+          ~stderr:stderr_w args
+      in
+      Eio.Flow.close stdin_r;
+      Eio.Flow.close stdin_w;
+      Eio.Flow.close stdout_w;
+      Eio.Flow.close stderr_w;
+      let stdout_buf = Eio.Buf_read.of_flow ~max_size:(1024 * 1024) stdout_r in
+      let stderr_buf = Eio.Buf_read.of_flow ~max_size:(1024 * 1024) stderr_r in
+      let err_ref = ref "" in
+      let got_events_ref = ref false in
+      Eio.Fiber.both
+        (fun () ->
+          let rec read_lines () =
+            match Eio.Buf_read.line stdout_buf with
+            | line ->
+                let events = process_line line in
+                if not (List.is_empty events) then got_events_ref := true;
+                List.iter events ~f:on_event;
+                read_lines ()
+            | exception End_of_file -> ()
+          in
+          read_lines ())
+        (fun () ->
+          try err_ref := Eio.Buf_read.take_all stderr_buf
+          with Eio.Buf_read.Buffer_limit_exceeded ->
+            err_ref := "<stderr exceeded 1MB limit, truncated>");
+      let status = Eio.Process.await child in
+      let code = match status with `Exited c -> c | `Signaled s -> 128 + s in
+      (!err_ref, code, !got_events_ref)
     in
-    Eio.Flow.close stdin_r;
-    Eio.Flow.close stdin_w;
-    Eio.Flow.close stdout_w;
-    Eio.Flow.close stderr_w;
-    let stdout_buf = Eio.Buf_read.of_flow ~max_size:(1024 * 1024) stdout_r in
-    let stderr_buf = Eio.Buf_read.of_flow ~max_size:(1024 * 1024) stderr_r in
-    let err_ref = ref "" in
-    let got_events_ref = ref false in
-    Eio.Fiber.both
-      (fun () ->
-        let rec read_lines () =
-          match Eio.Buf_read.line stdout_buf with
-          | line ->
-              let events = process_line line in
-              if not (List.is_empty events) then got_events_ref := true;
-              List.iter events ~f:on_event;
-              read_lines ()
-          | exception End_of_file -> ()
-        in
-        read_lines ())
-      (fun () -> err_ref := Eio.Buf_read.take_all stderr_buf);
-    let status = Eio.Process.await child in
-    let code = match status with `Exited c -> c | `Signaled s -> 128 + s in
-    (!err_ref, code, !got_events_ref)
+    Ok
+      {
+        exit_code;
+        stdout = "";
+        stderr = stderr_content;
+        got_events;
+        timed_out = false;
+      }
   in
-  { exit_code; stdout = ""; stderr = stderr_content; got_events }
+  match Eio.Time.with_timeout clock timeout run with
+  | Ok result -> result
+  | Error `Timeout ->
+      {
+        exit_code = 128 + 15 (* SIGTERM *);
+        stdout = "";
+        stderr = "process timed out";
+        got_events = false;
+        timed_out = true;
+      }
 
 type t = {
   name : string;

--- a/lib/llm_backend.ml
+++ b/lib/llm_backend.ml
@@ -45,8 +45,15 @@ let spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~args
           read_lines ())
         (fun () ->
           try err_ref := Eio.Buf_read.take_all stderr_buf
-          with Eio.Buf_read.Buffer_limit_exceeded ->
-            err_ref := "<stderr exceeded 1MB limit, truncated>");
+          with Eio.Buf_read.Buffer_limit_exceeded -> (
+            err_ref := "<stderr exceeded 1MB limit, truncated>";
+            let drain_buf = Bytes.create 4096 in
+            try
+              while true do
+                ignore
+                  (Eio.Flow.single_read stderr_r (Cstruct.of_bytes drain_buf))
+              done
+            with End_of_file -> ()));
       let status = Eio.Process.await child in
       let code = match status with `Exited c -> c | `Signaled s -> 128 + s in
       (!err_ref, code, !got_events_ref)

--- a/lib/llm_backend.mli
+++ b/lib/llm_backend.mli
@@ -3,19 +3,22 @@ open Base
 (** Generic LLM backend interface.
 
     A backend wraps an LLM CLI's streaming invocation behind a common type. The
-    process manager is captured at construction time so that the record type
-    avoids Eio's unquantifiable row variables. *)
+    process manager, clock, and timeout are captured at construction time so
+    that the record type avoids Eio's unquantifiable row variables. *)
 
 type result = {
   exit_code : int;
   stdout : string;
   stderr : string;
   got_events : bool;
+  timed_out : bool;
 }
 [@@deriving show, eq, sexp_of, compare]
 
 val spawn_and_stream :
   process_mgr:_ Eio.Process.mgr ->
+  clock:_ Eio.Time.clock ->
+  timeout:float ->
   cwd:Eio.Fs.dir_ty Eio.Path.t ->
   args:string list ->
   process_line:(string -> Types.Stream_event.t list) ->
@@ -24,7 +27,7 @@ val spawn_and_stream :
 (** Spawn a subprocess, read NDJSON lines from stdout, and stream parsed events.
     Each stdout line is passed to [process_line] which returns events to forward
     to [on_event]. Handles pipe setup, stdin EOF, stderr capture, and exit code
-    extraction. *)
+    extraction. The process is killed after [timeout] seconds. *)
 
 type t = {
   name : string;

--- a/lib/run_classification.ml
+++ b/lib/run_classification.ml
@@ -10,12 +10,14 @@ type run_outcome = {
   got_events : bool;
   stderr : string;
   stream_errors : string;
+  timed_out : bool;
 }
 [@@deriving show, eq]
 
 type classification =
   | Process_error of string
   | No_session_to_resume
+  | Timed_out
   | Success of { stream_errors : string }
   | Session_failed of { exit_code : int; detail : string }
 [@@deriving show, eq]
@@ -25,6 +27,7 @@ let truncate s n = if String.length s <= n then s else String.prefix s n ^ "..."
 let classify ~continue result =
   match result with
   | Error msg -> Process_error msg
+  | Ok r when r.timed_out -> Timed_out
   | Ok r when (not r.got_events) && continue -> No_session_to_resume
   | Ok r when r.exit_code = 0 -> Success { stream_errors = r.stream_errors }
   | Ok r ->

--- a/lib/run_classification.mli
+++ b/lib/run_classification.mli
@@ -10,12 +10,14 @@ type run_outcome = {
   got_events : bool;
   stderr : string;
   stream_errors : string;
+  timed_out : bool;
 }
 [@@deriving show, eq]
 
 type classification =
   | Process_error of string
   | No_session_to_resume
+  | Timed_out
   | Success of { stream_errors : string }
   | Session_failed of { exit_code : int; detail : string }
 [@@deriving show, eq]

--- a/lib/startup_reconciler.ml
+++ b/lib/startup_reconciler.ml
@@ -65,32 +65,14 @@ let discover_pr_from_json output =
   | Yojson.Basic.Util.Type_error (msg, _) ->
       Error (Printf.sprintf "unexpected JSON structure from gh: %s" msg)
 
-(** Query [gh pr list] for a branch, returning discovery info for the first
-    non-CLOSED PR. Iterates through all matching PRs to handle cases where the
-    most recent PR is CLOSED but an older one is still OPEN or MERGED. *)
-let discover_pr ~process_mgr ~token ~owner ~repo ~branch =
-  let args =
-    [
-      "gh";
-      "pr";
-      "list";
-      "--repo";
-      Printf.sprintf "%s/%s" owner repo;
-      "--head";
-      Branch.to_string branch;
-      "--state";
-      "all";
-      "--json";
-      "number,state,baseRefName";
-    ]
-  in
-  let base_env = Unix.environment () in
-  let env = Array.append [| Printf.sprintf "GH_TOKEN=%s" token |] base_env in
-  try
-    let buf = Buffer.create 256 in
-    Eio.Process.run ~stdout:(Eio.Flow.buffer_sink buf) ~env process_mgr args;
-    discover_pr_from_json (Buffer.contents buf)
-  with Eio.Exn.Io _ as exn -> Error (Stdlib.Printexc.to_string exn)
+(** Query GitHub REST API for a branch, returning discovery info for the first
+    non-CLOSED PR. *)
+let discover_pr ~net ~github ~branch =
+  match Github.list_prs ~net github ~branch ~state:`All () with
+  | Ok [] -> Ok None
+  | Ok ((pr_number, base_branch, merged) :: _) ->
+      Ok (Some (pr_number, base_branch, merged))
+  | Error err -> Error (Github.show_error err)
 
 (** Discover existing worktrees and match them to patches by branch name.
     Returns matched worktrees and an optional error string if listing failed. *)
@@ -125,14 +107,12 @@ let find_stale_busy ~agents =
   List.filter_map agents ~f:(fun (agent : Patch_agent.t) ->
       if agent.busy then Some agent.patch_id else None)
 
-let reconcile ~process_mgr ~token ~owner ~repo ~patches ?(repo_root = ".")
+let reconcile ~net ~github ~patches ?(repo_root = ".") ?process_mgr
     ?(agents = []) ?pre_recovered_worktrees () =
   let results =
     Eio.Fiber.List.map ~max_fibers:8
       (fun (patch : Patch.t) ->
-        let r =
-          discover_pr ~process_mgr ~token ~owner ~repo ~branch:patch.branch
-        in
+        let r = discover_pr ~net ~github ~branch:patch.branch in
         (patch, r))
       patches
   in
@@ -148,9 +128,11 @@ let reconcile ~process_mgr ~token ~owner ~repo ~patches ?(repo_root = ".")
         | Error err -> (discovered, (patch.Patch.id, err) :: errors))
   in
   let recovered_worktrees, worktree_error =
-    match pre_recovered_worktrees with
-    | Some wts -> (wts, None)
-    | None -> recover_worktrees ~process_mgr ~repo_root ~patches
+    match (pre_recovered_worktrees, process_mgr) with
+    | Some wts, _ -> (wts, None)
+    | None, Some pm -> recover_worktrees ~process_mgr:pm ~repo_root ~patches
+    | None, None ->
+        ([], Some "worktree recovery skipped: no process_mgr provided")
   in
   let reset_pending = find_stale_busy ~agents in
   {

--- a/lib/startup_reconciler.mli
+++ b/lib/startup_reconciler.mli
@@ -52,13 +52,11 @@ val discover_pr_from_json :
     Returns the first non-CLOSED PR entry or [None]. Pure function. *)
 
 val discover_pr :
-  process_mgr:_ Eio.Process.mgr ->
-  token:string ->
-  owner:string ->
-  repo:string ->
+  net:_ Eio.Net.t ->
+  github:Github.t ->
   branch:Branch.t ->
   ((Pr_number.t * Branch.t * bool) option, string) Result.t
-(** Query [gh pr list] for a branch, returning the first non-CLOSED PR as
+(** Query the GitHub REST API for a branch, returning the first non-CLOSED PR as
     [(pr_number, base_branch, merged)] or [None]. *)
 
 val recover_worktrees :
@@ -71,19 +69,19 @@ val recover_worktrees :
     Can be called before [reconcile] to capture worktree state early. *)
 
 val reconcile :
-  process_mgr:_ Eio.Process.mgr ->
-  token:string ->
-  owner:string ->
-  repo:string ->
+  net:_ Eio.Net.t ->
+  github:Github.t ->
   patches:Patch.t list ->
   ?repo_root:string ->
+  ?process_mgr:_ Eio.Process.mgr ->
   ?agents:Patch_agent.t list ->
   ?pre_recovered_worktrees:worktree_recovery list ->
   unit ->
   t
-(** [reconcile ~process_mgr ~token ~owner ~repo ~patches ?repo_root ?agents
-     ?pre_recovered_worktrees ()] queries GitHub for each patch's branch to find
-    existing PRs and identifies stale busy agents from [agents] (default [[]]).
-    When [pre_recovered_worktrees] is provided, uses it directly instead of
-    scanning the filesystem (avoids racing with concurrent worktree creation).
-    Otherwise discovers worktrees under [repo_root] (default ["."]). *)
+(** [reconcile ~net ~github ~patches ?repo_root ?process_mgr ?agents
+     ?pre_recovered_worktrees ()] queries GitHub REST API for each patch's
+    branch to find existing PRs and identifies stale busy agents from [agents]
+    (default [[]]). When [pre_recovered_worktrees] is provided, uses it directly
+    instead of scanning the filesystem (avoids racing with concurrent worktree
+    creation). Otherwise discovers worktrees under [repo_root] (default ["."])
+    using [process_mgr]. *)

--- a/lib/worktree.ml
+++ b/lib/worktree.ml
@@ -38,18 +38,20 @@ let rec has_cancellation = function
       List.exists exns ~f:(fun (exn, _bt) -> has_cancellation exn)
   | _ -> false
 
-let clean_git_env () =
-  Unix.environment () |> Array.to_list
-  |> List.filter ~f:(fun s ->
-      (not (String.is_prefix s ~prefix:"GIT_DIR="))
-      && (not (String.is_prefix s ~prefix:"GIT_WORK_TREE="))
-      && not (String.is_prefix s ~prefix:"GIT_INDEX_FILE="))
-  |> Array.of_list
+let clean_git_env =
+  Stdlib.Lazy.from_fun (fun () ->
+      Unix.environment () |> Array.to_list
+      |> List.filter ~f:(fun s ->
+          (not (String.is_prefix s ~prefix:"GIT_DIR="))
+          && (not (String.is_prefix s ~prefix:"GIT_WORK_TREE="))
+          && not (String.is_prefix s ~prefix:"GIT_INDEX_FILE="))
+      |> Array.of_list)
 
 let ref_exists ~process_mgr ~repo_root ref_path =
   let buf = Buffer.create 16 in
   match
-    Eio.Process.run process_mgr ~env:(clean_git_env ())
+    Eio.Process.run process_mgr
+      ~env:(Stdlib.Lazy.force clean_git_env)
       ~stdout:(Eio.Flow.buffer_sink buf)
       ~stderr:(Eio.Flow.buffer_sink (Buffer.create 16))
       [ "git"; "-C"; repo_root; "rev-parse"; "--verify"; ref_path ]
@@ -68,7 +70,8 @@ let resolve_main_root ~process_mgr ~repo_root =
   let buf = Buffer.create 128 in
   let stderr_buf = Buffer.create 64 in
   match
-    Eio.Process.run process_mgr ~env:(clean_git_env ())
+    Eio.Process.run process_mgr
+      ~env:(Stdlib.Lazy.force clean_git_env)
       ~stdout:(Eio.Flow.buffer_sink buf)
       ~stderr:(Eio.Flow.buffer_sink stderr_buf)
       [
@@ -93,7 +96,8 @@ let is_checked_out_in_repo_root ~process_mgr ~repo_root branch =
   let buf = Buffer.create 128 in
   let stderr_buf = Buffer.create 64 in
   match
-    Eio.Process.run process_mgr ~env:(clean_git_env ())
+    Eio.Process.run process_mgr
+      ~env:(Stdlib.Lazy.force clean_git_env)
       ~stdout:(Eio.Flow.buffer_sink buf)
       ~stderr:(Eio.Flow.buffer_sink stderr_buf)
       [ "git"; "-C"; main_root; "rev-parse"; "--abbrev-ref"; "HEAD" ]
@@ -107,7 +111,8 @@ let is_checked_out_in_repo_root ~process_mgr ~repo_root branch =
 let run_git ~process_mgr args =
   let stderr_buf = Buffer.create 128 in
   match
-    Eio.Process.run process_mgr ~env:(clean_git_env ())
+    Eio.Process.run process_mgr
+      ~env:(Stdlib.Lazy.force clean_git_env)
       ~stdout:(Eio.Flow.buffer_sink (Buffer.create 64))
       ~stderr:(Eio.Flow.buffer_sink stderr_buf)
       args
@@ -162,7 +167,8 @@ let check_case_insensitive_ref_collision ~process_mgr ~repo_root branch_str =
   let buf = Buffer.create 512 in
   let existing_branches =
     match
-      Eio.Process.run process_mgr ~env:(clean_git_env ())
+      Eio.Process.run process_mgr
+        ~env:(Stdlib.Lazy.force clean_git_env)
         ~stdout:(Eio.Flow.buffer_sink buf)
         ~stderr:(Eio.Flow.buffer_sink (Buffer.create 16))
         [
@@ -231,7 +237,8 @@ let create ~process_mgr ~repo_root ~project_name ~patch_id ~branch ~base_ref =
     { patch_id; branch; path }
 
 let remove ~process_mgr ~repo_root t =
-  Eio.Process.run process_mgr ~env:(clean_git_env ())
+  Eio.Process.run process_mgr
+    ~env:(Stdlib.Lazy.force clean_git_env)
     [ "git"; "-C"; repo_root; "worktree"; "remove"; "--force"; t.path ]
 
 let detect_branch ~process_mgr ~path =
@@ -239,7 +246,8 @@ let detect_branch ~process_mgr ~path =
   let path = normalize_path path in
   let stderr_buf = Buffer.create 64 in
   (match
-     Eio.Process.run process_mgr ~env:(clean_git_env ())
+     Eio.Process.run process_mgr
+       ~env:(Stdlib.Lazy.force clean_git_env)
        ~stdout:(Eio.Flow.buffer_sink buf)
        ~stderr:(Eio.Flow.buffer_sink stderr_buf)
        [ "git"; "-C"; path; "rev-parse"; "--abbrev-ref"; "HEAD" ]
@@ -313,7 +321,8 @@ let list_with_branches ~process_mgr ~repo_root =
   let buf = Buffer.create 512 in
   let stderr_buf = Buffer.create 64 in
   (match
-     Eio.Process.run process_mgr ~env:(clean_git_env ())
+     Eio.Process.run process_mgr
+       ~env:(Stdlib.Lazy.force clean_git_env)
        ~stdout:(Eio.Flow.buffer_sink buf)
        ~stderr:(Eio.Flow.buffer_sink stderr_buf)
        [ "git"; "-C"; repo_root; "worktree"; "list"; "--porcelain" ]
@@ -334,7 +343,7 @@ let run_git_exit_code ~process_mgr args =
   Eio.Switch.run @@ fun sw ->
   let stdout_buf = Buffer.create 0 in
   let stderr_buf = Buffer.create 64 in
-  let env = clean_git_env () in
+  let env = Stdlib.Lazy.force clean_git_env in
   let child =
     Eio.Process.spawn ~sw process_mgr ~env
       ~stdout:(Eio.Flow.buffer_sink stdout_buf)

--- a/lib_test/test_generators.ml
+++ b/lib_test/test_generators.ml
@@ -523,12 +523,12 @@ let gen_activity_log =
 let gen_run_outcome =
   QCheck2.Gen.(
     let open Onton.Run_classification in
-    map4
-      (fun exit_code got_events stderr stream_errors ->
-        { exit_code; got_events; stderr; stream_errors })
-      (int_range (-1) 255) bool
-      (string_size ~gen:printable (int_range 0 80))
-      (string_size ~gen:printable (int_range 0 80)))
+    let* exit_code = int_range (-1) 255 in
+    let* got_events = bool in
+    let* stderr = string_size ~gen:printable (int_range 0 80) in
+    let* stream_errors = string_size ~gen:printable (int_range 0 80) in
+    let* timed_out = bool in
+    return { exit_code; got_events; stderr; stream_errors; timed_out })
 
 let gen_porcelain_entry =
   QCheck2.Gen.(

--- a/test/test_run_classification.ml
+++ b/test/test_run_classification.ml
@@ -14,62 +14,86 @@ let () =
       (fun msg ->
         match classify ~continue:false (Error msg) with
         | Process_error m -> String.equal m msg
-        | No_session_to_resume | Success _ | Session_failed _ -> false)
+        | No_session_to_resume | Timed_out | Success _ | Session_failed _ ->
+            false)
+  in
+
+  (* Ok with timed_out -> Timed_out *)
+  let prop_timed_out =
+    Test.make ~name:"classify: timed_out -> Timed_out" ~count:500
+      gen_run_outcome (fun r ->
+        let r = { r with timed_out = true } in
+        match classify ~continue:false (Ok r) with
+        | Timed_out -> true
+        | Process_error _ | No_session_to_resume | Success _ | Session_failed _
+          ->
+            false)
   in
 
   (* Ok with no events + continue -> No_session_to_resume *)
   let prop_no_events_continue =
     Test.make ~name:"classify: no events + continue -> No_session_to_resume"
       ~count:500 gen_run_outcome (fun r ->
-        let r = { r with got_events = false } in
+        let r = { r with got_events = false; timed_out = false } in
         match classify ~continue:true (Ok r) with
         | No_session_to_resume -> true
-        | Process_error _ | Success _ | Session_failed _ -> false)
+        | Process_error _ | Timed_out | Success _ | Session_failed _ -> false)
   in
 
   (* Ok with exit_code=0 -> Success *)
   let prop_exit_zero_success =
     Test.make ~name:"classify: exit_code=0 -> Success" ~count:500
       gen_run_outcome (fun r ->
-        let r = { r with exit_code = 0; got_events = true } in
+        let r =
+          { r with exit_code = 0; got_events = true; timed_out = false }
+        in
         match classify ~continue:false (Ok r) with
         | Success _ -> true
-        | Process_error _ | No_session_to_resume | Session_failed _ -> false)
+        | Process_error _ | No_session_to_resume | Timed_out | Session_failed _
+          ->
+            false)
   in
 
   (* Non-zero exit code -> Session_failed *)
   let prop_nonzero_session_failed =
     Test.make ~name:"classify: non-zero exit -> Session_failed" ~count:500
       gen_run_outcome (fun r ->
-        let r = { r with exit_code = 1; got_events = true } in
+        let r =
+          { r with exit_code = 1; got_events = true; timed_out = false }
+        in
         match classify ~continue:false (Ok r) with
         | Session_failed _ -> true
-        | Process_error _ | No_session_to_resume | Success _ -> false)
+        | Process_error _ | No_session_to_resume | Timed_out | Success _ ->
+            false)
   in
 
   (* Detail string always <= 503 chars (500 + "...") *)
   let prop_detail_bounded =
     Test.make ~name:"classify: detail string bounded" ~count:500 gen_run_outcome
       (fun r ->
-        let r = { r with exit_code = 1; got_events = true } in
+        let r =
+          { r with exit_code = 1; got_events = true; timed_out = false }
+        in
         match classify ~continue:false (Ok r) with
         | Session_failed { detail; _ } -> String.length detail <= 503
-        | Process_error _ | No_session_to_resume | Success _ -> false)
+        | Process_error _ | No_session_to_resume | Timed_out | Success _ ->
+            false)
   in
 
   (* continue=false with no events still classifies by exit code *)
   let prop_no_continue_uses_exit_code =
     Test.make ~name:"classify: continue=false, no events -> uses exit code"
       ~count:500 gen_run_outcome (fun r ->
-        let r = { r with got_events = false } in
+        let r = { r with got_events = false; timed_out = false } in
         match classify ~continue:false (Ok r) with
         | No_session_to_resume -> false (* should not happen without continue *)
-        | Process_error _ | Success _ | Session_failed _ -> true)
+        | Process_error _ | Timed_out | Success _ | Session_failed _ -> true)
   in
 
   let suite =
     [
       prop_error_is_process_error;
+      prop_timed_out;
       prop_no_events_continue;
       prop_exit_zero_success;
       prop_nonzero_session_failed;


### PR DESCRIPTION
## Summary

- **GitHub API migration**: Replace all orchestrator `gh` CLI subprocess calls with direct REST/GraphQL via cohttp-eio. Adds `list_prs`, `update_pr_body`, `set_draft` to `Github` module. `startup_reconciler` and `main.ml` callsites updated. Agents still use `gh` for their own PR creation.
- **LLM process timeout**: 30-minute session timeout via `Eio.Time.with_timeout`, threaded through backend chain. Adds `timed_out` field and `Timed_out` classification.
- **Stderr buffer fix**: Catch `Buffer_limit_exceeded` in stderr fiber so large stderr doesn't cancel the stdout reader.
- **Shell-out cleanup**: `infer_owner_repo` and `infer_github_token` use `open_process_args_in` (argv) instead of `open_process_in` (shell string).
- **`clean_git_env` memoization**: Lazy value instead of rebuilding env array on every git call.
- **PTY platform guard**: `pty_wrap` detects Linux via `/proc/version` and uses `script -qc` syntax.

## Test plan

- [x] `dune build` passes (fatal warnings)
- [x] `dune runtest` passes (all inline + QCheck property tests)
- [x] `dune fmt` clean
- [ ] Run orchestrator in headless mode against a repo with existing PRs — verify PR discovery works via direct HTTP
- [ ] Verify timeout by setting a short value (e.g. 5s) and confirming `timed_out = true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable timeouts for AI model sessions; timeouts are detected and reported as session failures.
  * GitHub PR operations (discovering PRs, updating descriptions, toggling draft) now use the API for more reliable behavior.

* **Improvements**
  * More robust PR discovery and GitHub integration; clearer logging on API errors.
  * Worktree recovery now skips when not applicable and reports a clear message.

* **Tests**
  * Added tests to validate timeout handling and PR-list parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->