### PR TITLE
Fix infinite conflict notification loop

### DIFF
--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -478,14 +478,10 @@ let apply_conflict_push_result t patch_id decision
       let t = set_has_conflict t patch_id in
       let t = enqueue t patch_id Operation_kind.Merge_conflict in
       (t, Conflict_retry_push)
-  | Deliver_to_agent, Some Worktree.Push_ok ->
-      let t = clear_has_conflict t patch_id in
-      let t = complete t patch_id in
-      (t, Conflict_done)
   | ( Deliver_to_agent,
       ( None
       | Some
-          ( Worktree.Push_up_to_date | Worktree.Push_rejected
+          ( Worktree.Push_ok | Worktree.Push_up_to_date | Worktree.Push_rejected
           | Worktree.Push_error _ ) ) ) ->
       (t, Conflict_needs_agent)
   | Conflict_failed, _ -> (t, Conflict_give_up)

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -208,12 +208,13 @@ val apply_conflict_push_result :
     [Push_branch] effect ([None] when no push was requested). Returns the final
     resolution and updated state.
 
-    - [Conflict_done]: conflict fully resolved (push succeeded or was
-      redundant).
+    - [Conflict_done]: conflict fully resolved (rebase succeeded and push
+      landed).
     - [Conflict_retry_push]: rebase succeeded locally but push failed;
       re-enqueues [Merge_conflict] so the next cycle retries.
     - [Conflict_needs_agent]: the coding agent must resolve the conflict
-      manually (rebase was noop/conflict, or push was up-to-date).
+      manually (rebase was noop/conflict — push result is irrelevant because the
+      rebase itself didn't resolve the conflict).
     - [Conflict_give_up]: unrecoverable rebase error. *)
 
 val restore :

--- a/lib/patch_agent.ml
+++ b/lib/patch_agent.ml
@@ -346,13 +346,11 @@ let respond t k =
   let is_human = equal_k Human in
   let is_ci = equal_k Ci in
   let is_review = equal_k Review_comments in
-  let is_merge_conflict = equal_k Merge_conflict in
   let satisfies = if is_human then false else t.satisfies in
   (* Spec: changed' only when a valid pending comment exists. We set it
      unconditionally here because comment validity is resolved downstream
      by the agent session — a conservative simplification. *)
   let changed = if is_ci || is_review then true else t.changed in
-  let has_conflict = if is_merge_conflict then false else t.has_conflict in
   let ci_failure_count =
     if is_ci then t.ci_failure_count + 1 else t.ci_failure_count
   in
@@ -365,7 +363,6 @@ let respond t k =
     queue;
     satisfies;
     changed;
-    has_conflict;
     human_messages = t.human_messages;
     ci_failure_count;
     merge_ready = false;

--- a/test/test_interleaving_properties.ml
+++ b/test/test_interleaving_properties.ml
@@ -912,8 +912,13 @@ let mk_bootstrapped () =
 
 (** Simulate one full conflict-noop cycle: poll(conflict) → fire
     Respond(Merge_conflict) → apply_conflict_rebase_result(Noop) →
-    apply_conflict_push_result(Push_up_to_date) → session completes → complete.
-    Returns the updated orchestrator. *)
+    apply_conflict_push_result(Deliver_to_agent, Push_ok) → session completes →
+    complete. Returns the updated orchestrator.
+
+    The push result is [Push_ok] because [force_push_with_lease] succeeds even
+    when the rebase was a noop — it pushes the existing (conflicting) content.
+    This is the path observed in production; the previous version of this helper
+    skipped [apply_conflict_push_result] entirely. *)
 let conflict_noop_cycle orch pid patches =
   let branch_of = branch_of_patches patches in
   let gameplan = make_gameplan patches in
@@ -947,14 +952,24 @@ let conflict_noop_cycle orch pid patches =
     Graph.initial_base (Orchestrator.graph orch) pid ~has_merged ~branch_of
       ~main
   in
-  let orch, _decision, _effects =
+  let orch, decision, _effects =
     Orchestrator.apply_conflict_rebase_result orch pid Worktree.Noop new_base
   in
-  (* 4. Session completes without resolving the conflict *)
+  (* 4. Apply push result — force-push succeeds even on noop rebase *)
+  let orch, resolution =
+    Orchestrator.apply_conflict_push_result orch pid decision
+      (Some Worktree.Push_ok)
+  in
   let orch =
     Orchestrator.apply_session_result orch pid Orchestrator.Session_ok
   in
-  Orchestrator.complete orch pid
+  (* Conflict_done means the push handler already completed the agent.
+     Conflict_needs_agent means the agent session ran but we must complete. *)
+  match resolution with
+  | Orchestrator.Conflict_done -> orch
+  | Orchestrator.Conflict_needs_agent -> Orchestrator.complete orch pid
+  | Orchestrator.Conflict_retry_push | Orchestrator.Conflict_give_up ->
+      failwith "unexpected resolution in conflict_noop_cycle"
 
 (** PI-6: Repeated Noop conflict rebase converges to needs_intervention. If the
     rebase keeps returning Noop (stale refs or agent unable to resolve), the
@@ -1058,3 +1073,53 @@ let () =
   in
   QCheck2.Test.check_exn prop_pi7;
   Stdlib.print_endline "PI-7 passed"
+
+(** PI-8: Conflict noop cycle does not re-enqueue Merge_conflict on the next
+    poll. After a full conflict-noop cycle (poll → fire → rebase Noop → push
+    Push_ok → complete), the next poll must NOT re-enqueue Merge_conflict
+    because has_conflict should still be true (had_conflict_before = true). This
+    is a regression test for the infinite conflict notification loop. *)
+let () =
+  let prop_pi8 =
+    QCheck2.Test.make
+      ~name:
+        "PI-8: conflict noop cycle does not re-enqueue Merge_conflict on next \
+         poll"
+      (QCheck2.Gen.return ()) (fun () ->
+        let orch, pid, patches = mk_bootstrapped () in
+        (* Run one full conflict-noop cycle *)
+        let orch = conflict_noop_cycle orch pid patches in
+        let a = Orchestrator.agent orch pid in
+        (* After the cycle, has_conflict must be true so the next poll
+           sees had_conflict_before = true and skips re-enqueue. *)
+        if not a.Patch_agent.has_conflict then
+          failwith
+            "has_conflict is false after conflict_noop_cycle — next poll will \
+             re-enqueue";
+        (* Simulate the next poll with conflict still reported by GitHub *)
+        let branch_of = branch_of_patches patches in
+        let poll_result =
+          make_poll_result ~has_conflict:true ~merged:false ~ci_failed:false
+            ~checks_passing:false ~review_comments:false
+        in
+        let observation =
+          Patch_controller.
+            {
+              poll_result;
+              head_branch = Some (branch_of pid);
+              base_branch = None;
+              branch_in_root = false;
+              worktree_path = None;
+            }
+        in
+        let orch, _logs, _blocked =
+          Patch_controller.apply_poll_result orch pid observation
+        in
+        let a = Orchestrator.agent orch pid in
+        (* Merge_conflict must NOT be in the queue — it was already handled *)
+        not
+          (List.mem a.Patch_agent.queue Operation_kind.Merge_conflict
+             ~equal:Operation_kind.equal))
+  in
+  QCheck2.Test.check_exn prop_pi8;
+  Stdlib.print_endline "PI-8 passed"

--- a/test/test_orchestrator_properties.ml
+++ b/test/test_orchestrator_properties.ml
@@ -919,12 +919,15 @@ let () =
         with _ -> false)
   in
 
-  (* Deliver_to_agent + Push_ok -> Conflict_done (push resolved it) *)
+  (* Deliver_to_agent + Push_ok -> Conflict_needs_agent.  A Noop rebase
+     means the local branch was already up-to-date; pushing the same
+     conflicting content does not resolve the GitHub conflict.  The agent
+     must still handle it, so has_conflict must be preserved. *)
   let prop_conflict_push_deliver_ok =
     Test.make
       ~name:
         "apply_conflict_push_result: Deliver_to_agent + Push_ok -> \
-         Conflict_done" (Gen.pair gen_patch_list_unique gen_branch)
+         Conflict_needs_agent" (Gen.pair gen_patch_list_unique gen_branch)
       (fun (patches, new_base) ->
         try
           match patches with
@@ -943,9 +946,8 @@ let () =
               in
               let a = Orchestrator.agent orch pid in
               Orchestrator.equal_conflict_resolution resolution
-                Orchestrator.Conflict_done
-              && (not a.Patch_agent.busy)
-              && not a.Patch_agent.has_conflict
+                Orchestrator.Conflict_needs_agent
+              && a.Patch_agent.has_conflict
         with _ -> false)
   in
 

--- a/test/test_patch_agent.ml
+++ b/test/test_patch_agent.ml
@@ -274,8 +274,8 @@ let () =
             let a = complete a in
             (not a.busy) && Option.is_none a.current_op
           with _ -> false);
-      (* -- respond Merge_conflict clears has_conflict -- *)
-      Test.make ~name:"respond Merge_conflict clears has_conflict" ~count:1
+      (* -- respond Merge_conflict preserves has_conflict -- *)
+      Test.make ~name:"respond Merge_conflict preserves has_conflict" ~count:1
         Gen.(pure (pid0, br0))
         (fun (pid, br) ->
           let a =
@@ -285,7 +285,7 @@ let () =
           let a = set_has_conflict a in
           let a = enqueue a Operation_kind.Merge_conflict in
           let a = respond a Operation_kind.Merge_conflict in
-          not a.has_conflict);
+          a.has_conflict);
       (* -- respond Review_comments always sets changed (lazy fetch) -- *)
       Test.make ~name:"respond Review_comments always sets changed (lazy fetch)"
         ~count:1


### PR DESCRIPTION
## Summary

- **Bug**: When a merge conflict rebase returns Noop but force-push succeeds, `apply_conflict_push_result` treated `Deliver_to_agent + Push_ok` as "conflict resolved" — clearing `has_conflict` and completing the agent. Since the Noop rebase never actually resolved the conflict, GitHub still reports it on the next poll, which re-enqueues `Merge_conflict` (because `had_conflict_before=false`). This creates a ~30s loop that sent ~103 identical conflict messages until the Claude session context overflowed and failed with `Session_failed {is_fresh = false}`. The fresh fallback session then had no conversation history.
- **Fix 1**: Collapse `Deliver_to_agent + Push_ok` into the `Conflict_needs_agent` arm — push succeeding doesn't mean the conflict is resolved when the rebase was a Noop.
- **Fix 2**: Remove `has_conflict` reset from `Patch_agent.respond` for `Merge_conflict` — the flag should only be cleared by `clear_has_conflict` when the conflict is actually resolved (via poll detecting GitHub no longer reports it).

## Test plan

- [x] PI-6 `conflict_noop_cycle` now faithfully includes `apply_conflict_push_result(Push_ok)` instead of skipping the push step
- [x] PI-8 (new): regression test asserting no `Merge_conflict` re-enqueue after a noop cycle
- [x] Updated `prop_conflict_push_deliver_ok` to assert `Conflict_needs_agent` + `has_conflict=true`
- [x] Updated `respond Merge_conflict` test to assert `has_conflict` is preserved
- [x] TDD approach: tests written first, verified they fail, then fix applied
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an infinite Merge_conflict notification loop after a Noop rebase by preserving conflict state and not treating a successful push as resolution. This stops repeated conflict messages and session churn.

- **Bug Fixes**
  - Map Deliver_to_agent + Push_ok (and other push outcomes) after a Noop/failed rebase to Conflict_needs_agent. Do not complete or clear conflict.
  - Clarify `orchestrator.mli`: Conflict_done only when rebase succeeded and the push landed.
  - Remove has_conflict reset in `Patch_agent.respond Merge_conflict`; only clear via `clear_has_conflict` when GitHub stops reporting the conflict.
  - Tests: add PI-8 regression (no re-enqueue after a noop cycle), update PI-6 flow, and adjust properties to assert `has_conflict=true`.

<sup>Written for commit 5ff47095fd5e904a8c0b00ca80f3171f67a1aae4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

