### PR TITLE
Fix worktree mutex poisoning cascade

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -468,7 +468,7 @@ let ensure_worktree ~runtime ~process_mgr ~fs ~repo_root ~project_name ~patch_id
           log_event runtime ~patch_id
             (Printf.sprintf "Creating worktree at %s" path);
           (match
-             Eio.Mutex.use_rw ~protect:true worktree_mutex (fun () ->
+             Eio.Mutex.use_ro worktree_mutex (fun () ->
                  ignore
                    (Worktree.create ~process_mgr ~repo_root ~project_name
                       ~patch_id ~branch:br ~base_ref:base))


### PR DESCRIPTION
## Summary
- Replace `Eio.Mutex.use_rw ~protect:true` with `Eio.Mutex.use_ro` on the `worktree_mutex` in `bin/main.ml`
- Prevents a single worktree creation failure from permanently poisoning the mutex and blocking all other patches
- Same fix pattern as 1400f73 (which fixed the identical issue on `fetch_lock`)

Fixes #185

## Test plan
- [x] `dune build` passes
- [x] `dune runtest` passes
- [ ] Verify in a live run that a failed worktree creation no longer cascades `Poisoned(_)` to other patches

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch `worktree_mutex` to `Eio.Mutex.use_ro` to avoid poisoning when worktree creation fails. This prevents one failure from blocking other patches.

- **Bug Fixes**
  - Replace `Eio.Mutex.use_rw ~protect:true` with `Eio.Mutex.use_ro` so exceptions release the lock instead of poisoning it; mirrors the earlier `fetch_lock` fix. Fixes #185.

<sup>Written for commit 78053631c54237782acb66b0e0fefa202b744d38. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal concurrency handling during worktree creation for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->