### PR TITLE
Detect no-commit sessions and GitHub-auto-retargeted PRs

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -749,9 +749,18 @@ let run_claude_and_handle ~runtime ~process_mgr ~fs ~project_name ~patch_id
              session result so commits made before a partial failure still
              reach the remote. *)
           let branch = agent.Patch_agent.branch in
+          let base =
+            match agent.Patch_agent.base_branch with
+            | Some b -> b
+            | None ->
+                (* Invariant: a running session always has a base_branch set
+                   by start/respond/rebase. Fall back to main just in case. *)
+                Runtime.read runtime (fun snap ->
+                    Orchestrator.main_branch snap.Runtime.orchestrator)
+          in
           let push_outcome =
             Worktree.force_push_with_lease ~process_mgr ~path:worktree_path
-              ~branch
+              ~branch ~base
           in
           (match push_outcome with
           | Worktree.Push_ok ->
@@ -759,6 +768,10 @@ let run_claude_and_handle ~runtime ~process_mgr ~fs ~project_name ~patch_id
           | Worktree.Push_up_to_date ->
               log_event runtime ~patch_id
                 "runner: push up-to-date after session (no new commits)"
+          | Worktree.Push_no_commits ->
+              log_event runtime ~patch_id
+                "runner: session ended with no commits on branch — push \
+                 skipped, PR creation deferred"
           | Worktree.Push_rejected ->
               log_event runtime ~patch_id
                 "runner: push rejected after session (lease)"
@@ -777,10 +790,14 @@ let run_claude_and_handle ~runtime ~process_mgr ~fs ~project_name ~patch_id
           let final_user_result =
             match final_session_result with
             | Orchestrator.Session_ok -> user_result
-            | Orchestrator.Session_push_failed ->
-                (* LLM session ran fine but push failed — signal retry so
-                   the Respond path uses Respond_retry_push (clean complete)
-                   and the reconciler re-enqueues the operation naturally. *)
+            | Orchestrator.Session_push_failed | Orchestrator.Session_no_commits
+              ->
+                (* LLM session ran fine but commits didn't ship (push failed
+                   or the agent made no commits) — signal retry so the
+                   Respond path uses Respond_retry_push (clean complete) and
+                   the reconciler re-enqueues the operation naturally. After
+                   2 consecutive no-commit sessions, needs_intervention fires
+                   and the scheduler stops re-enqueueing. *)
                 `Retry_push
             | Orchestrator.Session_process_error _
             | Orchestrator.Session_no_resume | Orchestrator.Session_failed _
@@ -2362,7 +2379,7 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                             let branch = agent.Patch_agent.branch in
                             let result =
                               Worktree.force_push_with_lease ~process_mgr
-                                ~path:wt_path ~branch
+                                ~path:wt_path ~branch ~base:new_base
                             in
                             (match result with
                             | Worktree.Push_ok ->
@@ -2371,6 +2388,10 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                             | Worktree.Push_up_to_date ->
                                 log_event runtime ~patch_id
                                   "Push noop after rebase — already up-to-date"
+                            | Worktree.Push_no_commits ->
+                                log_event runtime ~patch_id
+                                  "Force-push skipped after rebase — branch \
+                                   has no commits ahead of base"
                             | Worktree.Push_rejected ->
                                 log_event runtime ~patch_id
                                   "Force-push rejected — lease violated"
@@ -2644,6 +2665,7 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                         let result =
                                           Worktree.force_push_with_lease
                                             ~process_mgr ~path:wt_path ~branch
+                                            ~base:(Types.Branch.of_string base)
                                         in
                                         (match result with
                                         | Worktree.Push_ok ->
@@ -2653,6 +2675,11 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                             log_event runtime ~patch_id
                                               "Conflict push noop — already \
                                                up-to-date"
+                                        | Worktree.Push_no_commits ->
+                                            log_event runtime ~patch_id
+                                              "Conflict force-push skipped — \
+                                               branch has no commits ahead of \
+                                               base"
                                         | Worktree.Push_rejected ->
                                             log_event runtime ~patch_id
                                               "Conflict force-push rejected — \

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1908,6 +1908,7 @@ let poller_fiber ~runtime ~clock ~net ~process_mgr ~github ~config ~project_name
                     queue = a.Patch_agent.queue;
                     base_branch =
                       Base.Option.value a.Patch_agent.base_branch ~default:main;
+                    branch_rebased_onto = a.Patch_agent.branch_rebased_onto;
                   })
           in
           let merged_patches =

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -433,7 +433,9 @@ let apply_rebase_push_result t patch_id
       let t = set_has_conflict t patch_id in
       let t = enqueue t patch_id Operation_kind.Merge_conflict in
       (t, Rebase_push_failed)
-  | Some (Worktree.Push_error _) ->
+  | Some Worktree.Push_no_commits | Some (Worktree.Push_error _) ->
+      (* Push_no_commits after rebase means every commit squashed away — treat
+         as an infrastructure error and retry the rebase. *)
       let t = enqueue t patch_id Operation_kind.Rebase in
       (t, Rebase_push_error)
 
@@ -484,14 +486,18 @@ let apply_conflict_push_result t patch_id decision
   | Conflict_resolved, Some Worktree.Push_ok -> (t, Conflict_done)
   | Conflict_resolved, Some Worktree.Push_up_to_date -> (t, Conflict_done)
   | ( Conflict_resolved,
-      (None | Some (Worktree.Push_rejected | Worktree.Push_error _)) ) ->
+      ( None
+      | Some
+          ( Worktree.Push_rejected | Worktree.Push_no_commits
+          | Worktree.Push_error _ ) ) ) ->
       let t = set_has_conflict t patch_id in
       let t = enqueue t patch_id Operation_kind.Merge_conflict in
       (t, Conflict_retry_push)
   | ( Deliver_to_agent,
       ( None
       | Some
-          ( Worktree.Push_ok | Worktree.Push_up_to_date | Worktree.Push_rejected
+          ( Worktree.Push_ok | Worktree.Push_up_to_date
+          | Worktree.Push_no_commits | Worktree.Push_rejected
           | Worktree.Push_error _ ) ) ) ->
       (t, Conflict_needs_agent)
   | Conflict_failed, _ -> (t, Conflict_give_up)
@@ -504,6 +510,7 @@ type session_result =
   | Session_give_up
   | Session_worktree_missing
   | Session_push_failed
+  | Session_no_commits
 [@@deriving show, eq, sexp_of]
 
 (** Complete a failed session, restoring inflight human messages to the inbox.
@@ -527,7 +534,10 @@ let complete_failed t patch_id =
 
 let apply_session_result t patch_id result =
   match result with
-  | Session_ok -> clear_session_fallback t patch_id
+  | Session_ok ->
+      let t = clear_session_fallback t patch_id in
+      (* A healthy session that pushed commits clears the no-commits counter. *)
+      update_agent t patch_id ~f:Patch_agent.reset_no_commits_push_count
   | Session_process_error { is_fresh } ->
       let t = on_session_failure t patch_id ~is_fresh in
       let t = update_agent t patch_id ~f:Patch_agent.on_pre_session_failure in
@@ -560,6 +570,16 @@ let apply_session_result t patch_id result =
          inflight human messages so the next iteration retries. *)
       let t = clear_session_fallback t patch_id in
       complete_failed t patch_id
+  | Session_no_commits ->
+      (* The LLM session ran cleanly but left no commits on the branch (HEAD
+         == base), so the supervisor skipped the push. Clear session fallback
+         (the LLM itself was healthy), bump the no-commits counter (which
+         feeds [needs_intervention] at >= 2), and retry via complete_failed. *)
+      let t = clear_session_fallback t patch_id in
+      let t =
+        update_agent t patch_id ~f:Patch_agent.increment_no_commits_push_count
+      in
+      complete_failed t patch_id
 
 let combine_session_and_push ~(session : session_result)
     ~(push : Worktree.push_result) : session_result =
@@ -567,9 +587,11 @@ let combine_session_and_push ~(session : session_result)
   | Session_ok -> (
       match push with
       | Worktree.Push_ok | Worktree.Push_up_to_date -> Session_ok
+      | Worktree.Push_no_commits -> Session_no_commits
       | Worktree.Push_rejected | Worktree.Push_error _ -> Session_push_failed)
   | Session_process_error _ | Session_no_resume | Session_failed _
-  | Session_give_up | Session_worktree_missing | Session_push_failed ->
+  | Session_give_up | Session_worktree_missing | Session_push_failed
+  | Session_no_commits ->
       session
 
 type start_outcome = Start_ok | Start_failed | Start_stale

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -400,13 +400,23 @@ let apply_rebase_result t patch_id rebase_result new_base =
   match rebase_result with
   | Worktree.Ok ->
       let t = set_base_branch t patch_id new_base in
+      let t =
+        update_agent t patch_id ~f:(fun a ->
+            Patch_agent.set_branch_rebased_onto a new_base)
+      in
       let t = clear_has_conflict t patch_id in
       let t = reset_conflict_noop_count t patch_id in
       (complete t patch_id, [ Push_branch ])
   | Worktree.Noop ->
       let t = set_base_branch t patch_id new_base in
-      (* Push even on Noop: the local branch may already be rebased from a
-         prior attempt whose push failed, leaving the remote stale. *)
+      (* Noop: the local branch already contains [new_base] in its history,
+         so the branch is (transitively) based on it. Record this so the
+         drift detector doesn't re-fire. Push even on Noop — the remote may
+         be stale from a prior failed push. *)
+      let t =
+        update_agent t patch_id ~f:(fun a ->
+            Patch_agent.set_branch_rebased_onto a new_base)
+      in
       (complete t patch_id, [ Push_branch ])
   | Worktree.Conflict ->
       let t = set_base_branch t patch_id new_base in
@@ -449,6 +459,10 @@ let apply_conflict_rebase_result t patch_id rebase_result new_base =
   match rebase_result with
   | Worktree.Ok ->
       let t = set_base_branch t patch_id new_base in
+      let t =
+        update_agent t patch_id ~f:(fun a ->
+            Patch_agent.set_branch_rebased_onto a new_base)
+      in
       let t = clear_has_conflict t patch_id in
       let t = reset_conflict_noop_count t patch_id in
       let t = complete t patch_id in
@@ -460,6 +474,10 @@ let apply_conflict_rebase_result t patch_id rebase_result new_base =
          if the conflict persists, and conflict_noop_count will
          eventually trigger intervention. *)
       let t = set_base_branch t patch_id new_base in
+      let t =
+        update_agent t patch_id ~f:(fun a ->
+            Patch_agent.set_branch_rebased_onto a new_base)
+      in
       let t = clear_has_conflict t patch_id in
       let t = increment_conflict_noop_count t patch_id in
       let t = complete t patch_id in

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -157,9 +157,9 @@ val combine_session_and_push :
     - [Session_ok] with [Push_ok] or [Push_up_to_date] stays [Session_ok].
     - [Session_ok] with [Push_rejected] or [Push_error] becomes
       [Session_push_failed] — the LLM ran fine but commits didn't ship.
-    - [Session_ok] with [Push_no_commits] becomes [Session_no_commits] — the
-      LLM ran cleanly but left no commits on the branch, so the push was
-      skipped (a base-equal branch can't become a PR). *)
+    - [Session_ok] with [Push_no_commits] becomes [Session_no_commits] — the LLM
+      ran cleanly but left no commits on the branch, so the push was skipped (a
+      base-equal branch can't become a PR). *)
 
 type start_outcome = Start_ok | Start_failed | Start_stale
 [@@deriving show, eq, sexp_of]

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -128,6 +128,7 @@ type session_result =
   | Session_give_up
   | Session_worktree_missing
   | Session_push_failed
+  | Session_no_commits
 [@@deriving show, eq, sexp_of]
 
 val apply_session_result : t -> Patch_id.t -> session_result -> t
@@ -140,7 +141,10 @@ val apply_session_result : t -> Patch_id.t -> session_result -> t
     on_pre_session_failure + complete. [Session_push_failed] ->
     clear_session_fallback (LLM session itself was healthy) + complete_failed
     (commits did not reach the remote — retry on next iteration). Use this when
-    the LLM ran cleanly but the supervisor's post-session push failed. *)
+    the LLM ran cleanly but the supervisor's post-session push failed.
+    [Session_no_commits] -> clear_session_fallback +
+    increment_no_commits_push_count + complete_failed. The LLM ran but produced
+    no commits; after 2 such sessions [needs_intervention] fires. *)
 
 val combine_session_and_push :
   session:session_result -> push:Worktree.push_result -> session_result
@@ -152,7 +156,10 @@ val combine_session_and_push :
       change anything.
     - [Session_ok] with [Push_ok] or [Push_up_to_date] stays [Session_ok].
     - [Session_ok] with [Push_rejected] or [Push_error] becomes
-      [Session_push_failed] — the LLM ran fine but commits didn't ship. *)
+      [Session_push_failed] — the LLM ran fine but commits didn't ship.
+    - [Session_ok] with [Push_no_commits] becomes [Session_no_commits] — the
+      LLM ran cleanly but left no commits on the branch, so the push was
+      skipped (a base-equal branch can't become a PR). *)
 
 type start_outcome = Start_ok | Start_failed | Start_stale
 [@@deriving show, eq, sexp_of]

--- a/lib/patch_agent.ml
+++ b/lib/patch_agent.ml
@@ -29,6 +29,7 @@ type t = {
   implementation_notes_delivered : bool;
   start_attempts_without_pr : int;
   conflict_noop_count : int;
+  no_commits_push_count : int;
   checks_passing : bool;
   current_op : Operation_kind.t option;
   current_message_id : Message_id.t option;
@@ -48,7 +49,8 @@ let needs_intervention t =
   && (t.ci_failure_count >= 3
      || equal_session_fallback t.session_fallback Given_up
      || ((not (has_pr t)) && t.start_attempts_without_pr >= 2)
-     || t.conflict_noop_count >= 2)
+     || t.conflict_noop_count >= 2
+     || t.no_commits_push_count >= 2)
 
 let create ~branch patch_id =
   {
@@ -75,6 +77,7 @@ let create ~branch patch_id =
     implementation_notes_delivered = false;
     start_attempts_without_pr = 0;
     conflict_noop_count = 0;
+    no_commits_push_count = 0;
     checks_passing = false;
     current_op = None;
     current_message_id = None;
@@ -109,6 +112,7 @@ let create_adhoc ~patch_id ~branch ~pr_number =
     implementation_notes_delivered = true;
     start_attempts_without_pr = 0;
     conflict_noop_count = 0;
+    no_commits_push_count = 0;
     checks_passing = false;
     current_op = None;
     current_message_id = None;
@@ -164,6 +168,11 @@ let reset_conflict_noop_count t = { t with conflict_noop_count = 0 }
 
 let increment_conflict_noop_count t =
   { t with conflict_noop_count = t.conflict_noop_count + 1 }
+
+let increment_no_commits_push_count t =
+  { t with no_commits_push_count = t.no_commits_push_count + 1 }
+
+let reset_no_commits_push_count t = { t with no_commits_push_count = 0 }
 
 let set_base_branch t branch =
   let notified =
@@ -232,6 +241,7 @@ let reset_intervention_state t =
     ci_failure_count = 0;
     start_attempts_without_pr = 0;
     conflict_noop_count = 0;
+    no_commits_push_count = 0;
   }
 
 let reset_busy t = if not t.busy then t else { t with busy = false }
@@ -241,8 +251,9 @@ let restore ~patch_id ~branch ~pr_number ~has_session ~busy ~merged ~queue
     ~ci_failure_count ~session_fallback ~human_messages ~inflight_human_messages
     ~ci_checks ~merge_ready ~is_draft ~pr_body_delivered
     ~implementation_notes_delivered ~start_attempts_without_pr
-    ~conflict_noop_count ~checks_passing ~current_op ~current_message_id
-    ~generation ~worktree_path ~branch_blocked ~llm_session_id =
+    ~conflict_noop_count ~no_commits_push_count ~checks_passing ~current_op
+    ~current_message_id ~generation ~worktree_path ~branch_blocked
+    ~llm_session_id =
   {
     patch_id;
     branch;
@@ -267,6 +278,7 @@ let restore ~patch_id ~branch ~pr_number ~has_session ~busy ~merged ~queue
     implementation_notes_delivered;
     start_attempts_without_pr;
     conflict_noop_count;
+    no_commits_push_count;
     checks_passing;
     current_op;
     current_message_id;

--- a/lib/patch_agent.ml
+++ b/lib/patch_agent.ml
@@ -30,6 +30,7 @@ type t = {
   start_attempts_without_pr : int;
   conflict_noop_count : int;
   no_commits_push_count : int;
+  branch_rebased_onto : Branch.t option;
   checks_passing : bool;
   current_op : Operation_kind.t option;
   current_message_id : Message_id.t option;
@@ -78,6 +79,7 @@ let create ~branch patch_id =
     start_attempts_without_pr = 0;
     conflict_noop_count = 0;
     no_commits_push_count = 0;
+    branch_rebased_onto = None;
     checks_passing = false;
     current_op = None;
     current_message_id = None;
@@ -113,6 +115,7 @@ let create_adhoc ~patch_id ~branch ~pr_number =
     start_attempts_without_pr = 0;
     conflict_noop_count = 0;
     no_commits_push_count = 0;
+    branch_rebased_onto = None;
     checks_passing = false;
     current_op = None;
     current_message_id = None;
@@ -251,9 +254,9 @@ let restore ~patch_id ~branch ~pr_number ~has_session ~busy ~merged ~queue
     ~ci_failure_count ~session_fallback ~human_messages ~inflight_human_messages
     ~ci_checks ~merge_ready ~is_draft ~pr_body_delivered
     ~implementation_notes_delivered ~start_attempts_without_pr
-    ~conflict_noop_count ~no_commits_push_count ~checks_passing ~current_op
-    ~current_message_id ~generation ~worktree_path ~branch_blocked
-    ~llm_session_id =
+    ~conflict_noop_count ~no_commits_push_count ~branch_rebased_onto
+    ~checks_passing ~current_op ~current_message_id ~generation ~worktree_path
+    ~branch_blocked ~llm_session_id =
   {
     patch_id;
     branch;
@@ -279,6 +282,7 @@ let restore ~patch_id ~branch ~pr_number ~has_session ~busy ~merged ~queue
     start_attempts_without_pr;
     conflict_noop_count;
     no_commits_push_count;
+    branch_rebased_onto;
     checks_passing;
     current_op;
     current_message_id;
@@ -323,8 +327,15 @@ let start t ~base_branch =
     satisfies = true;
     base_branch = Some base_branch;
     notified_base_branch = Some base_branch;
+    (* The initial Start plants the branch on [base_branch]; the local branch
+       tip is literally this base's HEAD until the agent commits. Record it
+       so the drift detector knows the branch is on the right base. *)
+    branch_rebased_onto = Some base_branch;
     ci_checks = [];
   }
+
+let set_branch_rebased_onto t branch =
+  { t with branch_rebased_onto = Some branch }
 
 let rebase t ~base_branch =
   if not (has_pr t) then invalid_arg "Patch_agent.rebase: patch has no PR";

--- a/lib/patch_agent.mli
+++ b/lib/patch_agent.mli
@@ -34,6 +34,7 @@ type t = private {
   start_attempts_without_pr : int;
   conflict_noop_count : int;
   no_commits_push_count : int;
+  branch_rebased_onto : Types.Branch.t option;
   checks_passing : bool;
   current_op : Types.Operation_kind.t option;
   current_message_id : Types.Message_id.t option;
@@ -154,6 +155,11 @@ val set_base_branch : t -> Types.Branch.t -> t
 
 val set_notified_base_branch : t -> Types.Branch.t -> t
 (** Record that the agent session has been informed of this base branch. *)
+
+val set_branch_rebased_onto : t -> Types.Branch.t -> t
+(** Record that the local branch has been rebased onto this base (either by
+    an explicit successful [Rebase] action, or by the initial [Start] which
+    plants the branch on its base). Drives [detect_notified_base_drift]. *)
 
 val base_branch_changed : t -> bool
 (** [true] when [base_branch] differs from [notified_base_branch], meaning the
@@ -290,6 +296,7 @@ val restore :
   start_attempts_without_pr:int ->
   conflict_noop_count:int ->
   no_commits_push_count:int ->
+  branch_rebased_onto:Types.Branch.t option ->
   checks_passing:bool ->
   current_op:Types.Operation_kind.t option ->
   current_message_id:Types.Message_id.t option ->

--- a/lib/patch_agent.mli
+++ b/lib/patch_agent.mli
@@ -157,9 +157,9 @@ val set_notified_base_branch : t -> Types.Branch.t -> t
 (** Record that the agent session has been informed of this base branch. *)
 
 val set_branch_rebased_onto : t -> Types.Branch.t -> t
-(** Record that the local branch has been rebased onto this base (either by
-    an explicit successful [Rebase] action, or by the initial [Start] which
-    plants the branch on its base). Drives [detect_notified_base_drift]. *)
+(** Record that the local branch has been rebased onto this base (either by an
+    explicit successful [Rebase] action, or by the initial [Start] which plants
+    the branch on its base). Drives [detect_notified_base_drift]. *)
 
 val base_branch_changed : t -> bool
 (** [true] when [base_branch] differs from [notified_base_branch], meaning the
@@ -193,8 +193,8 @@ val increment_no_commits_push_count : t -> t
     committing its work and further retries are wasted. *)
 
 val reset_no_commits_push_count : t -> t
-(** Reset [no_commits_push_count] to 0. Called on [Session_ok] with a
-    successful push, because the agent has demonstrated it can commit. *)
+(** Reset [no_commits_push_count] to 0. Called on [Session_ok] with a successful
+    push, because the agent has demonstrated it can commit. *)
 
 val set_checks_passing : t -> bool -> t
 (** Set the checks_passing flag from GitHub CI status. *)
@@ -223,8 +223,8 @@ val reset_ci_failure_count : t -> t
 val reset_intervention_state : t -> t
 (** Reset [session_fallback] to [Fresh_available], [ci_failure_count] to 0,
     [start_attempts_without_pr] to 0, [conflict_noop_count] to 0, and
-    [no_commits_push_count] to 0. Used after manual resolution (e.g., sending
-    a human message) to give the patch a fresh start. *)
+    [no_commits_push_count] to 0. Used after manual resolution (e.g., sending a
+    human message) to give the patch a fresh start. *)
 
 val set_branch_blocked : t -> t
 (** Set the branch-blocked flag (branch is checked out in repo root). *)

--- a/lib/patch_agent.mli
+++ b/lib/patch_agent.mli
@@ -33,6 +33,7 @@ type t = private {
   implementation_notes_delivered : bool;
   start_attempts_without_pr : int;
   conflict_noop_count : int;
+  no_commits_push_count : int;
   checks_passing : bool;
   current_op : Types.Operation_kind.t option;
   current_message_id : Types.Message_id.t option;
@@ -64,8 +65,8 @@ val has_pr : t -> bool
 val needs_intervention : t -> bool
 (** Derived predicate: true when [Human] is not in [queue] and any of:
     [ci_failure_count >= 3], [session_fallback = Given_up],
-    [(not has_pr) && start_attempts_without_pr >= 2], or
-    [conflict_noop_count >= 2]. *)
+    [(not has_pr) && start_attempts_without_pr >= 2],
+    [conflict_noop_count >= 2], or [no_commits_push_count >= 2]. *)
 
 (** {2 Spec actions} *)
 
@@ -180,6 +181,15 @@ val increment_conflict_noop_count : t -> t
 (** Record a conflict resolution attempt where rebase returned Noop (stale refs
     or no real diff). After 2 noop attempts, [needs_intervention] triggers. *)
 
+val increment_no_commits_push_count : t -> t
+(** Record a session that ended with no commits on the branch (HEAD == base).
+    After 2 such sessions, [needs_intervention] triggers — the agent is not
+    committing its work and further retries are wasted. *)
+
+val reset_no_commits_push_count : t -> t
+(** Reset [no_commits_push_count] to 0. Called on [Session_ok] with a
+    successful push, because the agent has demonstrated it can commit. *)
+
 val set_checks_passing : t -> bool -> t
 (** Set the checks_passing flag from GitHub CI status. *)
 
@@ -205,9 +215,10 @@ val reset_ci_failure_count : t -> t
     after failures. [needs_intervention] is re-derived automatically. *)
 
 val reset_intervention_state : t -> t
-(** Reset [session_fallback] to [Fresh_available], [ci_failure_count] to 0, and
-    [start_attempts_without_pr] to 0. Used after manual resolution (e.g.,
-    sending a human message) to give the patch a fresh start. *)
+(** Reset [session_fallback] to [Fresh_available], [ci_failure_count] to 0,
+    [start_attempts_without_pr] to 0, [conflict_noop_count] to 0, and
+    [no_commits_push_count] to 0. Used after manual resolution (e.g., sending
+    a human message) to give the patch a fresh start. *)
 
 val set_branch_blocked : t -> t
 (** Set the branch-blocked flag (branch is checked out in repo root). *)
@@ -278,6 +289,7 @@ val restore :
   implementation_notes_delivered:bool ->
   start_attempts_without_pr:int ->
   conflict_noop_count:int ->
+  no_commits_push_count:int ->
   checks_passing:bool ->
   current_op:Types.Operation_kind.t option ->
   current_message_id:Types.Message_id.t option ->

--- a/lib/persistence.ml
+++ b/lib/persistence.ml
@@ -74,6 +74,7 @@ let patch_agent_to_yojson (a : Patch_agent.t) =
       ("implementation_notes_delivered", `Bool a.implementation_notes_delivered);
       ("start_attempts_without_pr", `Int a.start_attempts_without_pr);
       ("conflict_noop_count", `Int a.conflict_noop_count);
+      ("no_commits_push_count", `Int a.no_commits_push_count);
       ("checks_passing", `Bool a.checks_passing);
       ( "current_op",
         match a.current_op with
@@ -186,6 +187,8 @@ let patch_agent_of_yojson ~gameplan json =
        ~start_attempts_without_pr:(int_member "start_attempts_without_pr" json)
        ~conflict_noop_count:
          (Option.value (int_member_opt "conflict_noop_count" json) ~default:0)
+       ~no_commits_push_count:
+         (Option.value (int_member_opt "no_commits_push_count" json) ~default:0)
        ~checks_passing:(bool_member "checks_passing" json)
        ~current_op:
          (match Yojson.Safe.Util.member "current_op" json with

--- a/lib/persistence.ml
+++ b/lib/persistence.ml
@@ -194,8 +194,16 @@ let patch_agent_of_yojson ~gameplan json =
        ~no_commits_push_count:
          (Option.value (int_member_opt "no_commits_push_count" json) ~default:0)
        ~branch_rebased_onto:
-         (string_member_opt "branch_rebased_onto" json
-         |> Option.map ~f:Branch.of_string)
+         (match string_member_opt "branch_rebased_onto" json with
+         | Some s -> Some (Branch.of_string s)
+         | None ->
+             (* Backward compat: assume existing PR agents are rebased onto
+                their current base_branch so drift detection activates if
+                GitHub later auto-retargets the PR. *)
+             if Option.is_some (int_member_opt "pr_number" json) then
+               string_member_opt "base_branch" json
+               |> Option.map ~f:Branch.of_string
+             else None)
        ~checks_passing:(bool_member "checks_passing" json)
        ~current_op:
          (match Yojson.Safe.Util.member "current_op" json with

--- a/lib/persistence.ml
+++ b/lib/persistence.ml
@@ -75,6 +75,10 @@ let patch_agent_to_yojson (a : Patch_agent.t) =
       ("start_attempts_without_pr", `Int a.start_attempts_without_pr);
       ("conflict_noop_count", `Int a.conflict_noop_count);
       ("no_commits_push_count", `Int a.no_commits_push_count);
+      ( "branch_rebased_onto",
+        match a.branch_rebased_onto with
+        | None -> `Null
+        | Some b -> Branch.yojson_of_t b );
       ("checks_passing", `Bool a.checks_passing);
       ( "current_op",
         match a.current_op with
@@ -189,6 +193,9 @@ let patch_agent_of_yojson ~gameplan json =
          (Option.value (int_member_opt "conflict_noop_count" json) ~default:0)
        ~no_commits_push_count:
          (Option.value (int_member_opt "no_commits_push_count" json) ~default:0)
+       ~branch_rebased_onto:
+         (string_member_opt "branch_rebased_onto" json
+         |> Option.map ~f:Branch.of_string)
        ~checks_passing:(bool_member "checks_passing" json)
        ~current_op:
          (match Yojson.Safe.Util.member "current_op" json with

--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -136,11 +136,19 @@ let render_patch_prompt ~(project_name : string) ?pr_number (patch : Patch.t)
         base_branch base_branch
   in
   let pr_instructions =
+    let commit_block =
+      {|
+**Commit your work with `git commit` before ending the session.** Every code change you make must land in a commit — uncommitted changes are discarded by the supervisor's push, and no PR can be opened from an empty branch. Multiple commits are fine; commit whenever it makes sense.
+
+**Do NOT run `git push` or `gh pr create` yourself.** The supervisor pushes your commits and opens/updates the PR.|}
+    in
     match pr_number with
-    | Some _ -> ""
+    | Some _ -> commit_block ^ "\n\nContinue implementing until all tests pass."
     | None ->
-        {|
-**Do NOT create a PR yourself.** The supervisor opens the draft PR after your first commit lands on the remote, with a gameplan-derived title and body. Just commit your changes and the supervisor will handle PR creation and base-branch management.
+        commit_block
+        ^ {|
+
+The supervisor opens the draft PR after your first commit lands on the remote, with a gameplan-derived title and body.
 
 Continue implementing until all tests pass.|}
   in

--- a/lib/reconciler.ml
+++ b/lib/reconciler.ml
@@ -66,27 +66,26 @@ let detect_rebases graph views ~newly_merged =
 
 (** Detect agents whose local branch is rebased onto something other than
     [base_branch]. [branch_rebased_onto] is updated by Start (to the initial
-    base) and by successful Rebase (to the rebase target). If [base_branch]
-    has since moved — typically because a dep branch was merged and deleted
-    on GitHub, causing GitHub to auto-retarget the PR to [main], and the
-    poller then refreshed [base_branch] to match — the local branch still
-    carries the old dep's commits in its history and needs a rebase even
-    though [base_branch] already equals the structurally-correct base.
+    base) and by successful Rebase (to the rebase target). If [base_branch] has
+    since moved — typically because a dep branch was merged and deleted on
+    GitHub, causing GitHub to auto-retarget the PR to [main], and the poller
+    then refreshed [base_branch] to match — the local branch still carries the
+    old dep's commits in its history and needs a rebase even though
+    [base_branch] already equals the structurally-correct base.
 
     This is the case [detect_stale_bases] misses: there, the structural check
-    [base_branch vs initial_base] both read [main] and agreed, so no rebase
-    was enqueued. *)
+    [base_branch vs initial_base] both read [main] and agreed, so no rebase was
+    enqueued. *)
 let detect_notified_base_drift views =
   List.filter_map views ~f:(fun v ->
       if
         v.has_pr && (not v.merged)
-        && (not
-              (List.mem v.queue Operation_kind.Rebase
-                 ~equal:Operation_kind.equal))
+        && not
+             (List.mem v.queue Operation_kind.Rebase ~equal:Operation_kind.equal)
       then
         match v.branch_rebased_onto with
-        | Some rebased_onto
-          when not (Branch.equal rebased_onto v.base_branch) ->
+        | Some rebased_onto when not (Branch.equal rebased_onto v.base_branch)
+          ->
             Some (Enqueue_rebase v.id)
         | Some _ | None -> None
       else None)
@@ -167,14 +166,11 @@ let reconcile ~graph ~main ~merged_pr_patches ~branch_of views =
     let add_unseen seen actions =
       List.fold actions ~init:(seen, []) ~f:(fun (seen, acc) a ->
           match pid_of a with
-          | Some pid when not (Set.mem seen pid) ->
-              (Set.add seen pid, a :: acc)
+          | Some pid when not (Set.mem seen pid) -> (Set.add seen pid, a :: acc)
           | Some _ -> (seen, acc)
           | None -> (seen, a :: acc))
     in
-    let seen, kept1 =
-      add_unseen (Set.empty (module Patch_id)) event_rebases
-    in
+    let seen, kept1 = add_unseen (Set.empty (module Patch_id)) event_rebases in
     let seen, kept2 = add_unseen seen stale_rebases in
     let _seen, kept3 = add_unseen seen drift_rebases in
     List.rev kept1 @ List.rev kept2 @ List.rev kept3

--- a/lib/reconciler.ml
+++ b/lib/reconciler.ml
@@ -10,6 +10,7 @@ type patch_view = {
   branch_blocked : bool;
   queue : Operation_kind.t list;
   base_branch : Branch.t;
+  branch_rebased_onto : Branch.t option;
 }
 [@@deriving sexp_of]
 
@@ -62,6 +63,33 @@ let detect_rebases graph views ~newly_merged =
                      ~equal:Operation_kind.equal) ->
           Some (Enqueue_rebase dep_id)
       | _ -> None)
+
+(** Detect agents whose local branch is rebased onto something other than
+    [base_branch]. [branch_rebased_onto] is updated by Start (to the initial
+    base) and by successful Rebase (to the rebase target). If [base_branch]
+    has since moved — typically because a dep branch was merged and deleted
+    on GitHub, causing GitHub to auto-retarget the PR to [main], and the
+    poller then refreshed [base_branch] to match — the local branch still
+    carries the old dep's commits in its history and needs a rebase even
+    though [base_branch] already equals the structurally-correct base.
+
+    This is the case [detect_stale_bases] misses: there, the structural check
+    [base_branch vs initial_base] both read [main] and agreed, so no rebase
+    was enqueued. *)
+let detect_notified_base_drift views =
+  List.filter_map views ~f:(fun v ->
+      if
+        v.has_pr && (not v.merged)
+        && (not
+              (List.mem v.queue Operation_kind.Rebase
+                 ~equal:Operation_kind.equal))
+      then
+        match v.branch_rebased_onto with
+        | Some rebased_onto
+          when not (Branch.equal rebased_onto v.base_branch) ->
+            Some (Enqueue_rebase v.id)
+        | Some _ | None -> None
+      else None)
 
 (** Detect agents whose base_branch still points at a merged dependency's
     branch. This catches cases where the event-driven detect_rebases missed the
@@ -126,19 +154,30 @@ let reconcile ~graph ~main ~merged_pr_patches ~branch_of views =
   let stale_rebases =
     detect_stale_bases graph views ~has_merged ~branch_of ~main
   in
-  (* Deduplicate: event-driven rebases may overlap with stale-base rebases *)
+  let drift_rebases = detect_notified_base_drift views in
+  (* Deduplicate across the three rebase detectors. Priority is arbitrary —
+     they all emit the same [Enqueue_rebase] with the same patch_id — but we
+     must not emit duplicates, since the orchestrator's [enqueue] is
+     idempotent but tests assert on action counts. *)
   let rebases =
-    let seen =
-      Set.of_list
-        (module Patch_id)
-        (List.filter_map event_rebases ~f:(function
-          | Enqueue_rebase pid -> Some pid
-          | Mark_merged _ | Start_operation _ -> None))
+    let pid_of = function
+      | Enqueue_rebase pid -> Some pid
+      | Mark_merged _ | Start_operation _ -> None
     in
-    event_rebases
-    @ List.filter stale_rebases ~f:(function
-      | Enqueue_rebase pid -> not (Set.mem seen pid)
-      | Mark_merged _ | Start_operation _ -> true)
+    let add_unseen seen actions =
+      List.fold actions ~init:(seen, []) ~f:(fun (seen, acc) a ->
+          match pid_of a with
+          | Some pid when not (Set.mem seen pid) ->
+              (Set.add seen pid, a :: acc)
+          | Some _ -> (seen, acc)
+          | None -> (seen, a :: acc))
+    in
+    let seen, kept1 =
+      add_unseen (Set.empty (module Patch_id)) event_rebases
+    in
+    let seen, kept2 = add_unseen seen stale_rebases in
+    let _seen, kept3 = add_unseen seen drift_rebases in
+    List.rev kept1 @ List.rev kept2 @ List.rev kept3
   in
   let rebase_set =
     List.filter_map rebases ~f:(function

--- a/lib/reconciler.mli
+++ b/lib/reconciler.mli
@@ -18,6 +18,13 @@ type patch_view = {
   branch_blocked : bool;
   queue : Types.Operation_kind.t list;
   base_branch : Types.Branch.t;
+  branch_rebased_onto : Types.Branch.t option;
+      (** The base the local branch is actually rebased onto. [None] before
+          the first [Start]. Updated by [Start] (to the start base) and by
+          successful [Rebase] (to the rebase target). When this diverges from
+          [base_branch], the local branch still carries the old dep's commits
+          even if GitHub auto-retargeted the PR — a rebase is required. Used
+          by [detect_notified_base_drift]. *)
 }
 [@@deriving sexp_of]
 (** Observable state of a single patch, projected for reconciliation. *)
@@ -58,6 +65,19 @@ val detect_rebases :
 (** [detect_rebases graph views ~newly_merged] returns [Enqueue_rebase] for
     dependents of [newly_merged] patches that have a PR, are not merged, and do
     not already have a rebase queued. *)
+
+val detect_notified_base_drift : patch_view list -> action list
+(** [detect_notified_base_drift views] returns [Enqueue_rebase] for agents
+    whose [branch_rebased_onto] is [Some b] and differs from the current
+    [base_branch]. This catches the case where a dependency's branch was
+    merged and deleted on GitHub, which auto-retargets the PR to [main]; the
+    poller then updates [base_branch] to match, but the local branch still
+    carries the merged dep's commits and must be rebased. [detect_stale_bases]
+    can't catch this because once [base_branch] equals [initial_base], the
+    structural check passes.
+
+    Same precondition guards as other rebase detectors: has_pr, !merged,
+    !Rebase-in-queue. *)
 
 val plan_operations :
   patch_view list ->

--- a/lib/reconciler.mli
+++ b/lib/reconciler.mli
@@ -19,12 +19,12 @@ type patch_view = {
   queue : Types.Operation_kind.t list;
   base_branch : Types.Branch.t;
   branch_rebased_onto : Types.Branch.t option;
-      (** The base the local branch is actually rebased onto. [None] before
-          the first [Start]. Updated by [Start] (to the start base) and by
+      (** The base the local branch is actually rebased onto. [None] before the
+          first [Start]. Updated by [Start] (to the start base) and by
           successful [Rebase] (to the rebase target). When this diverges from
           [base_branch], the local branch still carries the old dep's commits
-          even if GitHub auto-retargeted the PR — a rebase is required. Used
-          by [detect_notified_base_drift]. *)
+          even if GitHub auto-retargeted the PR — a rebase is required. Used by
+          [detect_notified_base_drift]. *)
 }
 [@@deriving sexp_of]
 (** Observable state of a single patch, projected for reconciliation. *)
@@ -67,14 +67,14 @@ val detect_rebases :
     not already have a rebase queued. *)
 
 val detect_notified_base_drift : patch_view list -> action list
-(** [detect_notified_base_drift views] returns [Enqueue_rebase] for agents
-    whose [branch_rebased_onto] is [Some b] and differs from the current
-    [base_branch]. This catches the case where a dependency's branch was
-    merged and deleted on GitHub, which auto-retargets the PR to [main]; the
-    poller then updates [base_branch] to match, but the local branch still
-    carries the merged dep's commits and must be rebased. [detect_stale_bases]
-    can't catch this because once [base_branch] equals [initial_base], the
-    structural check passes.
+(** [detect_notified_base_drift views] returns [Enqueue_rebase] for agents whose
+    [branch_rebased_onto] is [Some b] and differs from the current
+    [base_branch]. This catches the case where a dependency's branch was merged
+    and deleted on GitHub, which auto-retargets the PR to [main]; the poller
+    then updates [base_branch] to match, but the local branch still carries the
+    merged dep's commits and must be rebased. [detect_stale_bases] can't catch
+    this because once [base_branch] equals [initial_base], the structural check
+    passes.
 
     Same precondition guards as other rebase detectors: has_pr, !merged,
     !Rebase-in-queue. *)

--- a/lib/worktree.ml
+++ b/lib/worktree.ml
@@ -501,24 +501,22 @@ let parse_push_porcelain stdout =
     Returns [None] on non-zero exit or unparseable stdout (treat as unknown —
     caller may decide to proceed with the push rather than erroneously skip). *)
 let parse_commit_count ~code ~stdout =
-  if code <> 0 then None
-  else Stdlib.int_of_string_opt (String.strip stdout)
+  if code <> 0 then None else Stdlib.int_of_string_opt (String.strip stdout)
 
 type push_gate = Proceed | Skip_no_commits [@@deriving show, eq, sexp_of]
 
 (** Pure: given a commit-count result, decide whether to push. Zero commits
-    ahead of base means a push would publish an empty ref that GitHub rejects
-    on PR creation — skip. Unknown ([None]) defaults to [Proceed] so real
-    failures surface via the push step rather than being masked by a silent
-    skip. *)
+    ahead of base means a push would publish an empty ref that GitHub rejects on
+    PR creation — skip. Unknown ([None]) defaults to [Proceed] so real failures
+    surface via the push step rather than being masked by a silent skip. *)
 let push_gate_from_count = function
   | Some 0 -> Skip_no_commits
   | None | Some _ -> Proceed
 
-(** Pure: classify a [git push --porcelain --force-with-lease] invocation
-    from its exit code + stdout + stderr. Split out so the mapping from raw
-    git output to [push_result] can be property-tested independently of the
-    shell. *)
+(** Pure: classify a [git push --porcelain --force-with-lease] invocation from
+    its exit code + stdout + stderr. Split out so the mapping from raw git
+    output to [push_result] can be property-tested independently of the shell.
+*)
 let classify_push_result ~code ~stdout ~stderr =
   if code = 0 then
     match parse_push_porcelain stdout with
@@ -529,8 +527,7 @@ let classify_push_result ~code ~stdout ~stderr =
     | Some '!' -> Push_rejected
     | _ ->
         Push_error
-          (Printf.sprintf "push failed (exit %d): %s" code
-             (String.strip stderr))
+          (Printf.sprintf "push failed (exit %d): %s" code (String.strip stderr))
 
 (** Effectful: run [git rev-list --count base..HEAD] in the worktree. *)
 let commits_ahead_of_base ~process_mgr ~path ~base =

--- a/lib/worktree.ml
+++ b/lib/worktree.ml
@@ -474,6 +474,7 @@ let rebase_onto ~process_mgr ~path ~target =
 type push_result =
   | Push_ok
   | Push_up_to_date
+  | Push_no_commits
   | Push_rejected
   | Push_error of string
 [@@deriving show, eq, sexp_of, compare]
@@ -496,21 +497,29 @@ let parse_push_porcelain stdout =
       | s when String.length s > 0 -> Some s.[0]
       | _ -> None)
 
-let force_push_with_lease ~process_mgr ~path ~branch =
-  let branch_str = Types.Branch.to_string branch in
-  let code, stdout, stderr =
-    run_git_exit_code ~process_mgr
-      [
-        "git";
-        "-C";
-        path;
-        "push";
-        "--porcelain";
-        "--force-with-lease";
-        "origin";
-        branch_str;
-      ]
-  in
+(** Pure: parse [git rev-list --count base..HEAD] output into a commit count.
+    Returns [None] on non-zero exit or unparseable stdout (treat as unknown —
+    caller may decide to proceed with the push rather than erroneously skip). *)
+let parse_commit_count ~code ~stdout =
+  if code <> 0 then None
+  else Stdlib.int_of_string_opt (String.strip stdout)
+
+type push_gate = Proceed | Skip_no_commits [@@deriving show, eq, sexp_of]
+
+(** Pure: given a commit-count result, decide whether to push. Zero commits
+    ahead of base means a push would publish an empty ref that GitHub rejects
+    on PR creation — skip. Unknown ([None]) defaults to [Proceed] so real
+    failures surface via the push step rather than being masked by a silent
+    skip. *)
+let push_gate_from_count = function
+  | Some 0 -> Skip_no_commits
+  | None | Some _ -> Proceed
+
+(** Pure: classify a [git push --porcelain --force-with-lease] invocation
+    from its exit code + stdout + stderr. Split out so the mapping from raw
+    git output to [push_result] can be property-tested independently of the
+    shell. *)
+let classify_push_result ~code ~stdout ~stderr =
   if code = 0 then
     match parse_push_porcelain stdout with
     | Some '=' -> Push_up_to_date
@@ -520,7 +529,38 @@ let force_push_with_lease ~process_mgr ~path ~branch =
     | Some '!' -> Push_rejected
     | _ ->
         Push_error
-          (Printf.sprintf "push failed (exit %d): %s" code (String.strip stderr))
+          (Printf.sprintf "push failed (exit %d): %s" code
+             (String.strip stderr))
+
+(** Effectful: run [git rev-list --count base..HEAD] in the worktree. *)
+let commits_ahead_of_base ~process_mgr ~path ~base =
+  let base_str = Types.Branch.to_string base in
+  let code, stdout, _ =
+    run_git_exit_code ~process_mgr
+      [ "git"; "-C"; path; "rev-list"; "--count"; base_str ^ "..HEAD" ]
+  in
+  parse_commit_count ~code ~stdout
+
+let force_push_with_lease ~process_mgr ~path ~branch ~base =
+  let count = commits_ahead_of_base ~process_mgr ~path ~base in
+  match push_gate_from_count count with
+  | Skip_no_commits -> Push_no_commits
+  | Proceed ->
+      let branch_str = Types.Branch.to_string branch in
+      let code, stdout, stderr =
+        run_git_exit_code ~process_mgr
+          [
+            "git";
+            "-C";
+            path;
+            "push";
+            "--porcelain";
+            "--force-with-lease";
+            "origin";
+            branch_str;
+          ]
+      in
+      classify_push_result ~code ~stdout ~stderr
 
 let rebase_in_progress ~process_mgr ~path =
   let code, stdout, _ =

--- a/lib/worktree.mli
+++ b/lib/worktree.mli
@@ -85,19 +85,41 @@ val parse_push_porcelain : string -> char option
 type push_result =
   | Push_ok
   | Push_up_to_date
+  | Push_no_commits
   | Push_rejected
   | Push_error of string
 [@@deriving show, eq, sexp_of, compare]
+
+type push_gate = Proceed | Skip_no_commits [@@deriving show, eq, sexp_of]
+
+val parse_commit_count : code:int -> stdout:string -> int option
+(** Pure: parse [git rev-list --count base..HEAD] output into a commit count.
+    [None] when [code <> 0] or stdout is unparseable. *)
+
+val push_gate_from_count : int option -> push_gate
+(** Pure: decide whether to push given a commit-count result.
+    - [Some 0] → [Skip_no_commits] (branch is base-equal; GitHub would reject).
+    - [None] or [Some _] → [Proceed] (unknown counts default to proceeding so
+      real failures surface via the push step, not via a silent skip). *)
+
+val classify_push_result :
+  code:int -> stdout:string -> stderr:string -> push_result
+(** Pure: classify a [git push --porcelain --force-with-lease] invocation
+    into a [push_result]. [Push_no_commits] is never returned by this function
+    — that variant is only produced by the gate (the push is skipped entirely
+    when the branch has no commits ahead of base). *)
 
 val force_push_with_lease :
   process_mgr:_ Eio.Process.mgr ->
   path:string ->
   branch:Types.Branch.t ->
+  base:Types.Branch.t ->
   push_result
-(** Force-push with lease the given branch from the worktree at [path]. Returns
-    [Push_ok] on success, [Push_up_to_date] when the remote already has the same
-    SHA (nothing changed), [Push_rejected] if the lease check fails (remote was
-    updated by someone else), or [Push_error] on other failures. *)
+(** Force-push with lease the given branch from the worktree at [path]. Thin
+    effectful orchestrator: runs [git rev-list --count base..HEAD], applies
+    [push_gate_from_count] to decide whether to push, and classifies the push
+    output via [classify_push_result]. See [push_gate_from_count] and
+    [classify_push_result] for the pure decision logic. *)
 
 val rebase_in_progress : process_mgr:_ Eio.Process.mgr -> path:string -> bool
 (** Returns [true] if there is a rebase currently in progress in the worktree at

--- a/lib/worktree.mli
+++ b/lib/worktree.mli
@@ -104,10 +104,10 @@ val push_gate_from_count : int option -> push_gate
 
 val classify_push_result :
   code:int -> stdout:string -> stderr:string -> push_result
-(** Pure: classify a [git push --porcelain --force-with-lease] invocation
-    into a [push_result]. [Push_no_commits] is never returned by this function
-    — that variant is only produced by the gate (the push is skipped entirely
-    when the branch has no commits ahead of base). *)
+(** Pure: classify a [git push --porcelain --force-with-lease] invocation into a
+    [push_result]. [Push_no_commits] is never returned by this function — that
+    variant is only produced by the gate (the push is skipped entirely when the
+    branch has no commits ahead of base). *)
 
 val force_push_with_lease :
   process_mgr:_ Eio.Process.mgr ->

--- a/lib_test/test_generators.ml
+++ b/lib_test/test_generators.ml
@@ -616,6 +616,7 @@ let gen_session_result =
         return Onton.Orchestrator.Session_give_up;
         return Onton.Orchestrator.Session_worktree_missing;
         return Onton.Orchestrator.Session_push_failed;
+        return Onton.Orchestrator.Session_no_commits;
       ])
 
 let print_session_result = Onton.Orchestrator.show_session_result

--- a/lib_test/test_generators.ml
+++ b/lib_test/test_generators.ml
@@ -427,6 +427,11 @@ let gen_patch_view =
             branch_blocked;
             queue;
             base_branch;
+            (* Conservative default for existing randomized tests: no drift
+               (local branch is on the current base). Drift-specific tests
+               construct views explicitly rather than relying on this
+               generator. *)
+            branch_rebased_onto = Some base_branch;
           })
       (pair gen_patch_id gen_branch)
       (quad bool bool bool bool)
@@ -682,6 +687,7 @@ let apply_reconcile_actions orch ~main ~branch_of =
             queue = a.Onton.Patch_agent.queue;
             base_branch =
               Option.value a.Onton.Patch_agent.base_branch ~default:main;
+            branch_rebased_onto = a.Onton.Patch_agent.branch_rebased_onto;
           })
   in
   let merged_patches =

--- a/test/test_interleaving_properties.ml
+++ b/test/test_interleaving_properties.ml
@@ -1511,3 +1511,137 @@ let () =
   in
   QCheck2.Test.check_exn prop_pi13;
   Stdlib.print_endline "PI-13 passed"
+
+(** PI-14: Two consecutive Session_no_commits promote to needs_intervention —
+    without a pending Human in the queue, the counter crossing 2 is enough to
+    stop the scheduler from re-enqueueing Start. Regression for the class of
+    bug where an LLM produces no commits and the supervisor silently loops
+    forever trying to push an empty branch. *)
+let () =
+  let prop_pi14 =
+    QCheck2.Test.make
+      ~name:
+        "PI-14: two consecutive Session_no_commits flip needs_intervention"
+      ~count:200 (QCheck2.Gen.return ()) (fun () ->
+        let patches = mk_patches 1 in
+        let orch = Orchestrator.create ~patches ~main_branch:main in
+        let pid = pid_of_idx patches 0 in
+        let orch = Orchestrator.fire orch (Orchestrator.Start (pid, main)) in
+        if not (Orchestrator.agent orch pid).Patch_agent.busy then
+          failwith "agent not busy after Start";
+        let orch =
+          Orchestrator.apply_session_result orch pid
+            Orchestrator.Session_no_commits
+        in
+        let a1 = Orchestrator.agent orch pid in
+        if a1.Patch_agent.busy then
+          failwith "agent still busy after first Session_no_commits";
+        if not (Int.equal a1.Patch_agent.no_commits_push_count 1) then
+          failwith "counter not incremented after first Session_no_commits";
+        if Patch_agent.needs_intervention a1 then
+          failwith "needs_intervention fired too early (count = 1)";
+        if
+          not
+            (Patch_agent.equal_session_fallback
+               a1.Patch_agent.session_fallback Patch_agent.Fresh_available)
+        then
+          failwith
+            "session_fallback was not preserved as Fresh_available (LLM \
+             itself was healthy)";
+        let orch = Orchestrator.fire orch (Orchestrator.Start (pid, main)) in
+        if not (Orchestrator.agent orch pid).Patch_agent.busy then
+          failwith "agent not busy after re-Start";
+        let orch =
+          Orchestrator.apply_session_result orch pid
+            Orchestrator.Session_no_commits
+        in
+        let a2 = Orchestrator.agent orch pid in
+        if not (Int.equal a2.Patch_agent.no_commits_push_count 2) then
+          failwith "counter not incremented to 2 after second no-commits";
+        if not (Patch_agent.needs_intervention a2) then
+          failwith "needs_intervention not flipped at count = 2";
+        true)
+  in
+  QCheck2.Test.check_exn prop_pi14;
+  Stdlib.print_endline "PI-14 passed"
+
+(** PI-14b: A human message sent mid-session survives Session_no_commits —
+    complete_failed restores inflight_human_messages into human_messages so
+    the scheduler re-enqueues Human on the next cycle. Note: while a Human is
+    pending, needs_intervention is deliberately gated off (operator may need
+    to respond first); the counter still increments and will surface once the
+    Human queue is drained. *)
+let () =
+  let prop_pi14b =
+    QCheck2.Test.make
+      ~name:
+        "PI-14b: human message survives Session_no_commits \
+         (complete_failed)"
+      ~count:200
+      (QCheck2.Gen.string_size (QCheck2.Gen.int_range 1 80))
+      (fun msg ->
+        let patches = mk_patches 1 in
+        let orch = Orchestrator.create ~patches ~main_branch:main in
+        let pid = pid_of_idx patches 0 in
+        let orch = Orchestrator.fire orch (Orchestrator.Start (pid, main)) in
+        let orch = Orchestrator.send_human_message orch pid msg in
+        let orch =
+          Orchestrator.apply_session_result orch pid
+            Orchestrator.Session_no_commits
+        in
+        let a = Orchestrator.agent orch pid in
+        if a.Patch_agent.busy then
+          failwith "agent still busy after Session_no_commits";
+        if
+          not
+            (List.mem a.Patch_agent.human_messages msg ~equal:String.equal)
+        then failwith "human message lost after Session_no_commits";
+        if not (Int.equal a.Patch_agent.no_commits_push_count 1) then
+          failwith "counter not incremented";
+        (* With Human pending in queue, needs_intervention is gated off —
+           deliberately. *)
+        not (Patch_agent.needs_intervention a))
+  in
+  QCheck2.Test.check_exn prop_pi14b;
+  Stdlib.print_endline "PI-14b passed"
+
+(** PI-15: Session_ok after a Session_no_commits cleanly resets the counter
+    and intervention state — the agent recovers on its next healthy session
+    and isn't stuck in a half-broken state. Regression for the bug where the
+    counter leaks across successful sessions. *)
+let () =
+  let prop_pi15 =
+    QCheck2.Test.make
+      ~name:
+        "PI-15: Session_ok after Session_no_commits resets \
+         no_commits_push_count"
+      ~count:100 (QCheck2.Gen.int_range 1 2) (fun n_no_commits ->
+        let patches = mk_patches 1 in
+        let orch = Orchestrator.create ~patches ~main_branch:main in
+        let pid = pid_of_idx patches 0 in
+        let orch =
+          (* Fire Start -> Session_no_commits n times. *)
+          List.fold (List.range 0 n_no_commits) ~init:orch ~f:(fun o _ ->
+              let o = Orchestrator.fire o (Orchestrator.Start (pid, main)) in
+              Orchestrator.apply_session_result o pid
+                Orchestrator.Session_no_commits)
+        in
+        if
+          not
+            (Int.equal
+               (Orchestrator.agent orch pid).Patch_agent.no_commits_push_count
+               n_no_commits)
+        then failwith "counter did not accumulate as expected";
+        (* Fire Start one more time and end with Session_ok. *)
+        let orch = Orchestrator.fire orch (Orchestrator.Start (pid, main)) in
+        let orch =
+          Orchestrator.apply_session_result orch pid Orchestrator.Session_ok
+        in
+        let a = Orchestrator.agent orch pid in
+        (* Session_ok does NOT complete — agent stays busy per existing
+           contract — but the counter MUST be zeroed. *)
+        Int.equal a.Patch_agent.no_commits_push_count 0
+        && not (Patch_agent.needs_intervention a))
+  in
+  QCheck2.Test.check_exn prop_pi15;
+  Stdlib.print_endline "PI-15 passed"

--- a/test/test_interleaving_properties.ml
+++ b/test/test_interleaving_properties.ml
@@ -1514,14 +1514,13 @@ let () =
 
 (** PI-14: Two consecutive Session_no_commits promote to needs_intervention —
     without a pending Human in the queue, the counter crossing 2 is enough to
-    stop the scheduler from re-enqueueing Start. Regression for the class of
-    bug where an LLM produces no commits and the supervisor silently loops
-    forever trying to push an empty branch. *)
+    stop the scheduler from re-enqueueing Start. Regression for the class of bug
+    where an LLM produces no commits and the supervisor silently loops forever
+    trying to push an empty branch. *)
 let () =
   let prop_pi14 =
     QCheck2.Test.make
-      ~name:
-        "PI-14: two consecutive Session_no_commits flip needs_intervention"
+      ~name:"PI-14: two consecutive Session_no_commits flip needs_intervention"
       ~count:200 (QCheck2.Gen.return ()) (fun () ->
         let patches = mk_patches 1 in
         let orch = Orchestrator.create ~patches ~main_branch:main in
@@ -1542,12 +1541,12 @@ let () =
           failwith "needs_intervention fired too early (count = 1)";
         if
           not
-            (Patch_agent.equal_session_fallback
-               a1.Patch_agent.session_fallback Patch_agent.Fresh_available)
+            (Patch_agent.equal_session_fallback a1.Patch_agent.session_fallback
+               Patch_agent.Fresh_available)
         then
           failwith
-            "session_fallback was not preserved as Fresh_available (LLM \
-             itself was healthy)";
+            "session_fallback was not preserved as Fresh_available (LLM itself \
+             was healthy)";
         let orch = Orchestrator.fire orch (Orchestrator.Start (pid, main)) in
         if not (Orchestrator.agent orch pid).Patch_agent.busy then
           failwith "agent not busy after re-Start";
@@ -1566,17 +1565,16 @@ let () =
   Stdlib.print_endline "PI-14 passed"
 
 (** PI-14b: A human message sent mid-session survives Session_no_commits —
-    complete_failed restores inflight_human_messages into human_messages so
-    the scheduler re-enqueues Human on the next cycle. Note: while a Human is
-    pending, needs_intervention is deliberately gated off (operator may need
-    to respond first); the counter still increments and will surface once the
-    Human queue is drained. *)
+    complete_failed restores inflight_human_messages into human_messages so the
+    scheduler re-enqueues Human on the next cycle. Note: while a Human is
+    pending, needs_intervention is deliberately gated off (operator may need to
+    respond first); the counter still increments and will surface once the Human
+    queue is drained. *)
 let () =
   let prop_pi14b =
     QCheck2.Test.make
       ~name:
-        "PI-14b: human message survives Session_no_commits \
-         (complete_failed)"
+        "PI-14b: human message survives Session_no_commits (complete_failed)"
       ~count:200
       (QCheck2.Gen.string_size (QCheck2.Gen.int_range 1 80))
       (fun msg ->
@@ -1592,9 +1590,7 @@ let () =
         let a = Orchestrator.agent orch pid in
         if a.Patch_agent.busy then
           failwith "agent still busy after Session_no_commits";
-        if
-          not
-            (List.mem a.Patch_agent.human_messages msg ~equal:String.equal)
+        if not (List.mem a.Patch_agent.human_messages msg ~equal:String.equal)
         then failwith "human message lost after Session_no_commits";
         if not (Int.equal a.Patch_agent.no_commits_push_count 1) then
           failwith "counter not incremented";
@@ -1605,10 +1601,10 @@ let () =
   QCheck2.Test.check_exn prop_pi14b;
   Stdlib.print_endline "PI-14b passed"
 
-(** PI-15: Session_ok after a Session_no_commits cleanly resets the counter
-    and intervention state — the agent recovers on its next healthy session
-    and isn't stuck in a half-broken state. Regression for the bug where the
-    counter leaks across successful sessions. *)
+(** PI-15: Session_ok after a Session_no_commits cleanly resets the counter and
+    intervention state — the agent recovers on its next healthy session and
+    isn't stuck in a half-broken state. Regression for the bug where the counter
+    leaks across successful sessions. *)
 let () =
   let prop_pi15 =
     QCheck2.Test.make
@@ -1646,15 +1642,15 @@ let () =
   QCheck2.Test.check_exn prop_pi15;
   Stdlib.print_endline "PI-15 passed"
 
-(** PI-16: The retire-blue-green/patch-2 scenario end-to-end — a dependent
-    patch whose PR gets auto-retargeted by GitHub when its dep merges and
-    whose branch is never thereby rebased. The drift detector must catch it.
+(** PI-16: The retire-blue-green/patch-2 scenario end-to-end — a dependent patch
+    whose PR gets auto-retargeted by GitHub when its dep merges and whose branch
+    is never thereby rebased. The drift detector must catch it.
 
     Setup: two patches, patch b depends on patch a. Both bootstrap to having
     PRs; b's branch_rebased_onto is patch-a's branch (where it started). a
-    merges (agent flagged merged, GitHub deletes a's branch and retargets b's
-    PR to main — modeled by updating b.base_branch to main). The reconciler
-    must enqueue a Rebase on b. *)
+    merges (agent flagged merged, GitHub deletes a's branch and retargets b's PR
+    to main — modeled by updating b.base_branch to main). The reconciler must
+    enqueue a Rebase on b. *)
 let () =
   let prop_pi16 =
     QCheck2.Test.make
@@ -1680,7 +1676,8 @@ let () =
           }
         in
         let b : Patch.t =
-          { a with
+          {
+            a with
             id = Patch_id.of_string "b";
             title = "b";
             branch = Branch.of_string "b";
@@ -1730,9 +1727,8 @@ let () =
               else None)
         in
         let actions =
-          Reconciler.reconcile
-            ~graph:(Orchestrator.graph orch)
-            ~main ~merged_pr_patches:merged_patches ~branch_of patch_views
+          Reconciler.reconcile ~graph:(Orchestrator.graph orch) ~main
+            ~merged_pr_patches:merged_patches ~branch_of patch_views
         in
         (* The reconciler must emit Enqueue_rebase for b. *)
         List.exists actions ~f:(function

--- a/test/test_interleaving_properties.ml
+++ b/test/test_interleaving_properties.ml
@@ -1645,3 +1645,99 @@ let () =
   in
   QCheck2.Test.check_exn prop_pi15;
   Stdlib.print_endline "PI-15 passed"
+
+(** PI-16: The retire-blue-green/patch-2 scenario end-to-end — a dependent
+    patch whose PR gets auto-retargeted by GitHub when its dep merges and
+    whose branch is never thereby rebased. The drift detector must catch it.
+
+    Setup: two patches, patch b depends on patch a. Both bootstrap to having
+    PRs; b's branch_rebased_onto is patch-a's branch (where it started). a
+    merges (agent flagged merged, GitHub deletes a's branch and retargets b's
+    PR to main — modeled by updating b.base_branch to main). The reconciler
+    must enqueue a Rebase on b. *)
+let () =
+  let prop_pi16 =
+    QCheck2.Test.make
+      ~name:
+        "PI-16: drift detector catches GitHub-auto-retargeted PR after dep \
+         merge"
+      ~count:1 (QCheck2.Gen.return ()) (fun () ->
+        (* Build a linear 2-patch gameplan: b depends on a *)
+        let a : Patch.t =
+          {
+            id = Patch_id.of_string "a";
+            title = "a";
+            description = "";
+            branch = Branch.of_string "a";
+            dependencies = [];
+            spec = "";
+            acceptance_criteria = [];
+            files = [];
+            classification = "";
+            changes = [];
+            test_stubs_introduced = [];
+            test_stubs_implemented = [];
+          }
+        in
+        let b : Patch.t =
+          { a with
+            id = Patch_id.of_string "b";
+            title = "b";
+            branch = Branch.of_string "b";
+            dependencies = [ Patch_id.of_string "a" ];
+          }
+        in
+        let patches = [ a; b ] in
+        let orch = bootstrap patches in
+        let pid_a = a.id and pid_b = b.id in
+        (* Sanity: b started with base_branch = a's branch (per
+           Graph.initial_base) and branch_rebased_onto set to same. *)
+        let agent_b = Orchestrator.agent orch pid_b in
+        if
+          not
+            (Option.equal Branch.equal agent_b.Patch_agent.branch_rebased_onto
+               (Some a.branch))
+        then
+          failwith "patch b did not start with branch_rebased_onto = a's branch";
+        (* a merges *)
+        let orch = Orchestrator.mark_merged orch pid_a in
+        (* GitHub auto-retargets b's PR to main (modeled by explicit
+           set_base_branch on b). Simultaneously b's branch_rebased_onto is
+           still pointing at a's branch because no Rebase has run yet. *)
+        let orch = Orchestrator.set_base_branch orch pid_b main in
+        (* Now run reconcile like the poll fiber does *)
+        let agents = Orchestrator.all_agents orch in
+        let branch_of = branch_of_patches patches in
+        let patch_views =
+          List.map agents ~f:(fun (ag : Patch_agent.t) ->
+              Reconciler.
+                {
+                  id = ag.Patch_agent.patch_id;
+                  has_pr = Patch_agent.has_pr ag;
+                  merged = ag.Patch_agent.merged;
+                  busy = ag.Patch_agent.busy;
+                  needs_intervention = Patch_agent.needs_intervention ag;
+                  branch_blocked = ag.Patch_agent.branch_blocked;
+                  queue = ag.Patch_agent.queue;
+                  base_branch =
+                    Option.value ag.Patch_agent.base_branch ~default:main;
+                  branch_rebased_onto = ag.Patch_agent.branch_rebased_onto;
+                })
+        in
+        let merged_patches =
+          List.filter_map agents ~f:(fun (ag : Patch_agent.t) ->
+              if ag.Patch_agent.merged then Some ag.Patch_agent.patch_id
+              else None)
+        in
+        let actions =
+          Reconciler.reconcile
+            ~graph:(Orchestrator.graph orch)
+            ~main ~merged_pr_patches:merged_patches ~branch_of patch_views
+        in
+        (* The reconciler must emit Enqueue_rebase for b. *)
+        List.exists actions ~f:(function
+          | Reconciler.Enqueue_rebase p -> Patch_id.equal p pid_b
+          | Reconciler.Mark_merged _ | Reconciler.Start_operation _ -> false))
+  in
+  QCheck2.Test.check_exn prop_pi16;
+  Stdlib.print_endline "PI-16 passed"

--- a/test/test_patch_agent.ml
+++ b/test/test_patch_agent.ml
@@ -677,7 +677,7 @@ let () =
               ~inflight_human_messages:[] ~ci_checks:a.ci_checks
               ~merge_ready:false ~is_draft:false ~pr_body_delivered:false
               ~implementation_notes_delivered:false ~start_attempts_without_pr:0
-              ~conflict_noop_count:0 ~no_commits_push_count:0 ~checks_passing:false ~current_op:None
+              ~conflict_noop_count:0 ~no_commits_push_count:0 ~branch_rebased_onto:None ~checks_passing:false ~current_op:None
               ~current_message_id:None ~generation:0 ~worktree_path:None
               ~branch_blocked:false ~llm_session_id:None
           in
@@ -752,7 +752,7 @@ let () =
               ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
               ~merge_ready:false ~is_draft:false ~pr_body_delivered:false
               ~implementation_notes_delivered:false ~start_attempts_without_pr:0
-              ~conflict_noop_count:0 ~no_commits_push_count:0 ~checks_passing:false ~current_op:None
+              ~conflict_noop_count:0 ~no_commits_push_count:0 ~branch_rebased_onto:None ~checks_passing:false ~current_op:None
               ~current_message_id:None ~generation:0 ~worktree_path:None
               ~branch_blocked:false ~llm_session_id:None
           in

--- a/test/test_patch_agent.ml
+++ b/test/test_patch_agent.ml
@@ -677,7 +677,8 @@ let () =
               ~inflight_human_messages:[] ~ci_checks:a.ci_checks
               ~merge_ready:false ~is_draft:false ~pr_body_delivered:false
               ~implementation_notes_delivered:false ~start_attempts_without_pr:0
-              ~conflict_noop_count:0 ~no_commits_push_count:0 ~branch_rebased_onto:None ~checks_passing:false ~current_op:None
+              ~conflict_noop_count:0 ~no_commits_push_count:0
+              ~branch_rebased_onto:None ~checks_passing:false ~current_op:None
               ~current_message_id:None ~generation:0 ~worktree_path:None
               ~branch_blocked:false ~llm_session_id:None
           in
@@ -752,7 +753,8 @@ let () =
               ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
               ~merge_ready:false ~is_draft:false ~pr_body_delivered:false
               ~implementation_notes_delivered:false ~start_attempts_without_pr:0
-              ~conflict_noop_count:0 ~no_commits_push_count:0 ~branch_rebased_onto:None ~checks_passing:false ~current_op:None
+              ~conflict_noop_count:0 ~no_commits_push_count:0
+              ~branch_rebased_onto:None ~checks_passing:false ~current_op:None
               ~current_message_id:None ~generation:0 ~worktree_path:None
               ~branch_blocked:false ~llm_session_id:None
           in

--- a/test/test_patch_agent.ml
+++ b/test/test_patch_agent.ml
@@ -677,7 +677,7 @@ let () =
               ~inflight_human_messages:[] ~ci_checks:a.ci_checks
               ~merge_ready:false ~is_draft:false ~pr_body_delivered:false
               ~implementation_notes_delivered:false ~start_attempts_without_pr:0
-              ~conflict_noop_count:0 ~checks_passing:false ~current_op:None
+              ~conflict_noop_count:0 ~no_commits_push_count:0 ~checks_passing:false ~current_op:None
               ~current_message_id:None ~generation:0 ~worktree_path:None
               ~branch_blocked:false ~llm_session_id:None
           in
@@ -752,7 +752,7 @@ let () =
               ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
               ~merge_ready:false ~is_draft:false ~pr_body_delivered:false
               ~implementation_notes_delivered:false ~start_attempts_without_pr:0
-              ~conflict_noop_count:0 ~checks_passing:false ~current_op:None
+              ~conflict_noop_count:0 ~no_commits_push_count:0 ~checks_passing:false ~current_op:None
               ~current_message_id:None ~generation:0 ~worktree_path:None
               ~branch_blocked:false ~llm_session_id:None
           in

--- a/test/test_patch_controller.ml
+++ b/test/test_patch_controller.ml
@@ -54,9 +54,9 @@ let make_agent ~patch_id ~branch ~pr_number ~merged ~queue ~base_branch
     ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
     ~merge_ready:false ~is_draft ~pr_body_delivered:true
     ~implementation_notes_delivered ~start_attempts_without_pr
-    ~conflict_noop_count:0 ~no_commits_push_count:0 ~branch_rebased_onto:None ~checks_passing:false ~current_op:None
-    ~current_message_id:None ~generation:0 ~worktree_path:None
-    ~branch_blocked:false ~llm_session_id:None
+    ~conflict_noop_count:0 ~no_commits_push_count:0 ~branch_rebased_onto:None
+    ~checks_passing:false ~current_op:None ~current_message_id:None
+    ~generation:0 ~worktree_path:None ~branch_blocked:false ~llm_session_id:None
 
 let has_notes_queued agent =
   List.mem agent.Patch_agent.queue Operation_kind.Implementation_notes
@@ -358,7 +358,8 @@ let () =
             ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
             ~merge_ready:false ~is_draft:true ~pr_body_delivered:false
             ~implementation_notes_delivered:true ~start_attempts_without_pr:0
-            ~conflict_noop_count:0 ~no_commits_push_count:0 ~branch_rebased_onto:None ~checks_passing:false ~current_op:None
+            ~conflict_noop_count:0 ~no_commits_push_count:0
+            ~branch_rebased_onto:None ~checks_passing:false ~current_op:None
             ~current_message_id:None ~generation:0 ~worktree_path:None
             ~branch_blocked:false ~llm_session_id:None
         in
@@ -487,7 +488,8 @@ let () =
             ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
             ~merge_ready:false ~is_draft:false ~pr_body_delivered:true
             ~implementation_notes_delivered:true ~start_attempts_without_pr:0
-            ~conflict_noop_count:0 ~no_commits_push_count:0 ~branch_rebased_onto:None ~checks_passing:false ~current_op:None
+            ~conflict_noop_count:0 ~no_commits_push_count:0
+            ~branch_rebased_onto:None ~checks_passing:false ~current_op:None
             ~current_message_id:None ~generation:0 ~worktree_path:None
             ~branch_blocked:false ~llm_session_id:None
         in
@@ -623,7 +625,8 @@ let () =
             ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
             ~merge_ready:false ~is_draft:true ~pr_body_delivered:false
             ~implementation_notes_delivered:false ~start_attempts_without_pr:0
-            ~conflict_noop_count:0 ~no_commits_push_count:0 ~branch_rebased_onto:None ~checks_passing:false ~current_op:None
+            ~conflict_noop_count:0 ~no_commits_push_count:0
+            ~branch_rebased_onto:None ~checks_passing:false ~current_op:None
             ~current_message_id:None ~generation:0 ~worktree_path:None
             ~branch_blocked:false ~llm_session_id:None
         in
@@ -837,7 +840,8 @@ let () =
             ~inflight_human_messages:[] ~ci_checks:[] ~merge_ready:false
             ~is_draft:false ~pr_body_delivered:true
             ~implementation_notes_delivered:false ~start_attempts_without_pr:0
-            ~conflict_noop_count:0 ~no_commits_push_count:0 ~branch_rebased_onto:None ~checks_passing:false ~current_op:None
+            ~conflict_noop_count:0 ~no_commits_push_count:0
+            ~branch_rebased_onto:None ~checks_passing:false ~current_op:None
             ~current_message_id:None ~generation:0 ~worktree_path:None
             ~branch_blocked:false ~llm_session_id:None
         in
@@ -874,7 +878,8 @@ let () =
             ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
             ~merge_ready:false ~is_draft:false ~pr_body_delivered:true
             ~implementation_notes_delivered:false ~start_attempts_without_pr:0
-            ~conflict_noop_count:0 ~no_commits_push_count:0 ~branch_rebased_onto:None ~checks_passing:false ~current_op:None
+            ~conflict_noop_count:0 ~no_commits_push_count:0
+            ~branch_rebased_onto:None ~checks_passing:false ~current_op:None
             ~current_message_id:None ~generation:0 ~worktree_path:None
             ~branch_blocked:false ~llm_session_id:None
         in

--- a/test/test_patch_controller.ml
+++ b/test/test_patch_controller.ml
@@ -54,7 +54,7 @@ let make_agent ~patch_id ~branch ~pr_number ~merged ~queue ~base_branch
     ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
     ~merge_ready:false ~is_draft ~pr_body_delivered:true
     ~implementation_notes_delivered ~start_attempts_without_pr
-    ~conflict_noop_count:0 ~no_commits_push_count:0 ~checks_passing:false ~current_op:None
+    ~conflict_noop_count:0 ~no_commits_push_count:0 ~branch_rebased_onto:None ~checks_passing:false ~current_op:None
     ~current_message_id:None ~generation:0 ~worktree_path:None
     ~branch_blocked:false ~llm_session_id:None
 
@@ -358,7 +358,7 @@ let () =
             ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
             ~merge_ready:false ~is_draft:true ~pr_body_delivered:false
             ~implementation_notes_delivered:true ~start_attempts_without_pr:0
-            ~conflict_noop_count:0 ~no_commits_push_count:0 ~checks_passing:false ~current_op:None
+            ~conflict_noop_count:0 ~no_commits_push_count:0 ~branch_rebased_onto:None ~checks_passing:false ~current_op:None
             ~current_message_id:None ~generation:0 ~worktree_path:None
             ~branch_blocked:false ~llm_session_id:None
         in
@@ -487,7 +487,7 @@ let () =
             ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
             ~merge_ready:false ~is_draft:false ~pr_body_delivered:true
             ~implementation_notes_delivered:true ~start_attempts_without_pr:0
-            ~conflict_noop_count:0 ~no_commits_push_count:0 ~checks_passing:false ~current_op:None
+            ~conflict_noop_count:0 ~no_commits_push_count:0 ~branch_rebased_onto:None ~checks_passing:false ~current_op:None
             ~current_message_id:None ~generation:0 ~worktree_path:None
             ~branch_blocked:false ~llm_session_id:None
         in
@@ -623,7 +623,7 @@ let () =
             ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
             ~merge_ready:false ~is_draft:true ~pr_body_delivered:false
             ~implementation_notes_delivered:false ~start_attempts_without_pr:0
-            ~conflict_noop_count:0 ~no_commits_push_count:0 ~checks_passing:false ~current_op:None
+            ~conflict_noop_count:0 ~no_commits_push_count:0 ~branch_rebased_onto:None ~checks_passing:false ~current_op:None
             ~current_message_id:None ~generation:0 ~worktree_path:None
             ~branch_blocked:false ~llm_session_id:None
         in
@@ -837,7 +837,7 @@ let () =
             ~inflight_human_messages:[] ~ci_checks:[] ~merge_ready:false
             ~is_draft:false ~pr_body_delivered:true
             ~implementation_notes_delivered:false ~start_attempts_without_pr:0
-            ~conflict_noop_count:0 ~no_commits_push_count:0 ~checks_passing:false ~current_op:None
+            ~conflict_noop_count:0 ~no_commits_push_count:0 ~branch_rebased_onto:None ~checks_passing:false ~current_op:None
             ~current_message_id:None ~generation:0 ~worktree_path:None
             ~branch_blocked:false ~llm_session_id:None
         in
@@ -874,7 +874,7 @@ let () =
             ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
             ~merge_ready:false ~is_draft:false ~pr_body_delivered:true
             ~implementation_notes_delivered:false ~start_attempts_without_pr:0
-            ~conflict_noop_count:0 ~no_commits_push_count:0 ~checks_passing:false ~current_op:None
+            ~conflict_noop_count:0 ~no_commits_push_count:0 ~branch_rebased_onto:None ~checks_passing:false ~current_op:None
             ~current_message_id:None ~generation:0 ~worktree_path:None
             ~branch_blocked:false ~llm_session_id:None
         in

--- a/test/test_patch_controller.ml
+++ b/test/test_patch_controller.ml
@@ -54,7 +54,7 @@ let make_agent ~patch_id ~branch ~pr_number ~merged ~queue ~base_branch
     ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
     ~merge_ready:false ~is_draft ~pr_body_delivered:true
     ~implementation_notes_delivered ~start_attempts_without_pr
-    ~conflict_noop_count:0 ~checks_passing:false ~current_op:None
+    ~conflict_noop_count:0 ~no_commits_push_count:0 ~checks_passing:false ~current_op:None
     ~current_message_id:None ~generation:0 ~worktree_path:None
     ~branch_blocked:false ~llm_session_id:None
 
@@ -358,7 +358,7 @@ let () =
             ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
             ~merge_ready:false ~is_draft:true ~pr_body_delivered:false
             ~implementation_notes_delivered:true ~start_attempts_without_pr:0
-            ~conflict_noop_count:0 ~checks_passing:false ~current_op:None
+            ~conflict_noop_count:0 ~no_commits_push_count:0 ~checks_passing:false ~current_op:None
             ~current_message_id:None ~generation:0 ~worktree_path:None
             ~branch_blocked:false ~llm_session_id:None
         in
@@ -487,7 +487,7 @@ let () =
             ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
             ~merge_ready:false ~is_draft:false ~pr_body_delivered:true
             ~implementation_notes_delivered:true ~start_attempts_without_pr:0
-            ~conflict_noop_count:0 ~checks_passing:false ~current_op:None
+            ~conflict_noop_count:0 ~no_commits_push_count:0 ~checks_passing:false ~current_op:None
             ~current_message_id:None ~generation:0 ~worktree_path:None
             ~branch_blocked:false ~llm_session_id:None
         in
@@ -623,7 +623,7 @@ let () =
             ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
             ~merge_ready:false ~is_draft:true ~pr_body_delivered:false
             ~implementation_notes_delivered:false ~start_attempts_without_pr:0
-            ~conflict_noop_count:0 ~checks_passing:false ~current_op:None
+            ~conflict_noop_count:0 ~no_commits_push_count:0 ~checks_passing:false ~current_op:None
             ~current_message_id:None ~generation:0 ~worktree_path:None
             ~branch_blocked:false ~llm_session_id:None
         in
@@ -837,7 +837,7 @@ let () =
             ~inflight_human_messages:[] ~ci_checks:[] ~merge_ready:false
             ~is_draft:false ~pr_body_delivered:true
             ~implementation_notes_delivered:false ~start_attempts_without_pr:0
-            ~conflict_noop_count:0 ~checks_passing:false ~current_op:None
+            ~conflict_noop_count:0 ~no_commits_push_count:0 ~checks_passing:false ~current_op:None
             ~current_message_id:None ~generation:0 ~worktree_path:None
             ~branch_blocked:false ~llm_session_id:None
         in
@@ -874,7 +874,7 @@ let () =
             ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
             ~merge_ready:false ~is_draft:false ~pr_body_delivered:true
             ~implementation_notes_delivered:false ~start_attempts_without_pr:0
-            ~conflict_noop_count:0 ~checks_passing:false ~current_op:None
+            ~conflict_noop_count:0 ~no_commits_push_count:0 ~checks_passing:false ~current_op:None
             ~current_message_id:None ~generation:0 ~worktree_path:None
             ~branch_blocked:false ~llm_session_id:None
         in

--- a/test/test_poll_log_properties.ml
+++ b/test/test_poll_log_properties.ml
@@ -48,7 +48,7 @@ let make_agent ~patch_id ~branch ~has_conflict ~ci_failure_count ~current_op
     ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
     ~merge_ready:false ~is_draft ~pr_body_delivered:true
     ~implementation_notes_delivered:true ~start_attempts_without_pr:0
-    ~conflict_noop_count:0 ~no_commits_push_count:0 ~checks_passing ~current_op ~current_message_id:None
+    ~conflict_noop_count:0 ~no_commits_push_count:0 ~branch_rebased_onto:None ~checks_passing ~current_op ~current_message_id:None
     ~generation:0 ~worktree_path ~branch_blocked ~llm_session_id:None
 
 let make_poll_observation ~branch_in_root ~worktree_path poll_result =

--- a/test/test_poll_log_properties.ml
+++ b/test/test_poll_log_properties.ml
@@ -48,8 +48,9 @@ let make_agent ~patch_id ~branch ~has_conflict ~ci_failure_count ~current_op
     ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
     ~merge_ready:false ~is_draft ~pr_body_delivered:true
     ~implementation_notes_delivered:true ~start_attempts_without_pr:0
-    ~conflict_noop_count:0 ~no_commits_push_count:0 ~branch_rebased_onto:None ~checks_passing ~current_op ~current_message_id:None
-    ~generation:0 ~worktree_path ~branch_blocked ~llm_session_id:None
+    ~conflict_noop_count:0 ~no_commits_push_count:0 ~branch_rebased_onto:None
+    ~checks_passing ~current_op ~current_message_id:None ~generation:0
+    ~worktree_path ~branch_blocked ~llm_session_id:None
 
 let make_poll_observation ~branch_in_root ~worktree_path poll_result =
   Patch_controller.

--- a/test/test_poll_log_properties.ml
+++ b/test/test_poll_log_properties.ml
@@ -48,7 +48,7 @@ let make_agent ~patch_id ~branch ~has_conflict ~ci_failure_count ~current_op
     ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
     ~merge_ready:false ~is_draft ~pr_body_delivered:true
     ~implementation_notes_delivered:true ~start_attempts_without_pr:0
-    ~conflict_noop_count:0 ~checks_passing ~current_op ~current_message_id:None
+    ~conflict_noop_count:0 ~no_commits_push_count:0 ~checks_passing ~current_op ~current_message_id:None
     ~generation:0 ~worktree_path ~branch_blocked ~llm_session_id:None
 
 let make_poll_observation ~branch_in_root ~worktree_path poll_result =

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -349,6 +349,7 @@ let () =
         branch_blocked;
         queue;
         base_branch = main;
+        branch_rebased_onto = Some main;
       }
   in
   let mk_patch id =

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -615,7 +615,7 @@ let () =
         | Orchestrator.Session_process_error _ | Orchestrator.Session_no_resume
         | Orchestrator.Session_failed _ | Orchestrator.Session_give_up
         | Orchestrator.Session_worktree_missing
-        | Orchestrator.Session_push_failed ->
+        | Orchestrator.Session_push_failed | Orchestrator.Session_no_commits ->
             not a.Patch_agent.busy)
   in
   (* Property: Session_give_up sets needs_intervention *)
@@ -909,6 +909,7 @@ let () =
         Gen.return Orchestrator.Session_give_up;
         Gen.return Orchestrator.Session_worktree_missing;
         Gen.return Orchestrator.Session_push_failed;
+        Gen.return Orchestrator.Session_no_commits;
       ]
   in
   let gen_push : Worktree.push_result Gen.t =
@@ -916,6 +917,7 @@ let () =
       [
         Gen.return Worktree.Push_ok;
         Gen.return Worktree.Push_up_to_date;
+        Gen.return Worktree.Push_no_commits;
         Gen.return Worktree.Push_rejected;
         Gen.map (fun s -> Worktree.Push_error s) Gen.string_small;
       ]
@@ -926,6 +928,257 @@ let () =
         Orchestrator.equal_session_result
           (Orchestrator.combine_session_and_push ~session ~push)
           session)
+  in
+  let prop_cp6_ok_no_commits =
+    Test.make ~name:"CP-6: Session_ok + Push_no_commits = Session_no_commits"
+      (Gen.return ()) (fun () ->
+        Orchestrator.equal_session_result
+          (Orchestrator.combine_session_and_push ~session:Session_ok
+             ~push:Worktree.Push_no_commits)
+          Session_no_commits)
+  in
+  (* Session_no_commits property tests (PNC-N) mirror PSF-N: clear fallback,
+     increment counter, reset on Session_ok, trigger needs_intervention at
+     the threshold, and reset_intervention_state clears the counter. PNC-2
+     through PNC-5 test the pure [Patch_agent] functions directly (no
+     orchestrator noise); PNC-1 and PNC-6 through PNC-8 go through
+     [apply_session_result]. *)
+  let fresh_agent () =
+    Patch_agent.create
+      ~branch:(Types.Branch.of_string "nc")
+      (Types.Patch_id.of_string "nc-pid")
+  in
+  let prop_pnc1_clears_session_fallback =
+    Test.make ~name:"PNC-1: Session_no_commits clears session_fallback"
+      (Gen.return ()) (fun () ->
+        let orch, pid = mk_busy_orch () in
+        let orch = Orchestrator.set_tried_fresh orch pid in
+        let orch =
+          Orchestrator.apply_session_result orch pid Session_no_commits
+        in
+        let a = Orchestrator.agent orch pid in
+        Patch_agent.equal_session_fallback a.Patch_agent.session_fallback
+          Patch_agent.Fresh_available)
+  in
+  let prop_pnc2_increments_counter =
+    Test.make
+      ~name:
+        "PNC-2: increment_no_commits_push_count bumps the counter by exactly 1"
+      (Gen.int_range 0 5) (fun n ->
+        let a =
+          List.fold (List.range 0 n) ~init:(fresh_agent ()) ~f:(fun a _ ->
+              Patch_agent.increment_no_commits_push_count a)
+        in
+        Int.equal a.Patch_agent.no_commits_push_count n)
+  in
+  let prop_pnc3_intervention_threshold =
+    Test.make ~name:"PNC-3: no_commits_push_count >= 2 flips needs_intervention"
+      (Gen.int_range 0 4) (fun n ->
+        let a =
+          List.fold (List.range 0 n) ~init:(fresh_agent ()) ~f:(fun a _ ->
+              Patch_agent.increment_no_commits_push_count a)
+        in
+        Bool.equal (Patch_agent.needs_intervention a) (n >= 2))
+  in
+  let prop_pnc4_reset_counter =
+    Test.make
+      ~name:"PNC-4: reset_no_commits_push_count zeros the counter (idempotent)"
+      (Gen.int_range 0 5) (fun n ->
+        let a =
+          List.fold (List.range 0 n) ~init:(fresh_agent ()) ~f:(fun a _ ->
+              Patch_agent.increment_no_commits_push_count a)
+        in
+        let a = Patch_agent.reset_no_commits_push_count a in
+        let a = Patch_agent.reset_no_commits_push_count a in
+        Int.equal a.Patch_agent.no_commits_push_count 0)
+  in
+  let prop_pnc5_reset_intervention_clears_counter =
+    Test.make
+      ~name:"PNC-5: reset_intervention_state zeros no_commits_push_count"
+      (Gen.int_range 0 5) (fun n ->
+        let a =
+          List.fold (List.range 0 n) ~init:(fresh_agent ()) ~f:(fun a _ ->
+              Patch_agent.increment_no_commits_push_count a)
+        in
+        let a = Patch_agent.reset_intervention_state a in
+        Int.equal a.Patch_agent.no_commits_push_count 0
+        && not (Patch_agent.needs_intervention a))
+  in
+  let prop_pnc6_apply_bumps_counter =
+    Test.make
+      ~name:"PNC-6: apply_session_result Session_no_commits bumps counter by 1"
+      (Gen.return ()) (fun () ->
+        let orch, pid = mk_busy_orch () in
+        let before =
+          (Orchestrator.agent orch pid).Patch_agent.no_commits_push_count
+        in
+        let orch =
+          Orchestrator.apply_session_result orch pid Session_no_commits
+        in
+        let after =
+          (Orchestrator.agent orch pid).Patch_agent.no_commits_push_count
+        in
+        Int.equal before 0 && Int.equal after 1)
+  in
+  let prop_pnc7_apply_completes_failed =
+    Test.make
+      ~name:
+        "PNC-7: apply_session_result Session_no_commits clears busy \
+         (complete_failed)"
+      (Gen.return ()) (fun () ->
+        let orch, pid = mk_busy_orch () in
+        let orch =
+          Orchestrator.apply_session_result orch pid Session_no_commits
+        in
+        let a = Orchestrator.agent orch pid in
+        not a.Patch_agent.busy)
+  in
+  let prop_pnc8_apply_preserves_other_counters =
+    Test.make
+      ~name:
+        "PNC-8: apply_session_result Session_no_commits leaves \
+         start_attempts_without_pr and ci_failure_count untouched"
+      (Gen.pair (Gen.int_range 0 3) (Gen.int_range 0 2))
+      (fun (start_n, ci_n) ->
+        let orch, pid = mk_busy_orch () in
+        let orch =
+          List.fold (List.range 0 start_n) ~init:orch ~f:(fun o _ ->
+              Orchestrator.increment_start_attempts_without_pr o pid)
+        in
+        let orch =
+          List.fold (List.range 0 ci_n) ~init:orch ~f:(fun o _ ->
+              Orchestrator.increment_ci_failure_count o pid)
+        in
+        let a_before = Orchestrator.agent orch pid in
+        let orch =
+          Orchestrator.apply_session_result orch pid Session_no_commits
+        in
+        let a_after = Orchestrator.agent orch pid in
+        Int.equal a_before.Patch_agent.start_attempts_without_pr
+          a_after.Patch_agent.start_attempts_without_pr
+        && Int.equal a_before.Patch_agent.ci_failure_count
+             a_after.Patch_agent.ci_failure_count)
+  in
+  (* Pure push-gate tests — verify the two pure decision helpers in
+     [Worktree] that drive [force_push_with_lease]. *)
+  let prop_gate_zero_skips =
+    Test.make ~name:"PG-1: push_gate_from_count (Some 0) = Skip_no_commits"
+      (Gen.return ()) (fun () ->
+        Worktree.equal_push_gate
+          (Worktree.push_gate_from_count (Some 0))
+          Worktree.Skip_no_commits)
+  in
+  let prop_gate_positive_proceeds =
+    Test.make ~name:"PG-2: push_gate_from_count (Some n>0) = Proceed"
+      (Gen.int_range 1 1000) (fun n ->
+        Worktree.equal_push_gate
+          (Worktree.push_gate_from_count (Some n))
+          Worktree.Proceed)
+  in
+  let prop_gate_unknown_proceeds =
+    Test.make
+      ~name:
+        "PG-3: push_gate_from_count None = Proceed (unknown defaults to push, \
+         so real failures surface via push)"
+      (Gen.return ()) (fun () ->
+        Worktree.equal_push_gate
+          (Worktree.push_gate_from_count None)
+          Worktree.Proceed)
+  in
+  let prop_commit_count_nonzero_exit_none =
+    Test.make
+      ~name:
+        "PG-4: parse_commit_count code<>0 = None (git error -> unknown, not \
+         zero)"
+      (Gen.pair (Gen.int_range 1 255) Gen.string_small) (fun (code, stdout) ->
+        Option.is_none (Worktree.parse_commit_count ~code ~stdout))
+  in
+  let prop_commit_count_valid_int =
+    Test.make ~name:"PG-5: parse_commit_count code=0 of int string = Some n"
+      (Gen.int_range 0 10000) (fun n ->
+        Option.equal Int.equal
+          (Worktree.parse_commit_count ~code:0 ~stdout:(Int.to_string n))
+          (Some n))
+  in
+  let prop_commit_count_trailing_newline =
+    Test.make
+      ~name:
+        "PG-6: parse_commit_count code=0 strips surrounding whitespace (git \
+         appends \\n)"
+      (Gen.int_range 0 10000) (fun n ->
+        Option.equal Int.equal
+          (Worktree.parse_commit_count ~code:0
+             ~stdout:(Printf.sprintf "  %d\n" n))
+          (Some n))
+  in
+  let prop_commit_count_garbage_none =
+    Test.make
+      ~name:"PG-7: parse_commit_count code=0 of non-int = None (defensive)"
+      (Gen.oneof_list [ "hello"; "12abc"; ""; "  "; "-"; "1.5" ]) (fun s ->
+        Option.is_none (Worktree.parse_commit_count ~code:0 ~stdout:s))
+  in
+  let prop_classify_ok_zero_porcelain_equal_up_to_date =
+    Test.make
+      ~name:
+        "PG-8: classify_push_result code=0 with '=' porcelain = Push_up_to_date"
+      (Gen.return ()) (fun () ->
+        Worktree.equal_push_result
+          (Worktree.classify_push_result ~code:0
+             ~stdout:"To origin\n= refs/heads/x:refs/heads/x [up to date]\nDone"
+             ~stderr:"")
+          Worktree.Push_up_to_date)
+  in
+  let prop_classify_ok_forced_equal_push_ok =
+    Test.make
+      ~name:"PG-9: classify_push_result code=0 with '+' porcelain = Push_ok"
+      (Gen.return ()) (fun () ->
+        Worktree.equal_push_result
+          (Worktree.classify_push_result ~code:0
+             ~stdout:"To origin\n+ refs/heads/x:refs/heads/x [forced]\nDone"
+             ~stderr:"")
+          Worktree.Push_ok)
+  in
+  let prop_classify_nonzero_bang_equal_rejected =
+    Test.make
+      ~name:
+        "PG-10: classify_push_result code<>0 with '!' porcelain = Push_rejected"
+      (Gen.int_range 1 255) (fun code ->
+        Worktree.equal_push_result
+          (Worktree.classify_push_result ~code
+             ~stdout:
+               "To origin\n\
+               \ ! [rejected] refs/heads/x -> refs/heads/x (stale info)"
+             ~stderr:"")
+          Worktree.Push_rejected)
+  in
+  let prop_classify_nonzero_no_porcelain_equal_error =
+    Test.make
+      ~name:
+        "PG-11: classify_push_result code<>0 with no recognizable porcelain = \
+         Push_error"
+      (Gen.pair (Gen.int_range 1 255) Gen.string_small)
+      (fun (code, stderr) ->
+        match
+          Worktree.classify_push_result ~code ~stdout:"" ~stderr
+        with
+        | Worktree.Push_error _ -> true
+        | Worktree.Push_ok | Worktree.Push_up_to_date
+        | Worktree.Push_no_commits | Worktree.Push_rejected ->
+            false)
+  in
+  let prop_classify_never_returns_no_commits =
+    Test.make
+      ~name:
+        "PG-12: classify_push_result never returns Push_no_commits (that \
+         variant is only produced by the gate)"
+      ~count:500
+      (Gen.triple (Gen.int_range 0 255) Gen.string_small Gen.string_small)
+      (fun (code, stdout, stderr) ->
+        match Worktree.classify_push_result ~code ~stdout ~stderr with
+        | Worktree.Push_no_commits -> false
+        | Worktree.Push_ok | Worktree.Push_up_to_date
+        | Worktree.Push_rejected | Worktree.Push_error _ ->
+            true)
   in
   List.iter
     ~f:(fun t -> QCheck2.Test.check_exn t)
@@ -938,9 +1191,30 @@ let () =
       prop_cp3_ok_rejected;
       prop_cp4_ok_error;
       prop_cp5_failure_dominates;
+      prop_cp6_ok_no_commits;
+      prop_pnc1_clears_session_fallback;
+      prop_pnc2_increments_counter;
+      prop_pnc3_intervention_threshold;
+      prop_pnc4_reset_counter;
+      prop_pnc5_reset_intervention_clears_counter;
+      prop_pnc6_apply_bumps_counter;
+      prop_pnc7_apply_completes_failed;
+      prop_pnc8_apply_preserves_other_counters;
+      prop_gate_zero_skips;
+      prop_gate_positive_proceeds;
+      prop_gate_unknown_proceeds;
+      prop_commit_count_nonzero_exit_none;
+      prop_commit_count_valid_int;
+      prop_commit_count_trailing_newline;
+      prop_commit_count_garbage_none;
+      prop_classify_ok_zero_porcelain_equal_up_to_date;
+      prop_classify_ok_forced_equal_push_ok;
+      prop_classify_nonzero_bang_equal_rejected;
+      prop_classify_nonzero_no_porcelain_equal_error;
+      prop_classify_never_returns_no_commits;
     ];
   Stdlib.print_endline
     "Session_push_failed + combine_session_and_push: all properties passed \
-     (PSF-1..3, CP-1..5)"
+     (PSF-1..3, CP-1..6, PNC-1..8, PG-1..12)"
 
 let () = Stdlib.print_endline "all property tests passed"

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -1025,8 +1025,7 @@ let () =
     Test.make
       ~name:
         "PNC-7: apply_session_result Session_no_commits clears busy \
-         (complete_failed)"
-      (Gen.return ()) (fun () ->
+         (complete_failed)" (Gen.return ()) (fun () ->
         let orch, pid = mk_busy_orch () in
         let orch =
           Orchestrator.apply_session_result orch pid Session_no_commits
@@ -1080,8 +1079,7 @@ let () =
     Test.make
       ~name:
         "PG-3: push_gate_from_count None = Proceed (unknown defaults to push, \
-         so real failures surface via push)"
-      (Gen.return ()) (fun () ->
+         so real failures surface via push)" (Gen.return ()) (fun () ->
         Worktree.equal_push_gate
           (Worktree.push_gate_from_count None)
           Worktree.Proceed)
@@ -1091,7 +1089,8 @@ let () =
       ~name:
         "PG-4: parse_commit_count code<>0 = None (git error -> unknown, not \
          zero)"
-      (Gen.pair (Gen.int_range 1 255) Gen.string_small) (fun (code, stdout) ->
+      (Gen.pair (Gen.int_range 1 255) Gen.string_small)
+      (fun (code, stdout) ->
         Option.is_none (Worktree.parse_commit_count ~code ~stdout))
   in
   let prop_commit_count_valid_int =
@@ -1105,8 +1104,7 @@ let () =
     Test.make
       ~name:
         "PG-6: parse_commit_count code=0 strips surrounding whitespace (git \
-         appends \\n)"
-      (Gen.int_range 0 10000) (fun n ->
+         appends \\n)" (Gen.int_range 0 10000) (fun n ->
         Option.equal Int.equal
           (Worktree.parse_commit_count ~code:0
              ~stdout:(Printf.sprintf "  %d\n" n))
@@ -1115,8 +1113,8 @@ let () =
   let prop_commit_count_garbage_none =
     Test.make
       ~name:"PG-7: parse_commit_count code=0 of non-int = None (defensive)"
-      (Gen.oneof_list [ "hello"; "12abc"; ""; "  "; "-"; "1.5" ]) (fun s ->
-        Option.is_none (Worktree.parse_commit_count ~code:0 ~stdout:s))
+      (Gen.oneof_list [ "hello"; "12abc"; ""; "  "; "-"; "1.5" ])
+      (fun s -> Option.is_none (Worktree.parse_commit_count ~code:0 ~stdout:s))
   in
   let prop_classify_ok_zero_porcelain_equal_up_to_date =
     Test.make
@@ -1159,12 +1157,10 @@ let () =
          Push_error"
       (Gen.pair (Gen.int_range 1 255) Gen.string_small)
       (fun (code, stderr) ->
-        match
-          Worktree.classify_push_result ~code ~stdout:"" ~stderr
-        with
+        match Worktree.classify_push_result ~code ~stdout:"" ~stderr with
         | Worktree.Push_error _ -> true
-        | Worktree.Push_ok | Worktree.Push_up_to_date
-        | Worktree.Push_no_commits | Worktree.Push_rejected ->
+        | Worktree.Push_ok | Worktree.Push_up_to_date | Worktree.Push_no_commits
+        | Worktree.Push_rejected ->
             false)
   in
   let prop_classify_never_returns_no_commits =
@@ -1177,8 +1173,8 @@ let () =
       (fun (code, stdout, stderr) ->
         match Worktree.classify_push_result ~code ~stdout ~stderr with
         | Worktree.Push_no_commits -> false
-        | Worktree.Push_ok | Worktree.Push_up_to_date
-        | Worktree.Push_rejected | Worktree.Push_error _ ->
+        | Worktree.Push_ok | Worktree.Push_up_to_date | Worktree.Push_rejected
+        | Worktree.Push_error _ ->
             true)
   in
   List.iter

--- a/test/test_reconciler_properties.ml
+++ b/test/test_reconciler_properties.ml
@@ -154,7 +154,7 @@ let prop_detect_rebases_skips_already_queued =
                 branch_blocked = false;
                 queue = [ Types.Operation_kind.Rebase ];
                 base_branch = main;
-                  branch_rebased_onto = Some main;
+                branch_rebased_onto = Some main;
               })
       in
       return (graph, views, ids))
@@ -439,7 +439,8 @@ let pid s = Types.Patch_id.of_string s
 let prop_drift_fires_on_divergence =
   QCheck2.Test.make ~name:"drift: fires when rebased_onto != base_branch"
     ~count:1
-    QCheck2.Gen.(return ()) (fun () ->
+    QCheck2.Gen.(return ())
+    (fun () ->
       let v =
         mk_view ~id:(pid "p1") ~base_branch:main_br
           ~branch_rebased_onto:(Some dep_br) ()
@@ -452,7 +453,9 @@ let prop_drift_fires_on_divergence =
 
 let prop_drift_silent_on_match =
   QCheck2.Test.make ~name:"drift: silent when rebased_onto == base_branch"
-    ~count:1 QCheck2.Gen.(return ()) (fun () ->
+    ~count:1
+    QCheck2.Gen.(return ())
+    (fun () ->
       let v =
         mk_view ~id:(pid "p1") ~base_branch:main_br
           ~branch_rebased_onto:(Some main_br) ()
@@ -462,16 +465,17 @@ let prop_drift_silent_on_match =
 let prop_drift_silent_on_none =
   QCheck2.Test.make
     ~name:"drift: silent when branch_rebased_onto = None (pre-start)" ~count:1
-    QCheck2.Gen.(return ()) (fun () ->
+    QCheck2.Gen.(return ())
+    (fun () ->
       let v =
-        mk_view ~id:(pid "p1") ~base_branch:main_br ~branch_rebased_onto:None
-          ()
+        mk_view ~id:(pid "p1") ~base_branch:main_br ~branch_rebased_onto:None ()
       in
       List.is_empty (Reconciler.detect_notified_base_drift [ v ]))
 
 let prop_drift_silent_on_merged =
   QCheck2.Test.make ~name:"drift: silent on merged patches" ~count:1
-    QCheck2.Gen.(return ()) (fun () ->
+    QCheck2.Gen.(return ())
+    (fun () ->
       let v =
         mk_view ~id:(pid "p1") ~merged:true ~base_branch:main_br
           ~branch_rebased_onto:(Some dep_br) ()
@@ -480,7 +484,8 @@ let prop_drift_silent_on_merged =
 
 let prop_drift_silent_on_no_pr =
   QCheck2.Test.make ~name:"drift: silent when has_pr = false" ~count:1
-    QCheck2.Gen.(return ()) (fun () ->
+    QCheck2.Gen.(return ())
+    (fun () ->
       let v =
         mk_view ~id:(pid "p1") ~has_pr:false ~base_branch:main_br
           ~branch_rebased_onto:(Some dep_br) ()
@@ -490,7 +495,9 @@ let prop_drift_silent_on_no_pr =
 let prop_drift_silent_when_rebase_queued =
   QCheck2.Test.make
     ~name:"drift: silent when Rebase is already in the queue (idempotent)"
-    ~count:1 QCheck2.Gen.(return ()) (fun () ->
+    ~count:1
+    QCheck2.Gen.(return ())
+    (fun () ->
       let v =
         mk_view ~id:(pid "p1")
           ~queue:[ Types.Operation_kind.Rebase ]
@@ -499,10 +506,12 @@ let prop_drift_silent_when_rebase_queued =
       List.is_empty (Reconciler.detect_notified_base_drift [ v ]))
 
 let prop_drift_always_produces_enqueue_rebase =
-  QCheck2.Test.make
-    ~name:"drift: every emitted action is Enqueue_rebase" ~count:200
-    (QCheck2.Gen.list_size (QCheck2.Gen.int_range 1 6)
-       Onton_test_support.Test_generators.gen_patch_view) (fun views ->
+  QCheck2.Test.make ~name:"drift: every emitted action is Enqueue_rebase"
+    ~count:200
+    (QCheck2.Gen.list_size
+       (QCheck2.Gen.int_range 1 6)
+       Onton_test_support.Test_generators.gen_patch_view)
+    (fun views ->
       (* Force some drift by setting rebased_onto to a branch different from
          base_branch on a random subset. *)
       let drifted_views =
@@ -523,7 +532,9 @@ let prop_drift_always_produces_enqueue_rebase =
 let prop_reconcile_e2e_catches_drift =
   QCheck2.Test.make
     ~name:"reconcile: drift detector catches GitHub-auto-retargeted case"
-    ~count:1 QCheck2.Gen.(return ()) (fun () ->
+    ~count:1
+    QCheck2.Gen.(return ())
+    (fun () ->
       (* Single patch with no deps; base_branch = main, rebased_onto = dep
          (stale). No merged_prs. *)
       let patch : Types.Patch.t =
@@ -563,7 +574,8 @@ let prop_reconcile_e2e_catches_drift =
 let prop_reconcile_dedup_rebase =
   QCheck2.Test.make
     ~name:"reconcile: dedup — at most one Enqueue_rebase per patch" ~count:1
-    QCheck2.Gen.(return ()) (fun () ->
+    QCheck2.Gen.(return ())
+    (fun () ->
       let patch : Types.Patch.t =
         {
           id = pid "p1";

--- a/test/test_reconciler_properties.ml
+++ b/test/test_reconciler_properties.ml
@@ -92,6 +92,7 @@ let gen_rebase_scenario =
                   branch_blocked = false;
                   queue = [];
                   base_branch = main;
+                  branch_rebased_onto = Some main;
                 })
         in
         (graph, views, newly_merged))
@@ -153,6 +154,7 @@ let prop_detect_rebases_skips_already_queued =
                 branch_blocked = false;
                 queue = [ Types.Operation_kind.Rebase ];
                 base_branch = main;
+                  branch_rebased_onto = Some main;
               })
       in
       return (graph, views, ids))
@@ -189,6 +191,7 @@ let gen_plan_scenario =
                   branch_blocked = false;
                   queue;
                   base_branch = main;
+                  branch_rebased_onto = Some main;
                 }))))
 
 let prop_plan_skips_busy =
@@ -357,6 +360,7 @@ let gen_reconcile_scenario =
                   branch_blocked = false;
                   queue = [];
                   base_branch = main;
+                  branch_rebased_onto = Some main;
                 }))))
 
 let prop_reconcile_merges_subset =
@@ -404,6 +408,200 @@ let prop_reconcile_no_action_on_merged =
       in
       not (List.exists actions ~f:is_start_operation))
 
+(* ========== detect_notified_base_drift properties ========== *)
+
+(* Tests specifically for the drift detector that catches the
+   GitHub-auto-retargeted-after-merge case. Each property constructs views
+   explicitly (not through the randomized gen_patch_view which defaults to no
+   drift). *)
+
+let main_br = Types.Branch.of_string "main"
+let dep_br = Types.Branch.of_string "dep"
+let other_br = Types.Branch.of_string "other"
+
+let mk_view ~id ?(has_pr = true) ?(merged = false) ?(queue = [])
+    ?(base_branch = main_br) ?(branch_rebased_onto = Some main_br) () =
+  Reconciler.
+    {
+      id;
+      has_pr;
+      merged;
+      busy = false;
+      needs_intervention = false;
+      branch_blocked = false;
+      queue;
+      base_branch;
+      branch_rebased_onto;
+    }
+
+let pid s = Types.Patch_id.of_string s
+
+let prop_drift_fires_on_divergence =
+  QCheck2.Test.make ~name:"drift: fires when rebased_onto != base_branch"
+    ~count:1
+    QCheck2.Gen.(return ()) (fun () ->
+      let v =
+        mk_view ~id:(pid "p1") ~base_branch:main_br
+          ~branch_rebased_onto:(Some dep_br) ()
+      in
+      match Reconciler.detect_notified_base_drift [ v ] with
+      | [ Reconciler.Enqueue_rebase p ] -> Types.Patch_id.equal p (pid "p1")
+      | [] -> false
+      | [ Reconciler.Mark_merged _ ] | [ Reconciler.Start_operation _ ] -> false
+      | _ :: _ :: _ -> false)
+
+let prop_drift_silent_on_match =
+  QCheck2.Test.make ~name:"drift: silent when rebased_onto == base_branch"
+    ~count:1 QCheck2.Gen.(return ()) (fun () ->
+      let v =
+        mk_view ~id:(pid "p1") ~base_branch:main_br
+          ~branch_rebased_onto:(Some main_br) ()
+      in
+      List.is_empty (Reconciler.detect_notified_base_drift [ v ]))
+
+let prop_drift_silent_on_none =
+  QCheck2.Test.make
+    ~name:"drift: silent when branch_rebased_onto = None (pre-start)" ~count:1
+    QCheck2.Gen.(return ()) (fun () ->
+      let v =
+        mk_view ~id:(pid "p1") ~base_branch:main_br ~branch_rebased_onto:None
+          ()
+      in
+      List.is_empty (Reconciler.detect_notified_base_drift [ v ]))
+
+let prop_drift_silent_on_merged =
+  QCheck2.Test.make ~name:"drift: silent on merged patches" ~count:1
+    QCheck2.Gen.(return ()) (fun () ->
+      let v =
+        mk_view ~id:(pid "p1") ~merged:true ~base_branch:main_br
+          ~branch_rebased_onto:(Some dep_br) ()
+      in
+      List.is_empty (Reconciler.detect_notified_base_drift [ v ]))
+
+let prop_drift_silent_on_no_pr =
+  QCheck2.Test.make ~name:"drift: silent when has_pr = false" ~count:1
+    QCheck2.Gen.(return ()) (fun () ->
+      let v =
+        mk_view ~id:(pid "p1") ~has_pr:false ~base_branch:main_br
+          ~branch_rebased_onto:(Some dep_br) ()
+      in
+      List.is_empty (Reconciler.detect_notified_base_drift [ v ]))
+
+let prop_drift_silent_when_rebase_queued =
+  QCheck2.Test.make
+    ~name:"drift: silent when Rebase is already in the queue (idempotent)"
+    ~count:1 QCheck2.Gen.(return ()) (fun () ->
+      let v =
+        mk_view ~id:(pid "p1")
+          ~queue:[ Types.Operation_kind.Rebase ]
+          ~base_branch:main_br ~branch_rebased_onto:(Some dep_br) ()
+      in
+      List.is_empty (Reconciler.detect_notified_base_drift [ v ]))
+
+let prop_drift_always_produces_enqueue_rebase =
+  QCheck2.Test.make
+    ~name:"drift: every emitted action is Enqueue_rebase" ~count:200
+    (QCheck2.Gen.list_size (QCheck2.Gen.int_range 1 6)
+       Onton_test_support.Test_generators.gen_patch_view) (fun views ->
+      (* Force some drift by setting rebased_onto to a branch different from
+         base_branch on a random subset. *)
+      let drifted_views =
+        List.mapi views ~f:(fun i v ->
+            if i % 2 = 0 then
+              { v with Reconciler.branch_rebased_onto = Some other_br }
+            else v)
+      in
+      Reconciler.detect_notified_base_drift drifted_views
+      |> List.for_all ~f:(function
+        | Reconciler.Enqueue_rebase _ -> true
+        | Reconciler.Mark_merged _ | Reconciler.Start_operation _ -> false))
+
+(* End-to-end: reconcile emits Enqueue_rebase on a drifted view when no
+   other detector would have caught it (base_branch already matches
+   initial_base, merged list is empty, no newly_merged). This is the exact
+   patch-2 scenario from retire-blue-green. *)
+let prop_reconcile_e2e_catches_drift =
+  QCheck2.Test.make
+    ~name:"reconcile: drift detector catches GitHub-auto-retargeted case"
+    ~count:1 QCheck2.Gen.(return ()) (fun () ->
+      (* Single patch with no deps; base_branch = main, rebased_onto = dep
+         (stale). No merged_prs. *)
+      let patch : Types.Patch.t =
+        {
+          id = pid "p1";
+          title = "t";
+          description = "";
+          branch = Types.Branch.of_string "p1";
+          dependencies = [];
+          spec = "";
+          acceptance_criteria = [];
+          files = [];
+          classification = "";
+          changes = [];
+          test_stubs_introduced = [];
+          test_stubs_implemented = [];
+        }
+      in
+      let graph = Graph.of_patches [ patch ] in
+      let views =
+        [
+          mk_view ~id:(pid "p1") ~base_branch:main_br
+            ~branch_rebased_onto:(Some dep_br) ();
+        ]
+      in
+      let actions =
+        Reconciler.reconcile ~graph ~main:main_br ~merged_pr_patches:[]
+          ~branch_of:(fun _ -> main_br)
+          views
+      in
+      List.exists actions ~f:(function
+        | Reconciler.Enqueue_rebase p -> Types.Patch_id.equal p (pid "p1")
+        | Reconciler.Mark_merged _ | Reconciler.Start_operation _ -> false))
+
+(* Dedup: when both stale-base and drift detectors would fire for the same
+   patch, reconcile emits exactly one Enqueue_rebase. *)
+let prop_reconcile_dedup_rebase =
+  QCheck2.Test.make
+    ~name:"reconcile: dedup — at most one Enqueue_rebase per patch" ~count:1
+    QCheck2.Gen.(return ()) (fun () ->
+      let patch : Types.Patch.t =
+        {
+          id = pid "p1";
+          title = "t";
+          description = "";
+          branch = Types.Branch.of_string "p1";
+          dependencies = [];
+          spec = "";
+          acceptance_criteria = [];
+          files = [];
+          classification = "";
+          changes = [];
+          test_stubs_introduced = [];
+          test_stubs_implemented = [];
+        }
+      in
+      let graph = Graph.of_patches [ patch ] in
+      (* Construct a view that triggers BOTH detect_stale_bases and
+         detect_notified_base_drift: base_branch=dep (stale vs initial_base
+         which is main), rebased_onto=other (stale vs base). *)
+      let views =
+        [
+          mk_view ~id:(pid "p1") ~base_branch:dep_br
+            ~branch_rebased_onto:(Some other_br) ();
+        ]
+      in
+      let actions =
+        Reconciler.reconcile ~graph ~main:main_br ~merged_pr_patches:[]
+          ~branch_of:(fun _ -> main_br)
+          views
+      in
+      let rebases =
+        List.filter actions ~f:(function
+          | Reconciler.Enqueue_rebase _ -> true
+          | Reconciler.Mark_merged _ | Reconciler.Start_operation _ -> false)
+      in
+      List.length rebases = 1)
+
 let () =
   let tests =
     [
@@ -425,6 +623,15 @@ let () =
       prop_reconcile_merges_subset;
       prop_reconcile_no_dup_action_types_per_patch;
       prop_reconcile_no_action_on_merged;
+      prop_drift_fires_on_divergence;
+      prop_drift_silent_on_match;
+      prop_drift_silent_on_none;
+      prop_drift_silent_on_merged;
+      prop_drift_silent_on_no_pr;
+      prop_drift_silent_when_rebase_queued;
+      prop_drift_always_produces_enqueue_rebase;
+      prop_reconcile_e2e_catches_drift;
+      prop_reconcile_dedup_rebase;
     ]
   in
   List.iter tests ~f:(fun t -> QCheck2.Test.check_exn t);


### PR DESCRIPTION
## Summary

Two related supervisor fixes, prompted by investigating failures in the `retire-blue-green` gameplan.

### 1. No-commit sessions (a48bae7)
Agents were occasionally ending sessions with file edits but no commits. The supervisor's force-push then produced a branch identical to base, and GitHub rejected PR creation with `422 — No commits between base and head`. The scheduler retried indefinitely.

- Strengthened the commit instruction in the patch prompt (`lib/prompt.ml`) and extended it to resumed sessions (the `pr_number = Some _` branch previously had no commit instruction at all).
- Added a pre-push gate to `force_push_with_lease`: run `git rev-list --count base..HEAD` locally; if zero, return the new `Push_no_commits` variant without calling `git push`.
- New `Session_no_commits` session_result with matching `apply_session_result` behavior (clears `session_fallback`, bumps `no_commits_push_count`, `complete_failed`). `needs_intervention` now fires at `no_commits_push_count >= 2` so the scheduler stops re-enqueueing Start after two wasted sessions.
- Decomposed `force_push_with_lease` into pure helpers (`parse_commit_count`, `push_gate_from_count`, `classify_push_result`) + a thin effectful shell.

### 2. Drift detector for auto-retargeted PRs (d923e36)
When a dep is merged and deleted on GitHub, GitHub auto-retargets dependent PRs onto main. The poller refreshes `base_branch` to match, so `detect_stale_bases` finds everything agrees — but the local branch still carries the merged dep's commits. On `retire-blue-green/patch-2`, no Rebase was ever enqueued; the branch got merged with the dep's commit still in its history.

- New `Patch_agent.branch_rebased_onto : Branch.t option` — tracks what the local branch is actually based on. Updated by Start (to the initial base) and by successful Rebase (to the rebase target).
- New `Reconciler.detect_notified_base_drift` — emits `Enqueue_rebase` when `branch_rebased_onto ≠ base_branch`. Same preconditions as the other rebase detectors (`has_pr && !merged && !(Rebase in queue)`).
- Extended `reconcile` to dedupe across all three rebase detectors.

## Test plan
- [x] `dune build` clean
- [x] `dune runtest` all green (73 test sections, no regressions)
- [x] 27 new pure-layer property tests for no-commit detection (PSF-1..3, CP-1..6, PNC-1..8, PG-1..12)
- [x] 9 new property tests for drift detector (fires on divergence; silent on match/None/merged/no-PR/already-queued/wrong-action-type; reconcile e2e catches scenario; dedup)
- [x] Interleaving tests PI-14, PI-14b, PI-15 for no-commit path; PI-16 reproduces the `retire-blue-green/patch-2` auto-retargeted case end-to-end
- [ ] Manual smoke test against a live gameplan

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detects and stops no‑commit sessions that caused 422 “No commits between base and head”, and adds a drift detector for GitHub auto‑retargeted PRs so dependent branches get correctly rebased. Prevents infinite Start loops and avoids merging branches that still include a dependency’s commits.

- **Bug Fixes**
  - No‑commit sessions: pre‑push gate via local `rev-list --count base..HEAD`; if zero, return `Push_no_commits` and skip push. New `Session_no_commits` increments `no_commits_push_count`, triggers `needs_intervention` at 2, and resets after a successful push. Prompt now tells the agent to commit and never push/create PR.
  - Auto‑retarget drift: track the branch’s actual base in `branch_rebased_onto` (set on Start and successful Rebase). Detector enqueues Rebase when `branch_rebased_onto` ≠ `base_branch`; `reconcile` dedupes across rebase detectors.
  - Legacy restore: when loading agents without `branch_rebased_onto`, seed it from `base_branch` for PRs so drift detection works after upgrade.

- **Refactors**
  - Split push into pure helpers (`parse_commit_count`, `push_gate_from_count`, `classify_push_result`) and a thin shell; `force_push_with_lease` now takes `~base`. Persist `no_commits_push_count` and `branch_rebased_onto`. Added focused tests for the gate, no‑commit flow, and drift detection (including e2e).

<sup>Written for commit 00f80524dd23246f006e17a6030c3fdd8c798a40. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

