### PR TITLE
Gameplan_lint: aggregate structural + stylistic findings (--lint flag)

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -3462,23 +3462,23 @@ let lint_arg =
     findings, and exit. Exit codes: 0 = no errors (warnings only or clean), 1 =
     at least one error or the file could not be parsed, 2 = no --gameplan path
     supplied. *)
-let run_lint ~gameplan_path =
+let run_lint ~gameplan_path : int =
   match gameplan_path with
   | None ->
       Printf.eprintf
         "Error: --lint requires --gameplan PATH.\n\
          Usage: onton --lint --gameplan GAMEPLAN\n";
-      Stdlib.exit 2
+      2
   | Some path -> (
       match Gameplan_parser.parse_file path with
       | Error msg ->
           Printf.eprintf "Error: failed to parse %s: %s\n" path msg;
-          Stdlib.exit 1
+          1
       | Ok { Gameplan_parser.gameplan; dependency_graph = _ } ->
           let issues = Gameplan_lint.lint gameplan in
           if List.is_empty issues then (
             Printf.printf "%s: no issues found.\n" path;
-            Stdlib.exit 0)
+            0)
           else (
             print_string (Gameplan_lint.format_issues issues);
             let n_errors =
@@ -3490,13 +3490,13 @@ let run_lint ~gameplan_path =
             let n_warnings = Base.List.length issues - n_errors in
             Printf.printf "%s: %d error(s), %d warning(s)\n" path n_errors
               n_warnings;
-            Stdlib.exit (if n_errors > 0 then 1 else 0)))
+            if n_errors > 0 then 1 else 0))
 
 let main_cmd =
   let open Cmdliner in
   let run_cmd project gameplan_path github_token backend main_branch
       poll_interval repo_root max_concurrency headless upload_debug lint =
-    if lint then run_lint ~gameplan_path
+    if lint then Stdlib.exit (run_lint ~gameplan_path)
     else if upload_debug then (
       match project with
       | None ->

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -3448,11 +3448,56 @@ let upload_debug_arg =
           "Upload project debug state for troubleshooting. Requires a project \
            name.")
 
+let lint_arg =
+  let open Cmdliner in
+  Arg.(
+    value & flag
+    & info [ "lint" ]
+        ~doc:
+          "Validate the gameplan referenced by --gameplan and exit. Reports \
+           every structural error and stylistic warning without running any \
+           agents. Exits non-zero iff at least one error is found.")
+
+(** Lint mode: parse the gameplan, run {!Onton.Gameplan_lint.lint}, print the
+    findings, and exit. Exit codes: 0 = no errors (warnings only or clean), 1 =
+    at least one error or the file could not be parsed, 2 = no --gameplan path
+    supplied. *)
+let run_lint ~gameplan_path =
+  match gameplan_path with
+  | None ->
+      Printf.eprintf
+        "Error: --lint requires --gameplan PATH.\n\
+         Usage: onton --lint --gameplan GAMEPLAN\n";
+      Stdlib.exit 2
+  | Some path -> (
+      match Gameplan_parser.parse_file path with
+      | Error msg ->
+          Printf.eprintf "Error: failed to parse %s: %s\n" path msg;
+          Stdlib.exit 1
+      | Ok { Gameplan_parser.gameplan; dependency_graph = _ } ->
+          let issues = Gameplan_lint.lint gameplan in
+          if List.is_empty issues then (
+            Printf.printf "%s: no issues found.\n" path;
+            Stdlib.exit 0)
+          else (
+            print_string (Gameplan_lint.format_issues issues);
+            let n_errors =
+              Base.List.count issues
+                ~f:(fun { Gameplan_lint.Issue.severity; _ } ->
+                  Gameplan_lint.Severity.equal severity
+                    Gameplan_lint.Severity.Error)
+            in
+            let n_warnings = List.length issues - n_errors in
+            Printf.printf "%s: %d error(s), %d warning(s)\n" path n_errors
+              n_warnings;
+            Stdlib.exit (if n_errors > 0 then 1 else 0)))
+
 let main_cmd =
   let open Cmdliner in
   let run_cmd project gameplan_path github_token backend main_branch
-      poll_interval repo_root max_concurrency headless upload_debug =
-    if upload_debug then (
+      poll_interval repo_root max_concurrency headless upload_debug lint =
+    if lint then run_lint ~gameplan_path
+    else if upload_debug then (
       match project with
       | None ->
           Printf.eprintf
@@ -3481,7 +3526,7 @@ let main_cmd =
     Term.(
       const run_cmd $ project_arg $ gameplan_path_arg $ github_token_arg
       $ backend_arg $ main_branch_arg $ poll_interval_arg $ repo_arg
-      $ max_concurrency_arg $ headless_arg $ upload_debug_arg)
+      $ max_concurrency_arg $ headless_arg $ upload_debug_arg $ lint_arg)
   in
   let info =
     Cmd.info "onton" ~version:Version.s
@@ -3490,7 +3535,9 @@ let main_cmd =
          Usage:\n\
         \  onton [PROJECT] --gameplan GAMEPLAN [OPTIONS]   Start a new project\n\
         \  onton PROJECT [OPTIONS]                         Resume a saved \
-         project"
+         project\n\
+        \  onton --lint --gameplan GAMEPLAN                Validate a gameplan \
+         and exit"
   in
   Cmd.v info term
 

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -3487,7 +3487,7 @@ let run_lint ~gameplan_path =
                   Gameplan_lint.Severity.equal severity
                     Gameplan_lint.Severity.Error)
             in
-            let n_warnings = List.length issues - n_errors in
+            let n_warnings = Base.List.length issues - n_errors in
             Printf.printf "%s: %d error(s), %d warning(s)\n" path n_errors
               n_warnings;
             Stdlib.exit (if n_errors > 0 then 1 else 0)))

--- a/lib/gameplan_lint.ml
+++ b/lib/gameplan_lint.ml
@@ -1,0 +1,314 @@
+open Base
+
+module Severity = struct
+  type t = Error | Warning [@@deriving show, eq, compare, sexp_of]
+
+  let to_label (s : t) = match s with Error -> "error" | Warning -> "warning"
+  let rank (s : t) = match s with Error -> 0 | Warning -> 1
+end
+
+module Issue = struct
+  type t = {
+    severity : Severity.t;
+    patch_id : Types.Patch_id.t option;
+    message : string;
+  }
+  [@@deriving show, eq, compare, sexp_of]
+end
+
+let known_classifications = [ "INFRA"; "GATED"; "BEHAVIOR" ]
+let issue ?patch_id severity message = { Issue.severity; patch_id; message }
+
+(** Collect duplicates from [items] using [key] as the hash key. Returns the
+    duplicated keys in first-seen order, each appearing once. *)
+let duplicates ~key items =
+  let seen = Hashtbl.create (module String) in
+  let dups = ref [] in
+  List.iter items ~f:(fun item ->
+      let k = key item in
+      match Hashtbl.find seen k with
+      | None -> Hashtbl.set seen ~key:k ~data:()
+      | Some () ->
+          if not (List.mem !dups k ~equal:String.equal) then dups := k :: !dups);
+  List.rev !dups
+
+(** Tarjan-flavoured DFS that finds at least one cycle and returns the list of
+    patch ids that participate in it (in traversal order). Returns [None] when
+    the graph is acyclic. Uses the patches' declared dependencies as edges. *)
+let find_cycle (patches : Types.Patch.t list) =
+  let adj = Hashtbl.create (module Types.Patch_id) in
+  List.iter patches ~f:(fun p -> Hashtbl.set adj ~key:p.id ~data:p.dependencies);
+  let color = Hashtbl.create (module Types.Patch_id) in
+  let stack : Types.Patch_id.t list ref = ref [] in
+  let cycle : Types.Patch_id.t list option ref = ref None in
+  let rec visit node =
+    if Option.is_some !cycle then ()
+    else
+      match Hashtbl.find color node with
+      | Some `Black -> ()
+      | Some `Gray ->
+          let in_cycle =
+            List.take_while !stack ~f:(fun n ->
+                not (Types.Patch_id.equal n node))
+          in
+          cycle := Some (List.rev (node :: in_cycle))
+      | Some `White | None ->
+          Hashtbl.set color ~key:node ~data:`Gray;
+          stack := node :: !stack;
+          let neighbours = Hashtbl.find adj node |> Option.value ~default:[] in
+          List.iter neighbours ~f:visit;
+          stack := List.tl_exn !stack;
+          Hashtbl.set color ~key:node ~data:`Black
+  in
+  List.iter patches ~f:(fun p -> visit p.id);
+  !cycle
+
+(** Patch-level checks that do not depend on the rest of the gameplan. *)
+let lint_patch ~known_ids (p : Types.Patch.t) =
+  let acc = ref [] in
+  let add ?patch_id sev msg = acc := issue ?patch_id sev msg :: !acc in
+  let pid = Some p.id in
+  if String.is_empty (String.strip p.title) then
+    add ?patch_id:pid Severity.Error "title is empty";
+  if String.is_empty (String.strip (Types.Branch.to_string p.branch)) then
+    add ?patch_id:pid Severity.Error "branch name is empty";
+  if String.is_empty (String.strip p.spec) then
+    add ?patch_id:pid Severity.Warning "spec is empty";
+  if List.is_empty p.acceptance_criteria then
+    add ?patch_id:pid Severity.Warning "no acceptance criteria";
+  let cls = String.strip p.classification in
+  if
+    (not (String.is_empty cls))
+    && not (List.mem known_classifications cls ~equal:String.equal)
+  then
+    add ?patch_id:pid Severity.Warning
+      (Printf.sprintf "unknown classification %S (expected one of: %s)" cls
+         (String.concat ~sep:", " known_classifications));
+  if List.mem p.dependencies p.id ~equal:Types.Patch_id.equal then
+    add ?patch_id:pid Severity.Error "patch depends on itself";
+  let dep_dups = duplicates p.dependencies ~key:Types.Patch_id.to_string in
+  List.iter dep_dups ~f:(fun d ->
+      add ?patch_id:pid Severity.Warning
+        (Printf.sprintf "duplicate dependency %s" d));
+  List.iter p.dependencies ~f:(fun d ->
+      if not (Set.mem known_ids d) then
+        add ?patch_id:pid Severity.Error
+          (Printf.sprintf "depends on unknown patch %s"
+             (Types.Patch_id.to_string d)));
+  !acc
+
+(** Gameplan-level checks: cross-patch invariants and missing top-level fields.
+*)
+let lint_gameplan_globals (g : Types.Gameplan.t) =
+  let acc = ref [] in
+  let add sev msg = acc := issue sev msg :: !acc in
+  if String.is_empty (String.strip g.project_name) then
+    add Severity.Error "projectName is empty";
+  (if List.is_empty g.patches then add Severity.Error "gameplan has no patches"
+   else
+     let patch_id_strs =
+       List.map g.patches ~f:(fun p -> Types.Patch_id.to_string p.id)
+     in
+     List.iter (duplicates patch_id_strs ~key:Fn.id) ~f:(fun id ->
+         add Severity.Error (Printf.sprintf "duplicate patch id %s" id));
+     let branches =
+       List.map g.patches ~f:(fun p -> Types.Branch.to_string p.branch)
+     in
+     List.iter (duplicates branches ~key:Fn.id) ~f:(fun b ->
+         add Severity.Error (Printf.sprintf "duplicate branch name %s" b));
+     match find_cycle g.patches with
+     | None -> ()
+     | Some chain ->
+         let rendered =
+           List.map chain ~f:Types.Patch_id.to_string
+           |> String.concat ~sep:" -> "
+         in
+         add Severity.Error
+           (Printf.sprintf "dependency cycle: %s -> %s" rendered
+              (Types.Patch_id.to_string (List.hd_exn chain))));
+  !acc
+
+let compare_issue a b =
+  let by_severity =
+    Int.compare
+      (Severity.rank a.Issue.severity)
+      (Severity.rank b.Issue.severity)
+  in
+  if by_severity <> 0 then by_severity
+  else
+    let pid_key = function
+      | None -> ""
+      | Some p -> Types.Patch_id.to_string p
+    in
+    let by_patch = String.compare (pid_key a.patch_id) (pid_key b.patch_id) in
+    if by_patch <> 0 then by_patch else String.compare a.message b.message
+
+let lint (g : Types.Gameplan.t) =
+  let known_ids =
+    List.map g.patches ~f:(fun p -> p.Types.Patch.id)
+    |> Set.of_list (module Types.Patch_id)
+  in
+  let global = lint_gameplan_globals g in
+  let per_patch = List.concat_map g.patches ~f:(lint_patch ~known_ids) in
+  List.sort (global @ per_patch) ~compare:compare_issue
+
+let has_errors issues =
+  List.exists issues ~f:(fun i ->
+      Severity.equal i.Issue.severity Severity.Error)
+
+let format_issues issues =
+  if List.is_empty issues then ""
+  else
+    let lines =
+      List.map issues ~f:(fun i ->
+          let scope =
+            match i.Issue.patch_id with
+            | None -> "gameplan"
+            | Some p -> Printf.sprintf "patch %s" (Types.Patch_id.to_string p)
+          in
+          Printf.sprintf "[%s] %s: %s"
+            (Severity.to_label i.severity)
+            scope i.message)
+    in
+    String.concat ~sep:"\n" lines ^ "\n"
+
+(* -------------------------------------------------------------------------- *)
+(* Inline tests                                                                *)
+(* -------------------------------------------------------------------------- *)
+
+let%test_module "gameplan_lint" =
+  (module struct
+    let pid = Types.Patch_id.of_string
+    let br = Types.Branch.of_string
+
+    let mk_patch ?(deps = []) ?(spec = "spec body")
+        ?(acceptance = [ "criterion" ]) ?(classification = "BEHAVIOR")
+        ?(title = "Some title") ?(branch = None) id =
+      let branch = Option.value branch ~default:(br ("branch-" ^ id)) in
+      {
+        Types.Patch.id = pid id;
+        title;
+        description = "";
+        branch;
+        dependencies = List.map deps ~f:pid;
+        spec;
+        acceptance_criteria = acceptance;
+        files = [];
+        classification;
+        changes = [];
+        test_stubs_introduced = [];
+        test_stubs_implemented = [];
+      }
+
+    let mk_gameplan ?(name = "demo") patches =
+      {
+        Types.Gameplan.project_name = name;
+        problem_statement = "";
+        solution_summary = "";
+        final_state_spec = "";
+        patches;
+        current_state_analysis = "";
+        explicit_opinions = "";
+        acceptance_criteria = [];
+        open_questions = [];
+      }
+
+    let%test "clean gameplan produces no issues" =
+      let g = mk_gameplan [ mk_patch "a"; mk_patch ~deps:[ "a" ] "b" ] in
+      List.is_empty (lint g)
+
+    let%test "self-dependency is an error" =
+      let g = mk_gameplan [ mk_patch ~deps:[ "a" ] "a" ] in
+      List.exists (lint g) ~f:(fun i ->
+          Severity.equal i.severity Error
+          && String.is_substring i.message ~substring:"itself")
+
+    let%test "missing dep target is an error" =
+      let g = mk_gameplan [ mk_patch ~deps:[ "ghost" ] "a" ] in
+      List.exists (lint g) ~f:(fun i ->
+          Severity.equal i.severity Error
+          && String.is_substring i.message ~substring:"unknown patch")
+
+    let%test "duplicate patch id is an error" =
+      let g = mk_gameplan [ mk_patch "a"; mk_patch "a" ] in
+      List.exists (lint g) ~f:(fun i ->
+          Severity.equal i.severity Error
+          && String.is_substring i.message ~substring:"duplicate patch id")
+
+    let%test "duplicate branch is an error" =
+      let g =
+        mk_gameplan
+          [
+            mk_patch ~branch:(Some (br "shared")) "a";
+            mk_patch ~branch:(Some (br "shared")) "b";
+          ]
+      in
+      List.exists (lint g) ~f:(fun i ->
+          Severity.equal i.severity Error
+          && String.is_substring i.message ~substring:"duplicate branch")
+
+    let%test "cycle is detected" =
+      let g =
+        mk_gameplan [ mk_patch ~deps:[ "b" ] "a"; mk_patch ~deps:[ "a" ] "b" ]
+      in
+      List.exists (lint g) ~f:(fun i ->
+          Severity.equal i.severity Error
+          && String.is_substring i.message ~substring:"dependency cycle")
+
+    let%test "empty spec is a warning, not an error" =
+      let g = mk_gameplan [ mk_patch ~spec:"" "a" ] in
+      let issues = lint g in
+      (not (has_errors issues))
+      && List.exists issues ~f:(fun i ->
+          Severity.equal i.severity Warning
+          && String.is_substring i.message ~substring:"spec is empty")
+
+    let%test "missing acceptance criteria is a warning" =
+      let g = mk_gameplan [ mk_patch ~acceptance:[] "a" ] in
+      let issues = lint g in
+      (not (has_errors issues))
+      && List.exists issues ~f:(fun i ->
+          Severity.equal i.severity Warning
+          && String.is_substring i.message ~substring:"acceptance")
+
+    let%test "unknown classification is a warning" =
+      let g = mk_gameplan [ mk_patch ~classification:"WONKY" "a" ] in
+      List.exists (lint g) ~f:(fun i ->
+          Severity.equal i.severity Warning
+          && String.is_substring i.message ~substring:"unknown classification")
+
+    let%test "empty classification is tolerated silently" =
+      let g = mk_gameplan [ mk_patch ~classification:"" "a" ] in
+      not
+        (List.exists (lint g) ~f:(fun i ->
+             String.is_substring i.message ~substring:"classification"))
+
+    let%test "duplicate dependency is a warning" =
+      let g = mk_gameplan [ mk_patch "a"; mk_patch ~deps:[ "a"; "a" ] "b" ] in
+      let issues = lint g in
+      (not (has_errors issues))
+      && List.exists issues ~f:(fun i ->
+          Severity.equal i.severity Warning
+          && String.is_substring i.message ~substring:"duplicate dependency")
+
+    let%test "empty patch list is an error" =
+      let g = mk_gameplan [] in
+      has_errors (lint g)
+
+    let%test "errors come before warnings in output" =
+      let g = mk_gameplan [ mk_patch ~spec:"" ~deps:[ "ghost" ] "a" ] in
+      match lint g with
+      | first :: _ -> Severity.equal first.severity Error
+      | [] -> false
+
+    let%test "format_issues is empty when there are no issues" =
+      String.is_empty (format_issues [])
+
+    let%test "format_issues ends with newline when non-empty" =
+      let s =
+        format_issues [ issue Severity.Error "looks bad" ~patch_id:(pid "a") ]
+      in
+      String.is_suffix s ~suffix:"\n"
+      && String.is_substring s ~substring:"[error]"
+      && String.is_substring s ~substring:"patch a"
+  end)

--- a/lib/gameplan_lint.ml
+++ b/lib/gameplan_lint.ml
@@ -32,9 +32,10 @@ let duplicates ~key items =
           if not (List.mem !dups k ~equal:String.equal) then dups := k :: !dups);
   List.rev !dups
 
-(** Tarjan-flavoured DFS that finds at least one cycle and returns the list of
-    patch ids that participate in it (in traversal order). Returns [None] when
-    the graph is acyclic. Uses the patches' declared dependencies as edges. *)
+(** DFS-based cycle detector: finds at least one cycle and returns the nodes
+    participating in it (in the order a -> ... -> a). Returns [None] when the
+    graph is acyclic. Self-edges and unknown deps are excluded before building
+    the adjacency list. *)
 let find_cycle ~known_ids (patches : Types.Patch.t list) =
   let adj = Hashtbl.create (module Types.Patch_id) in
   List.iter patches ~f:(fun p ->
@@ -42,9 +43,7 @@ let find_cycle ~known_ids (patches : Types.Patch.t list) =
         List.filter p.dependencies ~f:(fun d ->
             (not (Types.Patch_id.equal d p.id)) && Set.mem known_ids d)
       in
-      Hashtbl.update adj p.id ~f:(function
-        | None -> real_deps
-        | Some deps -> deps @ real_deps));
+      Hashtbl.set adj ~key:p.id ~data:real_deps);
   let color = Hashtbl.create (module Types.Patch_id) in
   let stack : Types.Patch_id.t list ref = ref [] in
   let cycle : Types.Patch_id.t list option ref = ref None in
@@ -64,7 +63,7 @@ let find_cycle ~known_ids (patches : Types.Patch.t list) =
           stack := node :: !stack;
           let neighbours = Hashtbl.find adj node |> Option.value ~default:[] in
           List.iter neighbours ~f:visit;
-          stack := List.tl_exn !stack;
+          (stack := match !stack with _ :: rest -> rest | [] -> []);
           Hashtbl.set color ~key:node ~data:`Black
   in
   List.iter patches ~f:(fun p -> visit p.id);
@@ -98,10 +97,10 @@ let lint_patch ~known_ids (p : Types.Patch.t) =
   let dep_dups = duplicates non_self_deps ~key:Types.Patch_id.to_string in
   List.iter dep_dups ~f:(fun d ->
       add Severity.Warning (Printf.sprintf "duplicate dependency %s" d));
-  let unique_deps =
-    List.dedup_and_sort p.dependencies ~compare:Types.Patch_id.compare
+  let unique_non_self_deps =
+    List.dedup_and_sort non_self_deps ~compare:Types.Patch_id.compare
   in
-  List.iter unique_deps ~f:(fun d ->
+  List.iter unique_non_self_deps ~f:(fun d ->
       if not (Set.mem known_ids d) then
         add Severity.Error
           (Printf.sprintf "depends on unknown patch %s"

--- a/lib/gameplan_lint.ml
+++ b/lib/gameplan_lint.ml
@@ -37,7 +37,14 @@ let duplicates ~key items =
     the graph is acyclic. Uses the patches' declared dependencies as edges. *)
 let find_cycle (patches : Types.Patch.t list) =
   let adj = Hashtbl.create (module Types.Patch_id) in
-  List.iter patches ~f:(fun p -> Hashtbl.set adj ~key:p.id ~data:p.dependencies);
+  List.iter patches ~f:(fun p ->
+      let real_deps =
+        List.filter p.dependencies ~f:(fun d ->
+            not (Types.Patch_id.equal d p.id))
+      in
+      Hashtbl.update adj p.id ~f:(function
+        | None -> real_deps
+        | Some deps -> deps @ real_deps));
   let color = Hashtbl.create (module Types.Patch_id) in
   let stack : Types.Patch_id.t list ref = ref [] in
   let cycle : Types.Patch_id.t list option ref = ref None in
@@ -51,7 +58,7 @@ let find_cycle (patches : Types.Patch.t list) =
             List.take_while !stack ~f:(fun n ->
                 not (Types.Patch_id.equal n node))
           in
-          cycle := Some (List.rev (node :: in_cycle))
+          cycle := Some (node :: List.rev in_cycle)
       | Some `White | None ->
           Hashtbl.set color ~key:node ~data:`Gray;
           stack := node :: !stack;
@@ -90,7 +97,10 @@ let lint_patch ~known_ids (p : Types.Patch.t) =
   List.iter dep_dups ~f:(fun d ->
       add ?patch_id:pid Severity.Warning
         (Printf.sprintf "duplicate dependency %s" d));
-  List.iter p.dependencies ~f:(fun d ->
+  let unique_deps =
+    List.dedup_and_sort p.dependencies ~compare:Types.Patch_id.compare
+  in
+  List.iter unique_deps ~f:(fun d ->
       if not (Set.mem known_ids d) then
         add ?patch_id:pid Severity.Error
           (Printf.sprintf "depends on unknown patch %s"
@@ -116,16 +126,25 @@ let lint_gameplan_globals (g : Types.Gameplan.t) =
      in
      List.iter (duplicates branches ~key:Fn.id) ~f:(fun b ->
          add Severity.Error (Printf.sprintf "duplicate branch name %s" b));
-     match find_cycle g.patches with
-     | None -> ()
-     | Some chain ->
-         let rendered =
-           List.map chain ~f:Types.Patch_id.to_string
-           |> String.concat ~sep:" -> "
-         in
-         add Severity.Error
-           (Printf.sprintf "dependency cycle: %s -> %s" rendered
-              (Types.Patch_id.to_string (List.hd_exn chain))));
+     let known_ids =
+       List.map g.patches ~f:(fun p -> p.id)
+       |> Set.of_list (module Types.Patch_id)
+     in
+     let has_unknown_deps =
+       List.exists g.patches ~f:(fun p ->
+           List.exists p.dependencies ~f:(fun d -> not (Set.mem known_ids d)))
+     in
+     if not has_unknown_deps then
+       match find_cycle g.patches with
+       | None -> ()
+       | Some chain ->
+           let rendered =
+             List.map chain ~f:Types.Patch_id.to_string
+             |> String.concat ~sep:" -> "
+           in
+           add Severity.Error
+             (Printf.sprintf "dependency cycle: %s -> %s" rendered
+                (Types.Patch_id.to_string (List.hd_exn chain))));
   !acc
 
 let compare_issue a b =

--- a/lib/gameplan_lint.ml
+++ b/lib/gameplan_lint.ml
@@ -73,36 +73,37 @@ let find_cycle (patches : Types.Patch.t list) =
 (** Patch-level checks that do not depend on the rest of the gameplan. *)
 let lint_patch ~known_ids (p : Types.Patch.t) =
   let acc = ref [] in
-  let add ?patch_id sev msg = acc := issue ?patch_id sev msg :: !acc in
-  let pid = Some p.id in
+  let add sev msg = acc := issue ~patch_id:p.id sev msg :: !acc in
   if String.is_empty (String.strip p.title) then
-    add ?patch_id:pid Severity.Error "title is empty";
+    add Severity.Error "title is empty";
   if String.is_empty (String.strip (Types.Branch.to_string p.branch)) then
-    add ?patch_id:pid Severity.Error "branch name is empty";
+    add Severity.Error "branch name is empty";
   if String.is_empty (String.strip p.spec) then
-    add ?patch_id:pid Severity.Warning "spec is empty";
+    add Severity.Warning "spec is empty";
   if List.is_empty p.acceptance_criteria then
-    add ?patch_id:pid Severity.Warning "no acceptance criteria";
+    add Severity.Warning "no acceptance criteria";
   let cls = String.strip p.classification in
   if
     (not (String.is_empty cls))
     && not (List.mem known_classifications cls ~equal:String.equal)
   then
-    add ?patch_id:pid Severity.Warning
+    add Severity.Warning
       (Printf.sprintf "unknown classification %S (expected one of: %s)" cls
          (String.concat ~sep:", " known_classifications));
   if List.mem p.dependencies p.id ~equal:Types.Patch_id.equal then
-    add ?patch_id:pid Severity.Error "patch depends on itself";
-  let dep_dups = duplicates p.dependencies ~key:Types.Patch_id.to_string in
+    add Severity.Error "patch depends on itself";
+  let non_self_deps =
+    List.filter p.dependencies ~f:(fun d -> not (Types.Patch_id.equal d p.id))
+  in
+  let dep_dups = duplicates non_self_deps ~key:Types.Patch_id.to_string in
   List.iter dep_dups ~f:(fun d ->
-      add ?patch_id:pid Severity.Warning
-        (Printf.sprintf "duplicate dependency %s" d));
+      add Severity.Warning (Printf.sprintf "duplicate dependency %s" d));
   let unique_deps =
     List.dedup_and_sort p.dependencies ~compare:Types.Patch_id.compare
   in
   List.iter unique_deps ~f:(fun d ->
       if not (Set.mem known_ids d) then
-        add ?patch_id:pid Severity.Error
+        add Severity.Error
           (Printf.sprintf "depends on unknown patch %s"
              (Types.Patch_id.to_string d)));
   !acc
@@ -130,11 +131,12 @@ let lint_gameplan_globals (g : Types.Gameplan.t) =
        List.map g.patches ~f:(fun p -> p.id)
        |> Set.of_list (module Types.Patch_id)
      in
+     let has_dup_ids = List.length g.patches <> Set.length known_ids in
      let has_unknown_deps =
        List.exists g.patches ~f:(fun p ->
            List.exists p.dependencies ~f:(fun d -> not (Set.mem known_ids d)))
      in
-     if not has_unknown_deps then
+     if not (has_unknown_deps || has_dup_ids) then
        match find_cycle g.patches with
        | None -> ()
        | Some chain ->

--- a/lib/gameplan_lint.ml
+++ b/lib/gameplan_lint.ml
@@ -35,12 +35,12 @@ let duplicates ~key items =
 (** Tarjan-flavoured DFS that finds at least one cycle and returns the list of
     patch ids that participate in it (in traversal order). Returns [None] when
     the graph is acyclic. Uses the patches' declared dependencies as edges. *)
-let find_cycle (patches : Types.Patch.t list) =
+let find_cycle ~known_ids (patches : Types.Patch.t list) =
   let adj = Hashtbl.create (module Types.Patch_id) in
   List.iter patches ~f:(fun p ->
       let real_deps =
         List.filter p.dependencies ~f:(fun d ->
-            not (Types.Patch_id.equal d p.id))
+            (not (Types.Patch_id.equal d p.id)) && Set.mem known_ids d)
       in
       Hashtbl.update adj p.id ~f:(function
         | None -> real_deps
@@ -132,12 +132,8 @@ let lint_gameplan_globals (g : Types.Gameplan.t) =
        |> Set.of_list (module Types.Patch_id)
      in
      let has_dup_ids = List.length g.patches <> Set.length known_ids in
-     let has_unknown_deps =
-       List.exists g.patches ~f:(fun p ->
-           List.exists p.dependencies ~f:(fun d -> not (Set.mem known_ids d)))
-     in
-     if not (has_unknown_deps || has_dup_ids) then
-       match find_cycle g.patches with
+     if not has_dup_ids then
+       match find_cycle ~known_ids g.patches with
        | None -> ()
        | Some chain ->
            let rendered =

--- a/lib/gameplan_lint.mli
+++ b/lib/gameplan_lint.mli
@@ -1,5 +1,3 @@
-open Base
-
 (** Aggregate all structural and stylistic issues in a parsed gameplan.
 
     Complements {!Gameplan_parser.validate}, which fails fast on the first
@@ -26,8 +24,7 @@ end
 
 val known_classifications : string list
 (** Recognised values for {!Types.Patch.classification}. Empty classifications
-    are tolerated (warning, not error) for compatibility with older gameplans.
-*)
+    produce no issue (older gameplans often omit this field). *)
 
 val lint : Types.Gameplan.t -> Issue.t list
 (** Inspect [gameplan] and return all detected issues, ordered by severity

--- a/lib/gameplan_lint.mli
+++ b/lib/gameplan_lint.mli
@@ -1,0 +1,42 @@
+open Base
+
+(** Aggregate all structural and stylistic issues in a parsed gameplan.
+
+    Complements {!Gameplan_parser.validate}, which fails fast on the first
+    structural error encountered during parsing. This module accepts an
+    already-parsed gameplan and returns every issue it can find, classified by
+    severity, so that gameplan authors get all the feedback in one pass. *)
+
+module Severity : sig
+  type t = Error | Warning [@@deriving show, eq, compare, sexp_of]
+
+  val to_label : t -> string
+  (** Human-readable label, e.g. ["error"], ["warning"]. *)
+end
+
+module Issue : sig
+  type t = {
+    severity : Severity.t;
+    patch_id : Types.Patch_id.t option;
+        (** [None] for gameplan-level issues. *)
+    message : string;
+  }
+  [@@deriving show, eq, compare, sexp_of]
+end
+
+val known_classifications : string list
+(** Recognised values for {!Types.Patch.classification}. Empty classifications
+    are tolerated (warning, not error) for compatibility with older gameplans.
+*)
+
+val lint : Types.Gameplan.t -> Issue.t list
+(** Inspect [gameplan] and return all detected issues, ordered by severity
+    (errors first) then by patch id then by message. Pure: no IO, no exceptions.
+*)
+
+val has_errors : Issue.t list -> bool
+(** [true] iff at least one issue has severity {!Severity.Error}. *)
+
+val format_issues : Issue.t list -> string
+(** Render issues for terminal output. Returns the empty string when the list is
+    empty. The final character is a newline iff the result is non-empty. *)


### PR DESCRIPTION
## Summary
- New `Onton.Gameplan_lint` module: walks a parsed gameplan and returns *every* issue it can find — duplicate patch ids, duplicate branches, dangling deps, self-deps, dependency cycles (with the cycle path), empty specs, missing acceptance criteria, unknown classifications, duplicate dependency entries, empty title / branch / projectName.
- Each issue carries a `Severity.t` (`Error` | `Warning`), an optional `patch_id` scope, and a message; output is sorted errors-first, then by patch id.
- Complements `Gameplan_parser.validate`, which fails fast on the first structural error during parsing — the new module reports all findings in one pass so gameplan authors can fix them together.
- Wired into the CLI as `onton --lint --gameplan PATH`. Exits `0` when there are no errors (warnings allowed), `1` on parse failure or any error, `2` when `--gameplan` is missing.
- Inline tests cover the clean path, every error case, every warning case, severity ordering, and the formatter.

## Test plan
- [x] `dune build` clean
- [x] `dune runtest` green (new tests + full suite)
- [x] `dune fmt` clean
- [x] Manual: `onton --lint --gameplan skills/write-gameplan/references/example.json` reports the expected warnings and exits 0
- [x] Manual: a synthetic gameplan with an empty title and `WONKY` classification reports an error + warnings and exits 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI --lint mode to validate gameplan files, reporting errors and warnings for patch- and gameplan-level issues (titles, branches, specs, classifications, duplicate ids, branch names, missing deps, dependency cycles) and returning appropriate exit codes.
  * Added a linting API to produce deterministically sorted issues, detect presence of errors, and render formatted output.

* **Tests**
  * Added unit tests covering validation rules, cycle detection, and output ordering/formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `Onton.Gameplan_lint` and a `--lint` CLI mode to report all structural and stylistic gameplan issues in one pass, so authors can fix everything together. Improves cycle detection and reduces noisy findings; integrates with `onton` and exits non-zero on errors.

- **New Features**
  - Lints for: duplicate ids/branches, unknown/self deps, dependency cycles (with path), empty specs/patch lists/projectName, missing acceptance criteria, unknown classifications, duplicate dependency entries, and empty title/branch.
  - Classifies findings as Error/Warning, optionally scoped to a patch; deterministic sort. CLI: `onton --lint --gameplan PATH` prints findings and a summary; exit codes: 0 (no errors), 1 (parse failure or any error), 2 (missing `--gameplan`).

- **Bug Fixes**
  - Cycle checks: safer DFS stack handling; correct path rendering; filter self-loops and unknown deps so independent cycles are still found; skip cycle detection when duplicate ids exist.
  - Noise/robustness: filter self-deps before duplicate/unknown checks; deduplicate deps before the unknown-dep scan; use `Base.List` consistently; `run_lint` returns an int and `Stdlib.exit` is called at the call site.

<sup>Written for commit bef66884dcd19f7db4fa5c2ba6aebf1fd80c2a36. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

