### PR TITLE
Serialize git fetch across worktrees to prevent ref-lock races

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1984,6 +1984,9 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
     Fun.protect ~finally:(fun () -> Eio.Semaphore.release semaphore) f
   in
   let worktree_mutex = Eio.Mutex.create () in
+  (* Serializes [git fetch origin] across worktrees to avoid ref-lock races on
+     the shared [refs/remotes/origin/*] store. See [Worktree.fetch_origin]. *)
+  let fetch_mutex = Eio.Mutex.create () in
   let with_busy_guard ~patch_id f =
     Fun.protect
       ~finally:(fun () ->
@@ -2325,7 +2328,8 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                          stale refs. *)
                       let rebase_result =
                         match
-                          Worktree.fetch_origin ~process_mgr ~path:wt_path
+                          Worktree.fetch_origin ~fetch_lock:fetch_mutex
+                            ~process_mgr ~path:wt_path
                         with
                         | Result.Ok () ->
                             let remote_target =
@@ -2591,7 +2595,8 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                      stale refs. *)
                                   let rebase_result =
                                     match
-                                      Worktree.fetch_origin ~process_mgr
+                                      Worktree.fetch_origin
+                                        ~fetch_lock:fetch_mutex ~process_mgr
                                         ~path:wt_path
                                     with
                                     | Result.Ok () ->

--- a/lib/worktree.ml
+++ b/lib/worktree.ml
@@ -419,10 +419,17 @@ let fetch_origin ~fetch_lock ~process_mgr ~path =
      "cannot lock ref ...: is at X but expected Y" in the loser. The mutex
      eliminates that race by construction. *)
   Eio.Mutex.use_ro fetch_lock (fun () ->
-      let code, _stdout, stderr =
-        run_git_exit_code ~process_mgr [ "git"; "-C"; path; "fetch"; "origin" ]
-      in
-      classify_fetch_result ~code ~stderr)
+      try
+        let code, _stdout, stderr =
+          run_git_exit_code ~process_mgr
+            [ "git"; "-C"; path; "fetch"; "origin" ]
+        in
+        classify_fetch_result ~code ~stderr
+      with
+      | exn when has_cancellation exn -> raise exn
+      | exn ->
+          Result.Error
+            (Printf.sprintf "git fetch origin crashed: %s" (Exn.to_string exn)))
 
 let git_status ~process_mgr ~path =
   let code, stdout, _ =

--- a/lib/worktree.ml
+++ b/lib/worktree.ml
@@ -401,15 +401,28 @@ let find_old_base ~process_mgr ~path ~target =
                (String.strip stderr))
         else Result.Ok (String.strip stdout)
 
-let fetch_origin ~process_mgr ~path =
-  let code, _stdout, stderr =
-    run_git_exit_code ~process_mgr [ "git"; "-C"; path; "fetch"; "origin" ]
-  in
-  if code <> 0 then
+(** Pure: classify a [git fetch origin] invocation from its exit code and
+    stderr. Split out so the mapping from raw git output to fetch outcome can be
+    property-tested independently of the subprocess and mutex. *)
+let classify_fetch_result ~code ~stderr =
+  if code = 0 then Result.Ok ()
+  else
     Result.Error
       (Printf.sprintf "git fetch origin failed (exit %d): %s" code
          (String.strip stderr))
-  else Result.Ok ()
+
+let fetch_origin ~fetch_lock ~process_mgr ~path =
+  (* Serialize concurrent fetches across worktrees of the same repo. All
+     worktrees share the main repo's ref store, so simultaneous
+     [git fetch origin] processes race on the compare-and-swap update of
+     [refs/remotes/origin/*], producing
+     "cannot lock ref ...: is at X but expected Y" in the loser. The mutex
+     eliminates that race by construction. *)
+  Eio.Mutex.use_rw ~protect:true fetch_lock (fun () ->
+      let code, _stdout, stderr =
+        run_git_exit_code ~process_mgr [ "git"; "-C"; path; "fetch"; "origin" ]
+      in
+      classify_fetch_result ~code ~stderr)
 
 let git_status ~process_mgr ~path =
   let code, stdout, _ =

--- a/lib/worktree.ml
+++ b/lib/worktree.ml
@@ -418,7 +418,7 @@ let fetch_origin ~fetch_lock ~process_mgr ~path =
      [refs/remotes/origin/*], producing
      "cannot lock ref ...: is at X but expected Y" in the loser. The mutex
      eliminates that race by construction. *)
-  Eio.Mutex.use_rw ~protect:true fetch_lock (fun () ->
+  Eio.Mutex.use_ro fetch_lock (fun () ->
       let code, _stdout, stderr =
         run_git_exit_code ~process_mgr [ "git"; "-C"; path; "fetch"; "origin" ]
       in

--- a/lib/worktree.mli
+++ b/lib/worktree.mli
@@ -63,10 +63,26 @@ val conflict_diff : process_mgr:_ Eio.Process.mgr -> path:string -> string
     Returns empty string if no conflicts or on failure. Truncates at 4000 chars.
 *)
 
+val classify_fetch_result : code:int -> stderr:string -> (unit, string) Result.t
+(** Pure: classify a [git fetch origin] invocation from its exit code and stderr
+    into [Ok ()] (exit 0) or [Error msg] (non-zero, with the exit code and
+    stripped stderr embedded in the message). Split out from [fetch_origin] so
+    the decision can be property-tested independently of the subprocess and
+    mutex. *)
+
 val fetch_origin :
-  process_mgr:_ Eio.Process.mgr -> path:string -> (unit, string) Result.t
+  fetch_lock:Eio.Mutex.t ->
+  process_mgr:_ Eio.Process.mgr ->
+  path:string ->
+  (unit, string) Result.t
 (** Run [git fetch origin] in the worktree at [path] to update remote tracking
-    refs. Returns [Ok ()] on success, [Error msg] on failure. *)
+    refs. Returns [Ok ()] on success, [Error msg] on failure.
+
+    [fetch_lock] must be shared across all worktrees of the same repo. Git
+    worktrees share the main repo's ref store, so concurrent fetches race on the
+    compare-and-swap update of [refs/remotes/origin/*] and the losing process
+    fails with "cannot lock ref". The lock serializes fetches to prevent this.
+*)
 
 type rebase_result = Ok | Noop | Conflict | Error of string
 [@@deriving show, eq, sexp_of, compare]

--- a/test/test_rebase_onto.ml
+++ b/test/test_rebase_onto.ml
@@ -173,7 +173,8 @@ let () =
         match Worktree.classify_fetch_result ~code:1 ~stderr with
         | Result.Error msg ->
             String.is_substring msg ~substring:"oops"
-            && not (String.is_substring msg ~substring:stderr)
+            && not (String.is_substring msg ~substring:"  oops")
+            && not (String.is_substring msg ~substring:"oops  ")
         | Result.Ok () -> false)
   in
   let prop_regression_ref_lock_error =

--- a/test/test_rebase_onto.ml
+++ b/test/test_rebase_onto.ml
@@ -152,11 +152,10 @@ let () =
     Test.make ~name:"classify_fetch_result: exit != 0 -> Error" ~count:200
       Gen.(pair (int_range (-128) 255) string)
       (fun (code, stderr) ->
-        if code = 0 then true
-        else
-          match Worktree.classify_fetch_result ~code ~stderr with
-          | Result.Error _ -> true
-          | Result.Ok () -> false)
+        QCheck2.assume (code <> 0);
+        match Worktree.classify_fetch_result ~code ~stderr with
+        | Result.Error _ -> true
+        | Result.Ok () -> false)
   in
   let prop_error_message_includes_code =
     Test.make ~name:"classify_fetch_result: Error message embeds exit code"
@@ -168,37 +167,32 @@ let () =
             String.is_substring msg ~substring:(Printf.sprintf "exit %d" code)
         | Result.Ok () -> false)
   in
-  let prop_error_message_strips_stderr =
-    Test.make ~name:"classify_fetch_result: stderr is stripped in Error message"
-      ~count:1 Gen.unit (fun () ->
-        let stderr = "  oops  \n" in
-        match Worktree.classify_fetch_result ~code:1 ~stderr with
-        | Result.Error msg ->
-            String.is_substring msg ~substring:"oops"
-            && not (String.is_substring msg ~substring:"  oops")
-        | Result.Ok () -> false)
+  (* Unit assertions — deterministic fixtures, no generation needed. *)
+  let () =
+    let stderr = "  oops  \n" in
+    match Worktree.classify_fetch_result ~code:1 ~stderr with
+    | Result.Error msg ->
+        assert (String.is_substring msg ~substring:"oops");
+        assert (not (String.is_substring msg ~substring:"  oops"))
+    | Result.Ok () -> assert false
   in
-  let prop_ref_lock_error_surfaces_verbatim =
-    Test.make
-      ~name:
-        "classify_fetch_result: real 'cannot lock ref' stderr surfaces in Error"
-      ~count:1 Gen.unit (fun () ->
-        (* Regression: this was the stderr observed in the outcome-tracking
-           run. The classifier should surface it so downstream log/telemetry
-           can still identify the race. *)
-        let stderr =
-          "error: cannot lock ref 'refs/remotes/origin/main': is at \
-           11ea3d8d67b9c481e7c8ddec7a6e1d46f2db1ba8 but expected \
-           d97cc64a88e05401a2f8fdf3624b79dbfb16671d\n\
-           From github.com:flowglad/review-service\n\
-          \ ! d97cc64..11ea3d8  main       -> origin/main  (unable to update \
-           local ref)"
-        in
-        match Worktree.classify_fetch_result ~code:1 ~stderr with
-        | Result.Error msg ->
-            String.is_substring msg ~substring:"cannot lock ref"
-            && String.is_substring msg ~substring:"exit 1"
-        | Result.Ok () -> false)
+  let () =
+    (* Regression: this was the stderr observed in the outcome-tracking
+       run. The classifier should surface it so downstream log/telemetry
+       can still identify the race. *)
+    let stderr =
+      "error: cannot lock ref 'refs/remotes/origin/main': is at \
+       11ea3d8d67b9c481e7c8ddec7a6e1d46f2db1ba8 but expected \
+       d97cc64a88e05401a2f8fdf3624b79dbfb16671d\n\
+       From github.com:flowglad/review-service\n\
+      \ ! d97cc64..11ea3d8  main       -> origin/main  (unable to update \
+       local ref)"
+    in
+    match Worktree.classify_fetch_result ~code:1 ~stderr with
+    | Result.Error msg ->
+        assert (String.is_substring msg ~substring:"cannot lock ref");
+        assert (String.is_substring msg ~substring:"exit 1")
+    | Result.Ok () -> assert false
   in
   let prop_total_no_raise =
     (* Totality: the classifier never raises for any (code, stderr). *)
@@ -215,8 +209,6 @@ let () =
       prop_exit_zero_is_ok;
       prop_nonzero_is_error;
       prop_error_message_includes_code;
-      prop_error_message_strips_stderr;
-      prop_ref_lock_error_surfaces_verbatim;
       prop_total_no_raise;
     ]
   in

--- a/test/test_rebase_onto.ml
+++ b/test/test_rebase_onto.ml
@@ -174,6 +174,8 @@ let () =
         | Result.Error msg ->
             String.is_substring msg ~substring:"oops"
             && not (String.is_substring msg ~substring:"  oops")
+            && not (String.is_substring msg ~substring:"oops  ")
+            && not (String.is_substring msg ~substring:"oops\n")
         | Result.Ok () -> false)
   in
   let prop_regression_ref_lock_error =

--- a/test/test_rebase_onto.ml
+++ b/test/test_rebase_onto.ml
@@ -150,9 +150,8 @@ let () =
   in
   let prop_nonzero_is_error =
     Test.make ~name:"classify_fetch_result: exit != 0 -> Error" ~count:200
-      Gen.(pair (int_range (-128) 255) string)
+      Gen.(pair (int_range 1 255) string)
       (fun (code, stderr) ->
-        QCheck2.assume (code <> 0);
         match Worktree.classify_fetch_result ~code ~stderr with
         | Result.Error _ -> true
         | Result.Ok () -> false)
@@ -167,32 +166,35 @@ let () =
             String.is_substring msg ~substring:(Printf.sprintf "exit %d" code)
         | Result.Ok () -> false)
   in
-  (* Unit assertions — deterministic fixtures, no generation needed. *)
-  let () =
-    let stderr = "  oops  \n" in
-    match Worktree.classify_fetch_result ~code:1 ~stderr with
-    | Result.Error msg ->
-        assert (String.is_substring msg ~substring:"oops");
-        assert (not (String.is_substring msg ~substring:"  oops"))
-    | Result.Ok () -> assert false
+  let prop_stderr_stripped =
+    Test.make ~name:"classify_fetch_result: stderr is stripped in Error msg"
+      ~count:1 Gen.unit (fun () ->
+        let stderr = "  oops  \n" in
+        match Worktree.classify_fetch_result ~code:1 ~stderr with
+        | Result.Error msg ->
+            String.is_substring msg ~substring:"oops"
+            && not (String.is_substring msg ~substring:"  oops")
+        | Result.Ok () -> false)
   in
-  let () =
+  let prop_regression_ref_lock_error =
     (* Regression: this was the stderr observed in the outcome-tracking
        run. The classifier should surface it so downstream log/telemetry
        can still identify the race. *)
-    let stderr =
-      "error: cannot lock ref 'refs/remotes/origin/main': is at \
-       11ea3d8d67b9c481e7c8ddec7a6e1d46f2db1ba8 but expected \
-       d97cc64a88e05401a2f8fdf3624b79dbfb16671d\n\
-       From github.com:flowglad/review-service\n\
-      \ ! d97cc64..11ea3d8  main       -> origin/main  (unable to update \
-       local ref)"
-    in
-    match Worktree.classify_fetch_result ~code:1 ~stderr with
-    | Result.Error msg ->
-        assert (String.is_substring msg ~substring:"cannot lock ref");
-        assert (String.is_substring msg ~substring:"exit 1")
-    | Result.Ok () -> assert false
+    Test.make ~name:"classify_fetch_result: regression ref-lock stderr"
+      ~count:1 Gen.unit (fun () ->
+        let stderr =
+          "error: cannot lock ref 'refs/remotes/origin/main': is at \
+           11ea3d8d67b9c481e7c8ddec7a6e1d46f2db1ba8 but expected \
+           d97cc64a88e05401a2f8fdf3624b79dbfb16671d\n\
+           From github.com:flowglad/review-service\n\
+          \ ! d97cc64..11ea3d8  main       -> origin/main  (unable to update \
+           local ref)"
+        in
+        match Worktree.classify_fetch_result ~code:1 ~stderr with
+        | Result.Error msg ->
+            String.is_substring msg ~substring:"cannot lock ref"
+            && String.is_substring msg ~substring:"exit 1"
+        | Result.Ok () -> false)
   in
   let prop_total_no_raise =
     (* Totality: the classifier never raises for any (code, stderr). *)
@@ -209,6 +211,8 @@ let () =
       prop_exit_zero_is_ok;
       prop_nonzero_is_error;
       prop_error_message_includes_code;
+      prop_stderr_stripped;
+      prop_regression_ref_lock_error;
       prop_total_no_raise;
     ]
   in

--- a/test/test_rebase_onto.ml
+++ b/test/test_rebase_onto.ml
@@ -175,7 +175,7 @@ let () =
         match Worktree.classify_fetch_result ~code:1 ~stderr with
         | Result.Error msg ->
             String.is_substring msg ~substring:"oops"
-            && not (String.is_substring msg ~substring:"oops  \n")
+            && not (String.is_substring msg ~substring:"  oops")
         | Result.Ok () -> false)
   in
   let prop_ref_lock_error_surfaces_verbatim =

--- a/test/test_rebase_onto.ml
+++ b/test/test_rebase_onto.ml
@@ -173,7 +173,7 @@ let () =
         match Worktree.classify_fetch_result ~code:1 ~stderr with
         | Result.Error msg ->
             String.is_substring msg ~substring:"oops"
-            && not (String.is_substring msg ~substring:"  oops")
+            && (not (String.is_substring msg ~substring:"  oops"))
             && not (String.is_substring msg ~substring:"oops  ")
         | Result.Ok () -> false)
   in
@@ -181,8 +181,8 @@ let () =
     (* Regression: this was the stderr observed in the outcome-tracking
        run. The classifier should surface it so downstream log/telemetry
        can still identify the race. *)
-    Test.make ~name:"classify_fetch_result: regression ref-lock stderr"
-      ~count:1 Gen.unit (fun () ->
+    Test.make ~name:"classify_fetch_result: regression ref-lock stderr" ~count:1
+      Gen.unit (fun () ->
         let stderr =
           "error: cannot lock ref 'refs/remotes/origin/main': is at \
            11ea3d8d67b9c481e7c8ddec7a6e1d46f2db1ba8 but expected \

--- a/test/test_rebase_onto.ml
+++ b/test/test_rebase_onto.ml
@@ -136,6 +136,94 @@ let () =
   if errcode <> 0 then Stdlib.exit errcode
 
 (* ───────────────────────────────────────────────────────────────────────
+   Pure tests for [Worktree.classify_fetch_result]
+   ─────────────────────────────────────────────────────────────────────── *)
+
+let () =
+  let open QCheck2 in
+  let prop_exit_zero_is_ok =
+    Test.make ~name:"classify_fetch_result: exit 0 -> Ok ()" ~count:200
+      Gen.string (fun stderr ->
+        match Worktree.classify_fetch_result ~code:0 ~stderr with
+        | Result.Ok () -> true
+        | Result.Error _ -> false)
+  in
+  let prop_nonzero_is_error =
+    Test.make ~name:"classify_fetch_result: exit != 0 -> Error" ~count:200
+      Gen.(pair (int_range (-128) 255) string)
+      (fun (code, stderr) ->
+        if code = 0 then true
+        else
+          match Worktree.classify_fetch_result ~code ~stderr with
+          | Result.Error _ -> true
+          | Result.Ok () -> false)
+  in
+  let prop_error_message_includes_code =
+    Test.make ~name:"classify_fetch_result: Error message embeds exit code"
+      ~count:200
+      Gen.(pair (int_range 1 255) string)
+      (fun (code, stderr) ->
+        match Worktree.classify_fetch_result ~code ~stderr with
+        | Result.Error msg ->
+            String.is_substring msg ~substring:(Printf.sprintf "exit %d" code)
+        | Result.Ok () -> false)
+  in
+  let prop_error_message_strips_stderr =
+    Test.make ~name:"classify_fetch_result: stderr is stripped in Error message"
+      ~count:1 Gen.unit (fun () ->
+        let stderr = "  oops  \n" in
+        match Worktree.classify_fetch_result ~code:1 ~stderr with
+        | Result.Error msg ->
+            String.is_substring msg ~substring:"oops"
+            && not (String.is_substring msg ~substring:"oops  \n")
+        | Result.Ok () -> false)
+  in
+  let prop_ref_lock_error_surfaces_verbatim =
+    Test.make
+      ~name:
+        "classify_fetch_result: real 'cannot lock ref' stderr surfaces in Error"
+      ~count:1 Gen.unit (fun () ->
+        (* Regression: this was the stderr observed in the outcome-tracking
+           run. The classifier should surface it so downstream log/telemetry
+           can still identify the race. *)
+        let stderr =
+          "error: cannot lock ref 'refs/remotes/origin/main': is at \
+           11ea3d8d67b9c481e7c8ddec7a6e1d46f2db1ba8 but expected \
+           d97cc64a88e05401a2f8fdf3624b79dbfb16671d\n\
+           From github.com:flowglad/review-service\n\
+          \ ! d97cc64..11ea3d8  main       -> origin/main  (unable to update \
+           local ref)"
+        in
+        match Worktree.classify_fetch_result ~code:1 ~stderr with
+        | Result.Error msg ->
+            String.is_substring msg ~substring:"cannot lock ref"
+            && String.is_substring msg ~substring:"exit 1"
+        | Result.Ok () -> false)
+  in
+  let prop_total_no_raise =
+    (* Totality: the classifier never raises for any (code, stderr). *)
+    Test.make ~name:"classify_fetch_result: total (never raises)" ~count:500
+      Gen.(pair (int_range (-256) 512) string)
+      (fun (code, stderr) ->
+        try
+          let _ = Worktree.classify_fetch_result ~code ~stderr in
+          true
+        with _ -> false)
+  in
+  let suite =
+    [
+      prop_exit_zero_is_ok;
+      prop_nonzero_is_error;
+      prop_error_message_includes_code;
+      prop_error_message_strips_stderr;
+      prop_ref_lock_error_surfaces_verbatim;
+      prop_total_no_raise;
+    ]
+  in
+  let errcode = QCheck_base_runner.run_tests ~verbose:true suite in
+  if errcode <> 0 then Stdlib.exit errcode
+
+(* ───────────────────────────────────────────────────────────────────────
    Integration tests for [Worktree.rebase_onto]
 
    Each test creates a temporary git repo with a realistic branch topology,

--- a/test/test_rebase_onto.ml
+++ b/test/test_rebase_onto.ml
@@ -173,9 +173,7 @@ let () =
         match Worktree.classify_fetch_result ~code:1 ~stderr with
         | Result.Error msg ->
             String.is_substring msg ~substring:"oops"
-            && not (String.is_substring msg ~substring:"  oops")
-            && not (String.is_substring msg ~substring:"oops  ")
-            && not (String.is_substring msg ~substring:"oops\n")
+            && not (String.is_substring msg ~substring:stderr)
         | Result.Ok () -> false)
   in
   let prop_regression_ref_lock_error =


### PR DESCRIPTION
## Summary

- Serializes `git fetch origin` across worktrees via a single per-process `fetch_mutex`. Worktrees share the main repo's ref store, and concurrent fetches race on the CAS update of `refs/remotes/origin/*`, failing with `cannot lock ref ...: is at X but expected Y` in the loser. The mutex eliminates that race by construction.
- Decomposes `Worktree.fetch_origin` into a pure `classify_fetch_result ~code ~stderr` and an effectful handler that holds the mutex across the subprocess.
- Adds six QCheck2 property tests covering the pure classifier, including a regression fixture for the exact stderr observed in `~/.local/share/onton/outcome-tracking/events.jsonl`.

## Context

Supervisor on the `outcome-tracking` run hit this error twice within 14 minutes (patch 2 at 19:18:59Z, patch 5 at 19:32:34Z) — each time the expected-old value of one fetch was the winning-new value of a sibling fetch, the signature of a CAS race rather than a stale lock file. The fail-closed branch correctly refused to rebase against stale refs but promoted the transient loss to a terminal session failure (`session_fallback: ["Given_up"]`). Serializing fetches avoids the race entirely.

## Interleaving coverage

No new interleaving commands needed — a fetch failure synthesizes `Worktree.Error` which flows into `Orchestrator.apply_rebase_result` as the already-covered `Rebase_error` transition (`test_interleaving_properties.ml:83,210,336`), exercised by the 17 PI-* invariant properties.

## Test plan

- [x] `dune build` — clean
- [x] `dune runtest` — all green, including 6 new `classify_fetch_result` properties
- [ ] Observe next multi-patch merge on `outcome-tracking` to confirm no ref-lock errors in `events.jsonl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents ref-lock errors during concurrent worktree fetches by serializing `git fetch origin` with a shared mutex. Normalizes all fetch failures to `Result.Error` and adds a pure classifier with tests.

- **Bug Fixes**
  - Serialize `git fetch origin` across worktrees using a shared per-process `Eio.Mutex` (via `Eio.Mutex.use_ro`) to eliminate CAS races on `refs/remotes/origin/*` and avoid lock poisoning on exceptions.
  - Update `Worktree.fetch_origin` to require `~fetch_lock`; create and pass the shared lock from `bin/main.ml`.
  - Catch non-cancellation exceptions around `run_git_exit_code` and return `Result.Error` so callers get consistent failure results.
  - Add `classify_fetch_result` with property tests; tighten stderr-strip checks (both leading and trailing), include a ref-lock regression fixture, and use `int_range 1 255` for non-zero exits.

<sup>Written for commit 967b923970076821269ea1e888793618090f2032. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed a concurrency issue where simultaneous fetch operations across multiple worktrees could conflict, causing ref update failures.

* **Tests**
  * Added property-based tests to verify fetch operation behavior and error handling under various conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->