### PR TITLE
Codex backend: parse thread.started and pass prompt on resume

### DIFF
--- a/lib/codex_backend.ml
+++ b/lib/codex_backend.ml
@@ -3,7 +3,17 @@ open Base
 let build_args ~cwd_path ~prompt ~resume_session =
   match resume_session with
   | Some session_id ->
-      [ "codex"; "exec"; "resume"; session_id; "--json"; "-C"; cwd_path ]
+      [
+        "codex";
+        "exec";
+        "resume";
+        session_id;
+        prompt;
+        "--json";
+        "--dangerously-bypass-approvals-and-sandbox";
+        "-C";
+        cwd_path;
+      ]
   | None ->
       [
         "codex";
@@ -64,6 +74,11 @@ let parse_event (line : string) : Types.Stream_event.t list =
                   [ Types.Stream_event.Tool_use { name = "Bash"; input } ]
               | _ -> [])
           | _ -> [])
+      | Some "thread.started" -> (
+          match member "thread_id" json |> to_string_option with
+          | Some id when not (String.is_empty id) ->
+              [ Types.Stream_event.Session_init { session_id = id } ]
+          | _ -> [])
       | Some "turn.completed" ->
           [
             Types.Stream_event.Final_result
@@ -115,13 +130,37 @@ let%test "build_args fresh (no resume)" =
       "/tmp/work";
     ]
 
-let%test "build_args with resume session" =
+let%test "build_args with resume session passes prompt and bypass flag" =
   let args =
     build_args ~cwd_path:"/tmp/work" ~prompt:"do stuff"
       ~resume_session:(Some "sess-1")
   in
   List.equal String.equal args
-    [ "codex"; "exec"; "resume"; "sess-1"; "--json"; "-C"; "/tmp/work" ]
+    [
+      "codex";
+      "exec";
+      "resume";
+      "sess-1";
+      "do stuff";
+      "--json";
+      "--dangerously-bypass-approvals-and-sandbox";
+      "-C";
+      "/tmp/work";
+    ]
+
+let%test "parse_event thread.started emits Session_init" =
+  let line =
+    {|{"type":"thread.started","thread_id":"019d91e0-5731-7182-ac68-19922a243e95"}|}
+  in
+  List.equal Types.Stream_event.equal (parse_event line)
+    [
+      Types.Stream_event.Session_init
+        { session_id = "019d91e0-5731-7182-ac68-19922a243e95" };
+    ]
+
+let%test "parse_event thread.started without thread_id is ignored" =
+  let line = {|{"type":"thread.started"}|} in
+  List.is_empty (parse_event line)
 
 let%test "parse_event agent_message (content-array schema)" =
   let line =


### PR DESCRIPTION
## Summary
Two bugs prevented session continuity across turns with the Codex backend:

- `lib/codex_backend.ml` never parsed the `{"type":"thread.started","thread_id":"..."}` event that codex emits at the start of every `exec` run. Without it, `Session_init` was never propagated and `llm_session_id` stayed `None`, so each turn started a fresh conversation.
- The resume invocation built `codex exec resume <id> --json -C <cwd>`, dropping both the prompt and `--dangerously-bypass-approvals-and-sandbox`. Even after #1, codex would have hung waiting on stdin and re-enabled sandboxing.

## Test plan
- [x] `dune build` clean
- [x] `dune runtest` passes (new tests for `thread.started` parsing and resume args)
- [ ] Manual: confirm a multi-turn Codex run resumes prior thread instead of starting fresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for handling session initialization events to enable thread-based session management.

* **Bug Fixes**
  * Fixed session resumption to properly include user prompts and security configurations, ensuring consistent behavior between new and resumed sessions.

* **Tests**
  * Updated test coverage for session resumption and event handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes session continuity in the Codex backend by parsing `thread.started` to initialize the session and by passing the prompt and bypass flag on `codex exec resume`. Multi-turn runs now reuse the same thread instead of starting fresh or hanging on stdin.

- **Bug Fixes**
  - Parse `thread.started` and emit `Session_init` with the `thread_id` to set `llm_session_id`.
  - Build resume args as: `codex exec resume <id> <prompt> --json --dangerously-bypass-approvals-and-sandbox -C <cwd>`.

<sup>Written for commit b7ad98ec08f4035bb235617ff4eaed3260bf2a2d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

