### PR TITLE
Use --resume <session_id> instead of --continue for LLM sessions

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -294,19 +294,22 @@ let mark_session_failed runtime patch_id =
 
 (** Compute the session mode for the fallback chain.
 
-    The fallback chain is: continue existing session → fresh session → give up.
-    - [Fresh_available] with [has_pr]: use [--continue] to resume worktree
-      session.
-    - [Fresh_available] without [has_pr], or [Tried_fresh]: start fresh (no
-      --continue).
+    The fallback chain is: resume existing session → fresh session → give up.
+    - [Fresh_available] with [llm_session_id = Some id]: use [--resume <id>] to
+      target the specific session.
+    - [Fresh_available] without a stored session_id, or [Tried_fresh]: start
+      fresh (no --resume).
     - [Given_up]: the agent has exhausted its fallback chain — return
       [`Give_up]. *)
-let session_mode (agent : Patch_agent.t) : [ `Continue | `Fresh | `Give_up ] =
+let session_mode (agent : Patch_agent.t) :
+    [ `Resume of string | `Fresh | `Give_up ] =
   match agent.Patch_agent.session_fallback with
   | Patch_agent.Given_up -> `Give_up
   | Patch_agent.Tried_fresh -> `Fresh
-  | Patch_agent.Fresh_available ->
-      if Patch_agent.has_pr agent then `Continue else `Fresh
+  | Patch_agent.Fresh_available -> (
+      match agent.Patch_agent.llm_session_id with
+      | Some id -> `Resume id
+      | None -> `Fresh)
 
 (** Extract a PR number from text containing a GitHub PR URL. Scans for
     [github.com/owner/repo/pull/N] patterns. *)
@@ -491,9 +494,9 @@ let run_claude_and_handle ~runtime ~process_mgr ~fs ~project_name ~patch_id
           Orchestrator.apply_session_result orch patch_id
             Orchestrator.Session_give_up);
       `Failed
-  | (`Continue | `Fresh) as mode -> (
-      let continue, is_fresh =
-        match mode with `Continue -> (true, false) | `Fresh -> (false, true)
+  | (`Resume _ | `Fresh) as mode -> (
+      let resume_session, is_fresh =
+        match mode with `Resume id -> (Some id, false) | `Fresh -> (None, true)
       in
       match
         ensure_worktree ~runtime ~process_mgr ~fs ~repo_root ~project_name
@@ -521,7 +524,11 @@ let run_claude_and_handle ~runtime ~process_mgr ~fs ~project_name ~patch_id
                  "\n---\n**[%02d:%02d:%02d] Delivered to %s%s:**\n\n"
                  tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec
                  backend.Llm_backend.name
-                 (if continue then " (--continue)" else ""));
+                 (match resume_session with
+                 | Some id ->
+                     Printf.sprintf " (--resume %s)"
+                       (String.sub id 0 (min 8 (String.length id)))
+                 | None -> ""));
             Buffer.add_string buf prompt;
             Buffer.add_string buf
               (Printf.sprintf "\n\n---\n**%s response:**\n\n"
@@ -545,6 +552,7 @@ let run_claude_and_handle ~runtime ~process_mgr ~fs ~project_name ~patch_id
               last_sync := now;
               sync_transcript ())
           in
+          let captured_session_id = ref None in
           let on_event (event : Types.Stream_event.t) =
             match event with
             | Types.Stream_event.Text_delta text -> (
@@ -616,12 +624,14 @@ let run_claude_and_handle ~runtime ~process_mgr ~fs ~project_name ~patch_id
                 Buffer.add_string error_buf msg;
                 log_stream_entry runtime ~patch_id
                   (Activity_log.Stream_entry.Stream_error msg)
+            | Types.Stream_event.Session_init { session_id } ->
+                captured_session_id := Some session_id
           in
           let result =
             try
               Ok
                 (backend.Llm_backend.run_streaming ~cwd ~patch_id ~prompt
-                   ~continue ~on_event)
+                   ~resume_session ~on_event)
             with exn -> Error (Printexc.to_string exn)
           in
           let open Run_classification in
@@ -638,7 +648,9 @@ let run_claude_and_handle ~runtime ~process_mgr ~fs ~project_name ~patch_id
               result
           in
           let session_result, user_result =
-            match classify ~continue outcome with
+            match
+              classify ~is_resume:(Option.is_some resume_session) outcome
+            with
             | Process_error msg ->
                 log_event runtime ~patch_id
                   (Printf.sprintf "%s process error: %s"
@@ -646,7 +658,7 @@ let run_claude_and_handle ~runtime ~process_mgr ~fs ~project_name ~patch_id
                 (Orchestrator.Session_process_error { is_fresh }, `Failed)
             | No_session_to_resume ->
                 log_event runtime ~patch_id
-                  "--continue produced no events (no session to resume), will \
+                  "--resume produced no events (no session to resume), will \
                    retry fresh";
                 (Orchestrator.Session_no_resume, `Failed)
             | Timed_out ->
@@ -681,6 +693,14 @@ let run_claude_and_handle ~runtime ~process_mgr ~fs ~project_name ~patch_id
                 let agent_before = Orchestrator.agent orch patch_id in
                 let orch =
                   Orchestrator.apply_session_result orch patch_id session_result
+                in
+                (* Store the captured session_id for future --resume calls *)
+                let orch =
+                  match !captured_session_id with
+                  | Some _ ->
+                      Orchestrator.set_llm_session_id orch patch_id
+                        !captured_session_id
+                  | None -> orch
                 in
                 let agent_after = Orchestrator.agent orch patch_id in
                 (orch, (agent_before, agent_after)))

--- a/lib/claude_backend.ml
+++ b/lib/claude_backend.ml
@@ -2,7 +2,7 @@ let create ~process_mgr ~clock ~timeout : Llm_backend.t =
   {
     name = "Claude";
     run_streaming =
-      (fun ~cwd ~patch_id ~prompt ~continue ~on_event ->
+      (fun ~cwd ~patch_id ~prompt ~resume_session ~on_event ->
         Claude_runner.run_streaming ~process_mgr ~clock ~timeout ~cwd ~patch_id
-          ~prompt ~continue ~on_event);
+          ~prompt ~resume_session ~on_event);
   }

--- a/lib/claude_runner.ml
+++ b/lib/claude_runner.ml
@@ -39,17 +39,21 @@ let pty_wrap args =
     [ "/usr/bin/script"; "-qc"; cmd; "/dev/null" ]
   else "/usr/bin/script" :: "-q" :: "/dev/null" :: args
 
-let build_args ~prompt ~continue =
+let build_args ~prompt ~resume_session =
   let base = [ "claude"; "-p"; prompt; "--output-format"; "text" ] in
-  let session_args = if continue then [ "--continue" ] else [] in
+  let session_args =
+    match resume_session with Some id -> [ "--resume"; id ] | None -> []
+  in
   let flags = [ "--dangerously-skip-permissions"; "--max-turns"; "200" ] in
   base @ session_args @ flags
 
-let build_stream_args ~prompt ~continue =
+let build_stream_args ~prompt ~resume_session =
   let base =
     [ "claude"; "-p"; prompt; "--output-format"; "stream-json"; "--verbose" ]
   in
-  let session_args = if continue then [ "--continue" ] else [] in
+  let session_args =
+    match resume_session with Some id -> [ "--resume"; id ] | None -> []
+  in
   let flags = [ "--dangerously-skip-permissions"; "--max-turns"; "200" ] in
   base @ session_args @ flags
 
@@ -157,6 +161,15 @@ let parse_stream_events (line : string) : Types.Stream_event.t list =
             |> Option.value ~default:"unknown error"
           in
           [ Types.Stream_event.Error err ]
+      | Some "system" -> (
+          let subtype = member "subtype" json |> to_string_option in
+          match subtype with
+          | Some "init" -> (
+              match member "session_id" json |> to_string_option with
+              | Some session_id ->
+                  [ Types.Stream_event.Session_init { session_id } ]
+              | None -> [])
+          | _ -> [])
       | _ -> [])
   | exception Yojson.Json_error _ -> []
   | exception Yojson.Safe.Util.Type_error _ -> []
@@ -165,9 +178,9 @@ let parse_stream_events (line : string) : Types.Stream_event.t list =
 let parse_stream_event (line : string) : Types.Stream_event.t option =
   match parse_stream_events line with [] -> None | e :: _ -> Some e
 
-let run ~process_mgr ~cwd ~patch_id ~prompt ~continue =
+let run ~process_mgr ~cwd ~patch_id ~prompt ~resume_session =
   ignore (patch_id : Types.Patch_id.t);
-  let args = pty_wrap (build_args ~prompt ~continue) in
+  let args = pty_wrap (build_args ~prompt ~resume_session) in
   let stdout_content, stderr_content, exit_code =
     Eio.Switch.run @@ fun sw ->
     let stdin_r, stdin_w = Eio.Process.pipe ~sw process_mgr in
@@ -200,10 +213,10 @@ let run ~process_mgr ~cwd ~patch_id ~prompt ~continue =
     timed_out = false;
   }
 
-let run_streaming ~process_mgr ~clock ~timeout ~cwd ~patch_id ~prompt ~continue
-    ~on_event =
+let run_streaming ~process_mgr ~clock ~timeout ~cwd ~patch_id ~prompt
+    ~resume_session ~on_event =
   ignore (patch_id : Types.Patch_id.t);
-  let args = pty_wrap (build_stream_args ~prompt ~continue) in
+  let args = pty_wrap (build_stream_args ~prompt ~resume_session) in
   let process_line line =
     let trimmed = strip_ansi (String.strip line) in
     if String.is_empty trimmed then [] else parse_stream_events trimmed
@@ -211,8 +224,8 @@ let run_streaming ~process_mgr ~clock ~timeout ~cwd ~patch_id ~prompt ~continue
   Llm_backend.spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~args
     ~process_line ~on_event
 
-let%test "build_args without continue" =
-  let args = build_args ~prompt:"do stuff" ~continue:false in
+let%test "build_args fresh (no resume)" =
+  let args = build_args ~prompt:"do stuff" ~resume_session:None in
   List.equal String.equal args
     [
       "claude";
@@ -225,8 +238,8 @@ let%test "build_args without continue" =
       "200";
     ]
 
-let%test "build_args with continue" =
-  let args = build_args ~prompt:"do stuff" ~continue:true in
+let%test "build_args with resume session" =
+  let args = build_args ~prompt:"do stuff" ~resume_session:(Some "abc-123") in
   List.equal String.equal args
     [
       "claude";
@@ -234,14 +247,15 @@ let%test "build_args with continue" =
       "do stuff";
       "--output-format";
       "text";
-      "--continue";
+      "--resume";
+      "abc-123";
       "--dangerously-skip-permissions";
       "--max-turns";
       "200";
     ]
 
-let%test "build_stream_args without continue" =
-  let args = build_stream_args ~prompt:"do stuff" ~continue:false in
+let%test "build_stream_args fresh (no resume)" =
+  let args = build_stream_args ~prompt:"do stuff" ~resume_session:None in
   List.equal String.equal args
     [
       "claude";
@@ -255,8 +269,10 @@ let%test "build_stream_args without continue" =
       "200";
     ]
 
-let%test "build_stream_args with continue" =
-  let args = build_stream_args ~prompt:"do stuff" ~continue:true in
+let%test "build_stream_args with resume session" =
+  let args =
+    build_stream_args ~prompt:"do stuff" ~resume_session:(Some "abc-123")
+  in
   List.equal String.equal args
     [
       "claude";
@@ -265,7 +281,8 @@ let%test "build_stream_args with continue" =
       "--output-format";
       "stream-json";
       "--verbose";
-      "--continue";
+      "--resume";
+      "abc-123";
       "--dangerously-skip-permissions";
       "--max-turns";
       "200";
@@ -331,3 +348,21 @@ let%test "parse_stream_event invalid json returns None" =
 
 let%test "parse_stream_event unknown type returns None" =
   Option.is_none (parse_stream_event {|{"type":"ping"}|})
+
+let%test "parse_stream_events extracts session_id from system/init" =
+  let line =
+    {|{"type":"system","subtype":"init","session_id":"d3c2d71e-0399-4ed3-810a-9c1edce7dd00","tools":[]}|}
+  in
+  List.equal Types.Stream_event.equal (parse_stream_events line)
+    [
+      Types.Stream_event.Session_init
+        { session_id = "d3c2d71e-0399-4ed3-810a-9c1edce7dd00" };
+    ]
+
+let%test "parse_stream_events ignores system events without init subtype" =
+  let line = {|{"type":"system","subtype":"heartbeat"}|} in
+  List.is_empty (parse_stream_events line)
+
+let%test "parse_stream_events ignores system/init without session_id" =
+  let line = {|{"type":"system","subtype":"init"}|} in
+  List.is_empty (parse_stream_events line)

--- a/lib/claude_runner.mli
+++ b/lib/claude_runner.mli
@@ -3,12 +3,13 @@ open Base
 (** Claude subprocess runner.
 
     Spawns and manages Claude CLI processes for patches. Each patch gets at most
-    one Claude process (one fiber). The runner uses [--continue] to resume the
-    most recent session in the working directory (worktree).
+    one Claude process (one fiber). The runner uses [--resume <session_id>] to
+    resume a specific session by its ID.
 
     Unlike [--print] mode, we use [-p] which runs Claude in session-saving mode.
     This requires a PTY (allocated via [script -q /dev/null]) but enables
-    [--continue] to find and resume prior sessions.
+    session persistence. The session ID is captured from the [system/init]
+    streaming event and stored for subsequent [--resume] calls.
 
     Design decision: one fiber per Claude process for natural backpressure —
     busy patches don't get new work. *)
@@ -18,12 +19,12 @@ val run :
   cwd:Eio.Fs.dir_ty Eio.Path.t ->
   patch_id:Types.Patch_id.t ->
   prompt:string ->
-  continue:bool ->
+  resume_session:string option ->
   Llm_backend.result
 (** Spawn a Claude CLI process for [patch_id] in directory [cwd].
 
-    If [continue] is [true], the session is resumed with [--continue]. Otherwise
-    a new session is created.
+    If [resume_session] is [Some id], the session is resumed with
+    [--resume <id>]. Otherwise a new session is created.
 
     Returns a {!Llm_backend.result} with exit code and captured stdout/stderr.
 *)
@@ -35,14 +36,16 @@ val run_streaming :
   cwd:Eio.Fs.dir_ty Eio.Path.t ->
   patch_id:Types.Patch_id.t ->
   prompt:string ->
-  continue:bool ->
+  resume_session:string option ->
   on_event:(Types.Stream_event.t -> unit) ->
   Llm_backend.result
 (** Like {!run} but uses [--output-format stream-json]. Each NDJSON line is
     parsed into a {!Types.Stream_event.t} and passed to [on_event] as it
     arrives. The returned {!Llm_backend.result} has an empty [stdout] since
-    output was consumed incrementally. If [got_events] is [false] on return, the
-    [--continue] likely failed to find a session. *)
+    output was consumed incrementally. The [on_event] callback will receive a
+    {!Types.Stream_event.Session_init} with the session ID from the first
+    streaming event. If [got_events] is [false] on return, the [--resume] likely
+    failed to find the session. *)
 
 val parse_stream_event : string -> Types.Stream_event.t option
 (** Parse a single NDJSON line from Claude's stream-json output into a
@@ -56,9 +59,10 @@ val pty_wrap : string list -> string list
 (** Wrap a command in [script -q /dev/null] for PTY allocation. Exposed for
     testing. *)
 
-val build_args : prompt:string -> continue:bool -> string list
+val build_args : prompt:string -> resume_session:string option -> string list
 (** Build the CLI argument list for the Claude process. Exposed for testing. *)
 
-val build_stream_args : prompt:string -> continue:bool -> string list
+val build_stream_args :
+  prompt:string -> resume_session:string option -> string list
 (** Build the CLI argument list for stream-json output mode. Exposed for
     testing. *)

--- a/lib/codex_backend.ml
+++ b/lib/codex_backend.ml
@@ -2,7 +2,8 @@ open Base
 
 let build_args ~cwd_path ~prompt ~resume_session =
   match resume_session with
-  | Some _ -> [ "codex"; "exec"; "resume"; "--last"; "--json"; "-C"; cwd_path ]
+  | Some session_id ->
+      [ "codex"; "exec"; "resume"; session_id; "--json"; "-C"; cwd_path ]
   | None ->
       [
         "codex";
@@ -107,7 +108,7 @@ let%test "build_args with resume session" =
       ~resume_session:(Some "sess-1")
   in
   List.equal String.equal args
-    [ "codex"; "exec"; "resume"; "--last"; "--json"; "-C"; "/tmp/work" ]
+    [ "codex"; "exec"; "resume"; "sess-1"; "--json"; "-C"; "/tmp/work" ]
 
 let%test "parse_event agent_message" =
   let line =

--- a/lib/codex_backend.ml
+++ b/lib/codex_backend.ml
@@ -1,18 +1,18 @@
 open Base
 
-let build_args ~cwd_path ~prompt ~continue =
-  if continue then
-    [ "codex"; "exec"; "resume"; "--last"; "--json"; "-C"; cwd_path ]
-  else
-    [
-      "codex";
-      "exec";
-      prompt;
-      "--json";
-      "--dangerously-bypass-approvals-and-sandbox";
-      "-C";
-      cwd_path;
-    ]
+let build_args ~cwd_path ~prompt ~resume_session =
+  match resume_session with
+  | Some _ -> [ "codex"; "exec"; "resume"; "--last"; "--json"; "-C"; cwd_path ]
+  | None ->
+      [
+        "codex";
+        "exec";
+        prompt;
+        "--json";
+        "--dangerously-bypass-approvals-and-sandbox";
+        "-C";
+        cwd_path;
+      ]
 
 let parse_event (line : string) : Types.Stream_event.t list =
   match Yojson.Safe.from_string line with
@@ -65,11 +65,11 @@ let parse_event (line : string) : Types.Stream_event.t list =
   | exception Yojson.Json_error _ -> []
   | exception Yojson.Safe.Util.Type_error _ -> []
 
-let run_streaming ~process_mgr ~clock ~timeout ~cwd ~patch_id ~prompt ~continue
-    ~on_event =
+let run_streaming ~process_mgr ~clock ~timeout ~cwd ~patch_id ~prompt
+    ~resume_session ~on_event =
   ignore (patch_id : Types.Patch_id.t);
   let cwd_path = snd cwd in
-  let args = build_args ~cwd_path ~prompt ~continue in
+  let args = build_args ~cwd_path ~prompt ~resume_session in
   let process_line line =
     let trimmed = String.strip line in
     if String.is_empty trimmed then [] else parse_event trimmed
@@ -81,14 +81,14 @@ let create ~process_mgr ~clock ~timeout : Llm_backend.t =
   {
     name = "Codex";
     run_streaming =
-      (fun ~cwd ~patch_id ~prompt ~continue ~on_event ->
+      (fun ~cwd ~patch_id ~prompt ~resume_session ~on_event ->
         run_streaming ~process_mgr ~clock ~timeout ~cwd ~patch_id ~prompt
-          ~continue ~on_event);
+          ~resume_session ~on_event);
   }
 
-let%test "build_args without continue" =
+let%test "build_args fresh (no resume)" =
   let args =
-    build_args ~cwd_path:"/tmp/work" ~prompt:"do stuff" ~continue:false
+    build_args ~cwd_path:"/tmp/work" ~prompt:"do stuff" ~resume_session:None
   in
   List.equal String.equal args
     [
@@ -101,9 +101,10 @@ let%test "build_args without continue" =
       "/tmp/work";
     ]
 
-let%test "build_args with continue" =
+let%test "build_args with resume session" =
   let args =
-    build_args ~cwd_path:"/tmp/work" ~prompt:"do stuff" ~continue:true
+    build_args ~cwd_path:"/tmp/work" ~prompt:"do stuff"
+      ~resume_session:(Some "sess-1")
   in
   List.equal String.equal args
     [ "codex"; "exec"; "resume"; "--last"; "--json"; "-C"; "/tmp/work" ]

--- a/lib/llm_backend.ml
+++ b/lib/llm_backend.ml
@@ -84,7 +84,7 @@ type t = {
     cwd:Eio.Fs.dir_ty Eio.Path.t ->
     patch_id:Types.Patch_id.t ->
     prompt:string ->
-    continue:bool ->
+    resume_session:string option ->
     on_event:(Types.Stream_event.t -> unit) ->
     result;
 }

--- a/lib/llm_backend.mli
+++ b/lib/llm_backend.mli
@@ -35,7 +35,7 @@ type t = {
     cwd:Eio.Fs.dir_ty Eio.Path.t ->
     patch_id:Types.Patch_id.t ->
     prompt:string ->
-    continue:bool ->
+    resume_session:string option ->
     on_event:(Types.Stream_event.t -> unit) ->
     result;
 }

--- a/lib/opencode_backend.ml
+++ b/lib/opencode_backend.ml
@@ -1,8 +1,10 @@
 open Base
 
-let build_args ~cwd_path ~prompt ~continue =
+let build_args ~cwd_path ~prompt ~resume_session =
   let base = [ "opencode"; "run"; "--format"; "json"; "--dir"; cwd_path ] in
-  let continue_args = if continue then [ "--continue" ] else [] in
+  let continue_args =
+    if Option.is_some resume_session then [ "--continue" ] else []
+  in
   base @ continue_args @ [ prompt ]
 
 let parse_event (line : string) : Types.Stream_event.t list =
@@ -52,11 +54,11 @@ let parse_event (line : string) : Types.Stream_event.t list =
   | exception Yojson.Json_error _ -> []
   | exception Yojson.Safe.Util.Type_error _ -> []
 
-let run_streaming ~process_mgr ~clock ~timeout ~cwd ~patch_id ~prompt ~continue
-    ~on_event =
+let run_streaming ~process_mgr ~clock ~timeout ~cwd ~patch_id ~prompt
+    ~resume_session ~on_event =
   ignore (patch_id : Types.Patch_id.t);
   let cwd_path = snd cwd in
-  let args = build_args ~cwd_path ~prompt ~continue in
+  let args = build_args ~cwd_path ~prompt ~resume_session in
   let process_line line =
     let trimmed = String.strip line in
     if String.is_empty trimmed then [] else parse_event trimmed
@@ -68,21 +70,22 @@ let create ~process_mgr ~clock ~timeout : Llm_backend.t =
   {
     name = "OpenCode";
     run_streaming =
-      (fun ~cwd ~patch_id ~prompt ~continue ~on_event ->
+      (fun ~cwd ~patch_id ~prompt ~resume_session ~on_event ->
         run_streaming ~process_mgr ~clock ~timeout ~cwd ~patch_id ~prompt
-          ~continue ~on_event);
+          ~resume_session ~on_event);
   }
 
 let%test "build_args without continue" =
   let args =
-    build_args ~cwd_path:"/tmp/work" ~prompt:"do stuff" ~continue:false
+    build_args ~cwd_path:"/tmp/work" ~prompt:"do stuff" ~resume_session:None
   in
   List.equal String.equal args
     [ "opencode"; "run"; "--format"; "json"; "--dir"; "/tmp/work"; "do stuff" ]
 
 let%test "build_args with continue" =
   let args =
-    build_args ~cwd_path:"/tmp/work" ~prompt:"do stuff" ~continue:true
+    build_args ~cwd_path:"/tmp/work" ~prompt:"do stuff"
+      ~resume_session:(Some "x")
   in
   List.equal String.equal args
     [

--- a/lib/opencode_backend.ml
+++ b/lib/opencode_backend.ml
@@ -2,10 +2,12 @@ open Base
 
 let build_args ~cwd_path ~prompt ~resume_session =
   let base = [ "opencode"; "run"; "--format"; "json"; "--dir"; cwd_path ] in
-  let continue_args =
-    if Option.is_some resume_session then [ "--continue" ] else []
+  let resume_args =
+    match resume_session with
+    | Some session_id -> [ "--resume"; session_id ]
+    | None -> []
   in
-  base @ continue_args @ [ prompt ]
+  base @ resume_args @ [ prompt ]
 
 let parse_event (line : string) : Types.Stream_event.t list =
   match Yojson.Safe.from_string line with
@@ -95,7 +97,8 @@ let%test "build_args with continue" =
       "json";
       "--dir";
       "/tmp/work";
-      "--continue";
+      "--resume";
+      "x";
       "do stuff";
     ]
 

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -371,6 +371,10 @@ let reset_busy t patch_id = update_agent t patch_id ~f:Patch_agent.reset_busy
 let set_worktree_path t patch_id path =
   update_agent t patch_id ~f:(fun a -> Patch_agent.set_worktree_path a path)
 
+let set_llm_session_id t patch_id session_id =
+  update_agent t patch_id ~f:(fun a ->
+      Patch_agent.set_llm_session_id a session_id)
+
 let set_head_branch t patch_id branch =
   update_agent t patch_id ~f:(fun a -> Patch_agent.set_head_branch a branch)
 

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -101,6 +101,7 @@ val clear_branch_blocked : t -> Patch_id.t -> t
 val reset_busy : t -> Patch_id.t -> t
 val set_worktree_path : t -> Patch_id.t -> string -> t
 val set_head_branch : t -> Patch_id.t -> Branch.t -> t
+val set_llm_session_id : t -> Patch_id.t -> string option -> t
 
 (** {2 Queries} *)
 

--- a/lib/patch_agent.ml
+++ b/lib/patch_agent.ml
@@ -35,6 +35,7 @@ type t = {
   worktree_path : string option;
   head_branch : Branch.t option;
   branch_blocked : bool;
+  llm_session_id : string option;
 }
 [@@deriving eq, sexp_of, compare]
 
@@ -80,6 +81,7 @@ let create ~branch patch_id =
     worktree_path = None;
     head_branch = None;
     branch_blocked = false;
+    llm_session_id = None;
   }
 
 let create_adhoc ~patch_id ~branch ~pr_number =
@@ -113,6 +115,7 @@ let create_adhoc ~patch_id ~branch ~pr_number =
     worktree_path = None;
     head_branch = None;
     branch_blocked = false;
+    llm_session_id = None;
   }
 
 let highest_priority t =
@@ -132,13 +135,15 @@ let restore_human_messages t msgs = { t with human_messages = msgs }
 
 let set_session_failed t =
   match t.session_fallback with
-  | Fresh_available -> { t with session_fallback = Tried_fresh }
+  | Fresh_available ->
+      { t with session_fallback = Tried_fresh; llm_session_id = None }
   | Tried_fresh | Given_up -> t
 
 let set_tried_fresh t =
   match t.session_fallback with
-  | Fresh_available -> { t with session_fallback = Tried_fresh }
-  | Tried_fresh -> { t with session_fallback = Given_up }
+  | Fresh_available ->
+      { t with session_fallback = Tried_fresh; llm_session_id = None }
+  | Tried_fresh -> { t with session_fallback = Given_up; llm_session_id = None }
   | Given_up -> t
 
 let clear_session_fallback t = { t with session_fallback = Fresh_available }
@@ -150,7 +155,7 @@ let clear_session_fallback t = { t with session_fallback = Fresh_available }
 let on_session_failure t ~is_fresh =
   if (not (has_pr t)) && is_fresh then
     (* Start path fresh failure: full reset for clean retry *)
-    { t with session_fallback = Fresh_available }
+    { t with session_fallback = Fresh_available; llm_session_id = None }
   else
     let t = set_session_failed t in
     if is_fresh then set_tried_fresh t else t
@@ -214,6 +219,7 @@ let set_branch_blocked t = { t with branch_blocked = true }
 let clear_branch_blocked t = { t with branch_blocked = false }
 let set_current_message_id t current_message_id = { t with current_message_id }
 let bump_generation t = { t with generation = t.generation + 1 }
+let set_llm_session_id t llm_session_id = { t with llm_session_id }
 
 let resume_current_message t ~op =
   { t with busy = true; has_session = true; current_op = op }
@@ -235,7 +241,7 @@ let restore ~patch_id ~branch ~pr_number ~has_session ~busy ~merged ~queue
     ~is_draft ~pr_description_applied ~implementation_notes_delivered
     ~start_attempts_without_pr ~conflict_noop_count ~checks_passing ~current_op
     ~current_message_id ~generation ~worktree_path ~head_branch ~branch_blocked
-    =
+    ~llm_session_id =
   {
     patch_id;
     branch;
@@ -266,6 +272,7 @@ let restore ~patch_id ~branch ~pr_number ~has_session ~busy ~merged ~queue
     worktree_path;
     head_branch;
     branch_blocked;
+    llm_session_id;
   }
 
 let set_pr_number t pr_number =

--- a/lib/patch_agent.mli
+++ b/lib/patch_agent.mli
@@ -39,6 +39,7 @@ type t = private {
   worktree_path : string option;
   head_branch : Types.Branch.t option;
   branch_blocked : bool;
+  llm_session_id : string option;
 }
 [@@deriving show, eq, sexp_of, compare]
 
@@ -225,6 +226,10 @@ val set_current_message_id : t -> Types.Message_id.t option -> t
 val bump_generation : t -> t
 (** Advance the patch generation used for deterministic message IDs. *)
 
+val set_llm_session_id : t -> string option -> t
+(** Store the LLM backend's session ID for explicit session resumption. Cleared
+    automatically when [session_fallback] escalates (old session is stale). *)
+
 val resume_current_message : t -> op:Types.Operation_kind.t option -> t
 (** Resume execution of an already accepted message without reapplying its
     queue-consuming state transition. [~op] restores [current_op] from the
@@ -275,6 +280,7 @@ val restore :
   worktree_path:string option ->
   head_branch:Types.Branch.t option ->
   branch_blocked:bool ->
+  llm_session_id:string option ->
   t
 (** Reconstruct agent state from persisted field values. Bypasses precondition
     checks — use only for deserialization. *)

--- a/lib/persistence.ml
+++ b/lib/persistence.ml
@@ -84,6 +84,8 @@ let patch_agent_to_yojson (a : Patch_agent.t) =
         | None -> `Null
         | Some b -> Branch.yojson_of_t b );
       ("branch_blocked", `Bool a.branch_blocked);
+      ( "llm_session_id",
+        match a.llm_session_id with None -> `Null | Some s -> `String s );
     ]
 
 let patch_agent_of_yojson ~gameplan json =
@@ -170,7 +172,8 @@ let patch_agent_of_yojson ~gameplan json =
        ~worktree_path:(string_member_opt "worktree_path" json)
        ~head_branch:
          (string_member_opt "head_branch" json |> Option.map ~f:Branch.of_string)
-       ~branch_blocked:(bool_member "branch_blocked" json))
+       ~branch_blocked:(bool_member "branch_blocked" json)
+       ~llm_session_id:(string_member_opt "llm_session_id" json))
 
 (* ---------- Activity_log ---------- *)
 

--- a/lib/pi_backend.ml
+++ b/lib/pi_backend.ml
@@ -1,9 +1,11 @@
 open Base
 
-let build_args ~cwd_path ~patch_id ~prompt ~continue =
+let build_args ~cwd_path ~patch_id ~prompt ~resume_session =
   let session_dir = cwd_path ^ "/.pi-sessions/" ^ patch_id in
   let base = [ "pi"; "-p"; prompt; "--mode"; "json" ] in
-  let continue_args = if continue then [ "--continue" ] else [] in
+  let continue_args =
+    if Option.is_some resume_session then [ "--continue" ] else []
+  in
   let session_args = [ "--session-dir"; session_dir ] in
   base @ continue_args @ session_args
 
@@ -46,11 +48,13 @@ let parse_event (line : string) : Types.Stream_event.t list =
   | exception Yojson.Json_error _ -> []
   | exception Yojson.Safe.Util.Type_error _ -> []
 
-let run_streaming ~process_mgr ~clock ~timeout ~cwd ~patch_id ~prompt ~continue
-    ~on_event =
+let run_streaming ~process_mgr ~clock ~timeout ~cwd ~patch_id ~prompt
+    ~resume_session ~on_event =
   let cwd_path = snd cwd in
   let patch_id_str = Types.Patch_id.to_string patch_id in
-  let args = build_args ~cwd_path ~patch_id:patch_id_str ~prompt ~continue in
+  let args =
+    build_args ~cwd_path ~patch_id:patch_id_str ~prompt ~resume_session
+  in
   let process_line line =
     let trimmed = String.strip line in
     if String.is_empty trimmed then [] else parse_event trimmed
@@ -62,15 +66,15 @@ let create ~process_mgr ~clock ~timeout : Llm_backend.t =
   {
     name = "Pi";
     run_streaming =
-      (fun ~cwd ~patch_id ~prompt ~continue ~on_event ->
+      (fun ~cwd ~patch_id ~prompt ~resume_session ~on_event ->
         run_streaming ~process_mgr ~clock ~timeout ~cwd ~patch_id ~prompt
-          ~continue ~on_event);
+          ~resume_session ~on_event);
   }
 
 let%test "build_args without continue" =
   let args =
     build_args ~cwd_path:"/tmp/work" ~patch_id:"patch-1" ~prompt:"do stuff"
-      ~continue:false
+      ~resume_session:None
   in
   List.equal String.equal args
     [
@@ -86,7 +90,7 @@ let%test "build_args without continue" =
 let%test "build_args with continue" =
   let args =
     build_args ~cwd_path:"/tmp/work" ~patch_id:"patch-1" ~prompt:"do stuff"
-      ~continue:true
+      ~resume_session:(Some "x")
   in
   List.equal String.equal args
     [

--- a/lib/pi_backend.ml
+++ b/lib/pi_backend.ml
@@ -3,11 +3,13 @@ open Base
 let build_args ~cwd_path ~patch_id ~prompt ~resume_session =
   let session_dir = cwd_path ^ "/.pi-sessions/" ^ patch_id in
   let base = [ "pi"; "-p"; prompt; "--mode"; "json" ] in
-  let continue_args =
-    if Option.is_some resume_session then [ "--continue" ] else []
+  let resume_args =
+    match resume_session with
+    | Some session_id -> [ "--resume"; session_id ]
+    | None -> []
   in
   let session_args = [ "--session-dir"; session_dir ] in
-  base @ continue_args @ session_args
+  base @ resume_args @ session_args
 
 let parse_event (line : string) : Types.Stream_event.t list =
   match Yojson.Safe.from_string line with
@@ -99,7 +101,8 @@ let%test "build_args with continue" =
       "do stuff";
       "--mode";
       "json";
-      "--continue";
+      "--resume";
+      "x";
       "--session-dir";
       "/tmp/work/.pi-sessions/patch-1";
     ]

--- a/lib/run_classification.ml
+++ b/lib/run_classification.ml
@@ -24,11 +24,11 @@ type classification =
 
 let truncate s n = if String.length s <= n then s else String.prefix s n ^ "..."
 
-let classify ~continue result =
+let classify ~is_resume result =
   match result with
   | Error msg -> Process_error msg
   | Ok r when r.timed_out -> Timed_out
-  | Ok r when (not r.got_events) && continue -> No_session_to_resume
+  | Ok r when (not r.got_events) && is_resume -> No_session_to_resume
   | Ok r when r.exit_code = 0 -> Success { stream_errors = r.stream_errors }
   | Ok r ->
       let stderr = String.strip r.stderr in

--- a/lib/run_classification.mli
+++ b/lib/run_classification.mli
@@ -22,6 +22,7 @@ type classification =
   | Session_failed of { exit_code : int; detail : string }
 [@@deriving show, eq]
 
-val classify : continue:bool -> (run_outcome, string) Result.t -> classification
-(** Classify a Claude runner result into a pure decision value. [continue]
-    indicates whether this was a --continue session. *)
+val classify :
+  is_resume:bool -> (run_outcome, string) Result.t -> classification
+(** Classify a Claude runner result into a pure decision value. [is_resume]
+    indicates whether this was a --resume session (explicit session ID). *)

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -186,6 +186,7 @@ module Stream_event = struct
     | Tool_use of { name : string; input : string }
     | Final_result of { text : string; stop_reason : Stop_reason.t }
     | Error of string
+    | Session_init of { session_id : string }
   [@@deriving show, eq, sexp_of, compare, yojson]
 end
 

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -149,6 +149,7 @@ module Stream_event : sig
     | Tool_use of { name : string; input : string }
     | Final_result of { text : string; stop_reason : Stop_reason.t }
     | Error of string
+    | Session_init of { session_id : string }
   [@@deriving show, eq, sexp_of, compare]
 end
 

--- a/lib_test/test_generators.ml
+++ b/lib_test/test_generators.ml
@@ -306,7 +306,8 @@ let gen_patch_agent_started =
     map2
       (fun pid branch ->
         let a = Onton.Patch_agent.create ~branch pid in
-        Onton.Patch_agent.start a ~base_branch:branch)
+        let a = Onton.Patch_agent.start a ~base_branch:branch in
+        Onton.Patch_agent.set_llm_session_id a (Some "test-session"))
       gen_patch_id gen_branch)
 
 let gen_patch_agent_with_queue =
@@ -350,6 +351,9 @@ let gen_patch_agent_fully_populated =
     let* pr_number = option gen_pr_number in
     let* merge_ready = bool in
     let* checks_passing = bool in
+    let* raw_llm_session_id =
+      option (string_size ~gen:printable (int_range 8 36))
+    in
     let a = Onton.Patch_agent.create ~branch pid in
     let a = Onton.Patch_agent.start a ~base_branch:branch in
     let a =
@@ -362,6 +366,14 @@ let gen_patch_agent_fully_populated =
       | Onton.Patch_agent.Tried_fresh -> Onton.Patch_agent.set_tried_fresh a
       | Onton.Patch_agent.Given_up -> Onton.Patch_agent.set_session_failed a
     in
+    (* When session_fallback is Tried_fresh or Given_up, llm_session_id must
+       be None (escalation clears it). Only Fresh_available may have a value. *)
+    let llm_session_id =
+      match fallback with
+      | Onton.Patch_agent.Fresh_available -> raw_llm_session_id
+      | Onton.Patch_agent.Tried_fresh | Onton.Patch_agent.Given_up -> None
+    in
+    let a = Onton.Patch_agent.set_llm_session_id a llm_session_id in
     let a = Onton.Patch_agent.complete a in
     let a = List.fold ops ~init:a ~f:Onton.Patch_agent.enqueue in
     let a = Onton.Patch_agent.set_ci_checks a ci_checks in

--- a/test/test_interleaving_properties.ml
+++ b/test/test_interleaving_properties.ml
@@ -396,7 +396,18 @@ let rec apply_command orch patches cmd =
       | _ -> orch)
   | Apply_session_result { patch_idx; result } -> (
       let pid = resolve_pid patches patch_idx in
-      try Orchestrator.apply_session_result orch pid (to_session_result result)
+      try
+        let o =
+          Orchestrator.apply_session_result orch pid (to_session_result result)
+        in
+        match result with
+        | Sess_ok ->
+            Orchestrator.set_llm_session_id o pid
+              (Some (Printf.sprintf "sess-%s" (Patch_id.to_string pid)))
+        | Sess_failed_fresh | Sess_failed_resume | Sess_give_up
+        | Sess_worktree_missing | Sess_process_error_fresh
+        | Sess_process_error_resume | Sess_no_resume ->
+            o
       with Invalid_argument _ -> orch)
   | Apply_rebase_result { patch_idx; result } -> (
       let pid = resolve_pid patches patch_idx in
@@ -760,6 +771,20 @@ let check_notified_base_branch_coherence (a : Patch_agent.t) =
           notified_base_branch is Some but has_session is false"
          (Patch_id.to_string a.patch_id))
 
+(** I-13: llm_session_id coherence — when session_fallback is Tried_fresh or
+    Given_up, llm_session_id must be None (stale session cleared). *)
+let check_llm_session_id_coherence (a : Patch_agent.t) =
+  match a.session_fallback with
+  | Patch_agent.Tried_fresh | Patch_agent.Given_up ->
+      if Option.is_some a.llm_session_id then
+        failwith
+          (Printf.sprintf
+             "I-13 llm_session_id_coherence violated for %s: \
+              session_fallback=%s but llm_session_id is Some"
+             (Patch_id.to_string a.patch_id)
+             (Patch_agent.show_session_fallback a.session_fallback))
+  | Patch_agent.Fresh_available -> ()
+
 (* ========== Combined check ========== *)
 
 let merged_set_of orch =
@@ -778,7 +803,8 @@ let check_all_invariants orch patches ~prev_merged ~curr_merged ~removed_pids =
       check_ci_failure_count_non_negative a;
       check_queue_no_duplicates a;
       check_conflict_not_cleared_while_in_flight a;
-      check_notified_base_branch_coherence a);
+      check_notified_base_branch_coherence a;
+      check_llm_session_id_coherence a);
   (* Monotonicity *)
   check_merged_monotonicity ~prev_merged ~curr_merged ~removed_pids;
   (* Per-action invariants *)

--- a/test/test_patch_agent.ml
+++ b/test/test_patch_agent.ml
@@ -479,7 +479,7 @@ let () =
               ~implementation_notes_delivered:false ~start_attempts_without_pr:0
               ~conflict_noop_count:0 ~checks_passing:false ~current_op:None
               ~current_message_id:None ~generation:0 ~worktree_path:None
-              ~head_branch:None ~branch_blocked:false
+              ~head_branch:None ~branch_blocked:false ~llm_session_id:None
           in
           let a = start a ~base_branch:br in
           List.is_empty a.ci_checks);
@@ -554,7 +554,7 @@ let () =
               ~implementation_notes_delivered:false ~start_attempts_without_pr:0
               ~conflict_noop_count:0 ~checks_passing:false ~current_op:None
               ~current_message_id:None ~generation:0 ~worktree_path:None
-              ~head_branch:None ~branch_blocked:false
+              ~head_branch:None ~branch_blocked:false ~llm_session_id:None
           in
           let a = enqueue a Operation_kind.Rebase in
           let a = rebase a ~base_branch:new_base in

--- a/test/test_patch_controller.ml
+++ b/test/test_patch_controller.ml
@@ -53,7 +53,7 @@ let make_agent ~patch_id ~branch ~pr_number ~merged ~queue ~base_branch
     ~pr_description_applied ~implementation_notes_delivered
     ~start_attempts_without_pr ~conflict_noop_count:0 ~checks_passing:false
     ~current_op:None ~current_message_id:None ~generation:0 ~worktree_path:None
-    ~head_branch:None ~branch_blocked:false
+    ~head_branch:None ~branch_blocked:false ~llm_session_id:None
 
 let has_notes_queued agent =
   List.mem agent.Patch_agent.queue Operation_kind.Implementation_notes
@@ -530,7 +530,7 @@ let () =
             ~start_attempts_without_pr:0 ~conflict_noop_count:0
             ~checks_passing:false ~current_op:None ~current_message_id:None
             ~generation:0 ~worktree_path:None ~head_branch:None
-            ~branch_blocked:false
+            ~branch_blocked:false ~llm_session_id:None
         in
         let orch = make_orch patch agent in
         let poll =

--- a/test/test_patch_controller_state_machine.ml
+++ b/test/test_patch_controller_state_machine.ml
@@ -305,6 +305,102 @@ let () =
         with _ -> false
         end)
   in
+  (* F1: llm_session_id survives review → human sequence *)
+  let prop_session_id_survives_review_human =
+    Test.make
+      ~name:
+        "patch_controller_state_machine: llm_session_id survives review → \
+         human sequence"
+      ~count:300
+      Gen.(pair gen_patch_id gen_branch)
+      (fun (pid, branch) ->
+        begin try
+          let patch = make_patch pid branch in
+          let gameplan = make_gameplan patch in
+          let orch = Orchestrator.create ~patches:[ patch ] ~main_branch:main in
+          (* Start → get PR *)
+          let orch, _eff, msgs =
+            Patch_controller.plan_tick_messages orch
+              ~project_name:"test-project" ~gameplan
+          in
+          let orch = accept_all_messages orch msgs in
+          let orch = Orchestrator.complete orch pid in
+          let orch = Orchestrator.set_pr_number orch pid (Pr_number.of_int 1) in
+          (* Set llm_session_id *)
+          let orch = Orchestrator.set_llm_session_id orch pid (Some "sess-1") in
+          (* Enqueue Review_comments, plan, accept, session ok, complete *)
+          let orch =
+            Orchestrator.enqueue orch pid Operation_kind.Review_comments
+          in
+          let orch, _eff, msgs =
+            Patch_controller.plan_tick_messages orch
+              ~project_name:"test-project" ~gameplan
+          in
+          let orch = accept_all_messages orch msgs in
+          let orch =
+            Orchestrator.apply_session_result orch pid Orchestrator.Session_ok
+          in
+          let orch = Orchestrator.complete orch pid in
+          (* Send human message, plan, accept, session ok, complete *)
+          let orch = Orchestrator.send_human_message orch pid "fix the typo" in
+          let orch, _eff, msgs =
+            Patch_controller.plan_tick_messages orch
+              ~project_name:"test-project" ~gameplan
+          in
+          let orch = accept_all_messages orch msgs in
+          let orch =
+            Orchestrator.apply_session_result orch pid Orchestrator.Session_ok
+          in
+          let orch = Orchestrator.complete orch pid in
+          (* Assert session_id survived *)
+          let agent = Orchestrator.agent orch pid in
+          Option.equal String.equal agent.Patch_agent.llm_session_id
+            (Some "sess-1")
+        with _ -> false
+        end)
+  in
+  (* F2: llm_session_id cleared on Session_no_resume *)
+  let prop_session_id_cleared_on_no_resume =
+    Test.make
+      ~name:
+        "patch_controller_state_machine: llm_session_id cleared on \
+         Session_no_resume"
+      ~count:300
+      Gen.(pair gen_patch_id gen_branch)
+      (fun (pid, branch) ->
+        begin try
+          let patch = make_patch pid branch in
+          let gameplan = make_gameplan patch in
+          let orch = Orchestrator.create ~patches:[ patch ] ~main_branch:main in
+          (* Start → get PR *)
+          let orch, _eff, msgs =
+            Patch_controller.plan_tick_messages orch
+              ~project_name:"test-project" ~gameplan
+          in
+          let orch = accept_all_messages orch msgs in
+          let orch = Orchestrator.complete orch pid in
+          let orch = Orchestrator.set_pr_number orch pid (Pr_number.of_int 1) in
+          (* Set llm_session_id *)
+          let orch = Orchestrator.set_llm_session_id orch pid (Some "sess-1") in
+          (* Enqueue Ci, plan, accept, session no_resume *)
+          let orch = Orchestrator.enqueue orch pid Operation_kind.Ci in
+          let orch, _eff, msgs =
+            Patch_controller.plan_tick_messages orch
+              ~project_name:"test-project" ~gameplan
+          in
+          let orch = accept_all_messages orch msgs in
+          let orch =
+            Orchestrator.apply_session_result orch pid
+              Orchestrator.Session_no_resume
+          in
+          (* Assert session_id cleared and fallback is Tried_fresh *)
+          let agent = Orchestrator.agent orch pid in
+          Option.is_none agent.Patch_agent.llm_session_id
+          && Onton.Patch_agent.equal_session_fallback
+               agent.Patch_agent.session_fallback Onton.Patch_agent.Tried_fresh
+        with _ -> false
+        end)
+  in
   QCheck_base_runner.run_tests ~verbose:true
     [
       prop_replay_deterministic;
@@ -312,5 +408,7 @@ let () =
       prop_human_after_review_completes;
       prop_second_human_after_review;
       prop_human_messages_survive_session_failure;
+      prop_session_id_survives_review_human;
+      prop_session_id_cleared_on_no_resume;
     ]
   |> Stdlib.exit

--- a/test/test_poll_log_properties.ml
+++ b/test/test_poll_log_properties.ml
@@ -50,7 +50,7 @@ let make_agent ~patch_id ~branch ~has_conflict ~ci_failure_count ~current_op
     ~pr_description_applied:true ~implementation_notes_delivered:true
     ~start_attempts_without_pr:0 ~conflict_noop_count:0 ~checks_passing
     ~current_op ~current_message_id:None ~generation:0 ~worktree_path
-    ~head_branch ~branch_blocked
+    ~head_branch ~branch_blocked ~llm_session_id:None
 
 let make_poll_observation ~head_branch ~branch_in_root ~worktree_path
     poll_result =

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -640,4 +640,145 @@ let () =
     ];
   Stdlib.print_endline "session result: all properties passed"
 
+(* ========== llm_session_id properties (A1-A6) ========== *)
+
+let () =
+  let open QCheck2 in
+  let open Onton in
+  let module G = Onton_test_support.Test_generators in
+  let mk_busy_orch () =
+    let pid = Types.Patch_id.of_string "p1" in
+    let main = Types.Branch.of_string "main" in
+    let patches =
+      [
+        Types.Patch.
+          {
+            id = pid;
+            title = "P";
+            description = "";
+            branch = Types.Branch.of_string "b1";
+            dependencies = [];
+            spec = "";
+            acceptance_criteria = [];
+            files = [];
+            classification = "";
+            changes = [];
+            test_stubs_introduced = [];
+            test_stubs_implemented = [];
+          };
+      ]
+    in
+    let orch = Orchestrator.create ~patches ~main_branch:main in
+    let orch, _effects, _actions = tick orch ~patches in
+    (orch, pid)
+  in
+  (* A1: Session_ok preserves llm_session_id *)
+  let prop_a1_session_ok_preserves_session_id =
+    Test.make ~name:"A1: Session_ok preserves llm_session_id" (Gen.return ())
+      (fun () ->
+        let orch, pid = mk_busy_orch () in
+        let orch = Orchestrator.set_llm_session_id orch pid (Some "test-id") in
+        let orch = Orchestrator.apply_session_result orch pid Session_ok in
+        let orch = Orchestrator.complete orch pid in
+        let a = Orchestrator.agent orch pid in
+        Option.equal String.equal a.Patch_agent.llm_session_id (Some "test-id"))
+  in
+  (* A2: Resume failure (on_session_failure ~is_fresh:false) clears llm_session_id *)
+  let prop_a2_resume_failure_clears_session_id =
+    Test.make ~name:"A2: resume failure clears llm_session_id" (Gen.return ())
+      (fun () ->
+        let orch, pid = mk_busy_orch () in
+        let orch =
+          Orchestrator.set_pr_number orch pid (Types.Pr_number.of_int 1)
+        in
+        let orch = Orchestrator.set_llm_session_id orch pid (Some "test-id") in
+        let orch = Orchestrator.on_session_failure orch pid ~is_fresh:false in
+        let a = Orchestrator.agent orch pid in
+        Option.is_none a.Patch_agent.llm_session_id)
+  in
+  (* A3: Session_give_up clears llm_session_id *)
+  let prop_a3_give_up_clears_session_id =
+    Test.make ~name:"A3: Session_give_up clears llm_session_id" (Gen.return ())
+      (fun () ->
+        let orch, pid = mk_busy_orch () in
+        let orch = Orchestrator.set_llm_session_id orch pid (Some "test-id") in
+        let orch = Orchestrator.apply_session_result orch pid Session_give_up in
+        let a = Orchestrator.agent orch pid in
+        Option.is_none a.Patch_agent.llm_session_id)
+  in
+  (* A4: set_llm_session_id is idempotent *)
+  let prop_a4_set_session_id_idempotent =
+    Test.make ~name:"A4: set_llm_session_id is idempotent" ~count:200
+      (Gen.pair G.gen_patch_id (Gen.option Gen.string_small))
+      (fun (pid, v) ->
+        try
+          let main = Types.Branch.of_string "main" in
+          let patches =
+            [
+              Types.Patch.
+                {
+                  id = pid;
+                  title = "P";
+                  description = "";
+                  branch = Types.Branch.of_string "b1";
+                  dependencies = [];
+                  spec = "";
+                  acceptance_criteria = [];
+                  files = [];
+                  classification = "";
+                  changes = [];
+                  test_stubs_introduced = [];
+                  test_stubs_implemented = [];
+                };
+            ]
+          in
+          let orch = Orchestrator.create ~patches ~main_branch:main in
+          let once = Orchestrator.set_llm_session_id orch pid v in
+          let twice = Orchestrator.set_llm_session_id once pid v in
+          let a1 = Orchestrator.agent once pid in
+          let a2 = Orchestrator.agent twice pid in
+          Option.equal String.equal a1.Patch_agent.llm_session_id
+            a2.Patch_agent.llm_session_id
+        with Invalid_argument _ -> false)
+  in
+  (* A5: Fresh failure on respond path clears llm_session_id *)
+  let prop_a5_fresh_failure_clears_session_id =
+    Test.make ~name:"A5: fresh failure on respond path clears llm_session_id"
+      (Gen.return ()) (fun () ->
+        let orch, pid = mk_busy_orch () in
+        let orch =
+          Orchestrator.set_pr_number orch pid (Types.Pr_number.of_int 1)
+        in
+        let orch = Orchestrator.set_llm_session_id orch pid (Some "test-id") in
+        (* on_session_failure ~is_fresh:true with has_pr:
+           set_session_failed (Fresh_available → Tried_fresh, clears session_id)
+           then set_tried_fresh (Tried_fresh → Given_up, clears session_id) *)
+        let orch = Orchestrator.on_session_failure orch pid ~is_fresh:true in
+        let a = Orchestrator.agent orch pid in
+        Option.is_none a.Patch_agent.llm_session_id)
+  in
+  (* A6: Session_no_resume clears llm_session_id *)
+  let prop_a6_no_resume_clears_session_id =
+    Test.make ~name:"A6: Session_no_resume clears llm_session_id"
+      (Gen.return ()) (fun () ->
+        let orch, pid = mk_busy_orch () in
+        let orch = Orchestrator.set_llm_session_id orch pid (Some "test-id") in
+        let orch =
+          Orchestrator.apply_session_result orch pid Session_no_resume
+        in
+        let a = Orchestrator.agent orch pid in
+        Option.is_none a.Patch_agent.llm_session_id)
+  in
+  List.iter
+    ~f:(fun t -> QCheck2.Test.check_exn t)
+    [
+      prop_a1_session_ok_preserves_session_id;
+      prop_a2_resume_failure_clears_session_id;
+      prop_a3_give_up_clears_session_id;
+      prop_a4_set_session_id_idempotent;
+      prop_a5_fresh_failure_clears_session_id;
+      prop_a6_no_resume_clears_session_id;
+    ];
+  Stdlib.print_endline "llm_session_id: all properties passed (A1-A6)"
+
 let () = Stdlib.print_endline "all property tests passed"

--- a/test/test_run_classification.ml
+++ b/test/test_run_classification.ml
@@ -12,7 +12,7 @@ let () =
     Test.make ~name:"classify: Error msg -> Process_error msg" ~count:500
       Gen.(string_size ~gen:printable (int_range 1 80))
       (fun msg ->
-        match classify ~continue:false (Error msg) with
+        match classify ~is_resume:false (Error msg) with
         | Process_error m -> String.equal m msg
         | No_session_to_resume | Timed_out | Success _ | Session_failed _ ->
             false)
@@ -23,7 +23,7 @@ let () =
     Test.make ~name:"classify: timed_out -> Timed_out" ~count:500
       gen_run_outcome (fun r ->
         let r = { r with timed_out = true } in
-        match classify ~continue:false (Ok r) with
+        match classify ~is_resume:false (Ok r) with
         | Timed_out -> true
         | Process_error _ | No_session_to_resume | Success _ | Session_failed _
           ->
@@ -35,7 +35,7 @@ let () =
     Test.make ~name:"classify: no events + continue -> No_session_to_resume"
       ~count:500 gen_run_outcome (fun r ->
         let r = { r with got_events = false; timed_out = false } in
-        match classify ~continue:true (Ok r) with
+        match classify ~is_resume:true (Ok r) with
         | No_session_to_resume -> true
         | Process_error _ | Timed_out | Success _ | Session_failed _ -> false)
   in
@@ -47,7 +47,7 @@ let () =
         let r =
           { r with exit_code = 0; got_events = true; timed_out = false }
         in
-        match classify ~continue:false (Ok r) with
+        match classify ~is_resume:false (Ok r) with
         | Success _ -> true
         | Process_error _ | No_session_to_resume | Timed_out | Session_failed _
           ->
@@ -61,7 +61,7 @@ let () =
         let r =
           { r with exit_code = 1; got_events = true; timed_out = false }
         in
-        match classify ~continue:false (Ok r) with
+        match classify ~is_resume:false (Ok r) with
         | Session_failed _ -> true
         | Process_error _ | No_session_to_resume | Timed_out | Success _ ->
             false)
@@ -74,7 +74,7 @@ let () =
         let r =
           { r with exit_code = 1; got_events = true; timed_out = false }
         in
-        match classify ~continue:false (Ok r) with
+        match classify ~is_resume:false (Ok r) with
         | Session_failed { detail; _ } -> String.length detail <= 503
         | Process_error _ | No_session_to_resume | Timed_out | Success _ ->
             false)
@@ -85,7 +85,7 @@ let () =
     Test.make ~name:"classify: continue=false, no events -> uses exit code"
       ~count:500 gen_run_outcome (fun r ->
         let r = { r with got_events = false; timed_out = false } in
-        match classify ~continue:false (Ok r) with
+        match classify ~is_resume:false (Ok r) with
         | No_session_to_resume -> false (* should not happen without continue *)
         | Process_error _ | Timed_out | Success _ | Session_failed _ -> true)
   in


### PR DESCRIPTION
## Summary

- **Fix**: Replace `--continue` (implicit "most recent session" discovery) with `--resume <session_id>` (explicit session targeting) to prevent silent session loss
- **Root cause**: `--continue` silently starts a fresh conversation when session lookup fails (expired, cleaned up, not found), causing agents to lose all conversation context between messages
- **Backend-agnostic**: All 5 backends updated to `~resume_session:string option` interface; session ID captured from `system/init` streaming event and stored on patch agent

## Test plan

- [x] A1-A6: Property tests for `llm_session_id` preservation/clearing lifecycle
- [x] I-13: Interleaving invariant — `session_fallback ∈ {Tried_fresh, Given_up} → llm_session_id = None` — exercised across 1000×50 random command sequences
- [x] F1: Session ID survives review→human sequence (exact bug scenario, 300 runs)
- [x] F2: Session ID cleared on `Session_no_resume` (300 runs)
- [x] D1-D6: Claude runner inline tests for `--resume` args and `Session_init` parsing
- [x] All existing PI-1 through PI-11 interleaving tests pass
- [x] `dune build` + `dune runtest` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch LLM sessions from --continue to --resume <session_id> to stop context loss. We capture the session ID and reuse it on every run across all backends.

- **New Features**
  - Capture `session_id` from `system/init` and store as `llm_session_id`; persist it and expose `Orchestrator.set_llm_session_id`.
  - Update all backends (`claude`, `codex`, `pi`, `opencode`) to `~resume_session:string option`; pass `--resume <id>` when present, else start fresh.
  - Stream parser now emits `Session_init { session_id }`.

- **Bug Fixes**
  - Prevent silent session resets: if resume yields no events, treat as `Session_no_resume` and retry fresh; auto-clear `llm_session_id` on fallback escalation or `Session_no_resume`.
  - Fix `codex`, `pi`, and `opencode` to pass the actual session ID to `--resume` (was `--continue`/`--last`), ensuring the intended session is resumed.
  - Switch classification to `~is_resume`; extend tests to cover session ID lifecycle and invariants.

<sup>Written for commit 0c96022379b8187dccbbb2683ac6347afa52a287. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

