### PR TITLE
Eliminate head_branch: fetch real branch at ad-hoc registration

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -979,7 +979,7 @@ let input_fiber ~runtime ~process_mgr ~net ~github ~list_selected ~detail_scroll
                   end
               | Tui_input.Prompt_pr -> (
                   match Base.Int.of_string_opt line with
-                  | Some n when n > 0 -> (
+                  | Some n when n > 0 ->
                       let pr_number = Pr_number.of_int n in
                       let patch_id = Patch_id.of_string (Int.to_string n) in
                       let already_exists =
@@ -991,7 +991,14 @@ let input_fiber ~runtime ~process_mgr ~net ~github ~list_selected ~detail_scroll
                       if already_exists then
                         log_event runtime ~patch_id
                           (Printf.sprintf "Ad-hoc PR #%d already registered" n)
-                      else
+                      else (
+                        status_msg :=
+                          Some
+                            {
+                              Tui.level = Tui.Info;
+                              text = Printf.sprintf "Fetching PR #%d…" n;
+                              expires_at = None;
+                            };
                         match Github.pr_state ~net github pr_number with
                         | Error err ->
                             log_event runtime ~patch_id

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1001,16 +1001,19 @@ let input_fiber ~runtime ~process_mgr ~net ~github ~list_selected ~detail_scroll
                             };
                         match Github.pr_state ~net github pr_number with
                         | Error err ->
+                            status_msg := None;
                             log_event runtime ~patch_id
                               (Printf.sprintf "Cannot add ad-hoc PR #%d: %s" n
                                  (Github.show_error err))
                         | Ok pr_state when Pr_state.is_fork pr_state ->
+                            status_msg := None;
                             log_event runtime ~patch_id
                               (Printf.sprintf
                                  "Cannot add ad-hoc PR #%d: fork PRs not \
                                   supported"
                                  n)
                         | Ok pr_state -> (
+                            status_msg := None;
                             match pr_state.Pr_state.head_branch with
                             | None ->
                                 log_event runtime ~patch_id

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -361,14 +361,10 @@ let resolve_worktree_path ~process_mgr ~repo_root ~project_name ~patch_id
   | Some p -> p
   | None ->
       let search_branch =
-        match branch with
-        | Some b -> Some b
-        | None -> agent.Patch_agent.head_branch
+        match branch with Some b -> b | None -> agent.Patch_agent.branch
       in
       let found =
-        match search_branch with
-        | Some b -> Worktree.find_for_branch ~process_mgr ~repo_root b
-        | None -> None
+        Worktree.find_for_branch ~process_mgr ~repo_root search_branch
       in
       let path =
         match found with
@@ -393,92 +389,75 @@ let ensure_worktree ~runtime ~process_mgr ~fs ~repo_root ~project_name ~patch_id
         Orchestrator.set_worktree_path orch patch_id path);
     Some path)
   else
-    let search_branch =
-      match branch with
-      | Some b -> Some b
-      | None -> agent.Patch_agent.head_branch
+    let br =
+      match branch with Some b -> b | None -> agent.Patch_agent.branch
     in
-    match search_branch with
-    | None ->
+    match Worktree.find_for_branch ~process_mgr ~repo_root br with
+    | Some existing ->
         log_event runtime ~patch_id
-          "worktree not ready and branch unknown, waiting for poller";
-        None
-    | Some br -> (
-        match Worktree.find_for_branch ~process_mgr ~repo_root br with
-        | Some existing ->
-            log_event runtime ~patch_id
-              (Printf.sprintf "found existing worktree for branch at %s"
-                 existing);
+          (Printf.sprintf "found existing worktree for branch at %s" existing);
+        Runtime.update_orchestrator runtime (fun orch ->
+            Orchestrator.set_worktree_path orch patch_id existing);
+        Some existing
+    | None ->
+        if Worktree.is_checked_out_in_repo_root ~process_mgr ~repo_root br then (
+          let main_root = Worktree.resolve_main_root ~process_mgr ~repo_root in
+          log_event runtime ~patch_id
+            (Printf.sprintf
+               "branch %s is currently checked out in the main working tree \
+                (%s). Cannot create a worktree for a branch that is checked \
+                out there. Please switch to a different branch (e.g. `git -C \
+                %s checkout <default-branch>`) before continuing."
+               (Branch.to_string br) main_root main_root);
+          None)
+        else
+          let base =
+            match base_ref with
+            | Some b -> b
+            | None -> (
+                match agent.Patch_agent.base_branch with
+                | Some b -> Branch.to_string b
+                | None -> "HEAD")
+          in
+          log_event runtime ~patch_id
+            (Printf.sprintf "creating worktree at %s" path);
+          (match
+             Eio.Mutex.use_rw ~protect:true worktree_mutex (fun () ->
+                 ignore
+                   (Worktree.create ~process_mgr ~repo_root ~project_name
+                      ~patch_id ~branch:br ~base_ref:base))
+           with
+          | () -> ()
+          | exception (Eio.Cancel.Cancelled _ as exn) -> raise exn
+          | exception exn ->
+              log_event runtime ~patch_id
+                (Printf.sprintf "worktree creation failed: %s"
+                   (Printexc.to_string exn)));
+          if Stdlib.Sys.file_exists path then (
             Runtime.update_orchestrator runtime (fun orch ->
-                Orchestrator.set_worktree_path orch patch_id existing);
-            Some existing
-        | None ->
-            if Worktree.is_checked_out_in_repo_root ~process_mgr ~repo_root br
-            then (
-              let main_root =
-                Worktree.resolve_main_root ~process_mgr ~repo_root
-              in
-              log_event runtime ~patch_id
-                (Printf.sprintf
-                   "branch %s is currently checked out in the main working \
-                    tree (%s). Cannot create a worktree for a branch that is \
-                    checked out there. Please switch to a different branch \
-                    (e.g. `git -C %s checkout <default-branch>`) before \
-                    continuing."
-                   (Branch.to_string br) main_root main_root);
-              None)
-            else
-              let base =
-                match base_ref with
-                | Some b -> b
-                | None -> (
-                    match agent.Patch_agent.base_branch with
-                    | Some b -> Branch.to_string b
-                    | None -> "HEAD")
-              in
-              log_event runtime ~patch_id
-                (Printf.sprintf "creating worktree at %s" path);
-              (match
-                 Eio.Mutex.use_rw ~protect:true worktree_mutex (fun () ->
-                     ignore
-                       (Worktree.create ~process_mgr ~repo_root ~project_name
-                          ~patch_id ~branch:br ~base_ref:base))
-               with
-              | () -> ()
-              | exception (Eio.Cancel.Cancelled _ as exn) -> raise exn
-              | exception exn ->
-                  log_event runtime ~patch_id
-                    (Printf.sprintf "worktree creation failed: %s"
-                       (Printexc.to_string exn)));
-              if Stdlib.Sys.file_exists path then (
-                Runtime.update_orchestrator runtime (fun orch ->
-                    Orchestrator.set_worktree_path orch patch_id path);
-                (match user_config.User_config.on_worktree_create with
-                | Some script -> (
-                    let env =
-                      [
-                        ("ONTON_WORKTREE_PATH", path);
-                        ("ONTON_PATCH_ID", Patch_id.to_string patch_id);
-                        ("ONTON_BRANCH", Branch.to_string br);
-                      ]
-                    in
-                    let cwd = Eio.Path.(fs / path) in
-                    match
-                      User_config.run_hook ~process_mgr ~script ~cwd ~env
-                    with
-                    | Ok () ->
-                        log_event runtime ~patch_id
-                          "on_worktree_create hook ran"
-                    | Error msg ->
-                        log_event runtime ~patch_id
-                          (Printf.sprintf "on_worktree_create hook failed: %s"
-                             msg))
-                | None -> ());
-                Some path)
-              else (
-                log_event runtime ~patch_id
-                  (Printf.sprintf "worktree still missing at %s" path);
-                None))
+                Orchestrator.set_worktree_path orch patch_id path);
+            (match user_config.User_config.on_worktree_create with
+            | Some script -> (
+                let env =
+                  [
+                    ("ONTON_WORKTREE_PATH", path);
+                    ("ONTON_PATCH_ID", Patch_id.to_string patch_id);
+                    ("ONTON_BRANCH", Branch.to_string br);
+                  ]
+                in
+                let cwd = Eio.Path.(fs / path) in
+                match User_config.run_hook ~process_mgr ~script ~cwd ~env with
+                | Ok () ->
+                    log_event runtime ~patch_id "on_worktree_create hook ran"
+                | Error msg ->
+                    log_event runtime ~patch_id
+                      (Printf.sprintf "on_worktree_create hook failed: %s" msg))
+            | None -> ());
+            Some path)
+          else (
+            log_event runtime ~patch_id
+              (Printf.sprintf "worktree still missing at %s" path);
+            None)
 
 let truncate s n = if String.length s <= n then s else String.sub s 0 n ^ "..."
 
@@ -838,7 +817,7 @@ let normalize_paste text =
   let text = Base.String.tr text ~target:'\n' ~replacement:' ' in
   Base.String.tr text ~target:'\r' ~replacement:' '
 
-let input_fiber ~runtime ~process_mgr ~list_selected ~detail_scroll
+let input_fiber ~runtime ~process_mgr ~net ~github ~list_selected ~detail_scroll
     ~detail_follow ~timeline_scroll ~detail_scrolls ~view_mode ~pr_registry
     ~project_name ~show_help ~status_msg ~sorted_patch_ids ~input_mode
     ~prompt_line ~patches_start_row ~patches_scroll_offset
@@ -1000,7 +979,7 @@ let input_fiber ~runtime ~process_mgr ~list_selected ~detail_scroll
                   end
               | Tui_input.Prompt_pr -> (
                   match Base.Int.of_string_opt line with
-                  | Some n when n > 0 ->
+                  | Some n when n > 0 -> (
                       let pr_number = Pr_number.of_int n in
                       let patch_id = Patch_id.of_string (Int.to_string n) in
                       let already_exists =
@@ -1012,16 +991,34 @@ let input_fiber ~runtime ~process_mgr ~list_selected ~detail_scroll
                       if already_exists then
                         log_event runtime ~patch_id
                           (Printf.sprintf "Ad-hoc PR #%d already registered" n)
-                      else (
-                        Pr_registry.register pr_registry ~patch_id ~pr_number;
-                        let branch =
-                          Branch.of_string ("adhoc-" ^ Int.to_string n)
-                        in
-                        Runtime.update_orchestrator runtime (fun orch ->
-                            Orchestrator.add_agent orch ~patch_id ~branch
-                              ~pr_number);
-                        log_event runtime ~patch_id
-                          (Printf.sprintf "Ad-hoc PR #%d added" n))
+                      else
+                        match Github.pr_state ~net github pr_number with
+                        | Error err ->
+                            log_event runtime ~patch_id
+                              (Printf.sprintf "Cannot add ad-hoc PR #%d: %s" n
+                                 (Github.show_error err))
+                        | Ok pr_state when Pr_state.is_fork pr_state ->
+                            log_event runtime ~patch_id
+                              (Printf.sprintf
+                                 "Cannot add ad-hoc PR #%d: fork PRs not \
+                                  supported"
+                                 n)
+                        | Ok pr_state -> (
+                            match pr_state.Pr_state.head_branch with
+                            | None ->
+                                log_event runtime ~patch_id
+                                  (Printf.sprintf
+                                     "Cannot add ad-hoc PR #%d: no head branch"
+                                     n)
+                            | Some branch ->
+                                Pr_registry.register pr_registry ~patch_id
+                                  ~pr_number;
+                                Runtime.update_orchestrator runtime (fun orch ->
+                                    Orchestrator.add_agent orch ~patch_id
+                                      ~branch ~pr_number);
+                                log_event runtime ~patch_id
+                                  (Printf.sprintf "Ad-hoc PR #%d added (%s)" n
+                                     (Branch.to_string branch))))
                   | _ ->
                       if not (Base.String.is_empty line) then
                         log_event runtime
@@ -1620,10 +1617,7 @@ let poller_fiber ~runtime ~clock ~net ~process_mgr ~github ~config ~project_name
                                 Orchestrator.find_agent
                                   snap.Runtime.orchestrator patch_id
                               with
-                              | Some agent -> (
-                                  match agent.Patch_agent.head_branch with
-                                  | Some b -> b
-                                  | None -> agent.Patch_agent.branch)
+                              | Some agent -> agent.Patch_agent.branch
                               | None -> branch_of patch_id)
                     in
                     (match
@@ -1699,7 +1693,6 @@ let poller_fiber ~runtime ~clock ~net ~process_mgr ~github ~config ~project_name
                       Patch_controller.
                         {
                           poll_result;
-                          head_branch = pr_state.Pr_state.head_branch;
                           base_branch = pr_state.Pr_state.base_branch;
                           branch_in_root;
                           worktree_path = worktree_candidate;
@@ -1709,7 +1702,6 @@ let poller_fiber ~runtime ~clock ~net ~process_mgr ~github ~config ~project_name
                       ( patch_id,
                         observation,
                         failed_ci,
-                        pr_state.Pr_state.head_branch,
                         pr_state.Pr_state.ci_checks_truncated )))
     in
     (* Phase 2: Single atomic update — apply all poll results + reconcile.
@@ -1720,10 +1712,7 @@ let poller_fiber ~runtime ~clock ~net ~process_mgr ~github ~config ~project_name
           (* Apply all poll results *)
           let orch, sides =
             Base.List.fold observations ~init:(orch, [])
-              ~f:(fun
-                  (orch, sides)
-                  (patch_id, obs, failed_ci, head_branch, ci_truncated)
-                ->
+              ~f:(fun (orch, sides) (patch_id, obs, failed_ci, ci_truncated) ->
                 match Orchestrator.find_agent orch patch_id with
                 | None -> (orch, sides)
                 | Some agent_before ->
@@ -1743,7 +1732,6 @@ let poller_fiber ~runtime ~clock ~net ~process_mgr ~github ~config ~project_name
                         log_entries,
                         newly_blocked,
                         failed_ci,
-                        head_branch,
                         ci_truncated )
                       :: sides ))
           in
@@ -1789,14 +1777,7 @@ let poller_fiber ~runtime ~clock ~net ~process_mgr ~github ~config ~project_name
     in
     (* Phase 3: Side effects — outside the lock *)
     Base.List.iter per_patch_sides
-      ~f:(fun
-          ( patch_id,
-            log_entries,
-            newly_blocked,
-            failed_ci,
-            head_branch,
-            ci_truncated )
-        ->
+      ~f:(fun (patch_id, log_entries, newly_blocked, failed_ci, ci_truncated) ->
         if not (Base.List.is_empty failed_ci) then
           Hashtbl.replace ci_checks_cache patch_id failed_ci
         else Hashtbl.remove ci_checks_cache patch_id;
@@ -1805,19 +1786,23 @@ let poller_fiber ~runtime ~clock ~net ~process_mgr ~github ~config ~project_name
             log_event runtime ~patch_id:entry.Patch_controller.patch_id
               entry.Patch_controller.message);
         (if newly_blocked then
-           match head_branch with
-           | Some b ->
-               let main_root =
-                 Worktree.resolve_main_root ~process_mgr
-                   ~repo_root:config.repo_root
-               in
-               log_event runtime ~patch_id
-                 (Printf.sprintf
-                    "branch %s is checked out in the main working tree (%s) — \
-                     release it (e.g. `git -C %s checkout <default-branch>`) \
-                     before onton can work on this patch"
-                    (Branch.to_string b) main_root main_root)
-           | None -> ());
+           let b =
+             Runtime.read runtime (fun snap ->
+                 match
+                   Orchestrator.find_agent snap.Runtime.orchestrator patch_id
+                 with
+                 | Some a -> Branch.to_string a.Patch_agent.branch
+                 | None -> "unknown")
+           in
+           let main_root =
+             Worktree.resolve_main_root ~process_mgr ~repo_root:config.repo_root
+           in
+           log_event runtime ~patch_id
+             (Printf.sprintf
+                "branch %s is checked out in the main working tree (%s) — \
+                 release it (e.g. `git -C %s checkout <default-branch>`) \
+                 before onton can work on this patch"
+                b main_root main_root));
         if ci_truncated then
           log_event runtime ~patch_id
             "warning: CI check list was truncated (>100 checks); some failures \
@@ -3102,7 +3087,7 @@ let run_with_config (config : config) gameplan existing_snapshot =
                      ~input_mode ~prompt_line ~patches_start_row
                      ~patches_scroll_offset ~patches_visible_count)
                 :: (fun () ->
-                  input_fiber ~runtime ~process_mgr ~list_selected
+                  input_fiber ~runtime ~process_mgr ~net ~github ~list_selected
                     ~detail_scroll ~detail_follow ~timeline_scroll
                     ~detail_scrolls ~view_mode ~pr_registry ~project_name
                     ~show_help ~status_msg ~sorted_patch_ids ~input_mode

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -375,9 +375,6 @@ let set_llm_session_id t patch_id session_id =
   update_agent t patch_id ~f:(fun a ->
       Patch_agent.set_llm_session_id a session_id)
 
-let set_head_branch t patch_id branch =
-  update_agent t patch_id ~f:(fun a -> Patch_agent.set_head_branch a branch)
-
 (** {2 Queries} *)
 
 let all_agents t = Map.data t.agents

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -100,7 +100,6 @@ val set_branch_blocked : t -> Patch_id.t -> t
 val clear_branch_blocked : t -> Patch_id.t -> t
 val reset_busy : t -> Patch_id.t -> t
 val set_worktree_path : t -> Patch_id.t -> string -> t
-val set_head_branch : t -> Patch_id.t -> Branch.t -> t
 val set_llm_session_id : t -> Patch_id.t -> string option -> t
 
 (** {2 Queries} *)

--- a/lib/patch_agent.ml
+++ b/lib/patch_agent.ml
@@ -33,7 +33,6 @@ type t = {
   current_message_id : Message_id.t option;
   generation : int;
   worktree_path : string option;
-  head_branch : Branch.t option;
   branch_blocked : bool;
   llm_session_id : string option;
 }
@@ -79,7 +78,6 @@ let create ~branch patch_id =
     current_message_id = None;
     generation = 0;
     worktree_path = None;
-    head_branch = None;
     branch_blocked = false;
     llm_session_id = None;
   }
@@ -113,7 +111,6 @@ let create_adhoc ~patch_id ~branch ~pr_number =
     current_message_id = None;
     generation = 0;
     worktree_path = None;
-    head_branch = None;
     branch_blocked = false;
     llm_session_id = None;
   }
@@ -202,7 +199,6 @@ let on_pre_session_failure t =
 
 let set_checks_passing t v = { t with checks_passing = v }
 let set_worktree_path t path = { t with worktree_path = Some path }
-let set_head_branch t branch = { t with head_branch = Some branch }
 
 let is_approved t ~main_branch =
   has_pr t && t.merge_ready && (not t.busy)
@@ -240,7 +236,7 @@ let restore ~patch_id ~branch ~pr_number ~has_session ~busy ~merged ~queue
     ~ci_failure_count ~session_fallback ~human_messages ~ci_checks ~merge_ready
     ~is_draft ~pr_description_applied ~implementation_notes_delivered
     ~start_attempts_without_pr ~conflict_noop_count ~checks_passing ~current_op
-    ~current_message_id ~generation ~worktree_path ~head_branch ~branch_blocked
+    ~current_message_id ~generation ~worktree_path ~branch_blocked
     ~llm_session_id =
   {
     patch_id;
@@ -270,7 +266,6 @@ let restore ~patch_id ~branch ~pr_number ~has_session ~busy ~merged ~queue
     current_message_id;
     generation;
     worktree_path;
-    head_branch;
     branch_blocked;
     llm_session_id;
   }

--- a/lib/patch_agent.mli
+++ b/lib/patch_agent.mli
@@ -37,7 +37,6 @@ type t = private {
   current_message_id : Types.Message_id.t option;
   generation : int;
   worktree_path : string option;
-  head_branch : Types.Branch.t option;
   branch_blocked : bool;
   llm_session_id : string option;
 }
@@ -184,9 +183,6 @@ val set_checks_passing : t -> bool -> t
 val set_worktree_path : t -> string -> t
 (** Store the resolved worktree path for this patch. *)
 
-val set_head_branch : t -> Types.Branch.t -> t
-(** Store the PR's head branch (fetched from GitHub). *)
-
 val is_approved : t -> main_branch:Types.Branch.t -> bool
 (** Derived predicate:
     [has_pr && merge_ready && not is_draft && not busy && not needs_intervention
@@ -278,7 +274,6 @@ val restore :
   current_message_id:Types.Message_id.t option ->
   generation:int ->
   worktree_path:string option ->
-  head_branch:Types.Branch.t option ->
   branch_blocked:bool ->
   llm_session_id:string option ->
   t

--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -52,7 +52,6 @@ type poll_log_entry = { message : string; patch_id : Patch_id.t }
 
 type poll_observation = {
   poll_result : Poller.t;
-  head_branch : Branch.t option;
   base_branch : Branch.t option;
   branch_in_root : bool;
   worktree_path : string option;
@@ -74,7 +73,7 @@ let enqueue_notes_if_needed t patch_id (agent : Patch_agent.t) =
     else Orchestrator.enqueue t patch_id Operation_kind.Implementation_notes
 
 let apply_poll_result t patch_id
-    ({ poll_result; head_branch; base_branch; branch_in_root; worktree_path } :
+    ({ poll_result; base_branch; branch_in_root; worktree_path } :
       poll_observation) =
   let logs = ref [] in
   let log message = logs := { message; patch_id } :: !logs in
@@ -173,29 +172,25 @@ let apply_poll_result t patch_id
     | Patch_decision.No_ci_reset -> t
   in
   let t, newly_blocked =
-    match head_branch with
-    | Some branch ->
-        let t = Orchestrator.set_head_branch t patch_id branch in
-        if branch_in_root then
-          let agent = Orchestrator.agent t patch_id in
-          if
-            (not agent.Patch_agent.branch_blocked)
-            && Option.is_none agent.Patch_agent.worktree_path
-          then (
-            log "branch checked out in repo root, blocking worktree operations";
-            (Orchestrator.set_branch_blocked t patch_id, true))
-          else if
-            (not agent.Patch_agent.branch_blocked)
-            && Option.is_some agent.Patch_agent.worktree_path
-          then (t, false)
-          else (Orchestrator.set_branch_blocked t patch_id, false)
-        else
-          let agent = Orchestrator.agent t patch_id in
-          if agent.Patch_agent.branch_blocked then (
-            log "branch no longer in repo root, unblocked";
-            (Orchestrator.clear_branch_blocked t patch_id, false))
-          else (t, false)
-    | None -> (t, false)
+    if branch_in_root then
+      let agent = Orchestrator.agent t patch_id in
+      if
+        (not agent.Patch_agent.branch_blocked)
+        && Option.is_none agent.Patch_agent.worktree_path
+      then (
+        log "branch checked out in repo root, blocking worktree operations";
+        (Orchestrator.set_branch_blocked t patch_id, true))
+      else if
+        (not agent.Patch_agent.branch_blocked)
+        && Option.is_some agent.Patch_agent.worktree_path
+      then (t, false)
+      else (Orchestrator.set_branch_blocked t patch_id, false)
+    else
+      let agent = Orchestrator.agent t patch_id in
+      if agent.Patch_agent.branch_blocked then (
+        log "branch no longer in repo root, unblocked";
+        (Orchestrator.clear_branch_blocked t patch_id, false))
+      else (t, false)
   in
   let t =
     let agent = Orchestrator.agent t patch_id in
@@ -609,7 +604,6 @@ let%test "no merge-conflict re-enqueue after noop" =
   let obs =
     {
       poll_result = poll_conflict;
-      head_branch = Some (Branch.of_string "test-branch");
       base_branch = Some main;
       branch_in_root = false;
       worktree_path = None;

--- a/lib/patch_controller.mli
+++ b/lib/patch_controller.mli
@@ -18,7 +18,6 @@ type poll_log_entry = { message : string; patch_id : Patch_id.t }
 
 type poll_observation = {
   poll_result : Poller.t;
-  head_branch : Branch.t option;
   base_branch : Branch.t option;
   branch_in_root : bool;
   worktree_path : string option;

--- a/lib/persistence.ml
+++ b/lib/persistence.ml
@@ -79,10 +79,6 @@ let patch_agent_to_yojson (a : Patch_agent.t) =
       ("generation", `Int a.generation);
       ( "worktree_path",
         match a.worktree_path with None -> `Null | Some p -> `String p );
-      ( "head_branch",
-        match a.head_branch with
-        | None -> `Null
-        | Some b -> Branch.yojson_of_t b );
       ("branch_blocked", `Bool a.branch_blocked);
       ( "llm_session_id",
         match a.llm_session_id with None -> `Null | Some s -> `String s );
@@ -117,9 +113,14 @@ let patch_agent_of_yojson ~gameplan json =
        ~patch_id:(Patch_id.of_string (string_member "patch_id" json))
        ~branch:
          (let pid = string_member "patch_id" json in
+          (* Backward compat: old ad-hoc agents stored a synthetic "adhoc-N"
+             branch and the real branch in head_branch. Prefer head_branch
+             when present to migrate to the unified branch field. *)
+          let raw = string_member_opt "branch" json in
+          let head = string_member_opt "head_branch" json in
           Branch.of_string
             (Option.value
-               (string_member_opt "branch" json)
+               (match head with Some _ -> head | None -> raw)
                ~default:
                  (match
                     List.find gameplan.Gameplan.patches ~f:(fun p ->
@@ -170,8 +171,6 @@ let patch_agent_of_yojson ~gameplan json =
          |> Option.map ~f:Message_id.of_string)
        ~generation:(int_member "generation" json)
        ~worktree_path:(string_member_opt "worktree_path" json)
-       ~head_branch:
-         (string_member_opt "head_branch" json |> Option.map ~f:Branch.of_string)
        ~branch_blocked:(bool_member "branch_blocked" json)
        ~llm_session_id:(string_member_opt "llm_session_id" json))
 

--- a/lib/persistence.ml
+++ b/lib/persistence.ml
@@ -118,9 +118,19 @@ let patch_agent_of_yojson ~gameplan json =
              when present to migrate to the unified branch field. *)
           let raw = string_member_opt "branch" json in
           let head = string_member_opt "head_branch" json in
+          (* Treat synthetic "adhoc-N" raw values as unresolvable so they
+             fall through to the gameplan/pid default instead of creating
+             ghost worktrees that silently block worktree creation. *)
+          let resolved =
+            match head with
+            | Some _ -> head
+            | None -> (
+                match raw with
+                | Some r when String.is_prefix r ~prefix:"adhoc-" -> None
+                | _ -> raw)
+          in
           Branch.of_string
-            (Option.value
-               (match head with Some _ -> head | None -> raw)
+            (Option.value resolved
                ~default:
                  (match
                     List.find gameplan.Gameplan.patches ~f:(fun p ->

--- a/lib/persistence.ml
+++ b/lib/persistence.ml
@@ -126,7 +126,11 @@ let patch_agent_of_yojson ~gameplan json =
             | Some _ -> head
             | None -> (
                 match raw with
-                | Some r when String.is_prefix r ~prefix:"adhoc-" -> None
+                | Some r
+                  when String.is_prefix r ~prefix:"adhoc-"
+                       && String.for_all (String.drop_prefix r 6)
+                            ~f:Char.is_digit ->
+                    None
                 | _ -> raw)
           in
           Branch.of_string

--- a/lib/tui.ml
+++ b/lib/tui.ml
@@ -515,15 +515,12 @@ let patch_view_of_agent (agent : Patch_agent.t)
   let title =
     match patch_opt with
     | Some p -> p.Patch.title
-    | None -> (
-        match agent.head_branch with
-        | Some b -> Branch.to_string b
-        | None -> Patch_id.to_string patch_id)
+    | None -> Branch.to_string agent.Patch_agent.branch
   in
   let branch =
     match patch_opt with
     | Some p -> p.Patch.branch
-    | None -> Branch.of_string (Patch_id.to_string patch_id)
+    | None -> agent.Patch_agent.branch
   in
   let current_op = agent.Patch_agent.current_op in
   let ctx =

--- a/test/test_interleaving_properties.ml
+++ b/test/test_interleaving_properties.ml
@@ -362,7 +362,6 @@ let rec apply_command orch patches cmd =
         Patch_controller.
           {
             poll_result;
-            head_branch = Some (branch_of pid);
             base_branch = None;
             branch_in_root = false;
             worktree_path = None;
@@ -502,12 +501,10 @@ let rec apply_command_with_logs orch patches cmd =
             make_poll_result ~has_conflict ~merged ~ci_failed ~checks_passing
               ~review_comments
           in
-          let branch_of = extended_branch_of patches in
           let observation =
             Patch_controller.
               {
                 poll_result;
-                head_branch = Some (branch_of pid);
                 base_branch = None;
                 branch_in_root = false;
                 worktree_path = None;
@@ -1066,7 +1063,6 @@ let conflict_noop_cycle orch pid patches =
     Patch_controller.
       {
         poll_result;
-        head_branch = Some (branch_of pid);
         base_branch = None;
         branch_in_root = false;
         worktree_path = None;
@@ -1145,7 +1141,6 @@ let () =
           Patch_controller.
             {
               poll_result;
-              head_branch = Some (branch_of pid);
               base_branch = None;
               branch_in_root = false;
               worktree_path = None;
@@ -1225,7 +1220,6 @@ let () =
           failwith
             "has_conflict is true after conflict_noop_cycle — should be cleared";
         (* Simulate the next poll with conflict still reported by GitHub *)
-        let branch_of = branch_of_patches patches in
         let poll_result =
           make_poll_result ~has_conflict:true ~merged:false ~ci_failed:false
             ~checks_passing:false ~review_comments:false
@@ -1234,7 +1228,6 @@ let () =
           Patch_controller.
             {
               poll_result;
-              head_branch = Some (branch_of pid);
               base_branch = None;
               branch_in_root = false;
               worktree_path = None;
@@ -1277,7 +1270,6 @@ let () =
           Patch_controller.
             {
               poll_result;
-              head_branch = Some (adhoc_branch 0);
               base_branch = None;
               branch_in_root = false;
               worktree_path = None;

--- a/test/test_orchestrator_properties.ml
+++ b/test/test_orchestrator_properties.ml
@@ -1062,7 +1062,6 @@ let () =
                   Patch_controller.
                     {
                       poll_result = poll;
-                      head_branch = None;
                       base_branch = None;
                       branch_in_root = false;
                       worktree_path = None;
@@ -1102,7 +1101,6 @@ let () =
                   Patch_controller.
                     {
                       poll_result = poll;
-                      head_branch = None;
                       base_branch = None;
                       branch_in_root = false;
                       worktree_path = None;
@@ -1143,7 +1141,6 @@ let () =
                   Patch_controller.
                     {
                       poll_result = poll;
-                      head_branch = None;
                       base_branch = None;
                       branch_in_root = false;
                       worktree_path = None;
@@ -1188,7 +1185,6 @@ let () =
                   Patch_controller.
                     {
                       poll_result = poll;
-                      head_branch = None;
                       base_branch = None;
                       branch_in_root = false;
                       worktree_path = None;
@@ -1229,7 +1225,6 @@ let () =
                   Patch_controller.
                     {
                       poll_result = poll;
-                      head_branch = None;
                       base_branch = None;
                       branch_in_root = false;
                       worktree_path = None;
@@ -1279,7 +1274,6 @@ let () =
                   Patch_controller.
                     {
                       poll_result = poll;
-                      head_branch = None;
                       base_branch = None;
                       branch_in_root = false;
                       worktree_path = None;
@@ -1332,7 +1326,6 @@ let () =
                   Patch_controller.
                     {
                       poll_result = poll;
-                      head_branch = None;
                       base_branch = None;
                       branch_in_root = false;
                       worktree_path = None;
@@ -1375,7 +1368,6 @@ let () =
                   Patch_controller.
                     {
                       poll_result = poll;
-                      head_branch = None;
                       base_branch = None;
                       branch_in_root = false;
                       worktree_path = None;

--- a/test/test_patch_agent.ml
+++ b/test/test_patch_agent.ml
@@ -479,7 +479,7 @@ let () =
               ~implementation_notes_delivered:false ~start_attempts_without_pr:0
               ~conflict_noop_count:0 ~checks_passing:false ~current_op:None
               ~current_message_id:None ~generation:0 ~worktree_path:None
-              ~head_branch:None ~branch_blocked:false ~llm_session_id:None
+              ~branch_blocked:false ~llm_session_id:None
           in
           let a = start a ~base_branch:br in
           List.is_empty a.ci_checks);
@@ -554,7 +554,7 @@ let () =
               ~implementation_notes_delivered:false ~start_attempts_without_pr:0
               ~conflict_noop_count:0 ~checks_passing:false ~current_op:None
               ~current_message_id:None ~generation:0 ~worktree_path:None
-              ~head_branch:None ~branch_blocked:false ~llm_session_id:None
+              ~branch_blocked:false ~llm_session_id:None
           in
           let a = enqueue a Operation_kind.Rebase in
           let a = rebase a ~base_branch:new_base in
@@ -793,6 +793,13 @@ let () =
             let a = set_base_branch a br in
             not (base_branch_changed a)
           with _ -> false);
+      (* -- create_adhoc stores real branch -- *)
+      Test.make ~name:"create_adhoc stores real branch"
+        Gen.(
+          triple gen_pid gen_branch (map Pr_number.of_int (int_range 1 9999)))
+        (fun (pid, br, pr) ->
+          let a = create_adhoc ~patch_id:pid ~branch:br ~pr_number:pr in
+          Branch.equal a.branch br);
     ]
   in
   List.iter tests ~f:(fun t -> QCheck2.Test.check_exn t);

--- a/test/test_patch_controller.ml
+++ b/test/test_patch_controller.ml
@@ -53,7 +53,7 @@ let make_agent ~patch_id ~branch ~pr_number ~merged ~queue ~base_branch
     ~pr_description_applied ~implementation_notes_delivered
     ~start_attempts_without_pr ~conflict_noop_count:0 ~checks_passing:false
     ~current_op:None ~current_message_id:None ~generation:0 ~worktree_path:None
-    ~head_branch:None ~branch_blocked:false ~llm_session_id:None
+    ~branch_blocked:false ~llm_session_id:None
 
 let has_notes_queued agent =
   List.mem agent.Patch_agent.queue Operation_kind.Implementation_notes
@@ -101,7 +101,6 @@ let make_poll_observation poll_result =
   Patch_controller.
     {
       poll_result;
-      head_branch = None;
       base_branch = None;
       branch_in_root = false;
       worktree_path = None;
@@ -529,8 +528,8 @@ let () =
             ~pr_description_applied:true ~implementation_notes_delivered:true
             ~start_attempts_without_pr:0 ~conflict_noop_count:0
             ~checks_passing:false ~current_op:None ~current_message_id:None
-            ~generation:0 ~worktree_path:None ~head_branch:None
-            ~branch_blocked:false ~llm_session_id:None
+            ~generation:0 ~worktree_path:None ~branch_blocked:false
+            ~llm_session_id:None
         in
         let orch = make_orch patch agent in
         let poll =
@@ -594,12 +593,11 @@ let () =
   let prop_poll_observation_updates_branch_metadata =
     Test.make
       ~name:
-        "patch_controller: poll observation updates head branch, base branch, \
+        "patch_controller: poll observation updates base branch, \
          branch_blocked, and worktree"
       ~count:100
       Gen.(pair gen_patch_id gen_branch)
       (fun (pid, branch) ->
-        let head_branch = Branch.of_string "feature/head" in
         let observed_base = Branch.of_string "stack/base" in
         let patch = make_patch pid branch in
         let agent =
@@ -627,7 +625,6 @@ let () =
           Patch_controller.
             {
               poll_result = poll;
-              head_branch = Some head_branch;
               base_branch = Some observed_base;
               branch_in_root = true;
               worktree_path = Some "/tmp/custom-worktree";
@@ -637,9 +634,7 @@ let () =
           Patch_controller.apply_poll_result orch pid observation
         in
         let a = Orchestrator.agent orch pid in
-        Option.equal Branch.equal a.Patch_agent.head_branch (Some head_branch)
-        && Option.equal Branch.equal a.Patch_agent.base_branch
-             (Some observed_base)
+        Option.equal Branch.equal a.Patch_agent.base_branch (Some observed_base)
         && Option.equal String.equal a.Patch_agent.worktree_path
              (Some "/tmp/custom-worktree")
         && (not a.Patch_agent.branch_blocked)

--- a/test/test_persistence_properties.ml
+++ b/test/test_persistence_properties.ml
@@ -262,7 +262,9 @@ let () =
             List.fold_left pr_numbers ~init:orchestrator ~f:(fun orch n ->
                 let patch_id = Patch_id.of_string (Int.to_string n) in
                 let pr_number = Pr_number.of_int n in
-                let branch = Branch.of_string ("adhoc-" ^ Int.to_string n) in
+                let branch =
+                  Branch.of_string ("feature/pr-" ^ Int.to_string n)
+                in
                 Onton.Orchestrator.add_agent orch ~patch_id ~branch ~pr_number)
           in
           let snap =

--- a/test/test_poll_log_properties.ml
+++ b/test/test_poll_log_properties.ml
@@ -38,8 +38,7 @@ let make_orch patch agent =
     ~main_branch:main
 
 let make_agent ~patch_id ~branch ~has_conflict ~ci_failure_count ~current_op
-    ~checks_passing ~queue ~merged ~is_draft ~head_branch ~branch_blocked
-    ~worktree_path =
+    ~checks_passing ~queue ~merged ~is_draft ~branch_blocked ~worktree_path =
   let busy = Option.is_some current_op in
   Patch_agent.restore ~patch_id ~branch
     ~pr_number:(Some (Pr_number.of_int 42))
@@ -50,18 +49,11 @@ let make_agent ~patch_id ~branch ~has_conflict ~ci_failure_count ~current_op
     ~pr_description_applied:true ~implementation_notes_delivered:true
     ~start_attempts_without_pr:0 ~conflict_noop_count:0 ~checks_passing
     ~current_op ~current_message_id:None ~generation:0 ~worktree_path
-    ~head_branch ~branch_blocked ~llm_session_id:None
+    ~branch_blocked ~llm_session_id:None
 
-let make_poll_observation ~head_branch ~branch_in_root ~worktree_path
-    poll_result =
+let make_poll_observation ~branch_in_root ~worktree_path poll_result =
   Patch_controller.
-    {
-      poll_result;
-      head_branch;
-      base_branch = None;
-      branch_in_root;
-      worktree_path;
-    }
+    { poll_result; base_branch = None; branch_in_root; worktree_path }
 
 let make_poll ~has_conflict ~merged ~checks_passing ~is_draft ~queue =
   Poller.
@@ -107,11 +99,7 @@ let gen_poll_log_case =
     in
     let* agent_is_draft = bool in
     let* agent_branch_blocked = bool in
-    (* Agent head_branch / worktree_path: generate optionally *)
-    let* has_agent_head_branch = bool in
-    let* agent_head_branch =
-      if has_agent_head_branch then map Option.some gen_branch else pure None
-    in
+    (* Agent worktree_path: generate optionally *)
     let* has_agent_worktree_path = bool in
     let* agent_worktree_path =
       if has_agent_worktree_path then
@@ -129,10 +117,6 @@ let gen_poll_log_case =
         (list_small gen_feedback_kind)
     in
     (* Observation dimensions *)
-    let* has_obs_head_branch = bool in
-    let* obs_head_branch =
-      if has_obs_head_branch then map Option.some gen_branch else pure None
-    in
     let* obs_branch_in_root = bool in
     let* has_obs_worktree_path = bool in
     let* obs_worktree_path =
@@ -145,8 +129,7 @@ let gen_poll_log_case =
       make_agent ~patch_id:pid ~branch ~has_conflict:agent_has_conflict
         ~ci_failure_count ~current_op ~checks_passing:agent_checks_passing
         ~queue:agent_queue ~merged:agent_merged ~is_draft:agent_is_draft
-        ~head_branch:agent_head_branch ~branch_blocked:agent_branch_blocked
-        ~worktree_path:agent_worktree_path
+        ~branch_blocked:agent_branch_blocked ~worktree_path:agent_worktree_path
     in
     let orch = make_orch patch agent in
     let poll =
@@ -155,8 +138,8 @@ let gen_poll_log_case =
         ~queue:poll_queue
     in
     let observation =
-      make_poll_observation ~head_branch:obs_head_branch
-        ~branch_in_root:obs_branch_in_root ~worktree_path:obs_worktree_path poll
+      make_poll_observation ~branch_in_root:obs_branch_in_root
+        ~worktree_path:obs_worktree_path poll
     in
     return (patch, pid, orch, agent, observation, poll))
 
@@ -166,7 +149,7 @@ let print_case =
     "patch=%s pid=%s agent={merged=%b has_conflict=%b ci_failure_count=%d \
      checks_passing=%b is_draft=%b branch_blocked=%b queue=[%s] current_op=%s} \
      poll={merged=%b has_conflict=%b checks_passing=%b is_draft=%b queue=[%s]} \
-     obs={head_branch=%s branch_in_root=%b worktree_path=%s}"
+     obs={branch_in_root=%b worktree_path=%s}"
     (Patch_id.to_string patch.Patch.id)
     (Patch_id.to_string pid) agent.Patch_agent.merged agent.has_conflict
     agent.ci_failure_count agent.checks_passing agent.is_draft
@@ -176,10 +159,8 @@ let print_case =
        ~f:Operation_kind.to_label)
     poll.Poller.merged poll.has_conflict poll.checks_passing poll.is_draft
     (String.concat ~sep:"," (List.map poll.queue ~f:Operation_kind.to_label))
-    (Option.value_map obs.Patch_controller.head_branch ~default:"none"
-       ~f:Branch.to_string)
-    obs.branch_in_root
-    (Option.value obs.worktree_path ~default:"none")
+    obs.Patch_controller.branch_in_root
+    (Option.value obs.Patch_controller.worktree_path ~default:"none")
 
 (* -- Properties -- *)
 


### PR DESCRIPTION
## Summary
- Ad-hoc patches previously stored a synthetic `adhoc-N` branch and relied on polling to populate `head_branch` with the real PR branch from GitHub — this caused push failures when the synthetic name was used as a git refspec
- Fetch the real branch via `Github.pr_state` at ad-hoc registration time so `Patch_agent.branch` is always the real git branch
- Eliminates `head_branch`, `set_head_branch`, and `push_branch` from `Patch_agent`, `Orchestrator`, and `Patch_controller.poll_observation` — net deletion of 73 lines across 14 files
- Includes backward-compatible persistence migration for old snapshots with synthetic branch names

## Test plan
- [x] `dune build` passes with no warnings
- [x] `dune runtest` passes all property tests (PI-1 through PI-11, including random interleavings with ad-hoc patches)
- [x] Pre-commit hooks pass (build + test + format)
- [ ] Manual test: add an ad-hoc PR and verify the real branch name appears in TUI and push operations succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fetch the real PR branch at ad‑hoc registration and remove `head_branch`, so we always operate on the true branch. This fixes push failures and simplifies worktree handling, polling, and the TUI.

- **Bug Fixes**
  - Resolve the branch via `Github.pr_state` when adding ad‑hoc PRs; reject forks or missing head.
  - Fix push failures caused by synthetic `adhoc-N` refspecs.
  - TUI shows “Fetching PR #N…” during PR lookup and clears it after the fetch.

- **Refactors**
  - Removed `head_branch`, `set_head_branch`, and related wiring in `Patch_agent`, `Orchestrator`, `Patch_controller`, and the poll flow; snapshots no longer include `head_branch`.
  - Always use `Patch_agent.branch` for worktree lookup/creation and blocked-branch messages; TUI shows the real branch.
  - Persistence migration: prefer stored `head_branch` for old snapshots; treat `adhoc-\d+` synthetic branches as invalid and fall back to defaults to avoid ghost worktrees, while preserving legitimate names like `adhoc-feature`.

<sup>Written for commit cb0cb6097fed6e646184e4d92c9d881baf7885b3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

