### PR TITLE
Move git push from agent to supervisor

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -708,22 +708,28 @@ let run_claude_and_handle ~runtime ~process_mgr ~fs ~project_name ~patch_id
              session_result so commits made before a partial failure still
              reach the remote. *)
           let branch = agent.Patch_agent.branch in
-          (match
-             Worktree.force_push_with_lease ~process_mgr ~path:worktree_path
-               ~branch
-           with
-          | Worktree.Push_ok ->
-              log_event runtime ~patch_id "runner: pushed after session"
-          | Worktree.Push_up_to_date ->
-              log_event runtime ~patch_id
-                "runner: push up-to-date after session (no new commits)"
-          | Worktree.Push_rejected ->
-              log_event runtime ~patch_id
-                "runner: push rejected after session (lease)"
-          | Worktree.Push_error msg ->
-              log_event runtime ~patch_id
-                (Printf.sprintf "runner: push error after session: %s" msg));
-          user_result)
+          let push_result =
+            match
+              Worktree.force_push_with_lease ~process_mgr ~path:worktree_path
+                ~branch
+            with
+            | Worktree.Push_ok ->
+                log_event runtime ~patch_id "runner: pushed after session";
+                user_result
+            | Worktree.Push_up_to_date ->
+                log_event runtime ~patch_id
+                  "runner: push up-to-date after session (no new commits)";
+                user_result
+            | Worktree.Push_rejected ->
+                log_event runtime ~patch_id
+                  "runner: push rejected after session (lease)";
+                `Failed
+            | Worktree.Push_error msg ->
+                log_event runtime ~patch_id
+                  (Printf.sprintf "runner: push error after session: %s" msg);
+                `Failed
+          in
+          push_result)
 
 (** {1 Fibers} *)
 

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -2152,14 +2152,50 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                     (fun orch ->
                                       Orchestrator.set_pr_number orch patch_id
                                         pr_number)
-                              | Error e ->
-                                  log_event runtime ~patch_id
-                                    (Printf.sprintf "PR creation failed — %s"
-                                       (Github.show_error e));
-                                  Runtime.update_orchestrator runtime
-                                    (fun orch ->
-                                      Orchestrator.on_pr_discovery_failure orch
-                                        patch_id));
+                              | Error e -> (
+                                  match e with
+                                  | Github.Http_error { status = 422; _ } -> (
+                                      (* PR already exists — discover it rather
+                                         than treating this as failure *)
+                                      match
+                                        Github.list_prs ~net github
+                                          ~branch:patch.Patch.branch
+                                          ~base:(Some base_branch) ~state:`Open
+                                          ()
+                                      with
+                                      | Ok ((pr_number, _, _) :: _) ->
+                                          log_event runtime ~patch_id
+                                            (Printf.sprintf
+                                               "PR #%d already existed, \
+                                                associated"
+                                               (Pr_number.to_int pr_number));
+                                          Pr_registry.register pr_registry
+                                            ~patch_id ~pr_number;
+                                          Runtime.update_orchestrator runtime
+                                            (fun orch ->
+                                              Orchestrator.set_pr_number orch
+                                                patch_id pr_number)
+                                      | Ok [] | Error _ ->
+                                          log_event runtime ~patch_id
+                                            "PR creation failed (422) and \
+                                             discovery found nothing";
+                                          Runtime.update_orchestrator runtime
+                                            (fun orch ->
+                                              Orchestrator
+                                              .on_pr_discovery_failure orch
+                                                patch_id))
+                                  | Github.Http_error _
+                                  | Github.Json_parse_error _
+                                  | Github.Graphql_error _
+                                  | Github.Transport_error _ ->
+                                      log_event runtime ~patch_id
+                                        (Printf.sprintf
+                                           "PR creation failed — %s"
+                                           (Github.show_error e));
+                                      Runtime.update_orchestrator runtime
+                                        (fun orch ->
+                                          Orchestrator.on_pr_discovery_failure
+                                            orch patch_id)));
                               Runtime.update_orchestrator runtime (fun orch ->
                                   Orchestrator.complete orch patch_id)
                           | Orchestrator.Start_stale -> ())))

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -2175,10 +2175,21 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                             (fun orch ->
                                               Orchestrator.set_pr_number orch
                                                 patch_id pr_number)
-                                      | Ok [] | Error _ ->
+                                      | Ok [] ->
                                           log_event runtime ~patch_id
                                             "PR creation failed (422) and \
-                                             discovery found nothing";
+                                             discovery found no open PRs";
+                                          Runtime.update_orchestrator runtime
+                                            (fun orch ->
+                                              Orchestrator
+                                              .on_pr_discovery_failure orch
+                                                patch_id)
+                                      | Error disc_err ->
+                                          log_event runtime ~patch_id
+                                            (Printf.sprintf
+                                               "PR creation failed (422) and \
+                                                discovery also failed — %s"
+                                               (Github.show_error disc_err));
                                           Runtime.update_orchestrator runtime
                                             (fun orch ->
                                               Orchestrator

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -2611,6 +2611,7 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                     ( Patch_decision.Human_payload _
                                     | Patch_decision.Ci_payload _
                                     | Patch_decision.Review_payload _
+                                    | Patch_decision.Pr_body_payload
                                     | Patch_decision
                                       .Implementation_notes_payload ) as payload;
                                   base_change;
@@ -2635,6 +2636,7 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                            (Base.List.length messages)
                                            "message")
                                   | Patch_decision.Ci_payload _
+                                  | Patch_decision.Pr_body_payload
                                   | Patch_decision.Implementation_notes_payload
                                   | Patch_decision.Merge_conflict_payload ->
                                       Printf.sprintf "Delivering %s"
@@ -2656,6 +2658,27 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                   | Patch_decision.Human_payload { messages } ->
                                       Prompt.render_human_message_prompt
                                         ~project_name messages
+                                  | Patch_decision.Pr_body_payload ->
+                                      let patch =
+                                        Base.List.find_exn
+                                          gameplan.Gameplan.patches
+                                          ~f:(fun (p : Patch.t) ->
+                                            Patch_id.equal p.Patch.id patch_id)
+                                      in
+                                      let pr_body =
+                                        Prompt.render_pr_description
+                                          ~project_name patch gameplan
+                                      in
+                                      let artifact_path =
+                                        Project_store.pr_body_artifact_path
+                                          ~project_name ~patch_id
+                                      in
+                                      Project_store.ensure_dir
+                                        (Stdlib.Filename.dirname artifact_path);
+                                      Prompt.render_pr_body_prompt ~project_name
+                                        ~pr_number:
+                                          (Base.Option.value_exn pr_number)
+                                        ~pr_body ~artifact_path
                                   | Patch_decision.Implementation_notes_payload
                                     ->
                                       let patch =
@@ -2706,6 +2729,78 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                         Orchestrator.set_notified_base_branch
                                           orch patch_id (Branch.of_string base))
                                 | _ -> ());
+                                (* Pr_body: read the artifact the agent wrote
+                                   and PATCH the PR body. Falls back silently
+                                   to keep the gameplan-derived body if the
+                                   artifact is missing or unreadable. The
+                                   pr_body_delivered flag flips to true via
+                                   apply_respond_outcome on Respond_ok
+                                   regardless of whether the PATCH happened —
+                                   that's the documented fallback. *)
+                                (match payload with
+                                | Patch_decision.Pr_body_payload
+                                  when match result with
+                                       | `Ok -> true
+                                       | _ -> false -> (
+                                    let artifact_path =
+                                      Project_store.pr_body_artifact_path
+                                        ~project_name ~patch_id
+                                    in
+                                    let body_opt =
+                                      try
+                                        if Stdlib.Sys.file_exists artifact_path
+                                        then (
+                                          let ic =
+                                            Stdlib.open_in artifact_path
+                                          in
+                                          let len =
+                                            Stdlib.in_channel_length ic
+                                          in
+                                          let s = Bytes.create len in
+                                          Stdlib.really_input ic s 0 len;
+                                          Stdlib.close_in ic;
+                                          Some (Bytes.to_string s))
+                                        else None
+                                      with _ -> None
+                                    in
+                                    match (body_opt, pr_number) with
+                                    | None, _ ->
+                                        log_event runtime ~patch_id
+                                          (Printf.sprintf
+                                             "pr-body: artifact missing at %s; \
+                                              keeping gameplan body"
+                                             artifact_path)
+                                    | Some body, _
+                                      when String.length (String.trim body) = 0
+                                      ->
+                                        log_event runtime ~patch_id
+                                          "pr-body: artifact empty; keeping \
+                                           gameplan body"
+                                    | Some _, None ->
+                                        log_event runtime ~patch_id
+                                          "pr-body: no PR number to update"
+                                    | Some body, Some pr -> (
+                                        match
+                                          Github.update_pr_body ~net github
+                                            ~pr_number:pr ~body
+                                        with
+                                        | Ok () ->
+                                            log_event runtime ~patch_id
+                                              (Printf.sprintf
+                                                 "pr-body: PATCHed PR #%d"
+                                                 (Pr_number.to_int pr))
+                                        | Error e ->
+                                            log_event runtime ~patch_id
+                                              (Printf.sprintf
+                                                 "pr-body: PATCH failed — %s"
+                                                 (Github.show_error e))))
+                                | Patch_decision.Pr_body_payload
+                                | Patch_decision.Human_payload _
+                                | Patch_decision.Ci_payload _
+                                | Patch_decision.Review_payload _
+                                | Patch_decision.Implementation_notes_payload
+                                | Patch_decision.Merge_conflict_payload ->
+                                    ());
                                 result)
                       in
                       let respond_outcome =

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -701,6 +701,28 @@ let run_claude_and_handle ~runtime ~process_mgr ~fs ~project_name ~patch_id
           in
           Event_log.log_complete event_log ~patch_id ~result:session_result
             ~agent_before ~agent_after;
+          (* Supervisor-owned push: agent commits locally; we push every
+             local commit to the remote at session end. force_push_with_lease
+             is idempotent (Push_up_to_date when nothing new), and lease-safe
+             against concurrent remote updates. Runs regardless of
+             session_result so commits made before a partial failure still
+             reach the remote. *)
+          let branch = agent.Patch_agent.branch in
+          (match
+             Worktree.force_push_with_lease ~process_mgr ~path:worktree_path
+               ~branch
+           with
+          | Worktree.Push_ok ->
+              log_event runtime ~patch_id "runner: pushed after session"
+          | Worktree.Push_up_to_date ->
+              log_event runtime ~patch_id
+                "runner: push up-to-date after session (no new commits)"
+          | Worktree.Push_rejected ->
+              log_event runtime ~patch_id
+                "runner: push rejected after session (lease)"
+          | Worktree.Push_error msg ->
+              log_event runtime ~patch_id
+                (Printf.sprintf "runner: push error after session: %s" msg));
           user_result)
 
 (** {1 Fibers} *)

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -2763,23 +2763,27 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                         else None
                                       with _ -> None
                                     in
-                                    match (body_opt, pr_number) with
-                                    | None, _ ->
+                                    match body_opt with
+                                    | None ->
                                         log_event runtime ~patch_id
                                           (Printf.sprintf
                                              "pr-body: artifact missing at %s; \
                                               keeping gameplan body"
                                              artifact_path)
-                                    | Some body, _
+                                    | Some body
                                       when String.length (String.trim body) = 0
                                       ->
                                         log_event runtime ~patch_id
                                           "pr-body: artifact empty; keeping \
                                            gameplan body"
-                                    | Some _, None ->
-                                        log_event runtime ~patch_id
-                                          "pr-body: no PR number to update"
-                                    | Some body, Some pr -> (
+                                    | Some body -> (
+                                        (* pr_number is guaranteed Some here:
+                                           value_exn above would have raised
+                                           before the session started if it
+                                           were None. *)
+                                        let pr =
+                                          Base.Option.value_exn pr_number
+                                        in
                                         match
                                           Github.update_pr_body ~net github
                                             ~pr_number:pr ~body

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -338,13 +338,11 @@ let apply_notes_artifact ~runtime ~net ~github ~project_name ~patch_id
       log_event runtime ~patch_id "notes: artifact empty; not updating PR body"
   | Some notes -> (
       let body_base =
-        match
-          read_artifact_file
-            (Project_store.pr_body_artifact_path ~project_name ~patch_id)
-        with
-        | Some body when String.length (String.trim body) > 0 -> body
-        | Some _ | None ->
-            Prompt.render_pr_description ~project_name patch gameplan
+        Prompt.resolve_pr_body_source
+          ~artifact:
+            (read_artifact_file
+               (Project_store.pr_body_artifact_path ~project_name ~patch_id))
+          ~fallback:(Prompt.render_pr_description ~project_name patch gameplan)
       in
       let composed =
         Printf.sprintf "%s\n\n## Implementation Notes\n\n%s" body_base
@@ -768,27 +766,23 @@ let run_claude_and_handle ~runtime ~process_mgr ~fs ~project_name ~patch_id
               log_event runtime ~patch_id
                 (Printf.sprintf "runner: push error after session: %s" msg));
           (* Combine LLM session outcome with push outcome into a single
-             session_result. A push failure when the LLM was otherwise
-             healthy is recorded as Session_push_failed so the orchestrator
-             treats it as a retryable failure without poisoning
-             session_fallback. A pre-existing LLM failure takes precedence —
-             the push outcome doesn't change it. *)
-          let final_session_result, final_user_result =
-            match session_result with
-            | Orchestrator.Session_ok -> (
-                match push_outcome with
-                | Worktree.Push_ok | Worktree.Push_up_to_date ->
-                    (session_result, user_result)
-                | Worktree.Push_rejected | Worktree.Push_error _ ->
-                    (Orchestrator.Session_push_failed, `Failed))
+             session_result via the pure decision in
+             [Orchestrator.combine_session_and_push]. user_result mirrors:
+             same Ok/Failed disposition unless the combination promoted us
+             to Session_push_failed (which is always Failed). *)
+          let final_session_result =
+            Orchestrator.combine_session_and_push ~session:session_result
+              ~push:push_outcome
+          in
+          let final_user_result =
+            match final_session_result with
+            | Orchestrator.Session_ok -> user_result
             | Orchestrator.Session_process_error _
             | Orchestrator.Session_no_resume | Orchestrator.Session_failed _
             | Orchestrator.Session_give_up
             | Orchestrator.Session_worktree_missing
             | Orchestrator.Session_push_failed ->
-                (* Pre-existing LLM/setup failure — push outcome doesn't
-                   change anything. *)
-                (session_result, user_result)
+                `Failed
           in
           let agent_before, agent_after =
             Runtime.update_orchestrator_returning runtime (fun orch ->

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -777,11 +777,15 @@ let run_claude_and_handle ~runtime ~process_mgr ~fs ~project_name ~patch_id
           let final_user_result =
             match final_session_result with
             | Orchestrator.Session_ok -> user_result
+            | Orchestrator.Session_push_failed ->
+                (* LLM session ran fine but push failed — signal retry so
+                   the Respond path uses Respond_retry_push (clean complete)
+                   and the reconciler re-enqueues the operation naturally. *)
+                `Retry_push
             | Orchestrator.Session_process_error _
             | Orchestrator.Session_no_resume | Orchestrator.Session_failed _
             | Orchestrator.Session_give_up
-            | Orchestrator.Session_worktree_missing
-            | Orchestrator.Session_push_failed ->
+            | Orchestrator.Session_worktree_missing ->
                 `Failed
           in
           let agent_before, agent_after =
@@ -2168,7 +2172,7 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                           let start_outcome =
                             match result with
                             | `Stale -> Orchestrator.Start_stale
-                            | `Failed -> Orchestrator.Start_failed
+                            | `Failed | `Retry_push -> Orchestrator.Start_failed
                             | `Ok -> Orchestrator.Start_ok
                           in
                           Runtime.update_orchestrator runtime (fun orch ->

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -164,9 +164,6 @@ let execute_github_effects ~runtime ~net ~github effects =
   Base.List.iter effects ~f:(fun github_effect ->
       let label =
         match github_effect with
-        | Patch_controller.Set_pr_description { pr_number; _ } ->
-            Printf.sprintf "set_pr_description (PR #%d)"
-              (Pr_number.to_int pr_number)
         | Patch_controller.Set_pr_draft { pr_number; draft; _ } ->
             Printf.sprintf "set_pr_draft (PR #%d, draft=%b)"
               (Pr_number.to_int pr_number)
@@ -179,9 +176,6 @@ let execute_github_effects ~runtime ~net ~github effects =
       try
         let result =
           match github_effect with
-          | Patch_controller.Set_pr_description
-              { patch_id = _; pr_number; body } ->
-              Github.update_pr_body ~net github ~pr_number ~body
           | Patch_controller.Set_pr_draft { patch_id = _; pr_number; draft } ->
               Github.set_draft ~net github ~pr_number ~draft
           | Patch_controller.Set_pr_base { patch_id = _; pr_number; base } ->
@@ -286,6 +280,84 @@ let log_event runtime ?patch_id msg =
       Activity_log.add_event log
         (Activity_log.Event.create ~timestamp:(Unix.gettimeofday ()) ?patch_id
            msg))
+
+(** Read an artifact file. Returns [Some contents] if the file exists and is
+    readable, [None] otherwise. *)
+let read_artifact_file path =
+  try
+    if Stdlib.Sys.file_exists path then (
+      let ic = Stdlib.open_in path in
+      let len = Stdlib.in_channel_length ic in
+      let s = Bytes.create len in
+      Stdlib.really_input ic s 0 len;
+      Stdlib.close_in ic;
+      Some (Bytes.to_string s))
+    else None
+  with _ -> None
+
+(** Apply the agent-authored PR body artifact to the PR. Falls back to keeping
+    the gameplan-derived body if the artifact is missing or empty. *)
+let apply_pr_body_artifact ~runtime ~net ~github ~project_name ~patch_id
+    ~pr_number =
+  let artifact_path =
+    Project_store.pr_body_artifact_path ~project_name ~patch_id
+  in
+  match read_artifact_file artifact_path with
+  | None ->
+      log_event runtime ~patch_id
+        (Printf.sprintf "pr-body: artifact missing at %s; keeping gameplan body"
+           artifact_path)
+  | Some body when String.length (String.trim body) = 0 ->
+      log_event runtime ~patch_id
+        "pr-body: artifact empty; keeping gameplan body"
+  | Some body -> (
+      match Github.update_pr_body ~net github ~pr_number ~body with
+      | Ok () ->
+          log_event runtime ~patch_id
+            (Printf.sprintf "pr-body: PATCHed PR #%d"
+               (Pr_number.to_int pr_number))
+      | Error e ->
+          log_event runtime ~patch_id
+            (Printf.sprintf "pr-body: PATCH failed — %s" (Github.show_error e)))
+
+(** Apply the agent-authored notes artifact: compose
+    [<pr-body>\n\n## Implementation Notes\n\n<notes>] and PATCH the PR. The body
+    source is the local pr-body.md artifact; if missing, falls back to the
+    gameplan-derived body. *)
+let apply_notes_artifact ~runtime ~net ~github ~project_name ~patch_id
+    ~pr_number ~patch ~gameplan =
+  let notes_path =
+    Project_store.implementation_notes_artifact_path ~project_name ~patch_id
+  in
+  match read_artifact_file notes_path with
+  | None ->
+      log_event runtime ~patch_id
+        (Printf.sprintf "notes: artifact missing at %s; not updating PR body"
+           notes_path)
+  | Some notes when String.length (String.trim notes) = 0 ->
+      log_event runtime ~patch_id "notes: artifact empty; not updating PR body"
+  | Some notes -> (
+      let body_base =
+        match
+          read_artifact_file
+            (Project_store.pr_body_artifact_path ~project_name ~patch_id)
+        with
+        | Some body when String.length (String.trim body) > 0 -> body
+        | Some _ | None ->
+            Prompt.render_pr_description ~project_name patch gameplan
+      in
+      let composed =
+        Printf.sprintf "%s\n\n## Implementation Notes\n\n%s" body_base
+          (String.trim notes)
+      in
+      match Github.update_pr_body ~net github ~pr_number ~body:composed with
+      | Ok () ->
+          log_event runtime ~patch_id
+            (Printf.sprintf "notes: PATCHed PR #%d (body + notes section)"
+               (Pr_number.to_int pr_number))
+      | Error e ->
+          log_event runtime ~patch_id
+            (Printf.sprintf "notes: PATCH failed — %s" (Github.show_error e)))
 
 (** Terminal failure — forces [Given_up] so [complete] raises intervention. Used
     for non-retryable errors (patch not found, PR discovery failed). *)
@@ -2154,9 +2226,17 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                         pr_number)
                               | Error e -> (
                                   match e with
-                                  | Github.Http_error { status = 422; _ } -> (
+                                  | Github.Http_error { status = 422; body; _ }
+                                    when Github.response_error_message_contains
+                                           body
+                                           ~substring:
+                                             "pull request already exists" -> (
                                       (* PR already exists — discover it rather
-                                         than treating this as failure *)
+                                         than treating this as failure. We
+                                         only fall back on this specific 422;
+                                         other 422s (no commits, head missing,
+                                         etc.) propagate with the original
+                                         error message. *)
                                       match
                                         Github.list_prs ~net github
                                           ~branch:patch.Patch.branch
@@ -2177,8 +2257,9 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                                 patch_id pr_number)
                                       | Ok [] ->
                                           log_event runtime ~patch_id
-                                            "PR creation failed (422) and \
-                                             discovery found no open PRs";
+                                            "PR creation failed (422 \
+                                             already-exists) and discovery \
+                                             found no open PRs";
                                           Runtime.update_orchestrator runtime
                                             (fun orch ->
                                               Orchestrator
@@ -2187,8 +2268,9 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                       | Error disc_err ->
                                           log_event runtime ~patch_id
                                             (Printf.sprintf
-                                               "PR creation failed (422) and \
-                                                discovery also failed — %s"
+                                               "PR creation failed (422 \
+                                                already-exists) and discovery \
+                                                also failed — %s"
                                                (Github.show_error disc_err));
                                           Runtime.update_orchestrator runtime
                                             (fun orch ->
@@ -2681,21 +2763,18 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                         ~pr_body ~artifact_path
                                   | Patch_decision.Implementation_notes_payload
                                     ->
-                                      let patch =
-                                        Base.List.find_exn
-                                          gameplan.Gameplan.patches
-                                          ~f:(fun (p : Patch.t) ->
-                                            Patch_id.equal p.Patch.id patch_id)
+                                      let artifact_path =
+                                        Project_store
+                                        .implementation_notes_artifact_path
+                                          ~project_name ~patch_id
                                       in
-                                      let pr_body =
-                                        Prompt.render_pr_description
-                                          ~project_name patch gameplan
-                                      in
+                                      Project_store.ensure_dir
+                                        (Stdlib.Filename.dirname artifact_path);
                                       Prompt.render_implementation_notes_prompt
                                         ~project_name
                                         ~pr_number:
                                           (Base.Option.value_exn pr_number)
-                                        ~pr_body
+                                        ~artifact_path
                                   | Patch_decision.Merge_conflict_payload ->
                                       (* Invariant: Merge_conflict is handled
                                          in the dedicated match arm above *)
@@ -2729,82 +2808,43 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                         Orchestrator.set_notified_base_branch
                                           orch patch_id (Branch.of_string base))
                                 | _ -> ());
-                                (* Pr_body: read the artifact the agent wrote
-                                   and PATCH the PR body. Falls back silently
-                                   to keep the gameplan-derived body if the
-                                   artifact is missing or unreadable. The
-                                   pr_body_delivered flag flips to true via
-                                   apply_respond_outcome on Respond_ok
-                                   regardless of whether the PATCH happened —
-                                   that's the documented fallback. *)
-                                (match payload with
-                                | Patch_decision.Pr_body_payload
-                                  when match result with
-                                       | `Ok -> true
-                                       | _ -> false -> (
-                                    let artifact_path =
-                                      Project_store.pr_body_artifact_path
-                                        ~project_name ~patch_id
-                                    in
-                                    let body_opt =
-                                      try
-                                        if Stdlib.Sys.file_exists artifact_path
-                                        then (
-                                          let ic =
-                                            Stdlib.open_in artifact_path
-                                          in
-                                          let len =
-                                            Stdlib.in_channel_length ic
-                                          in
-                                          let s = Bytes.create len in
-                                          Stdlib.really_input ic s 0 len;
-                                          Stdlib.close_in ic;
-                                          Some (Bytes.to_string s))
-                                        else None
-                                      with _ -> None
-                                    in
-                                    match body_opt with
-                                    | None ->
-                                        log_event runtime ~patch_id
-                                          (Printf.sprintf
-                                             "pr-body: artifact missing at %s; \
-                                              keeping gameplan body"
-                                             artifact_path)
-                                    | Some body
-                                      when String.length (String.trim body) = 0
-                                      ->
-                                        log_event runtime ~patch_id
-                                          "pr-body: artifact empty; keeping \
-                                           gameplan body"
-                                    | Some body -> (
-                                        (* pr_number is guaranteed Some here:
-                                           value_exn above would have raised
-                                           before the session started if it
-                                           were None. *)
-                                        let pr =
-                                          Base.Option.value_exn pr_number
-                                        in
-                                        match
-                                          Github.update_pr_body ~net github
-                                            ~pr_number:pr ~body
-                                        with
-                                        | Ok () ->
-                                            log_event runtime ~patch_id
-                                              (Printf.sprintf
-                                                 "pr-body: PATCHed PR #%d"
-                                                 (Pr_number.to_int pr))
-                                        | Error e ->
-                                            log_event runtime ~patch_id
-                                              (Printf.sprintf
-                                                 "pr-body: PATCH failed — %s"
-                                                 (Github.show_error e))))
-                                | Patch_decision.Pr_body_payload
-                                | Patch_decision.Human_payload _
-                                | Patch_decision.Ci_payload _
-                                | Patch_decision.Review_payload _
-                                | Patch_decision.Implementation_notes_payload
-                                | Patch_decision.Merge_conflict_payload ->
-                                    ());
+                                (* Artifact-driven phases (Pr_body, Notes):
+                                   read the agent's artifact and PATCH the PR
+                                   body. Falls back gracefully if the artifact
+                                   is missing — the *_delivered flag flips
+                                   true via apply_respond_outcome on
+                                   Respond_ok regardless, so we don't loop. *)
+                                let session_ok =
+                                  match result with `Ok -> true | _ -> false
+                                in
+                                (if session_ok then
+                                   match payload with
+                                   | Patch_decision.Pr_body_payload ->
+                                       let pr =
+                                         Base.Option.value_exn pr_number
+                                       in
+                                       apply_pr_body_artifact ~runtime ~net
+                                         ~github ~project_name ~patch_id
+                                         ~pr_number:pr
+                                   | Patch_decision.Implementation_notes_payload
+                                     ->
+                                       let pr =
+                                         Base.Option.value_exn pr_number
+                                       in
+                                       let patch =
+                                         Base.List.find_exn
+                                           gameplan.Gameplan.patches
+                                           ~f:(fun (p : Patch.t) ->
+                                             Patch_id.equal p.Patch.id patch_id)
+                                       in
+                                       apply_notes_artifact ~runtime ~net
+                                         ~github ~project_name ~patch_id
+                                         ~pr_number:pr ~patch ~gameplan
+                                   | Patch_decision.Human_payload _
+                                   | Patch_decision.Ci_payload _
+                                   | Patch_decision.Review_payload _
+                                   | Patch_decision.Merge_conflict_payload ->
+                                       ());
                                 result)
                       in
                       let respond_outcome =

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -158,16 +158,6 @@ module Pr_registry = struct
         Hashtbl.remove t.table patch_id)
 end
 
-(** Discover PR number for a branch via GitHub REST API. Returns [Ok] with the
-    PR number or [Error] with a diagnostic message. *)
-let discover_pr_number ~net ~github ~branch ~base_branch =
-  match
-    Github.list_prs ~net github ~branch ~base:(Some base_branch) ~state:`Open ()
-  with
-  | Ok ((pr_number, _, _) :: _) -> Ok pr_number
-  | Ok [] -> Error "no PRs found for branch"
-  | Error e -> Error (Github.show_error e)
-
 (** Execute declarative GitHub effects and record successful observations back
     into durable state. *)
 let execute_github_effects ~runtime ~net ~github effects =
@@ -682,11 +672,58 @@ let run_claude_and_handle ~runtime ~process_mgr ~fs ~project_name ~patch_id
                      backend.Llm_backend.name exit_code detail);
                 (Orchestrator.Session_failed { is_fresh }, `Failed)
           in
+          (* Supervisor-owned push: agent commits locally; we push every
+             local commit to the remote at session end. force_push_with_lease
+             is idempotent (Push_up_to_date when nothing new), and lease-safe
+             against concurrent remote updates. Runs regardless of the LLM's
+             session result so commits made before a partial failure still
+             reach the remote. *)
+          let branch = agent.Patch_agent.branch in
+          let push_outcome =
+            Worktree.force_push_with_lease ~process_mgr ~path:worktree_path
+              ~branch
+          in
+          (match push_outcome with
+          | Worktree.Push_ok ->
+              log_event runtime ~patch_id "runner: pushed after session"
+          | Worktree.Push_up_to_date ->
+              log_event runtime ~patch_id
+                "runner: push up-to-date after session (no new commits)"
+          | Worktree.Push_rejected ->
+              log_event runtime ~patch_id
+                "runner: push rejected after session (lease)"
+          | Worktree.Push_error msg ->
+              log_event runtime ~patch_id
+                (Printf.sprintf "runner: push error after session: %s" msg));
+          (* Combine LLM session outcome with push outcome into a single
+             session_result. A push failure when the LLM was otherwise
+             healthy is recorded as Session_push_failed so the orchestrator
+             treats it as a retryable failure without poisoning
+             session_fallback. A pre-existing LLM failure takes precedence —
+             the push outcome doesn't change it. *)
+          let final_session_result, final_user_result =
+            match session_result with
+            | Orchestrator.Session_ok -> (
+                match push_outcome with
+                | Worktree.Push_ok | Worktree.Push_up_to_date ->
+                    (session_result, user_result)
+                | Worktree.Push_rejected | Worktree.Push_error _ ->
+                    (Orchestrator.Session_push_failed, `Failed))
+            | Orchestrator.Session_process_error _
+            | Orchestrator.Session_no_resume | Orchestrator.Session_failed _
+            | Orchestrator.Session_give_up
+            | Orchestrator.Session_worktree_missing
+            | Orchestrator.Session_push_failed ->
+                (* Pre-existing LLM/setup failure — push outcome doesn't
+                   change anything. *)
+                (session_result, user_result)
+          in
           let agent_before, agent_after =
             Runtime.update_orchestrator_returning runtime (fun orch ->
                 let agent_before = Orchestrator.agent orch patch_id in
                 let orch =
-                  Orchestrator.apply_session_result orch patch_id session_result
+                  Orchestrator.apply_session_result orch patch_id
+                    final_session_result
                 in
                 (* Store the captured session_id for future --resume calls *)
                 let orch =
@@ -699,37 +736,9 @@ let run_claude_and_handle ~runtime ~process_mgr ~fs ~project_name ~patch_id
                 let agent_after = Orchestrator.agent orch patch_id in
                 (orch, (agent_before, agent_after)))
           in
-          Event_log.log_complete event_log ~patch_id ~result:session_result
-            ~agent_before ~agent_after;
-          (* Supervisor-owned push: agent commits locally; we push every
-             local commit to the remote at session end. force_push_with_lease
-             is idempotent (Push_up_to_date when nothing new), and lease-safe
-             against concurrent remote updates. Runs regardless of
-             session_result so commits made before a partial failure still
-             reach the remote. *)
-          let branch = agent.Patch_agent.branch in
-          let push_result =
-            match
-              Worktree.force_push_with_lease ~process_mgr ~path:worktree_path
-                ~branch
-            with
-            | Worktree.Push_ok ->
-                log_event runtime ~patch_id "runner: pushed after session";
-                user_result
-            | Worktree.Push_up_to_date ->
-                log_event runtime ~patch_id
-                  "runner: push up-to-date after session (no new commits)";
-                user_result
-            | Worktree.Push_rejected ->
-                log_event runtime ~patch_id
-                  "runner: push rejected after session (lease)";
-                `Failed
-            | Worktree.Push_error msg ->
-                log_event runtime ~patch_id
-                  (Printf.sprintf "runner: push error after session: %s" msg);
-                `Failed
-          in
-          push_result)
+          Event_log.log_complete event_log ~patch_id
+            ~result:final_session_result ~agent_before ~agent_after;
+          final_user_result)
 
 (** {1 Fibers} *)
 
@@ -2115,35 +2124,42 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                        (Patch_id.to_string patch_id))
                                   ()
                           | Orchestrator.Start_ok ->
-                              (* Always confirm via REST API *)
-                              let rec discover remaining =
-                                match
-                                  discover_pr_number ~net ~github
-                                    ~branch:patch.Patch.branch ~base_branch
-                                with
-                                | Ok pr_number ->
-                                    log_event runtime ~patch_id
-                                      (Printf.sprintf "Created PR #%d"
-                                         (Pr_number.to_int pr_number));
-                                    Pr_registry.register pr_registry ~patch_id
-                                      ~pr_number;
-                                    Runtime.update_orchestrator runtime
-                                      (fun orch ->
-                                        Orchestrator.set_pr_number orch patch_id
-                                          pr_number)
-                                | Error _ when remaining > 0 ->
-                                    Eio.Time.sleep clock 2.0;
-                                    discover (remaining - 1)
-                                | Error msg ->
-                                    log_event runtime ~patch_id
-                                      (Printf.sprintf "PR discovery failed — %s"
-                                         msg);
-                                    Runtime.update_orchestrator runtime
-                                      (fun orch ->
-                                        Orchestrator.on_pr_discovery_failure
-                                          orch patch_id)
+                              (* Supervisor-owned PR creation: the agent
+                                 commits and the supervisor pushed at session
+                                 end; now we open the draft PR with a
+                                 gameplan-derived title and body. *)
+                              let pr_title =
+                                Printf.sprintf "[%s] Patch %s: %s" project_name
+                                  (Patch_id.to_string patch.Patch.id)
+                                  patch.Patch.title
                               in
-                              discover 2;
+                              let pr_body =
+                                Prompt.render_pr_description ~project_name patch
+                                  gameplan
+                              in
+                              (match
+                                 Github.create_pull_request ~net github
+                                   ~title:pr_title ~head:patch.Patch.branch
+                                   ~base:base_branch ~body:pr_body ~draft:true
+                               with
+                              | Ok pr_number ->
+                                  log_event runtime ~patch_id
+                                    (Printf.sprintf "PR #%d created"
+                                       (Pr_number.to_int pr_number));
+                                  Pr_registry.register pr_registry ~patch_id
+                                    ~pr_number;
+                                  Runtime.update_orchestrator runtime
+                                    (fun orch ->
+                                      Orchestrator.set_pr_number orch patch_id
+                                        pr_number)
+                              | Error e ->
+                                  log_event runtime ~patch_id
+                                    (Printf.sprintf "PR creation failed — %s"
+                                       (Github.show_error e));
+                                  Runtime.update_orchestrator runtime
+                                    (fun orch ->
+                                      Orchestrator.on_pr_discovery_failure orch
+                                        patch_id));
                               Runtime.update_orchestrator runtime (fun orch ->
                                   Orchestrator.complete orch patch_id)
                           | Orchestrator.Start_stale -> ())))

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -445,6 +445,31 @@ let update_pr_body ~net t ~pr_number ~body =
   | Ok _ -> Ok ()
   | Error _ as e -> e
 
+(** Create a draft pull request via REST API. Returns the new PR number. *)
+let create_pull_request ~net t ~title ~head ~base ~body ~draft =
+  let path = Printf.sprintf "/repos/%s/%s/pulls" t.owner t.repo in
+  let req_body =
+    `Assoc
+      [
+        ("title", `String title);
+        ("head", `String (Types.Branch.to_string head));
+        ("base", `String (Types.Branch.to_string base));
+        ("body", `String body);
+        ("draft", `Bool draft);
+      ]
+    |> Yojson.Safe.to_string
+  in
+  match request ~net t ~meth:`POST ~path ~body:req_body () with
+  | Error _ as e -> e
+  | Ok resp_str -> (
+      try
+        let json = Yojson.Safe.from_string resp_str in
+        let number = Yojson.Safe.Util.(json |> member "number" |> to_int) in
+        Ok (Types.Pr_number.of_int number)
+      with
+      | Yojson.Json_error msg -> Error (Json_parse_error msg)
+      | Yojson.Safe.Util.Type_error (msg, _) -> Error (Json_parse_error msg))
+
 (** Update the base (target) branch of a PR via REST API. *)
 let update_pr_base ~net t ~pr_number ~base =
   let path =

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -20,6 +20,44 @@ let extract_github_message body =
     | None -> truncate body
   with _ -> truncate body
 
+(* Returns [true] if any [errors[].message] in a GitHub 422 validation response
+   body contains [substring] (case-insensitive). 422 covers many distinct
+   validation cases (no commits between head/base, head doesn't exist, branch
+   already has PR, etc.) — callers use this to discriminate which one. Pure;
+   safe on malformed input (returns false). *)
+let response_error_message_contains body ~substring =
+  try
+    let json = Yojson.Safe.from_string body in
+    let errors = Yojson.Safe.Util.(json |> member "errors" |> to_list) in
+    let needle = String.lowercase substring in
+    List.exists errors ~f:(fun err ->
+        match
+          Yojson.Safe.Util.(err |> member "message" |> to_string_option)
+        with
+        | None -> false
+        | Some msg ->
+            String.is_substring (String.lowercase msg) ~substring:needle)
+  with _ -> false
+
+let%test "response_error_message_contains: empty body returns false" =
+  not (response_error_message_contains "" ~substring:"already exists")
+
+let%test "response_error_message_contains: matches errors[].message substring" =
+  response_error_message_contains
+    {|{"message":"Validation Failed","errors":[{"resource":"PullRequest","code":"custom","message":"A pull request already exists for foo/bar:branch."}]}|}
+    ~substring:"pull request already exists"
+
+let%test "response_error_message_contains: no match for unrelated error" =
+  not
+    (response_error_message_contains
+       {|{"message":"Validation Failed","errors":[{"resource":"PullRequest","code":"custom","message":"No commits between main and feature."}]}|}
+       ~substring:"pull request already exists")
+
+let%test "response_error_message_contains: missing errors[] returns false" =
+  not
+    (response_error_message_contains {|{"message":"Not Found"}|}
+       ~substring:"pull request already exists")
+
 (* Hint added to permission-related HTTP errors so users know which PAT scopes
    to check. Fine-grained PATs need distinct permissions per endpoint category,
    which is the root cause of the opaque-error problem in issue #166. *)

--- a/lib/github.mli
+++ b/lib/github.mli
@@ -58,6 +58,19 @@ val update_pr_body :
 (** [update_pr_body ~net t ~pr_number ~body] updates the PR description via
     [PATCH /repos/:owner/:repo/pulls/:number]. *)
 
+val create_pull_request :
+  net:_ Eio.Net.t ->
+  t ->
+  title:string ->
+  head:Types.Branch.t ->
+  base:Types.Branch.t ->
+  body:string ->
+  draft:bool ->
+  (Types.Pr_number.t, error) Result.t
+(** [create_pull_request ~net t ~title ~head ~base ~body ~draft] creates a pull
+    request via [POST /repos/:owner/:repo/pulls] and returns the new PR number.
+*)
+
 val update_pr_base :
   net:_ Eio.Net.t ->
   t ->

--- a/lib/github.mli
+++ b/lib/github.mli
@@ -14,6 +14,12 @@ val show_error : error -> string
     from the response body, and appends a hint about PAT scopes for 401/403/404
     so users can fix permission problems without guesswork. *)
 
+val response_error_message_contains : string -> substring:string -> bool
+(** Returns [true] if any [errors[].message] in a GitHub validation response
+    body contains [substring] (case-insensitive). Use this to discriminate
+    between distinct 422 cases (e.g. "pull request already exists" vs "no
+    commits between"). Pure; safe on malformed input. *)
+
 type t
 
 val create : token:string -> owner:string -> repo:string -> t

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -504,6 +504,7 @@ type session_result =
   | Session_failed of { is_fresh : bool }
   | Session_give_up
   | Session_worktree_missing
+  | Session_push_failed
 [@@deriving show, eq, sexp_of]
 
 (** Complete a failed session, restoring inflight human messages to the inbox.
@@ -552,6 +553,13 @@ let apply_session_result t patch_id result =
       complete_failed t patch_id
   | Session_worktree_missing ->
       let t = update_agent t patch_id ~f:Patch_agent.on_pre_session_failure in
+      complete_failed t patch_id
+  | Session_push_failed ->
+      (* The LLM session itself ran cleanly — clear its fallback state so we
+         resume the same session next iteration. The push failure is treated
+         as a soft failure: complete_failed clears busy and re-enqueues any
+         inflight human messages so the next iteration retries. *)
+      let t = clear_session_fallback t patch_id in
       complete_failed t patch_id
 
 type start_outcome = Start_ok | Start_failed | Start_stale

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -342,10 +342,6 @@ let set_merge_ready t patch_id v =
 let set_is_draft t patch_id v =
   update_agent t patch_id ~f:(fun a -> Patch_agent.set_is_draft a v)
 
-let set_pr_description_applied t patch_id v =
-  update_agent t patch_id ~f:(fun a ->
-      Patch_agent.set_pr_description_applied a v)
-
 let set_implementation_notes_delivered t patch_id v =
   update_agent t patch_id ~f:(fun a ->
       Patch_agent.set_implementation_notes_delivered a v)

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -350,6 +350,9 @@ let set_implementation_notes_delivered t patch_id v =
   update_agent t patch_id ~f:(fun a ->
       Patch_agent.set_implementation_notes_delivered a v)
 
+let set_pr_body_delivered t patch_id v =
+  update_agent t patch_id ~f:(fun a -> Patch_agent.set_pr_body_delivered a v)
+
 let increment_conflict_noop_count t patch_id =
   update_agent t patch_id ~f:Patch_agent.increment_conflict_noop_count
 
@@ -602,6 +605,11 @@ let apply_respond_outcome t patch_id kind outcome =
         if Operation_kind.equal kind Operation_kind.Merge_conflict then
           let t = clear_has_conflict t patch_id in
           reset_conflict_noop_count t patch_id
+        else t
+      in
+      let t =
+        if Operation_kind.equal kind Operation_kind.Pr_body then
+          set_pr_body_delivered t patch_id true
         else t
       in
       if Operation_kind.equal kind Operation_kind.Implementation_notes then

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -561,6 +561,17 @@ let apply_session_result t patch_id result =
       let t = clear_session_fallback t patch_id in
       complete_failed t patch_id
 
+let combine_session_and_push ~(session : session_result)
+    ~(push : Worktree.push_result) : session_result =
+  match session with
+  | Session_ok -> (
+      match push with
+      | Worktree.Push_ok | Worktree.Push_up_to_date -> Session_ok
+      | Worktree.Push_rejected | Worktree.Push_error _ -> Session_push_failed)
+  | Session_process_error _ | Session_no_resume | Session_failed _
+  | Session_give_up | Session_worktree_missing | Session_push_failed ->
+      session
+
 type start_outcome = Start_ok | Start_failed | Start_stale
 [@@deriving show, eq, sexp_of]
 

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -94,6 +94,7 @@ val set_merge_ready : t -> Patch_id.t -> bool -> t
 val set_is_draft : t -> Patch_id.t -> bool -> t
 val set_pr_description_applied : t -> Patch_id.t -> bool -> t
 val set_implementation_notes_delivered : t -> Patch_id.t -> bool -> t
+val set_pr_body_delivered : t -> Patch_id.t -> bool -> t
 val increment_start_attempts_without_pr : t -> Patch_id.t -> t
 val reset_intervention_state : t -> Patch_id.t -> t
 val set_branch_blocked : t -> Patch_id.t -> t

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -127,6 +127,7 @@ type session_result =
   | Session_failed of { is_fresh : bool }
   | Session_give_up
   | Session_worktree_missing
+  | Session_push_failed
 [@@deriving show, eq, sexp_of]
 
 val apply_session_result : t -> Patch_id.t -> session_result -> t
@@ -136,7 +137,10 @@ val apply_session_result : t -> Patch_id.t -> session_result -> t
     on_session_failure + complete. [Session_no_resume] -> on_session_failure
     (not fresh) + complete. [Session_give_up] -> set_session_failed +
     set_tried_fresh + complete. [Session_worktree_missing] ->
-    on_pre_session_failure + complete. *)
+    on_pre_session_failure + complete. [Session_push_failed] ->
+    clear_session_fallback (LLM session itself was healthy) + complete_failed
+    (commits did not reach the remote — retry on next iteration). Use this when
+    the LLM ran cleanly but the supervisor's post-session push failed. *)
 
 type start_outcome = Start_ok | Start_failed | Start_stale
 [@@deriving show, eq, sexp_of]

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -92,7 +92,6 @@ val set_ci_checks : t -> Patch_id.t -> Ci_check.t list -> t
 val set_checks_passing : t -> Patch_id.t -> bool -> t
 val set_merge_ready : t -> Patch_id.t -> bool -> t
 val set_is_draft : t -> Patch_id.t -> bool -> t
-val set_pr_description_applied : t -> Patch_id.t -> bool -> t
 val set_implementation_notes_delivered : t -> Patch_id.t -> bool -> t
 val set_pr_body_delivered : t -> Patch_id.t -> bool -> t
 val increment_start_attempts_without_pr : t -> Patch_id.t -> t

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -142,6 +142,18 @@ val apply_session_result : t -> Patch_id.t -> session_result -> t
     (commits did not reach the remote — retry on next iteration). Use this when
     the LLM ran cleanly but the supervisor's post-session push failed. *)
 
+val combine_session_and_push :
+  session:session_result -> push:Worktree.push_result -> session_result
+(** Pure: fold the LLM session outcome and the supervisor's post-session push
+    outcome into a single [session_result] for [apply_session_result].
+    - A pre-existing LLM failure ([Session_process_error], [Session_failed],
+      [Session_no_resume], [Session_give_up], [Session_worktree_missing],
+      [Session_push_failed]) is preserved unchanged — the push outcome doesn't
+      change anything.
+    - [Session_ok] with [Push_ok] or [Push_up_to_date] stays [Session_ok].
+    - [Session_ok] with [Push_rejected] or [Push_error] becomes
+      [Session_push_failed] — the LLM ran fine but commits didn't ship. *)
+
 type start_outcome = Start_ok | Start_failed | Start_stale
 [@@deriving show, eq, sexp_of]
 

--- a/lib/patch_agent.ml
+++ b/lib/patch_agent.ml
@@ -25,7 +25,6 @@ type t = {
   ci_checks : Ci_check.t list;
   merge_ready : bool;
   is_draft : bool;
-  pr_description_applied : bool;
   pr_body_delivered : bool;
   implementation_notes_delivered : bool;
   start_attempts_without_pr : int;
@@ -72,7 +71,6 @@ let create ~branch patch_id =
     ci_checks = [];
     merge_ready = false;
     is_draft = false;
-    pr_description_applied = false;
     pr_body_delivered = false;
     implementation_notes_delivered = false;
     start_attempts_without_pr = 0;
@@ -107,7 +105,6 @@ let create_adhoc ~patch_id ~branch ~pr_number =
     ci_checks = [];
     merge_ready = false;
     is_draft = false;
-    pr_description_applied = true;
     pr_body_delivered = true;
     implementation_notes_delivered = true;
     start_attempts_without_pr = 0;
@@ -186,7 +183,6 @@ let base_branch_changed t =
 
 let set_merge_ready t v = { t with merge_ready = v }
 let set_is_draft t v = { t with is_draft = v }
-let set_pr_description_applied t v = { t with pr_description_applied = v }
 
 let set_implementation_notes_delivered t v =
   { t with implementation_notes_delivered = v }
@@ -243,7 +239,7 @@ let reset_busy t = if not t.busy then t else { t with busy = false }
 let restore ~patch_id ~branch ~pr_number ~has_session ~busy ~merged ~queue
     ~satisfies ~changed ~has_conflict ~base_branch ~notified_base_branch
     ~ci_failure_count ~session_fallback ~human_messages ~inflight_human_messages
-    ~ci_checks ~merge_ready ~is_draft ~pr_description_applied ~pr_body_delivered
+    ~ci_checks ~merge_ready ~is_draft ~pr_body_delivered
     ~implementation_notes_delivered ~start_attempts_without_pr
     ~conflict_noop_count ~checks_passing ~current_op ~current_message_id
     ~generation ~worktree_path ~branch_blocked ~llm_session_id =
@@ -267,7 +263,6 @@ let restore ~patch_id ~branch ~pr_number ~has_session ~busy ~merged ~queue
     ci_checks;
     merge_ready;
     is_draft;
-    pr_description_applied;
     pr_body_delivered;
     implementation_notes_delivered;
     start_attempts_without_pr;
@@ -286,7 +281,6 @@ let set_pr_number t pr_number =
     t with
     pr_number = Some pr_number;
     is_draft = true;
-    pr_description_applied = false;
     pr_body_delivered = false;
     implementation_notes_delivered = false;
     start_attempts_without_pr = 0;
@@ -297,7 +291,6 @@ let clear_pr t =
     t with
     pr_number = None;
     is_draft = false;
-    pr_description_applied = false;
     merge_ready = false;
     checks_passing = false;
     ci_checks = [];

--- a/lib/patch_agent.ml
+++ b/lib/patch_agent.ml
@@ -26,6 +26,7 @@ type t = {
   merge_ready : bool;
   is_draft : bool;
   pr_description_applied : bool;
+  pr_body_delivered : bool;
   implementation_notes_delivered : bool;
   start_attempts_without_pr : int;
   conflict_noop_count : int;
@@ -72,6 +73,7 @@ let create ~branch patch_id =
     merge_ready = false;
     is_draft = false;
     pr_description_applied = false;
+    pr_body_delivered = false;
     implementation_notes_delivered = false;
     start_attempts_without_pr = 0;
     conflict_noop_count = 0;
@@ -106,6 +108,7 @@ let create_adhoc ~patch_id ~branch ~pr_number =
     merge_ready = false;
     is_draft = false;
     pr_description_applied = true;
+    pr_body_delivered = true;
     implementation_notes_delivered = true;
     start_attempts_without_pr = 0;
     conflict_noop_count = 0;
@@ -188,6 +191,8 @@ let set_pr_description_applied t v = { t with pr_description_applied = v }
 let set_implementation_notes_delivered t v =
   { t with implementation_notes_delivered = v }
 
+let set_pr_body_delivered t v = { t with pr_body_delivered = v }
+
 let increment_start_attempts_without_pr t =
   { t with start_attempts_without_pr = t.start_attempts_without_pr + 1 }
 
@@ -238,7 +243,7 @@ let reset_busy t = if not t.busy then t else { t with busy = false }
 let restore ~patch_id ~branch ~pr_number ~has_session ~busy ~merged ~queue
     ~satisfies ~changed ~has_conflict ~base_branch ~notified_base_branch
     ~ci_failure_count ~session_fallback ~human_messages ~inflight_human_messages
-    ~ci_checks ~merge_ready ~is_draft ~pr_description_applied
+    ~ci_checks ~merge_ready ~is_draft ~pr_description_applied ~pr_body_delivered
     ~implementation_notes_delivered ~start_attempts_without_pr
     ~conflict_noop_count ~checks_passing ~current_op ~current_message_id
     ~generation ~worktree_path ~branch_blocked ~llm_session_id =
@@ -263,6 +268,7 @@ let restore ~patch_id ~branch ~pr_number ~has_session ~busy ~merged ~queue
     merge_ready;
     is_draft;
     pr_description_applied;
+    pr_body_delivered;
     implementation_notes_delivered;
     start_attempts_without_pr;
     conflict_noop_count;
@@ -281,6 +287,7 @@ let set_pr_number t pr_number =
     pr_number = Some pr_number;
     is_draft = true;
     pr_description_applied = false;
+    pr_body_delivered = false;
     implementation_notes_delivered = false;
     start_attempts_without_pr = 0;
   }

--- a/lib/patch_agent.mli
+++ b/lib/patch_agent.mli
@@ -30,6 +30,7 @@ type t = private {
   merge_ready : bool;
   is_draft : bool;
   pr_description_applied : bool;
+  pr_body_delivered : bool;
   implementation_notes_delivered : bool;
   start_attempts_without_pr : int;
   conflict_noop_count : int;
@@ -170,6 +171,12 @@ val set_pr_description_applied : t -> bool -> t
 val set_implementation_notes_delivered : t -> bool -> t
 (** Record whether implementation notes were successfully delivered. *)
 
+val set_pr_body_delivered : t -> bool -> t
+(** Record whether the LLM-authored PR body has been written to the artifact and
+    PATCHed onto the PR. Set to [true] on Pr_body Respond_ok regardless of
+    whether the artifact existed (so we don't loop on missing artifacts —
+    documented fallback is to keep the gameplan-derived body). *)
+
 val increment_start_attempts_without_pr : t -> t
 (** Record a successful Start run that still failed to discover a PR. *)
 
@@ -272,6 +279,7 @@ val restore :
   merge_ready:bool ->
   is_draft:bool ->
   pr_description_applied:bool ->
+  pr_body_delivered:bool ->
   implementation_notes_delivered:bool ->
   start_attempts_without_pr:int ->
   conflict_noop_count:int ->

--- a/lib/patch_agent.mli
+++ b/lib/patch_agent.mli
@@ -29,7 +29,6 @@ type t = private {
   ci_checks : Types.Ci_check.t list;
   merge_ready : bool;
   is_draft : bool;
-  pr_description_applied : bool;
   pr_body_delivered : bool;
   implementation_notes_delivered : bool;
   start_attempts_without_pr : int;
@@ -165,9 +164,6 @@ val set_merge_ready : t -> bool -> t
 val set_is_draft : t -> bool -> t
 (** Set the draft flag from GitHub PR state. *)
 
-val set_pr_description_applied : t -> bool -> t
-(** Record whether the orchestrator has successfully applied the PR body. *)
-
 val set_implementation_notes_delivered : t -> bool -> t
 (** Record whether implementation notes were successfully delivered. *)
 
@@ -278,7 +274,6 @@ val restore :
   ci_checks:Types.Ci_check.t list ->
   merge_ready:bool ->
   is_draft:bool ->
-  pr_description_applied:bool ->
   pr_body_delivered:bool ->
   implementation_notes_delivered:bool ->
   start_attempts_without_pr:int ->

--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -35,11 +35,6 @@ let message_of_action (patch_agent : Patch_agent.t) action =
     }
 
 type github_effect =
-  | Set_pr_description of {
-      patch_id : Patch_id.t;
-      pr_number : Pr_number.t;
-      body : string;
-    }
   | Set_pr_draft of {
       patch_id : Patch_id.t;
       pr_number : Pr_number.t;
@@ -247,7 +242,7 @@ let apply_replacement_pr t patch_id ~pr_number ~base_branch ~merged =
   let t = Orchestrator.set_base_branch t patch_id base_branch in
   if merged then Orchestrator.mark_merged t patch_id else t
 
-let reconcile_patch t ~project_name ~gameplan ~(patch : Patch.t) =
+let reconcile_patch t ~project_name:_ ~gameplan:_ ~(patch : Patch.t) =
   let patch_id = patch.id in
   let agent = Orchestrator.agent t patch_id in
   if agent.Patch_agent.merged then (t, [])
@@ -259,16 +254,6 @@ let reconcile_patch t ~project_name ~gameplan ~(patch : Patch.t) =
     let effects = ref [] in
     (match agent.pr_number with
     | Some pr_number -> (
-        if (not agent.pr_description_applied) && not agent.pr_body_delivered
-        then
-          effects :=
-            Set_pr_description
-              {
-                patch_id;
-                pr_number;
-                body = Prompt.render_pr_description ~project_name patch gameplan;
-              }
-            :: !effects;
         match agent.base_branch with
         | Some actual_base ->
             let has_merged pid =
@@ -479,8 +464,6 @@ let tick t ~project_name ~gameplan =
   (t, effects, actions)
 
 let apply_github_effect_success t = function
-  | Set_pr_description { patch_id; _ } ->
-      Orchestrator.set_pr_description_applied t patch_id true
   | Set_pr_draft { patch_id; draft; _ } ->
       Orchestrator.set_is_draft t patch_id draft
   | Set_pr_base { patch_id; base; _ } ->
@@ -570,32 +553,6 @@ let%test "reconcile_patch enqueues pr_body before implementation_notes" =
     List.mem (Orchestrator.agent t pid).Patch_agent.queue
       Operation_kind.Implementation_notes ~equal:Operation_kind.equal
 
-let%test "reconcile_patch emits description effect while unapplied" =
-  let patch, t = make_orchestrator ~patch_id:pid ~main_branch:main in
-  let t = Orchestrator.fire t (Orchestrator.Start (pid, main)) in
-  let t = Orchestrator.set_pr_number t pid (Pr_number.of_int 42) in
-  let t = Orchestrator.complete t pid in
-  let _, effects =
-    reconcile_patch t ~project_name:"proj"
-      ~gameplan:
-        Gameplan.
-          {
-            project_name = "proj";
-            problem_statement = "";
-            solution_summary = "";
-            final_state_spec = "";
-            patches = [ patch ];
-            current_state_analysis = "";
-            explicit_opinions = "";
-            acceptance_criteria = [];
-            open_questions = [];
-          }
-      ~patch
-  in
-  List.exists effects ~f:(function
-    | Set_pr_description { patch_id; _ } -> Patch_id.equal patch_id pid
-    | Set_pr_draft _ | Set_pr_base _ -> false)
-
 let%test "reconcile_patch requests ready-for-review after notes on main" =
   let patch, t = make_orchestrator ~patch_id:pid ~main_branch:main in
   let t = Orchestrator.fire t (Orchestrator.Start (pid, main)) in
@@ -621,7 +578,7 @@ let%test "reconcile_patch requests ready-for-review after notes on main" =
   in
   List.exists effects ~f:(function
     | Set_pr_draft { patch_id; draft = false; _ } -> Patch_id.equal patch_id pid
-    | Set_pr_description _ | Set_pr_draft _ | Set_pr_base _ -> false)
+    | Set_pr_draft _ | Set_pr_base _ -> false)
 
 let%test "reconcile_patch emits no effects for merged agent" =
   let patch, t = make_orchestrator ~patch_id:pid ~main_branch:main in

--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -259,7 +259,8 @@ let reconcile_patch t ~project_name ~gameplan ~(patch : Patch.t) =
     let effects = ref [] in
     (match agent.pr_number with
     | Some pr_number -> (
-        if not agent.pr_description_applied then
+        if (not agent.pr_description_applied) && not agent.pr_body_delivered
+        then
           effects :=
             Set_pr_description
               {

--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -72,10 +72,26 @@ let discovery_intents orch =
       then Some (agent.patch_id, agent.branch)
       else None)
 
+let enqueue_pr_body_if_needed t patch_id (agent : Patch_agent.t) =
+  if (not (Patch_agent.has_pr agent)) || agent.merged || agent.pr_body_delivered
+  then t
+  else
+    let already_queued =
+      List.mem agent.queue Operation_kind.Pr_body ~equal:Operation_kind.equal
+      || Option.equal Operation_kind.equal agent.current_op
+           (Some Operation_kind.Pr_body)
+    in
+    if already_queued then t
+    else Orchestrator.enqueue t patch_id Operation_kind.Pr_body
+
+(* Notes wait until the PR body has been delivered so the body PATCH never
+   races with notes-appended writes. *)
 let enqueue_notes_if_needed t patch_id (agent : Patch_agent.t) =
   if
     (not (Patch_agent.has_pr agent))
-    || agent.merged || agent.implementation_notes_delivered
+    || agent.merged
+    || (not agent.pr_body_delivered)
+    || agent.implementation_notes_delivered
   then t
   else
     let already_queued =
@@ -156,7 +172,7 @@ let apply_poll_result t patch_id
             if is_new then
               log (Printf.sprintf "Enqueued %s" (Operation_kind.to_label kind));
             Orchestrator.enqueue acc patch_id kind
-        | Operation_kind.Rebase | Operation_kind.Human
+        | Operation_kind.Rebase | Operation_kind.Human | Operation_kind.Pr_body
         | Operation_kind.Implementation_notes ->
             if is_new then
               log (Printf.sprintf "Enqueued %s" (Operation_kind.to_label kind));
@@ -236,6 +252,8 @@ let reconcile_patch t ~project_name ~gameplan ~(patch : Patch.t) =
   let agent = Orchestrator.agent t patch_id in
   if agent.Patch_agent.merged then (t, [])
   else
+    let t = enqueue_pr_body_if_needed t patch_id agent in
+    let agent = Orchestrator.agent t patch_id in
     let t = enqueue_notes_if_needed t patch_id agent in
     let agent = Orchestrator.agent t patch_id in
     let effects = ref [] in
@@ -514,30 +532,42 @@ let%test "reconcile_patch escalates repeated start discovery failures" =
   in
   Patch_agent.needs_intervention (Orchestrator.agent t pid)
 
-let%test "reconcile_patch enqueues implementation notes while missing" =
+let%test "reconcile_patch enqueues pr_body before implementation_notes" =
   let patch, t = make_orchestrator ~patch_id:pid ~main_branch:main in
   let t = Orchestrator.fire t (Orchestrator.Start (pid, main)) in
   let t = Orchestrator.set_pr_number t pid (Pr_number.of_int 42) in
   let t = Orchestrator.complete t pid in
-  let t, _ =
-    reconcile_patch t ~project_name:"proj"
-      ~gameplan:
-        Gameplan.
-          {
-            project_name = "proj";
-            problem_statement = "";
-            solution_summary = "";
-            final_state_spec = "";
-            patches = [ patch ];
-            current_state_analysis = "";
-            explicit_opinions = "";
-            acceptance_criteria = [];
-            open_questions = [];
-          }
-      ~patch
+  let gp =
+    Gameplan.
+      {
+        project_name = "proj";
+        problem_statement = "";
+        solution_summary = "";
+        final_state_spec = "";
+        patches = [ patch ];
+        current_state_analysis = "";
+        explicit_opinions = "";
+        acceptance_criteria = [];
+        open_questions = [];
+      }
   in
-  List.mem (Orchestrator.agent t pid).Patch_agent.queue
-    Operation_kind.Implementation_notes ~equal:Operation_kind.equal
+  let t, _ = reconcile_patch t ~project_name:"proj" ~gameplan:gp ~patch in
+  let queue = (Orchestrator.agent t pid).Patch_agent.queue in
+  (* Pr_body fires; Implementation_notes is gated on pr_body_delivered so it
+     does NOT yet appear. After Pr_body delivery, notes joins the queue. *)
+  let has_pr_body =
+    List.mem queue Operation_kind.Pr_body ~equal:Operation_kind.equal
+  in
+  let has_notes =
+    List.mem queue Operation_kind.Implementation_notes
+      ~equal:Operation_kind.equal
+  in
+  if (not has_pr_body) || has_notes then false
+  else
+    let t = Orchestrator.set_pr_body_delivered t pid true in
+    let t, _ = reconcile_patch t ~project_name:"proj" ~gameplan:gp ~patch in
+    List.mem (Orchestrator.agent t pid).Patch_agent.queue
+      Operation_kind.Implementation_notes ~equal:Operation_kind.equal
 
 let%test "reconcile_patch emits description effect while unapplied" =
   let patch, t = make_orchestrator ~patch_id:pid ~main_branch:main in

--- a/lib/patch_controller.mli
+++ b/lib/patch_controller.mli
@@ -1,11 +1,6 @@
 open Types
 
 type github_effect =
-  | Set_pr_description of {
-      patch_id : Patch_id.t;
-      pr_number : Pr_number.t;
-      body : string;
-    }
   | Set_pr_draft of {
       patch_id : Patch_id.t;
       pr_number : Pr_number.t;

--- a/lib/patch_decision.ml
+++ b/lib/patch_decision.ml
@@ -31,7 +31,7 @@ let disposition (a : Patch_agent.t) : disposition =
         | Operation_kind.Rebase -> Ready_rebase
         | Operation_kind.Human | Operation_kind.Merge_conflict
         | Operation_kind.Ci | Operation_kind.Review_comments
-        | Operation_kind.Implementation_notes ->
+        | Operation_kind.Pr_body | Operation_kind.Implementation_notes ->
             Ready_respond k)
 
 type ci_decision =
@@ -99,6 +99,7 @@ type delivery_payload =
   | Human_payload of { messages : string list }
   | Ci_payload of { failed_checks : Ci_check.t list }
   | Review_payload of { comments : Comment.t list }
+  | Pr_body_payload
   | Implementation_notes_payload
   | Merge_conflict_payload
 [@@deriving show, eq, sexp_of, compare]
@@ -128,8 +129,8 @@ let respond_delivery ~(agent : Patch_agent.t) ~(kind : Operation_kind.t)
           not
             (List.exists source.ci_checks ~f:(fun (c : Ci_check.t) ->
                  List.mem failure_conclusions c.conclusion ~equal:String.equal))
-      | Operation_kind.Merge_conflict | Operation_kind.Implementation_notes
-      | Operation_kind.Rebase ->
+      | Operation_kind.Merge_conflict | Operation_kind.Pr_body
+      | Operation_kind.Implementation_notes | Operation_kind.Rebase ->
           false
     in
     if is_empty then Skip_empty
@@ -159,6 +160,7 @@ let respond_delivery ~(agent : Patch_agent.t) ~(kind : Operation_kind.t)
             Ci_payload { failed_checks = failed }
         | Operation_kind.Review_comments ->
             Review_payload { comments = prefetched_comments }
+        | Operation_kind.Pr_body -> Pr_body_payload
         | Operation_kind.Implementation_notes -> Implementation_notes_payload
         | Operation_kind.Merge_conflict -> Merge_conflict_payload
         | Operation_kind.Rebase ->

--- a/lib/patch_decision.mli
+++ b/lib/patch_decision.mli
@@ -80,6 +80,7 @@ type delivery_payload =
   | Human_payload of { messages : string list }
   | Ci_payload of { failed_checks : Ci_check.t list }
   | Review_payload of { comments : Comment.t list }
+  | Pr_body_payload
   | Implementation_notes_payload
   | Merge_conflict_payload
 [@@deriving show, eq, sexp_of, compare]

--- a/lib/persistence.ml
+++ b/lib/persistence.ml
@@ -17,6 +17,11 @@ let int_member_opt key json =
   | `Null -> None
   | v -> Some (Yojson.Safe.Util.to_int v)
 
+let bool_member_opt key json =
+  match Yojson.Safe.Util.member key json with
+  | `Null -> None
+  | v -> Some (Yojson.Safe.Util.to_bool v)
+
 let result_all xs =
   List.fold_right xs ~init:(Ok []) ~f:(fun x acc ->
       Result.bind acc ~f:(fun tl -> Result.map x ~f:(fun hd -> hd :: tl)))
@@ -66,6 +71,7 @@ let patch_agent_to_yojson (a : Patch_agent.t) =
       ("merge_ready", `Bool a.merge_ready);
       ("is_draft", `Bool a.is_draft);
       ("pr_description_applied", `Bool a.pr_description_applied);
+      ("pr_body_delivered", `Bool a.pr_body_delivered);
       ("implementation_notes_delivered", `Bool a.implementation_notes_delivered);
       ("start_attempts_without_pr", `Int a.start_attempts_without_pr);
       ("conflict_noop_count", `Int a.conflict_noop_count);
@@ -175,6 +181,10 @@ let patch_agent_of_yojson ~gameplan json =
        ~merge_ready:(bool_member "merge_ready" json)
        ~is_draft:(bool_member "is_draft" json)
        ~pr_description_applied:(bool_member "pr_description_applied" json)
+       ~pr_body_delivered:
+         (Option.value
+            (bool_member_opt "pr_body_delivered" json)
+            ~default:false)
        ~implementation_notes_delivered:
          (bool_member "implementation_notes_delivered" json)
        ~start_attempts_without_pr:(int_member "start_attempts_without_pr" json)

--- a/lib/persistence.ml
+++ b/lib/persistence.ml
@@ -182,9 +182,7 @@ let patch_agent_of_yojson ~gameplan json =
        ~is_draft:(bool_member "is_draft" json)
        ~pr_description_applied:(bool_member "pr_description_applied" json)
        ~pr_body_delivered:
-         (Option.value
-            (bool_member_opt "pr_body_delivered" json)
-            ~default:false)
+         (Option.value (bool_member_opt "pr_body_delivered" json) ~default:true)
        ~implementation_notes_delivered:
          (bool_member "implementation_notes_delivered" json)
        ~start_attempts_without_pr:(int_member "start_attempts_without_pr" json)

--- a/lib/persistence.ml
+++ b/lib/persistence.ml
@@ -70,7 +70,6 @@ let patch_agent_to_yojson (a : Patch_agent.t) =
       ("ci_checks", `List (List.map a.ci_checks ~f:Ci_check.yojson_of_t));
       ("merge_ready", `Bool a.merge_ready);
       ("is_draft", `Bool a.is_draft);
-      ("pr_description_applied", `Bool a.pr_description_applied);
       ("pr_body_delivered", `Bool a.pr_body_delivered);
       ("implementation_notes_delivered", `Bool a.implementation_notes_delivered);
       ("start_attempts_without_pr", `Int a.start_attempts_without_pr);
@@ -180,7 +179,6 @@ let patch_agent_of_yojson ~gameplan json =
        ~session_fallback ~human_messages ~inflight_human_messages ~ci_checks
        ~merge_ready:(bool_member "merge_ready" json)
        ~is_draft:(bool_member "is_draft" json)
-       ~pr_description_applied:(bool_member "pr_description_applied" json)
        ~pr_body_delivered:
          (Option.value (bool_member_opt "pr_body_delivered" json) ~default:true)
        ~implementation_notes_delivered:

--- a/lib/priority.ml
+++ b/lib/priority.ml
@@ -9,11 +9,12 @@ let priority (k : Ok.t) : int =
   | Ok.Merge_conflict -> 2
   | Ok.Ci -> 3
   | Ok.Review_comments -> 4
-  | Ok.Implementation_notes -> 5
+  | Ok.Pr_body -> 5
+  | Ok.Implementation_notes -> 6
 
 let is_feedback (k : Ok.t) : bool =
   match k with
-  | Ok.Human | Ok.Merge_conflict | Ok.Ci | Ok.Review_comments
+  | Ok.Human | Ok.Merge_conflict | Ok.Ci | Ok.Review_comments | Ok.Pr_body
   | Ok.Implementation_notes ->
       true
   | Ok.Rebase -> false

--- a/lib/project_store.ml
+++ b/lib/project_store.ml
@@ -41,6 +41,11 @@ let stored_gameplan_path project_name =
   let md = gameplan_path project_name in
   if Stdlib.Sys.file_exists md then md else gameplan_json_path project_name
 
+let pr_body_artifact_path ~project_name ~patch_id =
+  Stdlib.Filename.concat (project_dir project_name)
+    (Stdlib.Filename.concat "artifacts"
+       (Stdlib.Filename.concat (Types.Patch_id.to_string patch_id) "pr-body.md"))
+
 let ensure_dir path =
   let rec mkdir_p dir =
     if not (Stdlib.Sys.file_exists dir) then (

--- a/lib/project_store.ml
+++ b/lib/project_store.ml
@@ -41,10 +41,15 @@ let stored_gameplan_path project_name =
   let md = gameplan_path project_name in
   if Stdlib.Sys.file_exists md then md else gameplan_json_path project_name
 
-let pr_body_artifact_path ~project_name ~patch_id =
+let artifact_dir ~project_name ~patch_id =
   Stdlib.Filename.concat (project_dir project_name)
-    (Stdlib.Filename.concat "artifacts"
-       (Stdlib.Filename.concat (Types.Patch_id.to_string patch_id) "pr-body.md"))
+    (Stdlib.Filename.concat "artifacts" (Types.Patch_id.to_string patch_id))
+
+let pr_body_artifact_path ~project_name ~patch_id =
+  Stdlib.Filename.concat (artifact_dir ~project_name ~patch_id) "pr-body.md"
+
+let implementation_notes_artifact_path ~project_name ~patch_id =
+  Stdlib.Filename.concat (artifact_dir ~project_name ~patch_id) "notes.md"
 
 let ensure_dir path =
   let rec mkdir_p dir =

--- a/lib/project_store.mli
+++ b/lib/project_store.mli
@@ -66,6 +66,12 @@ val stored_gameplan_path : string -> string
 (** Returns the path to whichever stored gameplan file exists ([gameplan.md]
     takes precedence; falls back to [gameplan.json]). *)
 
+val pr_body_artifact_path :
+  project_name:string -> patch_id:Types.Patch_id.t -> string
+(** Absolute path the agent writes the LLM-authored PR body to. Lives under the
+    project's data directory at [artifacts/<patch_id>/pr-body.md] — outside the
+    worktree so it can never be accidentally committed. *)
+
 val project_exists : string -> bool
 (** Whether a project data directory with config exists. *)
 

--- a/lib/project_store.mli
+++ b/lib/project_store.mli
@@ -72,6 +72,13 @@ val pr_body_artifact_path :
     project's data directory at [artifacts/<patch_id>/pr-body.md] — outside the
     worktree so it can never be accidentally committed. *)
 
+val implementation_notes_artifact_path :
+  project_name:string -> patch_id:Types.Patch_id.t -> string
+(** Absolute path the agent writes the implementation-notes section to. Sibling
+    of [pr_body_artifact_path] at [artifacts/<patch_id>/notes.md]. The
+    supervisor composes the final PR body as
+    [<pr-body.md>\n\n## Implementation Notes\n\n<notes.md>]. *)
+
 val project_exists : string -> bool
 (** Whether a project data directory with config exists. *)
 

--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -412,7 +412,8 @@ let render_review_prompt ~(project_name : string) ?pr_number
             \   `gh api graphql -f query='mutation { \
              resolveReviewThread(input: {threadId: \"{thread_id}\"}) { thread \
              { isResolved } } }'`\n\n\
-             After addressing all comments, commit and push your changes."
+             After addressing all comments, commit your changes. The \
+             supervisor will push them for you — do not run `git push`."
             pr_ctx formatted pr_num_str)
 
 let render_ci_failure_prompt ~(project_name : string) ?pr_number
@@ -458,7 +459,8 @@ let render_ci_failure_prompt ~(project_name : string) ?pr_number
             "# CI Failures%s\n\n\
              The following CI checks failed:\n\n\
              %s\n\n\
-             After making your changes, commit and push."
+             After making your changes, commit them. The supervisor will push \
+             them for you — do not run `git push`."
             pr_ctx formatted)
 
 let render_ci_failure_unknown_prompt ~(project_name : string) ?pr_number () =
@@ -483,7 +485,8 @@ let render_ci_failure_unknown_prompt ~(project_name : string) ?pr_number () =
          One or more CI checks failed. Please investigate the failures and fix \
          them.\n\n\
          Run the CI checks locally or check the PR status for details.\n\n\
-         After making your changes, commit and push."
+         After making your changes, commit them. The supervisor will push them \
+         for you — do not run `git push`."
         pr_ctx)
 
 let render_merge_conflict_prompt ~(project_name : string) ?pr_number ?patch
@@ -577,7 +580,7 @@ Do NOT run `git rebase origin/%s` — the rebase is already set up with the
 correct --onto range. Starting a new rebase would re-introduce dependency
 commits that have already been stripped.
 
-After resolving all conflicts and completing the rebase, commit and push your changes.%s%s%s|}
+After resolving all conflicts and completing the rebase, commit your changes. The supervisor will push them for you — do not run `git push`.%s%s%s|}
         pr_ctx base_branch base_branch status_section diff_section task_context)
 
 let render_human_message_prompt ~(project_name : string)

--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -139,24 +139,10 @@ let render_patch_prompt ~(project_name : string) ?pr_number (patch : Patch.t)
     match pr_number with
     | Some _ -> ""
     | None ->
-        substitute_variables
-          {|
-**IMPORTANT: Open a draft PR immediately after your first commit.** Do not wait until implementation is complete.
+        {|
+**Do NOT create a PR yourself.** The supervisor opens the draft PR after your first commit lands on the remote, with a gameplan-derived title and body. Just commit your changes and the supervisor will handle PR creation and base-branch management.
 
-After your first commit, run:
-```bash
-gh pr create --draft --title '[{{project_name}}] Patch {{patch_id}}: {{title}}' --body 'Work in progress' --base {{base_branch}}
-```
-
-**NEVER change the PR base branch after creation.** The orchestrator manages PR base branches and draft status automatically.
-
-Then continue implementing until all tests pass.|}
-          [
-            ("project_name", project_name);
-            ("patch_id", patch_id);
-            ("title", patch.Patch.title);
-            ("base_branch", base_branch);
-          ]
+Continue implementing until all tests pass.|}
   in
   let vars =
     [
@@ -267,13 +253,6 @@ Then continue implementing until all tests pass.|}
 - Base branch: {{base_branch}}
 - PR: {{pr_str}}
 {{base_branch_note}}{{pr_instructions}}
-## PR Title (CRITICAL)
-**You MUST use this EXACT title format:**
-
-`[{{project_name}}] Patch {{patch_id}}: {{title}}`
-
-Do NOT use conventional commit format (e.g., `feat:`, `fix:`). The bracketed project name and patch number are required for tracking.
-
 ## Patches in Gameplan
 {{patches_list}}|}
         vars)

--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -257,6 +257,33 @@ Continue implementing until all tests pass.|}
 {{patches_list}}|}
         vars)
 
+let resolve_pr_body_source ~(artifact : string option) ~(fallback : string) :
+    string =
+  match artifact with
+  | Some body when String.length (String.strip body) > 0 -> body
+  | Some _ | None -> fallback
+
+let%test "resolve_pr_body_source: None artifact returns fallback" =
+  String.equal
+    (resolve_pr_body_source ~artifact:None ~fallback:"gameplan body")
+    "gameplan body"
+
+let%test "resolve_pr_body_source: empty artifact returns fallback" =
+  String.equal
+    (resolve_pr_body_source ~artifact:(Some "") ~fallback:"gameplan body")
+    "gameplan body"
+
+let%test "resolve_pr_body_source: whitespace-only artifact returns fallback" =
+  String.equal
+    (resolve_pr_body_source ~artifact:(Some "  \n\t  ")
+       ~fallback:"gameplan body")
+    "gameplan body"
+
+let%test "resolve_pr_body_source: non-empty artifact wins" =
+  String.equal
+    (resolve_pr_body_source ~artifact:(Some "agent body") ~fallback:"gameplan")
+    "agent body"
+
 let render_pr_description ~(project_name : string) (patch : Patch.t)
     (gameplan : Gameplan.t) =
   let patch_id = Patch_id.to_string patch.Patch.id in

--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -337,30 +337,26 @@ A separate, later phase will append `## Implementation Notes` to this body — d
         vars)
 
 let render_implementation_notes_prompt ~(project_name : string)
-    ~(pr_number : Pr_number.t) ~(pr_body : string) =
+    ~(pr_number : Pr_number.t) ~(artifact_path : string) =
   let pr_num_str = Int.to_string (Pr_number.to_int pr_number) in
-  let vars = [ ("pr_number", pr_num_str); ("pr_body", pr_body) ] in
+  let vars = [ ("pr_number", pr_num_str); ("artifact_path", artifact_path) ] in
   render_with_override ~project_name ~name:"implementation_notes" ~vars
     ~default:(fun () ->
       substitute_variables
-        {|You have just finished implementing this patch and a PR has been created.
+        {|You have just finished implementing this patch and a PR has been created. The supervisor opens a final phase where you write **just the implementation notes** — the "## Implementation Notes" section a reviewer cares about.
 
-The current PR description is:
+**Write the notes content (markdown, no header line) to `{{artifact_path}}`.** This is an absolute path outside the worktree — write it with the Write tool. The supervisor reads the file, prepends `## Implementation Notes`, and appends it to the PR body.
 
----
-{{pr_body}}
----
+Do NOT run `gh`, `git`, or any forge command — the supervisor handles upload.
 
-Your task: append an **## Implementation Notes** section to the PR body that describes what you actually did. Focus on:
+Focus on:
 
-- Key implementation decisions and trade-offs you made
-- Anything surprising or non-obvious about the approach
-- Deviations from the original plan (if any)
-- Important details a reviewer should know
+- Key implementation decisions and trade-offs you made.
+- Anything surprising or non-obvious about the approach.
+- Deviations from the original plan (if any).
+- Important details a reviewer should know.
 
-Do NOT repeat information already in the description. Keep it concise — a few bullet points is ideal.
-
-Use `gh pr edit {{pr_number}} --body-file -` to update the PR body. Read the current body first with `gh pr view {{pr_number}} --json body -q .body`, append your Implementation Notes section, then write the full body back. If an Implementation Notes section already exists, update it rather than duplicating it.|}
+Keep it concise — a few bullet points usually suffices. If you have nothing material to add (the patch is straightforward), write a single line acknowledging that.|}
         vars)
 
 let render_review_prompt ~(project_name : string) ?pr_number

--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -301,6 +301,41 @@ let render_pr_description ~(project_name : string) (patch : Patch.t)
 {{changes_section}}{{gameplan_spec_section}}{{patch_spec_section}}{{acceptance_criteria_section}}{{files_section}}|}
         vars)
 
+let render_pr_body_prompt ~(project_name : string) ~(pr_number : Pr_number.t)
+    ~(pr_body : string) ~(artifact_path : string) =
+  let pr_num_str = Int.to_string (Pr_number.to_int pr_number) in
+  let vars =
+    [
+      ("pr_number", pr_num_str);
+      ("pr_body", pr_body);
+      ("artifact_path", artifact_path);
+    ]
+  in
+  render_with_override ~project_name ~name:"pr_body" ~vars ~default:(fun () ->
+      substitute_variables
+        {|You have just finished implementing this patch. PR #{{pr_number}} was opened with a generic, gameplan-derived body. Your task is to write a better one — describing what you actually built — and the supervisor will upload it.
+
+The current PR body (gameplan-derived, will be replaced by what you write) is:
+
+---
+{{pr_body}}
+---
+
+**Write the full PR body to `{{artifact_path}}`.** This is an absolute path outside the worktree — write it with the Write tool. Do NOT run `gh`, `git`, or any forge command; the supervisor reads the file and PATCHes the PR.
+
+What to include in the body:
+
+- A short summary of what this patch does, in your own words.
+- Key implementation decisions and trade-offs you made.
+- Anything surprising or non-obvious about the approach.
+- Deviations from the original plan (if any).
+- Important context a reviewer should know.
+
+Write the **full body** (not a delta). It will replace the existing description verbatim. If you genuinely have nothing to add over the gameplan-derived body, write that body verbatim — the supervisor PATCH is idempotent.
+
+A separate, later phase will append `## Implementation Notes` to this body — do not include that section here.|}
+        vars)
+
 let render_implementation_notes_prompt ~(project_name : string)
     ~(pr_number : Pr_number.t) ~(pr_body : string) =
   let pr_num_str = Int.to_string (Pr_number.to_int pr_number) in

--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -580,7 +580,7 @@ Do NOT run `git rebase origin/%s` — the rebase is already set up with the
 correct --onto range. Starting a new rebase would re-introduce dependency
 commits that have already been stripped.
 
-After resolving all conflicts and completing the rebase, commit your changes. The supervisor will push them for you — do not run `git push`.%s%s%s|}
+After resolving all conflicts and completing the rebase, the supervisor will push the rebased commits for you — do not run `git push`.%s%s%s|}
         pr_ctx base_branch base_branch status_section diff_section task_context)
 
 let render_human_message_prompt ~(project_name : string)

--- a/lib/prompt.mli
+++ b/lib/prompt.mli
@@ -25,7 +25,7 @@ val render_pr_body_prompt :
   string
 
 val render_implementation_notes_prompt :
-  project_name:string -> pr_number:Pr_number.t -> pr_body:string -> string
+  project_name:string -> pr_number:Pr_number.t -> artifact_path:string -> string
 
 val render_review_prompt :
   project_name:string -> ?pr_number:Pr_number.t -> Comment.t list -> string

--- a/lib/prompt.mli
+++ b/lib/prompt.mli
@@ -17,6 +17,13 @@ val render_patch_prompt :
 val render_pr_description :
   project_name:string -> Patch.t -> Gameplan.t -> string
 
+val resolve_pr_body_source : artifact:string option -> fallback:string -> string
+(** Pure: choose between the agent-authored PR body artifact and a deterministic
+    fallback (typically the gameplan-derived body). Returns [fallback] when
+    [artifact] is [None] or contains only whitespace; returns the artifact
+    contents otherwise. Used by the supervisor when composing the final PR body
+    for the implementation-notes phase. *)
+
 val render_pr_body_prompt :
   project_name:string ->
   pr_number:Pr_number.t ->

--- a/lib/prompt.mli
+++ b/lib/prompt.mli
@@ -17,6 +17,13 @@ val render_patch_prompt :
 val render_pr_description :
   project_name:string -> Patch.t -> Gameplan.t -> string
 
+val render_pr_body_prompt :
+  project_name:string ->
+  pr_number:Pr_number.t ->
+  pr_body:string ->
+  artifact_path:string ->
+  string
+
 val render_implementation_notes_prompt :
   project_name:string -> pr_number:Pr_number.t -> pr_body:string -> string
 

--- a/lib/reconciler.ml
+++ b/lib/reconciler.ml
@@ -100,7 +100,7 @@ let plan_operations views ~has_merged ~branch_of ~graph ~main =
                     Some (merge_target graph v.id ~has_merged ~branch_of ~main)
               | Operation_kind.Human | Operation_kind.Merge_conflict
               | Operation_kind.Ci | Operation_kind.Review_comments
-              | Operation_kind.Implementation_notes ->
+              | Operation_kind.Pr_body | Operation_kind.Implementation_notes ->
                   None
             in
             if

--- a/lib/tui.ml
+++ b/lib/tui.ml
@@ -12,6 +12,7 @@ type display_status =
   | Addressing_review
   | Resolving_conflict
   | Responding_to_human
+  | Writing_pr_body
   | Adding_notes
   | Rebasing
   | Starting
@@ -36,6 +37,7 @@ let label = function
   | Addressing_review -> "addressing-review"
   | Resolving_conflict -> "resolving-conflict"
   | Responding_to_human -> "responding-to-human"
+  | Writing_pr_body -> "writing-pr-body"
   | Adding_notes -> "adding-notes"
   | Rebasing -> "rebasing"
   | Starting -> "starting"
@@ -56,6 +58,7 @@ let color = function
   | Addressing_review -> Term.Sgr.fg_yellow
   | Resolving_conflict -> Term.Sgr.fg_yellow
   | Responding_to_human -> Term.Sgr.fg_magenta
+  | Writing_pr_body -> Term.Sgr.fg_cyan
   | Adding_notes -> Term.Sgr.fg_cyan
   | Rebasing -> Term.Sgr.fg_cyan
   | Starting -> Term.Sgr.fg_cyan
@@ -98,6 +101,7 @@ let derive_display_status (ctx : State.Patch_ctx.t) ~patch_id
     | Some Review_comments -> Addressing_review
     | Some Merge_conflict -> Resolving_conflict
     | Some Human -> Responding_to_human
+    | Some Pr_body -> Writing_pr_body
     | Some Implementation_notes -> Adding_notes
     | Some Rebase -> Rebasing
     | None ->
@@ -353,7 +357,7 @@ let status_style = function
   | Approved_idle -> [ Term.Sgr.fg_green ]
   | Approved_running -> [ Term.Sgr.fg_green; Term.Sgr.bold ]
   | Fixing_ci | Addressing_review | Resolving_conflict | Responding_to_human
-  | Adding_notes ->
+  | Writing_pr_body | Adding_notes ->
       [ Term.Sgr.fg_cyan; Term.Sgr.bold ]
   | Rebasing -> [ Term.Sgr.fg_yellow ]
   | Starting | Updating -> [ Term.Sgr.fg_cyan ]
@@ -369,7 +373,7 @@ let status_indicator = function
   | Approved_idle -> "✓"
   | Approved_running -> "▶"
   | Fixing_ci | Addressing_review | Resolving_conflict | Responding_to_human
-  | Adding_notes ->
+  | Writing_pr_body | Adding_notes ->
       "▶"
   | Rebasing -> "↻"
   | Starting | Updating -> "▶"
@@ -637,6 +641,7 @@ let short_op_name = function
   | Operation_kind.Review_comments -> "review"
   | Operation_kind.Merge_conflict -> "conflict"
   | Operation_kind.Human -> "human"
+  | Operation_kind.Pr_body -> "pr-body"
   | Operation_kind.Implementation_notes -> "notes"
   | Operation_kind.Rebase -> "rebase"
 
@@ -745,7 +750,8 @@ let render_summary (views : patch_view list) =
   let is_running status =
     match status with
     | Fixing_ci | Addressing_review | Resolving_conflict | Responding_to_human
-    | Adding_notes | Rebasing | Starting | Updating | Approved_running ->
+    | Writing_pr_body | Adding_notes | Rebasing | Starting | Updating
+    | Approved_running ->
         true
     | Merged | Needs_help | Approved_idle | Ci_queued | Review_queued
     | Awaiting_ci | Awaiting_review | Blocked_by_dep | Pending ->

--- a/lib/tui.mli
+++ b/lib/tui.mli
@@ -10,6 +10,7 @@ type display_status =
   | Addressing_review
   | Resolving_conflict
   | Responding_to_human
+  | Writing_pr_body
   | Adding_notes
   | Rebasing
   | Starting

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -53,6 +53,7 @@ module Operation_kind = struct
     | Merge_conflict
     | Ci
     | Review_comments
+    | Pr_body
     | Implementation_notes
   [@@deriving show, eq, ord, sexp_of, compare, hash, yojson]
 
@@ -62,6 +63,7 @@ module Operation_kind = struct
     | Merge_conflict -> "merge-conflict"
     | Ci -> "ci"
     | Review_comments -> "review-comments"
+    | Pr_body -> "pr-body"
     | Implementation_notes -> "implementation-notes"
 end
 

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -51,6 +51,7 @@ module Operation_kind : sig
     | Merge_conflict
     | Ci
     | Review_comments
+    | Pr_body
     | Implementation_notes
   [@@deriving show, eq, ord, sexp_of, compare, hash, yojson]
 

--- a/lib_test/test_generators.ml
+++ b/lib_test/test_generators.ml
@@ -491,6 +491,7 @@ let all_display_statuses : Onton.Tui.display_status list =
     | Addressing_review -> Addressing_review
     | Resolving_conflict -> Resolving_conflict
     | Responding_to_human -> Responding_to_human
+    | Writing_pr_body -> Writing_pr_body
     | Adding_notes -> Adding_notes
     | Rebasing -> Rebasing
     | Starting -> Starting
@@ -512,6 +513,7 @@ let all_display_statuses : Onton.Tui.display_status list =
       Addressing_review;
       Resolving_conflict;
       Responding_to_human;
+      Writing_pr_body;
       Adding_notes;
       Rebasing;
       Starting;

--- a/lib_test/test_generators.ml
+++ b/lib_test/test_generators.ml
@@ -612,6 +612,7 @@ let gen_session_result =
         map (fun b -> Onton.Orchestrator.Session_failed { is_fresh = b }) bool;
         return Onton.Orchestrator.Session_give_up;
         return Onton.Orchestrator.Session_worktree_missing;
+        return Onton.Orchestrator.Session_push_failed;
       ])
 
 let print_session_result = Onton.Orchestrator.show_session_result

--- a/lib_test/test_generators.ml
+++ b/lib_test/test_generators.ml
@@ -517,6 +517,7 @@ let all_display_statuses : Onton.Tui.display_status list =
       Adding_notes;
       Rebasing;
       Starting;
+      Updating;
       Ci_queued;
       Review_queued;
       Awaiting_ci;

--- a/test/test_action_outcome_properties.ml
+++ b/test/test_action_outcome_properties.ml
@@ -79,6 +79,7 @@ let () =
       Operation_kind.Review_comments;
       Operation_kind.Human;
       Operation_kind.Merge_conflict;
+      Operation_kind.Pr_body;
       Operation_kind.Implementation_notes;
     ]
   in
@@ -153,7 +154,14 @@ let () =
     QCheck2.Test.make ~name:"AO-5: stale outcomes are identity"
       (QCheck2.Gen.oneof_list
          Operation_kind.
-           [ Ci; Review_comments; Human; Merge_conflict; Implementation_notes ])
+           [
+             Ci;
+             Review_comments;
+             Human;
+             Merge_conflict;
+             Pr_body;
+             Implementation_notes;
+           ])
       (fun kind ->
         try
           let orch, patches, gameplan, pid = bootstrap_one () in
@@ -270,3 +278,59 @@ let () =
   in
   assert (ci_count orch pid = before);
   Stdlib.print_endline "AO-7 passed"
+
+(* ========== AO-8: Respond_ok + Pr_body sets pr_body_delivered ========== *)
+
+let () =
+  let prop =
+    QCheck2.Test.make ~name:"AO-8: Respond_ok + Pr_body sets pr_body_delivered"
+      (QCheck2.Gen.return ()) (fun () ->
+        let orch, patches, gameplan, pid = bootstrap_one () in
+        assert (not (Orchestrator.agent orch pid).Patch_agent.pr_body_delivered);
+        let orch = make_busy orch patches gameplan pid Operation_kind.Pr_body in
+        let orch =
+          Orchestrator.apply_respond_outcome orch pid Operation_kind.Pr_body
+            Orchestrator.Respond_ok
+        in
+        (Orchestrator.agent orch pid).Patch_agent.pr_body_delivered)
+  in
+  QCheck2.Test.check_exn prop;
+  Stdlib.print_endline "AO-8 passed"
+
+(* ========== AO-9: Non-Respond_ok outcomes leave delivered flags untouched
+   ========== *)
+
+(* Pinned-down variant of AO-2: only Respond_ok flips the *_delivered flag.
+   Failed/Skip_empty/Retry_push/Stale must leave pr_body_delivered and
+   implementation_notes_delivered alone, so the next reconcile cycle re-
+   enqueues the phase. *)
+let () =
+  let non_ok_outcomes =
+    [
+      Orchestrator.Respond_failed;
+      Orchestrator.Respond_skip_empty;
+      Orchestrator.Respond_retry_push;
+      Orchestrator.Respond_stale;
+    ]
+  in
+  let prop =
+    QCheck2.Test.make
+      ~name:
+        "AO-9: non-Respond_ok outcomes leave Pr_body / Notes delivered flags \
+         false"
+      (QCheck2.Gen.pair
+         (QCheck2.Gen.oneof_list non_ok_outcomes)
+         (QCheck2.Gen.oneof_list
+            Operation_kind.[ Pr_body; Implementation_notes ]))
+      (fun (outcome, kind) ->
+        try
+          let orch, patches, gameplan, pid = bootstrap_one () in
+          let orch = make_busy orch patches gameplan pid kind in
+          let orch = Orchestrator.apply_respond_outcome orch pid kind outcome in
+          let a = Orchestrator.agent orch pid in
+          (not a.Patch_agent.pr_body_delivered)
+          && not a.Patch_agent.implementation_notes_delivered
+        with _ -> false)
+  in
+  QCheck2.Test.check_exn prop;
+  Stdlib.print_endline "AO-9 passed"

--- a/test/test_interleaving_properties.ml
+++ b/test/test_interleaving_properties.ml
@@ -1456,3 +1456,58 @@ let () =
   in
   QCheck2.Test.check_exn prop_pi12;
   Stdlib.print_endline "PI-12 passed"
+
+(** PI-13: Human messages enqueued while a Pr_body session is in flight are
+    re-delivered after the supervisor's push fails. This validates the
+    Session_push_failed contract end-to-end at the interleaving level: the LLM
+    session itself ran cleanly (so session_fallback is preserved), but
+    [complete_failed] still restored any inflight human messages so the next
+    iteration delivers them. Regression for the class of bug where a push
+    failure during a non-Human phase silently drops human messages. *)
+let () =
+  let prop_pi13 =
+    QCheck2.Test.make
+      ~name:"PI-13: human messages survive Session_push_failed during Pr_body"
+      ~count:300
+      (QCheck2.Gen.string_size (QCheck2.Gen.int_range 1 80))
+      (fun msg ->
+        let orch, pid, _patches = mk_bootstrapped () in
+        (* Reach a Pr_body-eligible state: PR exists, !pr_body_delivered.
+           Enqueue Pr_body so the Respond action's precondition holds. *)
+        let orch = Orchestrator.set_pr_body_delivered orch pid false in
+        let orch = Orchestrator.enqueue orch pid Operation_kind.Pr_body in
+        (* Begin a Pr_body session by firing the action — moves agent into
+           busy with current_op = Pr_body. *)
+        let orch =
+          Orchestrator.fire orch
+            (Orchestrator.Respond (pid, Operation_kind.Pr_body))
+        in
+        if not (Orchestrator.agent orch pid).Patch_agent.busy then
+          failwith "agent not busy after firing Respond(Pr_body)";
+        (* A human message arrives mid-session — supervisor enqueues it. *)
+        let orch = Orchestrator.send_human_message orch pid msg in
+        let pre = Orchestrator.agent orch pid in
+        if not (List.mem pre.Patch_agent.human_messages msg ~equal:String.equal)
+        then failwith "human message not in inbox after send";
+        (* Session ends with Session_push_failed (LLM ok, push failed).
+           apply_session_result must clear session_fallback (LLM was healthy)
+           AND complete_failed (commits did not ship — re-enqueue). *)
+        let orch =
+          Orchestrator.apply_session_result orch pid
+            Orchestrator.Session_push_failed
+        in
+        let post = Orchestrator.agent orch pid in
+        if post.Patch_agent.busy then
+          failwith "agent still busy after Session_push_failed";
+        (* The crucial invariant: the human message is still pending. *)
+        if
+          not (List.mem post.Patch_agent.human_messages msg ~equal:String.equal)
+        then failwith "human message lost after Session_push_failed";
+        (* And session_fallback was reset to Fresh_available so the next
+           iteration resumes the same session rather than burning its
+           fallback budget on a push problem. *)
+        Patch_agent.equal_session_fallback post.Patch_agent.session_fallback
+          Patch_agent.Fresh_available)
+  in
+  QCheck2.Test.check_exn prop_pi13;
+  Stdlib.print_endline "PI-13 passed"

--- a/test/test_orchestrator_properties.ml
+++ b/test/test_orchestrator_properties.ml
@@ -303,6 +303,15 @@ let () =
                 Orchestrator.set_pr_number orch first.Patch.id
                   (Pr_number.of_int 1)
               in
+              (* Mark post-PR phases done so the controller doesn't auto-
+                 enqueue Pr_body / Implementation_notes alongside [kind]. *)
+              let orch =
+                Orchestrator.set_pr_body_delivered orch first.Patch.id true
+              in
+              let orch =
+                Orchestrator.set_implementation_notes_delivered orch
+                  first.Patch.id true
+              in
               let orch = Orchestrator.complete orch first.Patch.id in
               let orch = Orchestrator.enqueue orch first.Patch.id kind in
               let _orch, _effects, actions = tick orch ~patches in

--- a/test/test_patch_agent.ml
+++ b/test/test_patch_agent.ml
@@ -677,10 +677,11 @@ let () =
               ~session_fallback:Fresh_available ~human_messages:[]
               ~inflight_human_messages:[] ~ci_checks:a.ci_checks
               ~merge_ready:false ~is_draft:false ~pr_description_applied:false
-              ~implementation_notes_delivered:false ~start_attempts_without_pr:0
-              ~conflict_noop_count:0 ~checks_passing:false ~current_op:None
-              ~current_message_id:None ~generation:0 ~worktree_path:None
-              ~branch_blocked:false ~llm_session_id:None
+              ~pr_body_delivered:false ~implementation_notes_delivered:false
+              ~start_attempts_without_pr:0 ~conflict_noop_count:0
+              ~checks_passing:false ~current_op:None ~current_message_id:None
+              ~generation:0 ~worktree_path:None ~branch_blocked:false
+              ~llm_session_id:None
           in
           let a = start a ~base_branch:br in
           List.is_empty a.ci_checks);
@@ -752,10 +753,11 @@ let () =
               ~ci_failure_count:0 ~session_fallback:Fresh_available
               ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
               ~merge_ready:false ~is_draft:false ~pr_description_applied:false
-              ~implementation_notes_delivered:false ~start_attempts_without_pr:0
-              ~conflict_noop_count:0 ~checks_passing:false ~current_op:None
-              ~current_message_id:None ~generation:0 ~worktree_path:None
-              ~branch_blocked:false ~llm_session_id:None
+              ~pr_body_delivered:false ~implementation_notes_delivered:false
+              ~start_attempts_without_pr:0 ~conflict_noop_count:0
+              ~checks_passing:false ~current_op:None ~current_message_id:None
+              ~generation:0 ~worktree_path:None ~branch_blocked:false
+              ~llm_session_id:None
           in
           let a = enqueue a Operation_kind.Rebase in
           let a = rebase a ~base_branch:new_base in

--- a/test/test_patch_agent.ml
+++ b/test/test_patch_agent.ml
@@ -47,7 +47,6 @@ let () =
           && Option.is_none t.base_branch
           && t.ci_failure_count = 0
           && equal_session_fallback t.session_fallback Fresh_available
-          && (not t.pr_description_applied)
           && (not t.implementation_notes_delivered)
           && t.start_attempts_without_pr = 0
           && List.is_empty t.human_messages
@@ -676,12 +675,11 @@ let () =
               ~base_branch:None ~notified_base_branch:None ~ci_failure_count:0
               ~session_fallback:Fresh_available ~human_messages:[]
               ~inflight_human_messages:[] ~ci_checks:a.ci_checks
-              ~merge_ready:false ~is_draft:false ~pr_description_applied:false
-              ~pr_body_delivered:false ~implementation_notes_delivered:false
-              ~start_attempts_without_pr:0 ~conflict_noop_count:0
-              ~checks_passing:false ~current_op:None ~current_message_id:None
-              ~generation:0 ~worktree_path:None ~branch_blocked:false
-              ~llm_session_id:None
+              ~merge_ready:false ~is_draft:false ~pr_body_delivered:false
+              ~implementation_notes_delivered:false ~start_attempts_without_pr:0
+              ~conflict_noop_count:0 ~checks_passing:false ~current_op:None
+              ~current_message_id:None ~generation:0 ~worktree_path:None
+              ~branch_blocked:false ~llm_session_id:None
           in
           let a = start a ~base_branch:br in
           List.is_empty a.ci_checks);
@@ -752,12 +750,11 @@ let () =
               ~base_branch:(Some br) ~notified_base_branch:(Some br)
               ~ci_failure_count:0 ~session_fallback:Fresh_available
               ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
-              ~merge_ready:false ~is_draft:false ~pr_description_applied:false
-              ~pr_body_delivered:false ~implementation_notes_delivered:false
-              ~start_attempts_without_pr:0 ~conflict_noop_count:0
-              ~checks_passing:false ~current_op:None ~current_message_id:None
-              ~generation:0 ~worktree_path:None ~branch_blocked:false
-              ~llm_session_id:None
+              ~merge_ready:false ~is_draft:false ~pr_body_delivered:false
+              ~implementation_notes_delivered:false ~start_attempts_without_pr:0
+              ~conflict_noop_count:0 ~checks_passing:false ~current_op:None
+              ~current_message_id:None ~generation:0 ~worktree_path:None
+              ~branch_blocked:false ~llm_session_id:None
           in
           let a = enqueue a Operation_kind.Rebase in
           let a = rebase a ~base_branch:new_base in
@@ -881,11 +878,10 @@ let () =
         (fun pid ->
           let a = create ~branch:br0 pid in
           let a = increment_start_attempts_without_pr a in
-          let a = set_pr_description_applied a true in
+          let a = set_pr_body_delivered a true in
           let a = set_implementation_notes_delivered a true in
           let a = set_pr_number a (Pr_number.of_int 7) in
-          has_pr a && a.is_draft
-          && (not a.pr_description_applied)
+          has_pr a && a.is_draft && (not a.pr_body_delivered)
           && (not a.implementation_notes_delivered)
           && a.start_attempts_without_pr = 0);
       Test.make ~name:"on_pr_discovery_failure increments durable attempt count"

--- a/test/test_patch_controller.ml
+++ b/test/test_patch_controller.ml
@@ -45,12 +45,15 @@ let make_orch patch agent =
 let make_agent ~patch_id ~branch ~pr_number ~merged ~queue ~base_branch
     ~is_draft ~pr_description_applied ~implementation_notes_delivered
     ~start_attempts_without_pr =
+  (* Default pr_body_delivered=true for existing tests so the notes-gate
+     does not block notes enqueuing. New Pr_body-specific tests construct
+     agents via Patch_agent.restore directly. *)
   Patch_agent.restore ~patch_id ~branch ~pr_number ~has_session:false
     ~busy:false ~merged ~queue ~satisfies:false ~changed:false
     ~has_conflict:false ~base_branch ~notified_base_branch:base_branch
     ~ci_failure_count:0 ~session_fallback:Patch_agent.Fresh_available
     ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
-    ~merge_ready:false ~is_draft ~pr_description_applied
+    ~merge_ready:false ~is_draft ~pr_description_applied ~pr_body_delivered:true
     ~implementation_notes_delivered ~start_attempts_without_pr
     ~conflict_noop_count:0 ~checks_passing:false ~current_op:None
     ~current_message_id:None ~generation:0 ~worktree_path:None
@@ -534,10 +537,11 @@ let () =
             ~ci_failure_count:1 ~session_fallback:Patch_agent.Fresh_available
             ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
             ~merge_ready:false ~is_draft:false ~pr_description_applied:true
-            ~implementation_notes_delivered:true ~start_attempts_without_pr:0
-            ~conflict_noop_count:0 ~checks_passing:false ~current_op:None
-            ~current_message_id:None ~generation:0 ~worktree_path:None
-            ~branch_blocked:false ~llm_session_id:None
+            ~pr_body_delivered:true ~implementation_notes_delivered:true
+            ~start_attempts_without_pr:0 ~conflict_noop_count:0
+            ~checks_passing:false ~current_op:None ~current_message_id:None
+            ~generation:0 ~worktree_path:None ~branch_blocked:false
+            ~llm_session_id:None
         in
         let orch = make_orch patch agent in
         let poll =
@@ -871,10 +875,11 @@ let () =
             ~session_fallback:Patch_agent.Fresh_available ~human_messages:[]
             ~inflight_human_messages:[] ~ci_checks:[] ~merge_ready:false
             ~is_draft:false ~pr_description_applied:false
-            ~implementation_notes_delivered:false ~start_attempts_without_pr:0
-            ~conflict_noop_count:0 ~checks_passing:false ~current_op:None
-            ~current_message_id:None ~generation:0 ~worktree_path:None
-            ~branch_blocked:false ~llm_session_id:None
+            ~pr_body_delivered:true ~implementation_notes_delivered:false
+            ~start_attempts_without_pr:0 ~conflict_noop_count:0
+            ~checks_passing:false ~current_op:None ~current_message_id:None
+            ~generation:0 ~worktree_path:None ~branch_blocked:false
+            ~llm_session_id:None
         in
         let orch =
           Orchestrator.restore
@@ -908,10 +913,11 @@ let () =
             ~ci_failure_count:0 ~session_fallback:Patch_agent.Fresh_available
             ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
             ~merge_ready:false ~is_draft:false ~pr_description_applied:false
-            ~implementation_notes_delivered:false ~start_attempts_without_pr:0
-            ~conflict_noop_count:0 ~checks_passing:false ~current_op:None
-            ~current_message_id:None ~generation:0 ~worktree_path:None
-            ~branch_blocked:false ~llm_session_id:None
+            ~pr_body_delivered:true ~implementation_notes_delivered:false
+            ~start_attempts_without_pr:0 ~conflict_noop_count:0
+            ~checks_passing:false ~current_op:None ~current_message_id:None
+            ~generation:0 ~worktree_path:None ~branch_blocked:false
+            ~llm_session_id:None
         in
         let orch =
           Orchestrator.restore

--- a/test/test_patch_controller.ml
+++ b/test/test_patch_controller.ml
@@ -43,8 +43,7 @@ let make_orch patch agent =
     ~main_branch:main
 
 let make_agent ~patch_id ~branch ~pr_number ~merged ~queue ~base_branch
-    ~is_draft ~pr_description_applied ~implementation_notes_delivered
-    ~start_attempts_without_pr =
+    ~is_draft ~implementation_notes_delivered ~start_attempts_without_pr =
   (* Default pr_body_delivered=true for existing tests so the notes-gate
      does not block notes enqueuing. New Pr_body-specific tests construct
      agents via Patch_agent.restore directly. *)
@@ -53,7 +52,7 @@ let make_agent ~patch_id ~branch ~pr_number ~merged ~queue ~base_branch
     ~has_conflict:false ~base_branch ~notified_base_branch:base_branch
     ~ci_failure_count:0 ~session_fallback:Patch_agent.Fresh_available
     ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
-    ~merge_ready:false ~is_draft ~pr_description_applied ~pr_body_delivered:true
+    ~merge_ready:false ~is_draft ~pr_body_delivered:true
     ~implementation_notes_delivered ~start_attempts_without_pr
     ~conflict_noop_count:0 ~checks_passing:false ~current_op:None
     ~current_message_id:None ~generation:0 ~worktree_path:None
@@ -63,27 +62,15 @@ let has_notes_queued agent =
   List.mem agent.Patch_agent.queue Operation_kind.Implementation_notes
     ~equal:Operation_kind.equal
 
-let has_description_effect effects =
-  List.exists effects ~f:(function
-    | Patch_controller.Set_pr_description _ -> true
-    | Patch_controller.Set_pr_draft _ | Patch_controller.Set_pr_base _ -> false)
-
 let has_draft_effect effects =
   List.exists effects ~f:(function
     | Patch_controller.Set_pr_draft _ -> true
-    | Patch_controller.Set_pr_description _ | Patch_controller.Set_pr_base _ ->
-        false)
-
-let description_effect effects =
-  List.find_map effects ~f:(function
-    | Patch_controller.Set_pr_description _ as e -> Some e
-    | Patch_controller.Set_pr_draft _ | Patch_controller.Set_pr_base _ -> None)
+    | Patch_controller.Set_pr_base _ -> false)
 
 let draft_effect effects =
   List.find_map effects ~f:(function
     | Patch_controller.Set_pr_draft _ as e -> Some e
-    | Patch_controller.Set_pr_description _ | Patch_controller.Set_pr_base _ ->
-        None)
+    | Patch_controller.Set_pr_base _ -> None)
 
 let apply_all_effect_successes orch effects =
   List.fold effects ~init:orch ~f:Patch_controller.apply_github_effect_success
@@ -124,7 +111,6 @@ let () =
       let* queue = gen_operation_kind_queue in
       let* use_main_base = bool in
       let* is_draft = bool in
-      let* pr_description_applied = bool in
       let* implementation_notes_delivered = bool in
       let* start_attempts_without_pr = int_range 0 3 in
       let base_branch =
@@ -134,8 +120,7 @@ let () =
       let patch = make_patch pid branch in
       let agent =
         make_agent ~patch_id:pid ~branch ~pr_number ~merged ~queue ~base_branch
-          ~is_draft ~pr_description_applied ~implementation_notes_delivered
-          ~start_attempts_without_pr
+          ~is_draft ~implementation_notes_delivered ~start_attempts_without_pr
       in
       return (patch, make_gameplan patch, make_orch patch agent))
   in
@@ -201,8 +186,7 @@ let () =
           make_agent ~patch_id:pid ~branch
             ~pr_number:(Some (Pr_number.of_int 42))
             ~merged:false ~queue:[] ~base_branch:(Some main) ~is_draft:true
-            ~pr_description_applied:true ~implementation_notes_delivered:false
-            ~start_attempts_without_pr:0
+            ~implementation_notes_delivered:false ~start_attempts_without_pr:0
         in
         let orch = make_orch patch agent in
         let orch1, effects1 =
@@ -222,54 +206,6 @@ let () =
         && List.is_empty effects1 && List.is_empty effects2)
   in
 
-  let prop_description_reemits_until_success =
-    Test.make
-      ~name:"patch_controller: description effect re-emits until acknowledged"
-      ~count:200
-      Gen.(pair gen_patch_id gen_branch)
-      (fun (pid, branch) ->
-        let patch = make_patch pid branch in
-        let gameplan = make_gameplan patch in
-        (* pr_body_delivered must be false so that Set_pr_description fires;
-           once the agent-authored body is delivered, it supersedes the
-           gameplan-derived description. *)
-        let agent =
-          Patch_agent.restore ~patch_id:pid ~branch
-            ~pr_number:(Some (Pr_number.of_int 42))
-            ~has_session:false ~busy:false ~merged:false ~queue:[]
-            ~satisfies:false ~changed:false ~has_conflict:false
-            ~base_branch:(Some branch) ~notified_base_branch:(Some branch)
-            ~ci_failure_count:0 ~session_fallback:Patch_agent.Fresh_available
-            ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
-            ~merge_ready:false ~is_draft:true ~pr_description_applied:false
-            ~pr_body_delivered:false ~implementation_notes_delivered:false
-            ~start_attempts_without_pr:0 ~conflict_noop_count:0
-            ~checks_passing:false ~current_op:None ~current_message_id:None
-            ~generation:0 ~worktree_path:None ~branch_blocked:false
-            ~llm_session_id:None
-        in
-        let orch = make_orch patch agent in
-        begin try
-          let orch1, effects1 =
-            Patch_controller.reconcile_patch orch ~project_name:"test-project"
-              ~gameplan ~patch
-          in
-          match description_effect effects1 with
-          | None -> false
-          | Some eff ->
-              let orch2 =
-                Patch_controller.apply_github_effect_success orch1 eff
-              in
-              let _orch3, effects2 =
-                Patch_controller.reconcile_patch orch2
-                  ~project_name:"test-project" ~gameplan ~patch
-              in
-              has_description_effect effects1
-              && not (has_description_effect effects2)
-        with _ -> false
-        end)
-  in
-
   let prop_draft_reemits_until_success =
     Test.make ~name:"patch_controller: draft effect re-emits until acknowledged"
       ~count:200
@@ -282,7 +218,7 @@ let () =
           make_agent ~patch_id:pid ~branch
             ~pr_number:(Some (Pr_number.of_int 42))
             ~merged:false ~queue:[] ~base_branch:(Some main)
-            ~is_draft:(not desired_draft) ~pr_description_applied:true
+            ~is_draft:(not desired_draft)
             ~implementation_notes_delivered:notes_delivered
             ~start_attempts_without_pr:0
         in
@@ -319,8 +255,7 @@ let () =
         let agent =
           make_agent ~patch_id:pid ~branch ~pr_number:None ~merged:false
             ~queue:[] ~base_branch:None ~is_draft:false
-            ~pr_description_applied:false ~implementation_notes_delivered:false
-            ~start_attempts_without_pr:2
+            ~implementation_notes_delivered:false ~start_attempts_without_pr:2
         in
         let orch = make_orch patch agent in
         let orch1, effects1 =
@@ -352,8 +287,7 @@ let () =
           make_agent ~patch_id:pid ~branch
             ~pr_number:(Some (Pr_number.of_int 42))
             ~merged:false ~queue:[] ~base_branch:(Some main) ~is_draft:true
-            ~pr_description_applied:true ~implementation_notes_delivered:false
-            ~start_attempts_without_pr:0
+            ~implementation_notes_delivered:false ~start_attempts_without_pr:0
         in
         let orch = make_orch patch agent in
         let orch, effects =
@@ -384,8 +318,7 @@ let () =
         let agent =
           make_agent ~patch_id:pid ~branch ~pr_number:None ~merged:false
             ~queue:[] ~base_branch:None ~is_draft:false
-            ~pr_description_applied:false ~implementation_notes_delivered:false
-            ~start_attempts_without_pr:2
+            ~implementation_notes_delivered:false ~start_attempts_without_pr:2
         in
         let orch = make_orch patch agent in
         let orch, effects =
@@ -423,12 +356,11 @@ let () =
             ~base_branch:(Some branch) ~notified_base_branch:(Some branch)
             ~ci_failure_count:0 ~session_fallback:Patch_agent.Fresh_available
             ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
-            ~merge_ready:false ~is_draft:true ~pr_description_applied:false
-            ~pr_body_delivered:false ~implementation_notes_delivered:true
-            ~start_attempts_without_pr:0 ~conflict_noop_count:0
-            ~checks_passing:false ~current_op:None ~current_message_id:None
-            ~generation:0 ~worktree_path:None ~branch_blocked:false
-            ~llm_session_id:None
+            ~merge_ready:false ~is_draft:true ~pr_body_delivered:false
+            ~implementation_notes_delivered:true ~start_attempts_without_pr:0
+            ~conflict_noop_count:0 ~checks_passing:false ~current_op:None
+            ~current_message_id:None ~generation:0 ~worktree_path:None
+            ~branch_blocked:false ~llm_session_id:None
         in
         let orch = make_orch patch agent in
         (* Apply effects in a loop until convergence (max 5 rounds). *)
@@ -446,8 +378,7 @@ let () =
           Patch_controller.reconcile_all orch ~project_name:"test-project"
             ~gameplan
         in
-        has_description_effect effects1
-        && converge (apply_all_effect_successes orch1 effects1) 2)
+        converge (apply_all_effect_successes orch1 effects1) 2)
   in
 
   let prop_poll_to_controller_promotes_ready_after_notes =
@@ -464,8 +395,7 @@ let () =
           make_agent ~patch_id:pid ~branch
             ~pr_number:(Some (Pr_number.of_int 42))
             ~merged:false ~queue:[] ~base_branch:(Some main) ~is_draft:true
-            ~pr_description_applied:true ~implementation_notes_delivered:true
-            ~start_attempts_without_pr:0
+            ~implementation_notes_delivered:true ~start_attempts_without_pr:0
         in
         let orch = make_orch patch agent in
         let poll =
@@ -506,8 +436,7 @@ let () =
           make_agent ~patch_id:pid ~branch
             ~pr_number:(Some (Pr_number.of_int 42))
             ~merged:false ~queue:[] ~base_branch:(Some main) ~is_draft:true
-            ~pr_description_applied:true ~implementation_notes_delivered:false
-            ~start_attempts_without_pr:0
+            ~implementation_notes_delivered:false ~start_attempts_without_pr:0
         in
         let orch = make_orch patch agent in
         let poll =
@@ -556,12 +485,11 @@ let () =
             ~base_branch:(Some main) ~notified_base_branch:(Some main)
             ~ci_failure_count:1 ~session_fallback:Patch_agent.Fresh_available
             ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
-            ~merge_ready:false ~is_draft:false ~pr_description_applied:true
-            ~pr_body_delivered:true ~implementation_notes_delivered:true
-            ~start_attempts_without_pr:0 ~conflict_noop_count:0
-            ~checks_passing:false ~current_op:None ~current_message_id:None
-            ~generation:0 ~worktree_path:None ~branch_blocked:false
-            ~llm_session_id:None
+            ~merge_ready:false ~is_draft:false ~pr_body_delivered:true
+            ~implementation_notes_delivered:true ~start_attempts_without_pr:0
+            ~conflict_noop_count:0 ~checks_passing:false ~current_op:None
+            ~current_message_id:None ~generation:0 ~worktree_path:None
+            ~branch_blocked:false ~llm_session_id:None
         in
         let orch = make_orch patch agent in
         let poll =
@@ -596,8 +524,7 @@ let () =
           make_agent ~patch_id:pid ~branch
             ~pr_number:(Some (Pr_number.of_int 42))
             ~merged:false ~queue:[] ~base_branch:(Some main) ~is_draft:true
-            ~pr_description_applied:true ~implementation_notes_delivered:false
-            ~start_attempts_without_pr:0
+            ~implementation_notes_delivered:false ~start_attempts_without_pr:0
         in
         let orch = make_orch patch agent in
         let poll =
@@ -636,8 +563,7 @@ let () =
           make_agent ~patch_id:pid ~branch
             ~pr_number:(Some (Pr_number.of_int 42))
             ~merged:false ~queue:[] ~base_branch:None ~is_draft:true
-            ~pr_description_applied:true ~implementation_notes_delivered:false
-            ~start_attempts_without_pr:0
+            ~implementation_notes_delivered:false ~start_attempts_without_pr:0
         in
         let orch = make_orch patch agent in
         let poll =
@@ -695,52 +621,49 @@ let () =
             ~base_branch:(Some main) ~notified_base_branch:(Some main)
             ~ci_failure_count:0 ~session_fallback:Patch_agent.Fresh_available
             ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
-            ~merge_ready:false ~is_draft:true ~pr_description_applied:false
-            ~pr_body_delivered:false ~implementation_notes_delivered:false
-            ~start_attempts_without_pr:0 ~conflict_noop_count:0
-            ~checks_passing:false ~current_op:None ~current_message_id:None
-            ~generation:0 ~worktree_path:None ~branch_blocked:false
-            ~llm_session_id:None
+            ~merge_ready:false ~is_draft:true ~pr_body_delivered:false
+            ~implementation_notes_delivered:false ~start_attempts_without_pr:0
+            ~conflict_noop_count:0 ~checks_passing:false ~current_op:None
+            ~current_message_id:None ~generation:0 ~worktree_path:None
+            ~branch_blocked:false ~llm_session_id:None
         in
         let orch = make_orch patch agent in
         begin try
-          (* Cycle 1: description effect fires, Pr_body enqueued *)
-          let orch1, effects1, _actions1 =
+          (* Cycle 1: Pr_body enqueued *)
+          let orch1, _effects1, _actions1 =
             run_controller_cycle ~gameplan orch
           in
-          if not (has_description_effect effects1) then false
-          else
-            (* Fire Pr_body action and simulate delivery *)
-            let orch1 =
-              Orchestrator.fire orch1
-                (Orchestrator.Respond (pid, Operation_kind.Pr_body))
-            in
-            let orch1 = Orchestrator.set_pr_body_delivered orch1 pid true in
-            let orch1 = Orchestrator.complete orch1 pid in
-            (* Cycle 2: notes now eligible *)
-            let orch2, _effects2, actions2 =
-              run_controller_cycle ~gameplan orch1
-            in
-            match implementation_notes_action actions2 pid with
-            | None -> false
-            | Some notes_action ->
-                let orch2 = Orchestrator.fire orch2 notes_action in
-                let orch2 =
-                  Orchestrator.set_implementation_notes_delivered orch2 pid true
-                in
-                let orch2 = Orchestrator.complete orch2 pid in
-                (* Cycle 3: should converge — only draft effect *)
-                let _orch3, effects3, actions3 =
-                  run_controller_cycle ~gameplan orch2
-                in
-                has_draft_effect effects3
-                && not
-                     (List.exists actions3 ~f:(function
-                       | Orchestrator.Respond (action_pid, kind) ->
-                           Patch_id.equal action_pid pid
-                           && Operation_kind.equal kind
-                                Operation_kind.Implementation_notes
-                       | Orchestrator.Start _ | Orchestrator.Rebase _ -> false))
+          (* Fire Pr_body action and simulate delivery *)
+          let orch1 =
+            Orchestrator.fire orch1
+              (Orchestrator.Respond (pid, Operation_kind.Pr_body))
+          in
+          let orch1 = Orchestrator.set_pr_body_delivered orch1 pid true in
+          let orch1 = Orchestrator.complete orch1 pid in
+          (* Cycle 2: notes now eligible *)
+          let orch2, _effects2, actions2 =
+            run_controller_cycle ~gameplan orch1
+          in
+          match implementation_notes_action actions2 pid with
+          | None -> false
+          | Some notes_action ->
+              let orch2 = Orchestrator.fire orch2 notes_action in
+              let orch2 =
+                Orchestrator.set_implementation_notes_delivered orch2 pid true
+              in
+              let orch2 = Orchestrator.complete orch2 pid in
+              (* Cycle 3: should converge — only draft effect *)
+              let _orch3, effects3, actions3 =
+                run_controller_cycle ~gameplan orch2
+              in
+              has_draft_effect effects3
+              && not
+                   (List.exists actions3 ~f:(function
+                     | Orchestrator.Respond (action_pid, kind) ->
+                         Patch_id.equal action_pid pid
+                         && Operation_kind.equal kind
+                              Operation_kind.Implementation_notes
+                     | Orchestrator.Start _ | Orchestrator.Rebase _ -> false))
         with _ -> false
         end)
   in
@@ -749,17 +672,13 @@ let () =
   let has_base_effect effects =
     List.exists effects ~f:(function
       | Patch_controller.Set_pr_base _ -> true
-      | Patch_controller.Set_pr_description _ | Patch_controller.Set_pr_draft _
-        ->
-          false)
+      | Patch_controller.Set_pr_draft _ -> false)
   in
 
   let base_effect effects =
     List.find_map effects ~f:(function
       | Patch_controller.Set_pr_base _ as e -> Some e
-      | Patch_controller.Set_pr_description _ | Patch_controller.Set_pr_draft _
-        ->
-          None)
+      | Patch_controller.Set_pr_draft _ -> None)
   in
 
   let prop_set_pr_base_emitted_on_mismatch =
@@ -777,8 +696,7 @@ let () =
           make_agent ~patch_id:pid ~branch
             ~pr_number:(Some (Pr_number.of_int 42))
             ~merged:false ~queue:[] ~base_branch:(Some branch) ~is_draft:true
-            ~pr_description_applied:true ~implementation_notes_delivered:true
-            ~start_attempts_without_pr:0
+            ~implementation_notes_delivered:true ~start_attempts_without_pr:0
         in
         let orch = make_orch patch agent in
         let _orch', effects =
@@ -790,10 +708,7 @@ let () =
           match base_effect effects with
           | Some (Patch_controller.Set_pr_base { base; _ }) ->
               Branch.equal base main
-          | Some (Patch_controller.Set_pr_description _)
-          | Some (Patch_controller.Set_pr_draft _)
-          | None ->
-              false)
+          | Some (Patch_controller.Set_pr_draft _) | None -> false)
   in
 
   let prop_set_pr_base_not_emitted_when_correct =
@@ -811,8 +726,7 @@ let () =
           make_agent ~patch_id:pid ~branch
             ~pr_number:(Some (Pr_number.of_int 42))
             ~merged:false ~queue:[] ~base_branch:(Some main) ~is_draft:true
-            ~pr_description_applied:true ~implementation_notes_delivered:true
-            ~start_attempts_without_pr:0
+            ~implementation_notes_delivered:true ~start_attempts_without_pr:0
         in
         let orch = make_orch patch agent in
         let _orch', effects =
@@ -835,8 +749,7 @@ let () =
           make_agent ~patch_id:pid ~branch
             ~pr_number:(Some (Pr_number.of_int 42))
             ~merged:false ~queue:[] ~base_branch:(Some branch) ~is_draft:true
-            ~pr_description_applied:true ~implementation_notes_delivered:true
-            ~start_attempts_without_pr:0
+            ~implementation_notes_delivered:true ~start_attempts_without_pr:0
         in
         let orch = make_orch patch agent in
         let orch1, effects1 =
@@ -864,8 +777,7 @@ let () =
           make_agent ~patch_id:pid ~branch
             ~pr_number:(Some (Pr_number.of_int 42))
             ~merged:false ~queue:[] ~base_branch:(Some branch) ~is_draft:false
-            ~pr_description_applied:true ~implementation_notes_delivered:true
-            ~start_attempts_without_pr:0
+            ~implementation_notes_delivered:true ~start_attempts_without_pr:0
         in
         let orch = make_orch patch agent in
         let obs =
@@ -914,12 +826,11 @@ let () =
             ~base_branch:None ~notified_base_branch:None ~ci_failure_count:0
             ~session_fallback:Patch_agent.Fresh_available ~human_messages:[]
             ~inflight_human_messages:[] ~ci_checks:[] ~merge_ready:false
-            ~is_draft:false ~pr_description_applied:false
-            ~pr_body_delivered:true ~implementation_notes_delivered:false
-            ~start_attempts_without_pr:0 ~conflict_noop_count:0
-            ~checks_passing:false ~current_op:None ~current_message_id:None
-            ~generation:0 ~worktree_path:None ~branch_blocked:false
-            ~llm_session_id:None
+            ~is_draft:false ~pr_body_delivered:true
+            ~implementation_notes_delivered:false ~start_attempts_without_pr:0
+            ~conflict_noop_count:0 ~checks_passing:false ~current_op:None
+            ~current_message_id:None ~generation:0 ~worktree_path:None
+            ~branch_blocked:false ~llm_session_id:None
         in
         let orch =
           Orchestrator.restore
@@ -952,12 +863,11 @@ let () =
             ~base_branch:(Some main) ~notified_base_branch:(Some main)
             ~ci_failure_count:0 ~session_fallback:Patch_agent.Fresh_available
             ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
-            ~merge_ready:false ~is_draft:false ~pr_description_applied:false
-            ~pr_body_delivered:true ~implementation_notes_delivered:false
-            ~start_attempts_without_pr:0 ~conflict_noop_count:0
-            ~checks_passing:false ~current_op:None ~current_message_id:None
-            ~generation:0 ~worktree_path:None ~branch_blocked:false
-            ~llm_session_id:None
+            ~merge_ready:false ~is_draft:false ~pr_body_delivered:true
+            ~implementation_notes_delivered:false ~start_attempts_without_pr:0
+            ~conflict_noop_count:0 ~checks_passing:false ~current_op:None
+            ~current_message_id:None ~generation:0 ~worktree_path:None
+            ~branch_blocked:false ~llm_session_id:None
         in
         let orch =
           Orchestrator.restore
@@ -974,7 +884,6 @@ let () =
       prop_deterministic;
       prop_plan_tick_deterministic;
       prop_notes_queue_idempotent;
-      prop_description_reemits_until_success;
       prop_draft_reemits_until_success;
       prop_intervention_stable_after_threshold;
       prop_reconcile_all_exposes_notes_as_next_action;

--- a/test/test_patch_controller.ml
+++ b/test/test_patch_controller.ml
@@ -630,40 +630,49 @@ let () =
         let orch = make_orch patch agent in
         begin try
           (* Cycle 1: Pr_body enqueued *)
-          let orch1, _effects1, _actions1 =
+          let orch1, _effects1, actions1 =
             run_controller_cycle ~gameplan orch
           in
-          (* Fire Pr_body action and simulate delivery *)
-          let orch1 =
-            Orchestrator.fire orch1
-              (Orchestrator.Respond (pid, Operation_kind.Pr_body))
+          let has_pr_body_action =
+            List.exists actions1 ~f:(function
+              | Orchestrator.Respond (action_pid, kind) ->
+                  Patch_id.equal action_pid pid
+                  && Operation_kind.equal kind Operation_kind.Pr_body
+              | Orchestrator.Start _ | Orchestrator.Rebase _ -> false)
           in
-          let orch1 = Orchestrator.set_pr_body_delivered orch1 pid true in
-          let orch1 = Orchestrator.complete orch1 pid in
-          (* Cycle 2: notes now eligible *)
-          let orch2, _effects2, actions2 =
-            run_controller_cycle ~gameplan orch1
-          in
-          match implementation_notes_action actions2 pid with
-          | None -> false
-          | Some notes_action ->
-              let orch2 = Orchestrator.fire orch2 notes_action in
-              let orch2 =
-                Orchestrator.set_implementation_notes_delivered orch2 pid true
-              in
-              let orch2 = Orchestrator.complete orch2 pid in
-              (* Cycle 3: should converge — only draft effect *)
-              let _orch3, effects3, actions3 =
-                run_controller_cycle ~gameplan orch2
-              in
-              has_draft_effect effects3
-              && not
-                   (List.exists actions3 ~f:(function
-                     | Orchestrator.Respond (action_pid, kind) ->
-                         Patch_id.equal action_pid pid
-                         && Operation_kind.equal kind
-                              Operation_kind.Implementation_notes
-                     | Orchestrator.Start _ | Orchestrator.Rebase _ -> false))
+          if not has_pr_body_action then false
+          else
+            (* Fire Pr_body action and simulate delivery *)
+            let orch1 =
+              Orchestrator.fire orch1
+                (Orchestrator.Respond (pid, Operation_kind.Pr_body))
+            in
+            let orch1 = Orchestrator.set_pr_body_delivered orch1 pid true in
+            let orch1 = Orchestrator.complete orch1 pid in
+            (* Cycle 2: notes now eligible *)
+            let orch2, _effects2, actions2 =
+              run_controller_cycle ~gameplan orch1
+            in
+            match implementation_notes_action actions2 pid with
+            | None -> false
+            | Some notes_action ->
+                let orch2 = Orchestrator.fire orch2 notes_action in
+                let orch2 =
+                  Orchestrator.set_implementation_notes_delivered orch2 pid true
+                in
+                let orch2 = Orchestrator.complete orch2 pid in
+                (* Cycle 3: should converge — only draft effect *)
+                let _orch3, effects3, actions3 =
+                  run_controller_cycle ~gameplan orch2
+                in
+                has_draft_effect effects3
+                && not
+                     (List.exists actions3 ~f:(function
+                       | Orchestrator.Respond (action_pid, kind) ->
+                           Patch_id.equal action_pid pid
+                           && Operation_kind.equal kind
+                                Operation_kind.Implementation_notes
+                       | Orchestrator.Start _ | Orchestrator.Rebase _ -> false))
         with _ -> false
         end)
   in

--- a/test/test_patch_controller.ml
+++ b/test/test_patch_controller.ml
@@ -230,12 +230,23 @@ let () =
       (fun (pid, branch) ->
         let patch = make_patch pid branch in
         let gameplan = make_gameplan patch in
+        (* pr_body_delivered must be false so that Set_pr_description fires;
+           once the agent-authored body is delivered, it supersedes the
+           gameplan-derived description. *)
         let agent =
-          make_agent ~patch_id:pid ~branch
+          Patch_agent.restore ~patch_id:pid ~branch
             ~pr_number:(Some (Pr_number.of_int 42))
-            ~merged:false ~queue:[] ~base_branch:(Some branch) ~is_draft:true
-            ~pr_description_applied:false ~implementation_notes_delivered:false
-            ~start_attempts_without_pr:0
+            ~has_session:false ~busy:false ~merged:false ~queue:[]
+            ~satisfies:false ~changed:false ~has_conflict:false
+            ~base_branch:(Some branch) ~notified_base_branch:(Some branch)
+            ~ci_failure_count:0 ~session_fallback:Patch_agent.Fresh_available
+            ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
+            ~merge_ready:false ~is_draft:true ~pr_description_applied:false
+            ~pr_body_delivered:false ~implementation_notes_delivered:false
+            ~start_attempts_without_pr:0 ~conflict_noop_count:0
+            ~checks_passing:false ~current_op:None ~current_message_id:None
+            ~generation:0 ~worktree_path:None ~branch_blocked:false
+            ~llm_session_id:None
         in
         let orch = make_orch patch agent in
         begin try
@@ -403,12 +414,21 @@ let () =
       (fun (pid, branch) ->
         let patch = make_patch pid branch in
         let gameplan = make_gameplan patch in
+        (* pr_body_delivered=false so Set_pr_description fires *)
         let agent =
-          make_agent ~patch_id:pid ~branch
+          Patch_agent.restore ~patch_id:pid ~branch
             ~pr_number:(Some (Pr_number.of_int 42))
-            ~merged:false ~queue:[] ~base_branch:(Some branch) ~is_draft:true
-            ~pr_description_applied:false ~implementation_notes_delivered:true
-            ~start_attempts_without_pr:0
+            ~has_session:false ~busy:false ~merged:false ~queue:[]
+            ~satisfies:false ~changed:false ~has_conflict:false
+            ~base_branch:(Some branch) ~notified_base_branch:(Some branch)
+            ~ci_failure_count:0 ~session_fallback:Patch_agent.Fresh_available
+            ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
+            ~merge_ready:false ~is_draft:true ~pr_description_applied:false
+            ~pr_body_delivered:false ~implementation_notes_delivered:true
+            ~start_attempts_without_pr:0 ~conflict_noop_count:0
+            ~checks_passing:false ~current_op:None ~current_message_id:None
+            ~generation:0 ~worktree_path:None ~branch_blocked:false
+            ~llm_session_id:None
         in
         let orch = make_orch patch agent in
         (* Apply effects in a loop until convergence (max 5 rounds). *)
@@ -663,44 +683,64 @@ let () =
       (fun (pid, branch) ->
         let patch = make_patch pid branch in
         let gameplan = make_gameplan patch in
+        (* pr_body_delivered=false so Set_pr_description fires in cycle 1.
+           After description ack + pr_body delivery, notes become eligible
+           in cycle 2. After notes delivery, cycle 3 should converge with
+           only a draft effect. *)
         let agent =
-          make_agent ~patch_id:pid ~branch
+          Patch_agent.restore ~patch_id:pid ~branch
             ~pr_number:(Some (Pr_number.of_int 42))
-            ~merged:false ~queue:[] ~base_branch:(Some main) ~is_draft:true
-            ~pr_description_applied:false ~implementation_notes_delivered:false
-            ~start_attempts_without_pr:0
+            ~has_session:false ~busy:false ~merged:false ~queue:[]
+            ~satisfies:false ~changed:false ~has_conflict:false
+            ~base_branch:(Some main) ~notified_base_branch:(Some main)
+            ~ci_failure_count:0 ~session_fallback:Patch_agent.Fresh_available
+            ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
+            ~merge_ready:false ~is_draft:true ~pr_description_applied:false
+            ~pr_body_delivered:false ~implementation_notes_delivered:false
+            ~start_attempts_without_pr:0 ~conflict_noop_count:0
+            ~checks_passing:false ~current_op:None ~current_message_id:None
+            ~generation:0 ~worktree_path:None ~branch_blocked:false
+            ~llm_session_id:None
         in
         let orch = make_orch patch agent in
         begin try
-          let orch1, effects1, actions1 = run_controller_cycle ~gameplan orch in
-          match implementation_notes_action actions1 pid with
-          | None -> false
-          | Some notes_action ->
-              let orch1 = Orchestrator.fire orch1 notes_action in
-              let orch1 =
-                let orch1 =
-                  Orchestrator.set_implementation_notes_delivered orch1 pid true
+          (* Cycle 1: description effect fires, Pr_body enqueued *)
+          let orch1, effects1, _actions1 =
+            run_controller_cycle ~gameplan orch
+          in
+          if not (has_description_effect effects1) then false
+          else
+            (* Fire Pr_body action and simulate delivery *)
+            let orch1 =
+              Orchestrator.fire orch1
+                (Orchestrator.Respond (pid, Operation_kind.Pr_body))
+            in
+            let orch1 = Orchestrator.set_pr_body_delivered orch1 pid true in
+            let orch1 = Orchestrator.complete orch1 pid in
+            (* Cycle 2: notes now eligible *)
+            let orch2, _effects2, actions2 =
+              run_controller_cycle ~gameplan orch1
+            in
+            match implementation_notes_action actions2 pid with
+            | None -> false
+            | Some notes_action ->
+                let orch2 = Orchestrator.fire orch2 notes_action in
+                let orch2 =
+                  Orchestrator.set_implementation_notes_delivered orch2 pid true
                 in
-                Orchestrator.complete orch1 pid
-              in
-              let _orch2, effects2, actions2 =
-                run_controller_cycle ~gameplan orch1
-              in
-              has_description_effect effects1
-              && List.exists actions1 ~f:(function
-                | Orchestrator.Respond (action_pid, kind) ->
-                    Patch_id.equal action_pid pid
-                    && Operation_kind.equal kind
-                         Operation_kind.Implementation_notes
-                | Orchestrator.Start _ | Orchestrator.Rebase _ -> false)
-              && has_draft_effect effects2
-              && not
-                   (List.exists actions2 ~f:(function
-                     | Orchestrator.Respond (action_pid, kind) ->
-                         Patch_id.equal action_pid pid
-                         && Operation_kind.equal kind
-                              Operation_kind.Implementation_notes
-                     | Orchestrator.Start _ | Orchestrator.Rebase _ -> false))
+                let orch2 = Orchestrator.complete orch2 pid in
+                (* Cycle 3: should converge — only draft effect *)
+                let _orch3, effects3, actions3 =
+                  run_controller_cycle ~gameplan orch2
+                in
+                has_draft_effect effects3
+                && not
+                     (List.exists actions3 ~f:(function
+                       | Orchestrator.Respond (action_pid, kind) ->
+                           Patch_id.equal action_pid pid
+                           && Operation_kind.equal kind
+                                Operation_kind.Implementation_notes
+                       | Orchestrator.Start _ | Orchestrator.Rebase _ -> false))
         with _ -> false
         end)
   in

--- a/test/test_patch_decision.ml
+++ b/test/test_patch_decision.ml
@@ -344,8 +344,8 @@ let () =
     | Deliver
         {
           payload =
-            ( Ci_payload _ | Review_payload _ | Implementation_notes_payload
-            | Merge_conflict_payload );
+            ( Ci_payload _ | Review_payload _ | Pr_body_payload
+            | Implementation_notes_payload | Merge_conflict_payload );
           _;
         }
     | Skip_empty | Respond_stale ->
@@ -377,8 +377,8 @@ let () =
     | Deliver
         {
           payload =
-            ( Ci_payload _ | Review_payload _ | Implementation_notes_payload
-            | Merge_conflict_payload );
+            ( Ci_payload _ | Review_payload _ | Pr_body_payload
+            | Implementation_notes_payload | Merge_conflict_payload );
           _;
         }
     | Skip_empty | Respond_stale ->
@@ -442,7 +442,7 @@ let () =
         | Deliver
             {
               payload =
-                ( Human_payload _ | Review_payload _
+                ( Human_payload _ | Review_payload _ | Pr_body_payload
                 | Implementation_notes_payload | Merge_conflict_payload );
               _;
             }

--- a/test/test_poll_log_properties.ml
+++ b/test/test_poll_log_properties.ml
@@ -47,9 +47,10 @@ let make_agent ~patch_id ~branch ~has_conflict ~ci_failure_count ~current_op
     ~ci_failure_count ~session_fallback:Patch_agent.Fresh_available
     ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
     ~merge_ready:false ~is_draft ~pr_description_applied:true
-    ~implementation_notes_delivered:true ~start_attempts_without_pr:0
-    ~conflict_noop_count:0 ~checks_passing ~current_op ~current_message_id:None
-    ~generation:0 ~worktree_path ~branch_blocked ~llm_session_id:None
+    ~pr_body_delivered:true ~implementation_notes_delivered:true
+    ~start_attempts_without_pr:0 ~conflict_noop_count:0 ~checks_passing
+    ~current_op ~current_message_id:None ~generation:0 ~worktree_path
+    ~branch_blocked ~llm_session_id:None
 
 let make_poll_observation ~branch_in_root ~worktree_path poll_result =
   Patch_controller.

--- a/test/test_poll_log_properties.ml
+++ b/test/test_poll_log_properties.ml
@@ -46,11 +46,10 @@ let make_agent ~patch_id ~branch ~has_conflict ~ci_failure_count ~current_op
     ~has_conflict ~base_branch:(Some main) ~notified_base_branch:(Some main)
     ~ci_failure_count ~session_fallback:Patch_agent.Fresh_available
     ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
-    ~merge_ready:false ~is_draft ~pr_description_applied:true
-    ~pr_body_delivered:true ~implementation_notes_delivered:true
-    ~start_attempts_without_pr:0 ~conflict_noop_count:0 ~checks_passing
-    ~current_op ~current_message_id:None ~generation:0 ~worktree_path
-    ~branch_blocked ~llm_session_id:None
+    ~merge_ready:false ~is_draft ~pr_body_delivered:true
+    ~implementation_notes_delivered:true ~start_attempts_without_pr:0
+    ~conflict_noop_count:0 ~checks_passing ~current_op ~current_message_id:None
+    ~generation:0 ~worktree_path ~branch_blocked ~llm_session_id:None
 
 let make_poll_observation ~branch_in_root ~worktree_path poll_result =
   Patch_controller.

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -779,4 +779,168 @@ let () =
     ];
   Stdlib.print_endline "llm_session_id: all properties passed (A1-A6)"
 
+(* Session_push_failed semantics — distinguishes "LLM ran fine but commits
+   didn't ship" from a genuine LLM failure. Pins down the three behaviors
+   that justify the variant's existence, plus the pure
+   combine_session_and_push mapping the runner uses to fold push outcomes
+   into session_result. *)
+let () =
+  let open QCheck2 in
+  let main = Types.Branch.of_string "main" in
+  let mk_busy_orch () =
+    let pid = Types.Patch_id.of_string "psf-pid" in
+    let patches =
+      [
+        Types.Patch.
+          {
+            id = pid;
+            title = "P";
+            description = "";
+            branch = Types.Branch.of_string "psf";
+            dependencies = [];
+            spec = "";
+            acceptance_criteria = [];
+            files = [];
+            classification = "";
+            changes = [];
+            test_stubs_introduced = [];
+            test_stubs_implemented = [];
+          };
+      ]
+    in
+    let orch = Orchestrator.create ~patches ~main_branch:main in
+    let orch, _, _ = tick orch ~patches in
+    (orch, pid)
+  in
+  let prop_psf1_clears_session_fallback =
+    Test.make ~name:"PSF-1: Session_push_failed clears session_fallback"
+      (Gen.return ()) (fun () ->
+        let orch, pid = mk_busy_orch () in
+        (* Drive the agent into Tried_fresh via an explicit fresh failure,
+           then assert Session_push_failed resets it back to
+           Fresh_available. *)
+        let orch = Orchestrator.set_tried_fresh orch pid in
+        let orch =
+          Orchestrator.apply_session_result orch pid Session_push_failed
+        in
+        let a = Orchestrator.agent orch pid in
+        Patch_agent.equal_session_fallback a.Patch_agent.session_fallback
+          Patch_agent.Fresh_available)
+  in
+  let prop_psf2_leaves_start_attempts_untouched =
+    Test.make
+      ~name:"PSF-2: Session_push_failed leaves start_attempts_without_pr"
+      (Gen.int_range 0 3) (fun n ->
+        let orch, pid = mk_busy_orch () in
+        let orch =
+          List.fold (List.range 0 n) ~init:orch ~f:(fun o _ ->
+              Orchestrator.increment_start_attempts_without_pr o pid)
+        in
+        let before =
+          (Orchestrator.agent orch pid).Patch_agent.start_attempts_without_pr
+        in
+        let orch =
+          Orchestrator.apply_session_result orch pid Session_push_failed
+        in
+        let after =
+          (Orchestrator.agent orch pid).Patch_agent.start_attempts_without_pr
+        in
+        Int.equal before after)
+  in
+  let prop_psf3_leaves_ci_failure_count_untouched =
+    Test.make ~name:"PSF-3: Session_push_failed leaves ci_failure_count"
+      (Gen.int_range 0 2) (fun n ->
+        let orch, pid = mk_busy_orch () in
+        let orch =
+          List.fold (List.range 0 n) ~init:orch ~f:(fun o _ ->
+              Orchestrator.increment_ci_failure_count o pid)
+        in
+        let before =
+          (Orchestrator.agent orch pid).Patch_agent.ci_failure_count
+        in
+        let orch =
+          Orchestrator.apply_session_result orch pid Session_push_failed
+        in
+        let after =
+          (Orchestrator.agent orch pid).Patch_agent.ci_failure_count
+        in
+        Int.equal before after)
+  in
+  let prop_cp1_ok_pushok =
+    Test.make ~name:"CP-1: Session_ok + Push_ok = Session_ok" (Gen.return ())
+      (fun () ->
+        Orchestrator.equal_session_result
+          (Orchestrator.combine_session_and_push ~session:Session_ok
+             ~push:Worktree.Push_ok)
+          Session_ok)
+  in
+  let prop_cp2_ok_uptodate =
+    Test.make ~name:"CP-2: Session_ok + Push_up_to_date = Session_ok"
+      (Gen.return ()) (fun () ->
+        Orchestrator.equal_session_result
+          (Orchestrator.combine_session_and_push ~session:Session_ok
+             ~push:Worktree.Push_up_to_date)
+          Session_ok)
+  in
+  let prop_cp3_ok_rejected =
+    Test.make ~name:"CP-3: Session_ok + Push_rejected = Session_push_failed"
+      (Gen.return ()) (fun () ->
+        Orchestrator.equal_session_result
+          (Orchestrator.combine_session_and_push ~session:Session_ok
+             ~push:Worktree.Push_rejected)
+          Session_push_failed)
+  in
+  let prop_cp4_ok_error =
+    Test.make ~name:"CP-4: Session_ok + Push_error = Session_push_failed"
+      Gen.string_small (fun msg ->
+        Orchestrator.equal_session_result
+          (Orchestrator.combine_session_and_push ~session:Session_ok
+             ~push:(Worktree.Push_error msg))
+          Session_push_failed)
+  in
+  let gen_non_ok_session : Orchestrator.session_result Gen.t =
+    Gen.oneof
+      [
+        Gen.map
+          (fun b -> Orchestrator.Session_process_error { is_fresh = b })
+          Gen.bool;
+        Gen.return Orchestrator.Session_no_resume;
+        Gen.map (fun b -> Orchestrator.Session_failed { is_fresh = b }) Gen.bool;
+        Gen.return Orchestrator.Session_give_up;
+        Gen.return Orchestrator.Session_worktree_missing;
+        Gen.return Orchestrator.Session_push_failed;
+      ]
+  in
+  let gen_push : Worktree.push_result Gen.t =
+    Gen.oneof
+      [
+        Gen.return Worktree.Push_ok;
+        Gen.return Worktree.Push_up_to_date;
+        Gen.return Worktree.Push_rejected;
+        Gen.map (fun s -> Worktree.Push_error s) Gen.string_small;
+      ]
+  in
+  let prop_cp5_failure_dominates =
+    Test.make ~name:"CP-5: pre-existing failure dominates any push outcome"
+      ~count:300 (Gen.pair gen_non_ok_session gen_push) (fun (session, push) ->
+        Orchestrator.equal_session_result
+          (Orchestrator.combine_session_and_push ~session ~push)
+          session)
+  in
+  List.iter
+    ~f:(fun t -> QCheck2.Test.check_exn t)
+    [
+      prop_psf1_clears_session_fallback;
+      prop_psf2_leaves_start_attempts_untouched;
+      prop_psf3_leaves_ci_failure_count_untouched;
+      prop_cp1_ok_pushok;
+      prop_cp2_ok_uptodate;
+      prop_cp3_ok_rejected;
+      prop_cp4_ok_error;
+      prop_cp5_failure_dominates;
+    ];
+  Stdlib.print_endline
+    "Session_push_failed + combine_session_and_push: all properties passed \
+     (PSF-1..3, CP-1..5)"
+
 let () = Stdlib.print_endline "all property tests passed"

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -614,7 +614,8 @@ let () =
             true
         | Orchestrator.Session_process_error _ | Orchestrator.Session_no_resume
         | Orchestrator.Session_failed _ | Orchestrator.Session_give_up
-        | Orchestrator.Session_worktree_missing ->
+        | Orchestrator.Session_worktree_missing
+        | Orchestrator.Session_push_failed ->
             not a.Patch_agent.busy)
   in
   (* Property: Session_give_up sets needs_intervention *)

--- a/test/test_reconciler_properties.ml
+++ b/test/test_reconciler_properties.ml
@@ -277,6 +277,7 @@ let prop_plan_new_base_only_for_rebase =
             | Types.Operation_kind.Rebase -> Option.is_some new_base
             | Types.Operation_kind.Human | Types.Operation_kind.Merge_conflict
             | Types.Operation_kind.Ci | Types.Operation_kind.Review_comments
+            | Types.Operation_kind.Pr_body
             | Types.Operation_kind.Implementation_notes ->
                 Option.is_none new_base)
         | Reconciler.Mark_merged _ | Reconciler.Enqueue_rebase _ -> true))
@@ -296,6 +297,7 @@ let prop_plan_suppresses_rebase_multi_dep =
                 List.length (Graph.open_pr_deps graph patch_id ~has_merged) <= 1
             | Types.Operation_kind.Human | Types.Operation_kind.Merge_conflict
             | Types.Operation_kind.Ci | Types.Operation_kind.Review_comments
+            | Types.Operation_kind.Pr_body
             | Types.Operation_kind.Implementation_notes ->
                 true)
         | Reconciler.Mark_merged _ | Reconciler.Enqueue_rebase _ -> true))

--- a/test/test_state_machine_properties.ml
+++ b/test/test_state_machine_properties.ml
@@ -205,6 +205,14 @@ let () =
                 let orch =
                   Orchestrator.set_pr_number orch pid (Types.Pr_number.of_int 1)
                 in
+                (* Mark the post-PR-creation phases done so the controller
+                   doesn't auto-enqueue Pr_body / Implementation_notes and
+                   shadow the [kind] under test (they have lower priority than
+                   each other but higher than the explicitly-enqueued kind). *)
+                let orch = Orchestrator.set_pr_body_delivered orch pid true in
+                let orch =
+                  Orchestrator.set_implementation_notes_delivered orch pid true
+                in
                 let orch = Orchestrator.complete orch pid in
                 let orch = Orchestrator.enqueue orch pid kind in
                 let _, _effects, actions =


### PR DESCRIPTION
## Summary

Moves `git push` ownership from the coding agent to the supervisor. The agent now only commits locally; the supervisor invokes `force_push_with_lease` at the tail of every agent session in `run_claude_and_handle`.

## Why

Recent run surfaced a bug: Patch 3 (deps: Patches 1, 2) reached the PR-creation step *after* Patch 2 had merged to main and its remote branch was deleted. Instead of rebasing onto main, the agent reasoned about remote state (\`git ls-remote\`, \`gh api\`), noticed Patch 2's branch was gone, and tried to **recreate** Patch 2 locally to use as a PR base.

This entire class of bug is unreachable if the agent never has to reason about remote state. After this change, the agent's git surface is purely local: read state, write commits. Pushes, force-pushes, and any future PR-mutation calls live on the supervisor side.

## What changed

- **\`bin/main.ml\`** — \`run_claude_and_handle\` now calls \`Worktree.force_push_with_lease\` after the session ends and before returning. Runs regardless of session result so commits made before a partial failure still reach the remote. Idempotent (\`Push_up_to_date\` when nothing new); lease-safe against concurrent remote updates.
- **\`lib/prompt.ml\`** — stripped \"and push\" from four templates (\`render_review_prompt\`, \`render_ci_failure_prompt\`, \`render_ci_failure_unknown_prompt\`, \`render_merge_conflict_prompt\`). All four now explicitly say *do not run \`git push\`*.

## Scope

This is **step 1** of a multi-step refactor. Future PRs will:
- Move \`gh pr create\` to the supervisor (step 2).
- Move \`gh pr edit\` / implementation-notes authoring to a \`.onton/pr-body.md\` artifact (step 3).
- Split initial implementation into phased prompts: implement → write PR body → write notes (step 4).

Comment-response flow (agent has \`gh\` access for replying to/resolving comments) is intentionally left as-is.

## Test plan

- [x] \`dune build\` clean
- [x] \`dune runtest\` all pass
- [x] \`dune fmt\` clean
- [ ] Manual end-to-end: run against a multi-patch gameplan, confirm agent transcript contains no \`git push\`, confirm \`runner: pushed after session\` log appears, confirm remote refs match local
- [ ] Manual: trigger a rebase flow and confirm the existing \`Push_branch\` effect path still works (and isn't duplicated harmfully by the new hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves `git push` and PR creation to the supervisor, with PR body and implementation notes authored via artifacts for safe, ordered updates. Improves push failure handling by retrying artifact delivery cleanly.

- **New Features**
  - Supervisor opens draft PRs with a gameplan-derived title/body, then reads agent-authored artifacts to update the PR: `artifacts/<patch_id>/pr-body.md` for the full body (PATCHed if non-empty) and `artifacts/<patch_id>/notes.md` for notes (appended as "<body>\n\n## Implementation Notes\n\n<notes>"). Notes run only after the PR body is delivered.

- **Refactors**
  - Supervisor pushes at session end using `Worktree.force_push_with_lease`. Push failures map to `Session_push_failed`; the respond path now returns `Retry_push` so the reconciler re-enqueues the undelivered op next tick. For Start, push failures map to `Start_failed`.
  - Supervisor creates PRs via `Github.create_pull_request`; on 422 with “pull request already exists” only, fall back to discovery and associate the PR.
  - Removed `Set_pr_description` and the old applied flag; persistence defaults `pr_body_delivered = true` for old snapshots. Prompts forbid `git push` and agent PR ops, rebase prompt simplified, and TUI shows “writing-pr-body”.
  - Extracted `Orchestrator.combine_session_and_push` for pure push/result mapping and updated notes handling to use `Prompt.resolve_pr_body_source`.

<sup>Written for commit a4dfbe2f7a2a799b6f013af42fe4002909bb72a6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

Closes #172.