### PR TITLE
Remove unused Tui_input.Refresh command

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1360,11 +1360,11 @@ let input_fiber ~runtime ~process_mgr ~list_selected ~detail_scroll
                         | Tui_input.Move_down -> 1
                         | Tui_input.Page_up -> -10
                         | Tui_input.Page_down -> 10
-                        | Tui_input.Quit | Tui_input.Refresh | Tui_input.Help
-                        | Tui_input.Select | Tui_input.Back | Tui_input.Timeline
-                        | Tui_input.Noop | Tui_input.Send_message _
-                        | Tui_input.Add_pr _ | Tui_input.Add_worktree _
-                        | Tui_input.Remove_patch | Tui_input.Open_in_browser ->
+                        | Tui_input.Quit | Tui_input.Help | Tui_input.Select
+                        | Tui_input.Back | Tui_input.Timeline | Tui_input.Noop
+                        | Tui_input.Send_message _ | Tui_input.Add_pr _
+                        | Tui_input.Add_worktree _ | Tui_input.Remove_patch
+                        | Tui_input.Open_in_browser ->
                             0
                       in
                       if delta <> 0 then detail_follow := false;
@@ -1458,9 +1458,8 @@ let input_fiber ~runtime ~process_mgr ~list_selected ~detail_scroll
                             log_event runtime ~patch_id "Ad-hoc patch removed"))
                   | Tui.Detail_view _ | Tui.Timeline_view -> ());
                   loop ()
-              | Tui_input.Refresh | Tui_input.Noop | Tui_input.Send_message _
-              | Tui_input.Add_pr _ | Tui_input.Add_worktree _
-              | Tui_input.Open_in_browser ->
+              | Tui_input.Noop | Tui_input.Send_message _ | Tui_input.Add_pr _
+              | Tui_input.Add_worktree _ | Tui_input.Open_in_browser ->
                   loop ()))
   in
   loop ()

--- a/lib/tui.ml
+++ b/lib/tui.ml
@@ -1104,7 +1104,6 @@ let render_help_overlay ~width ~height =
           "w         Register worktree (enter path)";
           "-/x       Remove selected patch";
           "t         Toggle timeline";
-          "r         Refresh";
           "q         Quit";
         ] );
       ( "Detail View",

--- a/lib/tui_input.ml
+++ b/lib/tui_input.ml
@@ -7,7 +7,6 @@ open Base
 
 type command =
   | Quit
-  | Refresh
   | Help
   | Move_up
   | Move_down
@@ -44,7 +43,6 @@ let prompt_prefix = function
 let of_key (key : Term.Key.t) : command =
   match key with
   | Char 'q' | Ctrl 'c' -> Quit
-  | Char 'r' -> Refresh
   | Char 'h' | Char '?' -> Help
   | Char 't' -> Timeline
   | Up | Char 'k' -> Move_up
@@ -78,13 +76,13 @@ let apply_move ~count ~selected (cmd : command) =
         if n >= count then -1 else n
     | Page_up -> if selected = -1 then -1 else clamp (selected - 5)
     | Page_down -> if selected = -1 then 0 else clamp (selected + 5)
-    | Quit | Refresh | Help | Select | Back | Timeline | Noop | Send_message _
-    | Add_pr _ | Add_worktree _ | Remove_patch | Open_in_browser ->
+    | Quit | Help | Select | Back | Timeline | Noop | Send_message _ | Add_pr _
+    | Add_worktree _ | Remove_patch | Open_in_browser ->
         if selected >= count then -1 else selected
 
 let%test "q maps to Quit" = equal_command (of_key (Char 'q')) Quit
 let%test "ctrl-c maps to Quit" = equal_command (of_key (Ctrl 'c')) Quit
-let%test "r maps to Refresh" = equal_command (of_key (Char 'r')) Refresh
+let%test "r maps to Noop" = equal_command (of_key (Char 'r')) Noop
 let%test "h maps to Help" = equal_command (of_key (Char 'h')) Help
 let%test "? maps to Help" = equal_command (of_key (Char '?')) Help
 let%test "up arrow maps to Move_up" = equal_command (of_key Up) Move_up

--- a/lib/tui_input.mli
+++ b/lib/tui_input.mli
@@ -5,7 +5,6 @@
 
 type command =
   | Quit
-  | Refresh
   | Help
   | Move_up
   | Move_down

--- a/test/test_tui_input.ml
+++ b/test/test_tui_input.ml
@@ -32,7 +32,7 @@ let () =
   assert (Tui_input.equal_command (Tui_input.of_key (Term.Key.Char 'h')) Help);
   assert (Tui_input.equal_command (Tui_input.of_key (Term.Key.Char '?')) Help);
   (* Non-navigation commands don't change selection *)
-  let s = Tui_input.apply_move ~count ~selected:5 Tui_input.Refresh in
+  let s = Tui_input.apply_move ~count ~selected:5 Tui_input.Noop in
   assert (s = 5);
   let s = Tui_input.apply_move ~count ~selected:5 Tui_input.Quit in
   assert (s = 5);


### PR DESCRIPTION
## Summary
- Remove the `Refresh` variant from `Tui_input.command` — it was never handled distinctly and fell through to noop behavior in every match arm
- Unmap the `r` keybinding and remove "Refresh" from the help overlay
- Update tests to reflect the removal

Closes #149

## Test plan
- [x] `dune build` passes
- [x] `dune runtest` passes (all inline + standalone tests)
- [x] `dune fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unused `Refresh` variant from `Tui_input.command`, unmapped the 'r' key, and removed "Refresh" from the help overlay; updated tests to match. This cleans up dead code with no behavior change (pressing 'r' now maps to `Noop`).

<sup>Written for commit 2969a433e836e21c5b09cf359e4843d6a4d3b58c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

