### PR TITLE
Fix spec section loss and stale base branch at PR creation

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -298,7 +298,7 @@ let read_artifact_file path =
 (** Apply the agent-authored PR body artifact to the PR. Falls back to keeping
     the gameplan-derived body if the artifact is missing or empty. *)
 let apply_pr_body_artifact ~runtime ~net ~github ~project_name ~patch_id
-    ~pr_number =
+    ~pr_number ~patch ~gameplan =
   let artifact_path =
     Project_store.pr_body_artifact_path ~project_name ~patch_id
   in
@@ -311,6 +311,7 @@ let apply_pr_body_artifact ~runtime ~net ~github ~project_name ~patch_id
       log_event runtime ~patch_id
         "pr-body: artifact empty; keeping gameplan body"
   | Some body -> (
+      let body = body ^ Prompt.render_spec_suffix patch gameplan in
       match Github.update_pr_body ~net github ~pr_number ~body with
       | Ok () ->
           log_event runtime ~patch_id
@@ -344,9 +345,10 @@ let apply_notes_artifact ~runtime ~net ~github ~project_name ~patch_id
                (Project_store.pr_body_artifact_path ~project_name ~patch_id))
           ~fallback:(Prompt.render_pr_description ~project_name patch gameplan)
       in
+      let spec_suffix = Prompt.render_spec_suffix patch gameplan in
       let composed =
-        Printf.sprintf "%s\n\n## Implementation Notes\n\n%s" body_base
-          (String.trim notes)
+        Printf.sprintf "%s\n\n## Implementation Notes\n\n%s%s" body_base
+          (String.trim notes) spec_suffix
       in
       match Github.update_pr_body ~net github ~pr_number ~body:composed with
       | Ok () ->
@@ -2224,6 +2226,7 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                               let pr_body =
                                 Prompt.render_pr_description ~project_name patch
                                   gameplan
+                                ^ Prompt.render_spec_suffix patch gameplan
                               in
                               (match
                                  Github.create_pull_request ~net github
@@ -2849,9 +2852,15 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                        let pr =
                                          Base.Option.value_exn pr_number
                                        in
+                                       let patch =
+                                         Base.List.find_exn
+                                           gameplan.Gameplan.patches
+                                           ~f:(fun (p : Patch.t) ->
+                                             Patch_id.equal p.Patch.id patch_id)
+                                       in
                                        apply_pr_body_artifact ~runtime ~net
                                          ~github ~project_name ~patch_id
-                                         ~pr_number:pr
+                                         ~pr_number:pr ~patch ~gameplan
                                    | Patch_decision.Implementation_notes_payload
                                      ->
                                        let pr =

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -2217,7 +2217,31 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                               (* Supervisor-owned PR creation: the agent
                                  commits and the supervisor pushed at session
                                  end; now we open the draft PR with a
-                                 gameplan-derived title and body. *)
+                                 gameplan-derived title and body.
+
+                                 Re-derive the base branch from current
+                                 orchestrator state — dependencies may have
+                                 merged while the agent session was running,
+                                 making the base captured at dispatch time
+                                 stale. *)
+                              let fresh_base =
+                                Runtime.read runtime (fun snap ->
+                                    let orch = snap.Runtime.orchestrator in
+                                    let has_merged pid =
+                                      (Orchestrator.agent orch pid)
+                                        .Patch_agent.merged
+                                    in
+                                    let branch_of pid =
+                                      (Base.List.find_exn
+                                         gameplan.Gameplan.patches
+                                         ~f:(fun (p : Patch.t) ->
+                                           Patch_id.equal p.Patch.id pid))
+                                        .Patch.branch
+                                    in
+                                    Graph.initial_base (Orchestrator.graph orch)
+                                      patch_id ~has_merged ~branch_of
+                                      ~main:(Orchestrator.main_branch orch))
+                              in
                               let pr_title =
                                 Printf.sprintf "[%s] Patch %s: %s" project_name
                                   (Patch_id.to_string patch.Patch.id)
@@ -2231,7 +2255,7 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                               (match
                                  Github.create_pull_request ~net github
                                    ~title:pr_title ~head:patch.Patch.branch
-                                   ~base:base_branch ~body:pr_body ~draft:true
+                                   ~base:fresh_base ~body:pr_body ~draft:true
                                with
                               | Ok pr_number ->
                                   log_event runtime ~patch_id
@@ -2259,7 +2283,7 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                       match
                                         Github.list_prs ~net github
                                           ~branch:patch.Patch.branch
-                                          ~base:(Some base_branch) ~state:`Open
+                                          ~base:(Some fresh_base) ~state:`Open
                                           ()
                                       with
                                       | Ok ((pr_number, _, _) :: _) ->

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -2282,9 +2282,8 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                          error message. *)
                                       match
                                         Github.list_prs ~net github
-                                          ~branch:patch.Patch.branch
-                                          ~base:(Some fresh_base) ~state:`Open
-                                          ()
+                                          ~branch:patch.Patch.branch ~base:None
+                                          ~state:`Open ()
                                       with
                                       | Ok ((pr_number, _, _) :: _) ->
                                           log_event runtime ~patch_id

--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -292,6 +292,154 @@ let%test "resolve_pr_body_source: non-empty artifact wins" =
     (resolve_pr_body_source ~artifact:(Some "agent body") ~fallback:"gameplan")
     "agent body"
 
+let render_spec_suffix (patch : Patch.t) (gameplan : Gameplan.t) : string =
+  let gp =
+    let ds = gameplan.Gameplan.final_state_spec in
+    if String.is_empty ds then ""
+    else "\n## Gameplan Specification\n\n```\n" ^ ds ^ "\n```\n"
+  in
+  let ps =
+    if String.is_empty patch.Patch.spec then ""
+    else "\n## Patch Specification\n\n```\n" ^ patch.spec ^ "\n```\n"
+  in
+  gp ^ ps
+
+let%test "render_spec_suffix: both empty" =
+  let patch =
+    {
+      Patch.id = Patch_id.of_string "1";
+      title = "";
+      description = "";
+      spec = "";
+      changes = [];
+      acceptance_criteria = [];
+      files = [];
+      dependencies = [];
+      branch = Branch.of_string "b";
+      classification = "";
+      test_stubs_introduced = [];
+      test_stubs_implemented = [];
+    }
+  in
+  let gameplan =
+    {
+      Gameplan.project_name = "";
+      problem_statement = "";
+      solution_summary = "";
+      final_state_spec = "";
+      patches = [];
+      current_state_analysis = "";
+      explicit_opinions = "";
+      acceptance_criteria = [];
+      open_questions = [];
+    }
+  in
+  String.equal (render_spec_suffix patch gameplan) ""
+
+let%test "render_spec_suffix: gameplan spec only" =
+  let patch =
+    {
+      Patch.id = Patch_id.of_string "1";
+      title = "";
+      description = "";
+      spec = "";
+      changes = [];
+      acceptance_criteria = [];
+      files = [];
+      dependencies = [];
+      branch = Branch.of_string "b";
+      classification = "";
+      test_stubs_introduced = [];
+      test_stubs_implemented = [];
+    }
+  in
+  let gameplan =
+    {
+      Gameplan.project_name = "";
+      problem_statement = "";
+      solution_summary = "";
+      final_state_spec = "module FOO.\nsome spec";
+      patches = [];
+      current_state_analysis = "";
+      explicit_opinions = "";
+      acceptance_criteria = [];
+      open_questions = [];
+    }
+  in
+  let result = render_spec_suffix patch gameplan in
+  String.is_substring result ~substring:"## Gameplan Specification"
+  && String.is_substring result ~substring:"module FOO."
+  && not (String.is_substring result ~substring:"## Patch Specification")
+
+let%test "render_spec_suffix: patch spec only" =
+  let patch =
+    {
+      Patch.id = Patch_id.of_string "1";
+      title = "";
+      description = "";
+      spec = "module BAR.\npatch spec";
+      changes = [];
+      acceptance_criteria = [];
+      files = [];
+      dependencies = [];
+      branch = Branch.of_string "b";
+      classification = "";
+      test_stubs_introduced = [];
+      test_stubs_implemented = [];
+    }
+  in
+  let gameplan =
+    {
+      Gameplan.project_name = "";
+      problem_statement = "";
+      solution_summary = "";
+      final_state_spec = "";
+      patches = [];
+      current_state_analysis = "";
+      explicit_opinions = "";
+      acceptance_criteria = [];
+      open_questions = [];
+    }
+  in
+  let result = render_spec_suffix patch gameplan in
+  String.is_substring result ~substring:"## Patch Specification"
+  && String.is_substring result ~substring:"module BAR."
+  && not (String.is_substring result ~substring:"## Gameplan Specification")
+
+let%test "render_spec_suffix: both present" =
+  let patch =
+    {
+      Patch.id = Patch_id.of_string "1";
+      title = "";
+      description = "";
+      spec = "module BAR.\npatch spec";
+      changes = [];
+      acceptance_criteria = [];
+      files = [];
+      dependencies = [];
+      branch = Branch.of_string "b";
+      classification = "";
+      test_stubs_introduced = [];
+      test_stubs_implemented = [];
+    }
+  in
+  let gameplan =
+    {
+      Gameplan.project_name = "";
+      problem_statement = "";
+      solution_summary = "";
+      final_state_spec = "module FOO.\ngameplan spec";
+      patches = [];
+      current_state_analysis = "";
+      explicit_opinions = "";
+      acceptance_criteria = [];
+      open_questions = [];
+    }
+  in
+  let result = render_spec_suffix patch gameplan in
+  String.is_substring result ~substring:"## Gameplan Specification"
+  && String.is_substring result ~substring:"## Patch Specification"
+
 let render_pr_description ~(project_name : string) (patch : Patch.t)
     (gameplan : Gameplan.t) =
   let patch_id = Patch_id.to_string patch.Patch.id in
@@ -313,13 +461,8 @@ let render_pr_description ~(project_name : string) (patch : Patch.t)
       ("solution_summary", gameplan.Gameplan.solution_summary);
       ("dependencies", deps);
       ("changes_section", optional_list_section ~header:"Changes" patch.changes);
-      ( "gameplan_spec_section",
-        let ds = gameplan.Gameplan.final_state_spec in
-        if String.is_empty ds then ""
-        else "\n## Gameplan Specification\n\n```\n" ^ ds ^ "\n```\n" );
-      ( "patch_spec_section",
-        if String.is_empty patch.spec then ""
-        else "\n## Patch Specification\n\n```\n" ^ patch.spec ^ "\n```\n" );
+      ("gameplan_spec_section", "");
+      ("patch_spec_section", "");
       ( "acceptance_criteria_section",
         optional_list_section ~header:"Acceptance Criteria"
           patch.acceptance_criteria );

--- a/lib/prompt.mli
+++ b/lib/prompt.mli
@@ -24,6 +24,12 @@ val resolve_pr_body_source : artifact:string option -> fallback:string -> string
     contents otherwise. Used by the supervisor when composing the final PR body
     for the implementation-notes phase. *)
 
+val render_spec_suffix : Types.Patch.t -> Types.Gameplan.t -> string
+(** Pure: render the Gameplan Specification and Patch Specification sections.
+    Returns the empty string when both specs are absent. Appended by the
+    supervisor after the agent-authored PR body, so the agent cannot
+    accidentally drop them. *)
+
 val render_pr_body_prompt :
   project_name:string ->
   pr_number:Pr_number.t ->

--- a/test/test_interleaving_properties.ml
+++ b/test/test_interleaving_properties.ml
@@ -1737,3 +1737,115 @@ let () =
   in
   QCheck2.Test.check_exn prop_pi16;
   Stdlib.print_endline "PI-16 passed"
+
+(** PI-17: When a dependency merges while its dependent's session is running,
+    re-deriving the base branch at PR-creation time yields [main], not the
+    now-deleted dependency branch.
+
+    Regression test for the spec-aware-review/patch-4 422: the Start message
+    captured [base = dep-branch] at dispatch time, but by the time the session
+    finished and the supervisor tried to create the PR, the dep had merged and
+    its branch was deleted — causing a GitHub 422. The fix re-computes
+    [Graph.initial_base] from fresh orchestrator state at PR creation time.
+
+    The property generates random linear chains of 2-5 patches. For each
+    dependent patch, it: 1. Fires Start (capturing the dep-branch as base) 2.
+    Merges the dependency while the dependent is busy 3. Re-derives initial_base
+    from current state 4. Asserts the fresh base is [main] (all deps now merged)
+*)
+let () =
+  let prop_pi17 =
+    QCheck2.Test.make
+      ~name:
+        "PI-17: fresh initial_base after dep merge yields main, not stale \
+         dep-branch" ~count:300 (QCheck2.Gen.int_range 2 5) (fun n ->
+        let patches = mk_patches n in
+        let branch_of = branch_of_patches patches in
+        let orch = Orchestrator.create ~patches ~main_branch:main in
+        (* Bootstrap: start and complete all patches in dependency order,
+           giving each a PR — except patch 1 (the first dependent), which
+           we leave without a PR to model the "first session" scenario. *)
+        let orch =
+          List.foldi patches ~init:orch ~f:(fun i o _p ->
+              let pid = pid_of_idx patches i in
+              let has_merged dep_pid =
+                (Orchestrator.agent o dep_pid).Patch_agent.merged
+              in
+              let base =
+                Graph.initial_base (Orchestrator.graph o) pid ~has_merged
+                  ~branch_of ~main
+              in
+              let o = Orchestrator.fire o (Orchestrator.Start (pid, base)) in
+              let o =
+                if i = 0 then
+                  Orchestrator.set_pr_number o pid (Pr_number.of_int 1)
+                else o
+              in
+              Orchestrator.complete o pid)
+        in
+        (* For each patch with a dependency, test the interleaving:
+           1. Start the dependent (no PR — first session)
+           2. Merge the immediate dependency while the dependent is busy
+           3. Re-derive initial_base from fresh state
+           4. Assert the fresh base is main (all deps of this patch merged) *)
+        List.for_alli patches ~f:(fun i _p ->
+            if i = 0 then true (* patch 0 has no deps *)
+            else
+              let dep_pid = pid_of_idx patches (i - 1) in
+              let pid = pid_of_idx patches i in
+              (* Merge all patches before the immediate dep so that
+                 the only open dep is [dep_pid] *)
+              let orch =
+                List.foldi patches ~init:orch ~f:(fun j o _p ->
+                    if j < i - 1 then
+                      let jpid = pid_of_idx patches j in
+                      if not (Orchestrator.agent o jpid).Patch_agent.merged then
+                        Orchestrator.mark_merged o jpid
+                      else o
+                    else o)
+              in
+              (* Verify the stale base is the dep's branch *)
+              let has_merged_pre dep =
+                (Orchestrator.agent orch dep).Patch_agent.merged
+              in
+              let stale_base =
+                Graph.initial_base (Orchestrator.graph orch) pid
+                  ~has_merged:has_merged_pre ~branch_of ~main
+              in
+              let dep_branch = branch_of dep_pid in
+              if not (Branch.equal stale_base dep_branch) then
+                QCheck2.Test.fail_reportf
+                  "PI-17 setup: expected stale_base=%s, got %s"
+                  (Branch.to_string dep_branch)
+                  (Branch.to_string stale_base);
+              (* Fire Start to make the dependent busy (no PR → fire succeeds) *)
+              let orch =
+                Orchestrator.fire orch (Orchestrator.Start (pid, stale_base))
+              in
+              let agent = Orchestrator.agent orch pid in
+              if not agent.Patch_agent.busy then
+                QCheck2.Test.fail_reportf
+                  "PI-17: patch %s should be busy after Start"
+                  (Patch_id.to_string pid);
+              (* Dependency merges while dependent is busy *)
+              let orch = Orchestrator.mark_merged orch dep_pid in
+              (* Re-derive initial_base from fresh state — this is what
+                 the supervisor now does at PR creation time *)
+              let has_merged_post dep =
+                (Orchestrator.agent orch dep).Patch_agent.merged
+              in
+              let fresh_base =
+                Graph.initial_base (Orchestrator.graph orch) pid
+                  ~has_merged:has_merged_post ~branch_of ~main
+              in
+              if not (Branch.equal fresh_base main) then
+                QCheck2.Test.fail_reportf
+                  "PI-17: after dep %s merged, fresh initial_base for %s \
+                   should be main, got %s"
+                  (Patch_id.to_string dep_pid)
+                  (Patch_id.to_string pid)
+                  (Branch.to_string fresh_base);
+              true))
+  in
+  QCheck2.Test.check_exn prop_pi17;
+  Stdlib.print_endline "PI-17 passed"

--- a/test/test_interleaving_properties.ml
+++ b/test/test_interleaving_properties.ml
@@ -1847,7 +1847,9 @@ let () =
                     (Patch_id.to_string pid)
                     (Branch.to_string fresh_base);
                 true)
-        with _ -> false)
+        with
+        | QCheck2.Test.Test_fail _ as e -> raise e
+        | _ -> false)
   in
   QCheck2.Test.check_exn prop_pi17;
   Stdlib.print_endline "PI-17 passed"

--- a/test/test_interleaving_properties.ml
+++ b/test/test_interleaving_properties.ml
@@ -1759,93 +1759,95 @@ let () =
       ~name:
         "PI-17: fresh initial_base after dep merge yields main, not stale \
          dep-branch" ~count:300 (QCheck2.Gen.int_range 2 5) (fun n ->
-        let patches = mk_patches n in
-        let branch_of = branch_of_patches patches in
-        let orch = Orchestrator.create ~patches ~main_branch:main in
-        (* Bootstrap: start and complete all patches in dependency order.
+        try
+          let patches = mk_patches n in
+          let branch_of = branch_of_patches patches in
+          let orch = Orchestrator.create ~patches ~main_branch:main in
+          (* Bootstrap: start and complete all patches in dependency order.
            Only patch 0 gets a PR; all dependents (patches 1..n-1) are left
            without one, so Start can fire for them again in each sub-scenario. *)
-        let orch =
-          List.foldi patches ~init:orch ~f:(fun i o _p ->
-              let pid = pid_of_idx patches i in
-              let has_merged dep_pid =
-                (Orchestrator.agent o dep_pid).Patch_agent.merged
-              in
-              let base =
-                Graph.initial_base (Orchestrator.graph o) pid ~has_merged
-                  ~branch_of ~main
-              in
-              let o = Orchestrator.fire o (Orchestrator.Start (pid, base)) in
-              let o =
-                if i = 0 then
-                  Orchestrator.set_pr_number o pid (Pr_number.of_int 1)
-                else o
-              in
-              Orchestrator.complete o pid)
-        in
-        (* For each patch with a dependency, test the interleaving:
+          let orch =
+            List.foldi patches ~init:orch ~f:(fun i o _p ->
+                let pid = pid_of_idx patches i in
+                let has_merged dep_pid =
+                  (Orchestrator.agent o dep_pid).Patch_agent.merged
+                in
+                let base =
+                  Graph.initial_base (Orchestrator.graph o) pid ~has_merged
+                    ~branch_of ~main
+                in
+                let o = Orchestrator.fire o (Orchestrator.Start (pid, base)) in
+                let o =
+                  if i = 0 then
+                    Orchestrator.set_pr_number o pid (Pr_number.of_int 1)
+                  else o
+                in
+                Orchestrator.complete o pid)
+          in
+          (* For each patch with a dependency, test the interleaving:
            1. Start the dependent (no PR — first session)
            2. Merge the immediate dependency while the dependent is busy
            3. Re-derive initial_base from fresh state
            4. Assert the fresh base is main (all deps of this patch merged) *)
-        List.for_alli patches ~f:(fun i _p ->
-            if i = 0 then true (* patch 0 has no deps *)
-            else
-              let dep_pid = pid_of_idx patches (i - 1) in
-              let pid = pid_of_idx patches i in
-              (* Merge all patches before the immediate dep so that
+          List.for_alli patches ~f:(fun i _p ->
+              if i = 0 then true (* patch 0 has no deps *)
+              else
+                let dep_pid = pid_of_idx patches (i - 1) in
+                let pid = pid_of_idx patches i in
+                (* Merge all patches before the immediate dep so that
                  the only open dep is [dep_pid] *)
-              let orch =
-                List.foldi patches ~init:orch ~f:(fun j o _p ->
-                    if j < i - 1 then
-                      let jpid = pid_of_idx patches j in
-                      if not (Orchestrator.agent o jpid).Patch_agent.merged then
-                        Orchestrator.mark_merged o jpid
-                      else o
-                    else o)
-              in
-              (* Verify the stale base is the dep's branch *)
-              let has_merged_pre dep =
-                (Orchestrator.agent orch dep).Patch_agent.merged
-              in
-              let stale_base =
-                Graph.initial_base (Orchestrator.graph orch) pid
-                  ~has_merged:has_merged_pre ~branch_of ~main
-              in
-              let dep_branch = branch_of dep_pid in
-              if not (Branch.equal stale_base dep_branch) then
-                QCheck2.Test.fail_reportf
-                  "PI-17 setup: expected stale_base=%s, got %s"
-                  (Branch.to_string dep_branch)
-                  (Branch.to_string stale_base);
-              (* Fire Start to make the dependent busy (no PR → fire succeeds) *)
-              let orch =
-                Orchestrator.fire orch (Orchestrator.Start (pid, stale_base))
-              in
-              let agent = Orchestrator.agent orch pid in
-              if not agent.Patch_agent.busy then
-                QCheck2.Test.fail_reportf
-                  "PI-17: patch %s should be busy after Start"
-                  (Patch_id.to_string pid);
-              (* Dependency merges while dependent is busy *)
-              let orch = Orchestrator.mark_merged orch dep_pid in
-              (* Re-derive initial_base from fresh state — this is what
+                let orch =
+                  List.foldi patches ~init:orch ~f:(fun j o _p ->
+                      if j < i - 1 then
+                        let jpid = pid_of_idx patches j in
+                        if not (Orchestrator.agent o jpid).Patch_agent.merged
+                        then Orchestrator.mark_merged o jpid
+                        else o
+                      else o)
+                in
+                (* Verify the stale base is the dep's branch *)
+                let has_merged_pre dep =
+                  (Orchestrator.agent orch dep).Patch_agent.merged
+                in
+                let stale_base =
+                  Graph.initial_base (Orchestrator.graph orch) pid
+                    ~has_merged:has_merged_pre ~branch_of ~main
+                in
+                let dep_branch = branch_of dep_pid in
+                if not (Branch.equal stale_base dep_branch) then
+                  QCheck2.Test.fail_reportf
+                    "PI-17 setup: expected stale_base=%s, got %s"
+                    (Branch.to_string dep_branch)
+                    (Branch.to_string stale_base);
+                (* Fire Start to make the dependent busy (no PR → fire succeeds) *)
+                let orch =
+                  Orchestrator.fire orch (Orchestrator.Start (pid, stale_base))
+                in
+                let agent = Orchestrator.agent orch pid in
+                if not agent.Patch_agent.busy then
+                  QCheck2.Test.fail_reportf
+                    "PI-17: patch %s should be busy after Start"
+                    (Patch_id.to_string pid);
+                (* Dependency merges while dependent is busy *)
+                let orch = Orchestrator.mark_merged orch dep_pid in
+                (* Re-derive initial_base from fresh state — this is what
                  the supervisor now does at PR creation time *)
-              let has_merged_post dep =
-                (Orchestrator.agent orch dep).Patch_agent.merged
-              in
-              let fresh_base =
-                Graph.initial_base (Orchestrator.graph orch) pid
-                  ~has_merged:has_merged_post ~branch_of ~main
-              in
-              if not (Branch.equal fresh_base main) then
-                QCheck2.Test.fail_reportf
-                  "PI-17: after dep %s merged, fresh initial_base for %s \
-                   should be main, got %s"
-                  (Patch_id.to_string dep_pid)
-                  (Patch_id.to_string pid)
-                  (Branch.to_string fresh_base);
-              true))
+                let has_merged_post dep =
+                  (Orchestrator.agent orch dep).Patch_agent.merged
+                in
+                let fresh_base =
+                  Graph.initial_base (Orchestrator.graph orch) pid
+                    ~has_merged:has_merged_post ~branch_of ~main
+                in
+                if not (Branch.equal fresh_base main) then
+                  QCheck2.Test.fail_reportf
+                    "PI-17: after dep %s merged, fresh initial_base for %s \
+                     should be main, got %s"
+                    (Patch_id.to_string dep_pid)
+                    (Patch_id.to_string pid)
+                    (Branch.to_string fresh_base);
+                true)
+        with _ -> false)
   in
   QCheck2.Test.check_exn prop_pi17;
   Stdlib.print_endline "PI-17 passed"

--- a/test/test_interleaving_properties.ml
+++ b/test/test_interleaving_properties.ml
@@ -1762,9 +1762,9 @@ let () =
         let patches = mk_patches n in
         let branch_of = branch_of_patches patches in
         let orch = Orchestrator.create ~patches ~main_branch:main in
-        (* Bootstrap: start and complete all patches in dependency order,
-           giving each a PR — except patch 1 (the first dependent), which
-           we leave without a PR to model the "first session" scenario. *)
+        (* Bootstrap: start and complete all patches in dependency order.
+           Only patch 0 gets a PR; all dependents (patches 1..n-1) are left
+           without one, so Start can fire for them again in each sub-scenario. *)
         let orch =
           List.foldi patches ~init:orch ~f:(fun i o _p ->
               let pid = pid_of_idx patches i in


### PR DESCRIPTION
## Summary

- **Spec sections preserved across PR body rewrites**: The agent-authored PR body phase (`Pr_body` operation) was silently dropping the Gameplan Specification and Patch Specification sections. Moved spec rendering into a supervisor-owned `render_spec_suffix` that is appended after every body PATCH — initial creation, pr-body artifact, and implementation-notes composition.

- **Fresh base branch at PR creation time**: The `Start` message captured the base branch at dispatch time, but dependencies could merge during the agent session (minutes), leaving the base stale and causing GitHub 422s. Now re-derives `Graph.initial_base` from current orchestrator state right before `create_pull_request`.

- **PI-17 regression test**: Property test generating random 2–5 patch linear chains, verifying that `initial_base` returns `main` after a dependency merges while the dependent is busy — the exact interleaving that caused the spec-aware-review/patch-4 422.

## Test plan

- [x] 4 inline tests for `render_spec_suffix` (both empty, gameplan-only, patch-only, both present)
- [x] PI-17 property test (300 cases, random chain lengths 2–5)
- [x] All existing tests pass (PI-1 through PI-16, all QCheck2 properties, all inline tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves spec sections in PR descriptions and fixes stale base branches at PR creation to avoid GitHub 422s. Improves 422 recovery and keeps PI-17 failure diagnostics visible.

- **Bug Fixes**
  - Always append specs via `render_spec_suffix` after every PR body update (initial creation, pr-body artifact, implementation notes) so agent rewrites can’t drop them.
  - Re-derive the base branch from fresh orchestrator state with `Graph.initial_base` right before `create_pull_request`, handling deps that merged during the session.
  - In 422 “PR already exists” recovery, drop the base filter when searching by head branch so the existing PR is found even if its base changed.

- **Tests**
  - PI-17: re-raise `QCheck2.Test_fail` to preserve assertion messages; property still runs 300 cases.

<sup>Written for commit e0e6d9cc8f01e4d3f6810eb7d35543d876d69975. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PR bodies now append a rendered specification suffix containing Gameplan and Patch Specification sections, omitting empty sections.
  * PR creation now uses a freshly computed base branch during the agent session to avoid staleness.

* **Tests**
  * Added unit tests for specification-suffix rendering and a property test validating base-branch freshness and dependent-patch workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->