### PR TITLE
Stateless tick-based PR discovery and base-branch reconciliation

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -158,16 +158,6 @@ module Pr_registry = struct
         Hashtbl.remove t.table patch_id)
 end
 
-(** Discover PR number for a branch via GitHub REST API. Returns [Ok] with the
-    PR number or [Error] with a diagnostic message. *)
-let discover_pr_number ~net ~github ~branch ~base_branch =
-  match
-    Github.list_prs ~net github ~branch ~base:(Some base_branch) ~state:`Open ()
-  with
-  | Ok ((pr_number, _, _) :: _) -> Ok pr_number
-  | Ok [] -> Error "no PRs found for branch"
-  | Error e -> Error (Github.show_error e)
-
 (** Execute declarative GitHub effects and record successful observations back
     into durable state. *)
 let execute_github_effects ~runtime ~net ~github effects =
@@ -181,6 +171,10 @@ let execute_github_effects ~runtime ~net ~github effects =
             Printf.sprintf "set_pr_draft (PR #%d, draft=%b)"
               (Pr_number.to_int pr_number)
               draft
+        | Patch_controller.Set_pr_base { pr_number; base; _ } ->
+            Printf.sprintf "set_pr_base (PR #%d, base=%s)"
+              (Pr_number.to_int pr_number)
+              (Branch.to_string base)
       in
       try
         let result =
@@ -190,6 +184,8 @@ let execute_github_effects ~runtime ~net ~github effects =
               Github.update_pr_body ~net github ~pr_number ~body
           | Patch_controller.Set_pr_draft { patch_id = _; pr_number; draft } ->
               Github.set_draft ~net github ~pr_number ~draft
+          | Patch_controller.Set_pr_base { patch_id = _; pr_number; base } ->
+              Github.update_pr_base ~net github ~pr_number ~base
         in
         match result with
         | Ok () ->
@@ -1564,6 +1560,28 @@ let poller_fiber ~runtime ~clock ~net ~process_mgr ~github ~config ~project_name
   let main = config.main_branch in
   let skip_logged : (Patch_id.t, bool) Hashtbl.t = Hashtbl.create 16 in
   let rec loop () =
+    (* Phase 0: Tick-based PR discovery for patches that have run but lack
+       a PR. Uses branch-only search (no base filter) so it finds PRs
+       regardless of which base they target. *)
+    let discovery_candidates =
+      Runtime.read runtime (fun snap ->
+          Patch_controller.discovery_intents snap.Runtime.orchestrator)
+    in
+    Base.List.iter discovery_candidates ~f:(fun (patch_id, branch) ->
+        match Github.list_prs ~net github ~branch ~state:`Open () with
+        | Ok ((pr_number, base_branch, _merged) :: _) ->
+            log_event runtime ~patch_id
+              (Printf.sprintf "tick discovery: PR #%d"
+                 (Pr_number.to_int pr_number));
+            Pr_registry.register pr_registry ~patch_id ~pr_number;
+            Runtime.update_orchestrator runtime (fun orch ->
+                let orch = Orchestrator.set_pr_number orch patch_id pr_number in
+                Orchestrator.set_base_branch orch patch_id base_branch)
+        | Ok [] -> ()
+        | Error err ->
+            log_event runtime ~patch_id
+              (Printf.sprintf "tick discovery error: %s" (Github.show_error err)));
+    (* Phase 1: Poll known PRs for state changes. *)
     let intents =
       Runtime.read runtime (fun snap ->
           let agents = Orchestrator.all_agents snap.Runtime.orchestrator in
@@ -1823,8 +1841,8 @@ let poller_fiber ~runtime ~clock ~net ~process_mgr ~github ~config ~project_name
 
 (** Runner fiber — executes orchestrator actions by spawning Claude processes
     concurrently. *)
-let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
-    ~github ~net ~event_log ?status_msg () =
+let runner_fiber ~runtime ~env ~config ~project_name ~transcripts ~github ~net
+    ~event_log ?status_msg () =
   let main = config.main_branch in
   let process_mgr = Eio.Stdenv.process_mgr env in
   let clock = Eio.Stdenv.clock env in
@@ -2059,35 +2077,13 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                        (Patch_id.to_string patch_id))
                                   ()
                           | Orchestrator.Start_ok ->
-                              (* Always confirm via REST API *)
-                              let rec discover remaining =
-                                match
-                                  discover_pr_number ~net ~github
-                                    ~branch:patch.Patch.branch ~base_branch
-                                with
-                                | Ok pr_number ->
-                                    log_event runtime ~patch_id
-                                      (Printf.sprintf "PR #%d created"
-                                         (Pr_number.to_int pr_number));
-                                    Pr_registry.register pr_registry ~patch_id
-                                      ~pr_number;
-                                    Runtime.update_orchestrator runtime
-                                      (fun orch ->
-                                        Orchestrator.set_pr_number orch patch_id
-                                          pr_number)
-                                | Error _ when remaining > 0 ->
-                                    Eio.Time.sleep clock 2.0;
-                                    discover (remaining - 1)
-                                | Error msg ->
-                                    log_event runtime ~patch_id
-                                      (Printf.sprintf "PR discovery failed: %s"
-                                         msg);
-                                    Runtime.update_orchestrator runtime
-                                      (fun orch ->
-                                        Orchestrator.on_pr_discovery_failure
-                                          orch patch_id)
-                              in
-                              discover 2;
+                              (* PR discovery is tick-based in the poller.
+                                 Bump the counter so needs_intervention
+                                 triggers after 2 Starts without a PR;
+                                 set_pr_number resets it when found. *)
+                              Runtime.update_orchestrator runtime (fun orch ->
+                                  Orchestrator.on_pr_discovery_failure orch
+                                    patch_id);
                               Runtime.update_orchestrator runtime (fun orch ->
                                   Orchestrator.complete orch patch_id)
                           | Orchestrator.Start_stale -> ())))
@@ -3082,8 +3078,8 @@ let run_with_config (config : config) gameplan existing_snapshot =
         Eio.Fiber.all
           ((fun () -> headless_fiber ~runtime ~clock ~stdout)
           :: (fun () ->
-            runner_fiber ~runtime ~env ~config ~project_name ~pr_registry
-              ~transcripts ~github ~net ~event_log ())
+            runner_fiber ~runtime ~env ~config ~project_name ~transcripts
+              ~github ~net ~event_log ())
           :: common_fibers)
       else
         let list_selected = ref 0 in
@@ -3132,8 +3128,8 @@ let run_with_config (config : config) gameplan existing_snapshot =
                     ~patches_visible_count ~owner:config.github_owner
                     ~repo:config.github_repo)
                 :: (fun () ->
-                  runner_fiber ~runtime ~env ~config ~project_name ~pr_registry
-                    ~transcripts ~github ~net ~event_log ~status_msg ())
+                  runner_fiber ~runtime ~env ~config ~project_name ~transcripts
+                    ~github ~net ~event_log ~status_msg ())
                 :: common_fibers)
             with Quit_tui -> ())
 

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -395,6 +395,20 @@ let update_pr_body ~net t ~pr_number ~body =
   | Ok _ -> Ok ()
   | Error _ as e -> e
 
+(** Update the base (target) branch of a PR via REST API. *)
+let update_pr_base ~net t ~pr_number ~base =
+  let path =
+    Printf.sprintf "/repos/%s/%s/pulls/%d" t.owner t.repo
+      (Types.Pr_number.to_int pr_number)
+  in
+  let req_body =
+    `Assoc [ ("base", `String (Types.Branch.to_string base)) ]
+    |> Yojson.Safe.to_string
+  in
+  match request ~net t ~meth:`PATCH ~path ~body:req_body () with
+  | Ok _ -> Ok ()
+  | Error _ as e -> e
+
 (** Fetch the GraphQL node ID for a PR via REST API. *)
 let pr_node_id ~net t ~pr_number =
   let path =

--- a/lib/github.mli
+++ b/lib/github.mli
@@ -53,6 +53,15 @@ val update_pr_body :
 (** [update_pr_body ~net t ~pr_number ~body] updates the PR description via
     [PATCH /repos/:owner/:repo/pulls/:number]. *)
 
+val update_pr_base :
+  net:_ Eio.Net.t ->
+  t ->
+  pr_number:Types.Pr_number.t ->
+  base:Types.Branch.t ->
+  (unit, error) Result.t
+(** [update_pr_base ~net t ~pr_number ~base] retargets the PR to [base] via
+    [PATCH /repos/:owner/:repo/pulls/:number]. *)
+
 val set_draft :
   net:_ Eio.Net.t ->
   t ->

--- a/lib/patch_agent.ml
+++ b/lib/patch_agent.ml
@@ -192,9 +192,9 @@ let increment_start_attempts_without_pr t =
   { t with start_attempts_without_pr = t.start_attempts_without_pr + 1 }
 
 (** Handle a successful Claude run where PR discovery failed by recording a
-    durable attempt. The controller derives intervention from this fact.
-    No-op when the agent already has a PR — reruns after the first session
-    should not accumulate this counter. *)
+    durable attempt. The controller derives intervention from this fact. No-op
+    when the agent already has a PR — reruns after the first session should not
+    accumulate this counter. *)
 let on_pr_discovery_failure t =
   if has_pr t then t else increment_start_attempts_without_pr t
 

--- a/lib/patch_agent.ml
+++ b/lib/patch_agent.ml
@@ -192,8 +192,11 @@ let increment_start_attempts_without_pr t =
   { t with start_attempts_without_pr = t.start_attempts_without_pr + 1 }
 
 (** Handle a successful Claude run where PR discovery failed by recording a
-    durable attempt. The controller derives intervention from this fact. *)
-let on_pr_discovery_failure t = increment_start_attempts_without_pr t
+    durable attempt. The controller derives intervention from this fact.
+    No-op when the agent already has a PR — reruns after the first session
+    should not accumulate this counter. *)
+let on_pr_discovery_failure t =
+  if has_pr t then t else increment_start_attempts_without_pr t
 
 let on_pre_session_failure t =
   if has_pr t then t else increment_start_attempts_without_pr t
@@ -451,3 +454,9 @@ let%test "on_pr_discovery_failure increments attempts again" =
   let t = on_pr_discovery_failure t in
   let t = on_pr_discovery_failure t in
   t.start_attempts_without_pr = 2
+
+let%test "on_pr_discovery_failure is no-op when agent has a PR" =
+  let t = create ~branch:(Branch.of_string "b1") (Patch_id.of_string "1") in
+  let t = set_pr_number t (Pr_number.of_int 42) in
+  let t = on_pr_discovery_failure t in
+  t.start_attempts_without_pr = 0

--- a/lib/patch_agent.mli
+++ b/lib/patch_agent.mli
@@ -125,8 +125,9 @@ val on_session_failure : t -> is_fresh:bool -> t
     - Respond path fresh failure: escalate to [Given_up] → needs_intervention *)
 
 val on_pr_discovery_failure : t -> t
-(** Handle a successful Claude run where PR discovery failed. Resets fallback so
-    the patch retries from scratch. *)
+(** Handle a successful Claude run where PR discovery failed. Increments the
+    durable attempt counter so [needs_intervention] fires after repeated
+    failures. No-op when the agent already has a PR. *)
 
 val on_pre_session_failure : t -> t
 (** Handle a failure that occurs before a Claude session starts (worktree

--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -45,6 +45,11 @@ type github_effect =
       pr_number : Pr_number.t;
       draft : bool;
     }
+  | Set_pr_base of {
+      patch_id : Patch_id.t;
+      pr_number : Pr_number.t;
+      base : Branch.t;
+    }
 [@@deriving show, eq, sexp_of]
 
 type poll_log_entry = { message : string; patch_id : Patch_id.t }
@@ -56,6 +61,16 @@ type poll_observation = {
   branch_in_root : bool;
   worktree_path : string option;
 }
+
+let discovery_intents orch =
+  Orchestrator.all_agents orch
+  |> List.filter_map ~f:(fun (agent : Patch_agent.t) ->
+      if
+        agent.has_session
+        && (not (Patch_agent.has_pr agent))
+        && not agent.merged
+      then Some (agent.patch_id, agent.branch)
+      else None)
 
 let enqueue_notes_if_needed t patch_id (agent : Patch_agent.t) =
   if
@@ -193,10 +208,9 @@ let apply_poll_result t patch_id
       else (t, false)
   in
   let t =
-    let agent = Orchestrator.agent t patch_id in
-    match (agent.Patch_agent.base_branch, base_branch) with
-    | None, Some branch -> Orchestrator.set_base_branch t patch_id branch
-    | _ -> t
+    match base_branch with
+    | Some branch -> Orchestrator.set_base_branch t patch_id branch
+    | None -> t
   in
   let t =
     let agent = Orchestrator.agent t patch_id in
@@ -237,16 +251,37 @@ let reconcile_patch t ~project_name ~gameplan ~(patch : Patch.t) =
               }
             :: !effects;
         match agent.base_branch with
-        | Some base_branch ->
+        | Some actual_base ->
             let desired_draft =
-              if Branch.equal base_branch (Orchestrator.main_branch t) then
+              if Branch.equal actual_base (Orchestrator.main_branch t) then
                 not agent.implementation_notes_delivered
               else true
             in
             if Bool.(agent.is_draft <> desired_draft) then
               effects :=
                 Set_pr_draft { patch_id; pr_number; draft = desired_draft }
-                :: !effects
+                :: !effects;
+            (* Base branch reconciliation: retarget PR if GitHub base differs
+               from the expected base computed from the dependency graph. *)
+            let has_merged pid =
+              (Orchestrator.agent t pid).Patch_agent.merged
+            in
+            let open_deps =
+              Graph.open_pr_deps (Orchestrator.graph t) patch_id ~has_merged
+            in
+            if List.length open_deps <= 1 then
+              let branch_of pid =
+                (Orchestrator.agent t pid).Patch_agent.branch
+              in
+              let expected_base =
+                Graph.initial_base (Orchestrator.graph t) patch_id ~has_merged
+                  ~branch_of
+                  ~main:(Orchestrator.main_branch t)
+              in
+              if not (Branch.equal actual_base expected_base) then
+                effects :=
+                  Set_pr_base { patch_id; pr_number; base = expected_base }
+                  :: !effects
         | None -> ())
     | None -> ());
     (t, List.rev !effects)
@@ -430,24 +465,25 @@ let apply_github_effect_success t = function
       Orchestrator.set_pr_description_applied t patch_id true
   | Set_pr_draft { patch_id; draft; _ } ->
       Orchestrator.set_is_draft t patch_id draft
+  | Set_pr_base { patch_id; base; _ } ->
+      Orchestrator.set_base_branch t patch_id base
 
 let make_orchestrator ~patch_id ~main_branch =
   let patch =
-    Patch.
-      {
-        id = patch_id;
-        title = "test";
-        description = "test";
-        branch = Branch.of_string "test-branch";
-        dependencies = [];
-        spec = "";
-        acceptance_criteria = [];
-        changes = [];
-        files = [];
-        classification = "";
-        test_stubs_introduced = [];
-        test_stubs_implemented = [];
-      }
+    {
+      Patch.id = patch_id;
+      title = "test";
+      description = "test";
+      branch = Branch.of_string "test-branch";
+      dependencies = [];
+      spec = "";
+      acceptance_criteria = [];
+      changes = [];
+      files = [];
+      classification = "";
+      test_stubs_introduced = [];
+      test_stubs_implemented = [];
+    }
   in
   (patch, Orchestrator.create ~patches:[ patch ] ~main_branch)
 
@@ -528,7 +564,7 @@ let%test "reconcile_patch emits description effect while unapplied" =
   in
   List.exists effects ~f:(function
     | Set_pr_description { patch_id; _ } -> Patch_id.equal patch_id pid
-    | Set_pr_draft _ -> false)
+    | Set_pr_draft _ | Set_pr_base _ -> false)
 
 let%test "reconcile_patch requests ready-for-review after notes on main" =
   let patch, t = make_orchestrator ~patch_id:pid ~main_branch:main in
@@ -555,7 +591,7 @@ let%test "reconcile_patch requests ready-for-review after notes on main" =
   in
   List.exists effects ~f:(function
     | Set_pr_draft { patch_id; draft = false; _ } -> Patch_id.equal patch_id pid
-    | Set_pr_description _ | Set_pr_draft _ -> false)
+    | Set_pr_description _ | Set_pr_draft _ | Set_pr_base _ -> false)
 
 let%test "reconcile_patch emits no effects for merged agent" =
   let patch, t = make_orchestrator ~patch_id:pid ~main_branch:main in

--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -252,24 +252,13 @@ let reconcile_patch t ~project_name ~gameplan ~(patch : Patch.t) =
             :: !effects;
         match agent.base_branch with
         | Some actual_base ->
-            let desired_draft =
-              if Branch.equal actual_base (Orchestrator.main_branch t) then
-                not agent.implementation_notes_delivered
-              else true
-            in
-            if Bool.(agent.is_draft <> desired_draft) then
-              effects :=
-                Set_pr_draft { patch_id; pr_number; draft = desired_draft }
-                :: !effects;
-            (* Base branch reconciliation: retarget PR if GitHub base differs
-               from the expected base computed from the dependency graph. *)
             let has_merged pid =
               (Orchestrator.agent t pid).Patch_agent.merged
             in
             let open_deps =
               Graph.open_pr_deps (Orchestrator.graph t) patch_id ~has_merged
             in
-            if List.length open_deps <= 1 then
+            if List.length open_deps <= 1 then begin
               let branch_of pid =
                 (Orchestrator.agent t pid).Patch_agent.branch
               in
@@ -278,10 +267,20 @@ let reconcile_patch t ~project_name ~gameplan ~(patch : Patch.t) =
                   ~branch_of
                   ~main:(Orchestrator.main_branch t)
               in
+              let desired_draft =
+                if Branch.equal expected_base (Orchestrator.main_branch t) then
+                  not agent.implementation_notes_delivered
+                else true
+              in
+              if Bool.(agent.is_draft <> desired_draft) then
+                effects :=
+                  Set_pr_draft { patch_id; pr_number; draft = desired_draft }
+                  :: !effects;
               if not (Branch.equal actual_base expected_base) then
                 effects :=
                   Set_pr_base { patch_id; pr_number; base = expected_base }
                   :: !effects
+            end
         | None -> ())
     | None -> ());
     (t, List.rev !effects)

--- a/lib/patch_controller.mli
+++ b/lib/patch_controller.mli
@@ -11,6 +11,11 @@ type github_effect =
       pr_number : Pr_number.t;
       draft : bool;
     }
+  | Set_pr_base of {
+      patch_id : Patch_id.t;
+      pr_number : Pr_number.t;
+      base : Branch.t;
+    }
 [@@deriving show, eq, sexp_of]
 
 type poll_log_entry = { message : string; patch_id : Patch_id.t }
@@ -22,6 +27,11 @@ type poll_observation = {
   branch_in_root : bool;
   worktree_path : string option;
 }
+
+val discovery_intents : Orchestrator.t -> (Patch_id.t * Branch.t) list
+(** Patches that have run at least once ([has_session]) but lack a PR and are
+    not merged. Returns [(patch_id, branch)] pairs for tick-based PR discovery
+    in the poller. *)
 
 val reconcile_patch :
   Orchestrator.t ->

--- a/test/test_interleaving_properties.ml
+++ b/test/test_interleaving_properties.ml
@@ -91,6 +91,7 @@ type command =
   | Apply_rebase_push_result of { patch_idx : int; result : push_result_kind }
   | Add_adhoc of int
   | Remove_adhoc of int
+  | Discover_pr of int
 
 let show_poll_kind = function
   | Poll_normal -> "Normal"
@@ -147,6 +148,7 @@ let show_command = function
         (show_push_result_kind result)
   | Add_adhoc i -> Printf.sprintf "Add_adhoc(%d)" i
   | Remove_adhoc i -> Printf.sprintf "Remove_adhoc(%d)" i
+  | Discover_pr i -> Printf.sprintf "Discover_pr(%d)" i
 
 (* -- Ad-hoc patch helpers -- *)
 
@@ -240,6 +242,7 @@ let gen_command ~n =
         map (fun i -> Reset_intervention i) gen_idx;
         map (fun i -> Add_adhoc i) (int_range 0 (max_adhoc - 1));
         map (fun i -> Remove_adhoc i) (int_range 0 (max_adhoc - 1));
+        map (fun i -> Discover_pr i) gen_idx;
       ])
 
 let gen_command_seq ~n ~len =
@@ -274,6 +277,7 @@ let gen_atomic_command ~n =
         map (fun i -> Reset_intervention i) gen_idx;
         map (fun i -> Add_adhoc i) (int_range 0 (max_adhoc - 1));
         map (fun i -> Remove_adhoc i) (int_range 0 (max_adhoc - 1));
+        map (fun i -> Discover_pr i) gen_idx;
       ])
 
 let gen_atomic_command_seq ~n ~len =
@@ -476,6 +480,29 @@ let rec apply_command orch patches cmd =
       Orchestrator.add_agent orch ~patch_id:(adhoc_pid i)
         ~branch:(adhoc_branch i) ~pr_number:(adhoc_pr i)
   | Remove_adhoc i -> Orchestrator.remove_agent orch (adhoc_pid i)
+  | Discover_pr patch_idx -> (
+      let pid = resolve_pid patches patch_idx in
+      match Orchestrator.find_agent orch pid with
+      | Some agent
+        when agent.Patch_agent.has_session
+             && (not (Patch_agent.has_pr agent))
+             && not agent.Patch_agent.merged ->
+          let pr = Pr_number.of_int (patch_idx + 50) in
+          let has_merged dep_pid =
+            match Orchestrator.find_agent orch dep_pid with
+            | Some a -> a.Patch_agent.merged
+            | None -> false
+          in
+          let base =
+            try
+              Graph.initial_base (Orchestrator.graph orch) pid ~has_merged
+                ~branch_of:(extended_branch_of patches)
+                ~main
+            with Invalid_argument _ -> main
+          in
+          let orch = Orchestrator.set_pr_number orch pid pr in
+          Orchestrator.set_base_branch orch pid base
+      | _ -> orch)
 
 type poll_log_info = {
   agent_before : Patch_agent.t;
@@ -527,7 +554,7 @@ let rec apply_command_with_logs orch patches cmd =
   | Reconcile | Runner_tick | Complete _ | Apply_session_result _
   | Apply_rebase_result _ | Send_human_message _ | Reset_intervention _
   | Apply_conflict_rebase_result _ | Apply_rebase_push_result _ | Add_adhoc _
-  | Remove_adhoc _ ->
+  | Remove_adhoc _ | Discover_pr _ ->
       (apply_command orch patches cmd, None)
 
 (* ========== Log invariant checks ========== *)
@@ -811,7 +838,8 @@ let removed_pids_of_cmd cmd prev_removed =
   | Add_adhoc _ | Apply_poll _ | Reconcile | Runner_tick | Complete _
   | Apply_session_result _ | Apply_rebase_result _ | Send_human_message _
   | Reset_intervention _ | Atomic_poll_reconcile _
-  | Apply_conflict_rebase_result _ | Apply_rebase_push_result _ ->
+  | Apply_conflict_rebase_result _ | Apply_rebase_push_result _ | Discover_pr _
+    ->
       prev_removed
 
 let run_sequence ?(debug = false) orch patches cmds =
@@ -834,7 +862,7 @@ let run_sequence ?(debug = false) orch patches cmds =
           | Apply_session_result _ | Apply_rebase_result _
           | Send_human_message _ | Reset_intervention _
           | Atomic_poll_reconcile _ | Apply_conflict_rebase_result _
-          | Apply_rebase_push_result _ ->
+          | Apply_rebase_push_result _ | Discover_pr _ ->
               merged_logged
         in
         let curr_merged = merged_set_of o in

--- a/test/test_patch_controller.ml
+++ b/test/test_patch_controller.ml
@@ -63,22 +63,24 @@ let has_notes_queued agent =
 let has_description_effect effects =
   List.exists effects ~f:(function
     | Patch_controller.Set_pr_description _ -> true
-    | Patch_controller.Set_pr_draft _ -> false)
+    | Patch_controller.Set_pr_draft _ | Patch_controller.Set_pr_base _ -> false)
 
 let has_draft_effect effects =
   List.exists effects ~f:(function
     | Patch_controller.Set_pr_draft _ -> true
-    | Patch_controller.Set_pr_description _ -> false)
+    | Patch_controller.Set_pr_description _ | Patch_controller.Set_pr_base _ ->
+        false)
 
 let description_effect effects =
   List.find_map effects ~f:(function
     | Patch_controller.Set_pr_description _ as e -> Some e
-    | Patch_controller.Set_pr_draft _ -> None)
+    | Patch_controller.Set_pr_draft _ | Patch_controller.Set_pr_base _ -> None)
 
 let draft_effect effects =
   List.find_map effects ~f:(function
     | Patch_controller.Set_pr_draft _ as e -> Some e
-    | Patch_controller.Set_pr_description _ -> None)
+    | Patch_controller.Set_pr_description _ | Patch_controller.Set_pr_base _ ->
+        None)
 
 let apply_all_effect_successes orch effects =
   List.fold effects ~init:orch ~f:Patch_controller.apply_github_effect_success
@@ -406,18 +408,23 @@ let () =
             ~start_attempts_without_pr:0
         in
         let orch = make_orch patch agent in
+        (* Apply effects in a loop until convergence (max 5 rounds). *)
+        let rec converge orch round =
+          if round > 5 then false
+          else
+            let orch', effects =
+              Patch_controller.reconcile_all orch ~project_name:"test-project"
+                ~gameplan
+            in
+            if List.is_empty effects then true
+            else converge (apply_all_effect_successes orch' effects) (round + 1)
+        in
         let orch1, effects1 =
           Patch_controller.reconcile_all orch ~project_name:"test-project"
             ~gameplan
         in
-        let orch2 = apply_all_effect_successes orch1 effects1 in
-        let _orch3, effects2 =
-          Patch_controller.reconcile_all orch2 ~project_name:"test-project"
-            ~gameplan
-        in
         has_description_effect effects1
-        && (not (has_description_effect effects2))
-        && not (has_draft_effect effects2))
+        && converge (apply_all_effect_successes orch1 effects1) 2)
   in
 
   let prop_poll_to_controller_promotes_ready_after_notes =
@@ -694,6 +701,228 @@ let () =
         end)
   in
 
+  (* -- Base branch reconciliation properties -- *)
+  let has_base_effect effects =
+    List.exists effects ~f:(function
+      | Patch_controller.Set_pr_base _ -> true
+      | Patch_controller.Set_pr_description _ | Patch_controller.Set_pr_draft _
+        ->
+          false)
+  in
+
+  let base_effect effects =
+    List.find_map effects ~f:(function
+      | Patch_controller.Set_pr_base _ as e -> Some e
+      | Patch_controller.Set_pr_description _ | Patch_controller.Set_pr_draft _
+        ->
+          None)
+  in
+
+  let prop_set_pr_base_emitted_on_mismatch =
+    Test.make
+      ~name:
+        "patch_controller: Set_pr_base emitted when actual base differs from \
+         graph-expected base"
+      ~count:200
+      Gen.(pair gen_patch_id gen_branch)
+      (fun (pid, branch) ->
+        let patch = make_patch pid branch in
+        let gameplan = make_gameplan patch in
+        (* Agent has base_branch = branch, but graph says main (no deps) *)
+        let agent =
+          make_agent ~patch_id:pid ~branch
+            ~pr_number:(Some (Pr_number.of_int 42))
+            ~merged:false ~queue:[] ~base_branch:(Some branch) ~is_draft:true
+            ~pr_description_applied:true ~implementation_notes_delivered:true
+            ~start_attempts_without_pr:0
+        in
+        let orch = make_orch patch agent in
+        let _orch', effects =
+          Patch_controller.reconcile_all orch ~project_name:"test-project"
+            ~gameplan
+        in
+        if Branch.equal branch main then not (has_base_effect effects)
+        else
+          match base_effect effects with
+          | Some (Patch_controller.Set_pr_base { base; _ }) ->
+              Branch.equal base main
+          | Some (Patch_controller.Set_pr_description _)
+          | Some (Patch_controller.Set_pr_draft _)
+          | None ->
+              false)
+  in
+
+  let prop_set_pr_base_not_emitted_when_correct =
+    Test.make
+      ~name:
+        "patch_controller: Set_pr_base not emitted when base matches \
+         graph-expected base"
+      ~count:200
+      Gen.(pair gen_patch_id gen_branch)
+      (fun (pid, branch) ->
+        let patch = make_patch pid branch in
+        let gameplan = make_gameplan patch in
+        (* Agent has base_branch = main, graph says main (no deps) → match *)
+        let agent =
+          make_agent ~patch_id:pid ~branch
+            ~pr_number:(Some (Pr_number.of_int 42))
+            ~merged:false ~queue:[] ~base_branch:(Some main) ~is_draft:true
+            ~pr_description_applied:true ~implementation_notes_delivered:true
+            ~start_attempts_without_pr:0
+        in
+        let orch = make_orch patch agent in
+        let _orch', effects =
+          Patch_controller.reconcile_all orch ~project_name:"test-project"
+            ~gameplan
+        in
+        not (has_base_effect effects))
+  in
+
+  let prop_set_pr_base_converges =
+    Test.make
+      ~name:
+        "patch_controller: Set_pr_base converges after applying effect success"
+      ~count:200
+      Gen.(pair gen_patch_id gen_branch)
+      (fun (pid, branch) ->
+        let patch = make_patch pid branch in
+        let gameplan = make_gameplan patch in
+        let agent =
+          make_agent ~patch_id:pid ~branch
+            ~pr_number:(Some (Pr_number.of_int 42))
+            ~merged:false ~queue:[] ~base_branch:(Some branch) ~is_draft:true
+            ~pr_description_applied:true ~implementation_notes_delivered:true
+            ~start_attempts_without_pr:0
+        in
+        let orch = make_orch patch agent in
+        let orch1, effects1 =
+          Patch_controller.reconcile_all orch ~project_name:"test-project"
+            ~gameplan
+        in
+        let orch2 = apply_all_effect_successes orch1 effects1 in
+        let _orch3, effects2 =
+          Patch_controller.reconcile_all orch2 ~project_name:"test-project"
+            ~gameplan
+        in
+        not (has_base_effect effects2))
+  in
+
+  let prop_poll_always_refreshes_base =
+    Test.make
+      ~name:
+        "patch_controller: poll always refreshes base_branch from observation"
+      ~count:200
+      Gen.(pair gen_patch_id gen_branch)
+      (fun (pid, branch) ->
+        let new_base = Branch.of_string "new-base" in
+        let patch = make_patch pid branch in
+        let agent =
+          make_agent ~patch_id:pid ~branch
+            ~pr_number:(Some (Pr_number.of_int 42))
+            ~merged:false ~queue:[] ~base_branch:(Some branch) ~is_draft:false
+            ~pr_description_applied:true ~implementation_notes_delivered:true
+            ~start_attempts_without_pr:0
+        in
+        let orch = make_orch patch agent in
+        let obs =
+          Patch_controller.
+            {
+              poll_result =
+                Poller.
+                  {
+                    queue = [];
+                    merged = false;
+                    closed = false;
+                    is_draft = false;
+                    has_conflict = false;
+                    merge_ready = false;
+                    checks_passing = false;
+                    ci_checks = [];
+                  };
+              base_branch = Some new_base;
+              branch_in_root = false;
+              worktree_path = None;
+            }
+        in
+        let orch', _logs, _blocked =
+          Patch_controller.apply_poll_result orch pid obs
+        in
+        let updated = Orchestrator.agent orch' pid in
+        Option.equal Branch.equal updated.Patch_agent.base_branch
+          (Some new_base))
+  in
+
+  (* -- Discovery intents properties -- *)
+  let prop_discovery_intents_filters_correctly =
+    Test.make
+      ~name:
+        "patch_controller: discovery_intents returns exactly has_session && \
+         !has_pr && !merged agents"
+      ~count:200
+      Gen.(pair gen_patch_id gen_branch)
+      (fun (pid, branch) ->
+        let patch = make_patch pid branch in
+        (* Agent with session but no PR → should appear *)
+        let agent_session_no_pr =
+          Patch_agent.restore ~patch_id:pid ~branch ~pr_number:None
+            ~has_session:true ~busy:false ~merged:false ~queue:[]
+            ~satisfies:false ~changed:false ~has_conflict:false
+            ~base_branch:None ~notified_base_branch:None ~ci_failure_count:0
+            ~session_fallback:Patch_agent.Fresh_available ~human_messages:[]
+            ~inflight_human_messages:[] ~ci_checks:[] ~merge_ready:false
+            ~is_draft:false ~pr_description_applied:false
+            ~implementation_notes_delivered:false ~start_attempts_without_pr:0
+            ~conflict_noop_count:0 ~checks_passing:false ~current_op:None
+            ~current_message_id:None ~generation:0 ~worktree_path:None
+            ~branch_blocked:false ~llm_session_id:None
+        in
+        let orch =
+          Orchestrator.restore
+            ~graph:(Graph.of_patches [ patch ])
+            ~agents:
+              (Map.of_alist_exn
+                 (module Patch_id)
+                 [ (pid, agent_session_no_pr) ])
+            ~outbox:(Map.empty (module Message_id))
+            ~main_branch:main
+        in
+        let intents = Patch_controller.discovery_intents orch in
+        List.length intents = 1
+        && List.exists intents ~f:(fun (intent_pid, _) ->
+            Patch_id.equal intent_pid pid))
+  in
+
+  let prop_discovery_intents_excludes_pr_agents =
+    Test.make
+      ~name:"patch_controller: discovery_intents excludes agents that have a PR"
+      ~count:200
+      Gen.(pair gen_patch_id gen_branch)
+      (fun (pid, branch) ->
+        let patch = make_patch pid branch in
+        let agent =
+          Patch_agent.restore ~patch_id:pid ~branch
+            ~pr_number:(Some (Pr_number.of_int 42))
+            ~has_session:true ~busy:false ~merged:false ~queue:[]
+            ~satisfies:false ~changed:false ~has_conflict:false
+            ~base_branch:(Some main) ~notified_base_branch:(Some main)
+            ~ci_failure_count:0 ~session_fallback:Patch_agent.Fresh_available
+            ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
+            ~merge_ready:false ~is_draft:false ~pr_description_applied:false
+            ~implementation_notes_delivered:false ~start_attempts_without_pr:0
+            ~conflict_noop_count:0 ~checks_passing:false ~current_op:None
+            ~current_message_id:None ~generation:0 ~worktree_path:None
+            ~branch_blocked:false ~llm_session_id:None
+        in
+        let orch =
+          Orchestrator.restore
+            ~graph:(Graph.of_patches [ patch ])
+            ~agents:(Map.of_alist_exn (module Patch_id) [ (pid, agent) ])
+            ~outbox:(Map.empty (module Message_id))
+            ~main_branch:main
+        in
+        List.is_empty (Patch_controller.discovery_intents orch))
+  in
+
   let suite =
     [
       prop_deterministic;
@@ -711,6 +940,12 @@ let () =
       prop_poll_result_persists_world_flags;
       prop_poll_observation_updates_branch_metadata;
       prop_mixed_cycle_converges_for_bootstrap_patch;
+      prop_set_pr_base_emitted_on_mismatch;
+      prop_set_pr_base_not_emitted_when_correct;
+      prop_set_pr_base_converges;
+      prop_poll_always_refreshes_base;
+      prop_discovery_intents_filters_correctly;
+      prop_discovery_intents_excludes_pr_agents;
     ]
   in
   let errcode = QCheck_base_runner.run_tests ~verbose:true suite in


### PR DESCRIPTION
## Summary

- Replace inline post-Start PR discovery retry loop with tick-based discovery in the poller fiber — queries GitHub by head branch only (no base filter), runs every poll cycle
- Add `Set_pr_base` effect to retarget PRs when their GitHub base branch diverges from the dependency graph's expected base
- `apply_poll_result` now always refreshes `base_branch` from poll observations (not just when `None`)
- Remove `discover_pr_number` and `pr_registry` from the runner fiber

Fixes the bug where patch 5 in `ts2pant-general-calls` got stuck in a "no PR found" state because `discover_pr_number` filtered by base branch, missing PR #92 which targeted `master` instead of `patch-4`.

## Test plan

- [x] 6 new QCheck2 properties for `Set_pr_base` emission/convergence, poll base refresh, and `discovery_intents` filtering
- [x] `Discover_pr` command added to interleaving test vocabulary (PI-1 through PI-11 pass with 1000 iterations each)
- [x] Existing convergence property updated to handle multi-round convergence (`Set_pr_base` → draft cascade)
- [x] All 21 patch_controller properties pass
- [ ] Manual: run against `ts2pant-general-calls` gameplan and verify patch 5 discovers PR #92 on first poller tick

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves PR discovery to a stateless, tick-based poller and adds base-branch reconciliation to auto-retarget PRs when bases diverge. Fixes missed PR discovery, prevents draft flicker after dependency merges, and stops false intervention counts once a PR exists.

- **New Features**
  - Tick-based PR discovery by head branch only (every poll; no base filter).
  - Base-branch reconciliation via `Set_pr_base` + `Github.update_pr_base`; poll always refreshes `base_branch`; adds `discovery_intents`; removes runner discovery/retries.

- **Bug Fixes**
  - Prevents "no PR found" when an open PR targets an unexpected base.
  - Uses expected base for draft decisions to avoid transient `Set_pr_draft` toggles when deps merge.
  - Guards `on_pr_discovery_failure` so it no-ops once a PR exists, avoiding inflated `start_attempts_without_pr`.

<sup>Written for commit 5d635b0a80040fb9b92b5c28fc6ddadea491b0bc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

