### PR TITLE
Add Pi coding agent backend

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -103,13 +103,16 @@ let infer_default_branch ~repo_root =
           | Some _ -> "master"
           | None -> "main"))
 
+let known_backends = [ "claude"; "codex"; "pi" ]
+
 let validate_resolved_config ~backend ~github_token ~github_owner ~github_repo
     ~main_branch ~poll_interval ~max_concurrency =
   let errors =
     Base.List.filter_map
       [
-        ( not (Base.List.mem [ "claude"; "codex" ] backend ~equal:String.equal),
-          Printf.sprintf "--backend must be one of: claude, codex (got %S)"
+        ( not (Base.List.mem known_backends backend ~equal:String.equal),
+          Printf.sprintf "--backend must be one of: %s (got %S)"
+            (String.concat ", " known_backends)
             backend );
         ( Base.String.is_empty (Base.String.strip github_token),
           "--token / GITHUB_TOKEN is required" );
@@ -1742,10 +1745,12 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry
         Claude_backend.create ~process_mgr ~clock ~timeout:session_timeout
     | "codex" ->
         Codex_backend.create ~process_mgr ~clock ~timeout:session_timeout
+    | "pi" ->
+        Pi_backend.create ~process_mgr ~clock ~timeout:session_timeout
     | other ->
         invalid_arg
-          (Printf.sprintf
-             "Unsupported --backend=%S (expected \"claude\" or \"codex\")" other)
+          (Printf.sprintf "Unsupported --backend=%S (expected %s)" other
+             (String.concat ", " known_backends))
   in
   let set_status ~level ~text ?expires_at () =
     match status_msg with

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1747,8 +1747,7 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry
         Codex_backend.create ~process_mgr ~clock ~timeout:session_timeout
     | "opencode" ->
         Opencode_backend.create ~process_mgr ~clock ~timeout:session_timeout
-    | "pi" ->
-        Pi_backend.create ~process_mgr ~clock ~timeout:session_timeout
+    | "pi" -> Pi_backend.create ~process_mgr ~clock ~timeout:session_timeout
     | other ->
         invalid_arg
           (Printf.sprintf "Unsupported --backend=%S (expected %s)" other

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -103,7 +103,7 @@ let infer_default_branch ~repo_root =
           | Some _ -> "master"
           | None -> "main"))
 
-let known_backends = [ "claude"; "codex"; "pi" ]
+let known_backends = [ "claude"; "codex"; "opencode"; "pi" ]
 
 let validate_resolved_config ~backend ~github_token ~github_owner ~github_repo
     ~main_branch ~poll_interval ~max_concurrency =
@@ -1745,6 +1745,8 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry
         Claude_backend.create ~process_mgr ~clock ~timeout:session_timeout
     | "codex" ->
         Codex_backend.create ~process_mgr ~clock ~timeout:session_timeout
+    | "opencode" ->
+        Opencode_backend.create ~process_mgr ~clock ~timeout:session_timeout
     | "pi" ->
         Pi_backend.create ~process_mgr ~clock ~timeout:session_timeout
     | other ->

--- a/lib/codex_backend.mli
+++ b/lib/codex_backend.mli
@@ -5,3 +5,6 @@ val create :
   Llm_backend.t
 (** Create an LLM backend that uses the Codex CLI. [timeout] is the maximum
     session duration in seconds before the process is killed. *)
+
+val parse_event : string -> Types.Stream_event.t list
+(** Parse a single NDJSON line from Codex's JSON output. Exposed for testing. *)

--- a/lib/opencode_backend.ml
+++ b/lib/opencode_backend.ml
@@ -1,0 +1,138 @@
+open Base
+
+let build_args ~cwd_path ~prompt ~continue =
+  let base = [ "opencode"; "run"; "--format"; "json"; "--dir"; cwd_path ] in
+  let continue_args = if continue then [ "--continue" ] else [] in
+  base @ continue_args @ [ prompt ]
+
+let parse_event (line : string) : Types.Stream_event.t list =
+  match Yojson.Safe.from_string line with
+  | json -> (
+      let open Yojson.Safe.Util in
+      let typ = member "type" json |> to_string_option in
+      match typ with
+      | Some "text" ->
+          let part = member "part" json in
+          let text =
+            member "text" part |> to_string_option |> Option.value ~default:""
+          in
+          if String.is_empty text then []
+          else [ Types.Stream_event.Text_delta text ]
+      | Some "tool_use" ->
+          let part = member "part" json in
+          let tool =
+            member "tool" part |> to_string_option |> Option.value ~default:""
+          in
+          let state = member "state" part in
+          let input =
+            match member "input" state with
+            | `Null -> ""
+            | v -> Yojson.Safe.to_string v
+          in
+          [ Types.Stream_event.Tool_use { name = tool; input } ]
+      | Some "step_finish" -> (
+          let part = member "part" json in
+          let reason =
+            member "reason" part |> to_string_option |> Option.value ~default:""
+          in
+          match reason with
+          | "stop" ->
+              [
+                Types.Stream_event.Final_result
+                  { text = ""; stop_reason = Types.Stop_reason.End_turn };
+              ]
+          | _ -> [])
+      | Some "error" ->
+          let msg =
+            member "message" json |> to_string_option
+            |> Option.value ~default:"unknown opencode error"
+          in
+          [ Types.Stream_event.Error msg ]
+      | _ -> [])
+  | exception Yojson.Json_error _ -> []
+  | exception Yojson.Safe.Util.Type_error _ -> []
+
+let run_streaming ~process_mgr ~clock ~timeout ~cwd ~patch_id ~prompt ~continue
+    ~on_event =
+  ignore (patch_id : Types.Patch_id.t);
+  let cwd_path = snd cwd in
+  let args = build_args ~cwd_path ~prompt ~continue in
+  let process_line line =
+    let trimmed = String.strip line in
+    if String.is_empty trimmed then [] else parse_event trimmed
+  in
+  Llm_backend.spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~args
+    ~process_line ~on_event
+
+let create ~process_mgr ~clock ~timeout : Llm_backend.t =
+  {
+    name = "OpenCode";
+    run_streaming =
+      (fun ~cwd ~patch_id ~prompt ~continue ~on_event ->
+        run_streaming ~process_mgr ~clock ~timeout ~cwd ~patch_id ~prompt
+          ~continue ~on_event);
+  }
+
+let%test "build_args without continue" =
+  let args =
+    build_args ~cwd_path:"/tmp/work" ~prompt:"do stuff" ~continue:false
+  in
+  List.equal String.equal args
+    [ "opencode"; "run"; "--format"; "json"; "--dir"; "/tmp/work"; "do stuff" ]
+
+let%test "build_args with continue" =
+  let args =
+    build_args ~cwd_path:"/tmp/work" ~prompt:"do stuff" ~continue:true
+  in
+  List.equal String.equal args
+    [
+      "opencode";
+      "run";
+      "--format";
+      "json";
+      "--dir";
+      "/tmp/work";
+      "--continue";
+      "do stuff";
+    ]
+
+let%test "parse_event text" =
+  let line = {|{"type":"text","part":{"type":"text","text":"hello"}}|} in
+  List.equal Types.Stream_event.equal (parse_event line)
+    [ Types.Stream_event.Text_delta "hello" ]
+
+let%test "parse_event tool_use" =
+  let line =
+    {|{"type":"tool_use","part":{"type":"tool","tool":"bash","state":{"status":"completed","input":{"command":"ls -la"}}}}|}
+  in
+  List.equal Types.Stream_event.equal (parse_event line)
+    [
+      Types.Stream_event.Tool_use
+        { name = "bash"; input = {|{"command":"ls -la"}|} };
+    ]
+
+let%test "parse_event step_finish stop" =
+  let line =
+    {|{"type":"step_finish","part":{"type":"step-finish","reason":"stop"}}|}
+  in
+  List.equal Types.Stream_event.equal (parse_event line)
+    [
+      Types.Stream_event.Final_result
+        { text = ""; stop_reason = Types.Stop_reason.End_turn };
+    ]
+
+let%test "parse_event step_finish tool-calls is ignored" =
+  let line =
+    {|{"type":"step_finish","part":{"type":"step-finish","reason":"tool-calls"}}|}
+  in
+  List.is_empty (parse_event line)
+
+let%test "parse_event step_start is ignored" =
+  let line = {|{"type":"step_start","part":{"type":"step-start"}}|} in
+  List.is_empty (parse_event line)
+
+let%test "parse_event invalid json" =
+  List.is_empty (parse_event "not json at all")
+
+let%test "parse_event unknown type" =
+  List.is_empty (parse_event {|{"type":"ping"}|})

--- a/lib/opencode_backend.mli
+++ b/lib/opencode_backend.mli
@@ -1,0 +1,7 @@
+val create :
+  process_mgr:_ Eio.Process.mgr ->
+  clock:_ Eio.Time.clock ->
+  timeout:float ->
+  Llm_backend.t
+(** Create an LLM backend that uses the OpenCode CLI. [timeout] is the maximum
+    session duration in seconds before the process is killed. *)

--- a/lib/opencode_backend.mli
+++ b/lib/opencode_backend.mli
@@ -5,3 +5,7 @@ val create :
   Llm_backend.t
 (** Create an LLM backend that uses the OpenCode CLI. [timeout] is the maximum
     session duration in seconds before the process is killed. *)
+
+val parse_event : string -> Types.Stream_event.t list
+(** Parse a single NDJSON line from OpenCode's JSON output. Exposed for testing.
+*)

--- a/lib/pi_backend.ml
+++ b/lib/pi_backend.ml
@@ -1,0 +1,156 @@
+open Base
+
+let build_args ~cwd_path ~patch_id ~prompt ~continue =
+  let session_dir = cwd_path ^ "/.pi-sessions/" ^ patch_id in
+  let base = [ "pi"; "-p"; prompt; "--mode"; "json" ] in
+  let continue_args = if continue then [ "--continue" ] else [] in
+  let session_args = [ "--session-dir"; session_dir ] in
+  base @ continue_args @ session_args
+
+let parse_event (line : string) : Types.Stream_event.t list =
+  match Yojson.Safe.from_string line with
+  | json -> (
+      let open Yojson.Safe.Util in
+      let typ = member "type" json |> to_string_option in
+      match typ with
+      | Some "message_update" -> (
+          let evt = member "assistantMessageEvent" json in
+          let evt_type = member "type" evt |> to_string_option in
+          match evt_type with
+          | Some "text_delta" ->
+              let delta =
+                member "delta" evt |> to_string_option
+                |> Option.value ~default:""
+              in
+              if String.is_empty delta then []
+              else [ Types.Stream_event.Text_delta delta ]
+          | Some "toolcall_end" ->
+              let tool_call = member "toolCall" evt in
+              let name =
+                member "name" tool_call |> to_string_option
+                |> Option.value ~default:""
+              in
+              let input =
+                match member "arguments" tool_call with
+                | `Null -> ""
+                | v -> Yojson.Safe.to_string v
+              in
+              [ Types.Stream_event.Tool_use { name; input } ]
+          | _ -> [])
+      | Some "agent_end" ->
+          [
+            Types.Stream_event.Final_result
+              { text = ""; stop_reason = Types.Stop_reason.End_turn };
+          ]
+      | _ -> [])
+  | exception Yojson.Json_error _ -> []
+  | exception Yojson.Safe.Util.Type_error _ -> []
+
+let run_streaming ~process_mgr ~clock ~timeout ~cwd ~patch_id ~prompt ~continue
+    ~on_event =
+  let cwd_path = snd cwd in
+  let patch_id_str = Types.Patch_id.to_string patch_id in
+  let args = build_args ~cwd_path ~patch_id:patch_id_str ~prompt ~continue in
+  let process_line line =
+    let trimmed = String.strip line in
+    if String.is_empty trimmed then [] else parse_event trimmed
+  in
+  Llm_backend.spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~args
+    ~process_line ~on_event
+
+let create ~process_mgr ~clock ~timeout : Llm_backend.t =
+  {
+    name = "Pi";
+    run_streaming =
+      (fun ~cwd ~patch_id ~prompt ~continue ~on_event ->
+        run_streaming ~process_mgr ~clock ~timeout ~cwd ~patch_id ~prompt
+          ~continue ~on_event);
+  }
+
+let%test "build_args without continue" =
+  let args =
+    build_args ~cwd_path:"/tmp/work" ~patch_id:"patch-1" ~prompt:"do stuff"
+      ~continue:false
+  in
+  List.equal String.equal args
+    [
+      "pi";
+      "-p";
+      "do stuff";
+      "--mode";
+      "json";
+      "--session-dir";
+      "/tmp/work/.pi-sessions/patch-1";
+    ]
+
+let%test "build_args with continue" =
+  let args =
+    build_args ~cwd_path:"/tmp/work" ~patch_id:"patch-1" ~prompt:"do stuff"
+      ~continue:true
+  in
+  List.equal String.equal args
+    [
+      "pi";
+      "-p";
+      "do stuff";
+      "--mode";
+      "json";
+      "--continue";
+      "--session-dir";
+      "/tmp/work/.pi-sessions/patch-1";
+    ]
+
+let%test "parse_event text_delta" =
+  let line =
+    {|{"type":"message_update","assistantMessageEvent":{"type":"text_delta","delta":"hello"}}|}
+  in
+  List.equal Types.Stream_event.equal (parse_event line)
+    [ Types.Stream_event.Text_delta "hello" ]
+
+let%test "parse_event toolcall_end" =
+  let line =
+    {|{"type":"message_update","assistantMessageEvent":{"type":"toolcall_end","toolCall":{"name":"bash","arguments":{"command":"ls -la"}}}}|}
+  in
+  List.equal Types.Stream_event.equal (parse_event line)
+    [
+      Types.Stream_event.Tool_use
+        { name = "bash"; input = {|{"command":"ls -la"}|} };
+    ]
+
+let%test "parse_event agent_end" =
+  let line = {|{"type":"agent_end","messages":[]}|} in
+  List.equal Types.Stream_event.equal (parse_event line)
+    [
+      Types.Stream_event.Final_result
+        { text = ""; stop_reason = Types.Stop_reason.End_turn };
+    ]
+
+let%test "parse_event session is ignored" =
+  let line =
+    {|{"type":"session","version":3,"id":"abc","timestamp":"2026-01-01T00:00:00Z","cwd":"/tmp"}|}
+  in
+  List.is_empty (parse_event line)
+
+let%test "parse_event message_end stop is ignored" =
+  let line =
+    {|{"type":"message_end","message":{"role":"assistant","content":[],"stopReason":"stop"}}|}
+  in
+  List.is_empty (parse_event line)
+
+let%test "parse_event message_end toolUse is ignored" =
+  let line =
+    {|{"type":"message_end","message":{"role":"assistant","content":[],"stopReason":"toolUse"}}|}
+  in
+  List.is_empty (parse_event line)
+
+let%test "parse_event toolcall_start is ignored" =
+  let line =
+    {|{"type":"message_update","assistantMessageEvent":{"type":"toolcall_start"}}|}
+  in
+  List.is_empty (parse_event line)
+
+let%test "parse_event invalid json" =
+  List.is_empty (parse_event "not json at all")
+
+let%test "parse_event unknown type" =
+  List.is_empty (parse_event {|{"type":"ping"}|})

--- a/lib/pi_backend.mli
+++ b/lib/pi_backend.mli
@@ -1,0 +1,7 @@
+val create :
+  process_mgr:_ Eio.Process.mgr ->
+  clock:_ Eio.Time.clock ->
+  timeout:float ->
+  Llm_backend.t
+(** Create an LLM backend that uses the Pi CLI. [timeout] is the maximum
+    session duration in seconds before the process is killed. *)

--- a/lib/pi_backend.mli
+++ b/lib/pi_backend.mli
@@ -3,8 +3,8 @@ val create :
   clock:_ Eio.Time.clock ->
   timeout:float ->
   Llm_backend.t
-(** Create an LLM backend that uses the Pi CLI. [timeout] is the maximum
-    session duration in seconds before the process is killed. *)
+(** Create an LLM backend that uses the Pi CLI. [timeout] is the maximum session
+    duration in seconds before the process is killed. *)
 
 val parse_event : string -> Types.Stream_event.t list
 (** Parse a single NDJSON line from Pi's JSON output. Exposed for testing. *)

--- a/lib/pi_backend.mli
+++ b/lib/pi_backend.mli
@@ -5,3 +5,6 @@ val create :
   Llm_backend.t
 (** Create an LLM backend that uses the Pi CLI. [timeout] is the maximum
     session duration in seconds before the process is killed. *)
+
+val parse_event : string -> Types.Stream_event.t list
+(** Parse a single NDJSON line from Pi's JSON output. Exposed for testing. *)

--- a/test/dune
+++ b/test/dune
@@ -115,3 +115,7 @@
  (libraries onton onton_test_support qcheck-core qcheck-core.runner)
  (ocamlopt_flags (:standard -w -40-42))
  (ocamlc_flags (:standard -w -40-42)))
+
+(test
+ (name test_backend_smoke)
+ (libraries onton eio eio_main))

--- a/test/test_backend_smoke.ml
+++ b/test/test_backend_smoke.ml
@@ -20,18 +20,23 @@ let smoke ~process_mgr ~clock ~cwd ~ndjson ~process_line =
   in
   (result, List.rev !events)
 
+let failures = ref 0
+
 let assert_smoke ~name ~result ~got ~expected =
   let open Llm_backend in
-  if result.exit_code <> 0 then
-    Stdio.printf "FAIL: %s exit_code=%d\n" name result.exit_code
-  else if not result.got_events then
-    Stdio.printf "FAIL: %s got_events=false\n" name
+  if result.exit_code <> 0 then (
+    Stdio.printf "FAIL: %s exit_code=%d\n" name result.exit_code;
+    Int.incr failures)
+  else if not result.got_events then (
+    Stdio.printf "FAIL: %s got_events=false\n" name;
+    Int.incr failures)
   else if not (List.equal Types.Stream_event.equal got expected) then (
     Stdio.printf "FAIL: %s event mismatch\n" name;
     Stdio.printf "  expected: %s\n"
       (List.map expected ~f:Types.Stream_event.show |> String.concat ~sep:"; ");
     Stdio.printf "  got:      %s\n"
-      (List.map got ~f:Types.Stream_event.show |> String.concat ~sep:"; "))
+      (List.map got ~f:Types.Stream_event.show |> String.concat ~sep:"; ");
+    Int.incr failures)
   else Stdio.printf "%s: passed\n" name
 
 let process_line_strip parse line =
@@ -119,4 +124,7 @@ let () =
         Types.Stream_event.Final_result
           { text = ""; stop_reason = Types.Stop_reason.End_turn };
       ];
-  Stdio.printf "all backend smoke tests passed\n"
+  if !failures > 0 then (
+    Stdio.printf "%d backend smoke test(s) failed\n" !failures;
+    Stdlib.exit 1)
+  else Stdio.printf "all backend smoke tests passed\n"

--- a/test/test_backend_smoke.ml
+++ b/test/test_backend_smoke.ml
@@ -1,0 +1,122 @@
+open Base
+open Onton
+
+(** Smoke integration tests for all LLM backends.
+
+    Each test spawns [printf] to emit representative NDJSON on stdout, feeds it
+    through [Llm_backend.spawn_and_stream] with the backend's parser, and
+    asserts the expected [Stream_event.t] list is collected. This exercises the
+    full subprocess → line-reading → parsing → callback pipeline without
+    requiring any LLM CLI to be installed. *)
+
+let smoke ~process_mgr ~clock ~cwd ~ndjson ~process_line =
+  let events = ref [] in
+  let on_event ev = events := ev :: !events in
+  let payload = String.concat ~sep:"\n" ndjson in
+  let args = [ "printf"; "%s"; payload ] in
+  let result =
+    Llm_backend.spawn_and_stream ~process_mgr ~clock ~timeout:60.0 ~cwd ~args
+      ~process_line ~on_event
+  in
+  (result, List.rev !events)
+
+let assert_smoke ~name ~result ~got ~expected =
+  let open Llm_backend in
+  if result.exit_code <> 0 then
+    Stdio.printf "FAIL: %s exit_code=%d\n" name result.exit_code
+  else if not result.got_events then
+    Stdio.printf "FAIL: %s got_events=false\n" name
+  else if not (List.equal Types.Stream_event.equal got expected) then (
+    Stdio.printf "FAIL: %s event mismatch\n" name;
+    Stdio.printf "  expected: %s\n"
+      (List.map expected ~f:Types.Stream_event.show |> String.concat ~sep:"; ");
+    Stdio.printf "  got:      %s\n"
+      (List.map got ~f:Types.Stream_event.show |> String.concat ~sep:"; "))
+  else Stdio.printf "%s: passed\n" name
+
+let process_line_strip parse line =
+  let trimmed = String.strip line in
+  if String.is_empty trimmed then [] else parse trimmed
+
+let process_line_claude line =
+  let trimmed = Claude_runner.strip_ansi (String.strip line) in
+  if String.is_empty trimmed then []
+  else
+    match Claude_runner.parse_stream_event trimmed with
+    | Some ev -> [ ev ]
+    | None -> []
+
+let () =
+  Eio_main.run @@ fun env ->
+  let process_mgr = Eio.Stdenv.process_mgr env in
+  let clock = Eio.Stdenv.clock env in
+  let cwd = Eio.Stdenv.cwd env in
+  (* --- Codex --- *)
+  let result, got =
+    smoke ~process_mgr ~clock ~cwd
+      ~ndjson:
+        [
+          {|{"type":"item.completed","item":{"type":"agent_message","content":[{"type":"output_text","text":"hello"}]}}|};
+          {|{"type":"turn.completed"}|};
+        ]
+      ~process_line:(process_line_strip Codex_backend.parse_event)
+  in
+  assert_smoke ~name:"codex" ~result ~got
+    ~expected:
+      [
+        Types.Stream_event.Text_delta "hello";
+        Types.Stream_event.Final_result
+          { text = ""; stop_reason = Types.Stop_reason.End_turn };
+      ];
+  (* --- Claude --- *)
+  let result, got =
+    smoke ~process_mgr ~clock ~cwd
+      ~ndjson:
+        [
+          {|{"type":"content_block_delta","delta":{"type":"text_delta","text":"hello"}}|};
+          {|{"type":"result","result":"done","stop_reason":"end_turn"}|};
+        ]
+      ~process_line:process_line_claude
+  in
+  assert_smoke ~name:"claude" ~result ~got
+    ~expected:
+      [
+        Types.Stream_event.Text_delta "hello";
+        Types.Stream_event.Final_result
+          { text = "done"; stop_reason = Types.Stop_reason.End_turn };
+      ];
+  (* --- Pi --- *)
+  let result, got =
+    smoke ~process_mgr ~clock ~cwd
+      ~ndjson:
+        [
+          {|{"type":"message_update","assistantMessageEvent":{"type":"text_delta","delta":"hello"}}|};
+          {|{"type":"agent_end","messages":[]}|};
+        ]
+      ~process_line:(process_line_strip Pi_backend.parse_event)
+  in
+  assert_smoke ~name:"pi" ~result ~got
+    ~expected:
+      [
+        Types.Stream_event.Text_delta "hello";
+        Types.Stream_event.Final_result
+          { text = ""; stop_reason = Types.Stop_reason.End_turn };
+      ];
+  (* --- OpenCode --- *)
+  let result, got =
+    smoke ~process_mgr ~clock ~cwd
+      ~ndjson:
+        [
+          {|{"type":"text","part":{"type":"text","text":"hello"}}|};
+          {|{"type":"step_finish","part":{"type":"step-finish","reason":"stop"}}|};
+        ]
+      ~process_line:(process_line_strip Opencode_backend.parse_event)
+  in
+  assert_smoke ~name:"opencode" ~result ~got
+    ~expected:
+      [
+        Types.Stream_event.Text_delta "hello";
+        Types.Stream_event.Final_result
+          { text = ""; stop_reason = Types.Stop_reason.End_turn };
+      ];
+  Stdio.printf "all backend smoke tests passed\n"


### PR DESCRIPTION
## Summary
- Adds `Pi_backend` module for the Pi CLI (`pi -p --mode json`), following the Codex backend pattern — NDJSON event parser, session-dir-per-patch isolation, inline tests
- Extracts `known_backends` list in `main.ml` so validation and error messages auto-update when adding new backends
- Wires Pi into backend selection (`--backend=pi`)

## Test plan
- [x] `dune build` passes
- [x] `dune runtest` passes (10 new inline tests for arg building + event parsing)
- [ ] Manual: `onton --backend=pi` runs Pi agent against a real gameplan

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Pi and OpenCode LLM backends with streaming, tool-use handling, and session-aware behavior.
* **Bug Fixes**
  * Improved unsupported-backend error to list all known backends for clearer guidance.
* **Tests**
  * Added unit tests for backend parsing/argument handling and a new end-to-end smoke test covering multiple backends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->