### PR TITLE
Add 'o' keybinding to open PR in browser from detail view

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1268,6 +1268,7 @@ let input_fiber ~runtime ~list_selected ~detail_scroll ~detail_follow
                               text = "Could not open browser";
                               expires_at = None;
                             }
+                      else status_msg := None
                   | None ->
                       status_msg :=
                         Some

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1237,16 +1237,17 @@ let input_fiber ~runtime ~list_selected ~detail_scroll ~detail_follow
               input_mode := Tui_input.Prompt_worktree;
               loop ()
           | Term.Key.Char 'o'
-            when (match !view_mode with
-                  | Tui.Detail_view _ -> true
-                  | Tui.List_view | Tui.Timeline_view -> false) -> (
-              match !view_mode with
+            when match !view_mode with
+                 | Tui.Detail_view _ -> true
+                 | Tui.List_view | Tui.Timeline_view -> false ->
+              (match !view_mode with
               | Tui.Detail_view patch_id -> (
                   match Pr_registry.find pr_registry ~patch_id with
                   | Some pr_number ->
                       let url =
                         Printf.sprintf "https://github.com/%s/%s/pull/%d" owner
-                          repo (Pr_number.to_int pr_number)
+                          repo
+                          (Pr_number.to_int pr_number)
                       in
                       let open_cmd =
                         if Sys.file_exists "/usr/bin/open" then "open"
@@ -1278,9 +1279,9 @@ let input_fiber ~runtime ~list_selected ~detail_scroll ~detail_follow
               | Tui.List_view | Tui.Timeline_view -> ());
               loop ()
           | Term.Key.Char 'm'
-            when (match !view_mode with
-                  | Tui.Detail_view _ -> true
-                  | Tui.List_view | Tui.Timeline_view -> false) ->
+            when match !view_mode with
+                 | Tui.Detail_view _ -> true
+                 | Tui.List_view | Tui.Timeline_view -> false ->
               input_mode := Tui_input.Manage_patch;
               loop ()
           | Term.Key.Char _ | Term.Key.Enter | Term.Key.Tab | Term.Key.Backspace

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -818,7 +818,8 @@ let normalize_paste text =
 let input_fiber ~runtime ~list_selected ~detail_scroll ~detail_follow
     ~timeline_scroll ~detail_scrolls ~view_mode ~pr_registry ~project_name
     ~show_help ~status_msg ~sorted_patch_ids ~input_mode ~prompt_line
-    ~patches_start_row ~patches_scroll_offset ~patches_visible_count =
+    ~patches_start_row ~patches_scroll_offset ~patches_visible_count ~owner
+    ~repo =
   let buf = Buffer.create 64 in
   let selected_pid () =
     let pids = !sorted_patch_ids in
@@ -1235,10 +1236,51 @@ let input_fiber ~runtime ~list_selected ~detail_scroll ~detail_follow
               Buffer.clear buf;
               input_mode := Tui_input.Prompt_worktree;
               loop ()
+          | Term.Key.Char 'o'
+            when (match !view_mode with
+                  | Tui.Detail_view _ -> true
+                  | Tui.List_view | Tui.Timeline_view -> false) -> (
+              match !view_mode with
+              | Tui.Detail_view patch_id -> (
+                  match Pr_registry.find pr_registry ~patch_id with
+                  | Some pr_number ->
+                      let url =
+                        Printf.sprintf "https://github.com/%s/%s/pull/%d" owner
+                          repo (Pr_number.to_int pr_number)
+                      in
+                      let open_cmd =
+                        if Sys.file_exists "/usr/bin/open" then "open"
+                        else "xdg-open"
+                      in
+                      let status =
+                        try
+                          Sys.command
+                            (Printf.sprintf "%s %s" open_cmd
+                               (Filename.quote url))
+                        with _ -> 1
+                      in
+                      if status <> 0 then
+                        status_msg :=
+                          Some
+                            {
+                              Tui.level = Tui.Error;
+                              text = "Could not open browser";
+                              expires_at = None;
+                            }
+                  | None ->
+                      status_msg :=
+                        Some
+                          {
+                            Tui.level = Tui.Info;
+                            text = "No PR to open";
+                            expires_at = None;
+                          })
+              | Tui.List_view | Tui.Timeline_view -> ());
+              loop ()
           | Term.Key.Char 'm'
-            when match !view_mode with
-                 | Tui.Detail_view _ -> true
-                 | Tui.List_view | Tui.Timeline_view -> false ->
+            when (match !view_mode with
+                  | Tui.Detail_view _ -> true
+                  | Tui.List_view | Tui.Timeline_view -> false) ->
               input_mode := Tui_input.Manage_patch;
               loop ()
           | Term.Key.Char _ | Term.Key.Enter | Term.Key.Tab | Term.Key.Backspace
@@ -1287,7 +1329,7 @@ let input_fiber ~runtime ~list_selected ~detail_scroll ~detail_follow
                         | Tui_input.Select | Tui_input.Back | Tui_input.Timeline
                         | Tui_input.Noop | Tui_input.Send_message _
                         | Tui_input.Add_pr _ | Tui_input.Add_worktree _
-                        | Tui_input.Remove_patch ->
+                        | Tui_input.Remove_patch | Tui_input.Open_in_browser ->
                             0
                       in
                       if delta <> 0 then detail_follow := false;
@@ -1382,7 +1424,8 @@ let input_fiber ~runtime ~list_selected ~detail_scroll ~detail_follow
                   | Tui.Detail_view _ | Tui.Timeline_view -> ());
                   loop ()
               | Tui_input.Refresh | Tui_input.Noop | Tui_input.Send_message _
-              | Tui_input.Add_pr _ | Tui_input.Add_worktree _ ->
+              | Tui_input.Add_pr _ | Tui_input.Add_worktree _
+              | Tui_input.Open_in_browser ->
                   loop ()))
   in
   loop ()
@@ -2874,7 +2917,8 @@ let run_with_config (config : config) gameplan existing_snapshot =
                     ~pr_registry ~project_name ~show_help ~status_msg
                     ~sorted_patch_ids ~input_mode ~prompt_line
                     ~patches_start_row ~patches_scroll_offset
-                    ~patches_visible_count)
+                    ~patches_visible_count ~owner:config.github_owner
+                    ~repo:config.github_repo)
                 :: (fun () ->
                   runner_fiber ~runtime ~env ~config ~project_name ~pr_registry
                     ~ci_checks_cache ~transcripts ~github ~net ~event_log

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -815,11 +815,11 @@ let normalize_paste text =
   let text = Base.String.tr text ~target:'\n' ~replacement:' ' in
   Base.String.tr text ~target:'\r' ~replacement:' '
 
-let input_fiber ~runtime ~list_selected ~detail_scroll ~detail_follow
-    ~timeline_scroll ~detail_scrolls ~view_mode ~pr_registry ~project_name
-    ~show_help ~status_msg ~sorted_patch_ids ~input_mode ~prompt_line
-    ~patches_start_row ~patches_scroll_offset ~patches_visible_count ~owner
-    ~repo =
+let input_fiber ~runtime ~process_mgr ~list_selected ~detail_scroll
+    ~detail_follow ~timeline_scroll ~detail_scrolls ~view_mode ~pr_registry
+    ~project_name ~show_help ~status_msg ~sorted_patch_ids ~input_mode
+    ~prompt_line ~patches_start_row ~patches_scroll_offset
+    ~patches_visible_count ~owner ~repo =
   let buf = Buffer.create 64 in
   let selected_pid () =
     let pids = !sorted_patch_ids in
@@ -1243,7 +1243,7 @@ let input_fiber ~runtime ~list_selected ~detail_scroll ~detail_follow
               (match !view_mode with
               | Tui.Detail_view patch_id -> (
                   match Pr_registry.find pr_registry ~patch_id with
-                  | Some pr_number ->
+                  | Some pr_number -> (
                       let url =
                         Printf.sprintf "https://github.com/%s/%s/pull/%d" owner
                           repo
@@ -1253,22 +1253,26 @@ let input_fiber ~runtime ~list_selected ~detail_scroll ~detail_follow
                         if Sys.file_exists "/usr/bin/open" then "open"
                         else "xdg-open"
                       in
-                      let status =
-                        try
-                          Sys.command
-                            (Printf.sprintf "%s %s" open_cmd
-                               (Filename.quote url))
-                        with _ -> 1
-                      in
-                      if status <> 0 then
-                        status_msg :=
-                          Some
-                            {
-                              Tui.level = Tui.Error;
-                              text = "Could not open browser";
-                              expires_at = None;
-                            }
-                      else status_msg := None
+                      match Eio.Process.run process_mgr [ open_cmd; url ] with
+                      | () -> (
+                          match !status_msg with
+                          | Some
+                              {
+                                Tui.text =
+                                  "No PR to open" | "Could not open browser";
+                                _;
+                              } ->
+                              status_msg := None
+                          | Some _ | None -> ())
+                      | exception (Eio.Cancel.Cancelled _ as exn) -> raise exn
+                      | exception _ ->
+                          status_msg :=
+                            Some
+                              {
+                                Tui.level = Tui.Error;
+                                text = "Could not open browser";
+                                expires_at = None;
+                              })
                   | None ->
                       status_msg :=
                         Some
@@ -2914,11 +2918,11 @@ let run_with_config (config : config) gameplan existing_snapshot =
                      ~input_mode ~prompt_line ~patches_start_row
                      ~patches_scroll_offset ~patches_visible_count)
                 :: (fun () ->
-                  input_fiber ~runtime ~list_selected ~detail_scroll
-                    ~detail_follow ~timeline_scroll ~detail_scrolls ~view_mode
-                    ~pr_registry ~project_name ~show_help ~status_msg
-                    ~sorted_patch_ids ~input_mode ~prompt_line
-                    ~patches_start_row ~patches_scroll_offset
+                  input_fiber ~runtime ~process_mgr ~list_selected
+                    ~detail_scroll ~detail_follow ~timeline_scroll
+                    ~detail_scrolls ~view_mode ~pr_registry ~project_name
+                    ~show_help ~status_msg ~sorted_patch_ids ~input_mode
+                    ~prompt_line ~patches_start_row ~patches_scroll_offset
                     ~patches_visible_count ~owner:config.github_owner
                     ~repo:config.github_repo)
                 :: (fun () ->

--- a/lib/tui.ml
+++ b/lib/tui.ml
@@ -1096,6 +1096,7 @@ let render_help_overlay ~width ~height =
           "PgDn      Page down (10 lines)";
           "Enter     Send message";
           "m         Manage patch";
+          "o         Open PR in browser";
           "Esc/Bksp  Back to list";
           "t         Toggle timeline";
         ] );

--- a/lib/tui_input.ml
+++ b/lib/tui_input.ml
@@ -21,6 +21,7 @@ type command =
   | Add_pr of Types.Pr_number.t
   | Add_worktree of string
   | Remove_patch
+  | Open_in_browser
 [@@deriving show, eq]
 
 type input_mode =
@@ -53,6 +54,7 @@ let of_key (key : Term.Key.t) : command =
   | Enter -> Select
   | Escape | Backspace -> Back
   | Char '-' | Char 'x' -> Remove_patch
+  | Char 'o' -> Open_in_browser
   | Char _ | Tab | Delete | Home | End | Left | Right | F _ | Ctrl _ | Paste _
   | Mouse _ | Unknown _ ->
       Noop
@@ -77,7 +79,7 @@ let apply_move ~count ~selected (cmd : command) =
     | Page_up -> if selected = -1 then -1 else clamp (selected - 5)
     | Page_down -> if selected = -1 then 0 else clamp (selected + 5)
     | Quit | Refresh | Help | Select | Back | Timeline | Noop | Send_message _
-    | Add_pr _ | Add_worktree _ | Remove_patch ->
+    | Add_pr _ | Add_worktree _ | Remove_patch | Open_in_browser ->
         if selected >= count then -1 else selected
 
 let%test "q maps to Quit" = equal_command (of_key (Char 'q')) Quit
@@ -103,6 +105,9 @@ let%test "- maps to Remove_patch" =
 
 let%test "x maps to Remove_patch" =
   equal_command (of_key (Char 'x')) Remove_patch
+
+let%test "o maps to Open_in_browser" =
+  equal_command (of_key (Char 'o')) Open_in_browser
 
 let%test "unknown key maps to Noop" = equal_command (of_key (Char 'z')) Noop
 let%test "tab maps to Noop" = equal_command (of_key Tab) Noop

--- a/lib/tui_input.mli
+++ b/lib/tui_input.mli
@@ -19,6 +19,7 @@ type command =
   | Add_pr of Types.Pr_number.t
   | Add_worktree of string
   | Remove_patch
+  | Open_in_browser
 [@@deriving show, eq]
 
 (** Input mode for the TUI prompt. *)


### PR DESCRIPTION
## Summary
- Pressing `o` in detail view opens the patch's PR in the default browser via `open` (macOS) / `xdg-open` (Linux)
- Shows "No PR to open" if no PR number is registered, "Could not open browser" if the command fails
- Added to help overlay and includes a key mapping test

Closes #135

## Test plan
- [x] `dune build` passes
- [x] `dune runtest` passes
- [ ] Manual: open detail view for a patch with a PR, press `o`, verify browser opens to correct URL
- [ ] Manual: open detail view for a patch without a PR, press `o`, verify "No PR to open" status message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Press `o` while viewing details to open the associated GitHub Pull Request in your browser. Uses the system opener; shows “No PR to open” if none is available, clears any status on success, and displays an error status if launching the browser fails.

* **Documentation**
  * Help overlay updated to document the new `o` keyboard shortcut.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->