### PR TITLE
Fetch origin before rebase to fix stale-ref conflict loop

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -2052,12 +2052,26 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry
                                 "runner: push up-to-date after rebase (noop)"
                           | Worktree.Push_rejected ->
                               log_event runtime ~patch_id
-                                "runner: force-push rejected (lease), will \
-                                 retry via merge-conflict"
+                                "runner: force-push rejected (lease), \
+                                 enqueuing merge-conflict for retry";
+                              Runtime.update_orchestrator runtime (fun orch ->
+                                  let orch =
+                                    Orchestrator.set_has_conflict orch patch_id
+                                  in
+                                  Orchestrator.enqueue orch patch_id
+                                    Operation_kind.Merge_conflict)
                           | Worktree.Push_error msg ->
                               log_event runtime ~patch_id
-                                (Printf.sprintf "runner: force-push error: %s"
-                                   msg));
+                                (Printf.sprintf
+                                   "runner: force-push error: %s, enqueuing \
+                                    merge-conflict for retry"
+                                   msg);
+                              Runtime.update_orchestrator runtime (fun orch ->
+                                  let orch =
+                                    Orchestrator.set_has_conflict orch patch_id
+                                  in
+                                  Orchestrator.enqueue orch patch_id
+                                    Operation_kind.Merge_conflict));
                       Event_log.log_rebase event_log ~patch_id
                         ~result:rebase_result ~agent_before ~agent_after))
           | Orchestrator.Respond (patch_id, kind) ->

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -2038,40 +2038,45 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry
                             in
                             (orch, (agent_before, (agent_after, effects))))
                       in
-                      Base.List.iter effects ~f:(fun Orchestrator.Push_branch ->
-                          let branch = agent.Patch_agent.branch in
-                          match
-                            Worktree.force_push_with_lease ~process_mgr
-                              ~path:wt_path ~branch
-                          with
-                          | Worktree.Push_ok ->
-                              log_event runtime ~patch_id
-                                "runner: force-pushed after rebase"
-                          | Worktree.Push_up_to_date ->
-                              log_event runtime ~patch_id
-                                "runner: push up-to-date after rebase (noop)"
-                          | Worktree.Push_rejected ->
-                              log_event runtime ~patch_id
-                                "runner: force-push rejected (lease), \
-                                 enqueuing merge-conflict for retry";
-                              Runtime.update_orchestrator runtime (fun orch ->
-                                  let orch =
-                                    Orchestrator.set_has_conflict orch patch_id
-                                  in
-                                  Orchestrator.enqueue orch patch_id
-                                    Operation_kind.Merge_conflict)
-                          | Worktree.Push_error msg ->
-                              log_event runtime ~patch_id
-                                (Printf.sprintf
-                                   "runner: force-push error: %s, enqueuing \
-                                    merge-conflict for retry"
-                                   msg);
-                              Runtime.update_orchestrator runtime (fun orch ->
-                                  let orch =
-                                    Orchestrator.set_has_conflict orch patch_id
-                                  in
-                                  Orchestrator.enqueue orch patch_id
-                                    Operation_kind.Merge_conflict));
+                      let push_outcome =
+                        Base.List.find_map effects
+                          ~f:(fun Orchestrator.Push_branch ->
+                            let branch = agent.Patch_agent.branch in
+                            let result =
+                              Worktree.force_push_with_lease ~process_mgr
+                                ~path:wt_path ~branch
+                            in
+                            (match result with
+                            | Worktree.Push_ok ->
+                                log_event runtime ~patch_id
+                                  "runner: force-pushed after rebase"
+                            | Worktree.Push_up_to_date ->
+                                log_event runtime ~patch_id
+                                  "runner: push up-to-date after rebase (noop)"
+                            | Worktree.Push_rejected ->
+                                log_event runtime ~patch_id
+                                  "runner: force-push rejected (lease)"
+                            | Worktree.Push_error msg ->
+                                log_event runtime ~patch_id
+                                  (Printf.sprintf "runner: force-push error: %s"
+                                     msg));
+                            Some result)
+                      in
+                      let resolution =
+                        Runtime.update_orchestrator_returning runtime
+                          (fun orch ->
+                            let orch, resolution =
+                              Orchestrator.apply_rebase_push_result orch
+                                patch_id push_outcome
+                            in
+                            (orch, resolution))
+                      in
+                      (match resolution with
+                      | Orchestrator.Rebase_push_ok -> ()
+                      | Orchestrator.Rebase_push_failed ->
+                          log_event runtime ~patch_id
+                            "runner: enqueuing merge-conflict after rebase \
+                             push failure");
                       Event_log.log_rebase event_log ~patch_id
                         ~result:rebase_result ~agent_before ~agent_after))
           | Orchestrator.Respond (patch_id, kind) ->

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1992,22 +1992,27 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry
                         | Some p -> p
                         | None -> Worktree.worktree_dir ~project_name ~patch_id
                       in
-                      (* Fetch fresh remote refs before rebasing. *)
-                      (match
-                         Worktree.fetch_origin ~process_mgr ~path:wt_path
-                       with
-                      | Result.Ok () -> ()
-                      | Result.Error msg ->
-                          log_event runtime ~patch_id
-                            (Printf.sprintf "runner: fetch warning: %s" msg));
-                      let remote_target =
-                        Types.Branch.of_string
-                          (Printf.sprintf "origin/%s"
-                             (Branch.to_string new_base))
-                      in
+                      (* Fetch fresh remote refs before rebasing.
+                         Fail closed: if fetch fails, don't rebase against
+                         stale refs. *)
                       let rebase_result =
-                        Worktree.rebase_onto ~process_mgr ~path:wt_path
-                          ~target:remote_target
+                        match
+                          Worktree.fetch_origin ~process_mgr ~path:wt_path
+                        with
+                        | Result.Ok () ->
+                            let remote_target =
+                              Types.Branch.of_string
+                                (Printf.sprintf "origin/%s"
+                                   (Branch.to_string new_base))
+                            in
+                            Worktree.rebase_onto ~process_mgr ~path:wt_path
+                              ~target:remote_target
+                        | Result.Error msg ->
+                            log_event runtime ~patch_id
+                              (Printf.sprintf "runner: fetch error: %s" msg);
+                            Worktree.Error
+                              (Printf.sprintf "fetch before rebase failed: %s"
+                                 msg)
                       in
                       (match rebase_result with
                       | Worktree.Ok ->
@@ -2076,7 +2081,10 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry
                       | Orchestrator.Rebase_push_failed ->
                           log_event runtime ~patch_id
                             "runner: enqueuing merge-conflict after rebase \
-                             push failure");
+                             push rejection"
+                      | Orchestrator.Rebase_push_error ->
+                          log_event runtime ~patch_id
+                            "runner: enqueuing rebase retry after push error");
                       Event_log.log_rebase event_log ~patch_id
                         ~result:rebase_result ~agent_before ~agent_after))
           | Orchestrator.Respond (patch_id, kind) ->
@@ -2166,7 +2174,7 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry
                               else if
                                 Operation_kind.equal kind
                                   Operation_kind.Merge_conflict
-                              then
+                              then (
                                 let wt_path =
                                   match agent.Patch_agent.worktree_path with
                                   | Some p -> p
@@ -2208,27 +2216,33 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry
                                     "delivering merge-conflict (rebase already \
                                      in progress)";
                                   deliver_to_agent ())
-                                else (
+                                else
                                   (* Fetch fresh remote refs so rebase_onto
                                      sees the latest origin/<base>, not a
-                                     stale local tracking ref. *)
-                                  (match
-                                     Worktree.fetch_origin ~process_mgr
-                                       ~path:wt_path
-                                   with
-                                  | Result.Ok () -> ()
-                                  | Result.Error msg ->
-                                      log_event runtime ~patch_id
-                                        (Printf.sprintf
-                                           "merge-conflict: fetch warning: %s"
-                                           msg));
-                                  let target =
-                                    Types.Branch.of_string
-                                      (Printf.sprintf "origin/%s" base)
-                                  in
+                                     stale local tracking ref. Fail closed:
+                                     if fetch fails, don't rebase against
+                                     stale refs. *)
                                   let rebase_result =
-                                    Worktree.rebase_onto ~process_mgr
-                                      ~path:wt_path ~target
+                                    match
+                                      Worktree.fetch_origin ~process_mgr
+                                        ~path:wt_path
+                                    with
+                                    | Result.Ok () ->
+                                        let target =
+                                          Types.Branch.of_string
+                                            (Printf.sprintf "origin/%s" base)
+                                        in
+                                        Worktree.rebase_onto ~process_mgr
+                                          ~path:wt_path ~target
+                                    | Result.Error msg ->
+                                        log_event runtime ~patch_id
+                                          (Printf.sprintf
+                                             "merge-conflict: fetch error: %s"
+                                             msg);
+                                        Worktree.Error
+                                          (Printf.sprintf
+                                             "fetch before rebase failed: %s"
+                                             msg)
                                   in
                                   (match rebase_result with
                                   | Worktree.Ok ->

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1992,9 +1992,22 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry
                         | Some p -> p
                         | None -> Worktree.worktree_dir ~project_name ~patch_id
                       in
+                      (* Fetch fresh remote refs before rebasing. *)
+                      (match
+                         Worktree.fetch_origin ~process_mgr ~path:wt_path
+                       with
+                      | Result.Ok () -> ()
+                      | Result.Error msg ->
+                          log_event runtime ~patch_id
+                            (Printf.sprintf "runner: fetch warning: %s" msg));
+                      let remote_target =
+                        Types.Branch.of_string
+                          (Printf.sprintf "origin/%s"
+                             (Branch.to_string new_base))
+                      in
                       let rebase_result =
                         Worktree.rebase_onto ~process_mgr ~path:wt_path
-                          ~target:new_base
+                          ~target:remote_target
                       in
                       (match rebase_result with
                       | Worktree.Ok ->
@@ -2134,7 +2147,7 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry
                               else if
                                 Operation_kind.equal kind
                                   Operation_kind.Merge_conflict
-                              then (
+                              then
                                 (* Before delivering a merge-conflict prompt,
                                    ensure a rebase is actually in progress.
                                    The poller path enqueues Merge_conflict
@@ -2171,8 +2184,24 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry
                                     ~repo:config.github_repo ~on_pr_detected
                                     ~transcripts ~user_config:config.user_config
                                     ~worktree_mutex ~backend ~event_log)
-                                else
-                                  let target = Types.Branch.of_string base in
+                                else (
+                                  (* Fetch fresh remote refs so rebase_onto
+                                     sees the latest origin/<base>, not a
+                                     stale local tracking ref. *)
+                                  (match
+                                     Worktree.fetch_origin ~process_mgr
+                                       ~path:wt_path
+                                   with
+                                  | Result.Ok () -> ()
+                                  | Result.Error msg ->
+                                      log_event runtime ~patch_id
+                                        (Printf.sprintf
+                                           "merge-conflict: fetch warning: %s"
+                                           msg));
+                                  let target =
+                                    Types.Branch.of_string
+                                      (Printf.sprintf "origin/%s" base)
+                                  in
                                   let rebase_result =
                                     Worktree.rebase_onto ~process_mgr
                                       ~path:wt_path ~target

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -2148,14 +2148,6 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry
                                 Operation_kind.equal kind
                                   Operation_kind.Merge_conflict
                               then
-                                (* Before delivering a merge-conflict prompt,
-                                   ensure a rebase is actually in progress.
-                                   The poller path enqueues Merge_conflict
-                                   when GitHub reports conflicts, but never
-                                   starts a rebase — so the agent would find
-                                   no rebase state. Attempt the rebase here;
-                                   if it succeeds the conflict is resolved
-                                   without bothering the agent. *)
                                 let wt_path =
                                   match agent.Patch_agent.worktree_path with
                                   | Some p -> p
@@ -2163,18 +2155,22 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry
                                       Worktree.worktree_dir ~project_name
                                         ~patch_id
                                 in
-                                if
-                                  Worktree.rebase_in_progress ~process_mgr
-                                    ~path:wt_path
-                                then (
-                                  log_event runtime ~patch_id
-                                    "delivering merge-conflict (rebase already \
-                                     in progress)";
+                                (* Helper: capture git context and deliver
+                                   an enriched prompt to the agent. *)
+                                let deliver_to_agent () =
                                   let pr_number = agent.Patch_agent.pr_number in
+                                  let git_status =
+                                    Worktree.git_status ~process_mgr
+                                      ~path:wt_path
+                                  in
+                                  let git_diff =
+                                    Worktree.conflict_diff ~process_mgr
+                                      ~path:wt_path
+                                  in
                                   let prompt =
                                     Prompt.render_merge_conflict_prompt
                                       ~project_name ?pr_number ~base_branch:base
-                                      ()
+                                      ~git_status ~git_diff ()
                                   in
                                   let on_pr_detected _pr_number = () in
                                   run_claude_and_handle ~runtime ~process_mgr
@@ -2183,7 +2179,16 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry
                                     ~owner:config.github_owner
                                     ~repo:config.github_repo ~on_pr_detected
                                     ~transcripts ~user_config:config.user_config
-                                    ~worktree_mutex ~backend ~event_log)
+                                    ~worktree_mutex ~backend ~event_log
+                                in
+                                if
+                                  Worktree.rebase_in_progress ~process_mgr
+                                    ~path:wt_path
+                                then (
+                                  log_event runtime ~patch_id
+                                    "delivering merge-conflict (rebase already \
+                                     in progress)";
+                                  deliver_to_agent ())
                                 else (
                                   (* Fetch fresh remote refs so rebase_onto
                                      sees the latest origin/<base>, not a
@@ -2253,8 +2258,6 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry
                                   Event_log.log_conflict_rebase event_log
                                     ~patch_id ~decision ~agent_before
                                     ~agent_after;
-                                  (* Execute push effects and capture
-                                     the push outcome. *)
                                   let push_outcome =
                                     Base.List.find_map effects
                                       ~f:(fun Orchestrator.Push_branch ->
@@ -2302,23 +2305,7 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry
                                          push failure";
                                       `Retry_push
                                   | Orchestrator.Conflict_needs_agent ->
-                                      let pr_number =
-                                        agent.Patch_agent.pr_number
-                                      in
-                                      let prompt =
-                                        Prompt.render_merge_conflict_prompt
-                                          ~project_name ?pr_number
-                                          ~base_branch:base ()
-                                      in
-                                      let on_pr_detected _pr_number = () in
-                                      run_claude_and_handle ~runtime
-                                        ~process_mgr ~fs ~project_name ~patch_id
-                                        ~repo_root:config.repo_root ~prompt
-                                        ~agent ~owner:config.github_owner
-                                        ~repo:config.github_repo ~on_pr_detected
-                                        ~transcripts
-                                        ~user_config:config.user_config
-                                        ~worktree_mutex ~backend ~event_log
+                                      deliver_to_agent ()
                                   | Orchestrator.Conflict_give_up -> `Failed)
                               else
                                 let pr_number = agent.Patch_agent.pr_number in

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -343,6 +343,9 @@ let set_implementation_notes_delivered t patch_id v =
   update_agent t patch_id ~f:(fun a ->
       Patch_agent.set_implementation_notes_delivered a v)
 
+let increment_conflict_noop_count t patch_id =
+  update_agent t patch_id ~f:Patch_agent.increment_conflict_noop_count
+
 let increment_start_attempts_without_pr t patch_id =
   update_agent t patch_id ~f:Patch_agent.increment_start_attempts_without_pr
 
@@ -421,6 +424,7 @@ let apply_conflict_rebase_result t patch_id rebase_result new_base =
   | Worktree.Noop ->
       let t = set_base_branch t patch_id new_base in
       let t = set_has_conflict t patch_id in
+      let t = increment_conflict_noop_count t patch_id in
       (t, Deliver_to_agent, [ Push_branch ])
   | Worktree.Conflict ->
       let t = set_base_branch t patch_id new_base in

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -410,6 +410,18 @@ let apply_rebase_result t patch_id rebase_result new_base =
       let t = set_tried_fresh t patch_id in
       (complete t patch_id, [])
 
+type rebase_push_resolution = Rebase_push_ok | Rebase_push_failed
+[@@deriving show, eq, sexp_of]
+
+let apply_rebase_push_result t patch_id
+    (push_outcome : Worktree.push_result option) =
+  match push_outcome with
+  | Some Worktree.Push_ok | Some Worktree.Push_up_to_date -> (t, Rebase_push_ok)
+  | None | Some (Worktree.Push_rejected | Worktree.Push_error _) ->
+      let t = set_has_conflict t patch_id in
+      let t = enqueue t patch_id Operation_kind.Merge_conflict in
+      (t, Rebase_push_failed)
+
 type conflict_rebase_decision =
   | Conflict_resolved
   | Deliver_to_agent

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -397,7 +397,9 @@ let apply_rebase_result t patch_id rebase_result new_base =
       (complete t patch_id, [ Push_branch ])
   | Worktree.Noop ->
       let t = set_base_branch t patch_id new_base in
-      (complete t patch_id, [])
+      (* Push even on Noop: the local branch may already be rebased from a
+         prior attempt whose push failed, leaving the remote stale. *)
+      (complete t patch_id, [ Push_branch ])
   | Worktree.Conflict ->
       let t = set_base_branch t patch_id new_base in
       let t = set_has_conflict t patch_id in

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -419,9 +419,9 @@ type rebase_push_resolution =
 let apply_rebase_push_result t patch_id
     (push_outcome : Worktree.push_result option) =
   match push_outcome with
+  | None -> (t, Rebase_push_ok) (* no push effect emitted; already handled *)
   | Some Worktree.Push_ok | Some Worktree.Push_up_to_date -> (t, Rebase_push_ok)
-  | None | Some Worktree.Push_rejected ->
-      let t = clear_has_conflict t patch_id in
+  | Some Worktree.Push_rejected ->
       let t = set_has_conflict t patch_id in
       let t = enqueue t patch_id Operation_kind.Merge_conflict in
       (t, Rebase_push_failed)

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -410,17 +410,24 @@ let apply_rebase_result t patch_id rebase_result new_base =
       let t = set_tried_fresh t patch_id in
       (complete t patch_id, [])
 
-type rebase_push_resolution = Rebase_push_ok | Rebase_push_failed
+type rebase_push_resolution =
+  | Rebase_push_ok
+  | Rebase_push_failed
+  | Rebase_push_error
 [@@deriving show, eq, sexp_of]
 
 let apply_rebase_push_result t patch_id
     (push_outcome : Worktree.push_result option) =
   match push_outcome with
   | Some Worktree.Push_ok | Some Worktree.Push_up_to_date -> (t, Rebase_push_ok)
-  | None | Some (Worktree.Push_rejected | Worktree.Push_error _) ->
+  | None | Some Worktree.Push_rejected ->
+      let t = clear_has_conflict t patch_id in
       let t = set_has_conflict t patch_id in
       let t = enqueue t patch_id Operation_kind.Merge_conflict in
       (t, Rebase_push_failed)
+  | Some (Worktree.Push_error _) ->
+      let t = enqueue t patch_id Operation_kind.Rebase in
+      (t, Rebase_push_error)
 
 type conflict_rebase_decision =
   | Conflict_resolved
@@ -463,6 +470,7 @@ let apply_conflict_push_result t patch_id decision
   | Conflict_resolved, Some Worktree.Push_up_to_date -> (t, Conflict_done)
   | ( Conflict_resolved,
       (None | Some (Worktree.Push_rejected | Worktree.Push_error _)) ) ->
+      let t = clear_has_conflict t patch_id in
       let t = set_has_conflict t patch_id in
       let t = enqueue t patch_id Operation_kind.Merge_conflict in
       (t, Conflict_retry_push)

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -153,7 +153,10 @@ val apply_rebase_result :
     set_has_conflict + enqueue Merge_conflict + complete. [Error _] ->
     set_session_failed + set_tried_fresh + complete. *)
 
-type rebase_push_resolution = Rebase_push_ok | Rebase_push_failed
+type rebase_push_resolution =
+  | Rebase_push_ok
+  | Rebase_push_failed
+  | Rebase_push_error
 [@@deriving show, eq, sexp_of]
 
 val apply_rebase_push_result :
@@ -163,8 +166,10 @@ val apply_rebase_push_result :
     updated state and resolution.
 
     - [Rebase_push_ok]: push succeeded or was up-to-date; no further action.
-    - [Rebase_push_failed]: push was rejected or errored; sets [has_conflict]
-      and enqueues [Merge_conflict] so the next poll cycle retries. *)
+    - [Rebase_push_failed]: push was rejected (lease failure); resets conflict
+      state and enqueues [Merge_conflict] so the next poll cycle retries.
+    - [Rebase_push_error]: infrastructure error; enqueues [Rebase] to retry
+      without entering the conflict path. *)
 
 type conflict_rebase_decision =
   | Conflict_resolved

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -153,6 +153,19 @@ val apply_rebase_result :
     set_has_conflict + enqueue Merge_conflict + complete. [Error _] ->
     set_session_failed + set_tried_fresh + complete. *)
 
+type rebase_push_resolution = Rebase_push_ok | Rebase_push_failed
+[@@deriving show, eq, sexp_of]
+
+val apply_rebase_push_result :
+  t -> Patch_id.t -> Worktree.push_result option -> t * rebase_push_resolution
+(** Pure second stage of rebase handling. Takes the push outcome from executing
+    the [Push_branch] effect ([None] when no push was requested). Returns the
+    updated state and resolution.
+
+    - [Rebase_push_ok]: push succeeded or was up-to-date; no further action.
+    - [Rebase_push_failed]: push was rejected or errored; sets [has_conflict]
+      and enqueues [Merge_conflict] so the next poll cycle retries. *)
+
 type conflict_rebase_decision =
   | Conflict_resolved
   | Deliver_to_agent

--- a/lib/patch_agent.ml
+++ b/lib/patch_agent.ml
@@ -26,6 +26,7 @@ type t = {
   pr_description_applied : bool;
   implementation_notes_delivered : bool;
   start_attempts_without_pr : int;
+  conflict_noop_count : int;
   checks_passing : bool;
   current_op : Operation_kind.t option;
   current_message_id : Message_id.t option;
@@ -44,7 +45,8 @@ let needs_intervention t =
   (not (List.mem t.queue Operation_kind.Human ~equal:Operation_kind.equal))
   && (t.ci_failure_count >= 3
      || equal_session_fallback t.session_fallback Given_up
-     || ((not (has_pr t)) && t.start_attempts_without_pr >= 2))
+     || ((not (has_pr t)) && t.start_attempts_without_pr >= 2)
+     || t.conflict_noop_count >= 2)
 
 let create ~branch patch_id =
   {
@@ -68,6 +70,7 @@ let create ~branch patch_id =
     pr_description_applied = false;
     implementation_notes_delivered = false;
     start_attempts_without_pr = 0;
+    conflict_noop_count = 0;
     checks_passing = false;
     current_op = None;
     current_message_id = None;
@@ -99,6 +102,7 @@ let create_adhoc ~patch_id ~branch ~pr_number =
     pr_description_applied = true;
     implementation_notes_delivered = true;
     start_attempts_without_pr = 0;
+    conflict_noop_count = 0;
     checks_passing = false;
     current_op = None;
     current_message_id = None;
@@ -149,7 +153,13 @@ let on_session_failure t ~is_fresh =
     if is_fresh then set_tried_fresh t else t
 
 let set_has_conflict t = { t with has_conflict = true }
-let clear_has_conflict t = { t with has_conflict = false }
+
+let clear_has_conflict t =
+  { t with has_conflict = false; conflict_noop_count = 0 }
+
+let increment_conflict_noop_count t =
+  { t with conflict_noop_count = t.conflict_noop_count + 1 }
+
 let set_base_branch t branch = { t with base_branch = Some branch }
 let set_merge_ready t v = { t with merge_ready = v }
 let set_is_draft t v = { t with is_draft = v }
@@ -197,6 +207,7 @@ let reset_intervention_state t =
     session_fallback = Fresh_available;
     ci_failure_count = 0;
     start_attempts_without_pr = 0;
+    conflict_noop_count = 0;
   }
 
 let reset_busy t = if not t.busy then t else { t with busy = false }
@@ -205,8 +216,9 @@ let restore ~patch_id ~branch ~pr_number ~has_session ~busy ~merged ~queue
     ~satisfies ~changed ~has_conflict ~base_branch ~ci_failure_count
     ~session_fallback ~human_messages ~ci_checks ~merge_ready ~is_draft
     ~pr_description_applied ~implementation_notes_delivered
-    ~start_attempts_without_pr ~checks_passing ~current_op ~current_message_id
-    ~generation ~worktree_path ~head_branch ~branch_blocked =
+    ~start_attempts_without_pr ~conflict_noop_count ~checks_passing ~current_op
+    ~current_message_id ~generation ~worktree_path ~head_branch ~branch_blocked
+    =
   {
     patch_id;
     branch;
@@ -228,6 +240,7 @@ let restore ~patch_id ~branch ~pr_number ~has_session ~busy ~merged ~queue
     pr_description_applied;
     implementation_notes_delivered;
     start_attempts_without_pr;
+    conflict_noop_count;
     checks_passing;
     current_op;
     current_message_id;

--- a/lib/patch_agent.mli
+++ b/lib/patch_agent.mli
@@ -30,6 +30,7 @@ type t = private {
   pr_description_applied : bool;
   implementation_notes_delivered : bool;
   start_attempts_without_pr : int;
+  conflict_noop_count : int;
   checks_passing : bool;
   current_op : Types.Operation_kind.t option;
   current_message_id : Types.Message_id.t option;
@@ -60,8 +61,9 @@ val has_pr : t -> bool
 
 val needs_intervention : t -> bool
 (** Derived predicate: true when [Human] is not in [queue] and any of:
-    [ci_failure_count >= 3], [session_fallback = Given_up], or
-    [(not has_pr) && start_attempts_without_pr >= 2]. *)
+    [ci_failure_count >= 3], [session_fallback = Given_up],
+    [(not has_pr) && start_attempts_without_pr >= 2], or
+    [conflict_noop_count >= 2]. *)
 
 (** {2 Spec actions} *)
 
@@ -156,6 +158,10 @@ val set_implementation_notes_delivered : t -> bool -> t
 val increment_start_attempts_without_pr : t -> t
 (** Record a successful Start run that still failed to discover a PR. *)
 
+val increment_conflict_noop_count : t -> t
+(** Record a conflict resolution attempt where rebase returned Noop (stale refs
+    or no real diff). After 2 noop attempts, [needs_intervention] triggers. *)
+
 val set_checks_passing : t -> bool -> t
 (** Set the checks_passing flag from GitHub CI status. *)
 
@@ -245,6 +251,7 @@ val restore :
   pr_description_applied:bool ->
   implementation_notes_delivered:bool ->
   start_attempts_without_pr:int ->
+  conflict_noop_count:int ->
   checks_passing:bool ->
   current_op:Types.Operation_kind.t option ->
   current_message_id:Types.Message_id.t option ->

--- a/lib/persistence.ml
+++ b/lib/persistence.ml
@@ -62,6 +62,7 @@ let patch_agent_to_yojson (a : Patch_agent.t) =
       ("pr_description_applied", `Bool a.pr_description_applied);
       ("implementation_notes_delivered", `Bool a.implementation_notes_delivered);
       ("start_attempts_without_pr", `Int a.start_attempts_without_pr);
+      ("conflict_noop_count", `Int a.conflict_noop_count);
       ("checks_passing", `Bool a.checks_passing);
       ( "current_op",
         match a.current_op with
@@ -138,6 +139,8 @@ let patch_agent_of_yojson ~gameplan json =
        ~implementation_notes_delivered:
          (bool_member "implementation_notes_delivered" json)
        ~start_attempts_without_pr:(int_member "start_attempts_without_pr" json)
+       ~conflict_noop_count:
+         (Option.value (int_member_opt "conflict_noop_count" json) ~default:0)
        ~checks_passing:(bool_member "checks_passing" json)
        ~current_op:
          (match Yojson.Safe.Util.member "current_op" json with

--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -483,11 +483,31 @@ let render_ci_failure_unknown_prompt ~(project_name : string) ?pr_number () =
         pr_ctx)
 
 let render_merge_conflict_prompt ~(project_name : string) ?pr_number
-    ~(base_branch : string) () =
+    ~(base_branch : string) ?(git_status = "") ?(git_diff = "") () =
   let pr_ctx =
     match pr_number with
     | Some n -> Printf.sprintf "\n\nPR: #%d\n" (Pr_number.to_int n)
     | None -> ""
+  in
+  let status_section =
+    if String.is_empty git_status then ""
+    else Printf.sprintf {|
+
+## Current rebase state
+
+```
+%s
+```|} git_status
+  in
+  let diff_section =
+    if String.is_empty git_diff then ""
+    else Printf.sprintf {|
+
+## Conflict markers
+
+```diff
+%s
+```|} git_diff
   in
   let vars =
     [
@@ -497,6 +517,8 @@ let render_merge_conflict_prompt ~(project_name : string) ?pr_number
         match pr_number with
         | Some n -> Int.to_string (Pr_number.to_int n)
         | None -> "" );
+      ("git_status", git_status);
+      ("git_diff", git_diff);
     ]
   in
   render_with_override ~project_name ~name:"merge_conflict" ~vars
@@ -517,8 +539,8 @@ If the rebase continues and hits further conflicts, repeat the process.
 
 Do NOT run `git rebase origin/%s` — the rebase is already set up with the
 correct --onto range. Starting a new rebase would re-introduce dependency
-commits that have already been stripped.|}
-        pr_ctx base_branch base_branch)
+commits that have already been stripped.%s%s|}
+        pr_ctx base_branch base_branch status_section diff_section)
 
 let render_human_message_prompt ~(project_name : string)
     (messages : string list) =

--- a/lib/prompt.mli
+++ b/lib/prompt.mli
@@ -53,6 +53,8 @@ val render_merge_conflict_prompt :
   project_name:string ->
   ?pr_number:Pr_number.t ->
   base_branch:string ->
+  ?git_status:string ->
+  ?git_diff:string ->
   unit ->
   string
 

--- a/lib/worktree.ml
+++ b/lib/worktree.ml
@@ -401,6 +401,16 @@ let find_old_base ~process_mgr ~path ~target =
                (String.strip stderr))
         else Result.Ok (String.strip stdout)
 
+let fetch_origin ~process_mgr ~path =
+  let code, _stdout, stderr =
+    run_git_exit_code ~process_mgr [ "git"; "-C"; path; "fetch"; "origin" ]
+  in
+  if code <> 0 then
+    Result.Error
+      (Printf.sprintf "git fetch origin failed (exit %d): %s" code
+         (String.strip stderr))
+  else Result.Ok ()
+
 let rebase_onto ~process_mgr ~path ~target =
   let target = Types.Branch.to_string target in
   let ancestor_code, _, ancestor_stderr =

--- a/lib/worktree.ml
+++ b/lib/worktree.ml
@@ -411,6 +411,23 @@ let fetch_origin ~process_mgr ~path =
          (String.strip stderr))
   else Result.Ok ()
 
+let git_status ~process_mgr ~path =
+  let code, stdout, _ =
+    run_git_exit_code ~process_mgr [ "git"; "-C"; path; "status" ]
+  in
+  if code <> 0 then "" else String.strip stdout
+
+let conflict_diff ~process_mgr ~path =
+  let code, stdout, _ =
+    run_git_exit_code ~process_mgr
+      [ "git"; "-C"; path; "diff"; "--diff-filter=U" ]
+  in
+  if code <> 0 then ""
+  else
+    let s = String.strip stdout in
+    (* Truncate to avoid blowing up the prompt *)
+    if String.length s > 4000 then String.prefix s 4000 ^ "\n[truncated]" else s
+
 let rebase_onto ~process_mgr ~path ~target =
   let target = Types.Branch.to_string target in
   let ancestor_code, _, ancestor_stderr =

--- a/lib/worktree.mli
+++ b/lib/worktree.mli
@@ -54,6 +54,15 @@ val oldest_unique_commit : string -> (string, string) Result.t
     [git rev-list --cherry-pick --right-only] output (newest-first). Returns
     [Error] when the output is empty (all commits already in target). *)
 
+val git_status : process_mgr:_ Eio.Process.mgr -> path:string -> string
+(** Run [git status] in the worktree and return its output. Returns empty string
+    on failure. *)
+
+val conflict_diff : process_mgr:_ Eio.Process.mgr -> path:string -> string
+(** Run [git diff --diff-filter=U] to show conflict markers for unmerged files.
+    Returns empty string if no conflicts or on failure. Truncates at 4000 chars.
+*)
+
 val fetch_origin :
   process_mgr:_ Eio.Process.mgr -> path:string -> (unit, string) Result.t
 (** Run [git fetch origin] in the worktree at [path] to update remote tracking

--- a/lib/worktree.mli
+++ b/lib/worktree.mli
@@ -54,6 +54,11 @@ val oldest_unique_commit : string -> (string, string) Result.t
     [git rev-list --cherry-pick --right-only] output (newest-first). Returns
     [Error] when the output is empty (all commits already in target). *)
 
+val fetch_origin :
+  process_mgr:_ Eio.Process.mgr -> path:string -> (unit, string) Result.t
+(** Run [git fetch origin] in the worktree at [path] to update remote tracking
+    refs. Returns [Ok ()] on success, [Error msg] on failure. *)
+
 type rebase_result = Ok | Noop | Conflict | Error of string
 [@@deriving show, eq, sexp_of, compare]
 

--- a/test/test_interleaving_properties.ml
+++ b/test/test_interleaving_properties.ml
@@ -375,14 +375,10 @@ let rec apply_command orch patches cmd =
         in
         match decision with
         | Orchestrator.Deliver_to_agent ->
-            (* Agent stays busy; simulate successful session + complete.
-               Mirror the runner: clear_has_conflict before complete. *)
-            let orch' =
-              Orchestrator.apply_session_result orch' pid
-                Orchestrator.Session_ok
-            in
-            let orch' = Orchestrator.clear_has_conflict orch' pid in
-            Orchestrator.complete orch' pid
+            (* Don't auto-resolve — leave the agent busy so subsequent random
+               Apply_session_result commands drive the outcome, just like real
+               execution. The agent may or may not clear has_conflict. *)
+            orch'
         | Orchestrator.Conflict_resolved | Orchestrator.Conflict_failed -> orch'
       with Invalid_argument _ -> orch)
 
@@ -840,3 +836,80 @@ let () =
   in
   QCheck2.Test.check_exn prop_pi5;
   Stdlib.print_endline "PI-5 passed"
+
+(** Helper: create a single-patch orchestrator with a PR, idle. Returns (orch,
+    patch_id). *)
+let mk_bootstrapped () =
+  let patches = mk_patches 1 in
+  let orch = bootstrap patches in
+  let pid = pid_of_idx patches 0 in
+  (orch, pid, patches)
+
+(** Simulate one full conflict-noop cycle: poll(conflict) → fire
+    Respond(Merge_conflict) → apply_conflict_rebase_result(Noop) →
+    apply_conflict_push_result(Push_up_to_date) → session completes → complete.
+    Returns the updated orchestrator. *)
+let conflict_noop_cycle orch pid patches =
+  let branch_of = branch_of_patches patches in
+  let gameplan = make_gameplan patches in
+  (* 1. Poll: conflict detected *)
+  let poll_result =
+    make_poll_result ~has_conflict:true ~merged:false ~ci_failed:false
+      ~checks_passing:false ~review_comments:false
+  in
+  let observation =
+    Patch_controller.
+      {
+        poll_result;
+        head_branch = Some (branch_of pid);
+        base_branch = None;
+        branch_in_root = false;
+        worktree_path = None;
+      }
+  in
+  let orch, _logs, _blocked =
+    Patch_controller.apply_poll_result orch pid observation
+  in
+  (* 2. Reconcile + fire to make agent busy with Merge_conflict *)
+  let orch, _effects, _actions =
+    Patch_controller.tick orch ~project_name:"test-project" ~gameplan
+  in
+  (* 3. Apply Noop rebase result *)
+  let has_merged dep_pid =
+    (Orchestrator.agent orch dep_pid).Patch_agent.merged
+  in
+  let new_base =
+    Graph.initial_base (Orchestrator.graph orch) pid ~has_merged ~branch_of
+      ~main
+  in
+  let orch, _decision, _effects =
+    Orchestrator.apply_conflict_rebase_result orch pid Worktree.Noop new_base
+  in
+  (* 4. Session completes without resolving the conflict *)
+  let orch =
+    Orchestrator.apply_session_result orch pid Orchestrator.Session_ok
+  in
+  Orchestrator.complete orch pid
+
+(** PI-6: Repeated Noop conflict rebase converges to needs_intervention. If the
+    rebase keeps returning Noop (stale refs or agent unable to resolve), the
+    system must eventually stop retrying. After 2 noop cycles,
+    needs_intervention must trigger. *)
+let () =
+  let prop_pi6 =
+    QCheck2.Test.make
+      ~name:"PI-6: repeated conflict noop converges to needs_intervention"
+      (QCheck2.Gen.return ()) (fun () ->
+        let orch, pid, patches = mk_bootstrapped () in
+        (* First noop cycle *)
+        let orch = conflict_noop_cycle orch pid patches in
+        let a = Orchestrator.agent orch pid in
+        if Patch_agent.needs_intervention a then
+          failwith "needs_intervention too early after 1 noop cycle";
+        (* Second noop cycle *)
+        let orch = conflict_noop_cycle orch pid patches in
+        let a = Orchestrator.agent orch pid in
+        Patch_agent.needs_intervention a)
+  in
+  QCheck2.Test.check_exn prop_pi6;
+  Stdlib.print_endline "PI-6 passed"

--- a/test/test_interleaving_properties.ml
+++ b/test/test_interleaving_properties.ml
@@ -413,13 +413,15 @@ let rec apply_command orch patches cmd =
             orch'
         | Orchestrator.Conflict_resolved | Orchestrator.Conflict_failed -> orch'
       with Invalid_argument _ -> orch)
-  | Apply_rebase_push_result { patch_idx; result } ->
-      let pid = pid_of_idx patches patch_idx in
-      let orch, _resolution =
-        Orchestrator.apply_rebase_push_result orch pid
-          (Some (to_push_result result))
-      in
-      orch
+  | Apply_rebase_push_result { patch_idx; result } -> (
+      try
+        let pid = pid_of_idx patches patch_idx in
+        let orch, _resolution =
+          Orchestrator.apply_rebase_push_result orch pid
+            (Some (to_push_result result))
+        in
+        orch
+      with Invalid_argument _ -> orch)
 
 type poll_log_info = {
   agent_before : Patch_agent.t;

--- a/test/test_interleaving_properties.ml
+++ b/test/test_interleaving_properties.ml
@@ -68,6 +68,12 @@ type rebase_result_kind =
   | Rebase_conflict
   | Rebase_error
 
+type push_result_kind =
+  | Push_ok_k
+  | Push_up_to_date_k
+  | Push_rejected_k
+  | Push_error_k
+
 type command =
   | Apply_poll of { patch_idx : int; poll_kind : poll_kind }
   | Reconcile
@@ -82,6 +88,7 @@ type command =
       patch_idx : int;
       result : rebase_result_kind;
     }
+  | Apply_rebase_push_result of { patch_idx : int; result : push_result_kind }
 
 let show_poll_kind = function
   | Poll_normal -> "Normal"
@@ -107,6 +114,12 @@ let show_rebase_result_kind = function
   | Rebase_conflict -> "Conflict"
   | Rebase_error -> "Error"
 
+let show_push_result_kind = function
+  | Push_ok_k -> "Push_ok"
+  | Push_up_to_date_k -> "Push_up_to_date"
+  | Push_rejected_k -> "Push_rejected"
+  | Push_error_k -> "Push_error"
+
 let show_command = function
   | Apply_poll { patch_idx; poll_kind } ->
       Printf.sprintf "Apply_poll(%d, %s)" patch_idx (show_poll_kind poll_kind)
@@ -127,6 +140,9 @@ let show_command = function
   | Apply_conflict_rebase_result { patch_idx; result } ->
       Printf.sprintf "Apply_conflict_rebase_result(%d, %s)" patch_idx
         (show_rebase_result_kind result)
+  | Apply_rebase_push_result { patch_idx; result } ->
+      Printf.sprintf "Apply_rebase_push_result(%d, %s)" patch_idx
+        (show_push_result_kind result)
 
 (* -- Generators -- *)
 
@@ -158,6 +174,10 @@ let gen_rebase_result_kind =
   QCheck2.Gen.oneof_list
     [ Rebase_ok; Rebase_noop; Rebase_conflict; Rebase_error ]
 
+let gen_push_result_kind =
+  QCheck2.Gen.oneof_list
+    [ Push_ok_k; Push_up_to_date_k; Push_rejected_k; Push_error_k ]
+
 let gen_command ~n =
   if n <= 0 then invalid_arg "gen_command: n must be positive";
   QCheck2.Gen.(
@@ -180,6 +200,9 @@ let gen_command ~n =
           (fun i r ->
             Apply_conflict_rebase_result { patch_idx = i; result = r })
           gen_idx gen_rebase_result_kind;
+        map2
+          (fun i r -> Apply_rebase_push_result { patch_idx = i; result = r })
+          gen_idx gen_push_result_kind;
         map (fun i -> Send_human_message i) gen_idx;
         map (fun i -> Reset_intervention i) gen_idx;
       ])
@@ -209,6 +232,9 @@ let gen_atomic_command ~n =
           (fun i r ->
             Apply_conflict_rebase_result { patch_idx = i; result = r })
           gen_idx gen_rebase_result_kind;
+        map2
+          (fun i r -> Apply_rebase_push_result { patch_idx = i; result = r })
+          gen_idx gen_push_result_kind;
         map (fun i -> Send_human_message i) gen_idx;
         map (fun i -> Reset_intervention i) gen_idx;
       ])
@@ -267,6 +293,12 @@ let to_worktree_result = function
   | Rebase_noop -> Worktree.Noop
   | Rebase_conflict -> Worktree.Conflict
   | Rebase_error -> Worktree.Error "simulated error"
+
+let to_push_result = function
+  | Push_ok_k -> Worktree.Push_ok
+  | Push_up_to_date_k -> Worktree.Push_up_to_date
+  | Push_rejected_k -> Worktree.Push_rejected
+  | Push_error_k -> Worktree.Push_error "simulated error"
 
 let poll_params_of_kind = function
   | Poll_normal -> (false, false, false, true, false)
@@ -381,6 +413,13 @@ let rec apply_command orch patches cmd =
             orch'
         | Orchestrator.Conflict_resolved | Orchestrator.Conflict_failed -> orch'
       with Invalid_argument _ -> orch)
+  | Apply_rebase_push_result { patch_idx; result } ->
+      let pid = pid_of_idx patches patch_idx in
+      let orch, _resolution =
+        Orchestrator.apply_rebase_push_result orch pid
+          (Some (to_push_result result))
+      in
+      orch
 
 type poll_log_info = {
   agent_before : Patch_agent.t;
@@ -431,7 +470,7 @@ let rec apply_command_with_logs orch patches cmd =
       (orch, info)
   | Reconcile | Runner_tick | Complete _ | Apply_session_result _
   | Apply_rebase_result _ | Send_human_message _ | Reset_intervention _
-  | Apply_conflict_rebase_result _ ->
+  | Apply_conflict_rebase_result _ | Apply_rebase_push_result _ ->
       (apply_command orch patches cmd, None)
 
 (* ========== Log invariant checks ========== *)
@@ -913,3 +952,83 @@ let () =
   in
   QCheck2.Test.check_exn prop_pi6;
   Stdlib.print_endline "PI-6 passed"
+
+(** PI-7: Rebase push failure converges to Merge_conflict retry. After a
+    successful rebase whose push is rejected, the system must enqueue
+    Merge_conflict and fire it on the next tick. *)
+let () =
+  let prop_pi7 =
+    QCheck2.Test.make
+      ~name:"PI-7: rebase push failure converges to merge-conflict retry"
+      (QCheck2.Gen.return ()) (fun () ->
+        let orch, pid, patches = mk_bootstrapped () in
+        let branch_of = branch_of_patches patches in
+        let gameplan = make_gameplan patches in
+        (* 1. Poll with conflict so Merge_conflict gets enqueued *)
+        let poll_result =
+          make_poll_result ~has_conflict:true ~merged:false ~ci_failed:false
+            ~checks_passing:false ~review_comments:false
+        in
+        let observation =
+          Patch_controller.
+            {
+              poll_result;
+              head_branch = Some (branch_of pid);
+              base_branch = None;
+              branch_in_root = false;
+              worktree_path = None;
+            }
+        in
+        let orch, _logs, _blocked =
+          Patch_controller.apply_poll_result orch pid observation
+        in
+        (* 2. Tick to fire the Merge_conflict → agent becomes busy *)
+        let orch, _effects, _actions =
+          Patch_controller.tick orch ~project_name:"test-project" ~gameplan
+        in
+        (* 3. Rebase succeeds *)
+        let has_merged dep_pid =
+          (Orchestrator.agent orch dep_pid).Patch_agent.merged
+        in
+        let new_base =
+          Graph.initial_base (Orchestrator.graph orch) pid ~has_merged
+            ~branch_of ~main
+        in
+        let orch, effects =
+          Orchestrator.apply_rebase_result orch pid Worktree.Ok new_base
+        in
+        (* Verify Push_branch effect was emitted *)
+        if
+          not
+            (List.equal Orchestrator.equal_rebase_effect effects
+               [ Orchestrator.Push_branch ])
+        then failwith "expected [Push_branch] effect";
+        (* 4. Push fails *)
+        let orch, resolution =
+          Orchestrator.apply_rebase_push_result orch pid
+            (Some Worktree.Push_rejected)
+        in
+        if
+          not
+            (Orchestrator.equal_rebase_push_resolution resolution
+               Orchestrator.Rebase_push_failed)
+        then failwith "expected Rebase_push_failed";
+        let a = Orchestrator.agent orch pid in
+        (* Verify: has_conflict set, Merge_conflict enqueued, agent idle *)
+        if not a.Patch_agent.has_conflict then failwith "expected has_conflict";
+        if
+          not
+            (List.mem a.Patch_agent.queue Operation_kind.Merge_conflict
+               ~equal:Operation_kind.equal)
+        then failwith "expected Merge_conflict in queue";
+        if a.Patch_agent.busy then failwith "expected agent idle";
+        (* 5. Next tick fires Merge_conflict for retry *)
+        let orch, _effects, _actions =
+          Patch_controller.tick orch ~project_name:"test-project" ~gameplan
+        in
+        let a = Orchestrator.agent orch pid in
+        (* Agent is now busy handling Merge_conflict *)
+        a.Patch_agent.busy)
+  in
+  QCheck2.Test.check_exn prop_pi7;
+  Stdlib.print_endline "PI-7 passed"

--- a/test/test_orchestrator_properties.ml
+++ b/test/test_orchestrator_properties.ml
@@ -684,9 +684,9 @@ let () =
         with _ -> false)
   in
 
-  (* None -> Rebase_push_failed (defensive) *)
+  (* None -> Rebase_push_ok (no push was requested; already handled) *)
   let prop_rebase_push_none =
-    Test.make ~name:"apply_rebase_push_result: None -> Rebase_push_failed"
+    Test.make ~name:"apply_rebase_push_result: None -> Rebase_push_ok"
       (Gen.pair gen_patch_list_unique gen_branch) (fun (patches, new_base) ->
         try
           match patches with
@@ -698,12 +698,11 @@ let () =
               let orch, _effects =
                 Orchestrator.apply_rebase_result orch pid Worktree.Ok new_base
               in
-              let orch, resolution =
+              let _orch, resolution =
                 Orchestrator.apply_rebase_push_result orch pid None
               in
               Orchestrator.equal_rebase_push_resolution resolution
-                Orchestrator.Rebase_push_failed
-              && (Orchestrator.agent orch pid).Patch_agent.has_conflict
+                Orchestrator.Rebase_push_ok
         with _ -> false)
   in
 

--- a/test/test_orchestrator_properties.ml
+++ b/test/test_orchestrator_properties.ml
@@ -572,6 +572,134 @@ let () =
         with _ -> false)
   in
 
+  (* ========== apply_rebase_push_result properties ========== *)
+
+  (* Push_ok -> Rebase_push_ok, no conflict *)
+  let prop_rebase_push_ok =
+    Test.make ~name:"apply_rebase_push_result: Push_ok -> Rebase_push_ok"
+      (Gen.pair gen_patch_list_unique gen_branch) (fun (patches, new_base) ->
+        try
+          match patches with
+          | [] -> true
+          | first :: _ ->
+              let pid = first.Patch.id in
+              let orch = Orchestrator.create ~patches ~main_branch:main in
+              let orch, _effects, _actions = tick orch ~patches in
+              let orch, _effects =
+                Orchestrator.apply_rebase_result orch pid Worktree.Ok new_base
+              in
+              let orch, resolution =
+                Orchestrator.apply_rebase_push_result orch pid
+                  (Some Worktree.Push_ok)
+              in
+              let a = Orchestrator.agent orch pid in
+              Orchestrator.equal_rebase_push_resolution resolution
+                Orchestrator.Rebase_push_ok
+              && (not a.Patch_agent.has_conflict)
+              && not
+                   (List.mem a.Patch_agent.queue Operation_kind.Merge_conflict
+                      ~equal:Operation_kind.equal)
+        with _ -> false)
+  in
+
+  (* Push_up_to_date -> Rebase_push_ok *)
+  let prop_rebase_push_up_to_date =
+    Test.make
+      ~name:"apply_rebase_push_result: Push_up_to_date -> Rebase_push_ok"
+      (Gen.pair gen_patch_list_unique gen_branch) (fun (patches, new_base) ->
+        try
+          match patches with
+          | [] -> true
+          | first :: _ ->
+              let pid = first.Patch.id in
+              let orch = Orchestrator.create ~patches ~main_branch:main in
+              let orch, _effects, _actions = tick orch ~patches in
+              let orch, _effects =
+                Orchestrator.apply_rebase_result orch pid Worktree.Ok new_base
+              in
+              let _orch, resolution =
+                Orchestrator.apply_rebase_push_result orch pid
+                  (Some Worktree.Push_up_to_date)
+              in
+              Orchestrator.equal_rebase_push_resolution resolution
+                Orchestrator.Rebase_push_ok
+        with _ -> false)
+  in
+
+  (* Push_rejected -> Rebase_push_failed, has_conflict, Merge_conflict queued *)
+  let prop_rebase_push_rejected =
+    Test.make
+      ~name:"apply_rebase_push_result: Push_rejected -> Rebase_push_failed"
+      (Gen.pair gen_patch_list_unique gen_branch) (fun (patches, new_base) ->
+        try
+          match patches with
+          | [] -> true
+          | first :: _ ->
+              let pid = first.Patch.id in
+              let orch = Orchestrator.create ~patches ~main_branch:main in
+              let orch, _effects, _actions = tick orch ~patches in
+              let orch, _effects =
+                Orchestrator.apply_rebase_result orch pid Worktree.Ok new_base
+              in
+              let orch, resolution =
+                Orchestrator.apply_rebase_push_result orch pid
+                  (Some Worktree.Push_rejected)
+              in
+              let a = Orchestrator.agent orch pid in
+              Orchestrator.equal_rebase_push_resolution resolution
+                Orchestrator.Rebase_push_failed
+              && a.Patch_agent.has_conflict
+              && List.mem a.Patch_agent.queue Operation_kind.Merge_conflict
+                   ~equal:Operation_kind.equal
+        with _ -> false)
+  in
+
+  (* Push_error -> Rebase_push_failed *)
+  let prop_rebase_push_error =
+    Test.make ~name:"apply_rebase_push_result: Push_error -> Rebase_push_failed"
+      (Gen.pair gen_patch_list_unique gen_branch) (fun (patches, new_base) ->
+        try
+          match patches with
+          | [] -> true
+          | first :: _ ->
+              let pid = first.Patch.id in
+              let orch = Orchestrator.create ~patches ~main_branch:main in
+              let orch, _effects, _actions = tick orch ~patches in
+              let orch, _effects =
+                Orchestrator.apply_rebase_result orch pid Worktree.Ok new_base
+              in
+              let _orch, resolution =
+                Orchestrator.apply_rebase_push_result orch pid
+                  (Some (Worktree.Push_error "test"))
+              in
+              Orchestrator.equal_rebase_push_resolution resolution
+                Orchestrator.Rebase_push_failed
+        with _ -> false)
+  in
+
+  (* None -> Rebase_push_failed (defensive) *)
+  let prop_rebase_push_none =
+    Test.make ~name:"apply_rebase_push_result: None -> Rebase_push_failed"
+      (Gen.pair gen_patch_list_unique gen_branch) (fun (patches, new_base) ->
+        try
+          match patches with
+          | [] -> true
+          | first :: _ ->
+              let pid = first.Patch.id in
+              let orch = Orchestrator.create ~patches ~main_branch:main in
+              let orch, _effects, _actions = tick orch ~patches in
+              let orch, _effects =
+                Orchestrator.apply_rebase_result orch pid Worktree.Ok new_base
+              in
+              let orch, resolution =
+                Orchestrator.apply_rebase_push_result orch pid None
+              in
+              Orchestrator.equal_rebase_push_resolution resolution
+                Orchestrator.Rebase_push_failed
+              && (Orchestrator.agent orch pid).Patch_agent.has_conflict
+        with _ -> false)
+  in
+
   (* ========== apply_conflict_rebase_result properties ========== *)
 
   (* Ok -> Conflict_resolved, not busy, conflict cleared *)
@@ -1273,6 +1401,11 @@ let () =
       prop_rebase_ok_clears_conflict;
       prop_rebase_noop_preserves_conflict;
       prop_rebase_error_fails;
+      prop_rebase_push_ok;
+      prop_rebase_push_up_to_date;
+      prop_rebase_push_rejected;
+      prop_rebase_push_error;
+      prop_rebase_push_none;
       prop_conflict_rebase_ok;
       prop_conflict_rebase_noop;
       prop_conflict_rebase_conflict;

--- a/test/test_orchestrator_properties.ml
+++ b/test/test_orchestrator_properties.ml
@@ -654,9 +654,9 @@ let () =
         with _ -> false)
   in
 
-  (* Push_error -> Rebase_push_failed *)
+  (* Push_error -> Rebase_push_error, enqueues Rebase (not Merge_conflict) *)
   let prop_rebase_push_error =
-    Test.make ~name:"apply_rebase_push_result: Push_error -> Rebase_push_failed"
+    Test.make ~name:"apply_rebase_push_result: Push_error -> Rebase_push_error"
       (Gen.pair gen_patch_list_unique gen_branch) (fun (patches, new_base) ->
         try
           match patches with
@@ -668,12 +668,19 @@ let () =
               let orch, _effects =
                 Orchestrator.apply_rebase_result orch pid Worktree.Ok new_base
               in
-              let _orch, resolution =
+              let orch, resolution =
                 Orchestrator.apply_rebase_push_result orch pid
                   (Some (Worktree.Push_error "test"))
               in
+              let a = Orchestrator.agent orch pid in
               Orchestrator.equal_rebase_push_resolution resolution
-                Orchestrator.Rebase_push_failed
+                Orchestrator.Rebase_push_error
+              && (not a.Patch_agent.has_conflict)
+              && List.mem a.Patch_agent.queue Operation_kind.Rebase
+                   ~equal:Operation_kind.equal
+              && not
+                   (List.mem a.Patch_agent.queue Operation_kind.Merge_conflict
+                      ~equal:Operation_kind.equal)
         with _ -> false)
   in
 

--- a/test/test_orchestrator_properties.ml
+++ b/test/test_orchestrator_properties.ml
@@ -545,7 +545,7 @@ let () =
                 Orchestrator.apply_rebase_result orch pid Worktree.Noop new_base
               in
               (Orchestrator.agent orch' pid).Patch_agent.has_conflict
-              && List.is_empty effects
+              && List.length effects = 1
         with _ -> false)
   in
 

--- a/test/test_patch_agent.ml
+++ b/test/test_patch_agent.ml
@@ -477,9 +477,9 @@ let () =
               ~ci_checks:a.ci_checks ~merge_ready:false ~is_draft:false
               ~pr_description_applied:false
               ~implementation_notes_delivered:false ~start_attempts_without_pr:0
-              ~checks_passing:false ~current_op:None ~current_message_id:None
-              ~generation:0 ~worktree_path:None ~head_branch:None
-              ~branch_blocked:false
+              ~conflict_noop_count:0 ~checks_passing:false ~current_op:None
+              ~current_message_id:None ~generation:0 ~worktree_path:None
+              ~head_branch:None ~branch_blocked:false
           in
           let a = start a ~base_branch:br in
           List.is_empty a.ci_checks);
@@ -551,9 +551,9 @@ let () =
               ~session_fallback:Fresh_available ~human_messages:[] ~ci_checks:[]
               ~merge_ready:false ~is_draft:false ~pr_description_applied:false
               ~implementation_notes_delivered:false ~start_attempts_without_pr:0
-              ~checks_passing:false ~current_op:None ~current_message_id:None
-              ~generation:0 ~worktree_path:None ~head_branch:None
-              ~branch_blocked:false
+              ~conflict_noop_count:0 ~checks_passing:false ~current_op:None
+              ~current_message_id:None ~generation:0 ~worktree_path:None
+              ~head_branch:None ~branch_blocked:false
           in
           let a = enqueue a Operation_kind.Rebase in
           let a = rebase a ~base_branch:new_base in

--- a/test/test_patch_controller.ml
+++ b/test/test_patch_controller.ml
@@ -51,8 +51,9 @@ let make_agent ~patch_id ~branch ~pr_number ~merged ~queue ~base_branch
     ~session_fallback:Patch_agent.Fresh_available ~human_messages:[]
     ~ci_checks:[] ~merge_ready:false ~is_draft ~pr_description_applied
     ~implementation_notes_delivered ~start_attempts_without_pr
-    ~checks_passing:false ~current_op:None ~current_message_id:None
-    ~generation:0 ~worktree_path:None ~head_branch:None ~branch_blocked:false
+    ~conflict_noop_count:0 ~checks_passing:false ~current_op:None
+    ~current_message_id:None ~generation:0 ~worktree_path:None ~head_branch:None
+    ~branch_blocked:false
 
 let has_notes_queued agent =
   List.mem agent.Patch_agent.queue Operation_kind.Implementation_notes
@@ -526,9 +527,10 @@ let () =
             ~session_fallback:Patch_agent.Fresh_available ~human_messages:[]
             ~ci_checks:[] ~merge_ready:false ~is_draft:false
             ~pr_description_applied:true ~implementation_notes_delivered:true
-            ~start_attempts_without_pr:0 ~checks_passing:false ~current_op:None
-            ~current_message_id:None ~generation:0 ~worktree_path:None
-            ~head_branch:None ~branch_blocked:false
+            ~start_attempts_without_pr:0 ~conflict_noop_count:0
+            ~checks_passing:false ~current_op:None ~current_message_id:None
+            ~generation:0 ~worktree_path:None ~head_branch:None
+            ~branch_blocked:false
         in
         let orch = make_orch patch agent in
         let poll =

--- a/test/test_poll_log_properties.ml
+++ b/test/test_poll_log_properties.ml
@@ -48,8 +48,8 @@ let make_agent ~patch_id ~branch ~has_conflict ~ci_failure_count ~current_op
     ~session_fallback:Patch_agent.Fresh_available ~human_messages:[]
     ~ci_checks:[] ~merge_ready:false ~is_draft ~pr_description_applied:true
     ~implementation_notes_delivered:true ~start_attempts_without_pr:0
-    ~checks_passing ~current_op ~current_message_id:None ~generation:0
-    ~worktree_path ~head_branch ~branch_blocked
+    ~conflict_noop_count:0 ~checks_passing ~current_op ~current_message_id:None
+    ~generation:0 ~worktree_path ~head_branch ~branch_blocked
 
 let make_poll_observation ~head_branch ~branch_in_root ~worktree_path
     poll_result =


### PR DESCRIPTION
## Summary
- `rebase_onto` was checking `merge-base --is-ancestor` against the local `main` ref, which could be stale in worktrees that hadn't fetched recently
- When GitHub reported a conflict but the stale local ref was already an ancestor of HEAD, `rebase_onto` returned `Noop`, causing an infinite loop: orchestrator delivers merge-conflict prompt → agent finds clean tree → says "already resolved" → next poll re-enqueues
- Both rebase call sites (runner rebase + merge-conflict handler) now call `Worktree.fetch_origin` first and target `origin/<base>` so the rebase operates on fresh remote tracking refs

## Test plan
- [x] `dune build` passes
- [x] `dune runtest` passes (all existing tests including rebase_onto integration tests)
- [ ] Verify on a live PR with a real merge conflict that the rebase now succeeds or correctly hands off to the agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Merge-conflict prompts now include repository status and conflict diff for clearer context.
  * The system counts consecutive conflict no-op cycles and requests human intervention after two.

* **Bug Fixes**
  * Rebases fetch remote state first and target the remote-tracking branch; fetch failures are logged as warnings.
  * Push outcomes are aggregated; rejected/errored pushes mark conflicts and enqueue immediate conflict delivery/retry.

* **Tests**
  * Added and updated properties covering rebase+push outcomes and conflict/noop cycles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->