### PR TITLE
Fix merge conflict Noop delivery and improve conflict diagnostics

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -2304,6 +2304,10 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry
                                    an enriched prompt to the agent. *)
                                 let deliver_to_agent () =
                                   let pr_number = agent.Patch_agent.pr_number in
+                                  let rebase_still_in_progress =
+                                    Worktree.rebase_in_progress ~process_mgr
+                                      ~path:wt_path
+                                  in
                                   let git_status =
                                     Worktree.git_status ~process_mgr
                                       ~path:wt_path
@@ -2312,12 +2316,21 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry
                                     Worktree.conflict_diff ~process_mgr
                                       ~path:wt_path
                                   in
+                                  Event_log.log_conflict_delivery event_log
+                                    ~patch_id ~path:wt_path
+                                    ~rebase_in_progress:rebase_still_in_progress
+                                    ~git_status ~git_diff;
+                                  let patch =
+                                    Base.List.find gameplan.Gameplan.patches
+                                      ~f:(fun (p : Patch.t) ->
+                                        Patch_id.equal p.Patch.id patch_id)
+                                  in
                                   let prompt =
                                     let raw =
                                       Prompt.render_merge_conflict_prompt
-                                        ~project_name ?pr_number
-                                        ~base_branch:base ~git_status ~git_diff
-                                        ()
+                                        ~project_name ?pr_number ?patch
+                                        ~gameplan ~base_branch:base ~git_status
+                                        ~git_diff ()
                                     in
                                     if String.equal base_changed_prefix "" then
                                       raw
@@ -2428,8 +2441,8 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry
                                             effects ) ))
                                   in
                                   Event_log.log_conflict_rebase event_log
-                                    ~patch_id ~decision ~agent_before
-                                    ~agent_after;
+                                    ~patch_id ~result:rebase_result ~decision
+                                    ~agent_before ~agent_after;
                                   let push_outcome =
                                     Base.List.find_map effects
                                       ~f:(fun Orchestrator.Push_branch ->

--- a/lib/event_log.ml
+++ b/lib/event_log.ml
@@ -80,17 +80,33 @@ let log_complete t ~patch_id ~result ~agent_before ~agent_after =
          ("agent_after", agent_json agent_after);
        ])
 
-let log_conflict_rebase t ~patch_id ~decision ~agent_before ~agent_after =
+let log_conflict_rebase t ~patch_id ~result ~decision ~agent_before ~agent_after
+    =
   write_entry t
     (`Assoc
        [
          ("ts", `String (timestamp ()));
          ("kind", `String "conflict_rebase");
          ("patch_id", patch_id_json patch_id);
+         ("result", `String (Worktree.show_rebase_result result));
          ( "decision",
            `String (Orchestrator.show_conflict_rebase_decision decision) );
          ("agent_before", agent_json agent_before);
          ("agent_after", agent_json agent_after);
+       ])
+
+let log_conflict_delivery t ~patch_id ~path ~rebase_in_progress ~git_status
+    ~git_diff =
+  write_entry t
+    (`Assoc
+       [
+         ("ts", `String (timestamp ()));
+         ("kind", `String "conflict_delivery");
+         ("patch_id", patch_id_json patch_id);
+         ("path", `String path);
+         ("rebase_in_progress", `Bool rebase_in_progress);
+         ("git_status", `String git_status);
+         ("git_diff_len", `Int (String.length git_diff));
        ])
 
 let log_rebase t ~patch_id ~result ~agent_before ~agent_after =

--- a/lib/event_log.mli
+++ b/lib/event_log.mli
@@ -40,11 +40,24 @@ val log_complete :
 val log_conflict_rebase :
   t ->
   patch_id:Patch_id.t ->
+  result:Worktree.rebase_result ->
   decision:Orchestrator.conflict_rebase_decision ->
   agent_before:Patch_agent.t ->
   agent_after:Patch_agent.t ->
   unit
 (** Log a conflict rebase decision with before/after state. *)
+
+val log_conflict_delivery :
+  t ->
+  patch_id:Patch_id.t ->
+  path:string ->
+  rebase_in_progress:bool ->
+  git_status:string ->
+  git_diff:string ->
+  unit
+(** Log the state at the moment a merge-conflict prompt is delivered to the
+    agent. Captures the worktree path, whether a rebase was already in progress,
+    and the git status/diff that were embedded in the prompt. *)
 
 val log_rebase :
   t ->

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -447,10 +447,16 @@ let apply_conflict_rebase_result t patch_id rebase_result new_base =
       let t = complete t patch_id in
       (t, Conflict_resolved, [ Push_branch ])
   | Worktree.Noop ->
+      (* Local branch already contains the target — just push to sync
+         the remote.  There is no in-progress rebase to hand to the
+         agent, so complete instead of delivering.  If GitHub still
+         reports a conflict after the push, the poller will re-enqueue
+         Merge_conflict, and conflict_noop_count will eventually trigger
+         intervention. *)
       let t = set_base_branch t patch_id new_base in
-      let t = set_has_conflict t patch_id in
       let t = increment_conflict_noop_count t patch_id in
-      (t, Deliver_to_agent, [ Push_branch ])
+      let t = complete t patch_id in
+      (t, Conflict_resolved, [ Push_branch ])
   | Worktree.Conflict ->
       let t = set_base_branch t patch_id new_base in
       let t = set_has_conflict t patch_id in

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -314,6 +314,9 @@ let set_has_conflict t patch_id =
 let clear_has_conflict t patch_id =
   update_agent t patch_id ~f:Patch_agent.clear_has_conflict
 
+let reset_conflict_noop_count t patch_id =
+  update_agent t patch_id ~f:Patch_agent.reset_conflict_noop_count
+
 let set_base_branch t patch_id branch =
   update_agent t patch_id ~f:(fun a -> Patch_agent.set_base_branch a branch)
 
@@ -398,6 +401,7 @@ let apply_rebase_result t patch_id rebase_result new_base =
   | Worktree.Ok ->
       let t = set_base_branch t patch_id new_base in
       let t = clear_has_conflict t patch_id in
+      let t = reset_conflict_noop_count t patch_id in
       (complete t patch_id, [ Push_branch ])
   | Worktree.Noop ->
       let t = set_base_branch t patch_id new_base in
@@ -444,6 +448,7 @@ let apply_conflict_rebase_result t patch_id rebase_result new_base =
   | Worktree.Ok ->
       let t = set_base_branch t patch_id new_base in
       let t = clear_has_conflict t patch_id in
+      let t = reset_conflict_noop_count t patch_id in
       let t = complete t patch_id in
       (t, Conflict_resolved, [ Push_branch ])
   | Worktree.Noop ->
@@ -570,7 +575,8 @@ let apply_respond_outcome t patch_id kind outcome =
       let t = complete t patch_id in
       let t =
         if Operation_kind.equal kind Operation_kind.Merge_conflict then
-          clear_has_conflict t patch_id
+          let t = clear_has_conflict t patch_id in
+          reset_conflict_noop_count t patch_id
         else t
       in
       if Operation_kind.equal kind Operation_kind.Implementation_notes then

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -485,7 +485,6 @@ let apply_conflict_push_result t patch_id decision
   | Conflict_resolved, Some Worktree.Push_up_to_date -> (t, Conflict_done)
   | ( Conflict_resolved,
       (None | Some (Worktree.Push_rejected | Worktree.Push_error _)) ) ->
-      let t = clear_has_conflict t patch_id in
       let t = set_has_conflict t patch_id in
       let t = enqueue t patch_id Operation_kind.Merge_conflict in
       (t, Conflict_retry_push)

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -453,12 +453,12 @@ let apply_conflict_rebase_result t patch_id rebase_result new_base =
       (t, Conflict_resolved, [ Push_branch ])
   | Worktree.Noop ->
       (* Local branch already contains the target — just push to sync
-         the remote.  There is no in-progress rebase to hand to the
-         agent, so complete instead of delivering.  If GitHub still
-         reports a conflict after the push, the poller will re-enqueue
-         Merge_conflict, and conflict_noop_count will eventually trigger
-         intervention. *)
+         the remote.  Clear has_conflict so it purely tracks GitHub
+         state; the poller will re-set it and re-enqueue Merge_conflict
+         if the conflict persists, and conflict_noop_count will
+         eventually trigger intervention. *)
       let t = set_base_branch t patch_id new_base in
+      let t = clear_has_conflict t patch_id in
       let t = increment_conflict_noop_count t patch_id in
       let t = complete t patch_id in
       (t, Conflict_resolved, [ Push_branch ])

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -210,11 +210,12 @@ val apply_conflict_rebase_result :
   t * conflict_rebase_decision * rebase_effect list
 (** Apply a rebase outcome during merge-conflict resolution. Pure function. [Ok]
     -> clear_has_conflict + reset_conflict_noop_count + complete +
-    [Conflict_resolved] + [[Push_branch]]. [Noop] ->
+    [Conflict_resolved] + [[Push_branch]]. [Noop] -> clear_has_conflict +
     increment_conflict_noop_count + complete + [Conflict_resolved] +
-    [[Push_branch]] (local is correct, push needed; has_conflict kept true to
-    suppress re-enqueue). [Conflict] -> set_has_conflict + [Deliver_to_agent] +
-    [[]]. [Error _] -> set_session_failed + complete + [Conflict_failed]. *)
+    [[Push_branch]] (local is correct; has_conflict cleared so it purely tracks
+    GitHub state — the poller will re-set and re-enqueue if conflict persists).
+    [Conflict] -> set_has_conflict + [Deliver_to_agent] + [[]]. [Error _] ->
+    set_session_failed + complete + [Conflict_failed]. *)
 
 type conflict_resolution =
   | Conflict_done

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -83,6 +83,7 @@ val on_session_failure : t -> Patch_id.t -> is_fresh:bool -> t
 val on_pr_discovery_failure : t -> Patch_id.t -> t
 val set_has_conflict : t -> Patch_id.t -> t
 val clear_has_conflict : t -> Patch_id.t -> t
+val reset_conflict_noop_count : t -> Patch_id.t -> t
 val set_base_branch : t -> Patch_id.t -> Branch.t -> t
 val set_notified_base_branch : t -> Patch_id.t -> Branch.t -> t
 val increment_ci_failure_count : t -> Patch_id.t -> t
@@ -155,10 +156,10 @@ type respond_outcome =
 val apply_respond_outcome :
   t -> Patch_id.t -> Operation_kind.t -> respond_outcome -> t
 (** Apply the outcome of a Respond action fiber. [Respond_ok] -> complete +
-    kind-specific transitions (Merge_conflict -> clear_has_conflict;
-    Implementation_notes -> set_implementation_notes_delivered).
-    [Respond_failed] -> complete. [Respond_retry_push] -> complete.
-    [Respond_stale] -> identity. *)
+    kind-specific transitions (Merge_conflict -> clear_has_conflict +
+    reset_conflict_noop_count; Implementation_notes ->
+    set_implementation_notes_delivered). [Respond_failed] -> complete.
+    [Respond_retry_push] -> complete. [Respond_stale] -> identity. *)
 
 (** Side effects emitted by rebase result application. The runner is responsible
     for executing these (e.g. force-pushing the branch to the remote). Modeled
@@ -172,10 +173,10 @@ val apply_rebase_result :
   Branch.t ->
   t * rebase_effect list
 (** Apply a rebase outcome to the orchestrator state. Pure function. [Ok] ->
-    set_base_branch + clear_has_conflict + complete + [[Push_branch]]. [Noop] ->
-    set_base_branch + complete + [[]]. [Conflict] -> set_base_branch +
-    set_has_conflict + enqueue Merge_conflict + complete. [Error _] ->
-    set_session_failed + set_tried_fresh + complete. *)
+    set_base_branch + clear_has_conflict + reset_conflict_noop_count + complete
+    \+ [[Push_branch]]. [Noop] -> set_base_branch + complete + [[]]. [Conflict]
+    -> set_base_branch + set_has_conflict + enqueue Merge_conflict + complete.
+    [Error _] -> set_session_failed + set_tried_fresh + complete. *)
 
 type rebase_push_resolution =
   | Rebase_push_ok
@@ -208,9 +209,11 @@ val apply_conflict_rebase_result :
   Branch.t ->
   t * conflict_rebase_decision * rebase_effect list
 (** Apply a rebase outcome during merge-conflict resolution. Pure function. [Ok]
-    -> clear_has_conflict + complete + [Conflict_resolved] + [[Push_branch]].
-    [Noop] -> set_has_conflict + [Deliver_to_agent] + [[Push_branch]] (local is
-    correct, push needed). [Conflict] -> set_has_conflict + [Deliver_to_agent] +
+    -> clear_has_conflict + reset_conflict_noop_count + complete +
+    [Conflict_resolved] + [[Push_branch]]. [Noop] ->
+    increment_conflict_noop_count + complete + [Conflict_resolved] +
+    [[Push_branch]] (local is correct, push needed; has_conflict kept true to
+    suppress re-enqueue). [Conflict] -> set_has_conflict + [Deliver_to_agent] +
     [[]]. [Error _] -> set_session_failed + complete + [Conflict_failed]. *)
 
 type conflict_resolution =

--- a/lib/patch_agent.ml
+++ b/lib/patch_agent.ml
@@ -156,9 +156,8 @@ let on_session_failure t ~is_fresh =
     if is_fresh then set_tried_fresh t else t
 
 let set_has_conflict t = { t with has_conflict = true }
-
-let clear_has_conflict t =
-  { t with has_conflict = false; conflict_noop_count = 0 }
+let clear_has_conflict t = { t with has_conflict = false }
+let reset_conflict_noop_count t = { t with conflict_noop_count = 0 }
 
 let increment_conflict_noop_count t =
   { t with conflict_noop_count = t.conflict_noop_count + 1 }

--- a/lib/patch_agent.mli
+++ b/lib/patch_agent.mli
@@ -139,7 +139,14 @@ val set_has_conflict : t -> t
 (** Mark the patch as having a merge conflict. *)
 
 val clear_has_conflict : t -> t
-(** Clear the merge conflict flag. Spec: [mergeable' p = world-mergeable p]. *)
+(** Clear the merge conflict flag. Does NOT reset [conflict_noop_count]; call
+    [reset_conflict_noop_count] explicitly when a conflict is truly resolved
+    (not just a noop). *)
+
+val reset_conflict_noop_count : t -> t
+(** Reset [conflict_noop_count] to 0. Call when a conflict is genuinely resolved
+    (successful rebase, agent resolution, or poll no longer reports conflict).
+*)
 
 val set_base_branch : t -> Types.Branch.t -> t
 (** Update the base branch. *)

--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -98,7 +98,8 @@ let apply_poll_result t patch_id
       if agent.Patch_agent.has_conflict then
         if Patch_decision.should_clear_conflict agent then (
           log "conflict cleared (no longer detected)";
-          Orchestrator.clear_has_conflict t patch_id)
+          let t = Orchestrator.clear_has_conflict t patch_id in
+          Orchestrator.reset_conflict_noop_count t patch_id)
         else (
           log "conflict flag retained (resolution in flight)";
           t)

--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -631,8 +631,7 @@ let%test "no merge-conflict re-enqueue after noop" =
   let t, decision, _effects =
     Orchestrator.apply_conflict_rebase_result t pid Worktree.Noop main
   in
-  (* Noop -> Deliver_to_agent, agent still busy *)
+  (* Noop -> Conflict_resolved, agent completed (not busy) *)
   Orchestrator.equal_conflict_rebase_decision decision
-    Orchestrator.Deliver_to_agent
-  && (Orchestrator.agent t pid).Patch_agent.has_conflict
-  && (Orchestrator.agent t pid).Patch_agent.busy
+    Orchestrator.Conflict_resolved
+  && not (Orchestrator.agent t pid).Patch_agent.busy

--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -85,9 +85,6 @@ let apply_poll_result t patch_id
       Orchestrator.mark_merged t patch_id)
     else t
   in
-  let had_conflict_before =
-    (Orchestrator.agent t patch_id).Patch_agent.has_conflict
-  in
   let t =
     if poll_result.has_conflict then (
       let agent = Orchestrator.agent t patch_id in
@@ -142,10 +139,9 @@ let apply_poll_result t patch_id
               log (Printf.sprintf "enqueued %s" (Operation_kind.to_label kind));
             Orchestrator.enqueue acc patch_id kind
         | Operation_kind.Merge_conflict ->
-            if is_new && not had_conflict_before then (
+            if is_new then
               log (Printf.sprintf "enqueued %s" (Operation_kind.to_label kind));
-              Orchestrator.enqueue acc patch_id kind)
-            else acc
+            Orchestrator.enqueue acc patch_id kind
         | Operation_kind.Rebase | Operation_kind.Human
         | Operation_kind.Implementation_notes ->
             if is_new then

--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -482,8 +482,8 @@ let render_ci_failure_unknown_prompt ~(project_name : string) ?pr_number () =
          Run the CI checks locally or check the PR status for details."
         pr_ctx)
 
-let render_merge_conflict_prompt ~(project_name : string) ?pr_number
-    ~(base_branch : string) ?(git_status = "") ?(git_diff = "") () =
+let render_merge_conflict_prompt ~(project_name : string) ?pr_number ?patch
+    ?gameplan ~(base_branch : string) ?(git_status = "") ?(git_diff = "") () =
   let pr_ctx =
     match pr_number with
     | Some n -> Printf.sprintf "\n\nPR: #%d\n" (Pr_number.to_int n)
@@ -508,6 +508,37 @@ let render_merge_conflict_prompt ~(project_name : string) ?pr_number
 ```diff
 %s
 ```|} git_diff
+  in
+  let task_context =
+    match (patch, gameplan) with
+    | Some (patch : Patch.t), Some (gp : Gameplan.t) ->
+        let patch_id = Patch_id.to_string patch.Patch.id in
+        let desc_section =
+          if String.is_empty patch.Patch.description then ""
+          else "\n\n### Your Task\n\n" ^ patch.Patch.description
+        in
+        let changes_section =
+          optional_list_section ~header:"Changes" patch.Patch.changes
+        in
+        let ac_section =
+          optional_list_section ~header:"Acceptance Criteria"
+            patch.Patch.acceptance_criteria
+        in
+        Printf.sprintf
+          {|
+
+## Task Context
+
+**Patch %s: %s**
+
+### Problem Statement
+%s
+
+### Solution Summary
+%s%s%s%s|}
+          patch_id patch.Patch.title gp.Gameplan.problem_statement
+          gp.Gameplan.solution_summary desc_section changes_section ac_section
+    | _ -> ""
   in
   let vars =
     [
@@ -539,8 +570,10 @@ If the rebase continues and hits further conflicts, repeat the process.
 
 Do NOT run `git rebase origin/%s` — the rebase is already set up with the
 correct --onto range. Starting a new rebase would re-introduce dependency
-commits that have already been stripped.%s%s|}
-        pr_ctx base_branch base_branch status_section diff_section)
+commits that have already been stripped.
+
+After resolving all conflicts and completing the rebase, push your changes.%s%s%s|}
+        pr_ctx base_branch base_branch status_section diff_section task_context)
 
 let render_human_message_prompt ~(project_name : string)
     (messages : string list) =

--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -550,6 +550,7 @@ let render_merge_conflict_prompt ~(project_name : string) ?pr_number ?patch
         | None -> "" );
       ("git_status", git_status);
       ("git_diff", git_diff);
+      ("task_context", task_context);
     ]
   in
   render_with_override ~project_name ~name:"merge_conflict" ~vars

--- a/lib/prompt.mli
+++ b/lib/prompt.mli
@@ -52,6 +52,8 @@ val render_ci_failure_unknown_prompt :
 val render_merge_conflict_prompt :
   project_name:string ->
   ?pr_number:Pr_number.t ->
+  ?patch:Patch.t ->
+  ?gameplan:Gameplan.t ->
   base_branch:string ->
   ?git_status:string ->
   ?git_diff:string ->

--- a/test/test_interleaving_properties.ml
+++ b/test/test_interleaving_properties.ml
@@ -1022,13 +1022,12 @@ let mk_bootstrapped () =
 
 (** Simulate one full conflict-noop cycle: poll(conflict) → fire
     Respond(Merge_conflict) → apply_conflict_rebase_result(Noop) →
-    apply_conflict_push_result(Deliver_to_agent, Push_ok) → session completes →
-    complete. Returns the updated orchestrator.
+    apply_conflict_push_result(Conflict_resolved, Push_ok) → done.
 
-    The push result is [Push_ok] because [force_push_with_lease] succeeds even
-    when the rebase was a noop — it pushes the existing (conflicting) content.
-    This is the path observed in production; the previous version of this helper
-    skipped [apply_conflict_push_result] entirely. *)
+    Noop means the local branch already contains the target, so there is no
+    in-progress rebase to hand to the agent. We just push and complete. The push
+    result is [Push_ok] because [force_push_with_lease] succeeds even when the
+    rebase was a noop — it pushes the existing (conflicting) content. *)
 let conflict_noop_cycle orch pid patches =
   let branch_of = branch_of_patches patches in
   let gameplan = make_gameplan patches in
@@ -1054,7 +1053,7 @@ let conflict_noop_cycle orch pid patches =
   let orch, _effects, _actions =
     Patch_controller.tick orch ~project_name:"test-project" ~gameplan
   in
-  (* 3. Apply Noop rebase result *)
+  (* 3. Apply Noop rebase result — agent is completed, not delivered to *)
   let has_merged dep_pid =
     (Orchestrator.agent orch dep_pid).Patch_agent.merged
   in
@@ -1070,15 +1069,11 @@ let conflict_noop_cycle orch pid patches =
     Orchestrator.apply_conflict_push_result orch pid decision
       (Some Worktree.Push_ok)
   in
-  let orch =
-    Orchestrator.apply_session_result orch pid Orchestrator.Session_ok
-  in
-  (* Conflict_done means the push handler already completed the agent.
-     Conflict_needs_agent means the agent session ran but we must complete. *)
+  (* Conflict_resolved + Push_ok -> Conflict_done. Agent already completed. *)
   match resolution with
   | Orchestrator.Conflict_done -> orch
-  | Orchestrator.Conflict_needs_agent -> Orchestrator.complete orch pid
-  | Orchestrator.Conflict_retry_push | Orchestrator.Conflict_give_up ->
+  | Orchestrator.Conflict_needs_agent | Orchestrator.Conflict_retry_push
+  | Orchestrator.Conflict_give_up ->
       failwith "unexpected resolution in conflict_noop_cycle"
 
 (** PI-6: Repeated Noop conflict rebase converges to needs_intervention. If the

--- a/test/test_interleaving_properties.ml
+++ b/test/test_interleaving_properties.ml
@@ -1179,28 +1179,25 @@ let () =
   QCheck2.Test.check_exn prop_pi7;
   Stdlib.print_endline "PI-7 passed"
 
-(** PI-8: Conflict noop cycle does not re-enqueue Merge_conflict on the next
-    poll. After a full conflict-noop cycle (poll → fire → rebase Noop → push
-    Push_ok → complete), the next poll must NOT re-enqueue Merge_conflict
-    because has_conflict should still be true (had_conflict_before = true). This
-    is a regression test for the infinite conflict notification loop. *)
+(** PI-8: After a noop cycle, has_conflict is cleared and the next poll
+    re-enqueues Merge_conflict. This ensures the system retries rather than
+    getting stuck — repeated retries increment conflict_noop_count towards the
+    intervention threshold (tested by PI-6). *)
 let () =
   let prop_pi8 =
     QCheck2.Test.make
       ~name:
-        "PI-8: conflict noop cycle does not re-enqueue Merge_conflict on next \
-         poll"
-      (QCheck2.Gen.return ()) (fun () ->
+        "PI-8: noop cycle clears has_conflict; next poll re-enqueues \
+         Merge_conflict" (QCheck2.Gen.return ()) (fun () ->
         let orch, pid, patches = mk_bootstrapped () in
         (* Run one full conflict-noop cycle *)
         let orch = conflict_noop_cycle orch pid patches in
         let a = Orchestrator.agent orch pid in
-        (* After the cycle, has_conflict must be true so the next poll
-           sees had_conflict_before = true and skips re-enqueue. *)
-        if not a.Patch_agent.has_conflict then
+        (* After the cycle, has_conflict must be false — it purely tracks
+           GitHub state, and the Noop path clears it. *)
+        if a.Patch_agent.has_conflict then
           failwith
-            "has_conflict is false after conflict_noop_cycle — next poll will \
-             re-enqueue";
+            "has_conflict is true after conflict_noop_cycle — should be cleared";
         (* Simulate the next poll with conflict still reported by GitHub *)
         let branch_of = branch_of_patches patches in
         let poll_result =
@@ -1221,10 +1218,9 @@ let () =
           Patch_controller.apply_poll_result orch pid observation
         in
         let a = Orchestrator.agent orch pid in
-        (* Merge_conflict must NOT be in the queue — it was already handled *)
-        not
-          (List.mem a.Patch_agent.queue Operation_kind.Merge_conflict
-             ~equal:Operation_kind.equal))
+        (* Merge_conflict MUST be re-enqueued — this drives convergence *)
+        List.mem a.Patch_agent.queue Operation_kind.Merge_conflict
+          ~equal:Operation_kind.equal)
   in
   QCheck2.Test.check_exn prop_pi8;
   Stdlib.print_endline "PI-8 passed"

--- a/test/test_orchestrator_properties.ml
+++ b/test/test_orchestrator_properties.ml
@@ -734,10 +734,10 @@ let () =
         with _ -> false)
   in
 
-  (* Noop -> Deliver_to_agent, still busy, has_conflict set *)
+  (* Noop -> Conflict_resolved, completed (not busy), conflict cleared *)
   let prop_conflict_rebase_noop =
     Test.make
-      ~name:"apply_conflict_rebase_result: Noop -> Deliver_to_agent, busy"
+      ~name:"apply_conflict_rebase_result: Noop -> Conflict_resolved, completed"
       (Gen.pair gen_patch_list_unique gen_branch) (fun (patches, new_base) ->
         try
           match patches with
@@ -752,8 +752,8 @@ let () =
               in
               let a = Orchestrator.agent orch' pid in
               Orchestrator.equal_conflict_rebase_decision decision
-                Orchestrator.Deliver_to_agent
-              && a.Patch_agent.busy && a.Patch_agent.has_conflict
+                Orchestrator.Conflict_resolved
+              && (not a.Patch_agent.busy)
               && List.equal Orchestrator.equal_rebase_effect effects
                    [ Orchestrator.Push_branch ]
         with _ -> false)
@@ -919,16 +919,14 @@ let () =
         with _ -> false)
   in
 
-  (* Deliver_to_agent + Push_ok -> Conflict_needs_agent.  A Noop rebase
-     means the local branch was already up-to-date; pushing the same
-     conflicting content does not resolve the GitHub conflict.  The agent
-     must still handle it, so has_conflict must be preserved. *)
+  (* Noop + Push_ok -> Conflict_done.  A Noop rebase means the local
+     branch was already up-to-date, so we just push and complete without
+     involving the agent. *)
   let prop_conflict_push_deliver_ok =
     Test.make
       ~name:
-        "apply_conflict_push_result: Deliver_to_agent + Push_ok -> \
-         Conflict_needs_agent" (Gen.pair gen_patch_list_unique gen_branch)
-      (fun (patches, new_base) ->
+        "apply_conflict_push_result: Noop/Resolved + Push_ok -> Conflict_done"
+      (Gen.pair gen_patch_list_unique gen_branch) (fun (patches, new_base) ->
         try
           match patches with
           | [] -> true
@@ -936,22 +934,24 @@ let () =
               let pid = first.Patch.id in
               let orch = Orchestrator.create ~patches ~main_branch:main in
               let orch, _effects, _actions = tick orch ~patches in
-              let orch, _decision, _effects =
+              let orch, decision, _effects =
                 Orchestrator.apply_conflict_rebase_result orch pid Worktree.Noop
                   new_base
               in
-              let orch, resolution =
-                Orchestrator.apply_conflict_push_result orch pid
-                  Orchestrator.Deliver_to_agent (Some Worktree.Push_ok)
+              Orchestrator.equal_conflict_rebase_decision decision
+                Orchestrator.Conflict_resolved
+              &&
+              let _orch, resolution =
+                Orchestrator.apply_conflict_push_result orch pid decision
+                  (Some Worktree.Push_ok)
               in
-              let a = Orchestrator.agent orch pid in
               Orchestrator.equal_conflict_resolution resolution
-                Orchestrator.Conflict_needs_agent
-              && a.Patch_agent.has_conflict
+                Orchestrator.Conflict_done
         with _ -> false)
   in
 
-  (* Deliver_to_agent + Push_up_to_date -> Conflict_needs_agent *)
+  (* Deliver_to_agent (from Conflict) + Push_up_to_date ->
+     Conflict_needs_agent *)
   let prop_conflict_push_deliver_up_to_date =
     Test.make
       ~name:
@@ -966,8 +966,8 @@ let () =
               let orch = Orchestrator.create ~patches ~main_branch:main in
               let orch, _effects, _actions = tick orch ~patches in
               let orch, _decision, _effects =
-                Orchestrator.apply_conflict_rebase_result orch pid Worktree.Noop
-                  new_base
+                Orchestrator.apply_conflict_rebase_result orch pid
+                  Worktree.Conflict new_base
               in
               let _orch, resolution =
                 Orchestrator.apply_conflict_push_result orch pid


### PR DESCRIPTION
## Summary
- When the poller detects a GitHub merge conflict and the local rebase returns Noop (target already ancestor of HEAD), the handler was sending the agent a "rebase is in progress" prompt when no rebase existed. Now Noop returns `Conflict_resolved` — we just push and complete, letting the poller re-detect if needed.
- Include task context (problem statement, description, acceptance criteria) in the merge conflict prompt so the agent has the same understanding as the initial patch prompt.
- Add `conflict_delivery` event log entry capturing worktree path, `rebase_in_progress` status, `git_status`, and `git_diff` length at delivery time — enabling diagnosis of cases where rebase state disappears between the rebase and the delivery.
- Add rebase result to `conflict_rebase` event log entries (was previously missing, making it impossible to distinguish Noop from Conflict).

## Test plan
- [x] All existing property tests pass (updated to reflect Noop → Conflict_resolved)
- [x] PI-6 (repeated noop converges to needs_intervention) still passes
- [ ] Deploy and monitor event log for `conflict_delivery` events to diagnose any remaining cases where rebase state is lost

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Noop handling in the merge-conflict flow to avoid delivering a phantom “rebase in progress,” makes `has_conflict` purely reflect GitHub state, and adds richer prompts and diagnostics.

- **Behavior and UX**
  - Noop during a GitHub-reported conflict now returns Conflict_resolved and pushes; we clear has_conflict, increment `conflict_noop_count`, and complete. The next poll re-enqueues Merge_conflict if GitHub still reports it.
  - Removed the `had_conflict_before` guard; Merge_conflict is enqueued when “is_new” like other ops, ensuring repeat Noops progress toward intervention.
  - Split `clear_has_conflict` from `reset_conflict_noop_count`; we reset only when the conflict is truly resolved (successful rebase, agent resolution, or poll stops reporting it).
  - Push-retry path: keep has_conflict set if a push fails after an Ok rebase (no clear+set toggle).
  - Merge-conflict prompt now includes task context (problem, solution summary, description, changes, acceptance criteria) and explicitly tells the agent to push after resolving.

- **Diagnostics**
  - Added `conflict_delivery` event with worktree path, `rebase_in_progress`, `git_status`, and `git_diff` length.
  - `conflict_rebase` events now include the rebase result.

<sup>Written for commit d599da787996298e7b97419d966fb49aecc5ef1f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

