### PR TITLE
Detect fork PRs and skip them gracefully

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1500,10 +1500,12 @@ let poller_fiber ~runtime ~clock ~net ~process_mgr ~github ~config ~project_name
                     (Printf.sprintf "poll error: %s" (Github.show_error err));
                   None
               | Ok pr_state when Pr_state.is_fork pr_state ->
-                  log_event runtime ~patch_id
-                    (Printf.sprintf
-                       "skipping PR #%d: fork PRs are not supported"
-                       (Pr_number.to_int pr_number));
+                  if not (Hashtbl.mem skip_logged patch_id) then (
+                    Hashtbl.replace skip_logged patch_id true;
+                    log_event runtime ~patch_id
+                      (Printf.sprintf
+                         "skipping PR #%d: fork PRs are not supported"
+                         (Pr_number.to_int pr_number)));
                   None
               | Ok pr_state ->
                   let poll_result = Poller.poll ~was_merged pr_state in

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1499,6 +1499,12 @@ let poller_fiber ~runtime ~clock ~net ~process_mgr ~github ~config ~project_name
                   log_event runtime ~patch_id
                     (Printf.sprintf "poll error: %s" (Github.show_error err));
                   None
+              | Ok pr_state when Pr_state.is_fork pr_state ->
+                  log_event runtime ~patch_id
+                    (Printf.sprintf
+                       "skipping PR #%d: fork PRs are not supported"
+                       (Pr_number.to_int pr_number));
+                  None
               | Ok pr_state ->
                   let poll_result = Poller.poll ~was_merged pr_state in
                   (* PR was closed — re-discover the current open PR.

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -21,6 +21,7 @@ let graphql_query =
       mergeStateStatus
       headRefName
       baseRefName
+      headRepositoryOwner { login }
       commits(last: 1) {
         nodes {
           commit {
@@ -139,7 +140,7 @@ let parse_comment_node ~thread_id node =
   let line = node |> member "line" |> to_int_option in
   Types.Comment.{ id; thread_id; body; path; line }
 
-let parse_response_json json =
+let parse_response_json ~owner json =
   let open Yojson.Safe.Util in
   try
     let errors = json |> member "errors" in
@@ -221,6 +222,15 @@ let parse_response_json json =
               pr |> member "baseRefName" |> to_string_option
               |> Option.map ~f:Types.Branch.of_string
             in
+            let is_fork =
+              match
+                pr
+                |> member "headRepositoryOwner"
+                |> member "login" |> to_string_option
+              with
+              | Some head_owner -> not (String.equal head_owner owner)
+              | None -> false
+            in
             Ok
               {
                 Pr_state.status;
@@ -234,6 +244,7 @@ let parse_response_json json =
                 unresolved_comment_count;
                 head_branch;
                 base_branch;
+                is_fork;
               })
     | errors ->
         let msgs =
@@ -243,8 +254,8 @@ let parse_response_json json =
         Error (Graphql_error msgs)
   with Yojson.Safe.Util.Type_error (msg, _) -> Error (Json_parse_error msg)
 
-let parse_response body =
-  try parse_response_json (Yojson.Safe.from_string body)
+let parse_response ~owner body =
+  try parse_response_json ~owner (Yojson.Safe.from_string body)
   with Yojson.Json_error msg -> Error (Json_parse_error msg)
 
 let https_config () =
@@ -316,7 +327,7 @@ let request ~net t ~meth ~path ?(query = []) ?body () =
 let pr_state ~net t pr =
   let body = build_request_body t pr in
   match request ~net t ~meth:`POST ~path:"/graphql" ~body () with
-  | Ok resp_str -> parse_response resp_str
+  | Ok resp_str -> parse_response ~owner:t.owner resp_str
   | Error _ as e -> e
 
 (** Parse the REST response from [GET /repos/:owner/:repo/pulls]. Returns a list

--- a/lib/github.mli
+++ b/lib/github.mli
@@ -14,11 +14,13 @@ type t
 val create : token:string -> owner:string -> repo:string -> t
 (** [create ~token ~owner ~repo] creates a GitHub API client. *)
 
-val parse_response_json : Yojson.Safe.t -> (Pr_state.t, error) Result.t
+val parse_response_json :
+  owner:string -> Yojson.Safe.t -> (Pr_state.t, error) Result.t
 (** Parse a GitHub GraphQL response JSON value into a [Pr_state.t]. Pure
-    function — no I/O or string parsing. *)
+    function — no I/O or string parsing. [~owner] is the configured repository
+    owner, used to detect fork PRs. *)
 
-val parse_response : string -> (Pr_state.t, error) Result.t
+val parse_response : owner:string -> string -> (Pr_state.t, error) Result.t
 (** Parse a GitHub GraphQL response body string into a [Pr_state.t]. *)
 
 val pr_state :

--- a/lib/pr_state.ml
+++ b/lib/pr_state.ml
@@ -16,6 +16,7 @@ type t = {
   unresolved_comment_count : int;
   head_branch : Types.Branch.t option;
   base_branch : Types.Branch.t option;
+  is_fork : bool;
 }
 [@@deriving show, eq]
 
@@ -31,3 +32,4 @@ let checks_passing (st : t) = equal_check_status st.check_status Passing
 let no_unresolved_comments (st : t) = st.unresolved_comment_count = 0
 let has_conflict (st : t) = equal_merge_state st.merge_state Conflicting
 let ci_failed (st : t) = equal_check_status st.check_status Failing
+let is_fork (st : t) = st.is_fork

--- a/lib/pr_state.mli
+++ b/lib/pr_state.mli
@@ -22,6 +22,7 @@ type t = {
   unresolved_comment_count : int;
   head_branch : Branch.t option;
   base_branch : Branch.t option;
+  is_fork : bool;
 }
 [@@deriving show, eq]
 
@@ -36,3 +37,4 @@ val checks_passing : t -> bool
 val no_unresolved_comments : t -> bool
 val has_conflict : t -> bool
 val ci_failed : t -> bool
+val is_fork : t -> bool

--- a/lib_test/test_generators.ml
+++ b/lib_test/test_generators.ml
@@ -229,6 +229,7 @@ let gen_pr_state =
   QCheck2.Gen.(
     let open Onton.Pr_state in
     let* is_draft = bool in
+    let* is_fork = bool in
     let* head_branch = option gen_branch in
     let* base_branch = option gen_branch in
     map5
@@ -246,6 +247,7 @@ let gen_pr_state =
           unresolved_comment_count;
           head_branch;
           base_branch;
+          is_fork;
         })
       (pair gen_pr_status gen_merge_state)
       bool


### PR DESCRIPTION
## Summary
- Add `is_fork` field to `Pr_state.t` by querying `headRepositoryOwner { login }` in the GraphQL query and comparing against the configured repo owner
- Skip fork PRs in the poller with a log message instead of silently failing
- Document full fork support requirements in #144

## Test plan
- [x] `dune build` passes
- [x] `dune runtest` — all property tests pass including updated QCheck2 generator
- [x] Verify fork PR #138 is skipped with appropriate log message

Closes #144 partially (detection + graceful skip only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added fork pull request detection. The system now automatically identifies pull requests from forked repositories, skips processing them, and logs an informational message. Fork PRs are not supported and will no longer be processed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->