### PR TITLE
Drop /usr/bin/script PTY wrapper from Claude backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,6 @@ of these must be installed and configured before onton can run.
 | `git` | Worktree CRUD, branch detection, rebase | `brew install git` (or system package manager) |
 | `gh` (GitHub CLI) | Token resolution, PR discovery (`gh pr list`), and the main vehicle agents use to interact with GitHub (`gh pr create`, `gh pr edit`, `gh pr view`, `gh api`, `gh api graphql`) | `brew install gh`, then `gh auth login` |
 | Coding-agent CLI | Drives the actual patches. One of: `claude` ([Claude Code](https://docs.anthropic.com/en/docs/claude-code)), `codex` ([OpenAI Codex CLI](https://github.com/openai/codex)), `opencode`, `pi`. Selected via `--backend` (default `claude`) and must be on `PATH` | See each tool's docs |
-| `/usr/bin/script` | Used to allocate a pseudo-TTY around the Claude CLI so `-p` streaming works. Ships with macOS and most Linux distros — no install needed | — |
 
 Onton is built and tested on macOS (ARM64 and x86_64). Linux should work but is
 not part of the release pipeline.
@@ -304,11 +303,9 @@ gameplan.md ──> Gameplan_parser ──> Graph + Patches
 
 Claude is invoked via `-p` (prompt mode, not `--print`) which saves sessions,
 enabling `--continue` to resume the most recent session in a worktree. This
-enables session resumption across restarts.
-
-Since `-p` mode requires a TTY for streaming output, each Claude process is
-wrapped in `/usr/bin/script -q /dev/null` to allocate a pseudo-TTY. ANSI
-escapes from the PTY are stripped before JSON parsing.
+enables session resumption across restarts. Claude is spawned directly against
+pipes — no PTY wrapper — and any stray control characters in the stream are
+stripped defensively before JSON parsing.
 
 The session fallback chain: `--continue` (resume worktree session) -> fresh
 session (no `--continue`) -> give up (needs intervention). If `--continue`
@@ -356,7 +353,7 @@ waiting for running sessions to finish. Backpressure is provided by a
 | `opencode_backend` | OpenCode backend implementation |
 | `pi_backend` | Pi coding agent backend implementation |
 | `claude_process` | Claude CLI session state machine (No_session -> Has_session) |
-| `claude_runner` | Claude subprocess spawning with PTY wrapping, NDJSON streaming, ANSI stripping, `got_events` resume-failure detection |
+| `claude_runner` | Claude subprocess spawning, NDJSON streaming, defensive control-char stripping, `got_events` resume-failure detection |
 | `spawn_logic` | Pure spawn/scheduling logic: which patches to run next |
 | `orchestrator` | Durable patch state plus primitive transitions, including the patch-agent outbox |
 | `reconciler` | Pure merge detection, rebase cascading, stale base detection, liveness enforcement |

--- a/lib/claude_runner.ml
+++ b/lib/claude_runner.ml
@@ -221,11 +221,12 @@ let run ~process_mgr ~cwd ~patch_id ~prompt ~resume_session =
     let code = match status with `Exited c -> c | `Signaled s -> 128 + s in
     (out, err, code)
   in
+  let got_events = not (String.is_empty (String.strip stdout_content)) in
   {
     Llm_backend.exit_code;
     stdout = strip_ansi stdout_content;
     stderr = stderr_content;
-    got_events = true;
+    got_events;
     timed_out = false;
   }
 

--- a/lib/claude_runner.ml
+++ b/lib/claude_runner.ml
@@ -221,10 +221,11 @@ let run ~process_mgr ~cwd ~patch_id ~prompt ~resume_session =
     let code = match status with `Exited c -> c | `Signaled s -> 128 + s in
     (out, err, code)
   in
-  let got_events = not (String.is_empty (String.strip stdout_content)) in
+  let cleaned_stdout = strip_ansi stdout_content in
+  let got_events = not (String.is_empty (String.strip cleaned_stdout)) in
   {
     Llm_backend.exit_code;
-    stdout = strip_ansi stdout_content;
+    stdout = cleaned_stdout;
     stderr = stderr_content;
     got_events;
     timed_out = false;

--- a/lib/claude_runner.ml
+++ b/lib/claude_runner.ml
@@ -206,16 +206,34 @@ let run ~process_mgr ~cwd ~patch_id ~prompt ~resume_session =
       Eio.Process.spawn ~sw process_mgr ~cwd ~stdin:stdin_r ~stdout:stdout_w
         ~stderr:stderr_w args
     in
+    Eio.Switch.on_release sw (fun () ->
+        try Eio.Process.signal child Stdlib.Sys.sigterm with _ -> ());
     Eio.Flow.close stdin_r;
     Eio.Flow.close stdin_w;
     Eio.Flow.close stdout_w;
     Eio.Flow.close stderr_w;
     let stdout_buf = Eio.Buf_read.of_flow ~max_size:(1024 * 1024) stdout_r in
     let stderr_buf = Eio.Buf_read.of_flow ~max_size:(1024 * 1024) stderr_r in
+    let drain flow =
+      let buf = Bytes.create 4096 in
+      try
+        while true do
+          ignore (Eio.Flow.single_read flow (Cstruct.of_bytes buf))
+        done
+      with End_of_file -> ()
+    in
     let out, err =
       Eio.Fiber.pair
-        (fun () -> Eio.Buf_read.take_all stdout_buf)
-        (fun () -> Eio.Buf_read.take_all stderr_buf)
+        (fun () ->
+          try Eio.Buf_read.take_all stdout_buf
+          with Eio.Buf_read.Buffer_limit_exceeded ->
+            drain stdout_r;
+            "<stdout exceeded 1MB limit, truncated>")
+        (fun () ->
+          try Eio.Buf_read.take_all stderr_buf
+          with Eio.Buf_read.Buffer_limit_exceeded ->
+            drain stderr_r;
+            "<stderr exceeded 1MB limit, truncated>")
     in
     let status = Eio.Process.await child in
     let code = match status with `Exited c -> c | `Signaled s -> 128 + s in

--- a/lib/claude_runner.ml
+++ b/lib/claude_runner.ml
@@ -1,13 +1,13 @@
 open Base
 
 (** Compiled regex for ANSI escape sequences, carriage returns, and stray
-    control characters injected by the PTY wrapper ([script]). Matches:
+    control characters. Retained as defense-in-depth so any incidental control
+    bytes in Claude's stream-json output don't break JSON parsing. Matches:
     - CSI sequences (ESC\[ ... letter)
     - OSC sequences (ESC\] ... BEL/ST)
-    - Bare \r from PTY line endings
-    - C0 control characters (0x00–0x1F except \n and \t) such as ^D/BS that
-      [script] prepends to its first output line. Compiled once at module load.
-*)
+    - Bare \r
+    - C0 control characters (0x00–0x1F except \n and \t). Compiled once at
+      module load. *)
 let ansi_re =
   let esc = Re.char '\x1b' in
   let csi =
@@ -36,24 +36,8 @@ let ansi_re =
   in
   Re.compile (Re.alt [ csi; osc; cr; c0 ])
 
-(** Strip ANSI escape sequences injected by the PTY wrapper. *)
+(** Strip ANSI escape sequences and stray control characters. *)
 let strip_ansi s = Re.replace_string ansi_re ~by:"" s
-
-(** Detect Linux (vs macOS) by the presence of [/proc/version]. *)
-let is_linux = Stdlib.Sys.file_exists "/proc/version"
-
-(** Wrap a command in a pseudo-TTY via [script].
-
-    Claude CLI requires a TTY to produce stream-json output when not in
-    [--print] mode. On macOS we use [script -q /dev/null <cmd> <args...>]. On
-    Linux the syntax is [script -qc "<cmd>" /dev/null]. *)
-let pty_wrap args =
-  if is_linux then
-    let cmd =
-      List.map args ~f:Stdlib.Filename.quote |> String.concat ~sep:" "
-    in
-    [ "/usr/bin/script"; "-qc"; cmd; "/dev/null" ]
-  else "/usr/bin/script" :: "-q" :: "/dev/null" :: args
 
 let build_args ~prompt ~resume_session =
   let base = [ "claude"; "-p"; prompt; "--output-format"; "text" ] in
@@ -73,9 +57,8 @@ let build_stream_args ~prompt ~resume_session =
   let flags = [ "--dangerously-skip-permissions"; "--max-turns"; "200" ] in
   base @ session_args @ flags
 
-(** Find the first '\{' in [s] and return the substring starting there. The PTY
-    wrapper ([script]) can prepend junk (e.g. literal "^D" + backspaces) before
-    the JSON object, which would cause [from_string] to fail. *)
+(** Find the first '\{' in [s] and return the substring starting there. Defense
+    against any leading garbage in a stream-json line. *)
 let find_json_start s =
   match String.lfindi s ~f:(fun _ c -> Char.equal c '{') with
   | Some 0 | None -> s
@@ -153,8 +136,7 @@ let parse_stream_events (line : string) : Types.Stream_event.t list =
             |> Option.value ~default:false
           in
           (* The result event also carries session_id — extract it as a
-             fallback in case the system/init event was lost (e.g. PTY
-             wrapper mangling the first line of output). *)
+             fallback in case the system/init event was lost. *)
           let session_init =
             match member "session_id" json |> to_string_option with
             | Some sid ->
@@ -214,7 +196,7 @@ let parse_stream_event (line : string) : Types.Stream_event.t option =
 
 let run ~process_mgr ~cwd ~patch_id ~prompt ~resume_session =
   ignore (patch_id : Types.Patch_id.t);
-  let args = pty_wrap (build_args ~prompt ~resume_session) in
+  let args = build_args ~prompt ~resume_session in
   let stdout_content, stderr_content, exit_code =
     Eio.Switch.run @@ fun sw ->
     let stdin_r, stdin_w = Eio.Process.pipe ~sw process_mgr in
@@ -250,7 +232,7 @@ let run ~process_mgr ~cwd ~patch_id ~prompt ~resume_session =
 let run_streaming ~process_mgr ~clock ~timeout ~cwd ~patch_id ~prompt
     ~resume_session ~on_event =
   ignore (patch_id : Types.Patch_id.t);
-  let args = pty_wrap (build_stream_args ~prompt ~resume_session) in
+  let args = build_stream_args ~prompt ~resume_session in
   let process_line line =
     let trimmed = strip_ansi (String.strip line) in
     if String.is_empty trimmed then [] else parse_stream_events trimmed
@@ -328,20 +310,11 @@ let%test "strip_ansi removes escape sequences" =
 let%test "strip_ansi passes clean text through" =
   String.equal (strip_ansi "hello world") "hello world"
 
-let%test "strip_ansi removes backspaces from PTY wrapper" =
+let%test "strip_ansi removes backspaces" =
   String.equal (strip_ansi "\x08\x08hello") "hello"
 
 let%test "strip_ansi removes NUL and other C0 chars" =
   String.equal (strip_ansi "\x04\x00\x01hello") "hello"
-
-let%test "pty_wrap prepends script command" =
-  let args = pty_wrap [ "claude"; "-p"; "hello" ] in
-  if is_linux then
-    List.equal String.equal args
-      [ "/usr/bin/script"; "-qc"; "'claude' '-p' 'hello'"; "/dev/null" ]
-  else
-    List.equal String.equal args
-      [ "/usr/bin/script"; "-q"; "/dev/null"; "claude"; "-p"; "hello" ]
 
 let%test "parse_stream_event text_delta" =
   let line =
@@ -407,9 +380,8 @@ let%test "parse_stream_events ignores system/init without session_id" =
   let line = {|{"type":"system","subtype":"init"}|} in
   List.is_empty (parse_stream_events line)
 
-let%test "parse_stream_events extracts session_id from PTY-mangled system/init"
-    =
-  (* script(1) on macOS prepends ^D + backspaces before the JSON *)
+let%test "parse_stream_events tolerates leading garbage before JSON" =
+  (* Defense-in-depth: find_json_start skips any non-'{' prefix. *)
   let line =
     "^D\x08\x08{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"abc-123\",\"tools\":[]}"
   in

--- a/lib/claude_runner.mli
+++ b/lib/claude_runner.mli
@@ -6,10 +6,10 @@ open Base
     one Claude process (one fiber). The runner uses [--resume <session_id>] to
     resume a specific session by its ID.
 
-    Unlike [--print] mode, we use [-p] which runs Claude in session-saving mode.
-    This requires a PTY (allocated via [script -q /dev/null]) but enables
-    session persistence. The session ID is captured from the [system/init]
-    streaming event and stored for subsequent [--resume] calls.
+    Unlike [--print] mode, we use [-p] which runs Claude in session-saving mode
+    so [--resume <session_id>] can rehydrate a prior turn. The session ID is
+    captured from the [system/init] streaming event and stored for subsequent
+    [--resume] calls.
 
     Design decision: one fiber per Claude process for natural backpressure —
     busy patches don't get new work. *)
@@ -53,11 +53,8 @@ val parse_stream_event : string -> Types.Stream_event.t option
 *)
 
 val strip_ansi : string -> string
-(** Strip ANSI escape sequences from PTY output. Exposed for testing. *)
-
-val pty_wrap : string list -> string list
-(** Wrap a command in [script -q /dev/null] for PTY allocation. Exposed for
-    testing. *)
+(** Strip ANSI escape sequences and stray control characters from a line.
+    Exposed for testing. *)
 
 val build_args : prompt:string -> resume_session:string option -> string list
 (** Build the CLI argument list for the Claude process. Exposed for testing. *)

--- a/lib/claude_runner.mli
+++ b/lib/claude_runner.mli
@@ -27,7 +27,12 @@ val run :
     [--resume <id>]. Otherwise a new session is created.
 
     Returns a {!Llm_backend.result} with exit code and captured stdout/stderr.
-*)
+
+    {b Warning: no timeout.} This function blocks until the child exits or its
+    enclosing switch is cancelled. There is no internal deadline, so callers
+    must impose their own bound (e.g. wrap in {!Eio.Time.with_timeout} or run
+    inside a switch they will release on a timer). The streaming counterpart
+    {!run_streaming} carries [~clock] and [~timeout] for this purpose. *)
 
 val run_streaming :
   process_mgr:_ Eio.Process.mgr ->


### PR DESCRIPTION
## Summary
- Spawn `claude -p` directly against pipes instead of wrapping it in `/usr/bin/script`. claude-code 2.1.112 saves sessions and accepts `--resume <id>` without a TTY, so the PTY dance is no longer load-bearing.
- Removes the structural hang where `Eio.Process.await` on the `script` wrapper would block indefinitely whenever a pre-commit subprocess or MCP server inherited the PTY and outlived `claude` itself — leaving the runner fiber stuck with `busy=true` and no log output.
- `strip_ansi` and `find_json_start` remain as defense-in-depth against stray control bytes; docstrings and tests are retargeted off the PTY framing.

## Context
Observed in the wild on a `retrieval-quality-eval` run: patch 2's Claude session emitted its final `result`, committed locally, then sat silent for 20 minutes with no runner logs until the TUI was quit — producing the force-complete path that skipped the supervisor push. Root cause traced to `/usr/bin/script` not exiting because a descendant process (biome pre-commit helper or MCP server) was still holding the pty. Confirmed empirically that non-PTY invocation of `claude -p … --output-format stream-json --verbose` now produces a clean session_id that resumes successfully.

Reverses the decision from 7aa299a, which was correct at the time of that Claude CLI version.

## Test plan
- [x] `dune build` clean
- [x] `dune runtest` — all inline, property, convergence, and backend-smoke suites pass
- [x] Manual: `claude -p 'say hi' --output-format stream-json --verbose --dangerously-skip-permissions --max-turns 1 < /dev/null` — exits 0, clean JSON, session persists
- [x] Manual: `--resume <id>` on the above session rehydrates prior context and exits cleanly
- [ ] Exercise against a real gameplan on macOS before merging
- [ ] Smoke test on Linux before trusting behavior there (untested in this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run `claude -p` directly over pipes and remove the `/usr/bin/script` PTY wrapper to prevent runner hangs and drop a system dependency. Non‑stream runs now compute `got_events` from sanitized stdout and are hardened against cancellation and oversized output; docs note that `claude_runner.run` has no internal timeout.

- **Bug Fixes**
  - Fixed a hang where the runner stayed busy with no logs because `script` waited for PTY descendants; the process now exits when `claude` exits.
  - Hardened non‑stream runs: derive `got_events` from ANSI‑stripped stdout, SIGTERM the child on cancellation/timeouts, and truncate+drain oversized stdout/stderr to avoid pipe‑block hangs.

- **Refactors**
  - Removed PTY wrapping; `claude_runner` now builds args and spawns `claude` directly.
  - Kept `strip_ansi` and `find_json_start` for defense; updated README and the public interface to drop the PTY requirement.
  - Documented that `claude_runner.run` has no built‑in timeout; callers must bound it.

<sup>Written for commit 8f8800b43e8983ab3737f29323fd54ec729defd0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Claude sessions now spawn directly over pipes (no PTY wrapper); removed `/usr/bin/script` runtime dependency
  * Improved output sanitization to defensively remove stray control characters before JSON parsing

* **Documentation**
  * Updated session management docs to describe direct spawning and the stricter control-character stripping behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->