### PR TITLE
Fix human message delivery bug and extract pure respond decisions

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1667,18 +1667,9 @@ let poller_fiber ~runtime ~clock ~net ~process_mgr ~github ~config ~project_name
                       | None -> false
                     in
                     let failed_ci =
-                      let failure_conclusions =
-                        [
-                          "failure";
-                          "error";
-                          "action_required";
-                          "timed_out";
-                          "startup_failure";
-                        ]
-                      in
                       Base.List.filter poll_result.Poller.ci_checks
                         ~f:(fun (c : Ci_check.t) ->
-                          Base.List.mem failure_conclusions
+                          Base.List.mem Patch_decision.failure_conclusions
                             c.Ci_check.conclusion ~equal:Base.String.equal)
                     in
                     let worktree_candidate =

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -158,6 +158,16 @@ module Pr_registry = struct
         Hashtbl.remove t.table patch_id)
 end
 
+(** Discover PR number for a branch via GitHub REST API. Returns [Ok] with the
+    PR number or [Error] with a diagnostic message. *)
+let discover_pr_number ~net ~github ~branch ~base_branch =
+  match
+    Github.list_prs ~net github ~branch ~base:(Some base_branch) ~state:`Open ()
+  with
+  | Ok ((pr_number, _, _) :: _) -> Ok pr_number
+  | Ok [] -> Error "no PRs found for branch"
+  | Error e -> Error (Github.show_error e)
+
 (** Execute declarative GitHub effects and record successful observations back
     into durable state. *)
 let execute_github_effects ~runtime ~net ~github effects =
@@ -1560,28 +1570,6 @@ let poller_fiber ~runtime ~clock ~net ~process_mgr ~github ~config ~project_name
   let main = config.main_branch in
   let skip_logged : (Patch_id.t, bool) Hashtbl.t = Hashtbl.create 16 in
   let rec loop () =
-    (* Phase 0: Tick-based PR discovery for patches that have run but lack
-       a PR. Uses branch-only search (no base filter) so it finds PRs
-       regardless of which base they target. *)
-    let discovery_candidates =
-      Runtime.read runtime (fun snap ->
-          Patch_controller.discovery_intents snap.Runtime.orchestrator)
-    in
-    Base.List.iter discovery_candidates ~f:(fun (patch_id, branch) ->
-        match Github.list_prs ~net github ~branch ~state:`Open () with
-        | Ok ((pr_number, base_branch, _merged) :: _) ->
-            log_event runtime ~patch_id
-              (Printf.sprintf "tick discovery: PR #%d"
-                 (Pr_number.to_int pr_number));
-            Pr_registry.register pr_registry ~patch_id ~pr_number;
-            Runtime.update_orchestrator runtime (fun orch ->
-                let orch = Orchestrator.set_pr_number orch patch_id pr_number in
-                Orchestrator.set_base_branch orch patch_id base_branch)
-        | Ok [] -> ()
-        | Error err ->
-            log_event runtime ~patch_id
-              (Printf.sprintf "tick discovery error: %s" (Github.show_error err)));
-    (* Phase 1: Poll known PRs for state changes. *)
     let intents =
       Runtime.read runtime (fun snap ->
           let agents = Orchestrator.all_agents snap.Runtime.orchestrator in
@@ -1679,8 +1667,19 @@ let poller_fiber ~runtime ~clock ~net ~process_mgr ~github ~config ~project_name
                       | None -> false
                     in
                     let failed_ci =
-                      Patch_decision.filter_failed_ci_checks
-                        poll_result.Poller.ci_checks
+                      let failure_conclusions =
+                        [
+                          "failure";
+                          "error";
+                          "action_required";
+                          "timed_out";
+                          "startup_failure";
+                        ]
+                      in
+                      Base.List.filter poll_result.Poller.ci_checks
+                        ~f:(fun (c : Ci_check.t) ->
+                          Base.List.mem failure_conclusions
+                            c.Ci_check.conclusion ~equal:Base.String.equal)
                     in
                     let worktree_candidate =
                       let agent =
@@ -1830,8 +1829,8 @@ let poller_fiber ~runtime ~clock ~net ~process_mgr ~github ~config ~project_name
 
 (** Runner fiber — executes orchestrator actions by spawning Claude processes
     concurrently. *)
-let runner_fiber ~runtime ~env ~config ~project_name ~transcripts ~github ~net
-    ~event_log ?status_msg () =
+let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
+    ~github ~net ~event_log ?status_msg () =
   let main = config.main_branch in
   let process_mgr = Eio.Stdenv.process_mgr env in
   let clock = Eio.Stdenv.clock env in
@@ -1992,7 +1991,12 @@ let runner_fiber ~runtime ~env ~config ~project_name ~transcripts ~github ~net
                                       Orchestrator.agent
                                         snap.Runtime.orchestrator patch_id)
                                 in
-                                if Patch_decision.is_stale agent then (
+                                if
+                                  agent.Patch_agent.merged
+                                  || Patch_agent.needs_intervention agent
+                                  || agent.Patch_agent.branch_blocked
+                                  || not agent.Patch_agent.busy
+                                then (
                                   log_event runtime ~patch_id
                                     "runner: action stale after semaphore \
                                      wait, skipping";
@@ -2061,13 +2065,35 @@ let runner_fiber ~runtime ~env ~config ~project_name ~transcripts ~github ~net
                                        (Patch_id.to_string patch_id))
                                   ()
                           | Orchestrator.Start_ok ->
-                              (* PR discovery is tick-based in the poller.
-                                 Bump the counter so needs_intervention
-                                 triggers after 2 Starts without a PR;
-                                 set_pr_number resets it when found. *)
-                              Runtime.update_orchestrator runtime (fun orch ->
-                                  Orchestrator.on_pr_discovery_failure orch
-                                    patch_id);
+                              (* Always confirm via REST API *)
+                              let rec discover remaining =
+                                match
+                                  discover_pr_number ~net ~github
+                                    ~branch:patch.Patch.branch ~base_branch
+                                with
+                                | Ok pr_number ->
+                                    log_event runtime ~patch_id
+                                      (Printf.sprintf "PR #%d created"
+                                         (Pr_number.to_int pr_number));
+                                    Pr_registry.register pr_registry ~patch_id
+                                      ~pr_number;
+                                    Runtime.update_orchestrator runtime
+                                      (fun orch ->
+                                        Orchestrator.set_pr_number orch patch_id
+                                          pr_number)
+                                | Error _ when remaining > 0 ->
+                                    Eio.Time.sleep clock 2.0;
+                                    discover (remaining - 1)
+                                | Error msg ->
+                                    log_event runtime ~patch_id
+                                      (Printf.sprintf "PR discovery failed: %s"
+                                         msg);
+                                    Runtime.update_orchestrator runtime
+                                      (fun orch ->
+                                        Orchestrator.on_pr_discovery_failure
+                                          orch patch_id)
+                              in
+                              discover 2;
                               Runtime.update_orchestrator runtime (fun orch ->
                                   Orchestrator.complete orch patch_id)
                           | Orchestrator.Start_stale -> ())))
@@ -2181,10 +2207,8 @@ let runner_fiber ~runtime ~env ~config ~project_name ~transcripts ~github ~net
                       Event_log.log_rebase event_log ~patch_id
                         ~result:rebase_result ~agent_before ~agent_after))
           | Orchestrator.Respond (patch_id, kind) ->
-              (* Use pre-fire agent state for ci_checks — fire/respond
-                 may clear them.  Human inflight_human_messages must use
-                 the post-fire agent (re-read from runtime) because
-                 respond is what moves human_messages → inflight. *)
+              (* Use pre-fire agent state for human_messages — fire/respond
+                 clears them as a postcondition. *)
               let pre_fire_agent =
                 Base.List.Assoc.find pre_fire_agents patch_id
                   ~equal:Patch_id.equal
@@ -2225,61 +2249,52 @@ let runner_fiber ~runtime ~env ~config ~project_name ~transcripts ~github ~net
                                   Orchestrator.agent snap.Runtime.orchestrator
                                     patch_id)
                             in
-                            if Patch_decision.is_stale agent then (
-                              log_event runtime ~patch_id
-                                "runner: action stale after semaphore wait, \
-                                 skipping";
-                              `Stale)
-                            else
-                              let base =
-                                Base.Option.value_map
-                                  agent.Patch_agent.base_branch
-                                  ~default:(Branch.to_string main)
-                                  ~f:Branch.to_string
-                              in
-                              let base_changed_prefix =
-                                if Patch_agent.base_branch_changed agent then (
-                                  let old_base =
-                                    Base.Option.value_map
-                                      agent.Patch_agent.notified_base_branch
-                                      ~default:(Branch.to_string main)
-                                      ~f:Branch.to_string
-                                  in
+                            let delivery =
+                              Patch_decision.respond_delivery ~agent ~kind
+                                ~pre_fire_agent ~prefetched_comments
+                                ~main_branch:(Branch.to_string main)
+                            in
+                            let render_base_changed_prefix base_change =
+                              match base_change with
+                              | Some bc ->
                                   log_event runtime ~patch_id
                                     (Printf.sprintf
                                        "runner: base branch changed from %s to \
                                         %s, will notify agent"
-                                       old_base base);
-                                  Prompt.render_base_branch_changed ~old_base
-                                    ~new_base:base)
-                                else ""
-                              in
-                              let source_agent =
-                                Base.Option.value pre_fire_agent ~default:agent
-                              in
-                              let delivery =
-                                Patch_decision.delivery_decision ~kind
-                                  ~inflight_human_messages:
-                                    agent.Patch_agent.inflight_human_messages
-                                  ~review_comment_count:
-                                    (Base.List.length prefetched_comments)
-                                  ~ci_checks:source_agent.Patch_agent.ci_checks
-                              in
-                              if
-                                Patch_decision.equal_delivery_decision delivery
-                                  Patch_decision.Skip_empty
-                              then (
+                                       bc.Patch_decision.old_base
+                                       bc.Patch_decision.new_base);
+                                  Prompt.render_base_branch_changed
+                                    ~old_base:bc.Patch_decision.old_base
+                                    ~new_base:bc.Patch_decision.new_base
+                              | None -> ""
+                            in
+                            match delivery with
+                            | Patch_decision.Respond_stale ->
+                                log_event runtime ~patch_id
+                                  "runner: action stale after semaphore wait, \
+                                   skipping";
+                                `Stale
+                            | Patch_decision.Skip_empty ->
                                 log_event runtime ~patch_id
                                   (Printf.sprintf
                                      "%s: nothing to deliver, skipping"
                                      (Operation_kind.to_label kind));
-                                Runtime.update_orchestrator runtime (fun orch ->
-                                    Orchestrator.complete orch patch_id);
-                                `Ok)
-                              else if
-                                Operation_kind.equal kind
-                                  Operation_kind.Merge_conflict
-                              then (
+                                `Skip_empty
+                            | Patch_decision.Deliver
+                                {
+                                  payload =
+                                    Patch_decision.Merge_conflict_payload;
+                                  base_change;
+                                } -> (
+                                let base =
+                                  Base.Option.value_map
+                                    agent.Patch_agent.base_branch
+                                    ~default:(Branch.to_string main)
+                                    ~f:Branch.to_string
+                                in
+                                let base_changed_prefix =
+                                  render_base_changed_prefix base_change
+                                in
                                 let wt_path =
                                   match agent.Patch_agent.worktree_path with
                                   | Some p -> p
@@ -2479,57 +2494,57 @@ let runner_fiber ~runtime ~env ~config ~project_name ~transcripts ~github ~net
                                   | Orchestrator.Conflict_needs_agent ->
                                       deliver_to_agent ()
                                   | Orchestrator.Conflict_give_up -> `Failed)
-                              else
+                            | Patch_decision.Deliver
+                                {
+                                  payload =
+                                    ( Patch_decision.Human_payload _
+                                    | Patch_decision.Ci_payload _
+                                    | Patch_decision.Review_payload _
+                                    | Patch_decision
+                                      .Implementation_notes_payload ) as payload;
+                                  base_change;
+                                } ->
                                 let pr_number = agent.Patch_agent.pr_number in
+                                let base_changed_prefix =
+                                  render_base_changed_prefix base_change
+                                in
                                 log_event runtime ~patch_id
-                                  (match kind with
-                                  | Operation_kind.Review_comments ->
+                                  (match payload with
+                                  | Patch_decision.Review_payload { comments }
+                                    ->
                                       Printf.sprintf
                                         "delivering %s (%d comments)"
                                         (Operation_kind.to_label kind)
-                                        (Base.List.length prefetched_comments)
-                                  | Operation_kind.Human ->
+                                        (Base.List.length comments)
+                                  | Patch_decision.Human_payload { messages } ->
                                       Printf.sprintf
                                         "delivering %s (%d messages)"
                                         (Operation_kind.to_label kind)
-                                        (Base.List.length
-                                           agent
-                                             .Patch_agent
-                                              .inflight_human_messages)
-                                  | Operation_kind.Ci | Operation_kind.Rebase
-                                  | Operation_kind.Merge_conflict
-                                  | Operation_kind.Implementation_notes ->
+                                        (Base.List.length messages)
+                                  | Patch_decision.Ci_payload _
+                                  | Patch_decision.Implementation_notes_payload
+                                  | Patch_decision.Merge_conflict_payload ->
                                       Printf.sprintf "delivering %s"
                                         (Operation_kind.to_label kind));
                                 let prompt =
-                                  match kind with
-                                  | Operation_kind.Ci -> (
-                                      match
-                                        Patch_decision.ci_prompt_kind
-                                          source_agent.Patch_agent.ci_checks
-                                      with
-                                      | Patch_decision.Unknown_failure ->
-                                          Prompt
-                                          .render_ci_failure_unknown_prompt
-                                            ~project_name ?pr_number ()
-                                      | Patch_decision.Known_failures failed ->
-                                          Prompt.render_ci_failure_prompt
-                                            ~project_name ?pr_number failed)
-                                  | Operation_kind.Review_comments ->
+                                  match payload with
+                                  | Patch_decision.Ci_payload { failed_checks }
+                                    ->
+                                      if Base.List.is_empty failed_checks then
+                                        Prompt.render_ci_failure_unknown_prompt
+                                          ~project_name ?pr_number ()
+                                      else
+                                        Prompt.render_ci_failure_prompt
+                                          ~project_name ?pr_number failed_checks
+                                  | Patch_decision.Review_payload { comments }
+                                    ->
                                       Prompt.render_review_prompt ~project_name
-                                        ?pr_number prefetched_comments
-                                  | Operation_kind.Merge_conflict ->
-                                      (* Invariant: Merge_conflict is handled
-                                         in the pre-rebase block above *)
-                                      assert false
-                                  | Operation_kind.Human ->
+                                        ?pr_number comments
+                                  | Patch_decision.Human_payload { messages } ->
                                       Prompt.render_human_message_prompt
-                                        ~project_name
-                                        (Base.List.rev
-                                           agent
-                                             .Patch_agent
-                                              .inflight_human_messages)
-                                  | Operation_kind.Implementation_notes ->
+                                        ~project_name messages
+                                  | Patch_decision.Implementation_notes_payload
+                                    ->
                                       let patch =
                                         Base.List.find_exn
                                           gameplan.Gameplan.patches
@@ -2545,9 +2560,9 @@ let runner_fiber ~runtime ~env ~config ~project_name ~transcripts ~github ~net
                                         ~pr_number:
                                           (Base.Option.value_exn pr_number)
                                         ~pr_body
-                                  | Operation_kind.Rebase ->
-                                      (* Invariant: Rebase is never routed
-                                       through Respond *)
+                                  | Patch_decision.Merge_conflict_payload ->
+                                      (* Invariant: Merge_conflict is handled
+                                         in the dedicated match arm above *)
                                       assert false
                                 in
                                 let prompt =
@@ -2556,6 +2571,12 @@ let runner_fiber ~runtime ~env ~config ~project_name ~transcripts ~github ~net
                                   else base_changed_prefix ^ "\n" ^ prompt
                                 in
                                 let on_pr_detected _pr_number = () in
+                                let base =
+                                  Base.Option.value_map
+                                    agent.Patch_agent.base_branch
+                                    ~default:(Branch.to_string main)
+                                    ~f:Branch.to_string
+                                in
                                 let result =
                                   run_claude_and_handle ~runtime ~process_mgr
                                     ~fs ~project_name ~patch_id
@@ -2566,9 +2587,7 @@ let runner_fiber ~runtime ~env ~config ~project_name ~transcripts ~github ~net
                                     ~worktree_mutex ~backend ~event_log
                                 in
                                 (match result with
-                                | `Ok
-                                  when not (String.equal base_changed_prefix "")
-                                  ->
+                                | `Ok when Base.Option.is_some base_change ->
                                     Runtime.update_orchestrator runtime
                                       (fun orch ->
                                         Orchestrator.set_notified_base_branch
@@ -2579,6 +2598,7 @@ let runner_fiber ~runtime ~env ~config ~project_name ~transcripts ~github ~net
                       let respond_outcome =
                         match result with
                         | `Stale -> Orchestrator.Respond_stale
+                        | `Skip_empty -> Orchestrator.Respond_skip_empty
                         | `Failed -> Orchestrator.Respond_failed
                         | `Retry_push -> Orchestrator.Respond_retry_push
                         | `Ok -> Orchestrator.Respond_ok
@@ -2614,7 +2634,8 @@ let runner_fiber ~runtime ~env ~config ~project_name ~transcripts ~github ~net
                               ~expires_at:(Unix.gettimeofday () +. 10.0)
                               ()
                       | Orchestrator.Respond_stale
-                      | Orchestrator.Respond_retry_push ->
+                      | Orchestrator.Respond_retry_push
+                      | Orchestrator.Respond_skip_empty ->
                           ())))
     in
     (* Spawn action fibers without waiting for completion. Each fiber is
@@ -3025,8 +3046,8 @@ let run_with_config (config : config) gameplan existing_snapshot =
         Eio.Fiber.all
           ((fun () -> headless_fiber ~runtime ~clock ~stdout)
           :: (fun () ->
-            runner_fiber ~runtime ~env ~config ~project_name ~transcripts
-              ~github ~net ~event_log ())
+            runner_fiber ~runtime ~env ~config ~project_name ~pr_registry
+              ~transcripts ~github ~net ~event_log ())
           :: common_fibers)
       else
         let list_selected = ref 0 in
@@ -3075,8 +3096,8 @@ let run_with_config (config : config) gameplan existing_snapshot =
                     ~patches_visible_count ~owner:config.github_owner
                     ~repo:config.github_repo)
                 :: (fun () ->
-                  runner_fiber ~runtime ~env ~config ~project_name ~transcripts
-                    ~github ~net ~event_log ~status_msg ())
+                  runner_fiber ~runtime ~env ~config ~project_name ~pr_registry
+                    ~transcripts ~github ~net ~event_log ~status_msg ())
                 :: common_fibers)
             with Quit_tui -> ())
 

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -571,13 +571,15 @@ type respond_outcome =
   | Respond_failed
   | Respond_retry_push
   | Respond_stale
+  | Respond_skip_empty
 [@@deriving show, eq, sexp_of]
 
 let apply_respond_outcome t patch_id kind outcome =
   match outcome with
   | Respond_stale -> t
-  | Respond_failed -> complete t patch_id
+  | Respond_failed -> complete_failed t patch_id
   | Respond_retry_push -> complete t patch_id
+  | Respond_skip_empty -> complete t patch_id
   | Respond_ok ->
       let t = complete t patch_id in
       let t =

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -151,6 +151,7 @@ type respond_outcome =
   | Respond_failed
   | Respond_retry_push
   | Respond_stale
+  | Respond_skip_empty
 [@@deriving show, eq, sexp_of]
 
 val apply_respond_outcome :
@@ -158,7 +159,8 @@ val apply_respond_outcome :
 (** Apply the outcome of a Respond action fiber. [Respond_ok] -> complete +
     kind-specific transitions (Merge_conflict -> clear_has_conflict +
     reset_conflict_noop_count; Implementation_notes ->
-    set_implementation_notes_delivered). [Respond_failed] -> complete.
+    set_implementation_notes_delivered). [Respond_failed] -> complete_failed
+    (restores inflight human messages). [Respond_skip_empty] -> complete.
     [Respond_retry_push] -> complete. [Respond_stale] -> identity. *)
 
 (** Side effects emitted by rebase result application. The runner is responsible

--- a/lib/patch_decision.ml
+++ b/lib/patch_decision.ml
@@ -88,42 +88,82 @@ let should_clear_conflict (a : Patch_agent.t) : bool =
     || Option.equal Operation_kind.equal a.current_op
          (Some Operation_kind.Merge_conflict))
 
-(** CI conclusion strings that count as failures. *)
-let ci_failure_conclusions =
+(** {2 Respond delivery — pre-session decisions for the runner} *)
+
+let failure_conclusions =
   [ "failure"; "error"; "action_required"; "timed_out"; "startup_failure" ]
 
-let filter_failed_ci_checks (checks : Ci_check.t list) : Ci_check.t list =
-  List.filter checks ~f:(fun (c : Ci_check.t) ->
-      List.mem ci_failure_conclusions c.conclusion ~equal:String.equal)
-
-let has_failed_ci_checks (checks : Ci_check.t list) : bool =
-  List.exists checks ~f:(fun (c : Ci_check.t) ->
-      List.mem ci_failure_conclusions c.conclusion ~equal:String.equal)
-
-type ci_prompt_kind =
-  | Known_failures of Ci_check.t list
-      (** Non-empty list of checks with failure conclusions. *)
-  | Unknown_failure  (** CI failed but no check matches failure conclusions. *)
+type base_change = { old_base : string; new_base : string }
 [@@deriving show, eq, sexp_of, compare]
 
-let ci_prompt_kind (checks : Ci_check.t list) : ci_prompt_kind =
-  let failed = filter_failed_ci_checks checks in
-  if List.is_empty failed then Unknown_failure else Known_failures failed
-
-let is_stale (a : Patch_agent.t) : bool =
-  a.merged || Patch_agent.needs_intervention a || a.branch_blocked || not a.busy
-
-type delivery_decision =
-  | Deliver  (** There is content to deliver to the agent. *)
-  | Skip_empty  (** Nothing to deliver — skip this operation. *)
+type delivery_payload =
+  | Human_payload of { messages : string list }
+  | Ci_payload of { failed_checks : Ci_check.t list }
+  | Review_payload of { comments : Comment.t list }
+  | Implementation_notes_payload
+  | Merge_conflict_payload
 [@@deriving show, eq, sexp_of, compare]
 
-let delivery_decision ~(kind : Operation_kind.t)
-    ~(inflight_human_messages : string list) ~(review_comment_count : int)
-    ~(ci_checks : Ci_check.t list) : delivery_decision =
-  match kind with
-  | Human ->
-      if List.is_empty inflight_human_messages then Skip_empty else Deliver
-  | Review_comments -> if review_comment_count = 0 then Skip_empty else Deliver
-  | Ci -> if has_failed_ci_checks ci_checks then Deliver else Skip_empty
-  | Merge_conflict | Implementation_notes | Rebase -> Deliver
+type respond_delivery =
+  | Deliver of { payload : delivery_payload; base_change : base_change option }
+  | Skip_empty
+  | Respond_stale
+[@@deriving show, eq, sexp_of, compare]
+
+let respond_delivery ~(agent : Patch_agent.t) ~(kind : Operation_kind.t)
+    ~(pre_fire_agent : Patch_agent.t option)
+    ~(prefetched_comments : Comment.t list) ~(main_branch : string) :
+    respond_delivery =
+  if
+    agent.merged
+    || Patch_agent.needs_intervention agent
+    || agent.branch_blocked || not agent.busy
+  then Respond_stale
+  else
+    let source = Option.value pre_fire_agent ~default:agent in
+    let is_empty =
+      match kind with
+      | Operation_kind.Review_comments -> List.is_empty prefetched_comments
+      | Operation_kind.Human -> List.is_empty source.human_messages
+      | Operation_kind.Ci ->
+          not
+            (List.exists source.ci_checks ~f:(fun (c : Ci_check.t) ->
+                 List.mem failure_conclusions c.conclusion ~equal:String.equal))
+      | Operation_kind.Merge_conflict | Operation_kind.Implementation_notes
+      | Operation_kind.Rebase ->
+          false
+    in
+    if is_empty then Skip_empty
+    else
+      let base_change =
+        if Patch_agent.base_branch_changed agent then
+          let old_base =
+            Option.value_map agent.notified_base_branch ~default:main_branch
+              ~f:Branch.to_string
+          in
+          let new_base =
+            Option.value_map agent.base_branch ~default:main_branch
+              ~f:Branch.to_string
+          in
+          Some { old_base; new_base }
+        else None
+      in
+      let payload =
+        match kind with
+        | Operation_kind.Human ->
+            Human_payload { messages = List.rev source.human_messages }
+        | Operation_kind.Ci ->
+            let failed =
+              List.filter source.ci_checks ~f:(fun (c : Ci_check.t) ->
+                  List.mem failure_conclusions c.conclusion ~equal:String.equal)
+            in
+            Ci_payload { failed_checks = failed }
+        | Operation_kind.Review_comments ->
+            Review_payload { comments = prefetched_comments }
+        | Operation_kind.Implementation_notes -> Implementation_notes_payload
+        | Operation_kind.Merge_conflict -> Merge_conflict_payload
+        | Operation_kind.Rebase ->
+            (* Invariant: Rebase is never routed through Respond *)
+            assert false
+      in
+      Deliver { payload; base_change }

--- a/lib/patch_decision.mli
+++ b/lib/patch_decision.mli
@@ -68,46 +68,39 @@ val should_clear_conflict : Patch_agent.t -> bool
     Merge_conflict operation is queued or in-flight, since clearing would race
     with the active resolution. *)
 
-(** {2 Delivery decision — should the runner skip an empty delivery?} *)
+(** {2 Respond delivery — pre-session decisions for the runner} *)
 
-val ci_failure_conclusions : string list
-(** CI conclusion strings that count as failures. *)
+val failure_conclusions : string list
+(** CI check conclusions that indicate failure. *)
 
-val filter_failed_ci_checks : Ci_check.t list -> Ci_check.t list
-(** Return only checks whose conclusion is in [ci_failure_conclusions]. *)
-
-val has_failed_ci_checks : Ci_check.t list -> bool
-(** Whether any check has a failure conclusion. *)
-
-type ci_prompt_kind =
-  | Known_failures of Ci_check.t list
-      (** Non-empty list of checks with failure conclusions. *)
-  | Unknown_failure  (** CI failed but no check matches failure conclusions. *)
+type base_change = { old_base : string; new_base : string }
 [@@deriving show, eq, sexp_of, compare]
 
-val ci_prompt_kind : Ci_check.t list -> ci_prompt_kind
-(** Decide which CI prompt variant to render. Returns [Known_failures] with the
-    filtered list when at least one check has a failure conclusion,
-    [Unknown_failure] otherwise. *)
-
-val is_stale : Patch_agent.t -> bool
-(** Whether an action should be skipped because the agent state changed while
-    waiting for a Claude slot. True when any of: merged, needs_intervention,
-    branch_blocked, or not busy. *)
-
-type delivery_decision =
-  | Deliver  (** There is content to deliver to the agent. *)
-  | Skip_empty  (** Nothing to deliver — skip this operation. *)
+type delivery_payload =
+  | Human_payload of { messages : string list }
+  | Ci_payload of { failed_checks : Ci_check.t list }
+  | Review_payload of { comments : Comment.t list }
+  | Implementation_notes_payload
+  | Merge_conflict_payload
 [@@deriving show, eq, sexp_of, compare]
 
-val delivery_decision :
+type respond_delivery =
+  | Deliver of { payload : delivery_payload; base_change : base_change option }
+  | Skip_empty
+  | Respond_stale
+[@@deriving show, eq, sexp_of, compare]
+
+val respond_delivery :
+  agent:Patch_agent.t ->
   kind:Operation_kind.t ->
-  inflight_human_messages:string list ->
-  review_comment_count:int ->
-  ci_checks:Ci_check.t list ->
-  delivery_decision
-(** Pure decision: given the operation kind and the relevant payload data,
-    decide whether there is content to deliver. The caller must pass:
-    - [inflight_human_messages]: post-fire agent's inflight messages
-    - [review_comment_count]: number of prefetched review comments
-    - [ci_checks]: agent's CI check list at fire time *)
+  pre_fire_agent:Patch_agent.t option ->
+  prefetched_comments:Comment.t list ->
+  main_branch:string ->
+  respond_delivery
+(** Pure pre-session decision for Respond actions. Determines whether the
+    delivery should proceed, be skipped (empty payload), or is stale.
+
+    When [pre_fire_agent] is [Some pfa], human messages and CI checks are read
+    from [pfa] (the snapshot before fire moved messages to inflight). When
+    [None], falls back to [agent]. Review comments come from
+    [prefetched_comments] (fetched from GitHub before the decision). *)

--- a/lib/tui.ml
+++ b/lib/tui.ml
@@ -876,7 +876,7 @@ let detail_info_rows (pv : patch_view) ~width =
   let ci_section =
     if List.is_empty pv.ci_checks then []
     else
-      let failure_conclusions = Patch_decision.ci_failure_conclusions in
+      let failure_conclusions = Patch_decision.failure_conclusions in
       (* Deduplicate by name, keeping the most recent result by started_at.
          ISO 8601 timestamps sort lexicographically. *)
       let deduped =

--- a/test/test_action_outcome_properties.ml
+++ b/test/test_action_outcome_properties.ml
@@ -70,6 +70,7 @@ let () =
       Orchestrator.Respond_ok;
       Orchestrator.Respond_failed;
       Orchestrator.Respond_retry_push;
+      Orchestrator.Respond_skip_empty;
     ]
   in
   let respond_kinds =
@@ -183,3 +184,24 @@ let () =
   in
   QCheck2.Test.check_exn prop;
   Stdlib.print_endline "AO-5 passed"
+
+(* ========== AO-6: Respond_failed restores inflight human messages ========== *)
+
+let () =
+  let orch, patches, gameplan, pid = bootstrap_one () in
+  let orch = Orchestrator.send_human_message orch pid "fix this" in
+  let orch = make_busy orch patches gameplan pid Operation_kind.Human in
+  let agent = Orchestrator.agent orch pid in
+  (* After fire, messages should be in inflight *)
+  assert (not (List.is_empty agent.Patch_agent.inflight_human_messages));
+  assert (List.is_empty agent.Patch_agent.human_messages);
+  let orch =
+    Orchestrator.apply_respond_outcome orch pid Operation_kind.Human
+      Orchestrator.Respond_failed
+  in
+  let agent = Orchestrator.agent orch pid in
+  (* Messages should be restored to human_messages *)
+  assert (not (List.is_empty agent.Patch_agent.human_messages));
+  assert (List.is_empty agent.Patch_agent.inflight_human_messages);
+  assert (not agent.Patch_agent.busy);
+  Stdlib.print_endline "AO-6 passed"

--- a/test/test_interleaving_properties.ml
+++ b/test/test_interleaving_properties.ml
@@ -800,6 +800,34 @@ let check_notified_base_branch_coherence (a : Patch_agent.t) =
     between session_fallback and llm_session_id. *)
 let check_llm_session_id_coherence (_a : Patch_agent.t) = ()
 
+(** I-14: human messages are never silently lost. The total count of messages
+    across human_messages + inflight_human_messages must be monotonically
+    non-decreasing between steps, except when a successful completion (busy→idle
+    with empty inflight) consumes them. In other words: messages can only
+    disappear via complete on a non-failed session. *)
+let check_human_messages_preserved ~(prev : Patch_agent.t)
+    ~(curr : Patch_agent.t) =
+  let prev_total =
+    List.length prev.human_messages + List.length prev.inflight_human_messages
+  in
+  let curr_total =
+    List.length curr.human_messages + List.length curr.inflight_human_messages
+  in
+  (* Messages can be added (send_human_message) or consumed (successful
+     complete). They must NEVER decrease without a successful delivery —
+     i.e. if the agent went busy→idle, inflight is consumed. Otherwise,
+     total must be >= prev_total. *)
+  let was_delivered =
+    prev.busy && (not curr.busy) && List.is_empty curr.inflight_human_messages
+  in
+  if (not was_delivered) && curr_total < prev_total then
+    failwith
+      (Printf.sprintf
+         "I-14 human_messages_preserved violated for %s: total went from %d to \
+          %d without successful delivery"
+         (Patch_id.to_string curr.patch_id)
+         prev_total curr_total)
+
 (* ========== Combined check ========== *)
 
 let merged_set_of orch =
@@ -807,19 +835,24 @@ let merged_set_of orch =
       if a.merged then Some a.patch_id else None)
   |> Set.of_list (module Patch_id)
 
-let check_all_invariants orch patches ~prev_merged ~curr_merged ~removed_pids =
+let check_all_invariants orch patches ~prev_agents ~prev_merged ~curr_merged
+    ~removed_pids =
   let agents = Orchestrator.all_agents orch in
   let actions =
     Patch_controller.plan_actions orch ~patches:(make_gameplan patches).patches
   in
   (* Per-agent invariants *)
-  List.iter agents ~f:(fun a ->
+  List.iter agents ~f:(fun (a : Patch_agent.t) ->
       check_busy_implies_has_session a;
       check_ci_failure_count_non_negative a;
       check_queue_no_duplicates a;
       check_conflict_not_cleared_while_in_flight a;
       check_notified_base_branch_coherence a;
-      check_llm_session_id_coherence a);
+      check_llm_session_id_coherence a;
+      (* I-14: human messages preserved — skip for removed/re-added patches *)
+      match Map.find prev_agents a.Patch_agent.patch_id with
+      | Some prev -> check_human_messages_preserved ~prev ~curr:a
+      | None -> ());
   (* Monotonicity *)
   check_merged_monotonicity ~prev_merged ~curr_merged ~removed_pids;
   (* Per-action invariants *)
@@ -843,14 +876,16 @@ let removed_pids_of_cmd cmd prev_removed =
       prev_removed
 
 let run_sequence ?(debug = false) orch patches cmds =
-  let final, _final_merged, _final_merged_logged, _final_removed =
+  let final, _final_merged, _final_merged_logged, _final_removed, _final_agents
+      =
     List.fold cmds
       ~init:
         ( orch,
           merged_set_of orch,
           Set.empty (module Patch_id),
-          Set.empty (module Patch_id) )
-      ~f:(fun (o, prev_merged, merged_logged, removed_pids) cmd ->
+          Set.empty (module Patch_id),
+          Orchestrator.agents_map orch )
+      ~f:(fun (o, prev_merged, merged_logged, removed_pids, prev_agents) cmd ->
         if debug then Stdlib.Printf.eprintf "  CMD: %s\n%!" (show_command cmd);
         let o, log_info = apply_command_with_logs o patches cmd in
         let removed_pids = removed_pids_of_cmd cmd removed_pids in
@@ -877,13 +912,15 @@ let run_sequence ?(debug = false) orch patches cmds =
                 (String.concat ~sep:","
                    (List.map a.queue ~f:Operation_kind.to_label))
                 (Patch_agent.needs_intervention a));
-        check_all_invariants o patches ~prev_merged ~curr_merged ~removed_pids;
+        check_all_invariants o patches ~prev_agents ~prev_merged ~curr_merged
+          ~removed_pids;
         let merged_logged =
           match log_info with
           | Some info -> check_log_invariants info ~merged_logged
           | None -> merged_logged
         in
-        (o, curr_merged, merged_logged, removed_pids))
+        let curr_agents = Orchestrator.agents_map o in
+        (o, curr_merged, merged_logged, removed_pids, curr_agents))
   in
   final
 
@@ -897,10 +934,11 @@ let drain_and_check orch patches =
   in
   let no_removed = Set.empty (module Patch_id) in
   List.fold busy_pids ~init:orch ~f:(fun o pid ->
+      let prev_agents = Orchestrator.agents_map o in
       let prev_merged = merged_set_of o in
       let o = Orchestrator.complete o pid in
       let curr_merged = merged_set_of o in
-      check_all_invariants o patches ~prev_merged ~curr_merged
+      check_all_invariants o patches ~prev_agents ~prev_merged ~curr_merged
         ~removed_pids:no_removed;
       o)
 
@@ -1355,3 +1393,49 @@ let () =
   in
   QCheck2.Test.check_exn prop_pi11;
   Stdlib.print_endline "PI-11 passed"
+
+(** PI-12: Human message liveness — send_human_message on an idle patch with a
+    PR always produces a Respond(Human) action on the next tick, and after
+    firing, the message is in inflight_human_messages. This is the end-to-end
+    invariant that the bug (reading inflight instead of inbox on the pre-fire
+    snapshot) violated. *)
+let () =
+  let prop_pi12 =
+    QCheck2.Test.make
+      ~name:
+        "PI-12: human message on idle patch produces Respond(Human) with \
+         inflight messages"
+      ~count:500
+      (QCheck2.Gen.string_size (QCheck2.Gen.int_range 1 100))
+      (fun msg ->
+        let orch, pid, patches = mk_bootstrapped () in
+        let gameplan = make_gameplan patches in
+        let orch = Orchestrator.send_human_message orch pid msg in
+        (* Tick fires the action *)
+        let orch, _effects, actions =
+          Patch_controller.tick orch ~project_name:"test-project" ~gameplan
+        in
+        (* Must have produced Respond(_, Human) *)
+        let has_human_respond =
+          List.exists actions ~f:(fun action ->
+              match action with
+              | Orchestrator.Respond (p, k) ->
+                  Patch_id.equal p pid
+                  && Operation_kind.equal k Operation_kind.Human
+              | Orchestrator.Start _ | Orchestrator.Rebase _ -> false)
+        in
+        if not has_human_respond then
+          failwith "no Respond(Human) action produced after send_human_message";
+        let agent = Orchestrator.agent orch pid in
+        (* Agent must be busy with inflight messages *)
+        if not agent.Patch_agent.busy then failwith "agent not busy after tick";
+        if List.is_empty agent.Patch_agent.inflight_human_messages then
+          failwith "inflight_human_messages empty after firing Human action";
+        if not (List.is_empty agent.Patch_agent.human_messages) then
+          failwith "human_messages not empty after firing Human action";
+        (* The message content must be preserved *)
+        List.mem agent.Patch_agent.inflight_human_messages msg
+          ~equal:String.equal)
+  in
+  QCheck2.Test.check_exn prop_pi12;
+  Stdlib.print_endline "PI-12 passed"

--- a/test/test_interleaving_properties.ml
+++ b/test/test_interleaving_properties.ml
@@ -414,23 +414,28 @@ let rec apply_command orch patches cmd =
       with Invalid_argument _ -> orch)
   | Apply_rebase_result { patch_idx; result } -> (
       let pid = resolve_pid patches patch_idx in
-      try
-        let has_merged dep_pid =
-          match Orchestrator.find_agent orch dep_pid with
-          | Some a -> a.Patch_agent.merged
-          | None -> false
-        in
-        let new_base =
-          Graph.initial_base (Orchestrator.graph orch) pid ~has_merged
-            ~branch_of ~main
-        in
-        let orch, _effects =
-          Orchestrator.apply_rebase_result orch pid
-            (to_worktree_result result)
-            new_base
-        in
-        orch
-      with Invalid_argument _ -> orch)
+      match Orchestrator.find_agent orch pid with
+      | Some agent
+        when Option.equal Operation_kind.equal agent.Patch_agent.current_op
+               (Some Operation_kind.Rebase) -> (
+          try
+            let has_merged dep_pid =
+              match Orchestrator.find_agent orch dep_pid with
+              | Some a -> a.Patch_agent.merged
+              | None -> false
+            in
+            let new_base =
+              Graph.initial_base (Orchestrator.graph orch) pid ~has_merged
+                ~branch_of ~main
+            in
+            let orch, _effects =
+              Orchestrator.apply_rebase_result orch pid
+                (to_worktree_result result)
+                new_base
+            in
+            orch
+          with Invalid_argument _ -> orch)
+      | _ -> orch)
   | Send_human_message patch_idx ->
       let pid = resolve_pid patches patch_idx in
       Orchestrator.send_human_message orch pid "test message"
@@ -444,29 +449,31 @@ let rec apply_command orch patches cmd =
       apply_command orch patches Reconcile
   | Apply_conflict_rebase_result { patch_idx; result } -> (
       let pid = resolve_pid patches patch_idx in
-      try
-        let has_merged dep_pid =
-          match Orchestrator.find_agent orch dep_pid with
-          | Some a -> a.Patch_agent.merged
-          | None -> false
-        in
-        let new_base =
-          Graph.initial_base (Orchestrator.graph orch) pid ~has_merged
-            ~branch_of ~main
-        in
-        let orch', decision, _effects =
-          Orchestrator.apply_conflict_rebase_result orch pid
-            (to_worktree_result result)
-            new_base
-        in
-        match decision with
-        | Orchestrator.Deliver_to_agent ->
-            (* Don't auto-resolve — leave the agent busy so subsequent random
-               Apply_session_result commands drive the outcome, just like real
-               execution. The agent may or may not clear has_conflict. *)
-            orch'
-        | Orchestrator.Conflict_resolved | Orchestrator.Conflict_failed -> orch'
-      with Invalid_argument _ -> orch)
+      match Orchestrator.find_agent orch pid with
+      | Some agent
+        when Option.equal Operation_kind.equal agent.Patch_agent.current_op
+               (Some Operation_kind.Merge_conflict) -> (
+          try
+            let has_merged dep_pid =
+              match Orchestrator.find_agent orch dep_pid with
+              | Some a -> a.Patch_agent.merged
+              | None -> false
+            in
+            let new_base =
+              Graph.initial_base (Orchestrator.graph orch) pid ~has_merged
+                ~branch_of ~main
+            in
+            let orch', decision, _effects =
+              Orchestrator.apply_conflict_rebase_result orch pid
+                (to_worktree_result result)
+                new_base
+            in
+            match decision with
+            | Orchestrator.Deliver_to_agent -> orch'
+            | Orchestrator.Conflict_resolved | Orchestrator.Conflict_failed ->
+                orch'
+          with Invalid_argument _ -> orch)
+      | _ -> orch)
   | Apply_rebase_push_result { patch_idx; result } -> (
       let pid = resolve_pid patches patch_idx in
       try
@@ -802,25 +809,19 @@ let check_llm_session_id_coherence (_a : Patch_agent.t) = ()
 
 (** I-14: human messages are never silently lost. The total count of messages
     across human_messages + inflight_human_messages must be monotonically
-    non-decreasing between steps, except when a successful completion (busy→idle
-    with empty inflight) consumes them. In other words: messages can only
-    disappear via complete on a non-failed session. *)
+    non-decreasing between steps, except when an explicit successful completion
+    consumes them. [~successfully_delivered] is determined from the command that
+    was applied, not inferred from state, so a failed delivery that drops
+    inflight messages is not silently exempted. *)
 let check_human_messages_preserved ~(prev : Patch_agent.t)
-    ~(curr : Patch_agent.t) =
+    ~(curr : Patch_agent.t) ~successfully_delivered =
   let prev_total =
     List.length prev.human_messages + List.length prev.inflight_human_messages
   in
   let curr_total =
     List.length curr.human_messages + List.length curr.inflight_human_messages
   in
-  (* Messages can be added (send_human_message) or consumed (successful
-     complete). They must NEVER decrease without a successful delivery —
-     i.e. if the agent went busy→idle, inflight is consumed. Otherwise,
-     total must be >= prev_total. *)
-  let was_delivered =
-    prev.busy && (not curr.busy) && List.is_empty curr.inflight_human_messages
-  in
-  if (not was_delivered) && curr_total < prev_total then
+  if (not successfully_delivered) && curr_total < prev_total then
     failwith
       (Printf.sprintf
          "I-14 human_messages_preserved violated for %s: total went from %d to \
@@ -836,7 +837,7 @@ let merged_set_of orch =
   |> Set.of_list (module Patch_id)
 
 let check_all_invariants orch patches ~prev_agents ~prev_merged ~curr_merged
-    ~removed_pids =
+    ~removed_pids ~delivered_pid =
   let agents = Orchestrator.all_agents orch in
   let actions =
     Patch_controller.plan_actions orch ~patches:(make_gameplan patches).patches
@@ -851,7 +852,13 @@ let check_all_invariants orch patches ~prev_agents ~prev_merged ~curr_merged
       check_llm_session_id_coherence a;
       (* I-14: human messages preserved — skip for removed/re-added patches *)
       match Map.find prev_agents a.Patch_agent.patch_id with
-      | Some prev -> check_human_messages_preserved ~prev ~curr:a
+      | Some prev ->
+          let successfully_delivered =
+            match delivered_pid with
+            | Some pid -> Patch_id.equal pid a.Patch_agent.patch_id
+            | None -> false
+          in
+          check_human_messages_preserved ~prev ~curr:a ~successfully_delivered
       | None -> ());
   (* Monotonicity *)
   check_merged_monotonicity ~prev_merged ~curr_merged ~removed_pids;
@@ -864,6 +871,15 @@ let check_all_invariants orch patches ~prev_agents ~prev_merged ~curr_merged
       check_base_branch_freshness orch patches action);
   (* Reconciliation invariants *)
   check_merged_no_github_effects orch patches
+
+let delivered_pid_of_cmd cmd patches =
+  match cmd with
+  | Complete patch_idx -> Some (resolve_pid patches patch_idx)
+  | Apply_poll _ | Reconcile | Runner_tick | Apply_session_result _
+  | Apply_rebase_result _ | Send_human_message _ | Reset_intervention _
+  | Atomic_poll_reconcile _ | Apply_conflict_rebase_result _
+  | Apply_rebase_push_result _ | Add_adhoc _ | Remove_adhoc _ | Discover_pr _ ->
+      None
 
 let removed_pids_of_cmd cmd prev_removed =
   match cmd with
@@ -912,8 +928,9 @@ let run_sequence ?(debug = false) orch patches cmds =
                 (String.concat ~sep:","
                    (List.map a.queue ~f:Operation_kind.to_label))
                 (Patch_agent.needs_intervention a));
+        let delivered_pid = delivered_pid_of_cmd cmd patches in
         check_all_invariants o patches ~prev_agents ~prev_merged ~curr_merged
-          ~removed_pids;
+          ~removed_pids ~delivered_pid;
         let merged_logged =
           match log_info with
           | Some info -> check_log_invariants info ~merged_logged
@@ -939,7 +956,7 @@ let drain_and_check orch patches =
       let o = Orchestrator.complete o pid in
       let curr_merged = merged_set_of o in
       check_all_invariants o patches ~prev_agents ~prev_merged ~curr_merged
-        ~removed_pids:no_removed;
+        ~removed_pids:no_removed ~delivered_pid:(Some pid);
       o)
 
 let safe_verbose cmds patches f =

--- a/test/test_patch_agent.ml
+++ b/test/test_patch_agent.ml
@@ -481,7 +481,7 @@ let () =
             (* ci_checks must still be readable so the runner can filter
                for failures at delivery time *)
             let failure_conclusions =
-              Onton.Patch_decision.ci_failure_conclusions
+              Onton.Patch_decision.failure_conclusions
             in
             let has_any_failure =
               List.exists a.ci_checks ~f:(fun c ->
@@ -525,7 +525,7 @@ let () =
             let a = enqueue a Operation_kind.Ci in
             let a = respond a Operation_kind.Ci in
             let failure_conclusions =
-              Onton.Patch_decision.ci_failure_conclusions
+              Onton.Patch_decision.failure_conclusions
             in
             not
               (List.exists a.ci_checks ~f:(fun c ->

--- a/test/test_patch_decision.ml
+++ b/test/test_patch_decision.ml
@@ -21,28 +21,6 @@ let feedback_ops =
 
 let gen_feedback_op = QCheck2.Gen.oneof_list feedback_ops
 
-let gen_conclusion =
-  QCheck2.Gen.oneof_list
-    (ci_failure_conclusions @ [ "success"; "neutral"; "cancelled"; "skipped" ])
-
-let gen_ci_check =
-  QCheck2.Gen.(
-    map
-      (fun (name, conclusion) ->
-        {
-          Ci_check.name;
-          conclusion;
-          details_url = None;
-          description = None;
-          started_at = None;
-        })
-      (pair
-         (string_size ~gen:(char_range 'a' 'z') (int_range 2 8))
-         gen_conclusion))
-
-let gen_ci_checks =
-  QCheck2.Gen.list_size (QCheck2.Gen.int_range 0 8) gen_ci_check
-
 (** Start + set PR so the agent is in has_pr=true, busy=false state. *)
 let with_pr pid br =
   let a = create ~branch:br pid |> fun a -> start a ~base_branch:br in
@@ -249,236 +227,256 @@ let () =
           let a = enqueue a Operation_kind.Human in
           let a = respond a Operation_kind.Human in
           should_clear_conflict a);
-      (* ---- delivery_decision: Human with messages -> Deliver ---- *)
-      Test.make ~name:"delivery_decision: Human with inflight -> Deliver"
-        Gen.(
-          list_size (int_range 0 5)
-            (string_size ~gen:(char_range 'a' 'z') (int_range 1 10)))
-        (fun msgs ->
-          let msgs = List.filter msgs ~f:(fun s -> not (String.is_empty s)) in
-          if List.is_empty msgs then true
-          else
-            equal_delivery_decision
-              (delivery_decision ~kind:Operation_kind.Human
-                 ~inflight_human_messages:msgs ~review_comment_count:0
-                 ~ci_checks:[])
-              Deliver);
-      (* ---- delivery_decision: Human with no messages -> Skip_empty ---- *)
-      Test.make
-        ~name:"delivery_decision: Human with empty inflight -> Skip_empty"
-        Gen.unit (fun () ->
-          equal_delivery_decision
-            (delivery_decision ~kind:Operation_kind.Human
-               ~inflight_human_messages:[] ~review_comment_count:0 ~ci_checks:[])
-            Skip_empty);
-      (* ---- delivery_decision: Review with comments -> Deliver ---- *)
-      Test.make ~name:"delivery_decision: Review with comments -> Deliver"
-        Gen.(int_range 1 100)
-        (fun n ->
-          equal_delivery_decision
-            (delivery_decision ~kind:Operation_kind.Review_comments
-               ~inflight_human_messages:[] ~review_comment_count:n ~ci_checks:[])
-            Deliver);
-      (* ---- delivery_decision: Review with 0 comments -> Skip_empty ---- *)
-      Test.make ~name:"delivery_decision: Review with 0 comments -> Skip_empty"
-        Gen.unit (fun () ->
-          equal_delivery_decision
-            (delivery_decision ~kind:Operation_kind.Review_comments
-               ~inflight_human_messages:[] ~review_comment_count:0 ~ci_checks:[])
-            Skip_empty);
-      (* ---- delivery_decision: Ci with failures -> Deliver ---- *)
-      Test.make ~name:"delivery_decision: Ci with failures -> Deliver"
-        Gen.(oneof_list ci_failure_conclusions)
-        (fun conclusion ->
-          let check =
-            {
-              Ci_check.name = "ci";
-              conclusion;
-              details_url = None;
-              description = None;
-              started_at = None;
-            }
-          in
-          equal_delivery_decision
-            (delivery_decision ~kind:Operation_kind.Ci
-               ~inflight_human_messages:[] ~review_comment_count:0
-               ~ci_checks:[ check ])
-            Deliver);
-      (* ---- delivery_decision: Ci with only success -> Skip_empty ---- *)
-      Test.make ~name:"delivery_decision: Ci with success only -> Skip_empty"
-        Gen.unit (fun () ->
-          let check =
-            {
-              Ci_check.name = "ci";
-              conclusion = "success";
-              details_url = None;
-              description = None;
-              started_at = None;
-            }
-          in
-          equal_delivery_decision
-            (delivery_decision ~kind:Operation_kind.Ci
-               ~inflight_human_messages:[] ~review_comment_count:0
-               ~ci_checks:[ check ])
-            Skip_empty);
-      (* ---- delivery_decision: Merge_conflict always Deliver ---- *)
-      Test.make ~name:"delivery_decision: Merge_conflict -> Deliver" Gen.unit
-        (fun () ->
-          equal_delivery_decision
-            (delivery_decision ~kind:Operation_kind.Merge_conflict
-               ~inflight_human_messages:[] ~review_comment_count:0 ~ci_checks:[])
-            Deliver);
-      (* ---- delivery_decision agrees with respond postcondition ---- *)
-      (* This is the property that would have caught the original bug:
-         after respond(Human), the post-fire agent's inflight_human_messages
-         is non-empty iff there were human_messages before respond. *)
-      Test.make
-        ~name:
-          "delivery_decision: after respond(Human), Deliver iff messages \
-           existed"
-        Gen.(
-          triple gen_pid gen_branch
-            (list_size (int_range 0 5)
-               (string_size ~gen:(char_range 'a' 'z') (int_range 1 10))))
-        (fun (pid, br, msgs) ->
-          try
-            let msgs = List.filter msgs ~f:(fun s -> not (String.is_empty s)) in
-            let a = with_pr pid br in
-            let a = List.fold msgs ~init:a ~f:add_human_message in
-            let a = enqueue a Operation_kind.Human in
-            let post_fire = respond a Operation_kind.Human in
-            let decision =
-              delivery_decision ~kind:Operation_kind.Human
-                ~inflight_human_messages:post_fire.inflight_human_messages
-                ~review_comment_count:0 ~ci_checks:[]
-            in
-            if List.is_empty msgs then
-              equal_delivery_decision decision Skip_empty
-            else equal_delivery_decision decision Deliver
-          with _ -> false);
-      (* ==== is_stale ==== *)
-      (* ---- merged implies stale (even when busy) ---- *)
-      Test.make ~name:"is_stale: merged -> true"
-        Gen.(pair gen_pid gen_branch)
-        (fun (pid, br) ->
-          try
-            let a = with_pr pid br in
-            let a = enqueue a Operation_kind.Human in
-            let a = respond a Operation_kind.Human in
-            (* busy=true now *)
-            let a = mark_merged a in
-            is_stale a
-          with _ -> false);
-      (* ---- needs_intervention implies stale ---- *)
-      Test.make ~name:"is_stale: needs_intervention -> true"
-        Gen.(pair gen_pid gen_branch)
-        (fun (pid, br) ->
-          try
-            let a = with_pr pid br in
-            let a =
-              increment_ci_failure_count a |> increment_ci_failure_count
-            in
-            let a = enqueue a Operation_kind.Ci in
-            let a = respond a Operation_kind.Ci in
-            (* ci_failure_count is now 3 after respond Ci increments;
-               agent is busy from respond — needs_intervention still true *)
-            is_stale a
-          with _ -> false);
-      (* ---- branch_blocked implies stale ---- *)
-      Test.make ~name:"is_stale: branch_blocked -> true"
-        Gen.(pair gen_pid gen_branch)
-        (fun (pid, br) ->
-          try
-            let a = with_pr pid br in
-            let a = enqueue a Operation_kind.Human in
-            let a = respond a Operation_kind.Human in
-            let a = set_branch_blocked a in
-            is_stale a
-          with _ -> false);
-      (* ---- not busy implies stale ---- *)
-      Test.make ~name:"is_stale: not busy -> true"
-        Gen.(pair gen_pid gen_branch)
-        (fun (pid, br) ->
-          let a = with_pr pid br in
-          (* a is idle (busy=false) after with_pr *)
-          is_stale a);
-      (* ---- busy + not merged + not intervention + not blocked -> not stale ---- *)
-      Test.make ~name:"is_stale: healthy busy agent -> false"
-        Gen.(pair gen_pid gen_branch)
-        (fun (pid, br) ->
-          try
-            let a = with_pr pid br in
-            let a = enqueue a Operation_kind.Human in
-            let a = respond a Operation_kind.Human in
-            (* busy=true, not merged, ci_failure_count=0, branch_blocked=false *)
-            not (is_stale a)
-          with _ -> false);
-      (* ---- is_stale cross-check with disposition ---- *)
-      Test.make ~name:"is_stale: merged disposition Skip -> stale when busy"
-        Gen.(pair gen_pid gen_branch)
-        (fun (pid, br) ->
-          try
-            let a = with_pr pid br in
-            let a = enqueue a Operation_kind.Human in
-            let a = respond a Operation_kind.Human in
-            let a = mark_merged a in
-            equal_disposition (disposition a) Skip && is_stale a
-          with _ -> false);
-      (* ==== filter_failed_ci_checks ==== *)
-      (* ---- output is subset of input ---- *)
-      Test.make ~name:"filter_failed_ci_checks: output subset of input"
-        gen_ci_checks (fun checks ->
-          let filtered = filter_failed_ci_checks checks in
-          List.for_all filtered ~f:(fun c ->
-              List.exists checks ~f:(Ci_check.equal c)));
-      (* ---- all results have failure conclusions ---- *)
-      Test.make ~name:"filter_failed_ci_checks: all results are failures"
-        gen_ci_checks (fun checks ->
-          let filtered = filter_failed_ci_checks checks in
-          List.for_all filtered ~f:(fun (c : Ci_check.t) ->
-              List.mem ci_failure_conclusions c.Ci_check.conclusion
-                ~equal:String.equal));
-      (* ---- no failures lost ---- *)
-      Test.make ~name:"filter_failed_ci_checks: no failures lost" gen_ci_checks
-        (fun checks ->
-          let filtered = filter_failed_ci_checks checks in
-          List.for_all checks ~f:(fun (c : Ci_check.t) ->
-              if
-                List.mem ci_failure_conclusions c.Ci_check.conclusion
-                  ~equal:String.equal
-              then List.exists filtered ~f:(Ci_check.equal c)
-              else true));
-      (* ---- idempotent ---- *)
-      Test.make ~name:"filter_failed_ci_checks: idempotent" gen_ci_checks
-        (fun checks ->
-          let once = filter_failed_ci_checks checks in
-          let twice = filter_failed_ci_checks once in
-          List.equal Ci_check.equal once twice);
-      (* ==== ci_prompt_kind ==== *)
-      (* ---- Known_failures list is non-empty ---- *)
-      Test.make ~name:"ci_prompt_kind: Known_failures is non-empty"
-        gen_ci_checks (fun checks ->
-          match ci_prompt_kind checks with
-          | Known_failures fs -> not (List.is_empty fs)
-          | Unknown_failure -> true);
-      (* ---- Unknown_failure means no failures ---- *)
-      Test.make ~name:"ci_prompt_kind: Unknown_failure -> no failed checks"
-        gen_ci_checks (fun checks ->
-          match ci_prompt_kind checks with
-          | Unknown_failure -> not (has_failed_ci_checks checks)
-          | Known_failures _ -> true);
-      (* ---- Known_failures agrees with filter ---- *)
-      Test.make ~name:"ci_prompt_kind: Known_failures = filter_failed_ci_checks"
-        gen_ci_checks (fun checks ->
-          match ci_prompt_kind checks with
-          | Known_failures fs ->
-              let expected = filter_failed_ci_checks checks in
-              List.equal
-                (fun (a : Ci_check.t) (b : Ci_check.t) ->
-                  String.equal a.Ci_check.name b.Ci_check.name
-                  && String.equal a.Ci_check.conclusion b.Ci_check.conclusion)
-                fs expected
-          | Unknown_failure -> true);
     ]
   in
-  List.iter tests ~f:(fun t -> QCheck2.Test.check_exn t)
+  List.iter tests ~f:(fun t -> QCheck2.Test.check_exn t);
+
+  (* ========== respond_delivery property tests ========== *)
+  let main_branch = "main" in
+
+  (* RD-1: Staleness — merged, intervention, blocked, not-busy → Respond_stale *)
+  let () =
+    (* merged → Stale (make busy first, then mark merged to simulate race) *)
+    let a = with_pr (Patch_id.of_string "rd1") (Branch.of_string "b") in
+    let a = enqueue a Operation_kind.Human in
+    let a = respond a Operation_kind.Human in
+    let a = mark_merged a in
+    assert (
+      equal_respond_delivery
+        (respond_delivery ~agent:a ~kind:Operation_kind.Human
+           ~pre_fire_agent:None ~prefetched_comments:[] ~main_branch)
+        Respond_stale);
+
+    (* needs_intervention → Stale *)
+    let a = with_pr (Patch_id.of_string "rd1b") (Branch.of_string "b") in
+    (* Make busy first, then drive to needs_intervention state *)
+    let a = enqueue a Operation_kind.Human in
+    let a = respond a Operation_kind.Human in
+    let a =
+      increment_ci_failure_count a
+      |> increment_ci_failure_count |> increment_ci_failure_count
+    in
+    (* ci_failure_count = 3 → needs_intervention, but agent is still busy *)
+    assert (needs_intervention a);
+    assert (
+      equal_respond_delivery
+        (respond_delivery ~agent:a ~kind:Operation_kind.Human
+           ~pre_fire_agent:None ~prefetched_comments:[] ~main_branch)
+        Respond_stale);
+
+    (* not busy → Stale *)
+    let a = with_pr (Patch_id.of_string "rd1c") (Branch.of_string "b") in
+    assert (
+      equal_respond_delivery
+        (respond_delivery ~agent:a ~kind:Operation_kind.Human
+           ~pre_fire_agent:None ~prefetched_comments:[] ~main_branch)
+        Respond_stale);
+    Stdlib.print_endline "RD-1 passed"
+  in
+
+  (* RD-2: Empty delivery — Human with no messages → Skip_empty *)
+  let () =
+    let pid = Patch_id.of_string "rd2" in
+    let br = Branch.of_string "b" in
+    let pre_fire = with_pr pid br in
+    (* pre_fire has no human_messages → Skip_empty *)
+    let a = enqueue pre_fire Operation_kind.Human in
+    let a = respond a Operation_kind.Human in
+    assert (
+      equal_respond_delivery
+        (respond_delivery ~agent:a ~kind:Operation_kind.Human
+           ~pre_fire_agent:(Some pre_fire) ~prefetched_comments:[] ~main_branch)
+        Skip_empty);
+    Stdlib.print_endline "RD-2a passed"
+  in
+
+  (* RD-2b: CI with no failure conclusions → Skip_empty *)
+  let () =
+    let pid = Patch_id.of_string "rd2b" in
+    let br = Branch.of_string "b" in
+    let pre_fire =
+      with_pr pid br |> fun a ->
+      set_ci_checks a
+        [
+          {
+            Ci_check.name = "build";
+            conclusion = "success";
+            details_url = None;
+            description = None;
+            started_at = None;
+          };
+        ]
+    in
+    let a = enqueue pre_fire Operation_kind.Ci in
+    let a = respond a Operation_kind.Ci in
+    assert (
+      equal_respond_delivery
+        (respond_delivery ~agent:a ~kind:Operation_kind.Ci
+           ~pre_fire_agent:(Some pre_fire) ~prefetched_comments:[] ~main_branch)
+        Skip_empty);
+    Stdlib.print_endline "RD-2b passed"
+  in
+
+  (* RD-2c: Review with no comments → Skip_empty *)
+  let () =
+    let pid = Patch_id.of_string "rd2c" in
+    let br = Branch.of_string "b" in
+    let a = with_pr pid br in
+    let a = enqueue a Operation_kind.Review_comments in
+    let a = respond a Operation_kind.Review_comments in
+    assert (
+      equal_respond_delivery
+        (respond_delivery ~agent:a ~kind:Operation_kind.Review_comments
+           ~pre_fire_agent:None ~prefetched_comments:[] ~main_branch)
+        Skip_empty);
+    Stdlib.print_endline "RD-2c passed"
+  in
+
+  (* RD-3: Human with messages → Deliver (Human_payload) *)
+  let () =
+    let pid = Patch_id.of_string "rd3" in
+    let br = Branch.of_string "b" in
+    let pre_fire = with_pr pid br |> fun a -> add_human_message a "fix this" in
+    let a = enqueue pre_fire Operation_kind.Human in
+    let a = respond a Operation_kind.Human in
+    (match
+       respond_delivery ~agent:a ~kind:Operation_kind.Human
+         ~pre_fire_agent:(Some pre_fire) ~prefetched_comments:[] ~main_branch
+     with
+    | Deliver { payload = Human_payload { messages }; _ } ->
+        assert (List.equal String.equal messages [ "fix this" ])
+    | Deliver
+        {
+          payload =
+            ( Ci_payload _ | Review_payload _ | Implementation_notes_payload
+            | Merge_conflict_payload );
+          _;
+        }
+    | Skip_empty | Respond_stale ->
+        failwith "RD-3: expected Deliver(Human_payload)");
+    Stdlib.print_endline "RD-3 passed"
+  in
+
+  (* RD-4: Source agent selection — pre_fire_agent's human_messages are used,
+     not agent's inflight_human_messages *)
+  let () =
+    let pid = Patch_id.of_string "rd4" in
+    let br = Branch.of_string "b" in
+    let pre_fire =
+      with_pr pid br |> fun a ->
+      add_human_message a "msg1" |> fun a -> add_human_message a "msg2"
+    in
+    (* After fire, messages move to inflight; human_messages is empty *)
+    let post_fire = enqueue pre_fire Operation_kind.Human in
+    let post_fire = respond post_fire Operation_kind.Human in
+    assert (List.is_empty post_fire.human_messages);
+    assert (not (List.is_empty post_fire.inflight_human_messages));
+    (match
+       respond_delivery ~agent:post_fire ~kind:Operation_kind.Human
+         ~pre_fire_agent:(Some pre_fire) ~prefetched_comments:[] ~main_branch
+     with
+    | Deliver { payload = Human_payload { messages }; _ } ->
+        (* Messages come from pre_fire.human_messages (reversed) *)
+        assert (Int.equal (List.length messages) 2)
+    | Deliver
+        {
+          payload =
+            ( Ci_payload _ | Review_payload _ | Implementation_notes_payload
+            | Merge_conflict_payload );
+          _;
+        }
+    | Skip_empty | Respond_stale ->
+        failwith "RD-4: expected Deliver(Human_payload)");
+    Stdlib.print_endline "RD-4 passed"
+  in
+
+  (* RD-5: Base change detection *)
+  let () =
+    let pid = Patch_id.of_string "rd5" in
+    let br = Branch.of_string "b" in
+    let pre_fire =
+      with_pr pid br |> fun a ->
+      add_human_message a "msg" |> fun a ->
+      set_base_branch a (Branch.of_string "feature")
+    in
+    let a = enqueue pre_fire Operation_kind.Human in
+    let a = respond a Operation_kind.Human in
+    (* notified_base_branch defaults to base_branch at start time (= br),
+       but base_branch is now "feature" → base changed *)
+    (match
+       respond_delivery ~agent:a ~kind:Operation_kind.Human
+         ~pre_fire_agent:(Some pre_fire) ~prefetched_comments:[] ~main_branch
+     with
+    | Deliver { base_change = Some bc; _ } ->
+        assert (String.equal bc.old_base (Branch.to_string br));
+        assert (String.equal bc.new_base "feature")
+    | (Deliver _ | Skip_empty | Respond_stale) as other ->
+        failwith
+          (Printf.sprintf "RD-5: expected Deliver with base_change, got %s"
+             (show_respond_delivery other)));
+    Stdlib.print_endline "RD-5 passed"
+  in
+
+  (* RD-6: failure_conclusions consistency — each conclusion produces Deliver *)
+  let () =
+    let pid = Patch_id.of_string "rd6" in
+    let br = Branch.of_string "b" in
+    List.iter failure_conclusions ~f:(fun conclusion ->
+        let pre_fire =
+          with_pr pid br |> fun a ->
+          set_ci_checks a
+            [
+              {
+                Ci_check.name = "test";
+                conclusion;
+                details_url = None;
+                description = None;
+                started_at = None;
+              };
+            ]
+        in
+        let a = enqueue pre_fire Operation_kind.Ci in
+        let a = respond a Operation_kind.Ci in
+        match
+          respond_delivery ~agent:a ~kind:Operation_kind.Ci
+            ~pre_fire_agent:(Some pre_fire) ~prefetched_comments:[] ~main_branch
+        with
+        | Deliver { payload = Ci_payload { failed_checks }; _ } ->
+            assert (not (List.is_empty failed_checks))
+        | Deliver
+            {
+              payload =
+                ( Human_payload _ | Review_payload _
+                | Implementation_notes_payload | Merge_conflict_payload );
+              _;
+            }
+        | Skip_empty | Respond_stale ->
+            failwith
+              (Printf.sprintf
+                 "RD-6: conclusion %s: expected Deliver(Ci_payload)" conclusion));
+    Stdlib.print_endline "RD-6 passed"
+  in
+
+  (* RD-7: Merge_conflict and Implementation_notes never Skip_empty *)
+  let () =
+    let pid = Patch_id.of_string "rd7" in
+    let br = Branch.of_string "b" in
+    List.iter
+      [ Operation_kind.Merge_conflict; Operation_kind.Implementation_notes ]
+      ~f:(fun kind ->
+        let a = with_pr pid br in
+        let a = enqueue a kind in
+        let a = respond a kind in
+        match
+          respond_delivery ~agent:a ~kind ~pre_fire_agent:None
+            ~prefetched_comments:[] ~main_branch
+        with
+        | Skip_empty ->
+            failwith
+              (Printf.sprintf "RD-7: %s should never be Skip_empty"
+                 (Operation_kind.to_label kind))
+        | Deliver _ | Respond_stale -> ());
+    Stdlib.print_endline "RD-7 passed"
+  in
+
+  ignore main_branch


### PR DESCRIPTION
## Summary

- **Fix**: Human messages were silently dropped when sent to a patch in awaiting-review state with no worktree. The runner's empty-delivery guard read `inflight_human_messages` from the pre-fire agent snapshot (where messages are still in `human_messages`), causing every Human delivery to be skipped. Also fixed `Respond_failed` calling `complete` instead of `complete_failed`, losing inflight messages on failure.
- **Extract**: Disentangle pure pre-session decisions from effectful runner into `Patch_decision.respond_delivery`, making the correct field choice structural rather than a convention to remember. Eliminates ~80 lines of interleaved decision/effect code.
- **Test**: Add I-14 invariant (human messages never silently lost), PI-12 liveness test, AO-6 failure recovery test, and RD-1..RD-7 property tests for the new decision function.

## Test plan
- [x] `dune build` passes with fatal warnings
- [x] `dune runtest` passes all existing + new tests (PI-1..PI-12, AO-1..AO-6, RD-1..RD-7)
- [x] I-14 invariant holds under 1000 random interleavings (PI-1, PI-2, PI-3, PI-10, PI-11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes skipped Human message deliveries by adding a pure respond decision layer and explicit empty-delivery handling. Also confirms PR creation immediately via REST and standardizes CI failure detection to avoid drift.

- **Bug Fixes**
  - Human deliveries were skipped by reading the wrong field; decisions now use `Patch_decision.respond_delivery` to read `human_messages` correctly.
  - `Respond_failed` now calls `complete_failed`, restoring inflight Human messages.
  - Added `Respond_skip_empty` so empty deliveries finish cleanly; strengthened invariants/tests (I-14, PI-12, AO-6, RD-1..RD-7).

- **Refactors**
  - Extracted pure respond decisions into `Patch_decision.respond_delivery` returning typed payloads and optional `base_change`; the runner matches on this for prompt rendering and state updates.
  - Moved PR discovery to runner-time REST confirmation with base filter and retries; PRs are registered immediately and failures recorded.
  - Poller and TUI now use `Patch_decision.failure_conclusions` for CI failure filtering (removes duplicate lists).

<sup>Written for commit 9207ebc29fe6f285b050743f4381e36075745f8c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

