### PR TITLE
Show 'o:open browser' hint and allow opening PR from list view

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1461,9 +1461,25 @@ let input_fiber ~runtime ~process_mgr ~net ~github ~list_selected ~detail_scroll
           | Term.Key.Char 'o'
             when match !view_mode with
                  | Tui.Detail_view _ -> true
-                 | Tui.List_view | Tui.Timeline_view -> false ->
-              (match !view_mode with
-              | Tui.Detail_view patch_id -> (
+                 | Tui.List_view ->
+                     let pids = !sorted_patch_ids in
+                     let count = Base.List.length pids in
+                     count > 0 && !list_selected >= 0
+                 | Tui.Timeline_view -> false ->
+              let target_patch_id =
+                match !view_mode with
+                | Tui.Detail_view patch_id -> Some patch_id
+                | Tui.List_view ->
+                    let pids = !sorted_patch_ids in
+                    let count = Base.List.length pids in
+                    if count > 0 && !list_selected >= 0 then
+                      let idx = Base.Int.min !list_selected (count - 1) in
+                      Some (Base.List.nth_exn pids idx)
+                    else None
+                | Tui.Timeline_view -> None
+              in
+              (match target_patch_id with
+              | Some patch_id -> (
                   match Pr_registry.find pr_registry ~patch_id with
                   | Some pr_number -> (
                       let url =
@@ -1503,7 +1519,7 @@ let input_fiber ~runtime ~process_mgr ~net ~github ~list_selected ~detail_scroll
                             text = "No PR to open";
                             expires_at = None;
                           })
-              | Tui.List_view | Tui.Timeline_view -> ());
+              | None -> ());
               loop ()
           | Term.Key.Char 'm'
             when match !view_mode with

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1461,21 +1461,12 @@ let input_fiber ~runtime ~process_mgr ~net ~github ~list_selected ~detail_scroll
           | Term.Key.Char 'o'
             when match !view_mode with
                  | Tui.Detail_view _ -> true
-                 | Tui.List_view ->
-                     let pids = !sorted_patch_ids in
-                     let count = Base.List.length pids in
-                     count > 0 && !list_selected >= 0
+                 | Tui.List_view -> Option.is_some (selected_pid ())
                  | Tui.Timeline_view -> false ->
               let target_patch_id =
                 match !view_mode with
                 | Tui.Detail_view patch_id -> Some patch_id
-                | Tui.List_view ->
-                    let pids = !sorted_patch_ids in
-                    let count = Base.List.length pids in
-                    if count > 0 && !list_selected >= 0 then
-                      let idx = Base.Int.min !list_selected (count - 1) in
-                      Some (Base.List.nth_exn pids idx)
-                    else None
+                | Tui.List_view -> selected_pid ()
                 | Tui.Timeline_view -> None
               in
               (match target_patch_id with

--- a/lib/tui.ml
+++ b/lib/tui.ml
@@ -1068,11 +1068,11 @@ let render_footer ~width ~view_mode ?prompt_line () =
         | List_view ->
             Term.styled [ Term.Sgr.dim ]
               " q:quit  ↑/↓:navigate  enter:detail  +:add PR  w:worktree  \
-               -:remove  h:help"
+               -:remove  o:open browser  h:help"
         | Detail_view _ ->
             Term.styled [ Term.Sgr.dim ]
-              " q:quit  esc/backspace:back  enter:message  m:manage  \
-               t:timeline  h:help"
+              " q:quit  esc/backspace:back  enter:message  m:manage  o:open \
+               browser  t:timeline  h:help"
         | Timeline_view ->
             Term.styled [ Term.Sgr.dim ]
               " q:quit  esc/backspace:back  ↑/↓:scroll  t:list  h:help"
@@ -1103,6 +1103,7 @@ let render_help_overlay ~width ~height =
           "+         Add PR (enter number)";
           "w         Register worktree (enter path)";
           "-/x       Remove selected patch";
+          "o         Open PR in browser";
           "t         Toggle timeline";
           "q         Quit";
         ] );


### PR DESCRIPTION
## Summary
- Adds `o:open browser` to the list-view and detail-view footer hints and to the help overlay, so the "open PR in browser" behavior is discoverable.
- Extends the `o` handler so it works in the list view by resolving the currently selected patch, not just the detail view.

Fixes #174

## Test plan
- [ ] `dune build` succeeds
- [ ] `dune runtest` passes
- [ ] Launch `onton`, see `o:open browser` in the footer in both list and detail views
- [ ] Press `o` with a patch selected in the list view — browser opens to the corresponding PR
- [ ] Press `o` in the list view with no PR registered for that patch — status shows "No PR to open"
- [ ] `o` in the detail view still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make "open PR in browser" discoverable and usable from the list. Show "o:open browser" in list/detail footers and help; in the list, "o" uses `selected_pid ()` to open the selected patch’s PR or show "No PR to open" (fixes #174).

<sup>Written for commit 013c3ddc13a734bc00e73c7ef7bff7e5d39d65b9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The 'o' key now opens a selected patch's pull request in your browser from the list view.

* **Documentation**
  * Updated help text to include the 'o' keyboard shortcut for opening pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->