### PR TITLE
Add cursor-aware input buffer with movement keys

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -841,7 +841,8 @@ let input_fiber ~runtime ~process_mgr ~list_selected ~detail_scroll
         let contents = Tui_input.Edit_buffer.contents buf in
         let cursor_col =
           Term.visible_length prefix
-          + Term.visible_length (String.sub contents 0 (Tui_input.Edit_buffer.cursor buf))
+          + Term.visible_length
+              (String.sub contents 0 (Tui_input.Edit_buffer.cursor buf))
         in
         prompt_line := Some { Tui.prompt_text = prefix ^ contents; cursor_col };
         Atomic.set Term.Raw.redraw_needed true

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -840,7 +840,8 @@ let input_fiber ~runtime ~process_mgr ~list_selected ~detail_scroll
         let prefix = Tui_input.prompt_prefix !input_mode in
         let contents = Tui_input.Edit_buffer.contents buf in
         let cursor_col =
-          String.length prefix + Tui_input.Edit_buffer.cursor buf
+          Term.visible_length prefix
+          + Term.visible_length (String.sub contents 0 (Tui_input.Edit_buffer.cursor buf))
         in
         prompt_line := Some { Tui.prompt_text = prefix ^ contents; cursor_col };
         Atomic.set Term.Raw.redraw_needed true

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -823,7 +823,7 @@ let input_fiber ~runtime ~process_mgr ~list_selected ~detail_scroll
     ~project_name ~show_help ~status_msg ~sorted_patch_ids ~input_mode
     ~prompt_line ~patches_start_row ~patches_scroll_offset
     ~patches_visible_count ~owner ~repo =
-  let buf = Buffer.create 64 in
+  let buf = Tui_input.Edit_buffer.create () in
   let selected_pid () =
     let pids = !sorted_patch_ids in
     let count = Base.List.length pids in
@@ -838,7 +838,12 @@ let input_fiber ~runtime ~process_mgr ~list_selected ~detail_scroll
     | Tui_input.Prompt_pr | Tui_input.Prompt_worktree | Tui_input.Prompt_message
     | Tui_input.Prompt_broadcast ->
         let prefix = Tui_input.prompt_prefix !input_mode in
-        prompt_line := Some (prefix ^ Buffer.contents buf)
+        let contents = Tui_input.Edit_buffer.contents buf in
+        let cursor_col =
+          String.length prefix + Tui_input.Edit_buffer.cursor buf
+        in
+        prompt_line := Some { Tui.prompt_text = prefix ^ contents; cursor_col };
+        Atomic.set Term.Raw.redraw_needed true
   in
   let history = Tui_input.History.create () in
   let saved_draft = ref "" in
@@ -900,20 +905,20 @@ let input_fiber ~runtime ~process_mgr ~list_selected ~detail_scroll
         then
           match key with
           | Term.Key.Paste text ->
-              Buffer.add_string buf (normalize_paste text);
+              Tui_input.Edit_buffer.insert_string buf (normalize_paste text);
               loop ()
           | Term.Key.Escape ->
-              Buffer.clear buf;
+              Tui_input.Edit_buffer.clear buf;
               saved_draft := "";
               Tui_input.History.reset_browse history;
               input_mode := Tui_input.Normal;
               loop ()
           | Term.Key.Enter ->
-              let line = Buffer.contents buf in
+              let line = Tui_input.Edit_buffer.contents buf in
               Tui_input.History.push history line;
               Tui_input.History.reset_browse history;
               let mode = !input_mode in
-              Buffer.clear buf;
+              Tui_input.Edit_buffer.clear buf;
               saved_draft := "";
               input_mode := Tui_input.Normal;
               let line = Base.String.strip line in
@@ -1113,15 +1118,11 @@ let input_fiber ~runtime ~process_mgr ~list_selected ~detail_scroll
                   )
               | Tui_input.Normal | Tui_input.Manage_patch -> ());
               loop ()
-          | Term.Key.Backspace | Term.Key.Delete ->
-              let len = Buffer.length buf in
-              if len > 0 then (
-                let contents = Buffer.contents buf in
-                Buffer.clear buf;
-                Buffer.add_string buf (String.sub contents 0 (len - 1)));
+          | Term.Key.Backspace ->
+              Tui_input.Edit_buffer.delete_before buf;
               loop ()
           | Term.Key.Char c ->
-              Buffer.add_char buf c;
+              Tui_input.Edit_buffer.insert_char buf c;
               loop ()
           | Term.Key.Ctrl 'z' ->
               Term.Raw.suspend ();
@@ -1130,23 +1131,46 @@ let input_fiber ~runtime ~process_mgr ~list_selected ~detail_scroll
               let was_browsing = Tui_input.History.is_browsing history in
               (match Tui_input.History.older history with
               | Some s ->
-                  if not was_browsing then saved_draft := Buffer.contents buf;
-                  Buffer.clear buf;
-                  Buffer.add_string buf s
+                  if not was_browsing then
+                    saved_draft := Tui_input.Edit_buffer.contents buf;
+                  Tui_input.Edit_buffer.set buf s
               | None -> ());
               loop ()
           | Term.Key.Down ->
               (if Tui_input.History.is_browsing history then
                  match Tui_input.History.newer history with
-                 | Tui_input.History.Entry s ->
-                     Buffer.clear buf;
-                     Buffer.add_string buf s
+                 | Tui_input.History.Entry s -> Tui_input.Edit_buffer.set buf s
                  | Tui_input.History.At_fresh ->
-                     Buffer.clear buf;
-                     Buffer.add_string buf !saved_draft);
+                     Tui_input.Edit_buffer.set buf !saved_draft);
               loop ()
-          | Term.Key.Tab | Term.Key.Left | Term.Key.Right | Term.Key.Home
-          | Term.Key.End | Term.Key.Page_up | Term.Key.Page_down | Term.Key.F _
+          | Term.Key.Left ->
+              Tui_input.Edit_buffer.move_left buf;
+              loop ()
+          | Term.Key.Right ->
+              Tui_input.Edit_buffer.move_right buf;
+              loop ()
+          | Term.Key.Home ->
+              Tui_input.Edit_buffer.move_home buf;
+              loop ()
+          | Term.Key.End ->
+              Tui_input.Edit_buffer.move_end buf;
+              loop ()
+          | Term.Key.Delete ->
+              Tui_input.Edit_buffer.delete_at buf;
+              loop ()
+          | Term.Key.Ctrl 'a' ->
+              Tui_input.Edit_buffer.move_home buf;
+              loop ()
+          | Term.Key.Ctrl 'e' ->
+              Tui_input.Edit_buffer.move_end buf;
+              loop ()
+          | Term.Key.Ctrl 'k' ->
+              ignore (Tui_input.Edit_buffer.kill_to_end buf);
+              loop ()
+          | Term.Key.Ctrl 'u' ->
+              ignore (Tui_input.Edit_buffer.kill_to_start buf);
+              loop ()
+          | Term.Key.Tab | Term.Key.Page_up | Term.Key.Page_down | Term.Key.F _
           | Term.Key.Ctrl _ | Term.Key.Mouse _ | Term.Key.Unknown _ ->
               loop ()
         else if Term.Key.equal key (Term.Key.Ctrl 'z') then (
@@ -1158,8 +1182,8 @@ let input_fiber ~runtime ~process_mgr ~list_selected ~detail_scroll
               (* In detail view, auto-enter message mode and buffer the paste *)
               match !view_mode with
               | Tui.Detail_view _ ->
-                  Buffer.clear buf;
-                  Buffer.add_string buf (normalize_paste text);
+                  Tui_input.Edit_buffer.clear buf;
+                  Tui_input.Edit_buffer.insert_string buf (normalize_paste text);
                   input_mode := Tui_input.Prompt_message;
                   loop ()
               | Tui.List_view | Tui.Timeline_view -> loop ())
@@ -1226,17 +1250,17 @@ let input_fiber ~runtime ~process_mgr ~list_selected ~detail_scroll
                   loop ())
           | Term.Key.Char '*' when Tui.equal_view_mode !view_mode Tui.List_view
             ->
-              Buffer.clear buf;
+              Tui_input.Edit_buffer.clear buf;
               input_mode := Tui_input.Prompt_broadcast;
               loop ()
           | Term.Key.Char '+' when Tui.equal_view_mode !view_mode Tui.List_view
             ->
-              Buffer.clear buf;
+              Tui_input.Edit_buffer.clear buf;
               input_mode := Tui_input.Prompt_pr;
               loop ()
           | Term.Key.Char 'w' when Tui.equal_view_mode !view_mode Tui.List_view
             ->
-              Buffer.clear buf;
+              Tui_input.Edit_buffer.clear buf;
               input_mode := Tui_input.Prompt_worktree;
               loop ()
           | Term.Key.Char 'o'

--- a/lib/term.ml
+++ b/lib/term.ml
@@ -227,6 +227,28 @@ let%test "fit_width truncates multibyte string" =
   let s = styled [ Sgr.fg_red ] "⚠ hello" in
   visible_length (fit_width 3 s) = 3
 
+(** Byte offset in a plain (no ANSI) string of the [col]-th visible character.
+    Returns [String.length s] when [col >= visible_length s]. *)
+let byte_offset_of_visible_col s col =
+  let len = String.length s in
+  let rec loop i n =
+    if n >= col || i >= len then i
+    else
+      let w = utf8_seq_width s i len in
+      loop (i + w) (n + 1)
+  in
+  loop 0 0
+
+let%test "byte_offset_of_visible_col ascii" =
+  byte_offset_of_visible_col "hello" 3 = 3
+
+let%test "byte_offset_of_visible_col multibyte" =
+  (* "⚠x" — ⚠ is 3 bytes, x is 1 byte *)
+  byte_offset_of_visible_col "⚠x" 1 = 3
+
+let%test "byte_offset_of_visible_col past end" =
+  byte_offset_of_visible_col "ab" 5 = 2
+
 (** Break a plain string into lines of at most [width] visible characters. Does
     not attempt to split on word boundaries — just hard-wraps at the column
     limit. Each resulting line is padded to [width] with spaces. Returns at

--- a/lib/tui.ml
+++ b/lib/tui.ml
@@ -1057,8 +1057,7 @@ let render_footer ~width ~view_mode ?prompt_line () =
               let before = String.sub line ~pos:0 ~len:bp in
               let ch = String.sub line ~pos:bp ~len:(bp_next - bp) in
               let after =
-                String.sub line ~pos:bp_next
-                  ~len:(String.length line - bp_next)
+                String.sub line ~pos:bp_next ~len:(String.length line - bp_next)
               in
               before ^ Term.Sgr.reverse ^ ch ^ Term.Sgr.reset ^ after)
       in

--- a/lib/tui.ml
+++ b/lib/tui.ml
@@ -380,6 +380,7 @@ let status_indicator = function
 
 (** {1 Status messages} *)
 
+type prompt_info = { prompt_text : string; cursor_col : int }
 type msg_level = Info | Warning | Error [@@deriving show, eq]
 
 type status_msg = {
@@ -1039,10 +1040,24 @@ let render_timeline ~width ~scroll (entries : activity_entry list) =
 
 let render_footer ~width ~view_mode ?prompt_line () =
   match prompt_line with
-  | Some text ->
+  | Some { prompt_text; cursor_col } ->
       let usable = Int.max 1 (width - 2) in
-      let wrapped = Term.wrap_lines usable text in
-      Term.hrule width :: wrapped
+      let wrapped = Term.wrap_lines usable prompt_text in
+      let cursor_line = cursor_col / usable in
+      let cursor_within = cursor_col % usable in
+      let with_cursor =
+        List.mapi wrapped ~f:(fun i line ->
+            if i <> cursor_line then line
+            else
+              let before = String.sub line ~pos:0 ~len:cursor_within in
+              let ch = String.sub line ~pos:cursor_within ~len:1 in
+              let after =
+                String.sub line ~pos:(cursor_within + 1)
+                  ~len:(String.length line - cursor_within - 1)
+              in
+              before ^ Term.Sgr.reverse ^ ch ^ Term.Sgr.reset ^ after)
+      in
+      Term.hrule width :: with_cursor
   | None ->
       let help =
         match view_mode with

--- a/lib/tui.ml
+++ b/lib/tui.ml
@@ -1047,13 +1047,18 @@ let render_footer ~width ~view_mode ?prompt_line () =
       let cursor_within = cursor_col % usable in
       let with_cursor =
         List.mapi wrapped ~f:(fun i line ->
-            if i <> cursor_line then line
+            if i <> cursor_line || cursor_within >= Term.visible_length line
+            then line
             else
-              let before = String.sub line ~pos:0 ~len:cursor_within in
-              let ch = String.sub line ~pos:cursor_within ~len:1 in
+              let bp = Term.byte_offset_of_visible_col line cursor_within in
+              let bp_next =
+                Term.byte_offset_of_visible_col line (cursor_within + 1)
+              in
+              let before = String.sub line ~pos:0 ~len:bp in
+              let ch = String.sub line ~pos:bp ~len:(bp_next - bp) in
               let after =
-                String.sub line ~pos:(cursor_within + 1)
-                  ~len:(String.length line - cursor_within - 1)
+                String.sub line ~pos:bp_next
+                  ~len:(String.length line - bp_next)
               in
               before ^ Term.Sgr.reverse ^ ch ^ Term.Sgr.reset ^ after)
       in

--- a/lib/tui.mli
+++ b/lib/tui.mli
@@ -133,6 +133,8 @@ val views_of_orchestrator :
 val render_help_overlay : width:int -> height:int -> string list
 val render_manage_overlay : width:int -> height:int -> string list
 
+type prompt_info = { prompt_text : string; cursor_col : int }
+
 val render_frame :
   width:int ->
   height:int ->
@@ -145,7 +147,7 @@ val render_frame :
   show_manage:bool ->
   ?transcript:string ->
   ?status_msg:status_msg ->
-  ?prompt_line:string ->
+  ?prompt_line:prompt_info ->
   patch_view list ->
   frame
 

--- a/lib/tui_input.ml
+++ b/lib/tui_input.ml
@@ -300,3 +300,168 @@ module History = struct
     (* browse should be reset *)
     not (is_browsing h)
 end
+
+module Edit_buffer = struct
+  type t = { mutable text : string; mutable pos : int }
+
+  let create () = { text = ""; pos = 0 }
+  let contents t = t.text
+  let cursor t = t.pos
+  let length t = String.length t.text
+
+  let clear t =
+    t.text <- "";
+    t.pos <- 0
+
+  let set t s =
+    t.text <- s;
+    t.pos <- String.length s
+
+  let insert_char t c =
+    let len = String.length t.text in
+    let s = String.make 1 c in
+    t.text <-
+      String.sub t.text ~pos:0 ~len:t.pos
+      ^ s
+      ^ String.sub t.text ~pos:t.pos ~len:(len - t.pos);
+    t.pos <- t.pos + 1
+
+  let insert_string t s =
+    let slen = String.length s in
+    if slen > 0 then begin
+      let len = String.length t.text in
+      t.text <-
+        String.sub t.text ~pos:0 ~len:t.pos
+        ^ s
+        ^ String.sub t.text ~pos:t.pos ~len:(len - t.pos);
+      t.pos <- t.pos + slen
+    end
+
+  let delete_before t =
+    if t.pos > 0 then begin
+      let len = String.length t.text in
+      t.text <-
+        String.sub t.text ~pos:0 ~len:(t.pos - 1)
+        ^ String.sub t.text ~pos:t.pos ~len:(len - t.pos);
+      t.pos <- t.pos - 1
+    end
+
+  let delete_at t =
+    let len = String.length t.text in
+    if t.pos < len then
+      t.text <-
+        String.sub t.text ~pos:0 ~len:t.pos
+        ^ String.sub t.text ~pos:(t.pos + 1) ~len:(len - t.pos - 1)
+
+  let move_left t = if t.pos > 0 then t.pos <- t.pos - 1
+  let move_right t = if t.pos < String.length t.text then t.pos <- t.pos + 1
+  let move_home t = t.pos <- 0
+  let move_end t = t.pos <- String.length t.text
+
+  let kill_to_end t =
+    let len = String.length t.text in
+    let killed = String.sub t.text ~pos:t.pos ~len:(len - t.pos) in
+    t.text <- String.sub t.text ~pos:0 ~len:t.pos;
+    killed
+
+  let kill_to_start t =
+    let len = String.length t.text in
+    let killed = String.sub t.text ~pos:0 ~len:t.pos in
+    t.text <- String.sub t.text ~pos:t.pos ~len:(len - t.pos);
+    t.pos <- 0;
+    killed
+
+  let%test "create is empty with cursor at 0" =
+    let b = create () in
+    String.equal (contents b) "" && cursor b = 0
+
+  let%test "insert_char at end" =
+    let b = create () in
+    insert_char b 'a';
+    insert_char b 'b';
+    String.equal (contents b) "ab" && cursor b = 2
+
+  let%test "insert_char at middle" =
+    let b = create () in
+    insert_char b 'a';
+    insert_char b 'c';
+    move_left b;
+    insert_char b 'b';
+    String.equal (contents b) "abc" && cursor b = 2
+
+  let%test "insert_string at middle" =
+    let b = create () in
+    set b "ac";
+    move_left b;
+    insert_string b "bb";
+    String.equal (contents b) "abbc" && cursor b = 3
+
+  let%test "delete_before at middle" =
+    let b = create () in
+    set b "abc";
+    move_left b;
+    delete_before b;
+    String.equal (contents b) "ac" && cursor b = 1
+
+  let%test "delete_before at start is no-op" =
+    let b = create () in
+    set b "abc";
+    move_home b;
+    delete_before b;
+    String.equal (contents b) "abc" && cursor b = 0
+
+  let%test "delete_at removes char under cursor" =
+    let b = create () in
+    set b "abc";
+    move_home b;
+    delete_at b;
+    String.equal (contents b) "bc" && cursor b = 0
+
+  let%test "delete_at at end is no-op" =
+    let b = create () in
+    set b "abc";
+    delete_at b;
+    String.equal (contents b) "abc" && cursor b = 3
+
+  let%test "move_left clamps at 0" =
+    let b = create () in
+    set b "ab";
+    move_home b;
+    move_left b;
+    cursor b = 0
+
+  let%test "move_right clamps at length" =
+    let b = create () in
+    set b "ab";
+    move_right b;
+    cursor b = 2
+
+  let%test "kill_to_end returns and removes suffix" =
+    let b = create () in
+    set b "abcde";
+    move_home b;
+    move_right b;
+    move_right b;
+    let killed = kill_to_end b in
+    String.equal killed "cde" && String.equal (contents b) "ab" && cursor b = 2
+
+  let%test "kill_to_start returns and removes prefix" =
+    let b = create () in
+    set b "abcde";
+    move_home b;
+    move_right b;
+    move_right b;
+    let killed = kill_to_start b in
+    String.equal killed "ab" && String.equal (contents b) "cde" && cursor b = 0
+
+  let%test "set puts cursor at end" =
+    let b = create () in
+    set b "hello";
+    cursor b = 5 && String.equal (contents b) "hello"
+
+  let%test "clear resets everything" =
+    let b = create () in
+    set b "hello";
+    clear b;
+    cursor b = 0 && String.equal (contents b) ""
+end

--- a/lib/tui_input.mli
+++ b/lib/tui_input.mli
@@ -79,3 +79,28 @@ module History : sig
   val is_browsing : t -> bool
   (** [true] when the browse cursor is not at the bottom. *)
 end
+
+(** Cursor-aware single-line editing buffer.
+
+    Tracks a cursor position within the text and supports insert, delete, and
+    movement operations at the cursor. *)
+module Edit_buffer : sig
+  type t
+
+  val create : unit -> t
+  val contents : t -> string
+  val cursor : t -> int
+  val length : t -> int
+  val clear : t -> unit
+  val set : t -> string -> unit
+  val insert_char : t -> char -> unit
+  val insert_string : t -> string -> unit
+  val delete_before : t -> unit
+  val delete_at : t -> unit
+  val move_left : t -> unit
+  val move_right : t -> unit
+  val move_home : t -> unit
+  val move_end : t -> unit
+  val kill_to_end : t -> string
+  val kill_to_start : t -> string
+end

--- a/onton.opam
+++ b/onton.opam
@@ -14,9 +14,9 @@ depends: [
   "tls-eio" {>= "2.0.0"}
   "mirage-crypto-rng" {>= "2.0.0"}
   "ca-certs" {>= "1.0.0"}
-  "cmarkit" {>= "0.3.0"}
+  "cmarkit" {>= "0.4.0"}
   "re" {>= "1.10.0"}
-  "cmdliner" {>= "1.3.0"}
+  "cmdliner" {>= "2.0.0"}
   "ppx_deriving" {>= "6.0"}
   "ppx_yojson_conv" {>= "v0.17.0"}
   "ppx_sexp_conv" {>= "v0.17.0"}


### PR DESCRIPTION
## Summary
- Add `Edit_buffer` module to `tui_input` with cursor position tracking, enabling mid-text insert/delete, Left/Right/Home/End movement, and readline shortcuts (Ctrl+A/E/K/U)
- Render the block cursor at the correct position within wrapped prompt lines instead of always at the end
- Set `redraw_needed` flag on prompt keystrokes to eliminate up to 100ms input latency

Closes #133

## Test plan
- [ ] `dune build` compiles with zero warnings
- [ ] `dune runtest` passes (14 new inline tests for Edit_buffer)
- [ ] Manual test: enter prompt mode (+, w, *, or message), type text, use Left/Right/Home/End/Ctrl+A/E to move cursor, verify cursor renders at correct position
- [ ] Backspace deletes char before cursor, Delete removes char at cursor
- [ ] Ctrl+K kills to end of line, Ctrl+U kills to start
- [ ] History navigation (Up/Down) places cursor at end of recalled line
- [ ] Input feels snappy with no perceptible lag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Visible cursor rendering in the prompt with correct wrapping and multibyte-aware positioning
  * Full-featured in-line edit buffer enabling insert/paste, delete/backspace, and start/end/killing operations
  * Keyboard shortcuts for navigation and editing: Left/Right, Home/End, Delete, Ctrl+A/Ctrl+E, Ctrl+K/Ctrl+U

* **Tests**
  * Added unit tests for editing buffer and cursor/byte-offset behavior

* **Chores**
  * Updated dependencies: cmarkit (0.3.0→0.4.0), cmdliner (1.3.0→2.0.0)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->