### PR TITLE
Split human_messages into inbox/inflight, eliminate ci_checks_cache

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1560,7 +1560,7 @@ type poll_intent =
 (** Poller fiber — periodically polls GitHub for PR state changes and
     reconciles. *)
 let poller_fiber ~runtime ~clock ~net ~process_mgr ~github ~config ~project_name
-    ~pr_registry ~branch_of ~ci_checks_cache ~event_log =
+    ~pr_registry ~branch_of ~event_log =
   let main = config.main_branch in
   let skip_logged : (Patch_id.t, bool) Hashtbl.t = Hashtbl.create 16 in
   let rec loop () =
@@ -1614,7 +1614,6 @@ let poller_fiber ~runtime ~clock ~net ~process_mgr ~github ~config ~project_name
                      This path does its own I/O and separate atomic update;
                      it doesn't participate in the batched update below. *)
                   if poll_result.Poller.closed then (
-                    Hashtbl.remove ci_checks_cache patch_id;
                     log_event runtime ~patch_id
                       (Printf.sprintf "PR #%d closed, looking for replacement"
                          (Pr_number.to_int pr_number));
@@ -1787,10 +1786,8 @@ let poller_fiber ~runtime ~clock ~net ~process_mgr ~github ~config ~project_name
     in
     (* Phase 3: Side effects — outside the lock *)
     Base.List.iter per_patch_sides
-      ~f:(fun (patch_id, log_entries, newly_blocked, failed_ci, ci_truncated) ->
-        if not (Base.List.is_empty failed_ci) then
-          Hashtbl.replace ci_checks_cache patch_id failed_ci
-        else Hashtbl.remove ci_checks_cache patch_id;
+      ~f:(fun
+          (patch_id, log_entries, newly_blocked, _failed_ci, ci_truncated) ->
         Base.List.iter log_entries
           ~f:(fun (entry : Patch_controller.poll_log_entry) ->
             log_event runtime ~patch_id:entry.Patch_controller.patch_id
@@ -1826,8 +1823,8 @@ let poller_fiber ~runtime ~clock ~net ~process_mgr ~github ~config ~project_name
 
 (** Runner fiber — executes orchestrator actions by spawning Claude processes
     concurrently. *)
-let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry
-    ~ci_checks_cache ~transcripts ~github ~net ~event_log ?status_msg () =
+let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
+    ~github ~net ~event_log ?status_msg () =
   let main = config.main_branch in
   let process_mgr = Eio.Stdenv.process_mgr env in
   let clock = Eio.Stdenv.clock env in
@@ -2522,7 +2519,8 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry
                                         (Operation_kind.to_label kind)
                                         (Base.List.length
                                            source_agent
-                                             .Patch_agent.human_messages)
+                                             .Patch_agent
+                                              .inflight_human_messages)
                                   | Operation_kind.Ci | Operation_kind.Rebase
                                   | Operation_kind.Merge_conflict
                                   | Operation_kind.Implementation_notes ->
@@ -2530,19 +2528,30 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry
                                         (Operation_kind.to_label kind));
                                 let prompt =
                                   match kind with
-                                  | Operation_kind.Ci -> (
-                                      match
-                                        Hashtbl.find_opt ci_checks_cache
-                                          patch_id
-                                      with
-                                      | Some checks
-                                        when not (Base.List.is_empty checks) ->
-                                          Prompt.render_ci_failure_prompt
-                                            ~project_name ?pr_number checks
-                                      | _ ->
-                                          Prompt
-                                          .render_ci_failure_unknown_prompt
-                                            ~project_name ?pr_number ())
+                                  | Operation_kind.Ci ->
+                                      let failure_conclusions =
+                                        [
+                                          "failure";
+                                          "error";
+                                          "action_required";
+                                          "timed_out";
+                                          "startup_failure";
+                                        ]
+                                      in
+                                      let failed =
+                                        Base.List.filter
+                                          source_agent.Patch_agent.ci_checks
+                                          ~f:(fun (c : Ci_check.t) ->
+                                            Base.List.mem failure_conclusions
+                                              c.Ci_check.conclusion
+                                              ~equal:Base.String.equal)
+                                      in
+                                      if Base.List.is_empty failed then
+                                        Prompt.render_ci_failure_unknown_prompt
+                                          ~project_name ?pr_number ()
+                                      else
+                                        Prompt.render_ci_failure_prompt
+                                          ~project_name ?pr_number failed
                                   | Operation_kind.Review_comments ->
                                       Prompt.render_review_prompt ~project_name
                                         ?pr_number prefetched_comments
@@ -2555,7 +2564,8 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry
                                         ~project_name
                                         (Base.List.rev
                                            source_agent
-                                             .Patch_agent.human_messages)
+                                             .Patch_agent
+                                              .inflight_human_messages)
                                   | Operation_kind.Implementation_notes ->
                                       let patch =
                                         Base.List.find_exn
@@ -2963,9 +2973,6 @@ let run_with_config (config : config) gameplan existing_snapshot =
       let clock = Eio.Stdenv.clock env in
       let net = Eio.Stdenv.net env in
       let stdout = Eio.Stdenv.stdout env in
-      let ci_checks_cache : (Patch_id.t, Ci_check.t list) Hashtbl.t =
-        Hashtbl.create 16
-      in
       (* Capture agent state and worktree list BEFORE launching concurrent
          fibers, so the reconciler sees the pre-session state rather than racing
          with the runner which creates worktrees and sets agents busy. *)
@@ -3046,7 +3053,7 @@ let run_with_config (config : config) gameplan existing_snapshot =
           reconciliation_fiber;
           (fun () ->
             poller_fiber ~runtime ~clock ~net ~process_mgr ~github ~config
-              ~project_name ~pr_registry ~branch_of ~ci_checks_cache ~event_log);
+              ~project_name ~pr_registry ~branch_of ~event_log);
           (fun () ->
             persistence_fiber ~runtime ~clock ~project_name ~transcripts);
         ]
@@ -3056,7 +3063,7 @@ let run_with_config (config : config) gameplan existing_snapshot =
           ((fun () -> headless_fiber ~runtime ~clock ~stdout)
           :: (fun () ->
             runner_fiber ~runtime ~env ~config ~project_name ~pr_registry
-              ~ci_checks_cache ~transcripts ~github ~net ~event_log ())
+              ~transcripts ~github ~net ~event_log ())
           :: common_fibers)
       else
         let list_selected = ref 0 in
@@ -3106,8 +3113,7 @@ let run_with_config (config : config) gameplan existing_snapshot =
                     ~repo:config.github_repo)
                 :: (fun () ->
                   runner_fiber ~runtime ~env ~config ~project_name ~pr_registry
-                    ~ci_checks_cache ~transcripts ~github ~net ~event_log
-                    ~status_msg ())
+                    ~transcripts ~github ~net ~event_log ~status_msg ())
                 :: common_fibers)
             with Quit_tui -> ())
 

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -2290,7 +2290,27 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                   Operation_kind.equal kind Operation_kind.Human
                                 then
                                   Base.List.is_empty
-                                    source_agent.Patch_agent.human_messages
+                                    source_agent
+                                      .Patch_agent.inflight_human_messages
+                                else if
+                                  Operation_kind.equal kind Operation_kind.Ci
+                                then
+                                  let failure_conclusions =
+                                    [
+                                      "failure";
+                                      "error";
+                                      "action_required";
+                                      "timed_out";
+                                      "startup_failure";
+                                    ]
+                                  in
+                                  not
+                                    (Base.List.exists
+                                       source_agent.Patch_agent.ci_checks
+                                       ~f:(fun (c : Ci_check.t) ->
+                                         Base.List.mem failure_conclusions
+                                           c.Ci_check.conclusion
+                                           ~equal:Base.String.equal))
                                 else false
                               in
                               if is_empty_delivery then (

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -506,25 +506,24 @@ type session_result =
   | Session_worktree_missing
 [@@deriving show, eq, sexp_of]
 
-(** Complete a failed session, preserving human messages. When
-    [current_op = Human], [complete] clears [human_messages] because it assumes
-    the messages were delivered. On failure they were NOT delivered, so we save
-    them before [complete] and restore + re-enqueue afterwards. *)
+(** Complete a failed session, restoring inflight human messages to the inbox.
+    On failure the messages were NOT delivered, so we prepend
+    [inflight_human_messages] back to [human_messages] before [complete] clears
+    the inflight slot. *)
 let complete_failed t patch_id =
-  let agent = agent t patch_id in
-  let was_human =
-    Option.equal Operation_kind.equal agent.Patch_agent.current_op
-      (Some Operation_kind.Human)
-  in
-  let saved_messages = agent.Patch_agent.human_messages in
-  let t = complete t patch_id in
-  if was_human && not (List.is_empty saved_messages) then
-    let t =
+  let a = agent t patch_id in
+  let inflight = a.Patch_agent.inflight_human_messages in
+  let t =
+    if not (List.is_empty inflight) then
       update_agent t patch_id ~f:(fun a ->
-          Patch_agent.restore_human_messages a saved_messages)
-    in
-    enqueue t patch_id Operation_kind.Human
-  else t
+          Patch_agent.add_human_messages a inflight)
+    else t
+  in
+  let t = complete t patch_id in
+  let has_messages =
+    not (List.is_empty (agent t patch_id).Patch_agent.human_messages)
+  in
+  if has_messages then enqueue t patch_id Operation_kind.Human else t
 
 let apply_session_result t patch_id result =
   match result with

--- a/lib/patch_agent.ml
+++ b/lib/patch_agent.ml
@@ -21,6 +21,7 @@ type t = {
   ci_failure_count : int;
   session_fallback : session_fallback;
   human_messages : string list;
+  inflight_human_messages : string list;
   ci_checks : Ci_check.t list;
   merge_ready : bool;
   is_draft : bool;
@@ -66,6 +67,7 @@ let create ~branch patch_id =
     ci_failure_count = 0;
     session_fallback = Fresh_available;
     human_messages = [];
+    inflight_human_messages = [];
     ci_checks = [];
     merge_ready = false;
     is_draft = false;
@@ -99,6 +101,7 @@ let create_adhoc ~patch_id ~branch ~pr_number =
     ci_failure_count = 0;
     session_fallback = Fresh_available;
     human_messages = [];
+    inflight_human_messages = [];
     ci_checks = [];
     merge_ready = false;
     is_draft = false;
@@ -128,7 +131,8 @@ let mark_merged t = { t with merged = true }
 let add_human_message t msg =
   { t with human_messages = msg :: t.human_messages }
 
-let restore_human_messages t msgs = { t with human_messages = msgs }
+let add_human_messages t msgs =
+  { t with human_messages = List.rev_append msgs t.human_messages }
 
 let set_session_failed t =
   match t.session_fallback with
@@ -233,11 +237,11 @@ let reset_busy t = if not t.busy then t else { t with busy = false }
 
 let restore ~patch_id ~branch ~pr_number ~has_session ~busy ~merged ~queue
     ~satisfies ~changed ~has_conflict ~base_branch ~notified_base_branch
-    ~ci_failure_count ~session_fallback ~human_messages ~ci_checks ~merge_ready
-    ~is_draft ~pr_description_applied ~implementation_notes_delivered
-    ~start_attempts_without_pr ~conflict_noop_count ~checks_passing ~current_op
-    ~current_message_id ~generation ~worktree_path ~branch_blocked
-    ~llm_session_id =
+    ~ci_failure_count ~session_fallback ~human_messages ~inflight_human_messages
+    ~ci_checks ~merge_ready ~is_draft ~pr_description_applied
+    ~implementation_notes_delivered ~start_attempts_without_pr
+    ~conflict_noop_count ~checks_passing ~current_op ~current_message_id
+    ~generation ~worktree_path ~branch_blocked ~llm_session_id =
   {
     patch_id;
     branch;
@@ -254,6 +258,7 @@ let restore ~patch_id ~branch ~pr_number ~has_session ~busy ~merged ~queue
     ci_failure_count;
     session_fallback;
     human_messages;
+    inflight_human_messages;
     ci_checks;
     merge_ready;
     is_draft;
@@ -377,7 +382,9 @@ let respond t k =
     queue;
     satisfies;
     changed;
-    human_messages = t.human_messages;
+    human_messages = (if is_human then [] else t.human_messages);
+    inflight_human_messages =
+      (if is_human then t.human_messages else t.inflight_human_messages);
     ci_failure_count;
     notified_base_branch =
       (match t.notified_base_branch with None -> t.base_branch | some -> some);
@@ -393,16 +400,7 @@ let complete t =
       busy = false;
       current_op = None;
       current_message_id = None;
-      human_messages =
-        (match t.current_op with
-        | Some Human -> []
-        | Some Rebase
-        | Some Ci
-        | Some Review_comments
-        | Some Merge_conflict
-        | Some Implementation_notes
-        | None ->
-            t.human_messages);
+      inflight_human_messages = [];
     }
 
 (* -- Tests for session failure recovery -- *)

--- a/lib/patch_agent.ml
+++ b/lib/patch_agent.ml
@@ -132,7 +132,7 @@ let add_human_message t msg =
   { t with human_messages = msg :: t.human_messages }
 
 let add_human_messages t msgs =
-  { t with human_messages = List.rev_append msgs t.human_messages }
+  { t with human_messages = List.append msgs t.human_messages }
 
 let set_session_failed t =
   match t.session_fallback with

--- a/lib/patch_agent.ml
+++ b/lib/patch_agent.ml
@@ -132,7 +132,7 @@ let add_human_message t msg =
   { t with human_messages = msg :: t.human_messages }
 
 let add_human_messages t msgs =
-  { t with human_messages = List.append msgs t.human_messages }
+  { t with human_messages = List.append t.human_messages msgs }
 
 let set_session_failed t =
   match t.session_fallback with

--- a/lib/patch_agent.mli
+++ b/lib/patch_agent.mli
@@ -25,6 +25,7 @@ type t = private {
   ci_failure_count : int;
   session_fallback : session_fallback;
   human_messages : string list;
+  inflight_human_messages : string list;
   ci_checks : Types.Ci_check.t list;
   merge_ready : bool;
   is_draft : bool;
@@ -104,10 +105,8 @@ val mark_merged : t -> t
 val add_human_message : t -> string -> t
 (** Add a human message to the pending list. *)
 
-val restore_human_messages : t -> string list -> t
-(** Replace [human_messages] wholesale. Used to preserve messages across a
-    failed Human session — [complete] clears them assuming delivery succeeded,
-    but on failure they must be restored for the retry. *)
+val add_human_messages : t -> string list -> t
+(** Prepend multiple messages to the pending list, preserving their order. *)
 
 val set_session_failed : t -> t
 (** Mark session fallback as [Given_up]. *)
@@ -262,6 +261,7 @@ val restore :
   ci_failure_count:int ->
   session_fallback:session_fallback ->
   human_messages:string list ->
+  inflight_human_messages:string list ->
   ci_checks:Types.Ci_check.t list ->
   merge_ready:bool ->
   is_draft:bool ->

--- a/lib/persistence.ml
+++ b/lib/persistence.ml
@@ -60,6 +60,8 @@ let patch_agent_to_yojson (a : Patch_agent.t) =
         Patch_agent.yojson_of_session_fallback a.session_fallback );
       ( "human_messages",
         `List (List.map a.human_messages ~f:(fun s -> `String s)) );
+      ( "inflight_human_messages",
+        `List (List.map a.inflight_human_messages ~f:(fun s -> `String s)) );
       ("ci_checks", `List (List.map a.ci_checks ~f:Ci_check.yojson_of_t));
       ("merge_ready", `Bool a.merge_ready);
       ("is_draft", `Bool a.is_draft);
@@ -93,6 +95,12 @@ let patch_agent_of_yojson ~gameplan json =
   in
   let human_messages =
     match Yojson.Safe.Util.member "human_messages" json with
+    | `List items ->
+        List.filter_map items ~f:(fun j -> Yojson.Safe.Util.to_string_option j)
+    | _ -> []
+  in
+  let inflight_human_messages =
+    match Yojson.Safe.Util.member "inflight_human_messages" json with
     | `List items ->
         List.filter_map items ~f:(fun j -> Yojson.Safe.Util.to_string_option j)
     | _ -> []
@@ -163,7 +171,7 @@ let patch_agent_of_yojson ~gameplan json =
                |> Option.map ~f:Branch.of_string
              else None)
        ~ci_failure_count:(int_member "ci_failure_count" json)
-       ~session_fallback ~human_messages ~ci_checks
+       ~session_fallback ~human_messages ~inflight_human_messages ~ci_checks
        ~merge_ready:(bool_member "merge_ready" json)
        ~is_draft:(bool_member "is_draft" json)
        ~pr_description_applied:(bool_member "pr_description_applied" json)

--- a/test/test_patch_agent.ml
+++ b/test/test_patch_agent.ml
@@ -419,6 +419,131 @@ let () =
             List.length a.human_messages = List.length during_msgs
             && List.is_empty a.inflight_human_messages
           with _ -> false);
+      (* -- property: inbox is always empty after respond Human, so any
+         empty-delivery guard must check inflight, not inbox -- *)
+      Test.make
+        ~name:
+          "respond Human: inbox always empty (guard must use inflight, not \
+           inbox)"
+        Gen.(
+          pair gen_pid
+            (list_size (int_range 1 10) (string_size ~gen:printable (pure 5))))
+        (fun (pid, msgs) ->
+          try
+            let a =
+              create ~branch:br0 pid |> fun a ->
+              start_with_pr a ~base_branch:br0
+            in
+            let a = complete a in
+            let a =
+              List.fold msgs ~init:a ~f:(fun a m -> add_human_message a m)
+            in
+            let a = enqueue a Operation_kind.Human in
+            let a = respond a Operation_kind.Human in
+            (* A guard that checks human_messages here would always skip
+               delivery — the bug we're guarding against. *)
+            List.is_empty a.human_messages
+            && not (List.is_empty a.inflight_human_messages)
+          with _ -> false);
+      (* -- property: CI checks remain accessible during Ci respond for
+         fresh-fetch filtering at delivery time -- *)
+      Test.make
+        ~name:
+          "respond Ci: ci_checks remain on agent for delivery-time filtering"
+        Gen.(
+          pair gen_pid
+            (list_size (int_range 1 5)
+               (pair
+                  (string_size ~gen:printable (pure 8))
+                  (oneof_list
+                     [ "failure"; "success"; "error"; "neutral"; "timed_out" ]))))
+        (fun (pid, check_specs) ->
+          try
+            let a =
+              create ~branch:br0 pid |> fun a ->
+              start_with_pr a ~base_branch:br0
+            in
+            let a = complete a in
+            let checks =
+              List.map check_specs ~f:(fun (name, conclusion) ->
+                  Ci_check.
+                    {
+                      name;
+                      conclusion;
+                      details_url = None;
+                      description = None;
+                      started_at = None;
+                    })
+            in
+            let a = set_ci_checks a checks in
+            let a = enqueue a Operation_kind.Ci in
+            let a = respond a Operation_kind.Ci in
+            (* ci_checks must still be readable so the runner can filter
+               for failures at delivery time *)
+            let failure_conclusions =
+              [
+                "failure";
+                "error";
+                "action_required";
+                "timed_out";
+                "startup_failure";
+              ]
+            in
+            let has_any_failure =
+              List.exists a.ci_checks ~f:(fun c ->
+                  List.mem failure_conclusions c.Ci_check.conclusion
+                    ~equal:String.equal)
+            in
+            let input_has_failure =
+              List.exists check_specs ~f:(fun (_name, conc) ->
+                  List.mem failure_conclusions conc ~equal:String.equal)
+            in
+            Bool.equal has_any_failure input_has_failure
+          with _ -> false);
+      (* -- property: CI with all-passing checks at delivery time yields
+         empty failure list (delivery should be skipped) -- *)
+      Test.make
+        ~name:
+          "respond Ci: all-passing checks -> empty failure filter (skip \
+           delivery)"
+        Gen.(
+          pair gen_pid
+            (list_size (int_range 1 5) (string_size ~gen:printable (pure 8))))
+        (fun (pid, check_names) ->
+          try
+            let a =
+              create ~branch:br0 pid |> fun a ->
+              start_with_pr a ~base_branch:br0
+            in
+            let a = complete a in
+            let checks =
+              List.map check_names ~f:(fun name ->
+                  Ci_check.
+                    {
+                      name;
+                      conclusion = "success";
+                      details_url = None;
+                      description = None;
+                      started_at = None;
+                    })
+            in
+            let a = set_ci_checks a checks in
+            let a = enqueue a Operation_kind.Ci in
+            let a = respond a Operation_kind.Ci in
+            let failure_conclusions =
+              [
+                "failure";
+                "error";
+                "action_required";
+                "timed_out";
+                "startup_failure";
+              ]
+            in
+            not
+              (List.exists a.ci_checks ~f:(fun c ->
+                   List.mem failure_conclusions c.Ci_check.conclusion
+                     ~equal:String.equal))
+          with _ -> false);
       (* -- property: non-Human respond preserves inbox, inflight unchanged -- *)
       Test.make ~name:"non-Human respond leaves human_messages untouched"
         Gen.(

--- a/test/test_patch_agent.ml
+++ b/test/test_patch_agent.ml
@@ -307,9 +307,8 @@ let () =
             List.fold msgs ~init:a ~f:(fun a m -> add_human_message a m)
           in
           List.length a.human_messages = List.length msgs);
-      (* -- respond Human preserves human_messages until completion -- *)
-      Test.make ~name:"respond Human preserves human_messages until completion"
-        ~count:1
+      (* -- respond Human moves messages to inflight -- *)
+      Test.make ~name:"respond Human moves inbox to inflight" ~count:1
         Gen.(pure (pid0, br0))
         (fun (pid, br) ->
           try
@@ -320,9 +319,11 @@ let () =
             let a = add_human_message a "hello" in
             let a = enqueue a Operation_kind.Human in
             let a = respond a Operation_kind.Human in
-            not (List.is_empty a.human_messages)
+            List.is_empty a.human_messages
+            && not (List.is_empty a.inflight_human_messages)
           with _ -> false);
-      Test.make ~name:"complete Human clears human_messages" ~count:1
+      (* -- complete clears inflight_human_messages -- *)
+      Test.make ~name:"complete clears inflight_human_messages" ~count:1
         Gen.(pure (pid0, br0))
         (fun (pid, br) ->
           try
@@ -335,6 +336,25 @@ let () =
             let a = respond a Operation_kind.Human in
             let a = complete a in
             List.is_empty a.human_messages
+            && List.is_empty a.inflight_human_messages
+          with _ -> false);
+      (* -- messages enqueued during busy are preserved -- *)
+      Test.make ~name:"messages enqueued during busy survive complete" ~count:1
+        Gen.(pure (pid0, br0))
+        (fun (pid, br) ->
+          try
+            let a =
+              create ~branch:br pid |> fun a -> start_with_pr a ~base_branch:br
+            in
+            let a = complete a in
+            let a = add_human_message a "first" in
+            let a = enqueue a Operation_kind.Human in
+            let a = respond a Operation_kind.Human in
+            (* message arrives while busy *)
+            let a = add_human_message a "second" in
+            let a = complete a in
+            List.length a.human_messages = 1
+            && List.is_empty a.inflight_human_messages
           with _ -> false);
       (* -- respond Review_comments does not clear human_messages -- *)
       Test.make ~name:"respond Review_comments preserves human_messages"
@@ -349,6 +369,80 @@ let () =
           let a = enqueue a Operation_kind.Review_comments in
           let a = respond a Operation_kind.Review_comments in
           List.length a.human_messages = 1);
+      (* -- property: respond Human partitions messages into inflight -- *)
+      Test.make ~name:"respond Human: total messages = inbox + inflight"
+        Gen.(
+          pair gen_pid
+            (list_size (int_range 1 10) (string_size ~gen:printable (pure 5))))
+        (fun (pid, msgs) ->
+          try
+            let a =
+              create ~branch:br0 pid |> fun a ->
+              start_with_pr a ~base_branch:br0
+            in
+            let a = complete a in
+            let a =
+              List.fold msgs ~init:a ~f:(fun a m -> add_human_message a m)
+            in
+            let n_before = List.length a.human_messages in
+            let a = enqueue a Operation_kind.Human in
+            let a = respond a Operation_kind.Human in
+            List.length a.inflight_human_messages = n_before
+            && List.is_empty a.human_messages
+          with _ -> false);
+      (* -- property: messages added during busy are disjoint from inflight -- *)
+      Test.make
+        ~name:
+          "inflight disjoint: busy-time messages survive, pre-respond cleared"
+        Gen.(
+          triple gen_pid
+            (list_size (int_range 1 5) (string_size ~gen:printable (pure 4)))
+            (list_size (int_range 1 5) (string_size ~gen:printable (pure 4))))
+        (fun (pid, before_msgs, during_msgs) ->
+          try
+            let a =
+              create ~branch:br0 pid |> fun a ->
+              start_with_pr a ~base_branch:br0
+            in
+            let a = complete a in
+            let a =
+              List.fold before_msgs ~init:a ~f:(fun a m ->
+                  add_human_message a m)
+            in
+            let a = enqueue a Operation_kind.Human in
+            let a = respond a Operation_kind.Human in
+            let a =
+              List.fold during_msgs ~init:a ~f:(fun a m ->
+                  add_human_message a m)
+            in
+            let a = complete a in
+            List.length a.human_messages = List.length during_msgs
+            && List.is_empty a.inflight_human_messages
+          with _ -> false);
+      (* -- property: non-Human respond preserves inbox, inflight unchanged -- *)
+      Test.make ~name:"non-Human respond leaves human_messages untouched"
+        Gen.(
+          triple gen_pid
+            (list_size (int_range 0 5) (string_size ~gen:printable (pure 4)))
+            (oneof_list
+               Operation_kind.
+                 [ Ci; Review_comments; Merge_conflict; Implementation_notes ]))
+        (fun (pid, msgs, op) ->
+          try
+            let a =
+              create ~branch:br0 pid |> fun a ->
+              start_with_pr a ~base_branch:br0
+            in
+            let a = complete a in
+            let a =
+              List.fold msgs ~init:a ~f:(fun a m -> add_human_message a m)
+            in
+            let n = List.length a.human_messages in
+            let a = enqueue a op in
+            let a = respond a op in
+            List.length a.human_messages = n
+            && List.is_empty a.inflight_human_messages
+          with _ -> false);
       (* -- 2 ci failures does NOT trigger needs_intervention (boundary) -- *)
       (* respond increments ci_failure_count, so 1 prior + 1 from respond = 2 *)
       Test.make ~name:"2 ci failures no intervention (boundary)" ~count:1
@@ -474,8 +568,8 @@ let () =
               ~queue:[] ~satisfies:false ~changed:false ~has_conflict:false
               ~base_branch:None ~notified_base_branch:None ~ci_failure_count:0
               ~session_fallback:Fresh_available ~human_messages:[]
-              ~ci_checks:a.ci_checks ~merge_ready:false ~is_draft:false
-              ~pr_description_applied:false
+              ~inflight_human_messages:[] ~ci_checks:a.ci_checks
+              ~merge_ready:false ~is_draft:false ~pr_description_applied:false
               ~implementation_notes_delivered:false ~start_attempts_without_pr:0
               ~conflict_noop_count:0 ~checks_passing:false ~current_op:None
               ~current_message_id:None ~generation:0 ~worktree_path:None
@@ -549,8 +643,8 @@ let () =
               ~satisfies:true ~changed:false ~has_conflict:false
               ~base_branch:(Some br) ~notified_base_branch:(Some br)
               ~ci_failure_count:0 ~session_fallback:Fresh_available
-              ~human_messages:[] ~ci_checks:[] ~merge_ready:false
-              ~is_draft:false ~pr_description_applied:false
+              ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
+              ~merge_ready:false ~is_draft:false ~pr_description_applied:false
               ~implementation_notes_delivered:false ~start_attempts_without_pr:0
               ~conflict_noop_count:0 ~checks_passing:false ~current_op:None
               ~current_message_id:None ~generation:0 ~worktree_path:None

--- a/test/test_patch_controller.ml
+++ b/test/test_patch_controller.ml
@@ -49,10 +49,11 @@ let make_agent ~patch_id ~branch ~pr_number ~merged ~queue ~base_branch
     ~busy:false ~merged ~queue ~satisfies:false ~changed:false
     ~has_conflict:false ~base_branch ~notified_base_branch:base_branch
     ~ci_failure_count:0 ~session_fallback:Patch_agent.Fresh_available
-    ~human_messages:[] ~ci_checks:[] ~merge_ready:false ~is_draft
-    ~pr_description_applied ~implementation_notes_delivered
-    ~start_attempts_without_pr ~conflict_noop_count:0 ~checks_passing:false
-    ~current_op:None ~current_message_id:None ~generation:0 ~worktree_path:None
+    ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
+    ~merge_ready:false ~is_draft ~pr_description_applied
+    ~implementation_notes_delivered ~start_attempts_without_pr
+    ~conflict_noop_count:0 ~checks_passing:false ~current_op:None
+    ~current_message_id:None ~generation:0 ~worktree_path:None
     ~branch_blocked:false ~llm_session_id:None
 
 let has_notes_queued agent =
@@ -524,12 +525,12 @@ let () =
             ~satisfies:false ~changed:false ~has_conflict:false
             ~base_branch:(Some main) ~notified_base_branch:(Some main)
             ~ci_failure_count:1 ~session_fallback:Patch_agent.Fresh_available
-            ~human_messages:[] ~ci_checks:[] ~merge_ready:false ~is_draft:false
-            ~pr_description_applied:true ~implementation_notes_delivered:true
-            ~start_attempts_without_pr:0 ~conflict_noop_count:0
-            ~checks_passing:false ~current_op:None ~current_message_id:None
-            ~generation:0 ~worktree_path:None ~branch_blocked:false
-            ~llm_session_id:None
+            ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
+            ~merge_ready:false ~is_draft:false ~pr_description_applied:true
+            ~implementation_notes_delivered:true ~start_attempts_without_pr:0
+            ~conflict_noop_count:0 ~checks_passing:false ~current_op:None
+            ~current_message_id:None ~generation:0 ~worktree_path:None
+            ~branch_blocked:false ~llm_session_id:None
         in
         let orch = make_orch patch agent in
         let poll =

--- a/test/test_patch_controller_state_machine.ml
+++ b/test/test_patch_controller_state_machine.ml
@@ -305,6 +305,108 @@ let () =
         with _ -> false
         end)
   in
+  (* Message enqueued during a busy Human session must survive complete
+     and be delivered in the next cycle. This is the root bug scenario:
+     complete used to blanket-clear human_messages, losing message B. *)
+  let prop_message_during_busy_human_survives =
+    Test.make
+      ~name:
+        "patch_controller_state_machine: message enqueued during busy Human is \
+         delivered in next cycle"
+      ~count:300
+      Gen.(pair gen_patch_id gen_branch)
+      (fun (pid, branch) ->
+        begin try
+          let patch = make_patch pid branch in
+          let gameplan = make_gameplan patch in
+          let orch = Orchestrator.create ~patches:[ patch ] ~main_branch:main in
+          (* Start → get PR *)
+          let orch, _eff, msgs =
+            Patch_controller.plan_tick_messages orch
+              ~project_name:"test-project" ~gameplan
+          in
+          let orch = accept_all_messages orch msgs in
+          let orch = Orchestrator.complete orch pid in
+          let orch = Orchestrator.set_pr_number orch pid (Pr_number.of_int 1) in
+          (* Send message A, plan + accept → agent busy with Human *)
+          let orch = Orchestrator.send_human_message orch pid "message A" in
+          let orch, _eff, msgs =
+            Patch_controller.plan_tick_messages orch
+              ~project_name:"test-project" ~gameplan
+          in
+          let orch = accept_all_messages orch msgs in
+          let agent = Orchestrator.agent orch pid in
+          assert agent.Patch_agent.busy;
+          assert (
+            Option.equal Operation_kind.equal agent.Patch_agent.current_op
+              (Some Operation_kind.Human));
+          (* Message B arrives while agent is busy *)
+          let orch = Orchestrator.send_human_message orch pid "message B" in
+          (* Agent finishes responding to A *)
+          let orch = Orchestrator.complete orch pid in
+          (* After complete: message B must be in inbox *)
+          let agent = Orchestrator.agent orch pid in
+          let b_in_inbox =
+            not (List.is_empty agent.Patch_agent.human_messages)
+          in
+          (* Next tick must plan a Human Respond for message B *)
+          let _orch2, _eff2, msgs2 =
+            Patch_controller.plan_tick_messages orch
+              ~project_name:"test-project" ~gameplan
+          in
+          let replanned =
+            List.exists msgs2 ~f:(fun msg ->
+                match Orchestrator.message_action msg with
+                | Orchestrator.Respond (p, kind) ->
+                    Patch_id.equal p pid
+                    && Operation_kind.equal kind Operation_kind.Human
+                | Orchestrator.Start _ | Orchestrator.Rebase _ -> false)
+          in
+          b_in_inbox && replanned
+        with _ -> false
+        end)
+  in
+  (* After respond Human + accept, the inflight messages are non-empty
+     while inbox is empty. A delivery guard that checks inbox would
+     incorrectly skip every Human delivery. *)
+  let prop_inflight_nonempty_after_accept =
+    Test.make
+      ~name:
+        "patch_controller_state_machine: after accept Human, inflight \
+         non-empty and inbox empty"
+      ~count:300
+      Gen.(pair gen_patch_id gen_branch)
+      (fun (pid, branch) ->
+        begin try
+          let patch = make_patch pid branch in
+          let gameplan = make_gameplan patch in
+          let orch = Orchestrator.create ~patches:[ patch ] ~main_branch:main in
+          (* Start → get PR *)
+          let orch, _eff, msgs =
+            Patch_controller.plan_tick_messages orch
+              ~project_name:"test-project" ~gameplan
+          in
+          let orch = accept_all_messages orch msgs in
+          let orch = Orchestrator.complete orch pid in
+          let orch = Orchestrator.set_pr_number orch pid (Pr_number.of_int 1) in
+          (* Send human message, plan + accept *)
+          let orch = Orchestrator.send_human_message orch pid "check this" in
+          let orch, _eff, msgs =
+            Patch_controller.plan_tick_messages orch
+              ~project_name:"test-project" ~gameplan
+          in
+          let orch = accept_all_messages orch msgs in
+          let agent = Orchestrator.agent orch pid in
+          (* inflight must be non-empty (deliverable content) *)
+          let inflight_ok =
+            not (List.is_empty agent.Patch_agent.inflight_human_messages)
+          in
+          (* inbox must be empty (messages moved to inflight) *)
+          let inbox_empty = List.is_empty agent.Patch_agent.human_messages in
+          inflight_ok && inbox_empty
+        with _ -> false
+        end)
+  in
   (* F1: llm_session_id survives review → human sequence *)
   let prop_session_id_survives_review_human =
     Test.make
@@ -408,6 +510,8 @@ let () =
       prop_human_after_review_completes;
       prop_second_human_after_review;
       prop_human_messages_survive_session_failure;
+      prop_message_during_busy_human_survives;
+      prop_inflight_nonempty_after_accept;
       prop_session_id_survives_review_human;
       prop_session_id_cleared_on_no_resume;
     ]

--- a/test/test_poll_log_properties.ml
+++ b/test/test_poll_log_properties.ml
@@ -45,11 +45,11 @@ let make_agent ~patch_id ~branch ~has_conflict ~ci_failure_count ~current_op
     ~has_session:busy ~busy ~merged ~queue ~satisfies:false ~changed:false
     ~has_conflict ~base_branch:(Some main) ~notified_base_branch:(Some main)
     ~ci_failure_count ~session_fallback:Patch_agent.Fresh_available
-    ~human_messages:[] ~ci_checks:[] ~merge_ready:false ~is_draft
-    ~pr_description_applied:true ~implementation_notes_delivered:true
-    ~start_attempts_without_pr:0 ~conflict_noop_count:0 ~checks_passing
-    ~current_op ~current_message_id:None ~generation:0 ~worktree_path
-    ~branch_blocked ~llm_session_id:None
+    ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
+    ~merge_ready:false ~is_draft ~pr_description_applied:true
+    ~implementation_notes_delivered:true ~start_attempts_without_pr:0
+    ~conflict_noop_count:0 ~checks_passing ~current_op ~current_message_id:None
+    ~generation:0 ~worktree_path ~branch_blocked ~llm_session_id:None
 
 let make_poll_observation ~branch_in_root ~worktree_path poll_result =
   Patch_controller.


### PR DESCRIPTION
## Summary

- **Fix message loss bug:** human messages enqueued while an agent was busy responding were silently discarded by `complete`, which blanket-cleared `human_messages = []`. Now `respond` moves inbox → `inflight_human_messages` and clears the inbox, so new arrivals accumulate safely. `complete` only clears inflight.
- **Simplify `complete_failed`:** instead of save/restore dance with `restore_human_messages`, just prepend inflight back to inbox on failure. Removed `restore_human_messages` entirely.
- **Eliminate `ci_checks_cache`:** the `Hashtbl` in main.ml was a parallel copy of agent state. CI checks are now fetched fresh from the agent's poller-managed `ci_checks` field at delivery time, matching the pattern used by review_comments and merge_conflict.

## Test plan

- [x] `dune build` — compiles clean
- [x] `dune runtest` — all existing tests pass
- [x] Updated 3 existing deterministic tests for new inbox/inflight semantics
- [x] Added 3 QCheck2 property tests:
  - `respond Human: total messages = inbox + inflight` — partitioning invariant
  - `inflight disjoint: busy-time messages survive, pre-respond cleared` — the core bug scenario
  - `non-Human respond leaves human_messages untouched` — non-interference
- [ ] Manual: send message A → agent starts → send message B → agent completes → B should remain in inbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes message loss for human inputs by splitting human messages into inbox and inflight queues, and adds proper empty-delivery guards. Also removes `ci_checks_cache` and uses live `ci_checks` at delivery time, with correct newest-first message ordering on failure recovery.

- **Bug Fixes**
  - Split `human_messages` (inbox) and `inflight_human_messages`; `respond` moves inbox → inflight; `complete` clears inflight only.
  - On failure, restore inflight back to inbox and requeue Human with newest-first order (new messages stay at the head; older inflight appended).
  - Empty-delivery guard: check inflight for Human; skip CI delivery if there are no failed checks.

- **Refactors**
  - Removed `ci_checks_cache`; CI prompts filter failures from `agent.ci_checks` at delivery time.
  - Persistence saves/loads `inflight_human_messages`; rendering uses inflight for Human deliveries; tests updated with properties for inflight partitioning, order, and empty-delivery guards.

<sup>Written for commit 0c95bdfa207c431b141e3eae3261231400a1e100. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

