### PR TITLE
Add busy→complete contract tests and extract outcome functions

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -2020,9 +2020,17 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry
                                         ~user_config:config.user_config
                                         ~worktree_mutex ~backend ~event_log)
                           in
-                          match result with
-                          | `Stale -> ()
-                          | `Failed ->
+                          let start_outcome =
+                            match result with
+                            | `Stale -> Orchestrator.Start_stale
+                            | `Failed -> Orchestrator.Start_failed
+                            | `Ok -> Orchestrator.Start_ok
+                          in
+                          Runtime.update_orchestrator runtime (fun orch ->
+                              Orchestrator.apply_start_outcome orch patch_id
+                                start_outcome);
+                          match start_outcome with
+                          | Orchestrator.Start_failed ->
                               let agent =
                                 Runtime.read runtime (fun snap ->
                                     Orchestrator.agent snap.Runtime.orchestrator
@@ -2036,7 +2044,7 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry
                                         review needed"
                                        (Patch_id.to_string patch_id))
                                   ()
-                          | `Ok ->
+                          | Orchestrator.Start_ok ->
                               (* Always confirm via REST API *)
                               let rec discover remaining =
                                 match
@@ -2065,7 +2073,8 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry
                                         Orchestrator.on_pr_discovery_failure
                                           orch patch_id)
                               in
-                              discover 2)))
+                              discover 2
+                          | Orchestrator.Start_stale -> ())))
           | Orchestrator.Rebase (patch_id, new_base) ->
               Some
                 (fun () ->
@@ -2173,6 +2182,8 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry
                       | Orchestrator.Rebase_push_error ->
                           log_event runtime ~patch_id
                             "runner: enqueuing rebase retry after push error");
+                      Runtime.update_orchestrator runtime (fun orch ->
+                          Orchestrator.complete orch patch_id);
                       Event_log.log_rebase event_log ~patch_id
                         ~result:rebase_result ~agent_before ~agent_after))
           | Orchestrator.Respond (patch_id, kind) ->
@@ -2562,9 +2573,18 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry
                                 | _ -> ());
                                 result)
                       in
-                      match result with
-                      | `Stale -> ()
-                      | `Failed ->
+                      let respond_outcome =
+                        match result with
+                        | `Stale -> Orchestrator.Respond_stale
+                        | `Failed -> Orchestrator.Respond_failed
+                        | `Retry_push -> Orchestrator.Respond_retry_push
+                        | `Ok -> Orchestrator.Respond_ok
+                      in
+                      Runtime.update_orchestrator runtime (fun orch ->
+                          Orchestrator.apply_respond_outcome orch patch_id kind
+                            respond_outcome);
+                      match respond_outcome with
+                      | Orchestrator.Respond_failed ->
                           let agent =
                             Runtime.read runtime (fun snap ->
                                 Orchestrator.agent snap.Runtime.orchestrator
@@ -2578,8 +2598,7 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry
                                     needed"
                                    (Patch_id.to_string patch_id))
                               ()
-                      | `Retry_push -> ()
-                      | `Ok ->
+                      | Orchestrator.Respond_ok ->
                           if
                             Operation_kind.equal kind
                               Operation_kind.Merge_conflict
@@ -2590,23 +2609,10 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry
                                    "Patch %s: conflict resolved, rebasing…"
                                    (Patch_id.to_string patch_id))
                               ~expires_at:(Unix.gettimeofday () +. 10.0)
-                              ();
-                          Runtime.update_orchestrator runtime (fun orch ->
-                              let orch =
-                                if
-                                  Operation_kind.equal kind
-                                    Operation_kind.Merge_conflict
-                                then
-                                  Orchestrator.clear_has_conflict orch patch_id
-                                else orch
-                              in
-                              if
-                                Operation_kind.equal kind
-                                  Operation_kind.Implementation_notes
-                              then
-                                Orchestrator.set_implementation_notes_delivered
-                                  orch patch_id true
-                              else orch))))
+                              ()
+                      | Orchestrator.Respond_stale
+                      | Orchestrator.Respond_retry_push ->
+                          ())))
     in
     (* Spawn action fibers without waiting for completion. Each fiber is
        guarded by with_busy_guard (ensures complete on exit) and

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -2073,7 +2073,9 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry
                                         Orchestrator.on_pr_discovery_failure
                                           orch patch_id)
                               in
-                              discover 2
+                              discover 2;
+                              Runtime.update_orchestrator runtime (fun orch ->
+                                  Orchestrator.complete orch patch_id)
                           | Orchestrator.Start_stale -> ())))
           | Orchestrator.Rebase (patch_id, new_base) ->
               Some
@@ -2182,8 +2184,6 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry
                       | Orchestrator.Rebase_push_error ->
                           log_event runtime ~patch_id
                             "runner: enqueuing rebase retry after push error");
-                      Runtime.update_orchestrator runtime (fun orch ->
-                          Orchestrator.complete orch patch_id);
                       Event_log.log_rebase event_log ~patch_id
                         ~result:rebase_result ~agent_before ~agent_after))
           | Orchestrator.Respond (patch_id, kind) ->

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -542,7 +542,10 @@ type start_outcome = Start_ok | Start_failed | Start_stale
 let apply_start_outcome t patch_id outcome =
   match outcome with
   | Start_stale -> t
-  | Start_ok -> complete t patch_id
+  | Start_ok ->
+      (* Caller must complete explicitly after PR discovery finishes,
+         so busy=true is held throughout the network call. *)
+      t
   | Start_failed -> complete t patch_id
 
 type respond_outcome =

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -535,3 +535,35 @@ let apply_session_result t patch_id result =
   | Session_worktree_missing ->
       let t = update_agent t patch_id ~f:Patch_agent.on_pre_session_failure in
       complete_failed t patch_id
+
+type start_outcome = Start_ok | Start_failed | Start_stale
+[@@deriving show, eq, sexp_of]
+
+let apply_start_outcome t patch_id outcome =
+  match outcome with
+  | Start_stale -> t
+  | Start_ok -> complete t patch_id
+  | Start_failed -> complete t patch_id
+
+type respond_outcome =
+  | Respond_ok
+  | Respond_failed
+  | Respond_retry_push
+  | Respond_stale
+[@@deriving show, eq, sexp_of]
+
+let apply_respond_outcome t patch_id kind outcome =
+  match outcome with
+  | Respond_stale -> t
+  | Respond_failed -> complete t patch_id
+  | Respond_retry_push -> complete t patch_id
+  | Respond_ok ->
+      let t = complete t patch_id in
+      let t =
+        if Operation_kind.equal kind Operation_kind.Merge_conflict then
+          clear_has_conflict t patch_id
+        else t
+      in
+      if Operation_kind.equal kind Operation_kind.Implementation_notes then
+        set_implementation_notes_delivered t patch_id true
+      else t

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -137,6 +137,28 @@ val apply_session_result : t -> Patch_id.t -> session_result -> t
     set_tried_fresh + complete. [Session_worktree_missing] ->
     on_pre_session_failure + complete. *)
 
+type start_outcome = Start_ok | Start_failed | Start_stale
+[@@deriving show, eq, sexp_of]
+
+val apply_start_outcome : t -> Patch_id.t -> start_outcome -> t
+(** Apply the outcome of a Start action fiber. [Start_ok] -> complete.
+    [Start_failed] -> complete. [Start_stale] -> identity. *)
+
+type respond_outcome =
+  | Respond_ok
+  | Respond_failed
+  | Respond_retry_push
+  | Respond_stale
+[@@deriving show, eq, sexp_of]
+
+val apply_respond_outcome :
+  t -> Patch_id.t -> Operation_kind.t -> respond_outcome -> t
+(** Apply the outcome of a Respond action fiber. [Respond_ok] -> complete +
+    kind-specific transitions (Merge_conflict -> clear_has_conflict;
+    Implementation_notes -> set_implementation_notes_delivered).
+    [Respond_failed] -> complete. [Respond_retry_push] -> complete.
+    [Respond_stale] -> identity. *)
+
 (** Side effects emitted by rebase result application. The runner is responsible
     for executing these (e.g. force-pushing the branch to the remote). Modeled
     as data so property tests can assert on effect presence. *)

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -141,8 +141,9 @@ type start_outcome = Start_ok | Start_failed | Start_stale
 [@@deriving show, eq, sexp_of]
 
 val apply_start_outcome : t -> Patch_id.t -> start_outcome -> t
-(** Apply the outcome of a Start action fiber. [Start_ok] -> complete.
-    [Start_failed] -> complete. [Start_stale] -> identity. *)
+(** Apply the outcome of a Start action fiber. [Start_failed] -> complete.
+    [Start_ok] -> identity (caller must [complete] after PR discovery).
+    [Start_stale] -> identity. *)
 
 type respond_outcome =
   | Respond_ok

--- a/test/dune
+++ b/test/dune
@@ -117,5 +117,9 @@
  (ocamlc_flags (:standard -w -40-42)))
 
 (test
+ (name test_action_outcome_properties)
+ (libraries onton onton_test_support qcheck-core))
+
+(test
  (name test_backend_smoke)
  (libraries onton eio eio_main))

--- a/test/test_action_outcome_properties.ml
+++ b/test/test_action_outcome_properties.ml
@@ -1,0 +1,173 @@
+open Base
+open Onton
+open Onton.Types
+
+(** Property tests for [Orchestrator.apply_start_outcome] and
+    [Orchestrator.apply_respond_outcome]. These encode the runner's contract:
+    every non-stale action fiber must call [complete] before exiting. *)
+
+let main = Branch.of_string "main"
+let mk_patches = Onton_test_support.Test_generators.mk_linear_patches
+let make_gameplan = Onton_test_support.Test_generators.make_test_gameplan
+let pid_of_idx = Onton_test_support.Test_generators.pid_of_idx
+
+(** Bootstrap a single-patch orchestrator with an idle agent that has a PR. *)
+let bootstrap_one () =
+  let patches = mk_patches 1 in
+  let gameplan = make_gameplan patches in
+  let orch = Orchestrator.create ~patches ~main_branch:main in
+  let pid = pid_of_idx patches 0 in
+  let orch = Orchestrator.fire orch (Orchestrator.Start (pid, main)) in
+  let orch = Orchestrator.set_pr_number orch pid (Pr_number.of_int 1) in
+  let orch = Orchestrator.complete orch pid in
+  (orch, patches, gameplan, pid)
+
+(** Make an agent busy via enqueue + tick for the given operation kind. *)
+let make_busy orch _patches gameplan pid kind =
+  let orch = Orchestrator.enqueue orch pid kind in
+  let orch, _effects, _actions =
+    Patch_controller.tick orch ~project_name:"test-project" ~gameplan
+  in
+  assert (Orchestrator.agent orch pid).Patch_agent.busy;
+  orch
+
+(* ========== AO-1: Non-stale start outcomes produce busy=false ========== *)
+
+let () =
+  let prop =
+    QCheck2.Test.make ~name:"AO-1: non-stale start outcomes produce busy=false"
+      (QCheck2.Gen.oneof_list
+         [ Orchestrator.Start_ok; Orchestrator.Start_failed ])
+      (fun outcome ->
+        let patches = mk_patches 1 in
+        let orch = Orchestrator.create ~patches ~main_branch:main in
+        let pid = pid_of_idx patches 0 in
+        let orch = Orchestrator.fire orch (Orchestrator.Start (pid, main)) in
+        assert (Orchestrator.agent orch pid).Patch_agent.busy;
+        let orch = Orchestrator.apply_start_outcome orch pid outcome in
+        not (Orchestrator.agent orch pid).Patch_agent.busy)
+  in
+  QCheck2.Test.check_exn prop;
+  Stdlib.print_endline "AO-1 passed"
+
+(* ========== AO-2: Non-stale respond outcomes produce busy=false ========== *)
+
+let () =
+  let respond_outcomes =
+    [
+      Orchestrator.Respond_ok;
+      Orchestrator.Respond_failed;
+      Orchestrator.Respond_retry_push;
+    ]
+  in
+  let respond_kinds =
+    [
+      Operation_kind.Ci;
+      Operation_kind.Review_comments;
+      Operation_kind.Human;
+      Operation_kind.Merge_conflict;
+      Operation_kind.Implementation_notes;
+    ]
+  in
+  let prop =
+    QCheck2.Test.make
+      ~name:"AO-2: non-stale respond outcomes produce busy=false"
+      (QCheck2.Gen.pair
+         (QCheck2.Gen.oneof_list respond_outcomes)
+         (QCheck2.Gen.oneof_list respond_kinds))
+      (fun (outcome, kind) ->
+        try
+          let orch, patches, gameplan, pid = bootstrap_one () in
+          let orch = make_busy orch patches gameplan pid kind in
+          let orch = Orchestrator.apply_respond_outcome orch pid kind outcome in
+          not (Orchestrator.agent orch pid).Patch_agent.busy
+        with _ -> false)
+  in
+  QCheck2.Test.check_exn prop;
+  Stdlib.print_endline "AO-2 passed"
+
+(* ========== AO-3: Respond_ok + Merge_conflict clears has_conflict ========== *)
+
+let () =
+  let prop =
+    QCheck2.Test.make
+      ~name:"AO-3: Respond_ok + Merge_conflict clears has_conflict"
+      (QCheck2.Gen.return ()) (fun () ->
+        let orch, patches, gameplan, pid = bootstrap_one () in
+        let orch = Orchestrator.set_has_conflict orch pid in
+        let orch =
+          make_busy orch patches gameplan pid Operation_kind.Merge_conflict
+        in
+        assert (Orchestrator.agent orch pid).Patch_agent.has_conflict;
+        let orch =
+          Orchestrator.apply_respond_outcome orch pid
+            Operation_kind.Merge_conflict Orchestrator.Respond_ok
+        in
+        not (Orchestrator.agent orch pid).Patch_agent.has_conflict)
+  in
+  QCheck2.Test.check_exn prop;
+  Stdlib.print_endline "AO-3 passed"
+
+(* ========== AO-4: Respond_ok + Implementation_notes sets delivered ========== *)
+
+let () =
+  let prop =
+    QCheck2.Test.make
+      ~name:"AO-4: Respond_ok + Implementation_notes sets delivered"
+      (QCheck2.Gen.return ()) (fun () ->
+        let orch, patches, gameplan, pid = bootstrap_one () in
+        assert (
+          not
+            (Orchestrator.agent orch pid)
+              .Patch_agent.implementation_notes_delivered);
+        let orch =
+          make_busy orch patches gameplan pid
+            Operation_kind.Implementation_notes
+        in
+        let orch =
+          Orchestrator.apply_respond_outcome orch pid
+            Operation_kind.Implementation_notes Orchestrator.Respond_ok
+        in
+        (Orchestrator.agent orch pid).Patch_agent.implementation_notes_delivered)
+  in
+  QCheck2.Test.check_exn prop;
+  Stdlib.print_endline "AO-4 passed"
+
+(* ========== AO-5: Stale outcomes are identity ========== *)
+
+let () =
+  let prop =
+    QCheck2.Test.make ~name:"AO-5: stale outcomes are identity"
+      (QCheck2.Gen.oneof_list
+         Operation_kind.
+           [ Ci; Review_comments; Human; Merge_conflict; Implementation_notes ])
+      (fun kind ->
+        try
+          let orch, patches, gameplan, pid = bootstrap_one () in
+          let orch_busy = make_busy orch patches gameplan pid kind in
+          let agents_before = Orchestrator.agents_map orch_busy in
+          let orch_after_respond =
+            Orchestrator.apply_respond_outcome orch_busy pid kind
+              Orchestrator.Respond_stale
+          in
+          let agents_after_respond =
+            Orchestrator.agents_map orch_after_respond
+          in
+          (* Start_stale: apply to a started-but-not-yet-completed agent *)
+          let patches2 = mk_patches 1 in
+          let orch2 = Orchestrator.create ~patches:patches2 ~main_branch:main in
+          let pid2 = pid_of_idx patches2 0 in
+          let orch2 =
+            Orchestrator.fire orch2 (Orchestrator.Start (pid2, main))
+          in
+          let agents_before2 = Orchestrator.agents_map orch2 in
+          let orch2_after =
+            Orchestrator.apply_start_outcome orch2 pid2 Orchestrator.Start_stale
+          in
+          let agents_after2 = Orchestrator.agents_map orch2_after in
+          Map.equal Patch_agent.equal agents_before agents_after_respond
+          && Map.equal Patch_agent.equal agents_before2 agents_after2
+        with _ -> false)
+  in
+  QCheck2.Test.check_exn prop;
+  Stdlib.print_endline "AO-5 passed"

--- a/test/test_action_outcome_properties.ml
+++ b/test/test_action_outcome_properties.ml
@@ -31,24 +31,36 @@ let make_busy orch _patches gameplan pid kind =
   assert (Orchestrator.agent orch pid).Patch_agent.busy;
   orch
 
-(* ========== AO-1: Non-stale start outcomes produce busy=false ========== *)
+(* ========== AO-1a: Start_failed produces busy=false ========== *)
 
 let () =
-  let prop =
-    QCheck2.Test.make ~name:"AO-1: non-stale start outcomes produce busy=false"
-      (QCheck2.Gen.oneof_list
-         [ Orchestrator.Start_ok; Orchestrator.Start_failed ])
-      (fun outcome ->
-        let patches = mk_patches 1 in
-        let orch = Orchestrator.create ~patches ~main_branch:main in
-        let pid = pid_of_idx patches 0 in
-        let orch = Orchestrator.fire orch (Orchestrator.Start (pid, main)) in
-        assert (Orchestrator.agent orch pid).Patch_agent.busy;
-        let orch = Orchestrator.apply_start_outcome orch pid outcome in
-        not (Orchestrator.agent orch pid).Patch_agent.busy)
+  let patches = mk_patches 1 in
+  let orch = Orchestrator.create ~patches ~main_branch:main in
+  let pid = pid_of_idx patches 0 in
+  let orch = Orchestrator.fire orch (Orchestrator.Start (pid, main)) in
+  assert (Orchestrator.agent orch pid).Patch_agent.busy;
+  let orch =
+    Orchestrator.apply_start_outcome orch pid Orchestrator.Start_failed
   in
-  QCheck2.Test.check_exn prop;
-  Stdlib.print_endline "AO-1 passed"
+  assert (not (Orchestrator.agent orch pid).Patch_agent.busy);
+  Stdlib.print_endline "AO-1a passed"
+
+(* ========== AO-1b: Start_ok keeps busy=true (caller completes after PR
+   discovery) ========== *)
+
+let () =
+  let patches = mk_patches 1 in
+  let orch = Orchestrator.create ~patches ~main_branch:main in
+  let pid = pid_of_idx patches 0 in
+  let orch = Orchestrator.fire orch (Orchestrator.Start (pid, main)) in
+  assert (Orchestrator.agent orch pid).Patch_agent.busy;
+  let orch = Orchestrator.apply_start_outcome orch pid Orchestrator.Start_ok in
+  (* busy stays true — caller will complete after PR discovery *)
+  assert (Orchestrator.agent orch pid).Patch_agent.busy;
+  (* caller completes after discovery *)
+  let orch = Orchestrator.complete orch pid in
+  assert (not (Orchestrator.agent orch pid).Patch_agent.busy);
+  Stdlib.print_endline "AO-1b passed"
 
 (* ========== AO-2: Non-stale respond outcomes produce busy=false ========== *)
 

--- a/test/test_interleaving_properties.ml
+++ b/test/test_interleaving_properties.ml
@@ -743,7 +743,7 @@ let check_all_invariants orch patches ~prev_merged ~curr_merged =
   check_merged_no_github_effects orch patches
 
 let run_sequence ?(debug = false) orch patches cmds =
-  let _final, _final_merged, _final_merged_logged =
+  let final, _final_merged, _final_merged_logged =
     List.fold cmds
       ~init:(orch, merged_set_of orch, Set.empty (module Patch_id))
       ~f:(fun (o, prev_merged, merged_logged) cmd ->
@@ -769,7 +769,22 @@ let run_sequence ?(debug = false) orch patches cmds =
         in
         (o, curr_merged, merged_logged))
   in
-  ()
+  final
+
+(** Drain all busy agents by completing them, checking invariants after each.
+    Models the runner's contract: every fired action must eventually complete
+    without violating invariants. *)
+let drain_and_check orch patches =
+  let busy_pids =
+    List.filter_map (Orchestrator.all_agents orch)
+      ~f:(fun (a : Patch_agent.t) -> if a.busy then Some a.patch_id else None)
+  in
+  List.fold busy_pids ~init:orch ~f:(fun o pid ->
+      let prev_merged = merged_set_of o in
+      let o = Orchestrator.complete o pid in
+      let curr_merged = merged_set_of o in
+      check_all_invariants o patches ~prev_merged ~curr_merged;
+      o)
 
 let safe_verbose cmds patches f =
   try f ()
@@ -777,7 +792,8 @@ let safe_verbose cmds patches f =
     if List.length cmds <= 100 then (
       Stdlib.Printf.eprintf "INVARIANT VIOLATION: %s\n%!" msg;
       let orch = bootstrap patches in
-      try run_sequence ~debug:true orch patches cmds with Failure _ -> ());
+      try ignore (run_sequence ~debug:true orch patches cmds)
+      with Failure _ -> ());
     false
 
 (* ========== Properties ========== *)
@@ -792,7 +808,8 @@ let () =
       ~count:1000 (gen_command_seq ~n ~len:50) (fun cmds ->
         (safe_verbose cmds patches) (fun () ->
             let orch = bootstrap patches in
-            run_sequence orch patches cmds;
+            let final = run_sequence orch patches cmds in
+            ignore (drain_and_check final patches);
             true))
   in
   QCheck2.Test.check_exn prop_pi1;
@@ -808,7 +825,8 @@ let () =
       ~count:1000 (gen_atomic_command_seq ~n ~len:50) (fun cmds ->
         (safe_verbose cmds patches) (fun () ->
             let orch = bootstrap patches in
-            run_sequence orch patches cmds;
+            let final = run_sequence orch patches cmds in
+            ignore (drain_and_check final patches);
             true))
   in
   QCheck2.Test.check_exn prop_pi2;
@@ -825,7 +843,8 @@ let () =
       ~count:1000 (gen_command_seq ~n ~len:50) (fun cmds ->
         (safe_verbose cmds patches) (fun () ->
             let orch = Orchestrator.create ~patches ~main_branch:main in
-            run_sequence orch patches cmds;
+            let final = run_sequence orch patches cmds in
+            ignore (drain_and_check final patches);
             true))
   in
   QCheck2.Test.check_exn prop_pi3;


### PR DESCRIPTION
## Summary

- Adds `apply_start_outcome` / `apply_respond_outcome` pure functions to `Orchestrator`, encoding the runner's contract that every non-stale action fiber must call `complete` before exiting
- Adds 5 property tests (AO-1 through AO-5) verifying the contract: non-stale outcomes produce `busy=false`, kind-specific transitions apply correctly, stale outcomes are identity
- Adds a quiescence drain check to interleaving tests PI-1/2/3: after each random command sequence, all busy agents are completed and all 12 invariants are re-verified
- Refactors `bin/main.ml` Start and Respond paths to use the new outcome functions instead of inline `complete` + transitions
- Adds explicit `Orchestrator.complete` call to the Rebase action path (was missing)

## Test plan

- [x] `dune build` — compiles with no warnings
- [x] `dune runtest` — all existing tests pass
- [x] AO-1 through AO-5 property tests pass
- [x] PI-1/2/3 with drain check pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted pure Start/Respond outcome handlers, added busy→complete contract tests, and fixed a Start_ok busy race by holding busy through PR discovery and completing afterward.

- **Refactors**
  - `apply_start_outcome` keeps `busy=true` on `Start_ok`; `runner_fiber` completes after PR discovery to avoid re-firing; updated `orchestrator.mli` docs.
  - `apply_respond_outcome` encodes completion and kind-specific transitions; Start/Respond paths in `bin/main.ml` now use it.
  - Removed a redundant `complete` after rebase push; rebase result application already completes.

- **Tests**
  - Added AO-1..AO-5 property tests for the contract, including `Start_ok` busy semantics and kind-specific transitions.
  - Interleaving tests PI-1/2/3 drain all busy agents after each sequence and re-check invariants.

<sup>Written for commit 3b0c9ea8470f59949f5148e274dab7d62aeefc61. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

