### PR TITLE
Decompose worktree fetch/rebase into pure plan + executor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,19 +10,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# Pinned opam version — setup-ocaml resolves the *latest* opam release
-# from GitHub and fails when that release has no pre-built binaries
-# (e.g. opam 2.5.1 shipped source-only on 2026-04-15).  Installing
-# opam manually lets us pin a known-good version with binaries.
-# TODO: revert to setup-ocaml once it gains an opam-version input or
-#       opam 2.5.1 publishes binaries.
-env:
-  OPAM_VERSION: "2.5.0"
-  OPAM_SHA256: "7aae51da01a66666c8733130852c2c00546eff486effb0999b78145cb75aee74"
-  OCAML_VERSION: "5.4.0"
-  OPAMYES: "1"
-  OPAMCONFIRMLEVEL: "unsafe-yes"
-
 jobs:
   build-and-test:
     name: Build & Test
@@ -30,28 +17,10 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Install opam
-        run: |
-          sudo curl -fsSL "https://github.com/ocaml/opam/releases/download/${OPAM_VERSION}/opam-${OPAM_VERSION}-x86_64-linux" \
-            -o /usr/local/bin/opam
-          echo "${OPAM_SHA256}  /usr/local/bin/opam" | sha256sum -c -
-          sudo chmod +x /usr/local/bin/opam
-
-      - name: Cache opam root
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+      - uses: ocaml/setup-ocaml@dec6499fef64fc5d7ed43d43a87251b7b1c306f5 # v3
         with:
-          path: ~/.opam
-          key: opam-${{ env.OPAM_VERSION }}-${{ env.OCAML_VERSION }}-${{ hashFiles('*.opam') }}
-          restore-keys: |
-            opam-${{ env.OPAM_VERSION }}-${{ env.OCAML_VERSION }}-
-
-      - name: Setup OCaml
-        run: |
-          opam init --auto-setup --bare --disable-sandboxing
-          if ! opam switch list 2>/dev/null | grep -q default; then
-            opam switch create default "ocaml-base-compiler.${OCAML_VERSION}"
-          fi
-          eval $(opam env)
+          ocaml-compiler: '5.4.0'
+          dune-cache: true
 
       - name: Install dependencies
         run: opam install . --deps-only --with-test -y
@@ -101,28 +70,10 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Install opam
-        run: |
-          sudo curl -fsSL "https://github.com/ocaml/opam/releases/download/${OPAM_VERSION}/opam-${OPAM_VERSION}-x86_64-linux" \
-            -o /usr/local/bin/opam
-          echo "${OPAM_SHA256}  /usr/local/bin/opam" | sha256sum -c -
-          sudo chmod +x /usr/local/bin/opam
-
-      - name: Cache opam root
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+      - uses: ocaml/setup-ocaml@dec6499fef64fc5d7ed43d43a87251b7b1c306f5 # v3
         with:
-          path: ~/.opam
-          key: opam-${{ env.OPAM_VERSION }}-${{ env.OCAML_VERSION }}-${{ hashFiles('*.opam') }}
-          restore-keys: |
-            opam-${{ env.OPAM_VERSION }}-${{ env.OCAML_VERSION }}-
-
-      - name: Setup OCaml
-        run: |
-          opam init --auto-setup --bare --disable-sandboxing
-          if ! opam switch list 2>/dev/null | grep -q default; then
-            opam switch create default "ocaml-base-compiler.${OCAML_VERSION}"
-          fi
-          eval $(opam env)
+          ocaml-compiler: '5.4.0'
+          dune-cache: true
 
       - name: Install dependencies
         run: opam install . --deps-only --with-test -y
@@ -149,33 +100,8 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Install opam
-        run: |
-          sudo curl -fsSL "https://github.com/ocaml/opam/releases/download/${OPAM_VERSION}/opam-${OPAM_VERSION}-x86_64-linux" \
-            -o /usr/local/bin/opam
-          echo "${OPAM_SHA256}  /usr/local/bin/opam" | sha256sum -c -
-          sudo chmod +x /usr/local/bin/opam
-
-      - name: Cache opam root (fmt)
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+      - uses: ocaml/setup-ocaml@dec6499fef64fc5d7ed43d43a87251b7b1c306f5 # v3
         with:
-          path: ~/.opam
-          key: opam-fmt-${{ env.OPAM_VERSION }}-${{ env.OCAML_VERSION }}-${{ hashFiles('.ocamlformat') }}
-          restore-keys: |
-            opam-fmt-${{ env.OPAM_VERSION }}-${{ env.OCAML_VERSION }}-
+          ocaml-compiler: '5.4.0'
 
-      - name: Setup OCaml
-        run: |
-          opam init --auto-setup --bare --disable-sandboxing
-          if ! opam switch list 2>/dev/null | grep -q default; then
-            opam switch create default "ocaml-base-compiler.${OCAML_VERSION}"
-          fi
-          eval $(opam env)
-
-      - name: Install ocamlformat and dune
-        run: |
-          OCAMLFORMAT_VERSION=$(sed -n 's/^version *= *//p' .ocamlformat)
-          opam install "ocamlformat=${OCAMLFORMAT_VERSION}" dune -y
-
-      - name: Check formatting
-        run: opam exec -- dune build @fmt
+      - uses: ocaml/setup-ocaml/lint-fmt@dec6499fef64fc5d7ed43d43a87251b7b1c306f5 # v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           sudo chmod +x /usr/local/bin/opam
 
       - name: Cache opam root
-        uses: actions/cache@v4
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
         with:
           path: ~/.opam
           key: opam-${{ env.OPAM_VERSION }}-${{ env.OCAML_VERSION }}-${{ hashFiles('*.opam') }}
@@ -109,7 +109,7 @@ jobs:
           sudo chmod +x /usr/local/bin/opam
 
       - name: Cache opam root
-        uses: actions/cache@v4
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
         with:
           path: ~/.opam
           key: opam-${{ env.OPAM_VERSION }}-${{ env.OCAML_VERSION }}-${{ hashFiles('*.opam') }}
@@ -157,7 +157,7 @@ jobs:
           sudo chmod +x /usr/local/bin/opam
 
       - name: Cache opam root (fmt)
-        uses: actions/cache@v4
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
         with:
           path: ~/.opam
           key: opam-fmt-${{ env.OPAM_VERSION }}-${{ env.OCAML_VERSION }}-${{ hashFiles('.ocamlformat') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: ocaml/setup-ocaml@dec6499fef64fc5d7ed43d43a87251b7b1c306f5 # v3
+      - uses: ocaml/setup-ocaml@fefd9c240b9d934d5d25aa9c2a8caae6c7b40079 # v3
         with:
           ocaml-compiler: '5.4.0'
           dune-cache: true
@@ -70,7 +70,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: ocaml/setup-ocaml@dec6499fef64fc5d7ed43d43a87251b7b1c306f5 # v3
+      - uses: ocaml/setup-ocaml@fefd9c240b9d934d5d25aa9c2a8caae6c7b40079 # v3
         with:
           ocaml-compiler: '5.4.0'
           dune-cache: true
@@ -100,8 +100,8 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: ocaml/setup-ocaml@dec6499fef64fc5d7ed43d43a87251b7b1c306f5 # v3
+      - uses: ocaml/setup-ocaml@fefd9c240b9d934d5d25aa9c2a8caae6c7b40079 # v3
         with:
           ocaml-compiler: '5.4.0'
 
-      - uses: ocaml/setup-ocaml/lint-fmt@dec6499fef64fc5d7ed43d43a87251b7b1c306f5 # v3
+      - uses: ocaml/setup-ocaml/lint-fmt@fefd9c240b9d934d5d25aa9c2a8caae6c7b40079 # v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,18 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Pinned opam version — setup-ocaml resolves the *latest* opam release
+# from GitHub and fails when that release has no pre-built binaries
+# (e.g. opam 2.5.1 shipped source-only on 2026-04-15).  Installing
+# opam manually lets us pin a known-good version with binaries.
+# TODO: revert to setup-ocaml once it gains an opam-version input or
+#       opam 2.5.1 publishes binaries.
+env:
+  OPAM_VERSION: "2.5.0"
+  OCAML_VERSION: "5.4.0"
+  OPAMYES: "1"
+  OPAMCONFIRMLEVEL: "unsafe-yes"
+
 jobs:
   build-and-test:
     name: Build & Test
@@ -17,10 +29,27 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: ocaml/setup-ocaml@fefd9c240b9d934d5d25aa9c2a8caae6c7b40079 # v3
+      - name: Install opam
+        run: |
+          sudo curl -fsSL "https://github.com/ocaml/opam/releases/download/${OPAM_VERSION}/opam-${OPAM_VERSION}-x86_64-linux" \
+            -o /usr/local/bin/opam
+          sudo chmod +x /usr/local/bin/opam
+
+      - name: Cache opam root
+        uses: actions/cache@v4
         with:
-          ocaml-compiler: '5.4.0'
-          dune-cache: true
+          path: ~/.opam
+          key: opam-${{ env.OPAM_VERSION }}-${{ env.OCAML_VERSION }}-${{ hashFiles('*.opam') }}
+          restore-keys: |
+            opam-${{ env.OPAM_VERSION }}-${{ env.OCAML_VERSION }}-
+
+      - name: Setup OCaml
+        run: |
+          opam init --auto-setup --bare --disable-sandboxing
+          if ! opam switch list 2>/dev/null | grep -q default; then
+            opam switch create default "ocaml-base-compiler.${OCAML_VERSION}"
+          fi
+          eval $(opam env)
 
       - name: Install dependencies
         run: opam install . --deps-only --with-test -y
@@ -70,10 +99,27 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: ocaml/setup-ocaml@fefd9c240b9d934d5d25aa9c2a8caae6c7b40079 # v3
+      - name: Install opam
+        run: |
+          sudo curl -fsSL "https://github.com/ocaml/opam/releases/download/${OPAM_VERSION}/opam-${OPAM_VERSION}-x86_64-linux" \
+            -o /usr/local/bin/opam
+          sudo chmod +x /usr/local/bin/opam
+
+      - name: Cache opam root
+        uses: actions/cache@v4
         with:
-          ocaml-compiler: '5.4.0'
-          dune-cache: true
+          path: ~/.opam
+          key: opam-${{ env.OPAM_VERSION }}-${{ env.OCAML_VERSION }}-${{ hashFiles('*.opam') }}
+          restore-keys: |
+            opam-${{ env.OPAM_VERSION }}-${{ env.OCAML_VERSION }}-
+
+      - name: Setup OCaml
+        run: |
+          opam init --auto-setup --bare --disable-sandboxing
+          if ! opam switch list 2>/dev/null | grep -q default; then
+            opam switch create default "ocaml-base-compiler.${OCAML_VERSION}"
+          fi
+          eval $(opam env)
 
       - name: Install dependencies
         run: opam install . --deps-only --with-test -y
@@ -100,8 +146,32 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: ocaml/setup-ocaml@fefd9c240b9d934d5d25aa9c2a8caae6c7b40079 # v3
-        with:
-          ocaml-compiler: '5.4.0'
+      - name: Install opam
+        run: |
+          sudo curl -fsSL "https://github.com/ocaml/opam/releases/download/${OPAM_VERSION}/opam-${OPAM_VERSION}-x86_64-linux" \
+            -o /usr/local/bin/opam
+          sudo chmod +x /usr/local/bin/opam
 
-      - uses: ocaml/setup-ocaml/lint-fmt@fefd9c240b9d934d5d25aa9c2a8caae6c7b40079 # v3
+      - name: Cache opam root (fmt)
+        uses: actions/cache@v4
+        with:
+          path: ~/.opam
+          key: opam-fmt-${{ env.OPAM_VERSION }}-${{ env.OCAML_VERSION }}-${{ hashFiles('.ocamlformat') }}
+          restore-keys: |
+            opam-fmt-${{ env.OPAM_VERSION }}-${{ env.OCAML_VERSION }}-
+
+      - name: Setup OCaml
+        run: |
+          opam init --auto-setup --bare --disable-sandboxing
+          if ! opam switch list 2>/dev/null | grep -q default; then
+            opam switch create default "ocaml-base-compiler.${OCAML_VERSION}"
+          fi
+          eval $(opam env)
+
+      - name: Install ocamlformat and dune
+        run: |
+          OCAMLFORMAT_VERSION=$(sed -n 's/^version *= *//p' .ocamlformat)
+          opam install "ocamlformat=${OCAMLFORMAT_VERSION}" dune -y
+
+      - name: Check formatting
+        run: opam exec -- dune build @fmt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ concurrency:
 #       opam 2.5.1 publishes binaries.
 env:
   OPAM_VERSION: "2.5.0"
+  OPAM_SHA256: "7aae51da01a66666c8733130852c2c00546eff486effb0999b78145cb75aee74"
   OCAML_VERSION: "5.4.0"
   OPAMYES: "1"
   OPAMCONFIRMLEVEL: "unsafe-yes"
@@ -33,6 +34,7 @@ jobs:
         run: |
           sudo curl -fsSL "https://github.com/ocaml/opam/releases/download/${OPAM_VERSION}/opam-${OPAM_VERSION}-x86_64-linux" \
             -o /usr/local/bin/opam
+          echo "${OPAM_SHA256}  /usr/local/bin/opam" | sha256sum -c -
           sudo chmod +x /usr/local/bin/opam
 
       - name: Cache opam root
@@ -103,6 +105,7 @@ jobs:
         run: |
           sudo curl -fsSL "https://github.com/ocaml/opam/releases/download/${OPAM_VERSION}/opam-${OPAM_VERSION}-x86_64-linux" \
             -o /usr/local/bin/opam
+          echo "${OPAM_SHA256}  /usr/local/bin/opam" | sha256sum -c -
           sudo chmod +x /usr/local/bin/opam
 
       - name: Cache opam root
@@ -150,6 +153,7 @@ jobs:
         run: |
           sudo curl -fsSL "https://github.com/ocaml/opam/releases/download/${OPAM_VERSION}/opam-${OPAM_VERSION}-x86_64-linux" \
             -o /usr/local/bin/opam
+          echo "${OPAM_SHA256}  /usr/local/bin/opam" | sha256sum -c -
           sudo chmod +x /usr/local/bin/opam
 
       - name: Cache opam root (fmt)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
           path: _opam
           key: opam-macos-14-ocaml-5.4.0-${{ hashFiles('*.opam') }}
 
-      - uses: ocaml/setup-ocaml@dec6499fef64fc5d7ed43d43a87251b7b1c306f5 # v3
+      - uses: ocaml/setup-ocaml@fefd9c240b9d934d5d25aa9c2a8caae6c7b40079 # v3
         if: steps.cache-opam.outputs.cache-hit != 'true'
         with:
           ocaml-compiler: '5.4.0'

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -506,6 +506,56 @@ let ensure_worktree ~runtime ~process_mgr ~fs ~repo_root ~project_name ~patch_id
               (Printf.sprintf "Worktree still missing at %s" path);
             None)
 
+(** Execute a [Worktree_plan.t] against the live filesystem. The plan is built
+    purely (see [Worktree_plan.for_rebase] / [for_merge_conflict]); this
+    function is the single place that turns its ops into git invocations.
+
+    Short-circuits on the first failing op:
+    - [Ensure_worktree] failure →
+      [Worktree.Error "<label> failed: worktree missing"]
+    - [Fetch_origin] error → [Worktree.Error "fetch before rebase failed: ..."]
+      (this exact prefix matches the historical log/event format)
+    - [Rebase_onto] returns its result verbatim; only [Worktree.Ok] continues.
+
+    Returns the final result paired with the worktree path so callers can use it
+    for follow-on effects like [Worktree.force_push_with_lease]. *)
+let execute_worktree_plan ~runtime ~process_mgr ~fs ~repo_root ~project_name
+    ~patch_id ~(agent : Patch_agent.t) ~user_config ~worktree_mutex ~fetch_lock
+    ~fail_label (plan : Worktree_plan.t) =
+  let default_path = Worktree.worktree_dir ~project_name ~patch_id in
+  let rec loop ~path = function
+    | [] -> (Worktree.Ok, path)
+    | Worktree_plan.Ensure_worktree :: rest -> (
+        match
+          ensure_worktree ~runtime ~process_mgr ~fs ~repo_root ~project_name
+            ~patch_id ~agent ~user_config ~worktree_mutex ()
+        with
+        | Some p -> loop ~path:p rest
+        | None ->
+            log_event runtime ~patch_id
+              (Printf.sprintf
+                 "Cannot %s — worktree missing and could not be created"
+                 fail_label);
+            ( Worktree.Error
+                (Printf.sprintf "%s failed: worktree missing" fail_label),
+              path ))
+    | Worktree_plan.Fetch_origin :: rest -> (
+        match Worktree.fetch_origin ~fetch_lock ~process_mgr ~path with
+        | Result.Ok () -> loop ~path rest
+        | Result.Error msg ->
+            log_event runtime ~patch_id
+              (Printf.sprintf "Fetch failed before %s — %s" fail_label msg);
+            ( Worktree.Error
+                (Printf.sprintf "fetch before rebase failed: %s" msg),
+              path ))
+    | Worktree_plan.Rebase_onto target :: rest -> (
+        match Worktree.rebase_onto ~process_mgr ~path ~target with
+        | Worktree.Ok -> loop ~path rest
+        | (Worktree.Noop | Worktree.Conflict | Worktree.Error _) as r ->
+            (r, path))
+  in
+  loop ~path:default_path plan
+
 let truncate s n = if String.length s <= n then s else String.sub s 0 n ^ "..."
 
 let run_claude_and_handle ~runtime ~process_mgr ~fs ~project_name ~patch_id
@@ -2318,34 +2368,12 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                             Orchestrator.agent snap.Runtime.orchestrator
                               patch_id)
                       in
-                      let wt_path =
-                        match agent.Patch_agent.worktree_path with
-                        | Some p -> p
-                        | None -> Worktree.worktree_dir ~project_name ~patch_id
-                      in
-                      (* Fetch fresh remote refs before rebasing.
-                         Fail closed: if fetch fails, don't rebase against
-                         stale refs. *)
-                      let rebase_result =
-                        match
-                          Worktree.fetch_origin ~fetch_lock:fetch_mutex
-                            ~process_mgr ~path:wt_path
-                        with
-                        | Result.Ok () ->
-                            let remote_target =
-                              Types.Branch.of_string
-                                (Printf.sprintf "origin/%s"
-                                   (Branch.to_string new_base))
-                            in
-                            Worktree.rebase_onto ~process_mgr ~path:wt_path
-                              ~target:remote_target
-                        | Result.Error msg ->
-                            log_event runtime ~patch_id
-                              (Printf.sprintf "Fetch failed before rebase — %s"
-                                 msg);
-                            Worktree.Error
-                              (Printf.sprintf "fetch before rebase failed: %s"
-                                 msg)
+                      let rebase_result, wt_path =
+                        execute_worktree_plan ~runtime ~process_mgr ~fs
+                          ~repo_root:config.repo_root ~project_name ~patch_id
+                          ~agent ~user_config:config.user_config ~worktree_mutex
+                          ~fetch_lock:fetch_mutex ~fail_label:"rebase"
+                          (Worktree_plan.for_rebase ~new_base)
                       in
                       (match rebase_result with
                       | Worktree.Ok ->
@@ -2512,8 +2540,15 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                 let base_changed_prefix =
                                   render_base_changed_prefix base_change
                                 in
+                                let wt_path_opt =
+                                  ensure_worktree ~runtime ~process_mgr ~fs
+                                    ~repo_root:config.repo_root ~project_name
+                                    ~patch_id ~agent
+                                    ~user_config:config.user_config
+                                    ~worktree_mutex ()
+                                in
                                 let wt_path =
-                                  match agent.Patch_agent.worktree_path with
+                                  match wt_path_opt with
                                   | Some p -> p
                                   | None ->
                                       Worktree.worktree_dir ~project_name
@@ -2588,34 +2623,22 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                      already in progress";
                                   deliver_to_agent ())
                                 else
-                                  (* Fetch fresh remote refs so rebase_onto
-                                     sees the latest origin/<base>, not a
-                                     stale local tracking ref. Fail closed:
-                                     if fetch fails, don't rebase against
-                                     stale refs. *)
-                                  let rebase_result =
-                                    match
-                                      Worktree.fetch_origin
-                                        ~fetch_lock:fetch_mutex ~process_mgr
-                                        ~path:wt_path
-                                    with
-                                    | Result.Ok () ->
-                                        let target =
-                                          Types.Branch.of_string
-                                            (Printf.sprintf "origin/%s" base)
-                                        in
-                                        Worktree.rebase_onto ~process_mgr
-                                          ~path:wt_path ~target
-                                    | Result.Error msg ->
-                                        log_event runtime ~patch_id
-                                          (Printf.sprintf
-                                             "Fetch failed before \
-                                              merge-conflict rebase — %s"
-                                             msg);
-                                        Worktree.Error
-                                          (Printf.sprintf
-                                             "fetch before rebase failed: %s"
-                                             msg)
+                                  (* Plan-driven: the planner guarantees
+                                     Ensure_worktree precedes Fetch_origin
+                                     and Rebase_onto. The executor short-
+                                     circuits on the first failure. Plans
+                                     target origin/<base> so we rebase
+                                     against fresh refs, not the stale
+                                     local tracking ref. *)
+                                  let rebase_result, _wt_path =
+                                    execute_worktree_plan ~runtime ~process_mgr
+                                      ~fs ~repo_root:config.repo_root
+                                      ~project_name ~patch_id ~agent
+                                      ~user_config:config.user_config
+                                      ~worktree_mutex ~fetch_lock:fetch_mutex
+                                      ~fail_label:"merge-conflict rebase"
+                                      (Worktree_plan.for_merge_conflict
+                                         ~base:(Types.Branch.of_string base))
                                   in
                                   (match rebase_result with
                                   | Worktree.Ok ->

--- a/lib/worktree_plan.ml
+++ b/lib/worktree_plan.ml
@@ -1,0 +1,24 @@
+open Base
+
+type op = Ensure_worktree | Fetch_origin | Rebase_onto of Types.Branch.t
+[@@deriving show, eq, sexp_of, compare]
+
+type t = op list [@@deriving show, eq, sexp_of, compare]
+
+let origin_of branch =
+  Types.Branch.of_string
+    (Printf.sprintf "origin/%s" (Types.Branch.to_string branch))
+
+let for_rebase ~new_base =
+  [ Ensure_worktree; Fetch_origin; Rebase_onto (origin_of new_base) ]
+
+let for_merge_conflict ~base =
+  [ Ensure_worktree; Fetch_origin; Rebase_onto (origin_of base) ]
+
+let ensures_worktree_before_fs (plan : t) =
+  let rec loop ensured = function
+    | [] -> true
+    | Ensure_worktree :: rest -> loop true rest
+    | (Fetch_origin | Rebase_onto _) :: rest -> ensured && loop ensured rest
+  in
+  loop false plan

--- a/lib/worktree_plan.mli
+++ b/lib/worktree_plan.mli
@@ -1,0 +1,36 @@
+(** Pure plans for sequences of worktree operations.
+
+    Every plan is a list of {!op}. The fundamental safety invariant — enforced
+    by {!ensures_worktree_before_fs} and verified by property tests in
+    [test_worktree_plan.ml] — is that any filesystem operation that runs inside
+    a worktree directory must be preceded by [Ensure_worktree] in the same plan.
+    This is what was violated by the bug in patch 48: a [Fetch_origin] ran in a
+    directory that had never been created.
+
+    The runner that executes plans lives in the binary (it needs Eio
+    capabilities), but the data is here so it can be inspected and
+    property-tested without I/O. *)
+
+type op =
+  | Ensure_worktree
+      (** Materialize the worktree on disk if missing. Must precede any
+          subsequent op in the plan. *)
+  | Fetch_origin  (** [git fetch origin] inside the worktree. *)
+  | Rebase_onto of Types.Branch.t
+      (** [git rebase --onto <branch>] inside the worktree. The branch is
+          typically [origin/<base>]. *)
+[@@deriving show, eq, sexp_of, compare]
+
+type t = op list [@@deriving show, eq, sexp_of, compare]
+
+val for_rebase : new_base:Types.Branch.t -> t
+(** Plan for [Orchestrator.Rebase]: ensure the worktree, fetch fresh refs, then
+    rebase onto [origin/<new_base>]. *)
+
+val for_merge_conflict : base:Types.Branch.t -> t
+(** Plan for the merge-conflict resolution path (post rebase-in-progress check):
+    ensure the worktree, fetch, then rebase onto [origin/<base>]. *)
+
+val ensures_worktree_before_fs : t -> bool
+(** Returns [true] iff every [Fetch_origin] / [Rebase_onto] is preceded by an
+    [Ensure_worktree] in the plan. The safety invariant. *)

--- a/test/dune
+++ b/test/dune
@@ -59,6 +59,10 @@
  (libraries onton qcheck-core))
 
 (test
+ (name test_worktree_plan)
+ (libraries onton qcheck-core))
+
+(test
  (name test_spawn_logic)
  (libraries onton onton_test_support qcheck-core))
 

--- a/test/test_worktree_plan.ml
+++ b/test/test_worktree_plan.ml
@@ -1,0 +1,104 @@
+open Base
+open Onton.Types
+open Onton.Worktree_plan
+
+(* Generators *)
+
+let gen_branch =
+  QCheck2.Gen.(
+    map Branch.of_string
+      (string_size ~gen:(char_range 'a' 'z') (int_range 1 20)))
+
+let gen_op : op QCheck2.Gen.t =
+  QCheck2.Gen.oneof
+    [
+      QCheck2.Gen.return Ensure_worktree;
+      QCheck2.Gen.return Fetch_origin;
+      QCheck2.Gen.map (fun b -> Rebase_onto b) gen_branch;
+    ]
+
+let gen_plan = QCheck2.Gen.list_size (QCheck2.Gen.int_range 0 8) gen_op
+
+(* Reference predicate, written independently of the implementation: every
+   filesystem op (Fetch_origin / Rebase_onto) must have an Ensure_worktree
+   somewhere earlier in the list. *)
+let reference_invariant (plan : t) =
+  let rec loop ensured = function
+    | [] -> true
+    | Ensure_worktree :: rest -> loop true rest
+    | Fetch_origin :: rest -> ensured && loop ensured rest
+    | Rebase_onto _ :: rest -> ensured && loop ensured rest
+  in
+  loop false plan
+
+let () =
+  let open QCheck2 in
+  let tests =
+    [
+      (* The safety invariant: any plan returned by [for_rebase] satisfies
+         [ensures_worktree_before_fs]. This is the property the patch-48
+         bug would have failed. *)
+      Test.make ~name:"for_rebase: ensures worktree before any fs op" gen_branch
+        (fun new_base -> ensures_worktree_before_fs (for_rebase ~new_base));
+      Test.make ~name:"for_merge_conflict: ensures worktree before any fs op"
+        gen_branch (fun base ->
+          ensures_worktree_before_fs (for_merge_conflict ~base));
+      (* Stronger: the very first op of these scenarios is Ensure_worktree.
+         Catches regressions where someone reorders or prepends. *)
+      Test.make ~name:"for_rebase: first op is Ensure_worktree" gen_branch
+        (fun new_base ->
+          match for_rebase ~new_base with
+          | Ensure_worktree :: _ -> true
+          | (Fetch_origin | Rebase_onto _) :: _ | [] -> false);
+      Test.make ~name:"for_merge_conflict: first op is Ensure_worktree"
+        gen_branch (fun base ->
+          match for_merge_conflict ~base with
+          | Ensure_worktree :: _ -> true
+          | (Fetch_origin | Rebase_onto _) :: _ | [] -> false);
+      (* Plans target origin/<base> rather than the local tracking ref —
+         this is the "fail closed against stale local refs" requirement
+         from the comments at the original bin/main.ml call sites. *)
+      Test.make ~name:"for_rebase: rebase target is origin/<new_base>"
+        gen_branch (fun new_base ->
+          let target =
+            Branch.of_string ("origin/" ^ Branch.to_string new_base)
+          in
+          List.exists (for_rebase ~new_base) ~f:(function
+            | Rebase_onto t -> Branch.equal t target
+            | Ensure_worktree | Fetch_origin -> false));
+      Test.make ~name:"for_merge_conflict: rebase target is origin/<base>"
+        gen_branch (fun base ->
+          let target = Branch.of_string ("origin/" ^ Branch.to_string base) in
+          List.exists (for_merge_conflict ~base) ~f:(function
+            | Rebase_onto t -> Branch.equal t target
+            | Ensure_worktree | Fetch_origin -> false));
+      (* ensures_worktree_before_fs agrees with the independently-written
+         reference predicate over arbitrary plans, including malformed ones
+         (so we know the predicate itself is right, not just the planners). *)
+      Test.make ~name:"ensures_worktree_before_fs: agrees with reference"
+        gen_plan (fun plan ->
+          Bool.equal
+            (ensures_worktree_before_fs plan)
+            (reference_invariant plan));
+      (* Negative cases: a plan that does fs work without Ensure_worktree
+         must be rejected. This is what would have caught patch 48's bug
+         had the planner produced such a sequence. *)
+      Test.make ~name:"ensures_worktree_before_fs: [Fetch_origin] is rejected"
+        Gen.unit (fun () -> not (ensures_worktree_before_fs [ Fetch_origin ]));
+      Test.make ~name:"ensures_worktree_before_fs: [Rebase_onto] is rejected"
+        gen_branch (fun b -> not (ensures_worktree_before_fs [ Rebase_onto b ]));
+      Test.make
+        ~name:
+          "ensures_worktree_before_fs: Fetch before Ensure (wrong order) is \
+           rejected"
+        Gen.unit (fun () ->
+          not (ensures_worktree_before_fs [ Fetch_origin; Ensure_worktree ]));
+      Test.make ~name:"ensures_worktree_before_fs: empty plan is accepted"
+        Gen.unit (fun () -> ensures_worktree_before_fs []);
+      Test.make
+        ~name:"ensures_worktree_before_fs: lone Ensure_worktree is accepted"
+        Gen.unit (fun () -> ensures_worktree_before_fs [ Ensure_worktree ]);
+    ]
+  in
+  List.iter tests ~f:(fun t -> QCheck2.Test.check_exn t);
+  Stdlib.print_endline "all worktree_plan tests passed"


### PR DESCRIPTION
## Summary

- Patch 48 hit `fatal: cannot change to '.../patch-48': No such file or directory` because the `Rebase` and `Merge_conflict` handlers in `bin/main.ml` called `Worktree.fetch_origin` without first calling `ensure_worktree`. Fix in #184 (just merged) plugged the immediate hole; this PR moves the invariant out of the imperative call sites and into a property-tested data structure.
- New `lib/worktree_plan` exposes pure ops (`Ensure_worktree | Fetch_origin | Rebase_onto`), planners (`for_rebase`, `for_merge_conflict`), and the `ensures_worktree_before_fs` predicate.
- `bin/main.ml` gains a single `execute_worktree_plan` interpreter — now the only site that turns plan ops into git invocations. Both former inline blocks become one-line `execute_worktree_plan ... (Worktree_plan.for_… ~base)` calls. The historical `"fetch before rebase failed: …"` error format is preserved.

## Why a plan, not just a function

The pre-existing `Orchestrator.rebase_effect = Push_branch` already follows the "side effects emitted as data so property tests can assert on effect presence" pattern. This PR extends the same treatment upstream: instead of relying on whoever-wrote-the-handler to remember to call `ensure_worktree` before any fs op, the safety invariant is a predicate on the plan's structure that gets exercised on every QCheck2 run.

## Test plan

- [x] `dune build` clean
- [x] `dune runtest` clean (incl. new `test_worktree_plan` — property tests on both planners, agreement of `ensures_worktree_before_fs` with an independently-written reference predicate, negative cases for missing / reordered Ensure)
- [x] `dune fmt` clean
- [x] pre-commit hook (build + test + format) passed on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Decomposed worktree fetch/rebase into a pure plan with a single executor to enforce “ensure worktree before any fs op” and preserve historical error messages. Replaced inline logic in rebase and merge-conflict flows.

- **Refactors**
  - Added `lib/worktree_plan` with ops (`Ensure_worktree`, `Fetch_origin`, `Rebase_onto`), planners (`for_rebase`, `for_merge_conflict`), and `ensures_worktree_before_fs`.
  - Introduced `execute_worktree_plan` to run plans, short-circuit on failure, and keep "fetch before rebase failed: ..." messaging; used in both handlers.
  - CI: release workflow reverts to pinned `ocaml/setup-ocaml@v3` for simpler setup and built-in caching.

- **Tests**
  - Added `test_worktree_plan` with property tests for the safety invariant, `origin/<base>` targets, agreement with a reference predicate, and negative cases.

<sup>Written for commit ddacdd6690b2b36c4b8d65e41e40c3f9fa2a0e70. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a planning layer and executor for worktree operations to drive rebase and merge-conflict flows reliably.

* **Refactor**
  * Consolidated duplicated worktree validation, ref fetch, and rebase control flow; standardized error messages and sequencing.

* **Tests**
  * Added property-based tests and a new test executable validating planning invariants and operation ordering.

* **Chores**
  * Updated CI workflows and formatting job setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->