### PR TITLE
Display both patch ID and PR number in TUI list view

### DIFF
--- a/lib/tui.ml
+++ b/lib/tui.ml
@@ -647,13 +647,11 @@ let render_patch_row ~width ~selected (pv : patch_view) =
   let badge = render_status_badge pv.status in
   let patch_label =
     let id_str = Patch_id.to_string pv.patch_id in
-    let is_redundant =
-      match pv.pr_number with
-      | Some n -> String.equal id_str (Int.to_string (Pr_number.to_int n))
-      | None -> false
+    let id_short =
+      if String.length id_str > 4 then String.sub id_str ~pos:0 ~len:4
+      else id_str
     in
-    if is_redundant then Printf.sprintf "%-10s" ""
-    else Printf.sprintf "Patch %-4s" id_str
+    Printf.sprintf "Patch %-4s" id_short
   in
   let pr_label =
     match pv.pr_number with

--- a/lib/tui.ml
+++ b/lib/tui.ml
@@ -645,10 +645,20 @@ let short_op_name = function
 
 let render_patch_row ~width ~selected (pv : patch_view) =
   let badge = render_status_badge pv.status in
+  let patch_label =
+    let id_str = Patch_id.to_string pv.patch_id in
+    let is_redundant =
+      match pv.pr_number with
+      | Some n -> String.equal id_str (Int.to_string (Pr_number.to_int n))
+      | None -> false
+    in
+    if is_redundant then Printf.sprintf "%-10s" ""
+    else Printf.sprintf "Patch %-4s" id_str
+  in
   let pr_label =
     match pv.pr_number with
-    | Some n -> Printf.sprintf "#%-4d " (Pr_number.to_int n)
-    | None -> ""
+    | Some n -> Printf.sprintf "#%-5d" (Pr_number.to_int n)
+    | None -> "  --  "
   in
   let op_suffix =
     match pv.current_op with
@@ -676,8 +686,8 @@ let render_patch_row ~width ~selected (pv : patch_view) =
   let cursor = if selected then "▸" else " " in
   let row =
     Term.fit_width width
-      (Printf.sprintf "%s%s%s  %s%s%s%s" cursor pr_label badge pv.title
-         op_suffix ci_info dep_info)
+      (Printf.sprintf "%s%s %s %s  %s%s%s%s" cursor patch_label pr_label badge
+         pv.title op_suffix ci_info dep_info)
   in
   if selected then Term.styled [ Term.Sgr.bold ] row else row
 


### PR DESCRIPTION
## Summary
- Show `Patch <id>` and `#<n>` (or `--`) for every row in the TUI patch list
- For ad-hoc patches where the patch ID matches the PR number, the redundant patch label is suppressed to avoid clutter

## Test plan
- [x] `dune build` compiles cleanly
- [x] `dune runtest` all tests pass
- [ ] Visual inspection with a gameplan containing both gameplan patches and ad-hoc patches

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Display both patch ID and PR number in the TUI list view for every row to make patches easier to scan. Always show "Patch <id>" (truncated to 4 chars to align columns) and "#<n>" or "--" when no PR number.

<sup>Written for commit 5bae92ac3b5f09f646c3878339b46ae7c87d2d47. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

