### PR TITLE
Fix session loss on fallback escalation

### DIFF
--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -535,6 +535,10 @@ let apply_session_result t patch_id result =
       complete_failed t patch_id
   | Session_no_resume ->
       let t = on_session_failure t patch_id ~is_fresh:false in
+      let t =
+        update_agent t patch_id ~f:(fun a ->
+            Patch_agent.set_llm_session_id a None)
+      in
       complete_failed t patch_id
   | Session_failed { is_fresh } ->
       let t = on_session_failure t patch_id ~is_fresh in
@@ -542,6 +546,10 @@ let apply_session_result t patch_id result =
   | Session_give_up ->
       let t = set_session_failed t patch_id in
       let t = set_tried_fresh t patch_id in
+      let t =
+        update_agent t patch_id ~f:(fun a ->
+            Patch_agent.set_llm_session_id a None)
+      in
       complete_failed t patch_id
   | Session_worktree_missing ->
       let t = update_agent t patch_id ~f:Patch_agent.on_pre_session_failure in

--- a/lib/patch_agent.ml
+++ b/lib/patch_agent.ml
@@ -132,15 +132,13 @@ let restore_human_messages t msgs = { t with human_messages = msgs }
 
 let set_session_failed t =
   match t.session_fallback with
-  | Fresh_available ->
-      { t with session_fallback = Tried_fresh; llm_session_id = None }
+  | Fresh_available -> { t with session_fallback = Tried_fresh }
   | Tried_fresh | Given_up -> t
 
 let set_tried_fresh t =
   match t.session_fallback with
-  | Fresh_available ->
-      { t with session_fallback = Tried_fresh; llm_session_id = None }
-  | Tried_fresh -> { t with session_fallback = Given_up; llm_session_id = None }
+  | Fresh_available -> { t with session_fallback = Tried_fresh }
+  | Tried_fresh -> { t with session_fallback = Given_up }
   | Given_up -> t
 
 let clear_session_fallback t = { t with session_fallback = Fresh_available }
@@ -148,14 +146,13 @@ let clear_session_fallback t = { t with session_fallback = Fresh_available }
 (** Handle a Claude session failure. Pure decision logic:
     - Start path (no PR) + fresh failure: reset to Fresh_available for retry
     - Resume failure: escalate to Tried_fresh (will try fresh next)
-    - Respond path fresh failure: escalate to Given_up → needs_intervention *)
+    - Fresh failure (respond path): escalate one step via set_tried_fresh *)
 let on_session_failure t ~is_fresh =
   if (not (has_pr t)) && is_fresh then
     (* Start path fresh failure: full reset for clean retry *)
     { t with session_fallback = Fresh_available; llm_session_id = None }
-  else
-    let t = set_session_failed t in
-    if is_fresh then set_tried_fresh t else t
+  else if is_fresh then set_tried_fresh t
+  else set_session_failed t
 
 let set_has_conflict t = { t with has_conflict = true }
 let clear_has_conflict t = { t with has_conflict = false }
@@ -421,7 +418,16 @@ let%test "on_session_failure: resume failure escalates to Tried_fresh" =
   let t = on_session_failure t ~is_fresh:false in
   equal_session_fallback t.session_fallback Tried_fresh
 
-let%test "on_session_failure: respond path fresh escalates to Given_up" =
+let%test "on_session_failure: respond path fresh escalates to Tried_fresh" =
+  let t = create ~branch:(Branch.of_string "b1") (Patch_id.of_string "1") in
+  let t = set_pr_number t (Pr_number.of_int 1) in
+  let t = { t with busy = true; session_fallback = Fresh_available } in
+  let t = on_session_failure t ~is_fresh:true in
+  equal_session_fallback t.session_fallback Tried_fresh
+
+let%test
+    "on_session_failure: respond path second fresh failure escalates to \
+     Given_up" =
   let t = create ~branch:(Branch.of_string "b1") (Patch_id.of_string "1") in
   let t = set_pr_number t (Pr_number.of_int 1) in
   let t = { t with busy = true; session_fallback = Tried_fresh } in

--- a/lib/patch_agent.mli
+++ b/lib/patch_agent.mli
@@ -223,8 +223,10 @@ val bump_generation : t -> t
 (** Advance the patch generation used for deterministic message IDs. *)
 
 val set_llm_session_id : t -> string option -> t
-(** Store the LLM backend's session ID for explicit session resumption. Cleared
-    automatically when [session_fallback] escalates (old session is stale). *)
+(** Store the LLM backend's session ID for explicit session resumption.
+    Preserved across fallback escalation so the operator can resume the session
+    after intervention. Cleared explicitly only when the session is known dead
+    (no-resume, give-up). *)
 
 val resume_current_message : t -> op:Types.Operation_kind.t option -> t
 (** Resume execution of an already accepted message without reapplying its

--- a/lib/patch_agent.mli
+++ b/lib/patch_agent.mli
@@ -225,8 +225,8 @@ val bump_generation : t -> t
 val set_llm_session_id : t -> string option -> t
 (** Store the LLM backend's session ID for explicit session resumption.
     Preserved across fallback escalation so the operator can resume the session
-    after intervention. Cleared explicitly only when the session is known dead
-    (no-resume, give-up). *)
+    after intervention. Cleared on start-path fresh-failure reset (clean retry)
+    and when the session is known dead (no-resume, give-up). *)
 
 val resume_current_message : t -> op:Types.Operation_kind.t option -> t
 (** Resume execution of an already accepted message without reapplying its

--- a/test/test_interleaving_properties.ml
+++ b/test/test_interleaving_properties.ml
@@ -768,19 +768,10 @@ let check_notified_base_branch_coherence (a : Patch_agent.t) =
           notified_base_branch is Some but has_session is false"
          (Patch_id.to_string a.patch_id))
 
-(** I-13: llm_session_id coherence — when session_fallback is Tried_fresh or
-    Given_up, llm_session_id must be None (stale session cleared). *)
-let check_llm_session_id_coherence (a : Patch_agent.t) =
-  match a.session_fallback with
-  | Patch_agent.Tried_fresh | Patch_agent.Given_up ->
-      if Option.is_some a.llm_session_id then
-        failwith
-          (Printf.sprintf
-             "I-13 llm_session_id_coherence violated for %s: \
-              session_fallback=%s but llm_session_id is Some"
-             (Patch_id.to_string a.patch_id)
-             (Patch_agent.show_session_fallback a.session_fallback))
-  | Patch_agent.Fresh_available -> ()
+(** I-13: llm_session_id coherence — session ID is preserved through fallback
+    escalation so the operator can resume after intervention. No constraint
+    between session_fallback and llm_session_id. *)
+let check_llm_session_id_coherence (_a : Patch_agent.t) = ()
 
 (* ========== Combined check ========== *)
 

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -683,10 +683,10 @@ let () =
         let a = Orchestrator.agent orch pid in
         Option.equal String.equal a.Patch_agent.llm_session_id (Some "test-id"))
   in
-  (* A2: Resume failure (on_session_failure ~is_fresh:false) clears llm_session_id *)
-  let prop_a2_resume_failure_clears_session_id =
-    Test.make ~name:"A2: resume failure clears llm_session_id" (Gen.return ())
-      (fun () ->
+  (* A2: Resume failure preserves llm_session_id (session may still be valid) *)
+  let prop_a2_resume_failure_preserves_session_id =
+    Test.make ~name:"A2: resume failure preserves llm_session_id"
+      (Gen.return ()) (fun () ->
         let orch, pid = mk_busy_orch () in
         let orch =
           Orchestrator.set_pr_number orch pid (Types.Pr_number.of_int 1)
@@ -694,7 +694,7 @@ let () =
         let orch = Orchestrator.set_llm_session_id orch pid (Some "test-id") in
         let orch = Orchestrator.on_session_failure orch pid ~is_fresh:false in
         let a = Orchestrator.agent orch pid in
-        Option.is_none a.Patch_agent.llm_session_id)
+        Option.equal String.equal a.Patch_agent.llm_session_id (Some "test-id"))
   in
   (* A3: Session_give_up clears llm_session_id *)
   let prop_a3_give_up_clears_session_id =
@@ -741,21 +741,18 @@ let () =
             a2.Patch_agent.llm_session_id
         with Invalid_argument _ -> false)
   in
-  (* A5: Fresh failure on respond path clears llm_session_id *)
-  let prop_a5_fresh_failure_clears_session_id =
-    Test.make ~name:"A5: fresh failure on respond path clears llm_session_id"
+  (* A5: Fresh failure on respond path preserves llm_session_id *)
+  let prop_a5_fresh_failure_preserves_session_id =
+    Test.make ~name:"A5: fresh failure on respond path preserves llm_session_id"
       (Gen.return ()) (fun () ->
         let orch, pid = mk_busy_orch () in
         let orch =
           Orchestrator.set_pr_number orch pid (Types.Pr_number.of_int 1)
         in
         let orch = Orchestrator.set_llm_session_id orch pid (Some "test-id") in
-        (* on_session_failure ~is_fresh:true with has_pr:
-           set_session_failed (Fresh_available → Tried_fresh, clears session_id)
-           then set_tried_fresh (Tried_fresh → Given_up, clears session_id) *)
         let orch = Orchestrator.on_session_failure orch pid ~is_fresh:true in
         let a = Orchestrator.agent orch pid in
-        Option.is_none a.Patch_agent.llm_session_id)
+        Option.equal String.equal a.Patch_agent.llm_session_id (Some "test-id"))
   in
   (* A6: Session_no_resume clears llm_session_id *)
   let prop_a6_no_resume_clears_session_id =
@@ -773,10 +770,10 @@ let () =
     ~f:(fun t -> QCheck2.Test.check_exn t)
     [
       prop_a1_session_ok_preserves_session_id;
-      prop_a2_resume_failure_clears_session_id;
+      prop_a2_resume_failure_preserves_session_id;
       prop_a3_give_up_clears_session_id;
       prop_a4_set_session_id_idempotent;
-      prop_a5_fresh_failure_clears_session_id;
+      prop_a5_fresh_failure_preserves_session_id;
       prop_a6_no_resume_clears_session_id;
     ];
   Stdlib.print_endline "llm_session_id: all properties passed (A1-A6)"


### PR DESCRIPTION
## Summary
- **Fix double-escalation**: `on_session_failure` on the respond path (has PR, `is_fresh=true`) called `set_session_failed` then `set_tried_fresh`, jumping `Fresh_available → Given_up` in one call. A single transient process error during CI respond triggered `needs_intervention` with no retry. Now uses `set_tried_fresh` directly for single-step escalation.
- **Preserve session ID through fallback**: `set_session_failed` and `set_tried_fresh` no longer clear `llm_session_id`. The session handle is only cleared when positively known dead (`Session_no_resume`, `Session_give_up`, start-path reset). After operator intervention + `reset_intervention_state`, the agent resumes the existing conversation instead of starting fresh.

## Repro
`~/.local/share/onton/local-const-inlining/` — P1 had a working session, hit one `Session_process_error` during CI respond, went directly to `Given_up` and lost all context.

## Test plan
- [x] All inline tests pass (`dune runtest`)
- [x] All property tests pass (A1-A6 session ID properties, PI-1 through PI-11 interleaving)
- [x] Updated A2/A5 to assert session ID preserved (was: cleared)
- [x] Added test for second-failure escalation to `Given_up`
- [x] Relaxed I-13 coherence invariant (session ID no longer tied to fallback state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes double escalation on the respond path and preserves `llm_session_id` through fallback so transient failures don’t trigger intervention or lose conversation history. The session ID is only cleared on start-path fresh reset or when the backend session is known dead.

- **Bug Fixes**
  - Respond path: `on_session_failure ~is_fresh:true` now escalates one step (Fresh_available → Tried_fresh); a second fresh failure escalates to Given_up.
  - Preserve `llm_session_id` across fallback; clear only on `Session_no_resume`, `Session_give_up`, and start-path fresh-failure reset (explicit clears in `orchestrator.ml`).
  - Tests and docs: update A2/A5 to expect preserved session ID, add second-failure escalation test, relax I-13; `set_llm_session_id` docs now include start-path fresh-failure reset as a clearing case.

<sup>Written for commit 185a14566df2966c8d810bd68620fe21b37ed6c4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

