### PR TITLE
Don't trip CI failure cap on cancelled/skipped rollups

### DIFF
--- a/lib/github.ml
+++ b/lib/github.ml
@@ -193,7 +193,17 @@ let parse_response_json ~owner json =
                          state — it conflates cancelled runs (e.g.
                          superseded by a newer commit) with real failures.
                          See [Pr_state.derive_check_status] for semantics. *)
-                      let status = Pr_state.derive_check_status checks in
+                      let status =
+                        let base = Pr_state.derive_check_status checks in
+                        (* Passing is only reliable when we've seen every check.
+                           If the list is truncated, treat as Pending to avoid
+                           approving a merge that might have failures on page 2+. *)
+                        if
+                          truncated
+                          && Pr_state.equal_check_status base Pr_state.Passing
+                        then Pr_state.Pending
+                        else base
+                      in
                       (status, checks, truncated))
             in
             let review_threads =

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -87,11 +87,6 @@ let parse_merge_state = function
   | "CONFLICTING" -> Pr_state.Conflicting
   | _ -> Pr_state.Unknown
 
-let parse_check_status = function
-  | "SUCCESS" -> Pr_state.Passing
-  | "FAILURE" | "ERROR" -> Pr_state.Failing
-  | _ -> Pr_state.Pending
-
 let parse_check_context_node node =
   let open Yojson.Safe.Util in
   let typename = node |> member "__typename" |> to_string_option in
@@ -183,10 +178,6 @@ let parse_response_json ~owner json =
                   match rollup with
                   | `Null -> (Pr_state.Pending, [], false)
                   | rollup ->
-                      let status =
-                        rollup |> member "state" |> to_string
-                        |> parse_check_status
-                      in
                       let contexts = rollup |> member "contexts" in
                       let truncated =
                         contexts |> member "pageInfo" |> member "hasNextPage"
@@ -197,6 +188,12 @@ let parse_response_json ~owner json =
                         contexts |> member "nodes" |> to_list
                         |> List.filter_map ~f:parse_check_context_node
                       in
+                      (* Derive check_status from individual conclusions.
+                         We deliberately do NOT use the GraphQL rollup
+                         state — it conflates cancelled runs (e.g.
+                         superseded by a newer commit) with real failures.
+                         See [Pr_state.derive_check_status] for semantics. *)
+                      let status = Pr_state.derive_check_status checks in
                       (status, checks, truncated))
             in
             let review_threads =

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -582,6 +582,14 @@ let apply_respond_outcome t patch_id kind outcome =
   | Respond_skip_empty -> complete t patch_id
   | Respond_ok ->
       let t = complete t patch_id in
+      (* Only count CI fix attempts that actually delivered a payload with
+         failure conclusions. Cancelled/pending/success-only runs yield
+         [Respond_skip_empty] above and do not pollute the cap. *)
+      let t =
+        if Operation_kind.equal kind Operation_kind.Ci then
+          increment_ci_failure_count t patch_id
+        else t
+      in
       let t =
         if Operation_kind.equal kind Operation_kind.Merge_conflict then
           let t = clear_has_conflict t patch_id in

--- a/lib/patch_agent.ml
+++ b/lib/patch_agent.ml
@@ -370,9 +370,10 @@ let respond t k =
      unconditionally here because comment validity is resolved downstream
      by the agent session — a conservative simplification. *)
   let changed = if is_ci || is_review then true else t.changed in
-  let ci_failure_count =
-    if is_ci then t.ci_failure_count + 1 else t.ci_failure_count
-  in
+  (* NB: [ci_failure_count] is NOT bumped here. The bump happens in
+     [Orchestrator.apply_respond_outcome] on [Respond_ok] for Ci, so the
+     counter only reflects CI fix attempts that actually delivered a payload
+     (i.e. had at least one failure conclusion) and ran to completion. *)
   {
     t with
     has_session = true;
@@ -385,7 +386,6 @@ let respond t k =
     human_messages = (if is_human then [] else t.human_messages);
     inflight_human_messages =
       (if is_human then t.human_messages else t.inflight_human_messages);
-    ci_failure_count;
     notified_base_branch =
       (match t.notified_base_branch with None -> t.base_branch | some -> some);
     merge_ready = false;

--- a/lib/patch_agent.mli
+++ b/lib/patch_agent.mli
@@ -192,7 +192,10 @@ val is_approved : t -> main_branch:Types.Branch.t -> bool
     passing checks, and branch protection. *)
 
 val increment_ci_failure_count : t -> t
-(** Increment the CI failure counter. *)
+(** Increment the CI failure counter. Called from
+    [Orchestrator.apply_respond_outcome] on [Respond_ok] for a Ci delivery, so
+    the counter only reflects CI fix attempts that actually delivered a payload
+    with failure conclusions. *)
 
 val reset_ci_failure_count : t -> t
 (** Reset [ci_failure_count] to 0. Called by the poller when CI checks pass

--- a/lib/patch_decision.ml
+++ b/lib/patch_decision.ml
@@ -90,8 +90,7 @@ let should_clear_conflict (a : Patch_agent.t) : bool =
 
 (** {2 Respond delivery — pre-session decisions for the runner} *)
 
-let failure_conclusions =
-  [ "failure"; "error"; "action_required"; "timed_out"; "startup_failure" ]
+let failure_conclusions = Ci_check.failure_conclusions
 
 type base_change = { old_base : string; new_base : string }
 [@@deriving show, eq, sexp_of, compare]

--- a/lib/pr_state.ml
+++ b/lib/pr_state.ml
@@ -33,3 +33,24 @@ let no_unresolved_comments (st : t) = st.unresolved_comment_count = 0
 let has_conflict (st : t) = equal_merge_state st.merge_state Conflicting
 let ci_failed (st : t) = equal_check_status st.check_status Failing
 let is_fork (st : t) = st.is_fork
+
+(** Derive the aggregate [check_status] from a list of individual CI check
+    conclusions. This is the source of truth for what the orchestrator considers
+    a "failing", "passing", or "pending" CI state — bypassing GitHub's
+    [statusCheckRollup.state] which conflates cancelled/superseded runs with
+    actual failures.
+
+    Semantics:
+    - [Failing] if at least one check has a conclusion in
+      [Ci_check.failure_conclusions].
+    - [Passing] if the list is non-empty and every check has a conclusion in
+      [Ci_check.success_conclusions].
+    - [Pending] otherwise (empty list, or any mix containing cancelled, pending,
+      in_progress, queued, unknown conclusions, …). *)
+let derive_check_status (checks : Types.Ci_check.t list) : check_status =
+  if List.exists checks ~f:Types.Ci_check.is_failure then Failing
+  else if
+    (not (List.is_empty checks))
+    && List.for_all checks ~f:Types.Ci_check.is_success
+  then Passing
+  else Pending

--- a/lib/pr_state.mli
+++ b/lib/pr_state.mli
@@ -38,3 +38,9 @@ val no_unresolved_comments : t -> bool
 val has_conflict : t -> bool
 val ci_failed : t -> bool
 val is_fork : t -> bool
+
+val derive_check_status : Ci_check.t list -> check_status
+(** Aggregate [check_status] from individual CI check conclusions. Source of
+    truth for the orchestrator's notion of passing/failing/pending CI,
+    independent of GitHub's [statusCheckRollup.state] (which treats cancelled
+    runs as FAILURE). See implementation for exact semantics. *)

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -142,6 +142,22 @@ module Ci_check = struct
     started_at : string option;
   }
   [@@deriving show, eq, sexp_of, compare, yojson]
+
+  (** Conclusions that represent an actionable CI failure the agent can fix.
+      Notably excludes ["cancelled"] — a cancelled check typically means the run
+      was superseded by a newer commit or manually cancelled, not that anything
+      actually failed. *)
+  let failure_conclusions =
+    [ "failure"; "error"; "action_required"; "timed_out"; "startup_failure" ]
+
+  (** Conclusions that represent a terminal successful outcome. *)
+  let success_conclusions = [ "success"; "skipped"; "neutral" ]
+
+  let is_failure (c : t) =
+    List.mem failure_conclusions c.conclusion ~equal:String.equal
+
+  let is_success (c : t) =
+    List.mem success_conclusions c.conclusion ~equal:String.equal
 end
 
 module Pr_url = struct

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -115,6 +115,17 @@ module Ci_check : sig
     started_at : string option;
   }
   [@@deriving show, eq, sexp_of, compare, yojson]
+
+  val failure_conclusions : string list
+  (** Conclusions that represent an actionable CI failure the agent can fix.
+      Excludes ["cancelled"] — a cancelled check typically means the run was
+      superseded by a newer commit or manually cancelled, not a real failure. *)
+
+  val success_conclusions : string list
+  (** Conclusions that represent a terminal successful outcome. *)
+
+  val is_failure : t -> bool
+  val is_success : t -> bool
 end
 
 module Pr_url : sig

--- a/lib_test/test_generators.ml
+++ b/lib_test/test_generators.ml
@@ -84,8 +84,30 @@ let gen_patch =
 let gen_ci_check =
   QCheck2.Gen.(
     let gen_name = string_size ~gen:(char_range 'a' 'z') (int_range 3 15) in
+    (* Cover the full GitHub CheckConclusionState / StatusState universe
+       the parser can produce, including ambiguous cases ("cancelled",
+       "stale", empty string, "pending") that are neither a terminal
+       failure nor a terminal success. Properties that conflate any subset
+       of these with "failure" will surface via QCheck rather than via
+       production incidents. *)
     let gen_conclusion =
-      oneof_list [ "success"; "failure"; "neutral"; "skipped" ]
+      oneof_list
+        [
+          "success";
+          "failure";
+          "error";
+          "neutral";
+          "skipped";
+          "cancelled";
+          "action_required";
+          "timed_out";
+          "startup_failure";
+          "stale";
+          "pending";
+          "in_progress";
+          "queued";
+          "";
+        ]
     in
     let gen_url = option (pure "https://ci.example.com/1") in
     let gen_desc = option (string_size ~gen:printable (int_range 5 40)) in

--- a/test/test_action_outcome_properties.ml
+++ b/test/test_action_outcome_properties.ml
@@ -205,3 +205,68 @@ let () =
   assert (List.is_empty agent.Patch_agent.inflight_human_messages);
   assert (not agent.Patch_agent.busy);
   Stdlib.print_endline "AO-6 passed"
+
+(* ========== AO-7: Ci respond counter is bumped only on Respond_ok ========== *)
+
+(* Respond_ok bumps ci_failure_count; Skip_empty / Failed / Retry_push /
+   Stale do NOT. This locks in the invariant that a CI fix attempt only
+   counts against the cap when a real payload was delivered. Regression for
+   the production incident where cancelled-only rollups drove the cap to 3
+   and forced needs_intervention without any actionable failures. *)
+let () =
+  let with_ci_busy () =
+    let orch, patches, gameplan, pid = bootstrap_one () in
+    let orch = make_busy orch patches gameplan pid Operation_kind.Ci in
+    let before = (Orchestrator.agent orch pid).Patch_agent.ci_failure_count in
+    (orch, pid, before)
+  in
+  let ci_count orch pid =
+    (Orchestrator.agent orch pid).Patch_agent.ci_failure_count
+  in
+  (* Respond_ok bumps *)
+  let orch, pid, before = with_ci_busy () in
+  let orch =
+    Orchestrator.apply_respond_outcome orch pid Operation_kind.Ci
+      Orchestrator.Respond_ok
+  in
+  assert (ci_count orch pid = before + 1);
+  (* Respond_skip_empty does NOT bump *)
+  let orch, pid, before = with_ci_busy () in
+  let orch =
+    Orchestrator.apply_respond_outcome orch pid Operation_kind.Ci
+      Orchestrator.Respond_skip_empty
+  in
+  assert (ci_count orch pid = before);
+  (* Respond_failed does NOT bump *)
+  let orch, pid, before = with_ci_busy () in
+  let orch =
+    Orchestrator.apply_respond_outcome orch pid Operation_kind.Ci
+      Orchestrator.Respond_failed
+  in
+  assert (ci_count orch pid = before);
+  (* Respond_retry_push does NOT bump *)
+  let orch, pid, before = with_ci_busy () in
+  let orch =
+    Orchestrator.apply_respond_outcome orch pid Operation_kind.Ci
+      Orchestrator.Respond_retry_push
+  in
+  assert (ci_count orch pid = before);
+  (* Respond_stale does NOT bump *)
+  let orch, pid, before = with_ci_busy () in
+  let orch =
+    Orchestrator.apply_respond_outcome orch pid Operation_kind.Ci
+      Orchestrator.Respond_stale
+  in
+  assert (ci_count orch pid = before);
+  (* Respond_ok for non-Ci kinds does NOT bump ci_failure_count *)
+  let orch, patches, gameplan, pid = bootstrap_one () in
+  let orch =
+    make_busy orch patches gameplan pid Operation_kind.Review_comments
+  in
+  let before = ci_count orch pid in
+  let orch =
+    Orchestrator.apply_respond_outcome orch pid Operation_kind.Review_comments
+      Orchestrator.Respond_ok
+  in
+  assert (ci_count orch pid = before);
+  Stdlib.print_endline "AO-7 passed"

--- a/test/test_patch_agent.ml
+++ b/test/test_patch_agent.ml
@@ -557,7 +557,6 @@ let () =
             && List.is_empty a.inflight_human_messages
           with _ -> false);
       (* -- 2 ci failures does NOT trigger needs_intervention (boundary) -- *)
-      (* respond increments ci_failure_count, so 1 prior + 1 from respond = 2 *)
       Test.make ~name:"2 ci failures no intervention (boundary)" ~count:1
         Gen.(pure (pid0, br0))
         (fun (pid, br) ->
@@ -566,12 +565,9 @@ let () =
           in
           let a = complete a in
           let a = increment_ci_failure_count a in
-          let a = enqueue a Operation_kind.Ci in
-          let a = respond a Operation_kind.Ci in
-          let a = complete a in
+          let a = increment_ci_failure_count a in
           not (needs_intervention a));
       (* -- 3 ci failures triggers needs_intervention -- *)
-      (* respond increments ci_failure_count, so 2 prior + 1 from respond = 3 *)
       Test.make ~name:"3 ci failures triggers intervention" ~count:1
         Gen.(pure (pid0, br0))
         (fun (pid, br) ->
@@ -581,9 +577,7 @@ let () =
           let a = complete a in
           let a = increment_ci_failure_count a in
           let a = increment_ci_failure_count a in
-          let a = enqueue a Operation_kind.Ci in
-          let a = respond a Operation_kind.Ci in
-          let a = complete a in
+          let a = increment_ci_failure_count a in
           needs_intervention a);
       (* -- session_failed triggers needs_intervention -- *)
       Test.make ~name:"session_failed triggers intervention" ~count:1
@@ -841,7 +835,6 @@ let () =
             not (is_approved a ~main_branch:br0)
           with _ -> false);
       (* -- is_approved false when needs_intervention -- *)
-      (* respond increments ci_failure_count, so 2 prior + 1 from respond = 3 *)
       Test.make ~name:"is_approved false when needs_intervention" ~count:1
         Gen.(pure (pid0, br0))
         (fun (pid, br) ->
@@ -852,9 +845,7 @@ let () =
             let a = complete a in
             let a = increment_ci_failure_count a in
             let a = increment_ci_failure_count a in
-            let a = enqueue a Operation_kind.Ci in
-            let a = respond a Operation_kind.Ci in
-            let a = complete a in
+            let a = increment_ci_failure_count a in
             let a = set_merge_ready a true in
             not (is_approved a ~main_branch:br0)
           with _ -> false);

--- a/test/test_patch_decision.ml
+++ b/test/test_patch_decision.ml
@@ -42,16 +42,12 @@ let () =
         Gen.(pair gen_pid gen_branch)
         (fun (pid, br) ->
           try
-            (* Drive ci_failure_count to 3 via respond (which increments on
-               Ci) to trigger needs_intervention after complete *)
+            (* Drive ci_failure_count to 3 to trigger needs_intervention *)
             let a = with_pr pid br in
             let a =
-              increment_ci_failure_count a |> increment_ci_failure_count
+              increment_ci_failure_count a
+              |> increment_ci_failure_count |> increment_ci_failure_count
             in
-            let a = enqueue a Operation_kind.Ci in
-            (* respond Ci increments ci_failure_count to 3 *)
-            let a = respond a Operation_kind.Ci in
-            let a = complete a in
             equal_disposition (disposition a) Blocked
           with _ -> false);
       (* ---- disposition: busy -> Busy ---- *)

--- a/test/test_poller_properties.ml
+++ b/test/test_poller_properties.ml
@@ -3,30 +3,85 @@ open Onton.Types
 
 let () =
   let open QCheck2 in
+  let open Onton_test_support.Test_generators in
   let tests =
     [
       (* merge_ready is passed through from PR state *)
-      Test.make ~name:"merge_ready passed through" ~count:500
-        Onton_test_support.Test_generators.gen_pr_state (fun pr ->
+      Test.make ~name:"merge_ready passed through" ~count:500 gen_pr_state
+        (fun pr ->
           let result = Onton.Poller.poll ~was_merged:false pr in
           Bool.equal result.Onton.Poller.merge_ready
             (Onton.Pr_state.merge_ready pr));
-      Test.make ~name:"is_draft passed through" ~count:500
-        Onton_test_support.Test_generators.gen_pr_state (fun pr ->
+      Test.make ~name:"is_draft passed through" ~count:500 gen_pr_state
+        (fun pr ->
           let result = Onton.Poller.poll ~was_merged:false pr in
           Bool.equal result.Onton.Poller.is_draft (Onton.Pr_state.is_draft pr));
       (* checks_passing is passed through from PR state *)
-      Test.make ~name:"checks_passing passed through" ~count:500
-        Onton_test_support.Test_generators.gen_pr_state (fun pr ->
+      Test.make ~name:"checks_passing passed through" ~count:500 gen_pr_state
+        (fun pr ->
           let result = Onton.Poller.poll ~was_merged:false pr in
           Bool.equal result.Onton.Poller.checks_passing
             (Onton.Pr_state.checks_passing pr));
       (* ci_checks are passed through from PR state *)
-      Test.make ~name:"ci_checks passed through" ~count:500
-        Onton_test_support.Test_generators.gen_pr_state (fun pr ->
+      Test.make ~name:"ci_checks passed through" ~count:500 gen_pr_state
+        (fun pr ->
           let result = Onton.Poller.poll ~was_merged:false pr in
           List.equal Ci_check.equal result.Onton.Poller.ci_checks
             pr.Onton.Pr_state.ci_checks);
+      (* -- derive_check_status semantics ------------------------------- *)
+      (* Failing iff any conclusion is in failure_conclusions *)
+      Test.make ~name:"derive_check_status: Failing iff any is_failure"
+        ~count:1000
+        Gen.(list_size (int_range 0 8) gen_ci_check)
+        (fun checks ->
+          let status = Onton.Pr_state.derive_check_status checks in
+          let any_failure = List.exists checks ~f:Ci_check.is_failure in
+          Bool.equal
+            (Onton.Pr_state.equal_check_status status Onton.Pr_state.Failing)
+            any_failure);
+      (* Passing iff non-empty and every conclusion is in success_conclusions *)
+      Test.make ~name:"derive_check_status: Passing iff non-empty all_success"
+        ~count:1000
+        Gen.(list_size (int_range 0 8) gen_ci_check)
+        (fun checks ->
+          let status = Onton.Pr_state.derive_check_status checks in
+          let all_success =
+            (not (List.is_empty checks))
+            && List.for_all checks ~f:Ci_check.is_success
+          in
+          Bool.equal
+            (Onton.Pr_state.equal_check_status status Onton.Pr_state.Passing)
+            all_success);
+      (* Cancelled-only lists must NOT be Failing (regression for the
+         orchestrator needs-intervention loop seen in production). *)
+      Test.make ~name:"derive_check_status: cancelled-only is not Failing"
+        ~count:500
+        Gen.(
+          list_size (int_range 1 6)
+            (map
+               (fun (name, details_url, description) ->
+                 Ci_check.
+                   {
+                     name;
+                     conclusion = "cancelled";
+                     details_url;
+                     description;
+                     started_at = None;
+                   })
+               (triple
+                  (string_size ~gen:(char_range 'a' 'z') (int_range 3 10))
+                  (option (pure "https://ci.example.com/x"))
+                  (option (string_size ~gen:printable (int_range 0 20))))))
+        (fun checks ->
+          let status = Onton.Pr_state.derive_check_status checks in
+          not (Onton.Pr_state.equal_check_status status Onton.Pr_state.Failing));
+      (* Empty list -> Pending (never Passing, never Failing) *)
+      Test.make ~name:"derive_check_status: empty is Pending" ~count:1
+        Gen.(pure ())
+        (fun () ->
+          Onton.Pr_state.equal_check_status
+            (Onton.Pr_state.derive_check_status [])
+            Onton.Pr_state.Pending);
     ]
   in
   List.iter tests ~f:(fun t -> QCheck2.Test.check_exn t)


### PR DESCRIPTION
## Summary

Fix the orchestrator sending patches to `needs_intervention` after 3 "CI failures" when the PR's only non-success check was cancelled or superseded. Traced from onton-debug case `8dde-1404-927b` / live log for patch 1712.

Root cause — two inconsistent notions of "CI failed":

- `Poller.ci_failed` reads `Pr_state.check_status`, derived in `Github.ml` from `statusCheckRollup.state`. GitHub reports `FAILURE` for any rollup containing a cancelled run, so cancelled-only PRs kept enqueuing `Ci`.
- `Patch_decision.failure_conclusions` (what the runner actually delivers) excludes `"cancelled"`. The runner would `Skip_empty`, but `Patch_agent.respond` had already bumped `ci_failure_count` unconditionally. Three no-op cycles later, the agent was capped.

## Changes

- Extract `Pr_state.derive_check_status` as the single source of truth for mapping conclusions → `Passing`/`Failing`/`Pending`. `Github.ml` now ignores `rollup.state` entirely. `failure_conclusions` / `success_conclusions` live on `Types.Ci_check` and are shared by parsing and decision code.
- Move the `ci_failure_count` bump out of `Patch_agent.respond` and into `Orchestrator.apply_respond_outcome` on `Respond_ok` + `Ci`. The counter now reflects only CI fix attempts that actually delivered a payload with failure conclusions.
- Expand `gen_ci_check`'s conclusion universe from 4 to 14 values (`cancelled`, `stale`, `action_required`, `timed_out`, `pending`, `queued`, empty string, etc.) so property tests exercise the full GitHub state space that let this bug slip through.
- Add property tests for `derive_check_status` (including a cancelled-only regression) and `AO-7` locking in that `ci_failure_count` bumps only on `Respond_ok` for `Ci`.

## Test plan

- [x] `dune build` clean
- [x] `dune runtest` green (existing tests updated to bump the counter explicitly where they previously relied on `respond`'s side-effect)
- [x] `dune fmt` idempotent
- [x] New `AO-7` verifies counter bumps only on `Respond_ok`, untouched by `Skip_empty` / `Failed` / `Retry_push` / `Stale`
- [x] New `derive_check_status: cancelled-only is not Failing` locks in the regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes false CI failures from cancelled/skipped rollups and only counts real CI delivery attempts. Also avoids reporting “Passing” when GitHub paginates CI checks.

- **Bug Fixes**
  - Derive CI status from individual check conclusions and centralize success/failure sets in `Types.Ci_check`; ignore GitHub rollup.state (cancelled-only is not failing).
  - When the CI check list is truncated (paginated), degrade Passing to Pending; propagate Failing immediately if any fetched check failed.
  - Increment `ci_failure_count` only on `Respond_ok` for `Ci` in the orchestrator; no bump on `Skip_empty`/`Failed`/`Retry`/`Stale` or non-Ci.
  - Tests: expand generated conclusions (14 values) and add properties for `derive_check_status` (incl. cancelled-only regression) and AO-7 counter behavior.

<sup>Written for commit 9d5215114058e599a59f5917bb7e4e0d85ed7508. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

