### PR TITLE
Overhaul terminal colors for legibility and consistency

### DIFF
--- a/lib/markdown_render.ml
+++ b/lib/markdown_render.ml
@@ -16,32 +16,32 @@ let rec render_inline (inline : Cmarkit.Inline.t) : string =
       List.map inlines ~f:render_inline |> String.concat
   | Cmarkit.Inline.Emphasis n ->
       let inner = render_inline (Cmarkit.Inline.Emphasis.inline (fst n)) in
-      Term.Sgr.italic ^ inner ^ Term.Sgr.reset
+      Term.styled [ Term.Sgr.italic ] inner
   | Cmarkit.Inline.Strong_emphasis n ->
       let inner = render_inline (Cmarkit.Inline.Emphasis.inline (fst n)) in
-      Term.Sgr.bold ^ inner ^ Term.Sgr.reset
+      Term.styled [ Term.Sgr.bold ] inner
   | Cmarkit.Inline.Code_span n ->
       let lines = Cmarkit.Inline.Code_span.code_layout (fst n) in
       let text =
         List.map lines ~f:(fun (_, bl) -> Cmarkit.Block_line.to_string bl)
         |> String.concat ~sep:" "
       in
-      Term.Sgr.fg_cyan ^ text ^ Term.Sgr.reset
+      Term.styled [ Term.Sgr.fg_cyan ] text
   | Cmarkit.Inline.Break n -> (
       match Cmarkit.Inline.Break.type' (fst n) with
       | `Hard -> "\n"
       | `Soft -> " ")
   | Cmarkit.Inline.Link n ->
       let text = render_inline (Cmarkit.Inline.Link.text (fst n)) in
-      Term.Sgr.underline ^ text ^ Term.Sgr.reset
+      Term.styled [ Term.Sgr.underline ] text
   | Cmarkit.Inline.Autolink n ->
       let uri = fst (Cmarkit.Inline.Autolink.link (fst n)) in
-      Term.Sgr.underline ^ Term.Sgr.fg_blue ^ uri ^ Term.Sgr.reset
+      Term.styled [ Term.Sgr.underline; Term.Sgr.fg_blue ] uri
   | Cmarkit.Inline.Raw_html _ -> ""
   | Cmarkit.Inline.Image _ -> "[image]"
   | Cmarkit.Inline.Ext_strikethrough n ->
       let inner = render_inline (Cmarkit.Inline.Strikethrough.inline (fst n)) in
-      Term.Sgr.strikethrough ^ inner ^ Term.Sgr.reset
+      Term.styled [ Term.Sgr.strikethrough ] inner
   | _ -> ""
 
 (** Render a block to a list of lines. *)
@@ -55,14 +55,14 @@ let rec render_block (block : Cmarkit.Block.t) : string list =
       let h = fst n in
       let level = Cmarkit.Block.Heading.level h in
       let text = render_inline (Cmarkit.Block.Heading.inline h) in
-      let color =
+      let style =
         match level with
-        | 1 -> Term.Sgr.fg_magenta ^ Term.Sgr.underline
-        | 2 -> Term.Sgr.fg_green
-        | _ -> Term.Sgr.fg_yellow
+        | 1 -> [ Term.Sgr.bold; Term.Sgr.fg_magenta; Term.Sgr.underline ]
+        | 2 -> [ Term.Sgr.bold; Term.Sgr.fg_green ]
+        | _ -> [ Term.Sgr.bold; Term.Sgr.fg_yellow ]
       in
       let marker = String.make level '#' in
-      [ Term.Sgr.bold ^ color ^ marker ^ " " ^ text ^ Term.Sgr.reset; "" ]
+      [ Term.styled style (marker ^ " " ^ text); "" ]
   | Cmarkit.Block.Code_block n ->
       let cb = fst n in
       let info_label =
@@ -76,18 +76,16 @@ let rec render_block (block : Cmarkit.Block.t) : string list =
       let code_lines = Cmarkit.Block.Code_block.code cb in
       let code =
         List.map code_lines ~f:(fun bl ->
-            "  " ^ Term.Sgr.dim
-            ^ Cmarkit.Block_line.to_string bl
-            ^ Term.Sgr.reset)
+            "  "
+            ^ Term.styled [ Term.Sgr.dim ] (Cmarkit.Block_line.to_string bl))
       in
-      [ Term.Sgr.dim ^ "```" ^ info_label ^ Term.Sgr.reset ]
+      [ Term.styled [ Term.Sgr.dim ] ("```" ^ info_label) ]
       @ code
-      @ [ Term.Sgr.dim ^ "```" ^ Term.Sgr.reset; "" ]
+      @ [ Term.styled [ Term.Sgr.dim ] "```"; "" ]
   | Cmarkit.Block.Block_quote n ->
       let inner = Cmarkit.Block.Block_quote.block (fst n) in
       let inner_lines = render_block inner in
-      List.map inner_lines ~f:(fun l ->
-          Term.Sgr.dim ^ "│ " ^ Term.Sgr.reset ^ l)
+      List.map inner_lines ~f:(fun l -> Term.styled [ Term.Sgr.dim ] "│ " ^ l)
       @ [ "" ]
   | Cmarkit.Block.List n ->
       let lst = fst n in
@@ -111,8 +109,7 @@ let rec render_block (block : Cmarkit.Block.t) : string list =
                 (marker ^ first) :: List.map rest ~f:(fun l -> pad ^ l))
       in
       result @ [ "" ]
-  | Cmarkit.Block.Thematic_break _ ->
-      [ Term.Sgr.dim ^ "───" ^ Term.Sgr.reset; "" ]
+  | Cmarkit.Block.Thematic_break _ -> [ Term.styled [ Term.Sgr.dim ] "───"; "" ]
   | Cmarkit.Block.Blank_line _ -> [ "" ]
   | Cmarkit.Block.Blocks (blocks, _) -> List.concat_map blocks ~f:render_block
   | Cmarkit.Block.Html_block _ -> []

--- a/lib/term.ml
+++ b/lib/term.ml
@@ -61,8 +61,17 @@ end
 type style = string list
 (** Style type for composing multiple attributes. *)
 
-let style codes = String.concat codes
-let styled codes text = String.concat codes ^ text ^ Sgr.reset
+(** Whether color output is enabled. Respects $NO_COLOR (https://no-color.org):
+    if set to any non-empty value, all styling is suppressed. *)
+let color_enabled =
+  lazy
+    (match Stdlib.Sys.getenv_opt "NO_COLOR" with
+    | Some s -> String.is_empty s
+    | None -> true)
+
+let styled codes text =
+  if Lazy.force color_enabled then String.concat codes ^ text ^ Sgr.reset
+  else text
 
 (** Strip all ANSI escape sequences from a string. *)
 let strip_ansi s =

--- a/lib/term.mli
+++ b/lib/term.mli
@@ -1,0 +1,174 @@
+(** Low-level ANSI terminal primitives.
+
+    Provides SGR styling, cursor/screen control, keyboard input parsing, mouse
+    event decoding, raw-mode management, and text-width utilities that account
+    for ANSI escape sequences and multi-byte UTF-8. *)
+
+(** {1 SGR (Select Graphic Rendition)} *)
+
+module Sgr : sig
+  val reset : string
+  val bold : string
+  val dim : string
+  val italic : string
+  val underline : string
+  val reverse : string
+  val strikethrough : string
+  val fg_black : string
+  val fg_red : string
+  val fg_green : string
+  val fg_yellow : string
+  val fg_blue : string
+  val fg_magenta : string
+  val fg_cyan : string
+  val fg_white : string
+  val fg_default : string
+  val bg_black : string
+  val bg_red : string
+  val bg_green : string
+  val bg_yellow : string
+  val bg_blue : string
+  val bg_magenta : string
+  val bg_cyan : string
+  val bg_white : string
+  val bg_default : string
+  val fg_rgb : int -> int -> int -> string
+  val bg_rgb : int -> int -> int -> string
+  val fg_256 : int -> string
+  val bg_256 : int -> string
+end
+
+(** {1 Cursor movement and screen control} *)
+
+module Cursor : sig
+  val up : int -> string
+  val down : int -> string
+  val forward : int -> string
+  val back : int -> string
+  val move_to : row:int -> col:int -> string
+  val save : string
+  val restore : string
+  val hide : string
+  val show : string
+end
+
+(** {1 Screen clearing} *)
+
+module Clear : sig
+  val screen : string
+  val to_end : string
+  val to_start : string
+  val line : string
+  val line_to_end : string
+  val line_to_start : string
+end
+
+(** {1 Styling} *)
+
+type style = string list
+(** A composable list of SGR codes. *)
+
+val color_enabled : bool Lazy.t
+(** Whether color output is enabled. [false] when [$NO_COLOR] is set to a
+    non-empty value (see {{:https://no-color.org} no-color.org}). *)
+
+val styled : style -> string -> string
+(** [styled codes text] wraps [text] in the given SGR codes and appends a reset.
+    Returns plain [text] when color is disabled. *)
+
+(** {1 Text width utilities} *)
+
+val strip_ansi : string -> string
+(** Remove all ANSI escape sequences from a string. *)
+
+val visible_length : string -> int
+(** Visible character count (strips ANSI, counts UTF-8 codepoints). *)
+
+val fit_width : int -> string -> string
+(** Pad or truncate to a visible width, preserving ANSI formatting. *)
+
+val byte_offset_of_visible_col : string -> int -> int
+(** [byte_offset_of_visible_col s col] returns the byte offset in plain string
+    [s] of the [col]-th visible character. Returns [String.length s] when
+    [col >= visible_length s]. *)
+
+val wrap_lines : int -> string -> string list
+(** Hard-wrap a plain string at [width] visible characters. Each line is padded
+    to [width]. Returns at least one line. *)
+
+val hrule : ?ch:string -> int -> string
+(** Draw a horizontal rule of [width] characters (default ["─"]). *)
+
+(** {1 Terminal size} *)
+
+type size = { rows : int; cols : int } [@@deriving show, eq]
+
+val get_size : unit -> size option
+(** Query terminal size via stty. *)
+
+(** {1 Raw mode} *)
+
+module Raw : sig
+  type state
+
+  val enter : unit -> state
+  (** Enter raw mode. Returns saved terminal state for {!leave}. *)
+
+  val leave : state -> unit
+  (** Restore original terminal settings. *)
+
+  val suspend : unit -> unit
+  (** Suspend the terminal (restore settings, show cursor, SIGSTOP). *)
+
+  val install_suspend_handlers : state -> unit
+  (** Install SIGTSTP/SIGCONT handlers for proper suspend/resume. *)
+
+  val clear_suspend_handlers : unit -> unit
+  (** Remove suspend handlers and restore original terminal settings. *)
+
+  val redraw_needed : bool Atomic.t
+  (** Set by the SIGCONT handler when the TUI should redraw. *)
+end
+
+(** {1 Mouse input} *)
+
+type mouse_button = Left | Middle | Right [@@deriving show, eq]
+type scroll_dir = Up | Down [@@deriving show, eq]
+
+type mouse_event =
+  | Click of { button : mouse_button; row : int; col : int; press : bool }
+  | Scroll of { dir : scroll_dir; row : int; col : int }
+[@@deriving show, eq]
+
+val enable_mouse : string
+val disable_mouse : string
+
+(** {1 Keyboard input} *)
+
+module Key : sig
+  type t =
+    | Char of char
+    | Enter
+    | Tab
+    | Backspace
+    | Escape
+    | Up
+    | Down
+    | Left
+    | Right
+    | Home
+    | End
+    | Page_up
+    | Page_down
+    | Delete
+    | F of int
+    | Ctrl of char
+    | Paste of string
+    | Mouse of mouse_event
+    | Unknown of string
+  [@@deriving show, eq]
+
+  val read : unit -> t option
+  (** Read and parse a single key press. Blocks until input is available. Must
+      be called while in raw mode. *)
+end

--- a/lib/tui.ml
+++ b/lib/tui.ml
@@ -65,7 +65,7 @@ let color = function
   | Awaiting_ci -> Term.Sgr.fg_blue
   | Awaiting_review -> Term.Sgr.fg_blue
   | Blocked_by_dep -> Term.Sgr.fg_blue
-  | Pending -> Term.Sgr.fg_white
+  | Pending -> Term.Sgr.fg_default
 
 let to_status_display status = { label = label status; color = color status }
 
@@ -679,8 +679,7 @@ let render_patch_row ~width ~selected (pv : patch_view) =
       (Printf.sprintf "%s%s%s  %s%s%s%s" cursor pr_label badge pv.title
          op_suffix ci_info dep_info)
   in
-  if selected then Term.styled [ Term.Sgr.bold; Term.Sgr.bg_256 236 ] row
-  else row
+  if selected then Term.styled [ Term.Sgr.bold ] row else row
 
 (** Compute visible window: returns (offset, count) for scrolling. *)
 let visible_window ~selected ~total ~max_visible =
@@ -1059,7 +1058,7 @@ let render_footer ~width ~view_mode ?prompt_line () =
               let after =
                 String.sub line ~pos:bp_next ~len:(String.length line - bp_next)
               in
-              before ^ Term.Sgr.reverse ^ ch ^ Term.Sgr.reset ^ after)
+              before ^ Term.styled [ Term.Sgr.underline ] ch ^ after)
       in
       Term.hrule width :: with_cursor
   | None ->
@@ -1067,8 +1066,8 @@ let render_footer ~width ~view_mode ?prompt_line () =
         match view_mode with
         | List_view ->
             Term.styled [ Term.Sgr.dim ]
-              " q:quit  r:refresh  ↑/↓:navigate  enter:detail  +:add PR  \
-               w:worktree  -:remove  h:help"
+              " q:quit  ↑/↓:navigate  enter:detail  +:add PR  w:worktree  \
+               -:remove  h:help"
         | Detail_view _ ->
             Term.styled [ Term.Sgr.dim ]
               " q:quit  esc/backspace:back  enter:message  m:manage  \


### PR DESCRIPTION
## Summary
- Fix selection highlight contrast (root cause of #136): remove `bg_256 236` which was broken by inner ANSI resets and had poor contrast. Selection is now indicated by `▸` cursor glyph + bold text.
- Fix `Pending` status visibility on light backgrounds: `fg_white` → `fg_default`
- Add `$NO_COLOR` support per [no-color.org](https://no-color.org) — `Term.styled` returns plain text when set
- Add `lib/term.mli` to formalize the public API and hide internal helpers
- Refactor `markdown_render.ml` to use `Term.styled` uniformly (respects `$NO_COLOR`)
- Replace `reverse` with `underline` for prompt cursor; remove stale "r:refresh" help text

Closes #136

## Test plan
- [x] `dune build` — compiles clean with fatal warnings
- [x] `dune runtest` — all tests pass
- [x] `dune fmt` — formatting clean
- [ ] Manual: verify selected row is legible on dark terminal background
- [ ] Manual: verify selected row is legible on light terminal background
- [ ] Manual: verify `NO_COLOR=1 dune exec bin/main.exe` produces no ANSI codes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Overhauled terminal colors for better legibility across light and dark themes. Selection now uses a ▸ cursor with bold text instead of a dim background; Pending uses default fg; `$NO_COLOR` disables all styling (fixes #136).

- **Refactors**
  - Added `lib/term.mli` to define the public API and hide internals.
  - Updated `markdown_render.ml` to use `Term.styled` so `$NO_COLOR` is respected everywhere.
  - Switched prompt cursor from reverse video to underline; removed stale "r:refresh" from footer help.

<sup>Written for commit ca8fe8b292abc41ba8b351fe2d86b1eb4afc3d33. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

