### PR TITLE
Merge pr_body and implementation_notes into a single phase

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -347,8 +347,8 @@ let apply_notes_artifact ~runtime ~net ~github ~project_name ~patch_id
       in
       let spec_suffix = Prompt.render_spec_suffix patch gameplan in
       let composed =
-        Printf.sprintf "%s\n\n## Implementation Notes\n\n%s%s" body_base
-          (String.trim notes) spec_suffix
+        Printf.sprintf "%s%s\n\n## Implementation Notes\n\n%s" body_base
+          spec_suffix (String.trim notes)
       in
       match Github.update_pr_body ~net github ~pr_number ~body:composed with
       | Ok () ->
@@ -2815,6 +2815,26 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                         ~pr_body ~artifact_path
                                   | Patch_decision.Implementation_notes_payload
                                     ->
+                                      let patch =
+                                        Base.List.find_exn
+                                          gameplan.Gameplan.patches
+                                          ~f:(fun (p : Patch.t) ->
+                                            Patch_id.equal p.Patch.id patch_id)
+                                      in
+                                      let pr_description =
+                                        Prompt.resolve_pr_body_source
+                                          ~artifact:
+                                            (read_artifact_file
+                                               (Project_store
+                                                .pr_body_artifact_path
+                                                  ~project_name ~patch_id))
+                                          ~fallback:
+                                            (Prompt.render_pr_description
+                                               ~project_name patch gameplan)
+                                      in
+                                      let spec_suffix =
+                                        Prompt.render_spec_suffix patch gameplan
+                                      in
                                       let artifact_path =
                                         Project_store
                                         .implementation_notes_artifact_path
@@ -2826,6 +2846,7 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                         ~project_name
                                         ~pr_number:
                                           (Base.Option.value_exn pr_number)
+                                        ~pr_description ~spec_suffix
                                         ~artifact_path
                                   | Patch_decision.Merge_conflict_payload ->
                                       (* Invariant: Merge_conflict is handled

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -295,8 +295,10 @@ let read_artifact_file path =
     else None
   with _ -> None
 
-(** Apply the agent-authored PR body artifact to the PR. Falls back to keeping
-    the gameplan-derived body if the artifact is missing or empty. *)
+(** Apply the agent-authored notes artifact to the PR. Composes the final body
+    as: gameplan description + specs + Implementation Notes (from artifact).
+    Falls back to keeping the existing PR body if the artifact is missing or
+    empty. *)
 let apply_pr_body_artifact ~runtime ~net ~github ~project_name ~patch_id
     ~pr_number ~patch ~gameplan =
   let artifact_path =
@@ -305,13 +307,21 @@ let apply_pr_body_artifact ~runtime ~net ~github ~project_name ~patch_id
   match read_artifact_file artifact_path with
   | None ->
       log_event runtime ~patch_id
-        (Printf.sprintf "pr-body: artifact missing at %s; keeping gameplan body"
+        (Printf.sprintf
+           "pr-body: artifact missing at %s; keeping initial PR body"
            artifact_path)
-  | Some body when String.length (String.trim body) = 0 ->
+  | Some notes when String.length (String.trim notes) = 0 ->
       log_event runtime ~patch_id
-        "pr-body: artifact empty; keeping gameplan body"
-  | Some body -> (
-      let body = body ^ Prompt.render_spec_suffix patch gameplan in
+        "pr-body: artifact empty; keeping initial PR body"
+  | Some notes -> (
+      let description =
+        Prompt.render_pr_description ~project_name patch gameplan
+      in
+      let spec_suffix = Prompt.render_spec_suffix patch gameplan in
+      let body =
+        Printf.sprintf "%s%s\n\n## Implementation Notes\n\n%s" description
+          spec_suffix (String.trim notes)
+      in
       match Github.update_pr_body ~net github ~pr_number ~body with
       | Ok () ->
           log_event runtime ~patch_id
@@ -320,44 +330,6 @@ let apply_pr_body_artifact ~runtime ~net ~github ~project_name ~patch_id
       | Error e ->
           log_event runtime ~patch_id
             (Printf.sprintf "pr-body: PATCH failed — %s" (Github.show_error e)))
-
-(** Apply the agent-authored notes artifact: compose
-    [<pr-body>\n\n## Implementation Notes\n\n<notes>] and PATCH the PR. The body
-    source is the local pr-body.md artifact; if missing, falls back to the
-    gameplan-derived body. *)
-let apply_notes_artifact ~runtime ~net ~github ~project_name ~patch_id
-    ~pr_number ~patch ~gameplan =
-  let notes_path =
-    Project_store.implementation_notes_artifact_path ~project_name ~patch_id
-  in
-  match read_artifact_file notes_path with
-  | None ->
-      log_event runtime ~patch_id
-        (Printf.sprintf "notes: artifact missing at %s; not updating PR body"
-           notes_path)
-  | Some notes when String.length (String.trim notes) = 0 ->
-      log_event runtime ~patch_id "notes: artifact empty; not updating PR body"
-  | Some notes -> (
-      let body_base =
-        Prompt.resolve_pr_body_source
-          ~artifact:
-            (read_artifact_file
-               (Project_store.pr_body_artifact_path ~project_name ~patch_id))
-          ~fallback:(Prompt.render_pr_description ~project_name patch gameplan)
-      in
-      let spec_suffix = Prompt.render_spec_suffix patch gameplan in
-      let composed =
-        Printf.sprintf "%s%s\n\n## Implementation Notes\n\n%s" body_base
-          spec_suffix (String.trim notes)
-      in
-      match Github.update_pr_body ~net github ~pr_number ~body:composed with
-      | Ok () ->
-          log_event runtime ~patch_id
-            (Printf.sprintf "notes: PATCHed PR #%d (body + notes section)"
-               (Pr_number.to_int pr_number))
-      | Error e ->
-          log_event runtime ~patch_id
-            (Printf.sprintf "notes: PATCH failed — %s" (Github.show_error e)))
 
 (** Terminal failure — forces [Given_up] so [complete] raises intervention. Used
     for non-retryable errors (patch not found, PR discovery failed). *)
@@ -2745,9 +2717,8 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                     ( Patch_decision.Human_payload _
                                     | Patch_decision.Ci_payload _
                                     | Patch_decision.Review_payload _
-                                    | Patch_decision.Pr_body_payload
-                                    | Patch_decision
-                                      .Implementation_notes_payload ) as payload;
+                                    | Patch_decision.Pr_body_payload ) as
+                                    payload;
                                   base_change;
                                 } ->
                                 let pr_number = agent.Patch_agent.pr_number in
@@ -2771,7 +2742,6 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                            "message")
                                   | Patch_decision.Ci_payload _
                                   | Patch_decision.Pr_body_payload
-                                  | Patch_decision.Implementation_notes_payload
                                   | Patch_decision.Merge_conflict_payload ->
                                       Printf.sprintf "Delivering %s"
                                         (Operation_kind.to_label kind));
@@ -2803,6 +2773,9 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                         Prompt.render_pr_description
                                           ~project_name patch gameplan
                                       in
+                                      let spec_suffix =
+                                        Prompt.render_spec_suffix patch gameplan
+                                      in
                                       let artifact_path =
                                         Project_store.pr_body_artifact_path
                                           ~project_name ~patch_id
@@ -2812,42 +2785,7 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                       Prompt.render_pr_body_prompt ~project_name
                                         ~pr_number:
                                           (Base.Option.value_exn pr_number)
-                                        ~pr_body ~artifact_path
-                                  | Patch_decision.Implementation_notes_payload
-                                    ->
-                                      let patch =
-                                        Base.List.find_exn
-                                          gameplan.Gameplan.patches
-                                          ~f:(fun (p : Patch.t) ->
-                                            Patch_id.equal p.Patch.id patch_id)
-                                      in
-                                      let pr_description =
-                                        Prompt.resolve_pr_body_source
-                                          ~artifact:
-                                            (read_artifact_file
-                                               (Project_store
-                                                .pr_body_artifact_path
-                                                  ~project_name ~patch_id))
-                                          ~fallback:
-                                            (Prompt.render_pr_description
-                                               ~project_name patch gameplan)
-                                      in
-                                      let spec_suffix =
-                                        Prompt.render_spec_suffix patch gameplan
-                                      in
-                                      let artifact_path =
-                                        Project_store
-                                        .implementation_notes_artifact_path
-                                          ~project_name ~patch_id
-                                      in
-                                      Project_store.ensure_dir
-                                        (Stdlib.Filename.dirname artifact_path);
-                                      Prompt.render_implementation_notes_prompt
-                                        ~project_name
-                                        ~pr_number:
-                                          (Base.Option.value_exn pr_number)
-                                        ~pr_description ~spec_suffix
-                                        ~artifact_path
+                                        ~pr_body ~spec_suffix ~artifact_path
                                   | Patch_decision.Merge_conflict_payload ->
                                       (* Invariant: Merge_conflict is handled
                                          in the dedicated match arm above *)
@@ -2881,12 +2819,12 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                         Orchestrator.set_notified_base_branch
                                           orch patch_id (Branch.of_string base))
                                 | _ -> ());
-                                (* Artifact-driven phases (Pr_body, Notes):
-                                   read the agent's artifact and PATCH the PR
-                                   body. Falls back gracefully if the artifact
-                                   is missing — the *_delivered flag flips
-                                   true via apply_respond_outcome on
-                                   Respond_ok regardless, so we don't loop. *)
+                                (* Artifact-driven phase (Pr_body): read
+                                   the agent's artifact and PATCH the PR body.
+                                   Falls back gracefully if the artifact is
+                                   missing — pr_body_delivered flips true via
+                                   apply_respond_outcome on Respond_ok
+                                   regardless, so we don't loop. *)
                                 let session_ok =
                                   match result with `Ok -> true | _ -> false
                                 in
@@ -2903,20 +2841,6 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                              Patch_id.equal p.Patch.id patch_id)
                                        in
                                        apply_pr_body_artifact ~runtime ~net
-                                         ~github ~project_name ~patch_id
-                                         ~pr_number:pr ~patch ~gameplan
-                                   | Patch_decision.Implementation_notes_payload
-                                     ->
-                                       let pr =
-                                         Base.Option.value_exn pr_number
-                                       in
-                                       let patch =
-                                         Base.List.find_exn
-                                           gameplan.Gameplan.patches
-                                           ~f:(fun (p : Patch.t) ->
-                                             Patch_id.equal p.Patch.id patch_id)
-                                       in
-                                       apply_notes_artifact ~runtime ~net
                                          ~github ~project_name ~patch_id
                                          ~pr_number:pr ~patch ~gameplan
                                    | Patch_decision.Human_payload _

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -342,10 +342,6 @@ let set_merge_ready t patch_id v =
 let set_is_draft t patch_id v =
   update_agent t patch_id ~f:(fun a -> Patch_agent.set_is_draft a v)
 
-let set_implementation_notes_delivered t patch_id v =
-  update_agent t patch_id ~f:(fun a ->
-      Patch_agent.set_implementation_notes_delivered a v)
-
 let set_pr_body_delivered t patch_id v =
   update_agent t patch_id ~f:(fun a -> Patch_agent.set_pr_body_delivered a v)
 
@@ -654,11 +650,6 @@ let apply_respond_outcome t patch_id kind outcome =
           reset_conflict_noop_count t patch_id
         else t
       in
-      let t =
-        if Operation_kind.equal kind Operation_kind.Pr_body then
-          set_pr_body_delivered t patch_id true
-        else t
-      in
-      if Operation_kind.equal kind Operation_kind.Implementation_notes then
-        set_implementation_notes_delivered t patch_id true
+      if Operation_kind.equal kind Operation_kind.Pr_body then
+        set_pr_body_delivered t patch_id true
       else t

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -92,7 +92,6 @@ val set_ci_checks : t -> Patch_id.t -> Ci_check.t list -> t
 val set_checks_passing : t -> Patch_id.t -> bool -> t
 val set_merge_ready : t -> Patch_id.t -> bool -> t
 val set_is_draft : t -> Patch_id.t -> bool -> t
-val set_implementation_notes_delivered : t -> Patch_id.t -> bool -> t
 val set_pr_body_delivered : t -> Patch_id.t -> bool -> t
 val increment_start_attempts_without_pr : t -> Patch_id.t -> t
 val reset_intervention_state : t -> Patch_id.t -> t
@@ -181,10 +180,10 @@ val apply_respond_outcome :
   t -> Patch_id.t -> Operation_kind.t -> respond_outcome -> t
 (** Apply the outcome of a Respond action fiber. [Respond_ok] -> complete +
     kind-specific transitions (Merge_conflict -> clear_has_conflict +
-    reset_conflict_noop_count; Implementation_notes ->
-    set_implementation_notes_delivered). [Respond_failed] -> complete_failed
-    (restores inflight human messages). [Respond_skip_empty] -> complete.
-    [Respond_retry_push] -> complete. [Respond_stale] -> identity. *)
+    reset_conflict_noop_count; Pr_body -> set_pr_body_delivered).
+    [Respond_failed] -> complete_failed (restores inflight human messages).
+    [Respond_skip_empty] -> complete. [Respond_retry_push] -> complete.
+    [Respond_stale] -> identity. *)
 
 (** Side effects emitted by rebase result application. The runner is responsible
     for executing these (e.g. force-pushing the branch to the remote). Modeled

--- a/lib/patch_agent.ml
+++ b/lib/patch_agent.ml
@@ -26,7 +26,6 @@ type t = {
   merge_ready : bool;
   is_draft : bool;
   pr_body_delivered : bool;
-  implementation_notes_delivered : bool;
   start_attempts_without_pr : int;
   conflict_noop_count : int;
   no_commits_push_count : int;
@@ -75,7 +74,6 @@ let create ~branch patch_id =
     merge_ready = false;
     is_draft = false;
     pr_body_delivered = false;
-    implementation_notes_delivered = false;
     start_attempts_without_pr = 0;
     conflict_noop_count = 0;
     no_commits_push_count = 0;
@@ -111,7 +109,6 @@ let create_adhoc ~patch_id ~branch ~pr_number =
     merge_ready = false;
     is_draft = false;
     pr_body_delivered = true;
-    implementation_notes_delivered = true;
     start_attempts_without_pr = 0;
     conflict_noop_count = 0;
     no_commits_push_count = 0;
@@ -195,10 +192,6 @@ let base_branch_changed t =
 
 let set_merge_ready t v = { t with merge_ready = v }
 let set_is_draft t v = { t with is_draft = v }
-
-let set_implementation_notes_delivered t v =
-  { t with implementation_notes_delivered = v }
-
 let set_pr_body_delivered t v = { t with pr_body_delivered = v }
 
 let increment_start_attempts_without_pr t =
@@ -253,10 +246,9 @@ let restore ~patch_id ~branch ~pr_number ~has_session ~busy ~merged ~queue
     ~satisfies ~changed ~has_conflict ~base_branch ~notified_base_branch
     ~ci_failure_count ~session_fallback ~human_messages ~inflight_human_messages
     ~ci_checks ~merge_ready ~is_draft ~pr_body_delivered
-    ~implementation_notes_delivered ~start_attempts_without_pr
-    ~conflict_noop_count ~no_commits_push_count ~branch_rebased_onto
-    ~checks_passing ~current_op ~current_message_id ~generation ~worktree_path
-    ~branch_blocked ~llm_session_id =
+    ~start_attempts_without_pr ~conflict_noop_count ~no_commits_push_count
+    ~branch_rebased_onto ~checks_passing ~current_op ~current_message_id
+    ~generation ~worktree_path ~branch_blocked ~llm_session_id =
   {
     patch_id;
     branch;
@@ -278,7 +270,6 @@ let restore ~patch_id ~branch ~pr_number ~has_session ~busy ~merged ~queue
     merge_ready;
     is_draft;
     pr_body_delivered;
-    implementation_notes_delivered;
     start_attempts_without_pr;
     conflict_noop_count;
     no_commits_push_count;
@@ -298,7 +289,6 @@ let set_pr_number t pr_number =
     pr_number = Some pr_number;
     is_draft = true;
     pr_body_delivered = false;
-    implementation_notes_delivered = false;
     start_attempts_without_pr = 0;
   }
 

--- a/lib/patch_agent.mli
+++ b/lib/patch_agent.mli
@@ -30,7 +30,6 @@ type t = private {
   merge_ready : bool;
   is_draft : bool;
   pr_body_delivered : bool;
-  implementation_notes_delivered : bool;
   start_attempts_without_pr : int;
   conflict_noop_count : int;
   no_commits_push_count : int;
@@ -171,9 +170,6 @@ val set_merge_ready : t -> bool -> t
 val set_is_draft : t -> bool -> t
 (** Set the draft flag from GitHub PR state. *)
 
-val set_implementation_notes_delivered : t -> bool -> t
-(** Record whether implementation notes were successfully delivered. *)
-
 val set_pr_body_delivered : t -> bool -> t
 (** Record whether the LLM-authored PR body has been written to the artifact and
     PATCHed onto the PR. Set to [true] on Pr_body Respond_ok regardless of
@@ -292,7 +288,6 @@ val restore :
   merge_ready:bool ->
   is_draft:bool ->
   pr_body_delivered:bool ->
-  implementation_notes_delivered:bool ->
   start_attempts_without_pr:int ->
   conflict_noop_count:int ->
   no_commits_push_count:int ->

--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -79,25 +79,6 @@ let enqueue_pr_body_if_needed t patch_id (agent : Patch_agent.t) =
     if already_queued then t
     else Orchestrator.enqueue t patch_id Operation_kind.Pr_body
 
-(* Notes wait until the PR body has been delivered so the body PATCH never
-   races with notes-appended writes. *)
-let enqueue_notes_if_needed t patch_id (agent : Patch_agent.t) =
-  if
-    (not (Patch_agent.has_pr agent))
-    || agent.merged
-    || (not agent.pr_body_delivered)
-    || agent.implementation_notes_delivered
-  then t
-  else
-    let already_queued =
-      List.mem agent.queue Operation_kind.Implementation_notes
-        ~equal:Operation_kind.equal
-      || Option.equal Operation_kind.equal agent.current_op
-           (Some Operation_kind.Implementation_notes)
-    in
-    if already_queued then t
-    else Orchestrator.enqueue t patch_id Operation_kind.Implementation_notes
-
 let apply_poll_result t patch_id
     ({ poll_result; base_branch; branch_in_root; worktree_path } :
       poll_observation) =
@@ -168,7 +149,7 @@ let apply_poll_result t patch_id
               log (Printf.sprintf "Enqueued %s" (Operation_kind.to_label kind));
             Orchestrator.enqueue acc patch_id kind
         | Operation_kind.Rebase | Operation_kind.Human | Operation_kind.Pr_body
-        | Operation_kind.Implementation_notes ->
+          ->
             if is_new then
               log (Printf.sprintf "Enqueued %s" (Operation_kind.to_label kind));
             Orchestrator.enqueue acc patch_id kind)
@@ -249,8 +230,6 @@ let reconcile_patch t ~project_name:_ ~gameplan:_ ~(patch : Patch.t) =
   else
     let t = enqueue_pr_body_if_needed t patch_id agent in
     let agent = Orchestrator.agent t patch_id in
-    let t = enqueue_notes_if_needed t patch_id agent in
-    let agent = Orchestrator.agent t patch_id in
     let effects = ref [] in
     (match agent.pr_number with
     | Some pr_number -> (
@@ -273,7 +252,7 @@ let reconcile_patch t ~project_name:_ ~gameplan:_ ~(patch : Patch.t) =
               in
               let desired_draft =
                 if Branch.equal expected_base (Orchestrator.main_branch t) then
-                  not agent.implementation_notes_delivered
+                  not agent.pr_body_delivered
                 else true
               in
               if Bool.(agent.is_draft <> desired_draft) then
@@ -516,7 +495,7 @@ let%test "reconcile_patch escalates repeated start discovery failures" =
   in
   Patch_agent.needs_intervention (Orchestrator.agent t pid)
 
-let%test "reconcile_patch enqueues pr_body before implementation_notes" =
+let%test "reconcile_patch enqueues pr_body after PR creation" =
   let patch, t = make_orchestrator ~patch_id:pid ~main_branch:main in
   let t = Orchestrator.fire t (Orchestrator.Start (pid, main)) in
   let t = Orchestrator.set_pr_number t pid (Pr_number.of_int 42) in
@@ -537,27 +516,13 @@ let%test "reconcile_patch enqueues pr_body before implementation_notes" =
   in
   let t, _ = reconcile_patch t ~project_name:"proj" ~gameplan:gp ~patch in
   let queue = (Orchestrator.agent t pid).Patch_agent.queue in
-  (* Pr_body fires; Implementation_notes is gated on pr_body_delivered so it
-     does NOT yet appear. After Pr_body delivery, notes joins the queue. *)
-  let has_pr_body =
-    List.mem queue Operation_kind.Pr_body ~equal:Operation_kind.equal
-  in
-  let has_notes =
-    List.mem queue Operation_kind.Implementation_notes
-      ~equal:Operation_kind.equal
-  in
-  if (not has_pr_body) || has_notes then false
-  else
-    let t = Orchestrator.set_pr_body_delivered t pid true in
-    let t, _ = reconcile_patch t ~project_name:"proj" ~gameplan:gp ~patch in
-    List.mem (Orchestrator.agent t pid).Patch_agent.queue
-      Operation_kind.Implementation_notes ~equal:Operation_kind.equal
+  List.mem queue Operation_kind.Pr_body ~equal:Operation_kind.equal
 
-let%test "reconcile_patch requests ready-for-review after notes on main" =
+let%test "reconcile_patch requests ready-for-review after pr_body on main" =
   let patch, t = make_orchestrator ~patch_id:pid ~main_branch:main in
   let t = Orchestrator.fire t (Orchestrator.Start (pid, main)) in
   let t = Orchestrator.set_pr_number t pid (Pr_number.of_int 42) in
-  let t = Orchestrator.set_implementation_notes_delivered t pid true in
+  let t = Orchestrator.set_pr_body_delivered t pid true in
   let t = Orchestrator.complete t pid in
   let _, effects =
     reconcile_patch t ~project_name:"proj"

--- a/lib/patch_decision.ml
+++ b/lib/patch_decision.ml
@@ -31,7 +31,7 @@ let disposition (a : Patch_agent.t) : disposition =
         | Operation_kind.Rebase -> Ready_rebase
         | Operation_kind.Human | Operation_kind.Merge_conflict
         | Operation_kind.Ci | Operation_kind.Review_comments
-        | Operation_kind.Pr_body | Operation_kind.Implementation_notes ->
+        | Operation_kind.Pr_body ->
             Ready_respond k)
 
 type ci_decision =
@@ -100,7 +100,6 @@ type delivery_payload =
   | Ci_payload of { failed_checks : Ci_check.t list }
   | Review_payload of { comments : Comment.t list }
   | Pr_body_payload
-  | Implementation_notes_payload
   | Merge_conflict_payload
 [@@deriving show, eq, sexp_of, compare]
 
@@ -130,7 +129,7 @@ let respond_delivery ~(agent : Patch_agent.t) ~(kind : Operation_kind.t)
             (List.exists source.ci_checks ~f:(fun (c : Ci_check.t) ->
                  List.mem failure_conclusions c.conclusion ~equal:String.equal))
       | Operation_kind.Merge_conflict | Operation_kind.Pr_body
-      | Operation_kind.Implementation_notes | Operation_kind.Rebase ->
+      | Operation_kind.Rebase ->
           false
     in
     if is_empty then Skip_empty
@@ -161,7 +160,6 @@ let respond_delivery ~(agent : Patch_agent.t) ~(kind : Operation_kind.t)
         | Operation_kind.Review_comments ->
             Review_payload { comments = prefetched_comments }
         | Operation_kind.Pr_body -> Pr_body_payload
-        | Operation_kind.Implementation_notes -> Implementation_notes_payload
         | Operation_kind.Merge_conflict -> Merge_conflict_payload
         | Operation_kind.Rebase ->
             (* Invariant: Rebase is never routed through Respond *)

--- a/lib/patch_decision.mli
+++ b/lib/patch_decision.mli
@@ -81,7 +81,6 @@ type delivery_payload =
   | Ci_payload of { failed_checks : Ci_check.t list }
   | Review_payload of { comments : Comment.t list }
   | Pr_body_payload
-  | Implementation_notes_payload
   | Merge_conflict_payload
 [@@deriving show, eq, sexp_of, compare]
 

--- a/lib/persistence.ml
+++ b/lib/persistence.ml
@@ -71,7 +71,6 @@ let patch_agent_to_yojson (a : Patch_agent.t) =
       ("merge_ready", `Bool a.merge_ready);
       ("is_draft", `Bool a.is_draft);
       ("pr_body_delivered", `Bool a.pr_body_delivered);
-      ("implementation_notes_delivered", `Bool a.implementation_notes_delivered);
       ("start_attempts_without_pr", `Int a.start_attempts_without_pr);
       ("conflict_noop_count", `Int a.conflict_noop_count);
       ("no_commits_push_count", `Int a.no_commits_push_count);
@@ -186,8 +185,6 @@ let patch_agent_of_yojson ~gameplan json =
        ~is_draft:(bool_member "is_draft" json)
        ~pr_body_delivered:
          (Option.value (bool_member_opt "pr_body_delivered" json) ~default:true)
-       ~implementation_notes_delivered:
-         (bool_member "implementation_notes_delivered" json)
        ~start_attempts_without_pr:(int_member "start_attempts_without_pr" json)
        ~conflict_noop_count:
          (Option.value (int_member_opt "conflict_noop_count" json) ~default:0)

--- a/lib/persistence.ml
+++ b/lib/persistence.ml
@@ -100,7 +100,7 @@ let patch_agent_of_yojson ~gameplan json =
   let* queue =
     result_all
       (List.map (list_member "queue" json) ~f:(fun j ->
-           try_of_yojson Operation_kind.t_of_yojson j))
+           try_of_yojson Operation_kind.t_of_yojson_compat j))
   in
   let human_messages =
     match Yojson.Safe.Util.member "human_messages" json with
@@ -206,7 +206,7 @@ let patch_agent_of_yojson ~gameplan json =
          (match Yojson.Safe.Util.member "current_op" json with
          | `Null -> None
          | v -> (
-             match try_of_yojson Operation_kind.t_of_yojson v with
+             match try_of_yojson Operation_kind.t_of_yojson_compat v with
              | Ok op -> Some op
              | Error _ -> None))
        ~current_message_id:
@@ -316,7 +316,7 @@ let action_of_yojson json =
              Branch.of_string (string_member "base_branch" json) ))
   | "respond" ->
       let* op_kind =
-        try_of_yojson Operation_kind.t_of_yojson
+        try_of_yojson Operation_kind.t_of_yojson_compat
           (Yojson.Safe.Util.member "operation_kind" json)
       in
       Ok

--- a/lib/priority.ml
+++ b/lib/priority.ml
@@ -10,12 +10,10 @@ let priority (k : Ok.t) : int =
   | Ok.Ci -> 3
   | Ok.Review_comments -> 4
   | Ok.Pr_body -> 5
-  | Ok.Implementation_notes -> 6
 
 let is_feedback (k : Ok.t) : bool =
   match k with
-  | Ok.Human | Ok.Merge_conflict | Ok.Ci | Ok.Review_comments | Ok.Pr_body
-  | Ok.Implementation_notes ->
+  | Ok.Human | Ok.Merge_conflict | Ok.Ci | Ok.Review_comments | Ok.Pr_body ->
       true
   | Ok.Rebase -> false
 

--- a/lib/project_store.ml
+++ b/lib/project_store.ml
@@ -48,9 +48,6 @@ let artifact_dir ~project_name ~patch_id =
 let pr_body_artifact_path ~project_name ~patch_id =
   Stdlib.Filename.concat (artifact_dir ~project_name ~patch_id) "pr-body.md"
 
-let implementation_notes_artifact_path ~project_name ~patch_id =
-  Stdlib.Filename.concat (artifact_dir ~project_name ~patch_id) "notes.md"
-
 let ensure_dir path =
   let rec mkdir_p dir =
     if not (Stdlib.Sys.file_exists dir) then (

--- a/lib/project_store.mli
+++ b/lib/project_store.mli
@@ -72,13 +72,6 @@ val pr_body_artifact_path :
     project's data directory at [artifacts/<patch_id>/pr-body.md] — outside the
     worktree so it can never be accidentally committed. *)
 
-val implementation_notes_artifact_path :
-  project_name:string -> patch_id:Types.Patch_id.t -> string
-(** Absolute path the agent writes the implementation-notes section to. Sibling
-    of [pr_body_artifact_path] at [artifacts/<patch_id>/notes.md]. The
-    supervisor composes the final PR body as
-    [<pr-body.md>\n\n## Implementation Notes\n\n<notes.md>]. *)
-
 val project_exists : string -> bool
 (** Whether a project data directory with config exists. *)
 

--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -515,15 +515,35 @@ A separate, later phase will append `## Implementation Notes` to this body — d
         vars)
 
 let render_implementation_notes_prompt ~(project_name : string)
-    ~(pr_number : Pr_number.t) ~(artifact_path : string) =
+    ~(pr_number : Pr_number.t) ~(pr_description : string)
+    ~(spec_suffix : string) ~(artifact_path : string) =
   let pr_num_str = Int.to_string (Pr_number.to_int pr_number) in
-  let vars = [ ("pr_number", pr_num_str); ("artifact_path", artifact_path) ] in
+  let spec_context =
+    if String.is_empty (String.strip spec_suffix) then ""
+    else
+      "\n\nThe following specifications govern this patch:\n" ^ spec_suffix
+      ^ "\n"
+  in
+  let vars =
+    [
+      ("pr_number", pr_num_str);
+      ("artifact_path", artifact_path);
+      ("pr_description", pr_description);
+      ("spec_context", spec_context);
+    ]
+  in
   render_with_override ~project_name ~name:"implementation_notes" ~vars
     ~default:(fun () ->
       substitute_variables
         {|You have just finished implementing this patch and a PR has been created. The supervisor opens a final phase where you write **just the implementation notes** — the "## Implementation Notes" section a reviewer cares about.
 
-**Write the notes content (markdown, no header line) to `{{artifact_path}}`.** This is an absolute path outside the worktree — write it with the Write tool. The supervisor reads the file, prepends `## Implementation Notes`, and appends it to the PR body.
+Here is the PR description you wrote:
+
+---
+{{pr_description}}
+---
+{{spec_context}}
+**Write the notes content (markdown, no header line) to `{{artifact_path}}`.** This is an absolute path outside the worktree — write it with the Write tool. The supervisor reads the file, prepends `## Implementation Notes`, and appends it to the PR body (after the description and specifications).
 
 Do NOT run `gh`, `git`, or any forge command — the supervisor handles upload.
 
@@ -533,6 +553,8 @@ Focus on:
 - Anything surprising or non-obvious about the approach.
 - Deviations from the original plan (if any).
 - Important details a reviewer should know.
+
+Do not repeat information already in the PR description — add only what a reviewer needs beyond what's already written above.
 
 Keep it concise — a few bullet points usually suffices. If you have nothing material to add (the patch is straightforward), write a single line acknowledging that.|}
         vars)

--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -265,33 +265,6 @@ Continue implementing until all tests pass.|}
 {{patches_list}}|}
         vars)
 
-let resolve_pr_body_source ~(artifact : string option) ~(fallback : string) :
-    string =
-  match artifact with
-  | Some body when String.length (String.strip body) > 0 -> body
-  | Some _ | None -> fallback
-
-let%test "resolve_pr_body_source: None artifact returns fallback" =
-  String.equal
-    (resolve_pr_body_source ~artifact:None ~fallback:"gameplan body")
-    "gameplan body"
-
-let%test "resolve_pr_body_source: empty artifact returns fallback" =
-  String.equal
-    (resolve_pr_body_source ~artifact:(Some "") ~fallback:"gameplan body")
-    "gameplan body"
-
-let%test "resolve_pr_body_source: whitespace-only artifact returns fallback" =
-  String.equal
-    (resolve_pr_body_source ~artifact:(Some "  \n\t  ")
-       ~fallback:"gameplan body")
-    "gameplan body"
-
-let%test "resolve_pr_body_source: non-empty artifact wins" =
-  String.equal
-    (resolve_pr_body_source ~artifact:(Some "agent body") ~fallback:"gameplan")
-    "agent body"
-
 let render_spec_suffix (patch : Patch.t) (gameplan : Gameplan.t) : string =
   let gp =
     let ds = gameplan.Gameplan.final_state_spec in
@@ -480,81 +453,42 @@ let render_pr_description ~(project_name : string) (patch : Patch.t)
         vars)
 
 let render_pr_body_prompt ~(project_name : string) ~(pr_number : Pr_number.t)
-    ~(pr_body : string) ~(artifact_path : string) =
+    ~(pr_body : string) ~(spec_suffix : string) ~(artifact_path : string) =
   let pr_num_str = Int.to_string (Pr_number.to_int pr_number) in
+  let spec_context =
+    if String.is_empty (String.strip spec_suffix) then ""
+    else "\n\nThe specifications governing this patch:\n" ^ spec_suffix ^ "\n"
+  in
   let vars =
     [
       ("pr_number", pr_num_str);
       ("pr_body", pr_body);
+      ("spec_context", spec_context);
       ("artifact_path", artifact_path);
     ]
   in
   render_with_override ~project_name ~name:"pr_body" ~vars ~default:(fun () ->
       substitute_variables
-        {|You have just finished implementing this patch. PR #{{pr_number}} was opened with a generic, gameplan-derived body. Your task is to write a better one — describing what you actually built — and the supervisor will upload it.
+        {|You have just finished implementing this patch. PR #{{pr_number}} was opened with a gameplan-derived body and specifications that will be kept as-is.
 
-The current PR body (gameplan-derived, will be replaced by what you write) is:
+The current PR body is:
 
 ---
 {{pr_body}}
 ---
-
-**Write the full PR body to `{{artifact_path}}`.** This is an absolute path outside the worktree — write it with the Write tool. Do NOT run `gh`, `git`, or any forge command; the supervisor reads the file and PATCHes the PR.
-
-What to include in the body:
-
-- A short summary of what this patch does, in your own words.
-- Key implementation decisions and trade-offs you made.
-- Anything surprising or non-obvious about the approach.
-- Deviations from the original plan (if any).
-- Important context a reviewer should know.
-
-Write the **full body** (not a delta). It will replace the existing description verbatim. If you genuinely have nothing to add over the gameplan-derived body, write that body verbatim — the supervisor PATCH is idempotent.
-
-A separate, later phase will append `## Implementation Notes` to this body — do not include that section here.|}
-        vars)
-
-let render_implementation_notes_prompt ~(project_name : string)
-    ~(pr_number : Pr_number.t) ~(pr_description : string)
-    ~(spec_suffix : string) ~(artifact_path : string) =
-  let pr_num_str = Int.to_string (Pr_number.to_int pr_number) in
-  let spec_context =
-    if String.is_empty (String.strip spec_suffix) then ""
-    else
-      "\n\nThe following specifications govern this patch:\n" ^ spec_suffix
-      ^ "\n"
-  in
-  let vars =
-    [
-      ("pr_number", pr_num_str);
-      ("artifact_path", artifact_path);
-      ("pr_description", pr_description);
-      ("spec_context", spec_context);
-    ]
-  in
-  render_with_override ~project_name ~name:"implementation_notes" ~vars
-    ~default:(fun () ->
-      substitute_variables
-        {|You have just finished implementing this patch and a PR has been created. The supervisor opens a final phase where you write **just the implementation notes** — the "## Implementation Notes" section a reviewer cares about.
-
-Here is the PR description you wrote:
-
----
-{{pr_description}}
----
 {{spec_context}}
-**Write the notes content (markdown, no header line) to `{{artifact_path}}`.** This is an absolute path outside the worktree — write it with the Write tool. The supervisor reads the file, prepends `## Implementation Notes`, and appends it to the PR body (after the description and specifications).
+The supervisor will keep this description and specs on the PR. Your job is to write **additional notes** — anything a reviewer needs beyond the gameplan description. The supervisor will append your notes to the PR body under an `## Implementation Notes` header.
 
-Do NOT run `gh`, `git`, or any forge command — the supervisor handles upload.
+**Write just the notes content (no header) to `{{artifact_path}}`.** This is an absolute path outside the worktree — write it with the Write tool. Do NOT run `gh`, `git`, or any forge command; the supervisor reads the file and PATCHes the PR.
 
-Focus on:
+What to include:
 
 - Key implementation decisions and trade-offs you made.
 - Anything surprising or non-obvious about the approach.
 - Deviations from the original plan (if any).
 - Important details a reviewer should know.
 
-Do not repeat information already in the PR description — add only what a reviewer needs beyond what's already written above.
+Do not repeat information already in the description or specs above — add only what's new.
 
 Keep it concise — a few bullet points usually suffices. If you have nothing material to add (the patch is straightforward), write a single line acknowledging that.|}
         vars)

--- a/lib/prompt.mli
+++ b/lib/prompt.mli
@@ -17,7 +17,6 @@ val render_patch_prompt :
 val render_pr_description :
   project_name:string -> Patch.t -> Gameplan.t -> string
 
-val resolve_pr_body_source : artifact:string option -> fallback:string -> string
 (** Pure: choose between the agent-authored PR body artifact and a deterministic
     fallback (typically the gameplan-derived body). Returns [fallback] when
     [artifact] is [None] or contains only whitespace; returns the artifact
@@ -34,13 +33,6 @@ val render_pr_body_prompt :
   project_name:string ->
   pr_number:Pr_number.t ->
   pr_body:string ->
-  artifact_path:string ->
-  string
-
-val render_implementation_notes_prompt :
-  project_name:string ->
-  pr_number:Pr_number.t ->
-  pr_description:string ->
   spec_suffix:string ->
   artifact_path:string ->
   string

--- a/lib/prompt.mli
+++ b/lib/prompt.mli
@@ -38,7 +38,12 @@ val render_pr_body_prompt :
   string
 
 val render_implementation_notes_prompt :
-  project_name:string -> pr_number:Pr_number.t -> artifact_path:string -> string
+  project_name:string ->
+  pr_number:Pr_number.t ->
+  pr_description:string ->
+  spec_suffix:string ->
+  artifact_path:string ->
+  string
 
 val render_review_prompt :
   project_name:string -> ?pr_number:Pr_number.t -> Comment.t list -> string

--- a/lib/reconciler.ml
+++ b/lib/reconciler.ml
@@ -127,7 +127,7 @@ let plan_operations views ~has_merged ~branch_of ~graph ~main =
                     Some (merge_target graph v.id ~has_merged ~branch_of ~main)
               | Operation_kind.Human | Operation_kind.Merge_conflict
               | Operation_kind.Ci | Operation_kind.Review_comments
-              | Operation_kind.Pr_body | Operation_kind.Implementation_notes ->
+              | Operation_kind.Pr_body ->
                   None
             in
             if

--- a/lib/tui.ml
+++ b/lib/tui.ml
@@ -13,7 +13,6 @@ type display_status =
   | Resolving_conflict
   | Responding_to_human
   | Writing_pr_body
-  | Adding_notes
   | Rebasing
   | Starting
   | Updating
@@ -38,7 +37,6 @@ let label = function
   | Resolving_conflict -> "resolving-conflict"
   | Responding_to_human -> "responding-to-human"
   | Writing_pr_body -> "writing-pr-body"
-  | Adding_notes -> "adding-notes"
   | Rebasing -> "rebasing"
   | Starting -> "starting"
   | Updating -> "updating"
@@ -59,7 +57,6 @@ let color = function
   | Resolving_conflict -> Term.Sgr.fg_yellow
   | Responding_to_human -> Term.Sgr.fg_magenta
   | Writing_pr_body -> Term.Sgr.fg_cyan
-  | Adding_notes -> Term.Sgr.fg_cyan
   | Rebasing -> Term.Sgr.fg_cyan
   | Starting -> Term.Sgr.fg_cyan
   | Updating -> Term.Sgr.fg_cyan
@@ -102,7 +99,6 @@ let derive_display_status (ctx : State.Patch_ctx.t) ~patch_id
     | Some Merge_conflict -> Resolving_conflict
     | Some Human -> Responding_to_human
     | Some Pr_body -> Writing_pr_body
-    | Some Implementation_notes -> Adding_notes
     | Some Rebase -> Rebasing
     | None ->
         if State.Patch_ctx.has_pr ctx ~patch_id then Updating else Starting
@@ -357,7 +353,7 @@ let status_style = function
   | Approved_idle -> [ Term.Sgr.fg_green ]
   | Approved_running -> [ Term.Sgr.fg_green; Term.Sgr.bold ]
   | Fixing_ci | Addressing_review | Resolving_conflict | Responding_to_human
-  | Writing_pr_body | Adding_notes ->
+  | Writing_pr_body ->
       [ Term.Sgr.fg_cyan; Term.Sgr.bold ]
   | Rebasing -> [ Term.Sgr.fg_yellow ]
   | Starting | Updating -> [ Term.Sgr.fg_cyan ]
@@ -373,7 +369,7 @@ let status_indicator = function
   | Approved_idle -> "✓"
   | Approved_running -> "▶"
   | Fixing_ci | Addressing_review | Resolving_conflict | Responding_to_human
-  | Writing_pr_body | Adding_notes ->
+  | Writing_pr_body ->
       "▶"
   | Rebasing -> "↻"
   | Starting | Updating -> "▶"
@@ -642,7 +638,6 @@ let short_op_name = function
   | Operation_kind.Merge_conflict -> "conflict"
   | Operation_kind.Human -> "human"
   | Operation_kind.Pr_body -> "pr-body"
-  | Operation_kind.Implementation_notes -> "notes"
   | Operation_kind.Rebase -> "rebase"
 
 let render_patch_row ~width ~selected (pv : patch_view) =
@@ -750,8 +745,7 @@ let render_summary (views : patch_view list) =
   let is_running status =
     match status with
     | Fixing_ci | Addressing_review | Resolving_conflict | Responding_to_human
-    | Writing_pr_body | Adding_notes | Rebasing | Starting | Updating
-    | Approved_running ->
+    | Writing_pr_body | Rebasing | Starting | Updating | Approved_running ->
         true
     | Merged | Needs_help | Approved_idle | Ci_queued | Review_queued
     | Awaiting_ci | Awaiting_review | Blocked_by_dep | Pending ->

--- a/lib/tui.mli
+++ b/lib/tui.mli
@@ -11,7 +11,6 @@ type display_status =
   | Resolving_conflict
   | Responding_to_human
   | Writing_pr_body
-  | Adding_notes
   | Rebasing
   | Starting
   | Updating

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -47,14 +47,7 @@ module Branch = struct
 end
 
 module Operation_kind = struct
-  type t =
-    | Rebase
-    | Human
-    | Merge_conflict
-    | Ci
-    | Review_comments
-    | Pr_body
-    | Implementation_notes
+  type t = Rebase | Human | Merge_conflict | Ci | Review_comments | Pr_body
   [@@deriving show, eq, ord, sexp_of, compare, hash, yojson]
 
   let to_label = function
@@ -64,7 +57,6 @@ module Operation_kind = struct
     | Ci -> "ci"
     | Review_comments -> "review-comments"
     | Pr_body -> "pr-body"
-    | Implementation_notes -> "implementation-notes"
 end
 
 module Comment_id = struct

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -50,6 +50,15 @@ module Operation_kind = struct
   type t = Rebase | Human | Merge_conflict | Ci | Review_comments | Pr_body
   [@@deriving show, eq, ord, sexp_of, compare, hash, yojson]
 
+  (** Migration-aware deserializer: maps removed constructors to their
+      replacements so persisted state from older versions can still load. *)
+  let t_of_yojson_compat json =
+    match json with
+    | `List [ `String "Implementation_notes" ] | `String "Implementation_notes"
+      ->
+        Pr_body
+    | _ -> t_of_yojson json
+
   let to_label = function
     | Rebase -> "rebase"
     | Human -> "human"

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -45,14 +45,7 @@ module Branch : sig
 end
 
 module Operation_kind : sig
-  type t =
-    | Rebase
-    | Human
-    | Merge_conflict
-    | Ci
-    | Review_comments
-    | Pr_body
-    | Implementation_notes
+  type t = Rebase | Human | Merge_conflict | Ci | Review_comments | Pr_body
   [@@deriving show, eq, ord, sexp_of, compare, hash, yojson]
 
   val to_label : t -> string

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -48,6 +48,10 @@ module Operation_kind : sig
   type t = Rebase | Human | Merge_conflict | Ci | Review_comments | Pr_body
   [@@deriving show, eq, ord, sexp_of, compare, hash, yojson]
 
+  val t_of_yojson_compat : Yojson.Safe.t -> t
+  (** Migration-aware deserializer that accepts removed constructors (e.g.
+      [Implementation_notes] -> [Pr_body]). *)
+
   val to_label : t -> string
   (** Human-readable label for log messages (e.g. ["ci"], ["review-comments"]).
   *)

--- a/lib_test/test_generators.ml
+++ b/lib_test/test_generators.ml
@@ -25,15 +25,11 @@ let gen_branch =
 
 let gen_operation_kind =
   QCheck2.Gen.oneof_list
-    Operation_kind.
-      [
-        Rebase; Human; Merge_conflict; Ci; Review_comments; Implementation_notes;
-      ]
+    Operation_kind.[ Rebase; Human; Merge_conflict; Ci; Review_comments ]
 
 let gen_feedback_kind =
   QCheck2.Gen.oneof_list
-    Operation_kind.
-      [ Human; Merge_conflict; Ci; Review_comments; Implementation_notes ]
+    Operation_kind.[ Human; Merge_conflict; Ci; Review_comments ]
 
 let gen_operation_kind_queue =
   QCheck2.Gen.(
@@ -497,7 +493,6 @@ let all_display_statuses : Onton.Tui.display_status list =
     | Resolving_conflict -> Resolving_conflict
     | Responding_to_human -> Responding_to_human
     | Writing_pr_body -> Writing_pr_body
-    | Adding_notes -> Adding_notes
     | Rebasing -> Rebasing
     | Starting -> Starting
     | Updating -> Updating
@@ -519,7 +514,6 @@ let all_display_statuses : Onton.Tui.display_status list =
       Resolving_conflict;
       Responding_to_human;
       Writing_pr_body;
-      Adding_notes;
       Rebasing;
       Starting;
       Updating;

--- a/lib_test/test_generators.ml
+++ b/lib_test/test_generators.ml
@@ -25,11 +25,12 @@ let gen_branch =
 
 let gen_operation_kind =
   QCheck2.Gen.oneof_list
-    Operation_kind.[ Rebase; Human; Merge_conflict; Ci; Review_comments ]
+    Operation_kind.
+      [ Rebase; Human; Merge_conflict; Ci; Review_comments; Pr_body ]
 
 let gen_feedback_kind =
   QCheck2.Gen.oneof_list
-    Operation_kind.[ Human; Merge_conflict; Ci; Review_comments ]
+    Operation_kind.[ Human; Merge_conflict; Ci; Review_comments; Pr_body ]
 
 let gen_operation_kind_queue =
   QCheck2.Gen.(

--- a/test/test_action_outcome_properties.ml
+++ b/test/test_action_outcome_properties.ml
@@ -121,24 +121,6 @@ let () =
   QCheck2.Test.check_exn prop;
   Stdlib.print_endline "AO-3 passed"
 
-(* ========== AO-4: Respond_ok + Pr_body sets delivered ========== *)
-
-let () =
-  let prop =
-    QCheck2.Test.make ~name:"AO-4: Respond_ok + Pr_body sets pr_body_delivered"
-      (QCheck2.Gen.return ()) (fun () ->
-        let orch, patches, gameplan, pid = bootstrap_one () in
-        assert (not (Orchestrator.agent orch pid).Patch_agent.pr_body_delivered);
-        let orch = make_busy orch patches gameplan pid Operation_kind.Pr_body in
-        let orch =
-          Orchestrator.apply_respond_outcome orch pid Operation_kind.Pr_body
-            Orchestrator.Respond_ok
-        in
-        (Orchestrator.agent orch pid).Patch_agent.pr_body_delivered)
-  in
-  QCheck2.Test.check_exn prop;
-  Stdlib.print_endline "AO-4 passed"
-
 (* ========== AO-5: Stale outcomes are identity ========== *)
 
 let () =

--- a/test/test_action_outcome_properties.ml
+++ b/test/test_action_outcome_properties.ml
@@ -80,7 +80,6 @@ let () =
       Operation_kind.Human;
       Operation_kind.Merge_conflict;
       Operation_kind.Pr_body;
-      Operation_kind.Implementation_notes;
     ]
   in
   let prop =
@@ -122,27 +121,20 @@ let () =
   QCheck2.Test.check_exn prop;
   Stdlib.print_endline "AO-3 passed"
 
-(* ========== AO-4: Respond_ok + Implementation_notes sets delivered ========== *)
+(* ========== AO-4: Respond_ok + Pr_body sets delivered ========== *)
 
 let () =
   let prop =
-    QCheck2.Test.make
-      ~name:"AO-4: Respond_ok + Implementation_notes sets delivered"
+    QCheck2.Test.make ~name:"AO-4: Respond_ok + Pr_body sets pr_body_delivered"
       (QCheck2.Gen.return ()) (fun () ->
         let orch, patches, gameplan, pid = bootstrap_one () in
-        assert (
-          not
-            (Orchestrator.agent orch pid)
-              .Patch_agent.implementation_notes_delivered);
+        assert (not (Orchestrator.agent orch pid).Patch_agent.pr_body_delivered);
+        let orch = make_busy orch patches gameplan pid Operation_kind.Pr_body in
         let orch =
-          make_busy orch patches gameplan pid
-            Operation_kind.Implementation_notes
+          Orchestrator.apply_respond_outcome orch pid Operation_kind.Pr_body
+            Orchestrator.Respond_ok
         in
-        let orch =
-          Orchestrator.apply_respond_outcome orch pid
-            Operation_kind.Implementation_notes Orchestrator.Respond_ok
-        in
-        (Orchestrator.agent orch pid).Patch_agent.implementation_notes_delivered)
+        (Orchestrator.agent orch pid).Patch_agent.pr_body_delivered)
   in
   QCheck2.Test.check_exn prop;
   Stdlib.print_endline "AO-4 passed"
@@ -153,15 +145,7 @@ let () =
   let prop =
     QCheck2.Test.make ~name:"AO-5: stale outcomes are identity"
       (QCheck2.Gen.oneof_list
-         Operation_kind.
-           [
-             Ci;
-             Review_comments;
-             Human;
-             Merge_conflict;
-             Pr_body;
-             Implementation_notes;
-           ])
+         Operation_kind.[ Ci; Review_comments; Human; Merge_conflict; Pr_body ])
       (fun kind ->
         try
           let orch, patches, gameplan, pid = bootstrap_one () in
@@ -300,10 +284,9 @@ let () =
 (* ========== AO-9: Non-Respond_ok outcomes leave delivered flags untouched
    ========== *)
 
-(* Pinned-down variant of AO-2: only Respond_ok flips the *_delivered flag.
-   Failed/Skip_empty/Retry_push/Stale must leave pr_body_delivered and
-   implementation_notes_delivered alone, so the next reconcile cycle re-
-   enqueues the phase. *)
+(* Pinned-down variant of AO-2: only Respond_ok flips pr_body_delivered.
+   Failed/Skip_empty/Retry_push/Stale must leave it alone, so the next
+   reconcile cycle re-enqueues the phase. *)
 let () =
   let non_ok_outcomes =
     [
@@ -315,21 +298,18 @@ let () =
   in
   let prop =
     QCheck2.Test.make
-      ~name:
-        "AO-9: non-Respond_ok outcomes leave Pr_body / Notes delivered flags \
-         false"
-      (QCheck2.Gen.pair
-         (QCheck2.Gen.oneof_list non_ok_outcomes)
-         (QCheck2.Gen.oneof_list
-            Operation_kind.[ Pr_body; Implementation_notes ]))
-      (fun (outcome, kind) ->
+      ~name:"AO-9: non-Respond_ok outcomes leave pr_body_delivered false"
+      (QCheck2.Gen.oneof_list non_ok_outcomes) (fun outcome ->
         try
           let orch, patches, gameplan, pid = bootstrap_one () in
-          let orch = make_busy orch patches gameplan pid kind in
-          let orch = Orchestrator.apply_respond_outcome orch pid kind outcome in
-          let a = Orchestrator.agent orch pid in
-          (not a.Patch_agent.pr_body_delivered)
-          && not a.Patch_agent.implementation_notes_delivered
+          let orch =
+            make_busy orch patches gameplan pid Operation_kind.Pr_body
+          in
+          let orch =
+            Orchestrator.apply_respond_outcome orch pid Operation_kind.Pr_body
+              outcome
+          in
+          not (Orchestrator.agent orch pid).Patch_agent.pr_body_delivered
         with _ -> false)
   in
   QCheck2.Test.check_exn prop;

--- a/test/test_orchestrator_properties.ml
+++ b/test/test_orchestrator_properties.ml
@@ -303,14 +303,10 @@ let () =
                 Orchestrator.set_pr_number orch first.Patch.id
                   (Pr_number.of_int 1)
               in
-              (* Mark post-PR phases done so the controller doesn't auto-
-                 enqueue Pr_body / Implementation_notes alongside [kind]. *)
+              (* Mark post-PR phase done so the controller doesn't auto-
+                 enqueue Pr_body alongside [kind]. *)
               let orch =
                 Orchestrator.set_pr_body_delivered orch first.Patch.id true
-              in
-              let orch =
-                Orchestrator.set_implementation_notes_delivered orch
-                  first.Patch.id true
               in
               let orch = Orchestrator.complete orch first.Patch.id in
               let orch = Orchestrator.enqueue orch first.Patch.id kind in

--- a/test/test_patch_agent.ml
+++ b/test/test_patch_agent.ml
@@ -3,8 +3,7 @@ open Onton.Types
 open Onton.Patch_agent
 
 let all_ops =
-  Operation_kind.
-    [ Rebase; Human; Merge_conflict; Ci; Review_comments; Implementation_notes ]
+  Operation_kind.[ Rebase; Human; Merge_conflict; Ci; Review_comments ]
 
 let gen_pid =
   QCheck2.Gen.(
@@ -17,11 +16,7 @@ let gen_branch =
       (string_size ~gen:(char_range 'a' 'z') (int_range 3 20)))
 
 let gen_op = QCheck2.Gen.oneof_list all_ops
-
-let feedback_ops =
-  Operation_kind.
-    [ Human; Merge_conflict; Ci; Review_comments; Implementation_notes ]
-
+let feedback_ops = Operation_kind.[ Human; Merge_conflict; Ci; Review_comments ]
 let gen_feedback_op = QCheck2.Gen.oneof_list feedback_ops
 
 (** Simulate the full start+PR-confirmed flow for tests that need has_pr=true.
@@ -47,7 +42,6 @@ let () =
           && Option.is_none t.base_branch
           && t.ci_failure_count = 0
           && equal_session_fallback t.session_fallback Fresh_available
-          && (not t.implementation_notes_delivered)
           && t.start_attempts_without_pr = 0
           && List.is_empty t.human_messages
           && List.is_empty t.ci_checks && (not t.merge_ready)
@@ -536,9 +530,7 @@ let () =
         Gen.(
           triple gen_pid
             (list_size (int_range 0 5) (string_size ~gen:printable (pure 4)))
-            (oneof_list
-               Operation_kind.
-                 [ Ci; Review_comments; Merge_conflict; Implementation_notes ]))
+            (oneof_list Operation_kind.[ Ci; Review_comments; Merge_conflict ]))
         (fun (pid, msgs, op) ->
           try
             let a =
@@ -676,11 +668,11 @@ let () =
               ~session_fallback:Fresh_available ~human_messages:[]
               ~inflight_human_messages:[] ~ci_checks:a.ci_checks
               ~merge_ready:false ~is_draft:false ~pr_body_delivered:false
-              ~implementation_notes_delivered:false ~start_attempts_without_pr:0
-              ~conflict_noop_count:0 ~no_commits_push_count:0
-              ~branch_rebased_onto:None ~checks_passing:false ~current_op:None
-              ~current_message_id:None ~generation:0 ~worktree_path:None
-              ~branch_blocked:false ~llm_session_id:None
+              ~start_attempts_without_pr:0 ~conflict_noop_count:0
+              ~no_commits_push_count:0 ~branch_rebased_onto:None
+              ~checks_passing:false ~current_op:None ~current_message_id:None
+              ~generation:0 ~worktree_path:None ~branch_blocked:false
+              ~llm_session_id:None
           in
           let a = start a ~base_branch:br in
           List.is_empty a.ci_checks);
@@ -752,11 +744,11 @@ let () =
               ~ci_failure_count:0 ~session_fallback:Fresh_available
               ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
               ~merge_ready:false ~is_draft:false ~pr_body_delivered:false
-              ~implementation_notes_delivered:false ~start_attempts_without_pr:0
-              ~conflict_noop_count:0 ~no_commits_push_count:0
-              ~branch_rebased_onto:None ~checks_passing:false ~current_op:None
-              ~current_message_id:None ~generation:0 ~worktree_path:None
-              ~branch_blocked:false ~llm_session_id:None
+              ~start_attempts_without_pr:0 ~conflict_noop_count:0
+              ~no_commits_push_count:0 ~branch_rebased_onto:None
+              ~checks_passing:false ~current_op:None ~current_message_id:None
+              ~generation:0 ~worktree_path:None ~branch_blocked:false
+              ~llm_session_id:None
           in
           let a = enqueue a Operation_kind.Rebase in
           let a = rebase a ~base_branch:new_base in
@@ -881,10 +873,8 @@ let () =
           let a = create ~branch:br0 pid in
           let a = increment_start_attempts_without_pr a in
           let a = set_pr_body_delivered a true in
-          let a = set_implementation_notes_delivered a true in
           let a = set_pr_number a (Pr_number.of_int 7) in
           has_pr a && a.is_draft && (not a.pr_body_delivered)
-          && (not a.implementation_notes_delivered)
           && a.start_attempts_without_pr = 0);
       Test.make ~name:"on_pr_discovery_failure increments durable attempt count"
         ~count:1

--- a/test/test_patch_agent.ml
+++ b/test/test_patch_agent.ml
@@ -3,7 +3,7 @@ open Onton.Types
 open Onton.Patch_agent
 
 let all_ops =
-  Operation_kind.[ Rebase; Human; Merge_conflict; Ci; Review_comments ]
+  Operation_kind.[ Rebase; Human; Merge_conflict; Ci; Review_comments; Pr_body ]
 
 let gen_pid =
   QCheck2.Gen.(
@@ -16,7 +16,10 @@ let gen_branch =
       (string_size ~gen:(char_range 'a' 'z') (int_range 3 20)))
 
 let gen_op = QCheck2.Gen.oneof_list all_ops
-let feedback_ops = Operation_kind.[ Human; Merge_conflict; Ci; Review_comments ]
+
+let feedback_ops =
+  Operation_kind.[ Human; Merge_conflict; Ci; Review_comments; Pr_body ]
+
 let gen_feedback_op = QCheck2.Gen.oneof_list feedback_ops
 
 (** Simulate the full start+PR-confirmed flow for tests that need has_pr=true.

--- a/test/test_patch_controller.ml
+++ b/test/test_patch_controller.ml
@@ -43,24 +43,16 @@ let make_orch patch agent =
     ~main_branch:main
 
 let make_agent ~patch_id ~branch ~pr_number ~merged ~queue ~base_branch
-    ~is_draft ~implementation_notes_delivered ~start_attempts_without_pr =
-  (* Default pr_body_delivered=true for existing tests so the notes-gate
-     does not block notes enqueuing. New Pr_body-specific tests construct
-     agents via Patch_agent.restore directly. *)
+    ~is_draft ~pr_body_delivered ~start_attempts_without_pr =
   Patch_agent.restore ~patch_id ~branch ~pr_number ~has_session:false
     ~busy:false ~merged ~queue ~satisfies:false ~changed:false
     ~has_conflict:false ~base_branch ~notified_base_branch:base_branch
     ~ci_failure_count:0 ~session_fallback:Patch_agent.Fresh_available
     ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
-    ~merge_ready:false ~is_draft ~pr_body_delivered:true
-    ~implementation_notes_delivered ~start_attempts_without_pr
+    ~merge_ready:false ~is_draft ~pr_body_delivered ~start_attempts_without_pr
     ~conflict_noop_count:0 ~no_commits_push_count:0 ~branch_rebased_onto:None
     ~checks_passing:false ~current_op:None ~current_message_id:None
     ~generation:0 ~worktree_path:None ~branch_blocked:false ~llm_session_id:None
-
-let has_notes_queued agent =
-  List.mem agent.Patch_agent.queue Operation_kind.Implementation_notes
-    ~equal:Operation_kind.equal
 
 let has_draft_effect effects =
   List.exists effects ~f:(function
@@ -74,13 +66,6 @@ let draft_effect effects =
 
 let apply_all_effect_successes orch effects =
   List.fold effects ~init:orch ~f:Patch_controller.apply_github_effect_success
-
-let implementation_notes_action actions pid =
-  List.find actions ~f:(function
-    | Orchestrator.Respond (action_pid, kind) ->
-        Patch_id.equal action_pid pid
-        && Operation_kind.equal kind Operation_kind.Implementation_notes
-    | Orchestrator.Start _ | Orchestrator.Rebase _ -> false)
 
 let run_controller_cycle ~gameplan orch =
   let orch, effects, actions =
@@ -111,7 +96,7 @@ let () =
       let* queue = gen_operation_kind_queue in
       let* use_main_base = bool in
       let* is_draft = bool in
-      let* implementation_notes_delivered = bool in
+      let* pr_body_delivered = bool in
       let* start_attempts_without_pr = int_range 0 3 in
       let base_branch =
         if has_pr then Some (if use_main_base then main else branch) else None
@@ -120,7 +105,7 @@ let () =
       let patch = make_patch pid branch in
       let agent =
         make_agent ~patch_id:pid ~branch ~pr_number ~merged ~queue ~base_branch
-          ~is_draft ~implementation_notes_delivered ~start_attempts_without_pr
+          ~is_draft ~pr_body_delivered ~start_attempts_without_pr
       in
       return (patch, make_gameplan patch, make_orch patch agent))
   in
@@ -174,9 +159,8 @@ let () =
         && List.equal action_equal actions1 actions2)
   in
 
-  let prop_notes_queue_idempotent =
-    Test.make
-      ~name:"patch_controller: implementation notes queueing is idempotent"
+  let prop_pr_body_queue_idempotent =
+    Test.make ~name:"patch_controller: pr_body queueing is idempotent"
       ~count:200
       Gen.(pair gen_patch_id gen_branch)
       (fun (pid, branch) ->
@@ -186,24 +170,27 @@ let () =
           make_agent ~patch_id:pid ~branch
             ~pr_number:(Some (Pr_number.of_int 42))
             ~merged:false ~queue:[] ~base_branch:(Some main) ~is_draft:true
-            ~implementation_notes_delivered:false ~start_attempts_without_pr:0
+            ~pr_body_delivered:false ~start_attempts_without_pr:0
         in
         let orch = make_orch patch agent in
-        let orch1, effects1 =
+        let orch1, _effects1 =
           Patch_controller.reconcile_patch orch ~project_name:"test-project"
             ~gameplan ~patch
         in
-        let orch2, effects2 =
+        let orch2, _effects2 =
           Patch_controller.reconcile_patch orch1 ~project_name:"test-project"
             ~gameplan ~patch
         in
         let a1 = Orchestrator.agent orch1 pid in
         let a2 = Orchestrator.agent orch2 pid in
-        has_notes_queued a1 && has_notes_queued a2
+        let has_pr_body a =
+          List.mem a.Patch_agent.queue Operation_kind.Pr_body
+            ~equal:Operation_kind.equal
+        in
+        has_pr_body a1 && has_pr_body a2
         && List.count a2.Patch_agent.queue
-             ~f:(Operation_kind.equal Operation_kind.Implementation_notes)
-           = 1
-        && List.is_empty effects1 && List.is_empty effects2)
+             ~f:(Operation_kind.equal Operation_kind.Pr_body)
+           = 1)
   in
 
   let prop_draft_reemits_until_success =
@@ -218,8 +205,7 @@ let () =
           make_agent ~patch_id:pid ~branch
             ~pr_number:(Some (Pr_number.of_int 42))
             ~merged:false ~queue:[] ~base_branch:(Some main)
-            ~is_draft:(not desired_draft)
-            ~implementation_notes_delivered:notes_delivered
+            ~is_draft:(not desired_draft) ~pr_body_delivered:notes_delivered
             ~start_attempts_without_pr:0
         in
         let orch = make_orch patch agent in
@@ -254,8 +240,8 @@ let () =
         let gameplan = make_gameplan patch in
         let agent =
           make_agent ~patch_id:pid ~branch ~pr_number:None ~merged:false
-            ~queue:[] ~base_branch:None ~is_draft:false
-            ~implementation_notes_delivered:false ~start_attempts_without_pr:2
+            ~queue:[] ~base_branch:None ~is_draft:false ~pr_body_delivered:false
+            ~start_attempts_without_pr:2
         in
         let orch = make_orch patch agent in
         let orch1, effects1 =
@@ -273,11 +259,11 @@ let () =
         && List.is_empty effects1 && List.is_empty effects2)
   in
 
-  let prop_reconcile_all_exposes_notes_as_next_action =
+  let prop_reconcile_all_exposes_pr_body_as_next_action =
     Test.make
       ~name:
-        "patch_controller: reconcile_all exposes missing implementation notes \
-         as next Respond action"
+        "patch_controller: reconcile_all exposes missing pr_body as next \
+         Respond action"
       ~count:200
       Gen.(pair gen_patch_id gen_branch)
       (fun (pid, branch) ->
@@ -287,7 +273,7 @@ let () =
           make_agent ~patch_id:pid ~branch
             ~pr_number:(Some (Pr_number.of_int 42))
             ~merged:false ~queue:[] ~base_branch:(Some main) ~is_draft:true
-            ~implementation_notes_delivered:false ~start_attempts_without_pr:0
+            ~pr_body_delivered:false ~start_attempts_without_pr:0
         in
         let orch = make_orch patch agent in
         let orch, effects =
@@ -301,7 +287,7 @@ let () =
         && List.exists actions ~f:(function
           | Orchestrator.Respond (action_pid, kind) ->
               Patch_id.equal action_pid pid
-              && Operation_kind.equal kind Operation_kind.Implementation_notes
+              && Operation_kind.equal kind Operation_kind.Pr_body
           | Orchestrator.Start _ | Orchestrator.Rebase _ -> false))
   in
 
@@ -317,8 +303,8 @@ let () =
         let gameplan = make_gameplan patch in
         let agent =
           make_agent ~patch_id:pid ~branch ~pr_number:None ~merged:false
-            ~queue:[] ~base_branch:None ~is_draft:false
-            ~implementation_notes_delivered:false ~start_attempts_without_pr:2
+            ~queue:[] ~base_branch:None ~is_draft:false ~pr_body_delivered:false
+            ~start_attempts_without_pr:2
         in
         let orch = make_orch patch agent in
         let orch, effects =
@@ -357,11 +343,11 @@ let () =
             ~ci_failure_count:0 ~session_fallback:Patch_agent.Fresh_available
             ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
             ~merge_ready:false ~is_draft:true ~pr_body_delivered:false
-            ~implementation_notes_delivered:true ~start_attempts_without_pr:0
-            ~conflict_noop_count:0 ~no_commits_push_count:0
-            ~branch_rebased_onto:None ~checks_passing:false ~current_op:None
-            ~current_message_id:None ~generation:0 ~worktree_path:None
-            ~branch_blocked:false ~llm_session_id:None
+            ~start_attempts_without_pr:0 ~conflict_noop_count:0
+            ~no_commits_push_count:0 ~branch_rebased_onto:None
+            ~checks_passing:false ~current_op:None ~current_message_id:None
+            ~generation:0 ~worktree_path:None ~branch_blocked:false
+            ~llm_session_id:None
         in
         let orch = make_orch patch agent in
         (* Apply effects in a loop until convergence (max 5 rounds). *)
@@ -382,10 +368,10 @@ let () =
         converge (apply_all_effect_successes orch1 effects1) 2)
   in
 
-  let prop_poll_to_controller_promotes_ready_after_notes =
+  let prop_poll_to_controller_promotes_ready_after_pr_body =
     Test.make
       ~name:
-        "patch_controller: poll draft state plus delivered notes yields no \
+        "patch_controller: poll draft state plus delivered pr_body yields no \
          further draft effect once acknowledged"
       ~count:200
       Gen.(pair gen_patch_id gen_branch)
@@ -396,7 +382,7 @@ let () =
           make_agent ~patch_id:pid ~branch
             ~pr_number:(Some (Pr_number.of_int 42))
             ~merged:false ~queue:[] ~base_branch:(Some main) ~is_draft:true
-            ~implementation_notes_delivered:true ~start_attempts_without_pr:0
+            ~pr_body_delivered:true ~start_attempts_without_pr:0
         in
         let orch = make_orch patch agent in
         let poll =
@@ -423,11 +409,11 @@ let () =
         has_draft_effect effects1 && not (has_draft_effect effects2))
   in
 
-  let prop_poll_ci_failure_never_erases_notes_followup =
+  let prop_poll_ci_failure_never_erases_pr_body_followup =
     Test.make
       ~name:
         "patch_controller: poll-applicator CI queue does not suppress missing \
-         implementation notes action"
+         pr_body action"
       ~count:200
       Gen.(pair gen_patch_id gen_branch)
       (fun (pid, branch) ->
@@ -437,7 +423,7 @@ let () =
           make_agent ~patch_id:pid ~branch
             ~pr_number:(Some (Pr_number.of_int 42))
             ~merged:false ~queue:[] ~base_branch:(Some main) ~is_draft:true
-            ~implementation_notes_delivered:false ~start_attempts_without_pr:0
+            ~pr_body_delivered:false ~start_attempts_without_pr:0
         in
         let orch = make_orch patch agent in
         let poll =
@@ -460,8 +446,9 @@ let () =
         let orch, _effects, actions = run_controller_cycle ~gameplan orch in
         let a = Orchestrator.agent orch pid in
         (* CI is dispatched as the current action (higher priority), while
-           implementation notes remain queued for the next cycle. *)
-        has_notes_queued a
+           pr_body remains queued for the next cycle. *)
+        List.mem a.Patch_agent.queue Operation_kind.Pr_body
+          ~equal:Operation_kind.equal
         && List.exists actions ~f:(function
           | Orchestrator.Respond (action_pid, kind) ->
               Patch_id.equal action_pid pid
@@ -487,11 +474,11 @@ let () =
             ~ci_failure_count:1 ~session_fallback:Patch_agent.Fresh_available
             ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
             ~merge_ready:false ~is_draft:false ~pr_body_delivered:true
-            ~implementation_notes_delivered:true ~start_attempts_without_pr:0
-            ~conflict_noop_count:0 ~no_commits_push_count:0
-            ~branch_rebased_onto:None ~checks_passing:false ~current_op:None
-            ~current_message_id:None ~generation:0 ~worktree_path:None
-            ~branch_blocked:false ~llm_session_id:None
+            ~start_attempts_without_pr:0 ~conflict_noop_count:0
+            ~no_commits_push_count:0 ~branch_rebased_onto:None
+            ~checks_passing:false ~current_op:None ~current_message_id:None
+            ~generation:0 ~worktree_path:None ~branch_blocked:false
+            ~llm_session_id:None
         in
         let orch = make_orch patch agent in
         let poll =
@@ -526,7 +513,7 @@ let () =
           make_agent ~patch_id:pid ~branch
             ~pr_number:(Some (Pr_number.of_int 42))
             ~merged:false ~queue:[] ~base_branch:(Some main) ~is_draft:true
-            ~implementation_notes_delivered:false ~start_attempts_without_pr:0
+            ~pr_body_delivered:false ~start_attempts_without_pr:0
         in
         let orch = make_orch patch agent in
         let poll =
@@ -565,7 +552,7 @@ let () =
           make_agent ~patch_id:pid ~branch
             ~pr_number:(Some (Pr_number.of_int 42))
             ~merged:false ~queue:[] ~base_branch:None ~is_draft:true
-            ~implementation_notes_delivered:false ~start_attempts_without_pr:0
+            ~pr_body_delivered:false ~start_attempts_without_pr:0
         in
         let orch = make_orch patch agent in
         let poll =
@@ -611,10 +598,9 @@ let () =
       (fun (pid, branch) ->
         let patch = make_patch pid branch in
         let gameplan = make_gameplan patch in
-        (* pr_body_delivered=false so Set_pr_description fires in cycle 1.
-           After description ack + pr_body delivery, notes become eligible
-           in cycle 2. After notes delivery, cycle 3 should converge with
-           only a draft effect. *)
+        (* pr_body_delivered=false so Pr_body is enqueued in cycle 1.
+           After pr_body delivery, cycle 2 should converge with only a
+           draft effect and no more Respond actions. *)
         let agent =
           Patch_agent.restore ~patch_id:pid ~branch
             ~pr_number:(Some (Pr_number.of_int 42))
@@ -624,11 +610,11 @@ let () =
             ~ci_failure_count:0 ~session_fallback:Patch_agent.Fresh_available
             ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
             ~merge_ready:false ~is_draft:true ~pr_body_delivered:false
-            ~implementation_notes_delivered:false ~start_attempts_without_pr:0
-            ~conflict_noop_count:0 ~no_commits_push_count:0
-            ~branch_rebased_onto:None ~checks_passing:false ~current_op:None
-            ~current_message_id:None ~generation:0 ~worktree_path:None
-            ~branch_blocked:false ~llm_session_id:None
+            ~start_attempts_without_pr:0 ~conflict_noop_count:0
+            ~no_commits_push_count:0 ~branch_rebased_onto:None
+            ~checks_passing:false ~current_op:None ~current_message_id:None
+            ~generation:0 ~worktree_path:None ~branch_blocked:false
+            ~llm_session_id:None
         in
         let orch = make_orch patch agent in
         begin try
@@ -652,30 +638,16 @@ let () =
             in
             let orch1 = Orchestrator.set_pr_body_delivered orch1 pid true in
             let orch1 = Orchestrator.complete orch1 pid in
-            (* Cycle 2: notes now eligible *)
-            let orch2, _effects2, actions2 =
+            (* Cycle 2: should converge — only draft effect *)
+            let _orch2, effects2, actions2 =
               run_controller_cycle ~gameplan orch1
             in
-            match implementation_notes_action actions2 pid with
-            | None -> false
-            | Some notes_action ->
-                let orch2 = Orchestrator.fire orch2 notes_action in
-                let orch2 =
-                  Orchestrator.set_implementation_notes_delivered orch2 pid true
-                in
-                let orch2 = Orchestrator.complete orch2 pid in
-                (* Cycle 3: should converge — only draft effect *)
-                let _orch3, effects3, actions3 =
-                  run_controller_cycle ~gameplan orch2
-                in
-                has_draft_effect effects3
-                && not
-                     (List.exists actions3 ~f:(function
-                       | Orchestrator.Respond (action_pid, kind) ->
-                           Patch_id.equal action_pid pid
-                           && Operation_kind.equal kind
-                                Operation_kind.Implementation_notes
-                       | Orchestrator.Start _ | Orchestrator.Rebase _ -> false))
+            has_draft_effect effects2
+            && not
+                 (List.exists actions2 ~f:(function
+                   | Orchestrator.Respond (action_pid, _kind) ->
+                       Patch_id.equal action_pid pid
+                   | Orchestrator.Start _ | Orchestrator.Rebase _ -> false))
         with _ -> false
         end)
   in
@@ -708,7 +680,7 @@ let () =
           make_agent ~patch_id:pid ~branch
             ~pr_number:(Some (Pr_number.of_int 42))
             ~merged:false ~queue:[] ~base_branch:(Some branch) ~is_draft:true
-            ~implementation_notes_delivered:true ~start_attempts_without_pr:0
+            ~pr_body_delivered:true ~start_attempts_without_pr:0
         in
         let orch = make_orch patch agent in
         let _orch', effects =
@@ -738,7 +710,7 @@ let () =
           make_agent ~patch_id:pid ~branch
             ~pr_number:(Some (Pr_number.of_int 42))
             ~merged:false ~queue:[] ~base_branch:(Some main) ~is_draft:true
-            ~implementation_notes_delivered:true ~start_attempts_without_pr:0
+            ~pr_body_delivered:true ~start_attempts_without_pr:0
         in
         let orch = make_orch patch agent in
         let _orch', effects =
@@ -761,7 +733,7 @@ let () =
           make_agent ~patch_id:pid ~branch
             ~pr_number:(Some (Pr_number.of_int 42))
             ~merged:false ~queue:[] ~base_branch:(Some branch) ~is_draft:true
-            ~implementation_notes_delivered:true ~start_attempts_without_pr:0
+            ~pr_body_delivered:true ~start_attempts_without_pr:0
         in
         let orch = make_orch patch agent in
         let orch1, effects1 =
@@ -789,7 +761,7 @@ let () =
           make_agent ~patch_id:pid ~branch
             ~pr_number:(Some (Pr_number.of_int 42))
             ~merged:false ~queue:[] ~base_branch:(Some branch) ~is_draft:false
-            ~implementation_notes_delivered:true ~start_attempts_without_pr:0
+            ~pr_body_delivered:true ~start_attempts_without_pr:0
         in
         let orch = make_orch patch agent in
         let obs =
@@ -838,8 +810,7 @@ let () =
             ~base_branch:None ~notified_base_branch:None ~ci_failure_count:0
             ~session_fallback:Patch_agent.Fresh_available ~human_messages:[]
             ~inflight_human_messages:[] ~ci_checks:[] ~merge_ready:false
-            ~is_draft:false ~pr_body_delivered:true
-            ~implementation_notes_delivered:false ~start_attempts_without_pr:0
+            ~is_draft:false ~pr_body_delivered:true ~start_attempts_without_pr:0
             ~conflict_noop_count:0 ~no_commits_push_count:0
             ~branch_rebased_onto:None ~checks_passing:false ~current_op:None
             ~current_message_id:None ~generation:0 ~worktree_path:None
@@ -877,11 +848,11 @@ let () =
             ~ci_failure_count:0 ~session_fallback:Patch_agent.Fresh_available
             ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
             ~merge_ready:false ~is_draft:false ~pr_body_delivered:true
-            ~implementation_notes_delivered:false ~start_attempts_without_pr:0
-            ~conflict_noop_count:0 ~no_commits_push_count:0
-            ~branch_rebased_onto:None ~checks_passing:false ~current_op:None
-            ~current_message_id:None ~generation:0 ~worktree_path:None
-            ~branch_blocked:false ~llm_session_id:None
+            ~start_attempts_without_pr:0 ~conflict_noop_count:0
+            ~no_commits_push_count:0 ~branch_rebased_onto:None
+            ~checks_passing:false ~current_op:None ~current_message_id:None
+            ~generation:0 ~worktree_path:None ~branch_blocked:false
+            ~llm_session_id:None
         in
         let orch =
           Orchestrator.restore
@@ -897,14 +868,14 @@ let () =
     [
       prop_deterministic;
       prop_plan_tick_deterministic;
-      prop_notes_queue_idempotent;
+      prop_pr_body_queue_idempotent;
       prop_draft_reemits_until_success;
       prop_intervention_stable_after_threshold;
-      prop_reconcile_all_exposes_notes_as_next_action;
+      prop_reconcile_all_exposes_pr_body_as_next_action;
       prop_reconcile_all_blocks_restart_after_intervention;
       prop_reconcile_all_converges_after_acknowledged_effects;
-      prop_poll_to_controller_promotes_ready_after_notes;
-      prop_poll_ci_failure_never_erases_notes_followup;
+      prop_poll_to_controller_promotes_ready_after_pr_body;
+      prop_poll_ci_failure_never_erases_pr_body_followup;
       prop_idle_ci_failure_count_allows_reenqueue;
       prop_poll_result_persists_world_flags;
       prop_poll_observation_updates_branch_metadata;

--- a/test/test_patch_decision.ml
+++ b/test/test_patch_decision.ml
@@ -15,10 +15,7 @@ let gen_branch =
     map Branch.of_string
       (string_size ~gen:(char_range 'a' 'z') (int_range 3 20)))
 
-let feedback_ops =
-  Operation_kind.
-    [ Human; Merge_conflict; Ci; Review_comments; Implementation_notes ]
-
+let feedback_ops = Operation_kind.[ Human; Merge_conflict; Ci; Review_comments ]
 let gen_feedback_op = QCheck2.Gen.oneof_list feedback_ops
 
 (** Start + set PR so the agent is in has_pr=true, busy=false state. *)
@@ -345,7 +342,7 @@ let () =
         {
           payload =
             ( Ci_payload _ | Review_payload _ | Pr_body_payload
-            | Implementation_notes_payload | Merge_conflict_payload );
+            | Merge_conflict_payload );
           _;
         }
     | Skip_empty | Respond_stale ->
@@ -378,7 +375,7 @@ let () =
         {
           payload =
             ( Ci_payload _ | Review_payload _ | Pr_body_payload
-            | Implementation_notes_payload | Merge_conflict_payload );
+            | Merge_conflict_payload );
           _;
         }
     | Skip_empty | Respond_stale ->
@@ -443,7 +440,7 @@ let () =
             {
               payload =
                 ( Human_payload _ | Review_payload _ | Pr_body_payload
-                | Implementation_notes_payload | Merge_conflict_payload );
+                | Merge_conflict_payload );
               _;
             }
         | Skip_empty | Respond_stale ->
@@ -453,12 +450,11 @@ let () =
     Stdlib.print_endline "RD-6 passed"
   in
 
-  (* RD-7: Merge_conflict and Implementation_notes never Skip_empty *)
+  (* RD-7: Merge_conflict and Pr_body never Skip_empty *)
   let () =
     let pid = Patch_id.of_string "rd7" in
     let br = Branch.of_string "b" in
-    List.iter
-      [ Operation_kind.Merge_conflict; Operation_kind.Implementation_notes ]
+    List.iter [ Operation_kind.Merge_conflict; Operation_kind.Pr_body ]
       ~f:(fun kind ->
         let a = with_pr pid br in
         let a = enqueue a kind in

--- a/test/test_patch_decision.ml
+++ b/test/test_patch_decision.ml
@@ -15,7 +15,9 @@ let gen_branch =
     map Branch.of_string
       (string_size ~gen:(char_range 'a' 'z') (int_range 3 20)))
 
-let feedback_ops = Operation_kind.[ Human; Merge_conflict; Ci; Review_comments ]
+let feedback_ops =
+  Operation_kind.[ Human; Merge_conflict; Ci; Review_comments; Pr_body ]
+
 let gen_feedback_op = QCheck2.Gen.oneof_list feedback_ops
 
 (** Start + set PR so the agent is in has_pr=true, busy=false state. *)

--- a/test/test_poll_log_properties.ml
+++ b/test/test_poll_log_properties.ml
@@ -47,10 +47,10 @@ let make_agent ~patch_id ~branch ~has_conflict ~ci_failure_count ~current_op
     ~ci_failure_count ~session_fallback:Patch_agent.Fresh_available
     ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
     ~merge_ready:false ~is_draft ~pr_body_delivered:true
-    ~implementation_notes_delivered:true ~start_attempts_without_pr:0
-    ~conflict_noop_count:0 ~no_commits_push_count:0 ~branch_rebased_onto:None
-    ~checks_passing ~current_op ~current_message_id:None ~generation:0
-    ~worktree_path ~branch_blocked ~llm_session_id:None
+    ~start_attempts_without_pr:0 ~conflict_noop_count:0 ~no_commits_push_count:0
+    ~branch_rebased_onto:None ~checks_passing ~current_op
+    ~current_message_id:None ~generation:0 ~worktree_path ~branch_blocked
+    ~llm_session_id:None
 
 let make_poll_observation ~branch_in_root ~worktree_path poll_result =
   Patch_controller.
@@ -327,14 +327,7 @@ let () =
                 let kind =
                   List.find
                     Operation_kind.
-                      [
-                        Rebase;
-                        Human;
-                        Merge_conflict;
-                        Ci;
-                        Review_comments;
-                        Implementation_notes;
-                      ]
+                      [ Rebase; Human; Merge_conflict; Ci; Review_comments ]
                     ~f:(fun k -> String.equal (Operation_kind.to_label k) label)
                 in
                 match kind with

--- a/test/test_reconciler_properties.ml
+++ b/test/test_reconciler_properties.ml
@@ -280,8 +280,7 @@ let prop_plan_new_base_only_for_rebase =
             | Types.Operation_kind.Rebase -> Option.is_some new_base
             | Types.Operation_kind.Human | Types.Operation_kind.Merge_conflict
             | Types.Operation_kind.Ci | Types.Operation_kind.Review_comments
-            | Types.Operation_kind.Pr_body
-            | Types.Operation_kind.Implementation_notes ->
+            | Types.Operation_kind.Pr_body ->
                 Option.is_none new_base)
         | Reconciler.Mark_merged _ | Reconciler.Enqueue_rebase _ -> true))
 
@@ -300,8 +299,7 @@ let prop_plan_suppresses_rebase_multi_dep =
                 List.length (Graph.open_pr_deps graph patch_id ~has_merged) <= 1
             | Types.Operation_kind.Human | Types.Operation_kind.Merge_conflict
             | Types.Operation_kind.Ci | Types.Operation_kind.Review_comments
-            | Types.Operation_kind.Pr_body
-            | Types.Operation_kind.Implementation_notes ->
+            | Types.Operation_kind.Pr_body ->
                 true)
         | Reconciler.Mark_merged _ | Reconciler.Enqueue_rebase _ -> true))
 

--- a/test/test_state_machine_properties.ml
+++ b/test/test_state_machine_properties.ml
@@ -210,9 +210,6 @@ let () =
                    shadow the [kind] under test (they have lower priority than
                    each other but higher than the explicitly-enqueued kind). *)
                 let orch = Orchestrator.set_pr_body_delivered orch pid true in
-                let orch =
-                  Orchestrator.set_implementation_notes_delivered orch pid true
-                in
                 let orch = Orchestrator.complete orch pid in
                 let orch = Orchestrator.enqueue orch pid kind in
                 let _, _effects, actions =


### PR DESCRIPTION
## Summary

- Removes the `Implementation_notes` operation kind entirely and merges both PR-writing phases into a single `Pr_body` phase
- PR is created with the gameplan-derived description + specs (unchanged), then the agent is prompted **once** for additional implementation notes
- Supervisor composes the final PR body as: description + specs + `## Implementation Notes` + agent notes
- Removes ~335 lines of now-unnecessary machinery: `enqueue_notes_if_needed`, `apply_notes_artifact`, `implementation_notes_delivered` flag, `Adding_notes` TUI status, notes artifact path, and all associated wiring

## Motivation

The two-phase flow (agent writes PR body, then separately writes implementation notes) confused agents because the prompts were too similar. Simplifying to a single prompt with a clear ask — "write additional notes, the description and specs are already handled" — produces better results.

## Test plan

- [x] `dune build` passes
- [x] `dune runtest` — all tests pass (property tests updated to reflect single-phase flow)
- [x] `dune fmt` — format check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * PR body composition now inlines any implementation notes into the final PR description and spec suffix when present.
  * Prompt behavior refined so generated content includes spec context and avoids repeating existing description/spec text.

* **UI**
  * Status simplified: separate "adding notes" state removed; note-writing is presented as part of the PR-body workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->