### PR TITLE
Notify agents when base branch changes after rebase

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -2247,12 +2247,17 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry
                                       ~user_config:config.user_config
                                       ~worktree_mutex ~backend ~event_log
                                   in
-                                  if not (String.equal base_changed_prefix "")
-                                  then
-                                    Runtime.update_orchestrator runtime
-                                      (fun orch ->
-                                        Orchestrator.set_notified_base_branch
-                                          orch patch_id (Branch.of_string base));
+                                  (match result with
+                                  | `Ok
+                                    when not
+                                           (String.equal base_changed_prefix "")
+                                    ->
+                                      Runtime.update_orchestrator runtime
+                                        (fun orch ->
+                                          Orchestrator.set_notified_base_branch
+                                            orch patch_id
+                                            (Branch.of_string base))
+                                  | _ -> ());
                                   result
                                 in
                                 if
@@ -2472,12 +2477,16 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry
                                     ~transcripts ~user_config:config.user_config
                                     ~worktree_mutex ~backend ~event_log
                                 in
-                                if not (String.equal base_changed_prefix "")
-                                then
-                                  Runtime.update_orchestrator runtime
-                                    (fun orch ->
-                                      Orchestrator.set_notified_base_branch orch
-                                        patch_id (Branch.of_string base));
+                                (match result with
+                                | `Ok
+                                  when not
+                                         (String.equal base_changed_prefix "")
+                                  ->
+                                    Runtime.update_orchestrator runtime
+                                      (fun orch ->
+                                        Orchestrator.set_notified_base_branch
+                                          orch patch_id (Branch.of_string base))
+                                | _ -> ());
                                 result)
                       in
                       match result with

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -2161,6 +2161,23 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry
                                   ~default:(Branch.to_string main)
                                   ~f:Branch.to_string
                               in
+                              let base_changed_prefix =
+                                if Patch_agent.base_branch_changed agent then (
+                                  let old_base =
+                                    Base.Option.value_map
+                                      agent.Patch_agent.notified_base_branch
+                                      ~default:(Branch.to_string main)
+                                      ~f:Branch.to_string
+                                  in
+                                  log_event runtime ~patch_id
+                                    (Printf.sprintf
+                                       "runner: base branch changed from %s to \
+                                        %s, will notify agent"
+                                       old_base base);
+                                  Prompt.render_base_branch_changed ~old_base
+                                    ~new_base:base)
+                                else ""
+                              in
                               let source_agent =
                                 Base.Option.value pre_fire_agent ~default:agent
                               in
@@ -2209,18 +2226,34 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry
                                       ~path:wt_path
                                   in
                                   let prompt =
-                                    Prompt.render_merge_conflict_prompt
-                                      ~project_name ?pr_number ~base_branch:base
-                                      ~git_status ~git_diff ()
+                                    let raw =
+                                      Prompt.render_merge_conflict_prompt
+                                        ~project_name ?pr_number
+                                        ~base_branch:base ~git_status ~git_diff
+                                        ()
+                                    in
+                                    if String.equal base_changed_prefix "" then
+                                      raw
+                                    else base_changed_prefix ^ "\n" ^ raw
                                   in
                                   let on_pr_detected _pr_number = () in
-                                  run_claude_and_handle ~runtime ~process_mgr
-                                    ~fs ~project_name ~patch_id
-                                    ~repo_root:config.repo_root ~prompt ~agent
-                                    ~owner:config.github_owner
-                                    ~repo:config.github_repo ~on_pr_detected
-                                    ~transcripts ~user_config:config.user_config
-                                    ~worktree_mutex ~backend ~event_log
+                                  let result =
+                                    run_claude_and_handle ~runtime ~process_mgr
+                                      ~fs ~project_name ~patch_id
+                                      ~repo_root:config.repo_root ~prompt ~agent
+                                      ~owner:config.github_owner
+                                      ~repo:config.github_repo ~on_pr_detected
+                                      ~transcripts
+                                      ~user_config:config.user_config
+                                      ~worktree_mutex ~backend ~event_log
+                                  in
+                                  if not (String.equal base_changed_prefix "")
+                                  then
+                                    Runtime.update_orchestrator runtime
+                                      (fun orch ->
+                                        Orchestrator.set_notified_base_branch
+                                          orch patch_id (Branch.of_string base));
+                                  result
                                 in
                                 if
                                   Worktree.rebase_in_progress ~process_mgr
@@ -2424,14 +2457,28 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry
                                        through Respond *)
                                       assert false
                                 in
+                                let prompt =
+                                  if String.equal base_changed_prefix "" then
+                                    prompt
+                                  else base_changed_prefix ^ "\n" ^ prompt
+                                in
                                 let on_pr_detected _pr_number = () in
-                                run_claude_and_handle ~runtime ~process_mgr ~fs
-                                  ~project_name ~patch_id
-                                  ~repo_root:config.repo_root ~prompt ~agent
-                                  ~owner:config.github_owner
-                                  ~repo:config.github_repo ~on_pr_detected
-                                  ~transcripts ~user_config:config.user_config
-                                  ~worktree_mutex ~backend ~event_log)
+                                let result =
+                                  run_claude_and_handle ~runtime ~process_mgr
+                                    ~fs ~project_name ~patch_id
+                                    ~repo_root:config.repo_root ~prompt ~agent
+                                    ~owner:config.github_owner
+                                    ~repo:config.github_repo ~on_pr_detected
+                                    ~transcripts ~user_config:config.user_config
+                                    ~worktree_mutex ~backend ~event_log
+                                in
+                                if not (String.equal base_changed_prefix "")
+                                then
+                                  Runtime.update_orchestrator runtime
+                                    (fun orch ->
+                                      Orchestrator.set_notified_base_branch orch
+                                        patch_id (Branch.of_string base));
+                                result)
                       in
                       match result with
                       | `Stale -> ()

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -2479,8 +2479,7 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry
                                 in
                                 (match result with
                                 | `Ok
-                                  when not
-                                         (String.equal base_changed_prefix "")
+                                  when not (String.equal base_changed_prefix "")
                                   ->
                                     Runtime.update_orchestrator runtime
                                       (fun orch ->

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -317,6 +317,10 @@ let clear_has_conflict t patch_id =
 let set_base_branch t patch_id branch =
   update_agent t patch_id ~f:(fun a -> Patch_agent.set_base_branch a branch)
 
+let set_notified_base_branch t patch_id branch =
+  update_agent t patch_id ~f:(fun a ->
+      Patch_agent.set_notified_base_branch a branch)
+
 let increment_ci_failure_count t patch_id =
   update_agent t patch_id ~f:Patch_agent.increment_ci_failure_count
 

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -84,6 +84,7 @@ val on_pr_discovery_failure : t -> Patch_id.t -> t
 val set_has_conflict : t -> Patch_id.t -> t
 val clear_has_conflict : t -> Patch_id.t -> t
 val set_base_branch : t -> Patch_id.t -> Branch.t -> t
+val set_notified_base_branch : t -> Patch_id.t -> Branch.t -> t
 val increment_ci_failure_count : t -> Patch_id.t -> t
 val reset_ci_failure_count : t -> Patch_id.t -> t
 val set_ci_checks : t -> Patch_id.t -> Ci_check.t list -> t

--- a/lib/patch_agent.ml
+++ b/lib/patch_agent.ml
@@ -17,6 +17,7 @@ type t = {
   changed : bool;
   has_conflict : bool;
   base_branch : Branch.t option;
+  notified_base_branch : Branch.t option;
   ci_failure_count : int;
   session_fallback : session_fallback;
   human_messages : string list;
@@ -61,6 +62,7 @@ let create ~branch patch_id =
     changed = false;
     has_conflict = false;
     base_branch = None;
+    notified_base_branch = None;
     ci_failure_count = 0;
     session_fallback = Fresh_available;
     human_messages = [];
@@ -93,6 +95,7 @@ let create_adhoc ~patch_id ~branch ~pr_number =
     changed = false;
     has_conflict = false;
     base_branch = None;
+    notified_base_branch = None;
     ci_failure_count = 0;
     session_fallback = Fresh_available;
     human_messages = [];
@@ -161,6 +164,13 @@ let increment_conflict_noop_count t =
   { t with conflict_noop_count = t.conflict_noop_count + 1 }
 
 let set_base_branch t branch = { t with base_branch = Some branch }
+
+let set_notified_base_branch t branch =
+  { t with notified_base_branch = Some branch }
+
+let base_branch_changed t =
+  not (Option.equal Branch.equal t.base_branch t.notified_base_branch)
+
 let set_merge_ready t v = { t with merge_ready = v }
 let set_is_draft t v = { t with is_draft = v }
 let set_pr_description_applied t v = { t with pr_description_applied = v }
@@ -213,9 +223,9 @@ let reset_intervention_state t =
 let reset_busy t = if not t.busy then t else { t with busy = false }
 
 let restore ~patch_id ~branch ~pr_number ~has_session ~busy ~merged ~queue
-    ~satisfies ~changed ~has_conflict ~base_branch ~ci_failure_count
-    ~session_fallback ~human_messages ~ci_checks ~merge_ready ~is_draft
-    ~pr_description_applied ~implementation_notes_delivered
+    ~satisfies ~changed ~has_conflict ~base_branch ~notified_base_branch
+    ~ci_failure_count ~session_fallback ~human_messages ~ci_checks ~merge_ready
+    ~is_draft ~pr_description_applied ~implementation_notes_delivered
     ~start_attempts_without_pr ~conflict_noop_count ~checks_passing ~current_op
     ~current_message_id ~generation ~worktree_path ~head_branch ~branch_blocked
     =
@@ -231,6 +241,7 @@ let restore ~patch_id ~branch ~pr_number ~has_session ~busy ~merged ~queue
     changed;
     has_conflict;
     base_branch;
+    notified_base_branch;
     ci_failure_count;
     session_fallback;
     human_messages;
@@ -271,6 +282,7 @@ let clear_pr t =
     ci_checks = [];
     ci_failure_count = 0;
     base_branch = None;
+    notified_base_branch = None;
   }
 
 let start t ~base_branch =
@@ -284,6 +296,7 @@ let start t ~base_branch =
     current_message_id = None;
     satisfies = true;
     base_branch = Some base_branch;
+    notified_base_branch = Some base_branch;
     ci_checks = [];
   }
 

--- a/lib/patch_agent.mli
+++ b/lib/patch_agent.mli
@@ -21,6 +21,7 @@ type t = private {
   changed : bool;
   has_conflict : bool;
   base_branch : Types.Branch.t option;
+  notified_base_branch : Types.Branch.t option;
   ci_failure_count : int;
   session_fallback : session_fallback;
   human_messages : string list;
@@ -143,6 +144,13 @@ val clear_has_conflict : t -> t
 val set_base_branch : t -> Types.Branch.t -> t
 (** Update the base branch. *)
 
+val set_notified_base_branch : t -> Types.Branch.t -> t
+(** Record that the agent session has been informed of this base branch. *)
+
+val base_branch_changed : t -> bool
+(** [true] when [base_branch] differs from [notified_base_branch], meaning the
+    agent session has not yet been told about the current base branch. *)
+
 val set_merge_ready : t -> bool -> t
 (** Set the merge_ready flag from GitHub mergeStateStatus. *)
 
@@ -242,6 +250,7 @@ val restore :
   changed:bool ->
   has_conflict:bool ->
   base_branch:Types.Branch.t option ->
+  notified_base_branch:Types.Branch.t option ->
   ci_failure_count:int ->
   session_fallback:session_fallback ->
   human_messages:string list ->

--- a/lib/persistence.ml
+++ b/lib/persistence.ml
@@ -51,6 +51,10 @@ let patch_agent_to_yojson (a : Patch_agent.t) =
         match a.base_branch with
         | None -> `Null
         | Some b -> Branch.yojson_of_t b );
+      ( "notified_base_branch",
+        match a.notified_base_branch with
+        | None -> `Null
+        | Some b -> Branch.yojson_of_t b );
       ("ci_failure_count", `Int a.ci_failure_count);
       ( "session_fallback",
         Patch_agent.yojson_of_session_fallback a.session_fallback );
@@ -131,6 +135,13 @@ let patch_agent_of_yojson ~gameplan json =
        ~has_conflict:(bool_member "has_conflict" json)
        ~base_branch:
          (string_member_opt "base_branch" json |> Option.map ~f:Branch.of_string)
+       ~notified_base_branch:
+         (match string_member_opt "notified_base_branch" json with
+         | Some s -> Some (Branch.of_string s)
+         | None ->
+             (* Backward compat: assume already-running agents were notified *)
+             string_member_opt "base_branch" json
+             |> Option.map ~f:Branch.of_string)
        ~ci_failure_count:(int_member "ci_failure_count" json)
        ~session_fallback ~human_messages ~ci_checks
        ~merge_ready:(bool_member "merge_ready" json)

--- a/lib/persistence.ml
+++ b/lib/persistence.ml
@@ -127,8 +127,7 @@ let patch_agent_of_yojson ~gameplan json =
                  | None -> pid)))
        ~pr_number:
          (int_member_opt "pr_number" json |> Option.map ~f:Pr_number.of_int)
-       ~has_session
-       ~busy:(bool_member "busy" json)
+       ~has_session ~busy:(bool_member "busy" json)
        ~merged:(bool_member "merged" json)
        ~queue
        ~satisfies:(bool_member "satisfies" json)

--- a/lib/persistence.ml
+++ b/lib/persistence.ml
@@ -109,6 +109,7 @@ let patch_agent_of_yojson ~gameplan json =
     result_all
       (List.map ci_checks_raw ~f:(fun j -> try_of_yojson Ci_check.t_of_yojson j))
   in
+  let has_session = bool_member "has_session" json in
   Ok
     (Patch_agent.restore
        ~patch_id:(Patch_id.of_string (string_member "patch_id" json))
@@ -126,7 +127,7 @@ let patch_agent_of_yojson ~gameplan json =
                  | None -> pid)))
        ~pr_number:
          (int_member_opt "pr_number" json |> Option.map ~f:Pr_number.of_int)
-       ~has_session:(bool_member "has_session" json)
+       ~has_session
        ~busy:(bool_member "busy" json)
        ~merged:(bool_member "merged" json)
        ~queue
@@ -139,9 +140,12 @@ let patch_agent_of_yojson ~gameplan json =
          (match string_member_opt "notified_base_branch" json with
          | Some s -> Some (Branch.of_string s)
          | None ->
-             (* Backward compat: assume already-running agents were notified *)
-             string_member_opt "base_branch" json
-             |> Option.map ~f:Branch.of_string)
+             (* Backward compat: only infer "already notified" for agents with
+                an active/established session. *)
+             if has_session then
+               string_member_opt "base_branch" json
+               |> Option.map ~f:Branch.of_string
+             else None)
        ~ci_failure_count:(int_member "ci_failure_count" json)
        ~session_fallback ~human_messages ~ci_checks
        ~merge_ready:(bool_member "merge_ready" json)

--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -566,6 +566,14 @@ let render_human_message_prompt ~(project_name : string)
             Printf.sprintf "# Message from Human\n\n%s" formatted_flat
           else Printf.sprintf "# Messages from Human\n\n%s" formatted_numbered)
 
+let render_base_branch_changed ~old_base ~new_base =
+  Printf.sprintf
+    "**NOTICE: Your base branch has changed from `%s` to `%s`.** Your PR now \
+     targets `%s`. The orchestrator has already rebased your branch and \
+     updated the PR target. Do NOT change the PR base branch. Your diff should \
+     show only your patch's changes relative to `%s`.\n"
+    old_base new_base new_base new_base
+
 let%test "patch prompt includes title and deps" =
   let patch : Patch.t =
     Patch.

--- a/lib/prompt.mli
+++ b/lib/prompt.mli
@@ -59,3 +59,6 @@ val render_merge_conflict_prompt :
   string
 
 val render_human_message_prompt : project_name:string -> string list -> string
+
+val render_base_branch_changed : old_base:string -> new_base:string -> string
+(** One-time notification that the agent's base branch has changed. *)

--- a/test/test_interleaving_properties.ml
+++ b/test/test_interleaving_properties.ml
@@ -688,6 +688,29 @@ let check_merged_no_github_effects orch patches =
                    (Patch_id.to_string a.patch_id)
                    (List.length effects)))
 
+(** I-12: notified_base_branch coherence — when has_session is true and the
+    agent has not been rebased (notified_base_branch is Some), then
+    notified_base_branch must have been set at start time. The field should only
+    be None before the first Start. After Start, it should be Some. *)
+let check_notified_base_branch_coherence (a : Patch_agent.t) =
+  (* If the agent has started (has_session), notified_base_branch should be
+     Some. If it hasn't started, both base_branch and notified_base_branch
+     should be None. *)
+  if a.has_session then (
+    if Option.is_some a.base_branch && Option.is_none a.notified_base_branch
+    then
+      failwith
+        (Printf.sprintf
+           "I-12 notified_base_branch_coherence violated for %s: base_branch \
+            is Some but notified_base_branch is None after session started"
+           (Patch_id.to_string a.patch_id)))
+  else if Option.is_some a.notified_base_branch then
+    failwith
+      (Printf.sprintf
+         "I-12 notified_base_branch_coherence violated for %s: \
+          notified_base_branch is Some but has_session is false"
+         (Patch_id.to_string a.patch_id))
+
 (* ========== Combined check ========== *)
 
 let merged_set_of orch =
@@ -705,7 +728,8 @@ let check_all_invariants orch patches ~prev_merged ~curr_merged =
       check_busy_implies_has_session a;
       check_ci_failure_count_non_negative a;
       check_queue_no_duplicates a;
-      check_conflict_not_cleared_while_in_flight a);
+      check_conflict_not_cleared_while_in_flight a;
+      check_notified_base_branch_coherence a);
   (* Monotonicity *)
   check_merged_monotonicity ~prev_merged ~curr_merged;
   (* Per-action invariants *)

--- a/test/test_patch_agent.ml
+++ b/test/test_patch_agent.ml
@@ -737,45 +737,55 @@ let () =
       Test.make ~name:"base_branch_changed false after start"
         Gen.(pair gen_pid gen_branch)
         (fun (pid, br) ->
-          let a = create ~branch:br pid |> fun a -> start a ~base_branch:br in
-          not (base_branch_changed a));
+          try
+            let a =
+              create ~branch:br pid |> fun a -> start a ~base_branch:br
+            in
+            not (base_branch_changed a)
+          with _ -> false);
       (* -- base_branch_changed true after rebase to different base -- *)
       Test.make ~name:"base_branch_changed true after rebase to different base"
         Gen.(pair gen_pid gen_branch)
         (fun (pid, br) ->
-          let new_base = Branch.of_string "rebased-target" in
-          let a =
-            create ~branch:br pid |> fun a -> start_with_pr a ~base_branch:br
-          in
-          let a = complete a in
-          let a = enqueue a Operation_kind.Rebase in
-          let a = rebase a ~base_branch:new_base in
-          base_branch_changed a);
+          try
+            let new_base = Branch.of_string "rebased-target" in
+            let a =
+              create ~branch:br pid |> fun a -> start_with_pr a ~base_branch:br
+            in
+            let a = complete a in
+            let a = enqueue a Operation_kind.Rebase in
+            let a = rebase a ~base_branch:new_base in
+            base_branch_changed a
+          with _ -> false);
       (* -- set_notified_base_branch clears base_branch_changed -- *)
       Test.make ~name:"set_notified_base_branch clears base_branch_changed"
         Gen.(pair gen_pid gen_branch)
         (fun (pid, br) ->
-          let new_base = Branch.of_string "rebased-target" in
-          let a =
-            create ~branch:br pid |> fun a -> start_with_pr a ~base_branch:br
-          in
-          let a = complete a in
-          let a = enqueue a Operation_kind.Rebase in
-          let a = rebase a ~base_branch:new_base in
-          let changed_before = base_branch_changed a in
-          let a = set_notified_base_branch a new_base in
-          changed_before && not (base_branch_changed a));
+          try
+            let new_base = Branch.of_string "rebased-target" in
+            let a =
+              create ~branch:br pid |> fun a -> start_with_pr a ~base_branch:br
+            in
+            let a = complete a in
+            let a = enqueue a Operation_kind.Rebase in
+            let a = rebase a ~base_branch:new_base in
+            let changed_before = base_branch_changed a in
+            let a = set_notified_base_branch a new_base in
+            changed_before && not (base_branch_changed a)
+          with _ -> false);
       (* -- rebase to same base does not trigger base_branch_changed -- *)
       Test.make ~name:"rebase to same base: base_branch_changed false"
         Gen.(pair gen_pid gen_branch)
         (fun (pid, br) ->
-          let a =
-            create ~branch:br pid |> fun a -> start_with_pr a ~base_branch:br
-          in
-          let a = complete a in
-          let a = enqueue a Operation_kind.Rebase in
-          let a = rebase a ~base_branch:br in
-          not (base_branch_changed a));
+          try
+            let a =
+              create ~branch:br pid |> fun a -> start_with_pr a ~base_branch:br
+            in
+            let a = complete a in
+            let a = enqueue a Operation_kind.Rebase in
+            let a = rebase a ~base_branch:br in
+            not (base_branch_changed a)
+          with _ -> false);
     ]
   in
   List.iter tests ~f:(fun t -> QCheck2.Test.check_exn t);

--- a/test/test_patch_agent.ml
+++ b/test/test_patch_agent.ml
@@ -738,9 +738,7 @@ let () =
         Gen.(pair gen_pid gen_branch)
         (fun (pid, br) ->
           try
-            let a =
-              create ~branch:br pid |> fun a -> start a ~base_branch:br
-            in
+            let a = create ~branch:br pid |> fun a -> start a ~base_branch:br in
             not (base_branch_changed a)
           with _ -> false);
       (* -- base_branch_changed true after rebase to different base -- *)

--- a/test/test_patch_agent.ml
+++ b/test/test_patch_agent.ml
@@ -472,7 +472,7 @@ let () =
             Onton.Patch_agent.restore ~patch_id:a.patch_id ~branch:br
               ~pr_number:None ~has_session:false ~busy:false ~merged:false
               ~queue:[] ~satisfies:false ~changed:false ~has_conflict:false
-              ~base_branch:None ~ci_failure_count:0
+              ~base_branch:None ~notified_base_branch:None ~ci_failure_count:0
               ~session_fallback:Fresh_available ~human_messages:[]
               ~ci_checks:a.ci_checks ~merge_ready:false ~is_draft:false
               ~pr_description_applied:false
@@ -547,9 +547,10 @@ let () =
               ~pr_number:(Some (Pr_number.of_int 1))
               ~has_session:false ~busy:false ~merged:false ~queue:[]
               ~satisfies:true ~changed:false ~has_conflict:false
-              ~base_branch:(Some br) ~ci_failure_count:0
-              ~session_fallback:Fresh_available ~human_messages:[] ~ci_checks:[]
-              ~merge_ready:false ~is_draft:false ~pr_description_applied:false
+              ~base_branch:(Some br) ~notified_base_branch:(Some br)
+              ~ci_failure_count:0 ~session_fallback:Fresh_available
+              ~human_messages:[] ~ci_checks:[] ~merge_ready:false
+              ~is_draft:false ~pr_description_applied:false
               ~implementation_notes_delivered:false ~start_attempts_without_pr:0
               ~conflict_noop_count:0 ~checks_passing:false ~current_op:None
               ~current_message_id:None ~generation:0 ~worktree_path:None
@@ -732,6 +733,49 @@ let () =
           let before = a.has_conflict in
           let a = clear_has_conflict a in
           before && not a.has_conflict);
+      (* -- base_branch_changed false after start -- *)
+      Test.make ~name:"base_branch_changed false after start"
+        Gen.(pair gen_pid gen_branch)
+        (fun (pid, br) ->
+          let a = create ~branch:br pid |> fun a -> start a ~base_branch:br in
+          not (base_branch_changed a));
+      (* -- base_branch_changed true after rebase to different base -- *)
+      Test.make ~name:"base_branch_changed true after rebase to different base"
+        Gen.(pair gen_pid gen_branch)
+        (fun (pid, br) ->
+          let new_base = Branch.of_string "rebased-target" in
+          let a =
+            create ~branch:br pid |> fun a -> start_with_pr a ~base_branch:br
+          in
+          let a = complete a in
+          let a = enqueue a Operation_kind.Rebase in
+          let a = rebase a ~base_branch:new_base in
+          base_branch_changed a);
+      (* -- set_notified_base_branch clears base_branch_changed -- *)
+      Test.make ~name:"set_notified_base_branch clears base_branch_changed"
+        Gen.(pair gen_pid gen_branch)
+        (fun (pid, br) ->
+          let new_base = Branch.of_string "rebased-target" in
+          let a =
+            create ~branch:br pid |> fun a -> start_with_pr a ~base_branch:br
+          in
+          let a = complete a in
+          let a = enqueue a Operation_kind.Rebase in
+          let a = rebase a ~base_branch:new_base in
+          let changed_before = base_branch_changed a in
+          let a = set_notified_base_branch a new_base in
+          changed_before && not (base_branch_changed a));
+      (* -- rebase to same base does not trigger base_branch_changed -- *)
+      Test.make ~name:"rebase to same base: base_branch_changed false"
+        Gen.(pair gen_pid gen_branch)
+        (fun (pid, br) ->
+          let a =
+            create ~branch:br pid |> fun a -> start_with_pr a ~base_branch:br
+          in
+          let a = complete a in
+          let a = enqueue a Operation_kind.Rebase in
+          let a = rebase a ~base_branch:br in
+          not (base_branch_changed a));
     ]
   in
   List.iter tests ~f:(fun t -> QCheck2.Test.check_exn t);

--- a/test/test_patch_controller.ml
+++ b/test/test_patch_controller.ml
@@ -47,13 +47,13 @@ let make_agent ~patch_id ~branch ~pr_number ~merged ~queue ~base_branch
     ~start_attempts_without_pr =
   Patch_agent.restore ~patch_id ~branch ~pr_number ~has_session:false
     ~busy:false ~merged ~queue ~satisfies:false ~changed:false
-    ~has_conflict:false ~base_branch ~ci_failure_count:0
-    ~session_fallback:Patch_agent.Fresh_available ~human_messages:[]
-    ~ci_checks:[] ~merge_ready:false ~is_draft ~pr_description_applied
-    ~implementation_notes_delivered ~start_attempts_without_pr
-    ~conflict_noop_count:0 ~checks_passing:false ~current_op:None
-    ~current_message_id:None ~generation:0 ~worktree_path:None ~head_branch:None
-    ~branch_blocked:false
+    ~has_conflict:false ~base_branch ~notified_base_branch:base_branch
+    ~ci_failure_count:0 ~session_fallback:Patch_agent.Fresh_available
+    ~human_messages:[] ~ci_checks:[] ~merge_ready:false ~is_draft
+    ~pr_description_applied ~implementation_notes_delivered
+    ~start_attempts_without_pr ~conflict_noop_count:0 ~checks_passing:false
+    ~current_op:None ~current_message_id:None ~generation:0 ~worktree_path:None
+    ~head_branch:None ~branch_blocked:false
 
 let has_notes_queued agent =
   List.mem agent.Patch_agent.queue Operation_kind.Implementation_notes
@@ -523,9 +523,9 @@ let () =
             ~pr_number:(Some (Pr_number.of_int 42))
             ~has_session:false ~busy:false ~merged:false ~queue:[]
             ~satisfies:false ~changed:false ~has_conflict:false
-            ~base_branch:(Some main) ~ci_failure_count:1
-            ~session_fallback:Patch_agent.Fresh_available ~human_messages:[]
-            ~ci_checks:[] ~merge_ready:false ~is_draft:false
+            ~base_branch:(Some main) ~notified_base_branch:(Some main)
+            ~ci_failure_count:1 ~session_fallback:Patch_agent.Fresh_available
+            ~human_messages:[] ~ci_checks:[] ~merge_ready:false ~is_draft:false
             ~pr_description_applied:true ~implementation_notes_delivered:true
             ~start_attempts_without_pr:0 ~conflict_noop_count:0
             ~checks_passing:false ~current_op:None ~current_message_id:None

--- a/test/test_poll_log_properties.ml
+++ b/test/test_poll_log_properties.ml
@@ -44,12 +44,13 @@ let make_agent ~patch_id ~branch ~has_conflict ~ci_failure_count ~current_op
   Patch_agent.restore ~patch_id ~branch
     ~pr_number:(Some (Pr_number.of_int 42))
     ~has_session:busy ~busy ~merged ~queue ~satisfies:false ~changed:false
-    ~has_conflict ~base_branch:(Some main) ~ci_failure_count
-    ~session_fallback:Patch_agent.Fresh_available ~human_messages:[]
-    ~ci_checks:[] ~merge_ready:false ~is_draft ~pr_description_applied:true
-    ~implementation_notes_delivered:true ~start_attempts_without_pr:0
-    ~conflict_noop_count:0 ~checks_passing ~current_op ~current_message_id:None
-    ~generation:0 ~worktree_path ~head_branch ~branch_blocked
+    ~has_conflict ~base_branch:(Some main) ~notified_base_branch:(Some main)
+    ~ci_failure_count ~session_fallback:Patch_agent.Fresh_available
+    ~human_messages:[] ~ci_checks:[] ~merge_ready:false ~is_draft
+    ~pr_description_applied:true ~implementation_notes_delivered:true
+    ~start_attempts_without_pr:0 ~conflict_noop_count:0 ~checks_passing
+    ~current_op ~current_message_id:None ~generation:0 ~worktree_path
+    ~head_branch ~branch_blocked
 
 let make_poll_observation ~head_branch ~branch_in_root ~worktree_path
     poll_result =

--- a/test/test_state_machine_properties.ml
+++ b/test/test_state_machine_properties.ml
@@ -89,6 +89,23 @@ let check_agent_invariants (a : Patch_agent.t) =
   if a.ci_failure_count < 0 then
     failwith
       (Printf.sprintf "ci_failure_count_non_negative violated for %s"
+         (Patch_id.to_string a.patch_id));
+  (* notified_base_branch coherence: after session starts, if base_branch is
+     Some then notified_base_branch must also be Some. Before any session,
+     notified_base_branch must be None. *)
+  if a.has_session then (
+    if Option.is_some a.base_branch && Option.is_none a.notified_base_branch
+    then
+      failwith
+        (Printf.sprintf
+           "notified_base_branch_coherence violated for %s: base_branch is \
+            Some but notified_base_branch is None"
+           (Patch_id.to_string a.patch_id)))
+  else if Option.is_some a.notified_base_branch then
+    failwith
+      (Printf.sprintf
+         "notified_base_branch_coherence violated for %s: notified_base_branch \
+          is Some but has_session is false"
          (Patch_id.to_string a.patch_id))
 
 (** Run a command sequence and check invariants after every step. Returns the


### PR DESCRIPTION
## Summary
- When a dependency merges and the orchestrator rebases a dependent patch onto a new base, the Claude session still has the old base branch in its initial prompt. This prepends a one-time "your base branch changed" notification to the next message delivered to the agent.
- Tracks `notified_base_branch` on `Patch_agent` — the base branch last communicated to the session. When it differs from `base_branch`, a notice is prepended to the next Respond prompt and marked delivered.
- Adds I-12 invariant (notified_base_branch coherence) to interleaving and state machine property tests, plus 4 targeted property tests for `base_branch_changed`.

Closes #137

## Test plan
- [x] `dune build` — compiles cleanly
- [x] `dune runtest` — all property and interleaving tests pass, including new I-12 invariant checked after every step
- [ ] Manual: start a gameplan with A → B dependency, let A merge, verify B's next transcript includes the base-branch-changed notice
- [ ] Persistence round-trip: stop/restart orchestrator, verify `notified_base_branch` survives and no spurious notifications fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * One-time notification shown when a patch's base branch changes, explaining the PR was rebased and advising not to change the PR base.

* **Improvements**
  * Notification state tracking so the base-branch change message is sent only once per session.

* **Tests**
  * Added invariants and property tests to ensure notified-base tracking and related lifecycle behaviors remain consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->