### PR TITLE
Fix false-positive base_branch_changed when notified_base_branch is None

### DIFF
--- a/lib/patch_agent.ml
+++ b/lib/patch_agent.ml
@@ -169,7 +169,9 @@ let set_notified_base_branch t branch =
   { t with notified_base_branch = Some branch }
 
 let base_branch_changed t =
-  not (Option.equal Branch.equal t.base_branch t.notified_base_branch)
+  match (t.notified_base_branch, t.base_branch) with
+  | Some old_base, Some new_base -> not (Branch.equal old_base new_base)
+  | _ -> false
 
 let set_merge_ready t v = { t with merge_ready = v }
 let set_is_draft t v = { t with is_draft = v }

--- a/test/test_patch_agent.ml
+++ b/test/test_patch_agent.ml
@@ -784,6 +784,15 @@ let () =
             let a = rebase a ~base_branch:br in
             not (base_branch_changed a)
           with _ -> false);
+      (* -- set_base_branch before start does not trigger base_branch_changed -- *)
+      Test.make ~name:"set_base_branch before start: base_branch_changed false"
+        Gen.(pair gen_pid gen_branch)
+        (fun (pid, br) ->
+          try
+            let a = create ~branch:br pid in
+            let a = set_base_branch a br in
+            not (base_branch_changed a)
+          with _ -> false);
     ]
   in
   List.iter tests ~f:(fun t -> QCheck2.Test.check_exn t);


### PR DESCRIPTION
## Summary
- `base_branch_changed` compared `base_branch` and `notified_base_branch` as raw Options, so `Some main ≠ None` was treated as a "change" — producing spurious "base branch changed from main to main" log messages
- Fixed to only report a change when both fields are `Some` and differ; `None` on either side means no meaningful comparison
- Added QCheck2 property test for the `set_base_branch` before `start` case

## Test plan
- [x] `dune build` passes
- [x] `dune runtest` passes (all existing + new property test)
- [x] `dune fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix false positives in base branch change detection by only reporting a change when both base branches exist and differ. Removes "base branch changed from main to main" logs when `set_base_branch` runs before any notification.

- **Bug Fixes**
  - Updated `base_branch_changed` to compare only when both `notified_base_branch` and `base_branch` are `Some`; otherwise returns false.
  - Added a `QCheck2` property test for the "set_base_branch before start" case.

<sup>Written for commit 1a0ce11613938d49a3964dc98bc70e9de0ea2c33. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

