### PR TITLE
Add per-patch automerge with 5-minute idle timer

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1228,9 +1228,9 @@ let input_fiber ~runtime ~process_mgr ~net ~github ~list_selected ~detail_scroll
                     log_event runtime ~patch_id "Force-marked as merged")
               | Tui.List_view | Tui.Timeline_view -> ())
           | Term.Key.Char 'a' -> (
-              input_mode := Tui_input.Normal;
               match !view_mode with
               | Tui.Detail_view patch_id -> (
+                  input_mode := Tui_input.Normal;
                   let enabled_after =
                     Runtime.update_orchestrator_returning runtime (fun orch ->
                         match Orchestrator.find_agent orch patch_id with
@@ -3150,13 +3150,16 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
               (Printf.sprintf "automerge fiber error — %s"
                  (Printexc.to_string exn)));
         (* [Eio.Time.sleep] is the only yield point outside the guard above.
-           If the switch is being torn down it raises [Eio.Cancel.Cancelled],
-           which propagates out of [amloop] and exits the [fork_daemon]
-           callback. Cancellation is the expected teardown path for daemon
-           fibers — Eio does not treat it as a fiber failure — so no
-           additional catch is needed here. *)
-        Eio.Time.sleep clock 1.0;
-        amloop ()
+           On switch teardown it raises [Cancelled]; catching it here and
+           returning [`Stop_daemon] gives the [fork_daemon] contract a clean
+           voluntary-exit signal (matching the other [fork_daemon] callers
+           in this file) rather than exiting by exception. *)
+        match
+          try Ok (Eio.Time.sleep clock 1.0)
+          with Eio.Cancel.Cancelled _ -> Error `Cancelled
+        with
+        | Error `Cancelled -> `Stop_daemon
+        | Ok () -> amloop ()
       in
       amloop ());
   loop sw

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -283,8 +283,10 @@ let log_event runtime ?patch_id msg =
 
 (** Reconcile per-patch automerge deadlines. For each deadline that has elapsed,
     merge the PR on GitHub and mark the patch merged on success. On failure the
-    deadline is left in place; the next tick will either re-fire (if still a
-    candidate) or clear it (if feedback arrived). *)
+    failure counter is incremented and the deadline cleared; the next tick will
+    re-arm a fresh 5-minute window and retry until the consecutive failure cap
+    is reached, at which point reconciliation stops issuing merge calls until
+    the user toggles automerge off/on. *)
 let reconcile_and_execute_automerge ~runtime ~net ~github =
   let now = Unix.gettimeofday () in
   let decisions =
@@ -299,22 +301,75 @@ let reconcile_and_execute_automerge ~runtime ~net ~github =
       let label =
         Printf.sprintf "automerge PR #%d" (Pr_number.to_int pr_number)
       in
-      try
-        match Github.merge_pr ~net github ~pr_number ~merge_method:`Squash with
-        | Ok () ->
-            Runtime.update_orchestrator runtime (fun orch ->
-                Patch_controller.apply_automerge_success orch patch_id);
+      (* [reconcile_automerge] set [automerge_inflight = true] when it emitted
+         this decision. Every exit path below must either call
+         [apply_automerge_success]/[apply_automerge_failure] (both of which
+         clear the inflight flag) or run the [Fun.protect] finaliser. *)
+      let inflight_cleared = ref false in
+      let clear_inflight_if_needed () =
+        if not !inflight_cleared then (
+          inflight_cleared := true;
+          Runtime.update_orchestrator runtime (fun orch ->
+              Orchestrator.set_automerge_inflight orch patch_id false))
+      in
+      Fun.protect ~finally:clear_inflight_if_needed (fun () ->
+          (* Re-read the patch just before hitting GitHub. The original
+             decision came from an earlier orchestrator snapshot; between then
+             and now the patch may have been merged, lost [merge_ready], gone
+             busy again, or had its failure cap hit (via a parallel tick). Any
+             of these make the call both unnecessary and noisy (GitHub 405). *)
+          let still_candidate =
+            Runtime.read runtime (fun snap ->
+                match
+                  Orchestrator.find_agent snap.Runtime.orchestrator patch_id
+                with
+                | None -> false
+                | Some agent ->
+                    let main_branch =
+                      Orchestrator.main_branch snap.Runtime.orchestrator
+                    in
+                    (not agent.Patch_agent.merged)
+                    && agent.Patch_agent.automerge_enabled
+                    && Patch_agent.is_approved agent ~main_branch
+                    && agent.Patch_agent.checks_passing
+                    && Base.List.is_empty agent.Patch_agent.queue
+                    && agent.Patch_agent.automerge_failure_count
+                       < Patch_controller.automerge_max_failures)
+          in
+          if not still_candidate then (
             log_event runtime ~patch_id
-              (Printf.sprintf "Automerge complete — PR #%d merged"
-                 (Pr_number.to_int pr_number))
-        | Error err ->
-            log_event runtime ~patch_id
-              (Printf.sprintf "Automerge failed — %s" (Github.show_error err))
-      with
-      | Eio.Cancel.Cancelled _ as exn -> raise exn
-      | exn ->
-          log_event runtime ~patch_id
-            (Printf.sprintf "%s crashed — %s" label (Printexc.to_string exn)))
+              (Printf.sprintf "%s skipped — no longer a candidate" label);
+            (* Clear inflight via the finaliser; leave deadline as-is so the
+               next reconcile sees current state (clear + re-arm or no-op). *)
+            ())
+          else
+            try
+              match
+                Github.merge_pr ~net github ~pr_number ~merge_method:`Squash
+              with
+              | Ok () ->
+                  inflight_cleared := true;
+                  Runtime.update_orchestrator runtime (fun orch ->
+                      Patch_controller.apply_automerge_success orch patch_id);
+                  log_event runtime ~patch_id
+                    (Printf.sprintf "Automerge complete — PR #%d merged"
+                       (Pr_number.to_int pr_number))
+              | Error err ->
+                  inflight_cleared := true;
+                  Runtime.update_orchestrator runtime (fun orch ->
+                      Patch_controller.apply_automerge_failure orch patch_id);
+                  log_event runtime ~patch_id
+                    (Printf.sprintf "Automerge failed — %s"
+                       (Github.show_error err))
+            with
+            | Eio.Cancel.Cancelled _ as exn -> raise exn
+            | exn ->
+                inflight_cleared := true;
+                Runtime.update_orchestrator runtime (fun orch ->
+                    Patch_controller.apply_automerge_failure orch patch_id);
+                log_event runtime ~patch_id
+                  (Printf.sprintf "%s crashed — %s" label
+                     (Printexc.to_string exn))))
 
 (** Read an artifact file. Returns [Some contents] if the file exists and is
     readable, [None] otherwise. *)

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -340,9 +340,11 @@ let reconcile_and_execute_automerge ~runtime ~net ~github =
           if not still_candidate then (
             log_event runtime ~patch_id
               (Printf.sprintf "%s skipped — no longer a candidate" label);
-            (* Clear inflight via the finaliser; leave deadline as-is so the
-               next reconcile sees current state (clear + re-arm or no-op). *)
-            ())
+            (* Clear inflight explicitly (don't rely on the finaliser's
+               not-yet-cleared fallback) and leave the deadline alone — the
+               next reconcile inspects current state and either clears the
+               deadline (feedback arrived / candidate lost) or re-arms. *)
+            clear_inflight_if_needed ())
           else
             try
               match

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -281,6 +281,41 @@ let log_event runtime ?patch_id msg =
         (Activity_log.Event.create ~timestamp:(Unix.gettimeofday ()) ?patch_id
            msg))
 
+(** Reconcile per-patch automerge deadlines. For each deadline that has elapsed,
+    merge the PR on GitHub and mark the patch merged on success. On failure the
+    deadline is left in place; the next tick will either re-fire (if still a
+    candidate) or clear it (if feedback arrived). *)
+let reconcile_and_execute_automerge ~runtime ~net ~github =
+  let now = Unix.gettimeofday () in
+  let decisions =
+    Runtime.update_orchestrator_returning runtime (fun orch ->
+        Patch_controller.reconcile_automerge orch ~now)
+  in
+  Base.List.iter decisions
+    ~f:(fun
+        Patch_controller.
+          { merge_patch_id = patch_id; merge_pr_number = pr_number }
+      ->
+      let label =
+        Printf.sprintf "automerge PR #%d" (Pr_number.to_int pr_number)
+      in
+      try
+        match Github.merge_pr ~net github ~pr_number ~merge_method:`Squash with
+        | Ok () ->
+            Runtime.update_orchestrator runtime (fun orch ->
+                Patch_controller.apply_automerge_success orch patch_id);
+            log_event runtime ~patch_id
+              (Printf.sprintf "Automerge complete — PR #%d merged"
+                 (Pr_number.to_int pr_number))
+        | Error err ->
+            log_event runtime ~patch_id
+              (Printf.sprintf "Automerge failed — %s" (Github.show_error err))
+      with
+      | Eio.Cancel.Cancelled _ as exn -> raise exn
+      | exn ->
+          log_event runtime ~patch_id
+            (Printf.sprintf "%s crashed — %s" label (Printexc.to_string exn)))
+
 (** Read an artifact file. Returns [Some contents] if the file exists and is
     readable, [None] otherwise. *)
 let read_artifact_file path =
@@ -1058,6 +1093,27 @@ let input_fiber ~runtime ~process_mgr ~net ~github ~list_selected ~detail_scroll
                     Runtime.update_orchestrator runtime (fun orch ->
                         Orchestrator.mark_merged orch patch_id);
                     log_event runtime ~patch_id "Force-marked as merged")
+              | Tui.List_view | Tui.Timeline_view -> ())
+          | Term.Key.Char 'a' -> (
+              input_mode := Tui_input.Normal;
+              match !view_mode with
+              | Tui.Detail_view patch_id -> (
+                  let enabled_after =
+                    Runtime.update_orchestrator_returning runtime (fun orch ->
+                        match Orchestrator.find_agent orch patch_id with
+                        | None -> (orch, None)
+                        | Some agent ->
+                            let v = not agent.Patch_agent.automerge_enabled in
+                            let orch =
+                              Orchestrator.set_automerge_enabled orch patch_id v
+                            in
+                            (orch, Some v))
+                  in
+                  match enabled_after with
+                  | Some true -> log_event runtime ~patch_id "Automerge enabled"
+                  | Some false ->
+                      log_event runtime ~patch_id "Automerge disabled"
+                  | None -> ())
               | Tui.List_view | Tui.Timeline_view -> ())
           | Term.Key.Char _ | Term.Key.Enter | Term.Key.Tab | Term.Key.Paste _
           | Term.Key.Backspace | Term.Key.Up | Term.Key.Down | Term.Key.Left
@@ -2127,6 +2183,7 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
           (orch, (effects, List.rev dispatched, pre_fire_agents)))
     in
     execute_github_effects ~runtime ~net ~github lifecycle_effects;
+    reconcile_and_execute_automerge ~runtime ~net ~github;
     (* Log dispatched actions to event log *)
     Base.List.iter messages ~f:(fun (msg : Orchestrator.patch_agent_message) ->
         let action = Orchestrator.message_action msg in

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -318,7 +318,10 @@ let reconcile_and_execute_automerge ~runtime ~net ~github =
              decision came from an earlier orchestrator snapshot; between then
              and now the patch may have been merged, lost [merge_ready], gone
              busy again, or had its failure cap hit (via a parallel tick). Any
-             of these make the call both unnecessary and noisy (GitHub 405). *)
+             of these make the call both unnecessary and noisy (GitHub 405).
+             [is_automerge_candidate] does not gate on [automerge_inflight],
+             so the flag we set when claiming this decision is transparent
+             here. *)
           let still_candidate =
             Runtime.read runtime (fun snap ->
                 match
@@ -331,11 +334,8 @@ let reconcile_and_execute_automerge ~runtime ~net ~github =
                     in
                     (not agent.Patch_agent.merged)
                     && agent.Patch_agent.automerge_enabled
-                    && Patch_agent.is_approved agent ~main_branch
-                    && agent.Patch_agent.checks_passing
-                    && Base.List.is_empty agent.Patch_agent.queue
-                    && agent.Patch_agent.automerge_failure_count
-                       < Patch_controller.automerge_max_failures)
+                    && Patch_controller.is_automerge_candidate agent
+                         ~main_branch)
           in
           if not still_candidate then (
             log_event runtime ~patch_id
@@ -1038,7 +1038,8 @@ let tui_fiber ~runtime ~clock ~stdout ~list_selected ~detail_scroll
         ~show_help:!show_help
         ~show_manage:
           (Tui_input.equal_input_mode !input_mode Tui_input.Manage_patch)
-        ~transcript ?status_msg:!status_msg ?prompt_line:!prompt_line views
+        ~now:(Unix.gettimeofday ()) ~transcript ?status_msg:!status_msg
+        ?prompt_line:!prompt_line views
     in
     (* Write back the clamped scroll offset so delta-based input in
        input_fiber works from a real value, not a sentinel like max_value.

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -350,9 +350,10 @@ let reconcile_and_execute_automerge ~runtime ~net ~github =
              and now the patch may have been merged, lost [merge_ready], gone
              busy again, or had its failure cap hit (via a parallel tick). Any
              of these make the call both unnecessary and noisy (GitHub 405).
-             [is_automerge_candidate] does not gate on [automerge_inflight],
-             so the flag we set when claiming this decision is transparent
-             here. *)
+             We call [is_automerge_candidate] with [~ignore_inflight:true]
+             because we ourselves set the inflight flag when claiming this
+             decision — the default [ignore_inflight:false] would see our own
+             flag and short-circuit every merge. *)
           let still_candidate =
             Runtime.read runtime (fun snap ->
                 match
@@ -364,26 +365,23 @@ let reconcile_and_execute_automerge ~runtime ~net ~github =
                       Orchestrator.main_branch snap.Runtime.orchestrator
                     in
                     (* Verify the agent's current PR still matches the one this
-                       decision was emitted for. If the poller has remapped the
-                       patch to a replacement PR between reconcile and execute,
-                       hitting GitHub with the stale [pr_number] would either
-                       merge the wrong PR (on the rare chance the old PR is
-                       still open) or 405 and bump [automerge_failure_count]
-                       for no reason. [is_automerge_candidate] already gates on
-                       everything else: not merged, automerge enabled,
-                       approval, CI, empty queue, and the failure cap.
-
-                       [automerge_inflight] is intentionally NOT checked here:
-                       the executor set it to [true] when claiming this
-                       decision, and by design [is_automerge_candidate] returns
-                       [true] while inflight so this re-check can confirm the
-                       merge should still proceed. Adding [not inflight] would
-                       short-circuit every merge call. *)
+                       decision was emitted for. If the poller has remapped
+                       the patch to a replacement PR between reconcile and
+                       execute, hitting GitHub with the stale [pr_number]
+                       would either merge the wrong PR (on the rare chance
+                       the old PR is still open) or 405 and bump
+                       [automerge_failure_count] for no reason.
+                       [is_automerge_candidate] gates on everything else (not
+                       merged, automerge enabled, approval, CI, empty queue,
+                       failure cap) and [~ignore_inflight:true] opts out of
+                       the inflight short-circuit that the predicate applies
+                       by default — necessary here because this re-check runs
+                       while we hold the flag. *)
                     (match agent.Patch_agent.pr_number with
                       | Some current -> Pr_number.equal current pr_number
                       | None -> false)
-                    && Patch_controller.is_automerge_candidate agent
-                         ~main_branch)
+                    && Patch_controller.is_automerge_candidate
+                         ~ignore_inflight:true agent ~main_branch)
           in
           if not still_candidate then (
             log_event runtime ~patch_id
@@ -3151,6 +3149,12 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
             log_event runtime
               (Printf.sprintf "automerge fiber error — %s"
                  (Printexc.to_string exn)));
+        (* [Eio.Time.sleep] is the only yield point outside the guard above.
+           If the switch is being torn down it raises [Eio.Cancel.Cancelled],
+           which propagates out of [amloop] and exits the [fork_daemon]
+           callback. Cancellation is the expected teardown path for daemon
+           fibers — Eio does not treat it as a fiber failure — so no
+           additional catch is needed here. *)
         Eio.Time.sleep clock 1.0;
         amloop ()
       in

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -2303,15 +2303,6 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
           (orch, (effects, List.rev dispatched, pre_fire_agents)))
     in
     execute_github_effects ~runtime ~net ~github lifecycle_effects;
-    (* Fire automerge reconciliation and execution on a background fiber so a
-       slow merge call does not stall the runner tick — the next tick's
-       polling, rebase dispatch, and action spawn shouldn't wait on GitHub's
-       PUT /merge round-trip. [reconcile_automerge] marks [automerge_inflight]
-       atomically before returning decisions, so a follow-up tick that fires
-       before this fiber resolves will see the inflight flag and skip. *)
-    Eio.Fiber.fork_daemon ~sw (fun () ->
-        reconcile_and_execute_automerge ~runtime ~net ~github;
-        `Stop_daemon);
     (* Log dispatched actions to event log *)
     Base.List.iter messages ~f:(fun (msg : Orchestrator.patch_agent_message) ->
         let action = Orchestrator.message_action msg in
@@ -3124,7 +3115,21 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
     Eio.Time.sleep clock 1.0;
     loop sw
   in
-  Eio.Switch.run @@ fun sw -> loop sw
+  Eio.Switch.run @@ fun sw ->
+  (* Single long-lived automerge fiber. Spawning fork_daemon once before the
+     loop (rather than per-tick from inside [loop]) keeps at most one automerge
+     fiber alive on the switch — per-tick forking would let brief no-op fibers
+     accumulate during a slow GitHub call even though [automerge_inflight]
+     guards the real merge. The fiber paces itself with its own 1s sleep,
+     independent of the runner tick. *)
+  Eio.Fiber.fork_daemon ~sw (fun () ->
+      let rec amloop () =
+        reconcile_and_execute_automerge ~runtime ~net ~github;
+        Eio.Time.sleep clock 1.0;
+        amloop ()
+      in
+      amloop ());
+  loop sw
 
 (** {1 Persistence fiber} *)
 

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -294,10 +294,18 @@ let reconcile_and_execute_automerge ~runtime ~net ~github =
     Runtime.update_orchestrator_returning runtime (fun orch ->
         Patch_controller.reconcile_automerge orch ~now)
   in
-  (* Dispatch concurrently so a slow merge call does not stall the runner
-     tick — each call can take up to GitHub's request timeout, and serial
-     iteration would block PR polling, rebase dispatch, and every other
-     lifecycle step for that duration. *)
+  (* Dispatch concurrently with a bounded fiber pool. A slow merge call can
+     take up to GitHub's request timeout (~30s), so serial iteration would
+     compound that over [N] decisions.
+
+     This call still blocks the enclosing [amloop] fiber until all in-flight
+     merges return, which means under simultaneous slow responses the 1s
+     automerge cadence can degrade to one-per-timeout. That trade-off is
+     intentional: bounded concurrency avoids a thundering herd against GitHub
+     rate limits and keeps exactly one automerge fiber alive on the switch
+     (the runner loop is already decoupled — it does not wait on this). The
+     1s cadence is not load-bearing either: deadlines fire on 5-minute idle
+     windows, and [automerge_inflight] already prevents double-claiming. *)
   Eio.Fiber.List.iter ~max_fibers:4
     (fun Patch_controller.
            { merge_patch_id = patch_id; merge_pr_number = pr_number } ->

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -294,11 +294,13 @@ let reconcile_and_execute_automerge ~runtime ~net ~github =
     Runtime.update_orchestrator_returning runtime (fun orch ->
         Patch_controller.reconcile_automerge orch ~now)
   in
-  Base.List.iter decisions
-    ~f:(fun
-        Patch_controller.
-          { merge_patch_id = patch_id; merge_pr_number = pr_number }
-      ->
+  (* Dispatch concurrently so a slow merge call does not stall the runner
+     tick — each call can take up to GitHub's request timeout, and serial
+     iteration would block PR polling, rebase dispatch, and every other
+     lifecycle step for that duration. *)
+  Eio.Fiber.List.iter ~max_fibers:4
+    (fun Patch_controller.
+           { merge_patch_id = patch_id; merge_pr_number = pr_number } ->
       let label =
         Printf.sprintf "automerge PR #%d" (Pr_number.to_int pr_number)
       in
@@ -312,6 +314,19 @@ let reconcile_and_execute_automerge ~runtime ~net ~github =
           inflight_cleared := true;
           Runtime.update_orchestrator runtime (fun orch ->
               Orchestrator.set_automerge_inflight orch patch_id false))
+      in
+      (* Push the deadline out by one idle window after a non-terminal response
+         (GitHub queued the merge or responded with an unrecognised shape). The
+         deadline that fired this decision is already in the past, and merely
+         clearing [inflight] would make the patch eligible again on the very
+         next reconcile tick — producing a tight loop of PUT /merge calls
+         until the poller observes a terminal state. A fresh idle window gives
+         the poller time to catch up. *)
+      let push_deadline_out () =
+        let now_ts = Unix.gettimeofday () in
+        Runtime.update_orchestrator runtime (fun orch ->
+            Orchestrator.set_automerge_deadline orch patch_id
+              (now_ts +. Patch_controller.automerge_idle_timeout))
       in
       Fun.protect ~finally:clear_inflight_if_needed (fun () ->
           (* Re-read the patch just before hitting GitHub. The original
@@ -332,8 +347,13 @@ let reconcile_and_execute_automerge ~runtime ~net ~github =
                     let main_branch =
                       Orchestrator.main_branch snap.Runtime.orchestrator
                     in
+                    (* [is_automerge_candidate] checks [automerge_enabled],
+                       approval, CI, empty queue, and the failure-count cap.
+                       [not merged] is still required here because the
+                       predicate doesn't gate on it directly — a merged PR
+                       with stale [merge_ready = true] would otherwise
+                       requalify. *)
                     (not agent.Patch_agent.merged)
-                    && agent.Patch_agent.automerge_enabled
                     && Patch_controller.is_automerge_candidate agent
                          ~main_branch)
           in
@@ -359,9 +379,10 @@ let reconcile_and_execute_automerge ~runtime ~net ~github =
                        (Pr_number.to_int pr_number))
               | Ok (Github.Merge_queued msg) ->
                   (* GitHub accepted the request into its native auto-merge
-                     queue. Not a failure — don't bump the counter. Clear
-                     inflight so the next reconcile can observe the eventual
-                     merge via the poller. *)
+                     queue. Not a failure — don't bump the counter. Push the
+                     deadline forward so we don't re-fire before the poller
+                     observes the eventual merge. *)
+                  push_deadline_out ();
                   clear_inflight_if_needed ();
                   log_event runtime ~patch_id
                     (Printf.sprintf
@@ -369,7 +390,9 @@ let reconcile_and_execute_automerge ~runtime ~net ~github =
               | Ok Github.Merge_unconfirmed ->
                   (* 2xx response with an unexpected shape. Not authoritative
                      either way — let the poller confirm via PR state rather
-                     than guess. Don't count as failure. *)
+                     than guess. Don't count as failure, but push the
+                     deadline forward so we don't retry every tick. *)
+                  push_deadline_out ();
                   clear_inflight_if_needed ();
                   log_event runtime ~patch_id
                     (Printf.sprintf
@@ -393,6 +416,7 @@ let reconcile_and_execute_automerge ~runtime ~net ~github =
                 log_event runtime ~patch_id
                   (Printf.sprintf "%s crashed — %s" label
                      (Printexc.to_string exn))))
+    decisions
 
 (** Read an artifact file. Returns [Some contents] if the file exists and is
     readable, [None] otherwise. *)

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -350,13 +350,31 @@ let reconcile_and_execute_automerge ~runtime ~net ~github =
               match
                 Github.merge_pr ~net github ~pr_number ~merge_method:`Squash
               with
-              | Ok () ->
+              | Ok Github.Merge_succeeded ->
                   inflight_cleared := true;
                   Runtime.update_orchestrator runtime (fun orch ->
                       Patch_controller.apply_automerge_success orch patch_id);
                   log_event runtime ~patch_id
                     (Printf.sprintf "Automerge complete — PR #%d merged"
                        (Pr_number.to_int pr_number))
+              | Ok (Github.Merge_queued msg) ->
+                  (* GitHub accepted the request into its native auto-merge
+                     queue. Not a failure — don't bump the counter. Clear
+                     inflight so the next reconcile can observe the eventual
+                     merge via the poller. *)
+                  clear_inflight_if_needed ();
+                  log_event runtime ~patch_id
+                    (Printf.sprintf
+                       "Automerge queued by GitHub — awaiting checks (%s)" msg)
+              | Ok Github.Merge_unconfirmed ->
+                  (* 2xx response with an unexpected shape. Not authoritative
+                     either way — let the poller confirm via PR state rather
+                     than guess. Don't count as failure. *)
+                  clear_inflight_if_needed ();
+                  log_event runtime ~patch_id
+                    (Printf.sprintf
+                       "%s accepted but merge not confirmed — awaiting poll"
+                       label)
               | Error err ->
                   inflight_cleared := true;
                   Runtime.update_orchestrator runtime (fun orch ->

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -360,10 +360,14 @@ let reconcile_and_execute_automerge ~runtime ~net ~github =
           if not still_candidate then (
             log_event runtime ~patch_id
               (Printf.sprintf "%s skipped — no longer a candidate" label);
-            (* Clear inflight explicitly (don't rely on the finaliser's
-               not-yet-cleared fallback) and leave the deadline alone — the
-               next reconcile inspects current state and either clears the
-               deadline (feedback arrived / candidate lost) or re-arms. *)
+            (* Clear inflight here explicitly (rather than relying on the
+               [Fun.protect] finaliser) and deliberately leave the deadline in
+               place — the next [reconcile_automerge] tick will clear it via
+               the [(false, Some _)] branch if candidacy is genuinely lost,
+               or re-arm it if the patch became a candidate again. Keeping
+               deadline-clearing centralised in reconcile avoids a redundant
+               write here and the divergence risk of two call sites managing
+               the same invariant. *)
             clear_inflight_if_needed ())
           else
             try
@@ -2286,7 +2290,15 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
           (orch, (effects, List.rev dispatched, pre_fire_agents)))
     in
     execute_github_effects ~runtime ~net ~github lifecycle_effects;
-    reconcile_and_execute_automerge ~runtime ~net ~github;
+    (* Fire automerge reconciliation and execution on a background fiber so a
+       slow merge call does not stall the runner tick — the next tick's
+       polling, rebase dispatch, and action spawn shouldn't wait on GitHub's
+       PUT /merge round-trip. [reconcile_automerge] marks [automerge_inflight]
+       atomically before returning decisions, so a follow-up tick that fires
+       before this fiber resolves will see the inflight flag and skip. *)
+    Eio.Fiber.fork_daemon ~sw (fun () ->
+        reconcile_and_execute_automerge ~runtime ~net ~github;
+        `Stop_daemon);
     (* Log dispatched actions to event log *)
     Base.List.iter messages ~f:(fun (msg : Orchestrator.patch_agent_message) ->
         let action = Orchestrator.message_action msg in

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -316,17 +316,25 @@ let reconcile_and_execute_automerge ~runtime ~net ~github =
               Orchestrator.set_automerge_inflight orch patch_id false))
       in
       (* Push the deadline out by one idle window after a non-terminal response
-         (GitHub queued the merge or responded with an unrecognised shape). The
-         deadline that fired this decision is already in the past, and merely
-         clearing [inflight] would make the patch eligible again on the very
-         next reconcile tick — producing a tight loop of PUT /merge calls
-         until the poller observes a terminal state. A fresh idle window gives
-         the poller time to catch up. *)
-      let push_deadline_out () =
-        let now_ts = Unix.gettimeofday () in
-        Runtime.update_orchestrator runtime (fun orch ->
-            Orchestrator.set_automerge_deadline orch patch_id
-              (now_ts +. Patch_controller.automerge_idle_timeout))
+         (GitHub queued the merge or responded with an unrecognised shape) and
+         clear [inflight] in the same orchestrator update. The deadline that
+         fired this decision is already in the past, and merely clearing
+         [inflight] would make the patch eligible again on the very next
+         reconcile tick — producing a tight loop of PUT /merge calls until the
+         poller observes a terminal state. A fresh idle window gives the
+         poller time to catch up. Doing both writes atomically avoids a brief
+         window where a concurrent read sees the pushed-out deadline with
+         [inflight = true]. *)
+      let push_deadline_and_clear_inflight () =
+        if not !inflight_cleared then (
+          inflight_cleared := true;
+          let now_ts = Unix.gettimeofday () in
+          Runtime.update_orchestrator runtime (fun orch ->
+              let orch =
+                Orchestrator.set_automerge_inflight orch patch_id false
+              in
+              Orchestrator.set_automerge_deadline orch patch_id
+                (now_ts +. Patch_controller.automerge_idle_timeout)))
       in
       Fun.protect ~finally:clear_inflight_if_needed (fun () ->
           (* Re-read the patch just before hitting GitHub. The original
@@ -347,13 +355,18 @@ let reconcile_and_execute_automerge ~runtime ~net ~github =
                     let main_branch =
                       Orchestrator.main_branch snap.Runtime.orchestrator
                     in
-                    (* [is_automerge_candidate] checks [automerge_enabled],
-                       approval, CI, empty queue, and the failure-count cap.
-                       [not merged] is still required here because the
-                       predicate doesn't gate on it directly — a merged PR
-                       with stale [merge_ready = true] would otherwise
-                       requalify. *)
-                    (not agent.Patch_agent.merged)
+                    (* Verify the agent's current PR still matches the one this
+                       decision was emitted for. If the poller has remapped the
+                       patch to a replacement PR between reconcile and execute,
+                       hitting GitHub with the stale [pr_number] would either
+                       merge the wrong PR (on the rare chance the old PR is
+                       still open) or 405 and bump [automerge_failure_count]
+                       for no reason. [is_automerge_candidate] already gates on
+                       everything else: not merged, automerge enabled,
+                       approval, CI, empty queue, and the failure cap. *)
+                    (match agent.Patch_agent.pr_number with
+                      | Some current -> Pr_number.equal current pr_number
+                      | None -> false)
                     && Patch_controller.is_automerge_candidate agent
                          ~main_branch)
           in
@@ -384,10 +397,10 @@ let reconcile_and_execute_automerge ~runtime ~net ~github =
               | Ok (Github.Merge_queued msg) ->
                   (* GitHub accepted the request into its native auto-merge
                      queue. Not a failure — don't bump the counter. Push the
-                     deadline forward so we don't re-fire before the poller
-                     observes the eventual merge. *)
-                  push_deadline_out ();
-                  clear_inflight_if_needed ();
+                     deadline forward (atomically with clearing [inflight]) so
+                     we don't re-fire before the poller observes the eventual
+                     merge. *)
+                  push_deadline_and_clear_inflight ();
                   log_event runtime ~patch_id
                     (Printf.sprintf
                        "Automerge queued by GitHub — awaiting checks (%s)" msg)
@@ -395,9 +408,9 @@ let reconcile_and_execute_automerge ~runtime ~net ~github =
                   (* 2xx response with an unexpected shape. Not authoritative
                      either way — let the poller confirm via PR state rather
                      than guess. Don't count as failure, but push the
-                     deadline forward so we don't retry every tick. *)
-                  push_deadline_out ();
-                  clear_inflight_if_needed ();
+                     deadline forward (atomic with clearing [inflight]) so we
+                     don't retry every tick. *)
+                  push_deadline_and_clear_inflight ();
                   log_event runtime ~patch_id
                     (Printf.sprintf
                        "%s accepted but merge not confirmed — awaiting poll"

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -371,7 +371,14 @@ let reconcile_and_execute_automerge ~runtime ~net ~github =
                        still open) or 405 and bump [automerge_failure_count]
                        for no reason. [is_automerge_candidate] already gates on
                        everything else: not merged, automerge enabled,
-                       approval, CI, empty queue, and the failure cap. *)
+                       approval, CI, empty queue, and the failure cap.
+
+                       [automerge_inflight] is intentionally NOT checked here:
+                       the executor set it to [true] when claiming this
+                       decision, and by design [is_automerge_candidate] returns
+                       [true] while inflight so this re-check can confirm the
+                       merge should still proceed. Adding [not inflight] would
+                       short-circuit every merge call. *)
                     (match agent.Patch_agent.pr_number with
                       | Some current -> Pr_number.equal current pr_number
                       | None -> false)
@@ -3132,7 +3139,18 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
      independent of the runner tick. *)
   Eio.Fiber.fork_daemon ~sw (fun () ->
       let rec amloop () =
-        reconcile_and_execute_automerge ~runtime ~net ~github;
+        (* Top-level guard: [reconcile_and_execute_automerge] catches
+           exceptions per-decision, but [Eio.Fiber.List.iter] (or a future
+           refactor) could still let one escape. Re-raise [Cancelled] so
+           switch teardown propagates normally; swallow any other exception
+           to the activity log so a single bad tick can't kill the fiber
+           permanently and leave automerge silently disabled. *)
+        (try reconcile_and_execute_automerge ~runtime ~net ~github with
+        | Eio.Cancel.Cancelled _ as exn -> raise exn
+        | exn ->
+            log_event runtime
+              (Printf.sprintf "automerge fiber error — %s"
+                 (Printexc.to_string exn)));
         Eio.Time.sleep clock 1.0;
         amloop ()
       in

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -283,10 +283,11 @@ let log_event runtime ?patch_id msg =
 
 (** Reconcile per-patch automerge deadlines. For each deadline that has elapsed,
     merge the PR on GitHub and mark the patch merged on success. On failure the
-    failure counter is incremented and the deadline cleared; the next tick will
-    re-arm a fresh 5-minute window and retry until the consecutive failure cap
-    is reached, at which point reconciliation stops issuing merge calls until
-    the user toggles automerge off/on. *)
+    failure counter is incremented and the deadline pushed out by a fresh idle
+    window, so the retry is at least 5 minutes out regardless of how often the
+    runner tick fires. Retries continue until the consecutive failure cap is
+    reached, at which point reconciliation stops issuing merge calls until the
+    user toggles automerge off/on. *)
 let reconcile_and_execute_automerge ~runtime ~net ~github =
   let now = Unix.gettimeofday () in
   let decisions =
@@ -357,7 +358,8 @@ let reconcile_and_execute_automerge ~runtime ~net ~github =
               | Error err ->
                   inflight_cleared := true;
                   Runtime.update_orchestrator runtime (fun orch ->
-                      Patch_controller.apply_automerge_failure orch patch_id);
+                      Patch_controller.apply_automerge_failure orch
+                        ~now:(Unix.gettimeofday ()) patch_id);
                   log_event runtime ~patch_id
                     (Printf.sprintf "Automerge failed — %s"
                        (Github.show_error err))
@@ -366,7 +368,8 @@ let reconcile_and_execute_automerge ~runtime ~net ~github =
             | exn ->
                 inflight_cleared := true;
                 Runtime.update_orchestrator runtime (fun orch ->
-                    Patch_controller.apply_automerge_failure orch patch_id);
+                    Patch_controller.apply_automerge_failure orch
+                      ~now:(Unix.gettimeofday ()) patch_id);
                 log_event runtime ~patch_id
                   (Printf.sprintf "%s crashed — %s" label
                      (Printexc.to_string exn))))

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -587,36 +587,47 @@ let set_draft ~net t ~pr_number ~draft =
           )
       | Error _ as e -> e)
 
-(** Interpret a 2xx body from [PUT /pulls/:n/merge]. A 2xx does not guarantee
-    the merge completed: GitHub returns 200 with
-    [{"merged": false, "message": "..."}] when the request is queued (native
-    auto-merge queue waiting on required checks). Treating that as [Ok ()] would
-    cause callers to mark the patch merged prematurely.
-    - Valid JSON with [merged = true] → [Ok ()].
-    - Valid JSON with [merged = false] → [Error (Http_error ...)] carrying
-      GitHub's [message].
-    - Missing [merged] field → default to [true] (matches historical behavior
-      for shapes we don't recognize).
-    - Non-JSON or malformed body → [Ok ()] (treat 2xx without a useful body as
-      success). *)
-let interpret_merge_response ~path body =
+(** Outcome of a [PUT /pulls/:n/merge] call that returned a 2xx status. GitHub
+    does not guarantee a 2xx means the merge completed — the endpoint is used
+    for both immediate merges and the native auto-merge queue. *)
+type merge_result =
+  | Merge_succeeded
+      (** Response body confirmed [merged = true]; the PR is merged. *)
+  | Merge_queued of string
+      (** Response body had [merged = false]; GitHub accepted the request
+          (typically into its auto-merge queue waiting for required checks) but
+          has not yet merged. Carries GitHub's [message] for logs. *)
+  | Merge_unconfirmed
+      (** Response was 2xx but did not include a parseable [merged] field (no
+          JSON, unexpected shape, etc.). Treat as non-authoritative: don't mark
+          the patch merged, but also don't count as a failure — the poller will
+          observe the real PR state next cycle. *)
+
+(** Interpret a 2xx body from [PUT /pulls/:n/merge].
+    - Valid JSON with [merged = true] → [Merge_succeeded].
+    - Valid JSON with [merged = false] → [Merge_queued msg].
+    - Anything else (malformed JSON, non-JSON body, missing/non-bool [merged]) →
+      [Merge_unconfirmed]. GitHub's documented shape always includes
+      [merged : bool], so absence is suspicious and we let the poller confirm
+      rather than guessing. *)
+let interpret_merge_response body =
   try
     let json = Yojson.Safe.from_string body in
-    let merged =
-      Yojson.Safe.Util.(member "merged" json |> to_bool_option)
-      |> Option.value ~default:true
-    in
-    if merged then Ok ()
-    else
-      let msg =
-        Yojson.Safe.Util.(member "message" json |> to_string_option)
-        |> Option.value ~default:"merged=false"
-      in
-      Error (Http_error { meth = "PUT"; path; status = 200; body = msg })
-  with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> Ok ()
+    match Yojson.Safe.Util.(member "merged" json |> to_bool_option) with
+    | Some true -> Merge_succeeded
+    | Some false ->
+        let msg =
+          Yojson.Safe.Util.(member "message" json |> to_string_option)
+          |> Option.value ~default:"merged=false"
+        in
+        Merge_queued msg
+    | None -> Merge_unconfirmed
+  with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ ->
+    Merge_unconfirmed
 
 (** Merge a pull request via the REST API. Maps to
-    [PUT /repos/:owner/:repo/pulls/:number/merge]. *)
+    [PUT /repos/:owner/:repo/pulls/:number/merge]. Returns the parsed
+    [merge_result] on 2xx or an [error] on transport/4xx/5xx failures. *)
 let merge_pr ~net t ~pr_number ~merge_method =
   let path =
     Printf.sprintf "/repos/%s/%s/pulls/%d/merge" t.owner t.repo
@@ -632,7 +643,7 @@ let merge_pr ~net t ~pr_number ~merge_method =
     `Assoc [ ("merge_method", `String method_str) ] |> Yojson.Safe.to_string
   in
   match request ~net t ~meth:`PUT ~path ~body:req_body () with
-  | Ok body -> interpret_merge_response ~path body
+  | Ok body -> Ok (interpret_merge_response body)
   | Error _ as e -> e
 
 let owner t = t.owner
@@ -678,35 +689,31 @@ let%test "parse_rest_pr_list mixed" =
 let%test "parse_rest_pr_list invalid json" =
   match parse_rest_pr_list "not json" with Error _ -> true | Ok _ -> false
 
-let%test "interpret_merge_response merged=true -> Ok" =
+let%test "interpret_merge_response merged=true -> Merge_succeeded" =
   match
-    interpret_merge_response ~path:"/x"
+    interpret_merge_response
       {|{"sha":"abc","merged":true,"message":"Pull Request successfully merged"}|}
   with
-  | Ok () -> true
-  | Error _ -> false
+  | Merge_succeeded -> true
+  | Merge_queued _ | Merge_unconfirmed -> false
 
-let%test "interpret_merge_response merged=false -> Error with message" =
+let%test "interpret_merge_response merged=false -> Merge_queued with message" =
   match
-    interpret_merge_response ~path:"/x"
+    interpret_merge_response
       {|{"merged":false,"message":"Required status check did not succeed"}|}
   with
-  | Error (Http_error { status = 200; body; _ }) ->
-      String.equal body "Required status check did not succeed"
-  | Error
-      (Http_error _ | Json_parse_error _ | Graphql_error _ | Transport_error _)
-  | Ok () ->
-      false
+  | Merge_queued msg -> String.equal msg "Required status check did not succeed"
+  | Merge_succeeded | Merge_unconfirmed -> false
 
-let%test "interpret_merge_response missing merged field -> Ok" =
-  match interpret_merge_response ~path:"/x" {|{"sha":"abc"}|} with
-  | Ok () -> true
-  | Error _ -> false
+let%test "interpret_merge_response missing merged field -> Merge_unconfirmed" =
+  match interpret_merge_response {|{"sha":"abc"}|} with
+  | Merge_unconfirmed -> true
+  | Merge_succeeded | Merge_queued _ -> false
 
-let%test "interpret_merge_response non-json body -> Ok" =
-  match interpret_merge_response ~path:"/x" "" with
-  | Ok () -> true
-  | Error _ -> false
+let%test "interpret_merge_response non-json body -> Merge_unconfirmed" =
+  match interpret_merge_response "" with
+  | Merge_unconfirmed -> true
+  | Merge_succeeded | Merge_queued _ -> false
 
 let%expect_test "show_error includes endpoint + permission hint on 403" =
   let err =

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -361,6 +361,7 @@ let meth_to_string = function
   | `GET -> "GET"
   | `POST -> "POST"
   | `PATCH -> "PATCH"
+  | `PUT -> "PUT"
 
 let request ~net t ~meth ~path ?(query = []) ?body () =
   let meth_s = meth_to_string meth in
@@ -401,6 +402,11 @@ let request ~net t ~meth ~path ?(query = []) ?body () =
                 Cohttp_eio.Body.of_string (Option.value body ~default:"{}")
               in
               Cohttp_eio.Client.patch client ~sw ~headers ~body uri
+          | `PUT ->
+              let body =
+                Cohttp_eio.Body.of_string (Option.value body ~default:"{}")
+              in
+              Cohttp_eio.Client.put client ~sw ~headers ~body uri
         in
         let status = Http.Response.status resp |> Http.Status.to_int in
         let resp_str =
@@ -580,6 +586,26 @@ let set_draft ~net t ~pr_number ~draft =
           | Yojson.Safe.Util.Type_error (msg, _) -> Error (Json_parse_error msg)
           )
       | Error _ as e -> e)
+
+(** Merge a pull request via the REST API. Maps to
+    [PUT /repos/:owner/:repo/pulls/:number/merge]. *)
+let merge_pr ~net t ~pr_number ~merge_method =
+  let path =
+    Printf.sprintf "/repos/%s/%s/pulls/%d/merge" t.owner t.repo
+      (Types.Pr_number.to_int pr_number)
+  in
+  let method_str =
+    match merge_method with
+    | `Merge -> "merge"
+    | `Squash -> "squash"
+    | `Rebase -> "rebase"
+  in
+  let req_body =
+    `Assoc [ ("merge_method", `String method_str) ] |> Yojson.Safe.to_string
+  in
+  match request ~net t ~meth:`PUT ~path ~body:req_body () with
+  | Ok _ -> Ok ()
+  | Error _ as e -> e
 
 let owner t = t.owner
 

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -587,6 +587,34 @@ let set_draft ~net t ~pr_number ~draft =
           )
       | Error _ as e -> e)
 
+(** Interpret a 2xx body from [PUT /pulls/:n/merge]. A 2xx does not guarantee
+    the merge completed: GitHub returns 200 with
+    [{"merged": false, "message": "..."}] when the request is queued (native
+    auto-merge queue waiting on required checks). Treating that as [Ok ()] would
+    cause callers to mark the patch merged prematurely.
+    - Valid JSON with [merged = true] → [Ok ()].
+    - Valid JSON with [merged = false] → [Error (Http_error ...)] carrying
+      GitHub's [message].
+    - Missing [merged] field → default to [true] (matches historical behavior
+      for shapes we don't recognize).
+    - Non-JSON or malformed body → [Ok ()] (treat 2xx without a useful body as
+      success). *)
+let interpret_merge_response ~path body =
+  try
+    let json = Yojson.Safe.from_string body in
+    let merged =
+      Yojson.Safe.Util.(member "merged" json |> to_bool_option)
+      |> Option.value ~default:true
+    in
+    if merged then Ok ()
+    else
+      let msg =
+        Yojson.Safe.Util.(member "message" json |> to_string_option)
+        |> Option.value ~default:"merged=false"
+      in
+      Error (Http_error { meth = "PUT"; path; status = 200; body = msg })
+  with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> Ok ()
+
 (** Merge a pull request via the REST API. Maps to
     [PUT /repos/:owner/:repo/pulls/:number/merge]. *)
 let merge_pr ~net t ~pr_number ~merge_method =
@@ -604,7 +632,7 @@ let merge_pr ~net t ~pr_number ~merge_method =
     `Assoc [ ("merge_method", `String method_str) ] |> Yojson.Safe.to_string
   in
   match request ~net t ~meth:`PUT ~path ~body:req_body () with
-  | Ok _ -> Ok ()
+  | Ok body -> interpret_merge_response ~path body
   | Error _ as e -> e
 
 let owner t = t.owner
@@ -649,6 +677,36 @@ let%test "parse_rest_pr_list mixed" =
 
 let%test "parse_rest_pr_list invalid json" =
   match parse_rest_pr_list "not json" with Error _ -> true | Ok _ -> false
+
+let%test "interpret_merge_response merged=true -> Ok" =
+  match
+    interpret_merge_response ~path:"/x"
+      {|{"sha":"abc","merged":true,"message":"Pull Request successfully merged"}|}
+  with
+  | Ok () -> true
+  | Error _ -> false
+
+let%test "interpret_merge_response merged=false -> Error with message" =
+  match
+    interpret_merge_response ~path:"/x"
+      {|{"merged":false,"message":"Required status check did not succeed"}|}
+  with
+  | Error (Http_error { status = 200; body; _ }) ->
+      String.equal body "Required status check did not succeed"
+  | Error
+      (Http_error _ | Json_parse_error _ | Graphql_error _ | Transport_error _)
+  | Ok () ->
+      false
+
+let%test "interpret_merge_response missing merged field -> Ok" =
+  match interpret_merge_response ~path:"/x" {|{"sha":"abc"}|} with
+  | Ok () -> true
+  | Error _ -> false
+
+let%test "interpret_merge_response non-json body -> Ok" =
+  match interpret_merge_response ~path:"/x" "" with
+  | Ok () -> true
+  | Error _ -> false
 
 let%expect_test "show_error includes endpoint + permission hint on 403" =
   let err =

--- a/lib/github.mli
+++ b/lib/github.mli
@@ -95,5 +95,17 @@ val set_draft :
 (** [set_draft ~net t ~pr_number ~draft] sets draft status via GraphQL mutation.
     REST API does not support changing the draft field. *)
 
+val merge_pr :
+  net:_ Eio.Net.t ->
+  t ->
+  pr_number:Types.Pr_number.t ->
+  merge_method:[ `Merge | `Squash | `Rebase ] ->
+  (unit, error) Result.t
+(** [merge_pr ~net t ~pr_number ~merge_method] merges a PR via
+    [PUT /repos/:owner/:repo/pulls/:number/merge]. Returns [Ok ()] on success
+    (HTTP 2xx). The caller is responsible for ensuring the PR is actually
+    mergeable — the REST API returns 405 "Pull Request is not mergeable"
+    otherwise. *)
+
 val owner : t -> string
 (** [owner t] returns the repository owner. *)

--- a/lib/github.mli
+++ b/lib/github.mli
@@ -95,17 +95,31 @@ val set_draft :
 (** [set_draft ~net t ~pr_number ~draft] sets draft status via GraphQL mutation.
     REST API does not support changing the draft field. *)
 
+type merge_result =
+  | Merge_succeeded
+      (** Response body confirmed [merged = true]; the PR is merged. *)
+  | Merge_queued of string
+      (** Response body had [merged = false]; GitHub accepted the request
+          (typically into its auto-merge queue waiting for required checks) but
+          has not yet merged. Carries GitHub's [message] for logs. *)
+  | Merge_unconfirmed
+      (** Response was 2xx but did not include a parseable [merged] field. Treat
+          as non-authoritative: don't mark merged, don't count as failure — the
+          poller will observe the real PR state next cycle. *)
+
 val merge_pr :
   net:_ Eio.Net.t ->
   t ->
   pr_number:Types.Pr_number.t ->
   merge_method:[ `Merge | `Squash | `Rebase ] ->
-  (unit, error) Result.t
+  (merge_result, error) Result.t
 (** [merge_pr ~net t ~pr_number ~merge_method] merges a PR via
-    [PUT /repos/:owner/:repo/pulls/:number/merge]. Returns [Ok ()] on success
-    (HTTP 2xx). The caller is responsible for ensuring the PR is actually
-    mergeable — the REST API returns 405 "Pull Request is not mergeable"
-    otherwise. *)
+    [PUT /repos/:owner/:repo/pulls/:number/merge]. A 2xx HTTP status does NOT
+    imply the merge completed: the caller must inspect the returned
+    [merge_result] to distinguish an actual merge from a queued request or an
+    unconfirmed response. Transport errors and 4xx/5xx statuses return an
+    [error]; the REST API returns 405 "Pull Request is not mergeable" when the
+    PR is not in a mergeable state. *)
 
 val owner : t -> string
 (** [owner t] returns the repository owner. *)

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -370,6 +370,16 @@ let set_llm_session_id t patch_id session_id =
   update_agent t patch_id ~f:(fun a ->
       Patch_agent.set_llm_session_id a session_id)
 
+let set_automerge_enabled t patch_id v =
+  update_agent t patch_id ~f:(fun a -> Patch_agent.set_automerge_enabled a v)
+
+let set_automerge_deadline t patch_id deadline =
+  update_agent t patch_id ~f:(fun a ->
+      Patch_agent.set_automerge_deadline a deadline)
+
+let clear_automerge_deadline t patch_id =
+  update_agent t patch_id ~f:Patch_agent.clear_automerge_deadline
+
 (** {2 Queries} *)
 
 let all_agents t = Map.data t.agents

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -380,6 +380,15 @@ let set_automerge_deadline t patch_id deadline =
 let clear_automerge_deadline t patch_id =
   update_agent t patch_id ~f:Patch_agent.clear_automerge_deadline
 
+let set_automerge_inflight t patch_id v =
+  update_agent t patch_id ~f:(fun a -> Patch_agent.set_automerge_inflight a v)
+
+let increment_automerge_failure_count t patch_id =
+  update_agent t patch_id ~f:Patch_agent.increment_automerge_failure_count
+
+let reset_automerge_failure_count t patch_id =
+  update_agent t patch_id ~f:Patch_agent.reset_automerge_failure_count
+
 (** {2 Queries} *)
 
 let all_agents t = Map.data t.agents

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -103,6 +103,9 @@ val set_llm_session_id : t -> Patch_id.t -> string option -> t
 val set_automerge_enabled : t -> Patch_id.t -> bool -> t
 val set_automerge_deadline : t -> Patch_id.t -> float -> t
 val clear_automerge_deadline : t -> Patch_id.t -> t
+val set_automerge_inflight : t -> Patch_id.t -> bool -> t
+val increment_automerge_failure_count : t -> Patch_id.t -> t
+val reset_automerge_failure_count : t -> Patch_id.t -> t
 
 (** {2 Queries} *)
 

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -100,6 +100,9 @@ val clear_branch_blocked : t -> Patch_id.t -> t
 val reset_busy : t -> Patch_id.t -> t
 val set_worktree_path : t -> Patch_id.t -> string -> t
 val set_llm_session_id : t -> Patch_id.t -> string option -> t
+val set_automerge_enabled : t -> Patch_id.t -> bool -> t
+val set_automerge_deadline : t -> Patch_id.t -> float -> t
+val clear_automerge_deadline : t -> Patch_id.t -> t
 
 (** {2 Queries} *)
 

--- a/lib/patch_agent.ml
+++ b/lib/patch_agent.ml
@@ -42,6 +42,15 @@ type t = {
       (** Unix timestamp at which the supervisor should merge the PR if the
           patch is still approved. [None] when automerge is disabled or the
           patch has not yet been observed in the approved state. *)
+  automerge_inflight : bool;
+      (** [true] between the moment [reconcile_automerge] claims a merge
+          decision and the moment the merge call resolves (success or failure).
+          Prevents a second overlapping tick from issuing the same merge call.
+      *)
+  automerge_failure_count : int;
+      (** Consecutive merge-call failures. After [automerge_max_failures] the
+          patch is no longer an automerge candidate until the user re-toggles
+          automerge or a successful merge resets the counter. *)
 }
 [@@deriving eq, sexp_of, compare]
 
@@ -109,6 +118,8 @@ let create ~branch patch_id =
     llm_session_id = None;
     automerge_enabled = false;
     automerge_deadline = None;
+    automerge_inflight = false;
+    automerge_failure_count = 0;
   }
 
 let create_adhoc ~patch_id ~branch ~pr_number =
@@ -146,6 +157,8 @@ let create_adhoc ~patch_id ~branch ~pr_number =
     llm_session_id = None;
     automerge_enabled = false;
     automerge_deadline = None;
+    automerge_inflight = false;
+    automerge_failure_count = 0;
   }
 
 let highest_priority t =
@@ -256,13 +269,29 @@ let set_llm_session_id t llm_session_id = { t with llm_session_id }
 let set_automerge_enabled t v =
   if Bool.equal t.automerge_enabled v then t
   else
+    (* Toggling automerge always resets the failure counter and clears any
+       inflight flag, so a previously-capped patch can retry and any stale
+       inflight state (e.g. from a crashed supervisor) cannot permanently block
+       reconciliation. Disabling additionally clears the pending deadline. *)
     let automerge_deadline = if v then t.automerge_deadline else None in
-    { t with automerge_enabled = v; automerge_deadline }
+    {
+      t with
+      automerge_enabled = v;
+      automerge_deadline;
+      automerge_inflight = false;
+      automerge_failure_count = 0;
+    }
 
 let set_automerge_deadline t deadline =
   { t with automerge_deadline = Some deadline }
 
 let clear_automerge_deadline t = { t with automerge_deadline = None }
+let set_automerge_inflight t v = { t with automerge_inflight = v }
+
+let increment_automerge_failure_count t =
+  { t with automerge_failure_count = t.automerge_failure_count + 1 }
+
+let reset_automerge_failure_count t = { t with automerge_failure_count = 0 }
 
 let resume_current_message t ~op =
   { t with busy = true; has_session = true; current_op = op }
@@ -286,7 +315,8 @@ let restore ~patch_id ~branch ~pr_number ~has_session ~busy ~merged ~queue
     ~start_attempts_without_pr ~conflict_noop_count ~no_commits_push_count
     ~branch_rebased_onto ~checks_passing ~current_op ~current_message_id
     ~generation ~worktree_path ~branch_blocked ~llm_session_id
-    ~automerge_enabled ~automerge_deadline =
+    ~automerge_enabled ~automerge_deadline ~automerge_inflight
+    ~automerge_failure_count =
   {
     patch_id;
     branch;
@@ -321,6 +351,8 @@ let restore ~patch_id ~branch ~pr_number ~has_session ~busy ~merged ~queue
     llm_session_id;
     automerge_enabled;
     automerge_deadline;
+    automerge_inflight;
+    automerge_failure_count;
   }
 
 let set_pr_number t pr_number =

--- a/lib/patch_agent.ml
+++ b/lib/patch_agent.ml
@@ -37,6 +37,11 @@ type t = {
   worktree_path : string option;
   branch_blocked : bool;
   llm_session_id : string option;
+  automerge_enabled : bool;
+  automerge_deadline : float option;
+      (** Unix timestamp at which the supervisor should merge the PR if the
+          patch is still approved. [None] when automerge is disabled or the
+          patch has not yet been observed in the approved state. *)
 }
 [@@deriving eq, sexp_of, compare]
 
@@ -102,6 +107,8 @@ let create ~branch patch_id =
     worktree_path = None;
     branch_blocked = false;
     llm_session_id = None;
+    automerge_enabled = false;
+    automerge_deadline = None;
   }
 
 let create_adhoc ~patch_id ~branch ~pr_number =
@@ -137,6 +144,8 @@ let create_adhoc ~patch_id ~branch ~pr_number =
     worktree_path = None;
     branch_blocked = false;
     llm_session_id = None;
+    automerge_enabled = false;
+    automerge_deadline = None;
   }
 
 let highest_priority t =
@@ -244,6 +253,17 @@ let set_current_message_id t current_message_id = { t with current_message_id }
 let bump_generation t = { t with generation = t.generation + 1 }
 let set_llm_session_id t llm_session_id = { t with llm_session_id }
 
+let set_automerge_enabled t v =
+  if Bool.equal t.automerge_enabled v then t
+  else
+    let automerge_deadline = if v then t.automerge_deadline else None in
+    { t with automerge_enabled = v; automerge_deadline }
+
+let set_automerge_deadline t deadline =
+  { t with automerge_deadline = Some deadline }
+
+let clear_automerge_deadline t = { t with automerge_deadline = None }
+
 let resume_current_message t ~op =
   { t with busy = true; has_session = true; current_op = op }
 
@@ -265,7 +285,8 @@ let restore ~patch_id ~branch ~pr_number ~has_session ~busy ~merged ~queue
     ~ci_checks ~merge_ready ~is_draft ~pr_body_delivered
     ~start_attempts_without_pr ~conflict_noop_count ~no_commits_push_count
     ~branch_rebased_onto ~checks_passing ~current_op ~current_message_id
-    ~generation ~worktree_path ~branch_blocked ~llm_session_id =
+    ~generation ~worktree_path ~branch_blocked ~llm_session_id
+    ~automerge_enabled ~automerge_deadline =
   {
     patch_id;
     branch;
@@ -298,6 +319,8 @@ let restore ~patch_id ~branch ~pr_number ~has_session ~busy ~merged ~queue
     worktree_path;
     branch_blocked;
     llm_session_id;
+    automerge_enabled;
+    automerge_deadline;
   }
 
 let set_pr_number t pr_number =

--- a/lib/patch_agent.mli
+++ b/lib/patch_agent.mli
@@ -252,9 +252,11 @@ val set_llm_session_id : t -> string option -> t
     and when the session is known dead (no-resume, give-up). *)
 
 val set_automerge_enabled : t -> bool -> t
-(** Enable or disable automerge for this patch. Toggling clears any inflight
-    flag and resets [automerge_failure_count]; disabling additionally clears any
-    pending deadline so the next enable starts a fresh timer. *)
+(** Enable or disable automerge for this patch. When the value actually changes,
+    the inflight flag is cleared and [automerge_failure_count] is reset;
+    disabling additionally clears any pending deadline so the next enable starts
+    a fresh timer. Calling with the current value is a no-op — the failure count
+    and inflight flag are not reset in that case. *)
 
 val set_automerge_deadline : t -> float -> t
 (** Record the Unix timestamp at which the supervisor should merge this patch if

--- a/lib/patch_agent.mli
+++ b/lib/patch_agent.mli
@@ -41,6 +41,8 @@ type t = private {
   worktree_path : string option;
   branch_blocked : bool;
   llm_session_id : string option;
+  automerge_enabled : bool;
+  automerge_deadline : float option;
 }
 [@@deriving show, eq, sexp_of, compare]
 
@@ -247,6 +249,17 @@ val set_llm_session_id : t -> string option -> t
     after intervention. Cleared on start-path fresh-failure reset (clean retry)
     and when the session is known dead (no-resume, give-up). *)
 
+val set_automerge_enabled : t -> bool -> t
+(** Enable or disable automerge for this patch. Disabling clears any pending
+    deadline so the next enable starts a fresh timer. *)
+
+val set_automerge_deadline : t -> float -> t
+(** Record the Unix timestamp at which the supervisor should merge this patch if
+    it is still approved. *)
+
+val clear_automerge_deadline : t -> t
+(** Clear a pending automerge deadline without disabling automerge. *)
+
 val resume_current_message : t -> op:Types.Operation_kind.t option -> t
 (** Resume execution of an already accepted message without reapplying its
     queue-consuming state transition. [~op] restores [current_op] from the
@@ -299,6 +312,8 @@ val restore :
   worktree_path:string option ->
   branch_blocked:bool ->
   llm_session_id:string option ->
+  automerge_enabled:bool ->
+  automerge_deadline:float option ->
   t
 (** Reconstruct agent state from persisted field values. Bypasses precondition
     checks — use only for deserialization. *)

--- a/lib/patch_agent.mli
+++ b/lib/patch_agent.mli
@@ -255,8 +255,12 @@ val set_automerge_enabled : t -> bool -> t
 (** Enable or disable automerge for this patch. When the value actually changes,
     the inflight flag is cleared and [automerge_failure_count] is reset;
     disabling additionally clears any pending deadline so the next enable starts
-    a fresh timer. Calling with the current value is a no-op — the failure count
-    and inflight flag are not reset in that case. *)
+    a fresh timer. Calling with the current value is a no-op — the failure
+    count, inflight flag, and [automerge_deadline] are NOT reset in that case.
+    If the preserved deadline has already elapsed, the next reconcile tick will
+    fire immediately rather than waiting [automerge_idle_timeout]; callers that
+    need a fresh timer must call [clear_automerge_deadline] explicitly after
+    this function. *)
 
 val set_automerge_deadline : t -> float -> t
 (** Record the Unix timestamp at which the supervisor should merge this patch if

--- a/lib/patch_agent.mli
+++ b/lib/patch_agent.mli
@@ -43,6 +43,8 @@ type t = private {
   llm_session_id : string option;
   automerge_enabled : bool;
   automerge_deadline : float option;
+  automerge_inflight : bool;
+  automerge_failure_count : int;
 }
 [@@deriving show, eq, sexp_of, compare]
 
@@ -250,8 +252,9 @@ val set_llm_session_id : t -> string option -> t
     and when the session is known dead (no-resume, give-up). *)
 
 val set_automerge_enabled : t -> bool -> t
-(** Enable or disable automerge for this patch. Disabling clears any pending
-    deadline so the next enable starts a fresh timer. *)
+(** Enable or disable automerge for this patch. Toggling clears any inflight
+    flag and resets [automerge_failure_count]; disabling additionally clears any
+    pending deadline so the next enable starts a fresh timer. *)
 
 val set_automerge_deadline : t -> float -> t
 (** Record the Unix timestamp at which the supervisor should merge this patch if
@@ -259,6 +262,19 @@ val set_automerge_deadline : t -> float -> t
 
 val clear_automerge_deadline : t -> t
 (** Clear a pending automerge deadline without disabling automerge. *)
+
+val set_automerge_inflight : t -> bool -> t
+(** Set the [automerge_inflight] flag. The reconciler sets it [true] when it
+    claims a merge decision; the caller clears it on every exit path (success,
+    failure, exception). *)
+
+val increment_automerge_failure_count : t -> t
+(** Record a failed automerge call. After [automerge_max_failures] consecutive
+    failures the patch is no longer an automerge candidate. *)
+
+val reset_automerge_failure_count : t -> t
+(** Reset the consecutive-failure counter to zero. Called on a successful merge
+    and whenever automerge is re-toggled. *)
 
 val resume_current_message : t -> op:Types.Operation_kind.t option -> t
 (** Resume execution of an already accepted message without reapplying its
@@ -314,6 +330,8 @@ val restore :
   llm_session_id:string option ->
   automerge_enabled:bool ->
   automerge_deadline:float option ->
+  automerge_inflight:bool ->
+  automerge_failure_count:int ->
   t
 (** Reconstruct agent state from persisted field values. Bypasses precondition
     checks — use only for deserialization. *)

--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -449,13 +449,21 @@ let apply_github_effect_success t = function
       Orchestrator.set_base_branch t patch_id base
 
 let automerge_idle_timeout = 300.0
+let automerge_max_failures = 3
 
 (** Pure predicate: a patch is a candidate for automerge merging when it is
-    approved AND has no queued work. New feedback (Review_comments, Human, Ci,
-    Merge_conflict, Pr_body) enqueues an operation, which fails this check and
-    so resets the deadline. *)
+    approved, passing CI, has no queued work, has no merge call in flight, and
+    has not exceeded [automerge_max_failures] consecutive failures. New feedback
+    (Review_comments, Human, Ci, Merge_conflict, Pr_body) enqueues an operation,
+    which fails this check and so resets the deadline. [checks_passing] is
+    derived separately from [merge_ready] and captures CI conclusions that
+    GitHub's [mergeStateStatus] may consider optional. *)
 let is_automerge_candidate (agent : Patch_agent.t) ~main_branch =
-  Patch_agent.is_approved agent ~main_branch && List.is_empty agent.queue
+  Patch_agent.is_approved agent ~main_branch
+  && agent.Patch_agent.checks_passing
+  && List.is_empty agent.Patch_agent.queue
+  && (not agent.Patch_agent.automerge_inflight)
+  && agent.Patch_agent.automerge_failure_count < automerge_max_failures
 
 type automerge_decision = {
   merge_patch_id : Patch_id.t;
@@ -467,26 +475,41 @@ type automerge_decision = {
     orchestrator and the list of patches whose deadline has now elapsed (the
     caller is responsible for invoking the GitHub merge API for each).
 
-    For each agent with [automerge_enabled = true]:
+    For each agent:
+    - If the patch is [merged], clear any stale deadline/inflight flag — PRs
+      merged outside [apply_automerge_success] (manual merge, replacement PR,
+      etc.) must not keep a leftover timer in persisted state or the UI.
+    - If [automerge_enabled = false], nothing to do.
     - If the patch is a candidate and has no deadline, set one at
       [now +. automerge_idle_timeout].
     - If the patch is not a candidate and has a deadline, clear it — any
       feedback resets the timer, so enabling again must wait out a fresh
       5-minute window.
-    - If the patch is a candidate and the deadline has elapsed, include it in
-      the returned decision list. The deadline is left in place; clearing it is
-      the caller's responsibility after the merge side-effect completes (either
-      via [apply_automerge_success] on success or by re-reconciling on failure).
-*)
+    - If the patch is a candidate and the deadline has elapsed, mark the agent
+      [automerge_inflight = true] atomically and include it in the returned
+      decision list. The deadline is left in place; clearing it, clearing the
+      inflight flag, and advancing the failure counter are the caller's
+      responsibility via [apply_automerge_success]/[apply_automerge_failure]. *)
 let reconcile_automerge t ~now =
   let agents = Orchestrator.all_agents t in
   let main_branch = Orchestrator.main_branch t in
   List.fold agents ~init:(t, []) ~f:(fun (t, decisions) agent ->
-      if agent.Patch_agent.merged || not agent.Patch_agent.automerge_enabled
-      then (t, decisions)
+      let patch_id = agent.Patch_agent.patch_id in
+      if agent.Patch_agent.merged then
+        let t =
+          if Option.is_some agent.Patch_agent.automerge_deadline then
+            Orchestrator.clear_automerge_deadline t patch_id
+          else t
+        in
+        let t =
+          if agent.Patch_agent.automerge_inflight then
+            Orchestrator.set_automerge_inflight t patch_id false
+          else t
+        in
+        (t, decisions)
+      else if not agent.Patch_agent.automerge_enabled then (t, decisions)
       else
         let candidate = is_automerge_candidate agent ~main_branch in
-        let patch_id = agent.Patch_agent.patch_id in
         match (candidate, agent.Patch_agent.automerge_deadline) with
         | false, Some _ ->
             (Orchestrator.clear_automerge_deadline t patch_id, decisions)
@@ -498,6 +521,7 @@ let reconcile_automerge t ~now =
             if Float.( >= ) now deadline then
               match agent.Patch_agent.pr_number with
               | Some pr_number ->
+                  let t = Orchestrator.set_automerge_inflight t patch_id true in
                   ( t,
                     { merge_patch_id = patch_id; merge_pr_number = pr_number }
                     :: decisions )
@@ -507,6 +531,17 @@ let reconcile_automerge t ~now =
 
 let apply_automerge_success t patch_id =
   let t = Orchestrator.mark_merged t patch_id in
+  let t = Orchestrator.clear_automerge_deadline t patch_id in
+  let t = Orchestrator.set_automerge_inflight t patch_id false in
+  Orchestrator.reset_automerge_failure_count t patch_id
+
+(** Apply the durable state change that follows a failed merge call. Clears the
+    inflight flag, increments the failure counter, and drops the deadline so the
+    next reconcile either retries after a fresh idle window (if still a
+    candidate and under the cap) or no-ops (if the cap is hit). *)
+let apply_automerge_failure t patch_id =
+  let t = Orchestrator.set_automerge_inflight t patch_id false in
+  let t = Orchestrator.increment_automerge_failure_count t patch_id in
   Orchestrator.clear_automerge_deadline t patch_id
 
 let make_orchestrator ~patch_id ~main_branch =
@@ -675,3 +710,107 @@ let%test "no merge-conflict re-enqueue after noop" =
   Orchestrator.equal_conflict_rebase_decision decision
     Orchestrator.Conflict_resolved
   && not (Orchestrator.agent t pid).Patch_agent.busy
+
+(* -- Automerge reconciliation tests -- *)
+
+let make_approved_agent t =
+  let t = Orchestrator.fire t (Orchestrator.Start (pid, main)) in
+  let t = Orchestrator.set_pr_number t pid (Pr_number.of_int 42) in
+  let t = Orchestrator.complete t pid in
+  let t = Orchestrator.set_is_draft t pid false in
+  let t = Orchestrator.set_merge_ready t pid true in
+  let t = Orchestrator.set_checks_passing t pid true in
+  let t = Orchestrator.set_pr_body_delivered t pid true in
+  Orchestrator.set_automerge_enabled t pid true
+
+let%test "reconcile_automerge clears deadline on merged agent" =
+  let _patch, t = make_orchestrator ~patch_id:pid ~main_branch:main in
+  let t = make_approved_agent t in
+  let t = Orchestrator.set_automerge_deadline t pid 1.0 in
+  let t = Orchestrator.mark_merged t pid in
+  let t, decisions = reconcile_automerge t ~now:100.0 in
+  List.is_empty decisions
+  && Option.is_none (Orchestrator.agent t pid).Patch_agent.automerge_deadline
+
+let%test "reconcile_automerge clears inflight on merged agent" =
+  let _patch, t = make_orchestrator ~patch_id:pid ~main_branch:main in
+  let t = make_approved_agent t in
+  let t = Orchestrator.set_automerge_inflight t pid true in
+  let t = Orchestrator.mark_merged t pid in
+  let t, decisions = reconcile_automerge t ~now:100.0 in
+  List.is_empty decisions
+  && not (Orchestrator.agent t pid).Patch_agent.automerge_inflight
+
+let%test "reconcile_automerge skips when checks_passing is false" =
+  let _patch, t = make_orchestrator ~patch_id:pid ~main_branch:main in
+  let t = make_approved_agent t in
+  let t = Orchestrator.set_checks_passing t pid false in
+  let t, decisions = reconcile_automerge t ~now:1000.0 in
+  List.is_empty decisions
+  && Option.is_none (Orchestrator.agent t pid).Patch_agent.automerge_deadline
+
+let%test "reconcile_automerge marks inflight when firing a decision" =
+  let _patch, t = make_orchestrator ~patch_id:pid ~main_branch:main in
+  let t = make_approved_agent t in
+  let t = Orchestrator.set_automerge_deadline t pid 1.0 in
+  let t, decisions = reconcile_automerge t ~now:100.0 in
+  List.length decisions = 1
+  && (Orchestrator.agent t pid).Patch_agent.automerge_inflight
+
+let%test "reconcile_automerge skips when inflight is true" =
+  let _patch, t = make_orchestrator ~patch_id:pid ~main_branch:main in
+  let t = make_approved_agent t in
+  let t = Orchestrator.set_automerge_deadline t pid 1.0 in
+  let t = Orchestrator.set_automerge_inflight t pid true in
+  let t, decisions = reconcile_automerge t ~now:100.0 in
+  List.is_empty decisions
+  && Option.is_none (Orchestrator.agent t pid).Patch_agent.automerge_deadline
+
+let%test "reconcile_automerge skips when failure cap is hit" =
+  let _patch, t = make_orchestrator ~patch_id:pid ~main_branch:main in
+  let t = make_approved_agent t in
+  let t =
+    Fn.apply_n_times ~n:automerge_max_failures
+      (fun t -> Orchestrator.increment_automerge_failure_count t pid)
+      t
+  in
+  let t, decisions = reconcile_automerge t ~now:1000.0 in
+  List.is_empty decisions
+  && Option.is_none (Orchestrator.agent t pid).Patch_agent.automerge_deadline
+
+let%test "apply_automerge_success clears inflight and resets failures" =
+  let _patch, t = make_orchestrator ~patch_id:pid ~main_branch:main in
+  let t = make_approved_agent t in
+  let t = Orchestrator.set_automerge_inflight t pid true in
+  let t = Orchestrator.increment_automerge_failure_count t pid in
+  let t = apply_automerge_success t pid in
+  let a = Orchestrator.agent t pid in
+  a.Patch_agent.merged
+  && (not a.Patch_agent.automerge_inflight)
+  && a.Patch_agent.automerge_failure_count = 0
+  && Option.is_none a.Patch_agent.automerge_deadline
+
+let%test "apply_automerge_failure clears deadline and bumps count" =
+  let _patch, t = make_orchestrator ~patch_id:pid ~main_branch:main in
+  let t = make_approved_agent t in
+  let t = Orchestrator.set_automerge_deadline t pid 1.0 in
+  let t = Orchestrator.set_automerge_inflight t pid true in
+  let t = apply_automerge_failure t pid in
+  let a = Orchestrator.agent t pid in
+  a.Patch_agent.automerge_failure_count = 1
+  && (not a.Patch_agent.automerge_inflight)
+  && Option.is_none a.Patch_agent.automerge_deadline
+
+let%test "toggling automerge resets failure count and inflight" =
+  let _patch, t = make_orchestrator ~patch_id:pid ~main_branch:main in
+  let t = make_approved_agent t in
+  let t = Orchestrator.increment_automerge_failure_count t pid in
+  let t = Orchestrator.increment_automerge_failure_count t pid in
+  let t = Orchestrator.set_automerge_inflight t pid true in
+  (* Disable → enable *)
+  let t = Orchestrator.set_automerge_enabled t pid false in
+  let t = Orchestrator.set_automerge_enabled t pid true in
+  let a = Orchestrator.agent t pid in
+  a.Patch_agent.automerge_enabled
+  && a.Patch_agent.automerge_failure_count = 0
+  && not a.Patch_agent.automerge_inflight

--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -533,7 +533,13 @@ let reconcile_automerge t ~now =
         (* A merge is already in flight for this patch. Don't touch the
            deadline or issue a second decision — the caller clears the
            inflight flag and advances state via apply_automerge_success /
-           apply_automerge_failure on resolution. *)
+           apply_automerge_failure on resolution.
+
+           Belt-and-suspenders: [is_automerge_candidate] with its default
+           [~ignore_inflight:false] also rejects inflight agents below. This
+           explicit short-circuit is load-bearing for deadline preservation
+           (the [(false, Some _)] branch would otherwise clear the deadline),
+           so both guards must stay in sync. *)
         (t, decisions)
       else
         let candidate = is_automerge_candidate agent ~main_branch in

--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -476,6 +476,13 @@ let automerge_max_failures = 3
 let is_automerge_candidate ?(ignore_inflight = false) (agent : Patch_agent.t)
     ~main_branch =
   (ignore_inflight || not agent.Patch_agent.automerge_inflight)
+  (* [not merged] looks redundant with [reconcile_automerge]'s early-return
+     on [agent.merged], but it is specifically load-bearing for the executor
+     re-check in [reconcile_and_execute_automerge], which uses
+     [~ignore_inflight:true] and runs on a later snapshot — a concurrent
+     poller can mark the agent merged between reconcile and execute. Do not
+     remove this guard; [reconcile_automerge]'s early-return is not
+     sufficient on its own. *)
   && (not agent.Patch_agent.merged)
   && agent.Patch_agent.automerge_enabled
   && Patch_agent.is_approved agent ~main_branch
@@ -928,9 +935,16 @@ let%test "apply_automerge_failure does not re-arm when automerge is disabled" =
   let t = Orchestrator.set_automerge_enabled t pid false in
   let t = apply_automerge_failure t ~now:1000.0 pid in
   let a = Orchestrator.agent t pid in
+  (* The counter IS incremented (0 → 1) by [apply_automerge_failure] even
+     though automerge is now disabled — the implementation bumps the counter
+     unconditionally and only skips the deadline re-arm when disabled.
+     [set_automerge_enabled true] on a later re-enable resets the counter,
+     so this increment is invisible across a disable/enable cycle. The key
+     invariant the test guards is that no deadline is re-armed. *)
   (not a.Patch_agent.automerge_enabled)
   && (not a.Patch_agent.automerge_inflight)
   && Option.is_none a.Patch_agent.automerge_deadline
+  && a.Patch_agent.automerge_failure_count = 1
 
 let%test "toggling automerge resets failure count and inflight" =
   let _patch, t = make_orchestrator ~patch_id:pid ~main_branch:main in

--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -525,7 +525,13 @@ let reconcile_automerge t ~now =
                   ( t,
                     { merge_patch_id = patch_id; merge_pr_number = pr_number }
                     :: decisions )
-              | None -> (t, decisions)
+              | None ->
+                  (* Unreachable today because [is_automerge_candidate]
+                     requires [is_approved] which requires [has_pr]. Defensive
+                     clear so a future predicate change can't leave a patch
+                     with a permanently-elapsed deadline that fires every
+                     tick. *)
+                  (Orchestrator.clear_automerge_deadline t patch_id, decisions)
             else (t, decisions))
   |> fun (t, decisions) -> (t, List.rev decisions)
 
@@ -536,13 +542,18 @@ let apply_automerge_success t patch_id =
   Orchestrator.reset_automerge_failure_count t patch_id
 
 (** Apply the durable state change that follows a failed merge call. Clears the
-    inflight flag, increments the failure counter, and drops the deadline so the
-    next reconcile either retries after a fresh idle window (if still a
-    candidate and under the cap) or no-ops (if the cap is hit). *)
-let apply_automerge_failure t patch_id =
+    inflight flag, increments the failure counter, and pushes the deadline out
+    by [automerge_idle_timeout] so the retry is at least one idle window away.
+    This bound matters because the runner may call
+    [reconcile_and_execute_ automerge] every tick (~1s) — without an explicit
+    push-out, a persistent GitHub failure could produce a burst of merge calls
+    within a single poll cycle. If the cap has been hit the predicate flips
+    [is_automerge_candidate] to [false] and the next reconcile clears the
+    deadline via the normal non-candidate path. *)
+let apply_automerge_failure t ~now patch_id =
   let t = Orchestrator.set_automerge_inflight t patch_id false in
   let t = Orchestrator.increment_automerge_failure_count t patch_id in
-  Orchestrator.clear_automerge_deadline t patch_id
+  Orchestrator.set_automerge_deadline t patch_id (now +. automerge_idle_timeout)
 
 let make_orchestrator ~patch_id ~main_branch =
   let patch =
@@ -790,16 +801,20 @@ let%test "apply_automerge_success clears inflight and resets failures" =
   && a.Patch_agent.automerge_failure_count = 0
   && Option.is_none a.Patch_agent.automerge_deadline
 
-let%test "apply_automerge_failure clears deadline and bumps count" =
+let%test "apply_automerge_failure bumps deadline one idle window out" =
   let _patch, t = make_orchestrator ~patch_id:pid ~main_branch:main in
   let t = make_approved_agent t in
   let t = Orchestrator.set_automerge_deadline t pid 1.0 in
   let t = Orchestrator.set_automerge_inflight t pid true in
-  let t = apply_automerge_failure t pid in
+  let now = 1000.0 in
+  let t = apply_automerge_failure t ~now pid in
   let a = Orchestrator.agent t pid in
   a.Patch_agent.automerge_failure_count = 1
   && (not a.Patch_agent.automerge_inflight)
-  && Option.is_none a.Patch_agent.automerge_deadline
+  &&
+  match a.Patch_agent.automerge_deadline with
+  | Some d -> Float.( = ) d (now +. automerge_idle_timeout)
+  | None -> false
 
 let%test "toggling automerge resets failure count and inflight" =
   let _patch, t = make_orchestrator ~patch_id:pid ~main_branch:main in

--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -857,8 +857,10 @@ let%test "reconcile_automerge skips when failure cap is hit" =
       t
   in
   let t, decisions = reconcile_automerge t ~now:1000.0 in
+  let a = Orchestrator.agent t pid in
   List.is_empty decisions
-  && Option.is_none (Orchestrator.agent t pid).Patch_agent.automerge_deadline
+  && Option.is_none a.Patch_agent.automerge_deadline
+  && not a.Patch_agent.automerge_inflight
 
 let%test "apply_automerge_success clears inflight and resets failures" =
   let _patch, t = make_orchestrator ~patch_id:pid ~main_branch:main in

--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -790,13 +790,20 @@ let%test "reconcile_automerge clears inflight on merged agent" =
   List.is_empty decisions
   && not (Orchestrator.agent t pid).Patch_agent.automerge_inflight
 
-let%test "reconcile_automerge skips when checks_passing is false" =
+let%test "reconcile_automerge (false, None) is a stable no-op" =
+  (* Complement to the (false, Some _) clearing test below: when the patch is
+     not a candidate AND has no deadline, reconcile must not arm one or emit a
+     decision. [make_approved_agent] enables automerge but does not set a
+     deadline, so disabling checks_passing lands us on the no-op branch. *)
   let _patch, t = make_orchestrator ~patch_id:pid ~main_branch:main in
   let t = make_approved_agent t in
   let t = Orchestrator.set_checks_passing t pid false in
+  let t_before = t in
   let t, decisions = reconcile_automerge t ~now:1000.0 in
   List.is_empty decisions
-  && Option.is_none (Orchestrator.agent t pid).Patch_agent.automerge_deadline
+  && Patch_agent.equal
+       (Orchestrator.agent t_before pid)
+       (Orchestrator.agent t pid)
 
 let%test "reconcile_automerge clears deadline when checks_passing flips false" =
   let _patch, t = make_orchestrator ~patch_id:pid ~main_branch:main in

--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -451,13 +451,19 @@ let apply_github_effect_success t = function
 let automerge_idle_timeout = 300.0
 let automerge_max_failures = 3
 
-(** Pure predicate: a patch is a candidate for automerge merging when automerge
-    is enabled, the PR is approved, CI is passing, the queue is empty, and the
-    consecutive failure count is under [automerge_max_failures]. New feedback
-    (Review_comments, Human, Ci, Merge_conflict, Pr_body) enqueues an operation,
-    which fails this check and so resets the deadline. [checks_passing] is
-    derived separately from [merge_ready] and captures CI conclusions that
-    GitHub's [mergeStateStatus] may consider optional.
+(** Pure predicate: a patch is a candidate for automerge merging when it is not
+    already merged, automerge is enabled, the PR is approved, CI is passing, the
+    queue is empty, and the consecutive failure count is under
+    [automerge_max_failures]. New feedback (Review_comments, Human, Ci,
+    Merge_conflict, Pr_body) enqueues an operation, which fails this check and
+    so resets the deadline. [checks_passing] is derived separately from
+    [merge_ready] and captures CI conclusions that GitHub's [mergeStateStatus]
+    may consider optional.
+
+    The [not merged] guard is included here because a merged PR can retain a
+    stale [merge_ready = true] in the orchestrator snapshot (e.g. the poller
+    hasn't yet observed the merge or the PR was merged out-of-band); without
+    this guard such a PR would re-qualify as a candidate.
 
     [automerge_inflight] is intentionally NOT checked here: that flag protects
     the reconciler from double-claiming a decision, not the predicate's
@@ -467,7 +473,8 @@ let automerge_max_failures = 3
     and relies on this predicate returning [true] so long as the underlying
     candidacy still holds. *)
 let is_automerge_candidate (agent : Patch_agent.t) ~main_branch =
-  agent.Patch_agent.automerge_enabled
+  (not agent.Patch_agent.merged)
+  && agent.Patch_agent.automerge_enabled
   && Patch_agent.is_approved agent ~main_branch
   && agent.Patch_agent.checks_passing
   && List.is_empty agent.Patch_agent.queue

--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -560,18 +560,30 @@ let apply_automerge_success t patch_id =
   Orchestrator.reset_automerge_failure_count t patch_id
 
 (** Apply the durable state change that follows a failed merge call. Clears the
-    inflight flag, increments the failure counter, and pushes the deadline out
-    by [automerge_idle_timeout] so the retry is at least one idle window away.
-    This bound matters because the runner may call
-    [reconcile_and_execute_ automerge] every tick (~1s) — without an explicit
-    push-out, a persistent GitHub failure could produce a burst of merge calls
-    within a single poll cycle. If the cap has been hit the predicate flips
-    [is_automerge_candidate] to [false] and the next reconcile clears the
-    deadline via the normal non-candidate path. *)
+    inflight flag and increments the failure counter. Pushes the deadline out by
+    [automerge_idle_timeout] so the retry is at least one idle window away — the
+    runner may call [reconcile_and_execute_automerge] every tick (~1s), and
+    without an explicit push-out a persistent GitHub failure could produce a
+    burst of calls within a single poll cycle.
+
+    Skip the deadline re-arm in two terminal cases:
+    - The failure cap has now been reached: reconciliation will no longer issue
+      merge calls for this patch, so writing a deadline that the next reconcile
+      will immediately clear is wasted work and confusing in traces.
+    - Automerge has been disabled (the user toggled it off while the merge was
+      in flight): writing a deadline would contradict the disabled state and
+      stick around until the next tick cleared it. *)
 let apply_automerge_failure t ~now patch_id =
   let t = Orchestrator.set_automerge_inflight t patch_id false in
   let t = Orchestrator.increment_automerge_failure_count t patch_id in
-  Orchestrator.set_automerge_deadline t patch_id (now +. automerge_idle_timeout)
+  let agent = Orchestrator.agent t patch_id in
+  if
+    agent.Patch_agent.automerge_failure_count >= automerge_max_failures
+    || not agent.Patch_agent.automerge_enabled
+  then t
+  else
+    Orchestrator.set_automerge_deadline t patch_id
+      (now +. automerge_idle_timeout)
 
 let make_orchestrator ~patch_id ~main_branch =
   let patch =
@@ -837,6 +849,45 @@ let%test "apply_automerge_failure bumps deadline one idle window out" =
   match a.Patch_agent.automerge_deadline with
   | Some d -> Float.( = ) d (now +. automerge_idle_timeout)
   | None -> false
+
+let%test "apply_automerge_failure does not re-arm once cap is reached" =
+  let _patch, t = make_orchestrator ~patch_id:pid ~main_branch:main in
+  let t = make_approved_agent t in
+  (* Prime the counter so this failure hits the cap. *)
+  let t =
+    Fn.apply_n_times
+      ~n:(automerge_max_failures - 1)
+      (fun t -> Orchestrator.increment_automerge_failure_count t pid)
+      t
+  in
+  let pre_deadline = 1.0 in
+  let t = Orchestrator.set_automerge_deadline t pid pre_deadline in
+  let t = Orchestrator.set_automerge_inflight t pid true in
+  let now = 1000.0 in
+  let t = apply_automerge_failure t ~now pid in
+  let a = Orchestrator.agent t pid in
+  (* Deadline must not be bumped to [now +. idle_timeout]; the next reconcile
+     tick will clear it via the non-candidate path. *)
+  a.Patch_agent.automerge_failure_count = automerge_max_failures
+  && (not a.Patch_agent.automerge_inflight)
+  &&
+  match a.Patch_agent.automerge_deadline with
+  | None -> true
+  | Some d -> not (Float.( = ) d (now +. automerge_idle_timeout))
+
+let%test "apply_automerge_failure does not re-arm when automerge is disabled" =
+  let _patch, t = make_orchestrator ~patch_id:pid ~main_branch:main in
+  let t = make_approved_agent t in
+  let t = Orchestrator.set_automerge_deadline t pid 1.0 in
+  let t = Orchestrator.set_automerge_inflight t pid true in
+  (* User disables automerge while the merge call is in flight. Toggling
+     clears the deadline and inflight flag; the late failure then resolves. *)
+  let t = Orchestrator.set_automerge_enabled t pid false in
+  let t = apply_automerge_failure t ~now:1000.0 pid in
+  let a = Orchestrator.agent t pid in
+  (not a.Patch_agent.automerge_enabled)
+  && (not a.Patch_agent.automerge_inflight)
+  && Option.is_none a.Patch_agent.automerge_deadline
 
 let%test "toggling automerge resets failure count and inflight" =
   let _patch, t = make_orchestrator ~patch_id:pid ~main_branch:main in

--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -577,10 +577,16 @@ let apply_automerge_failure t ~now patch_id =
   let t = Orchestrator.set_automerge_inflight t patch_id false in
   let t = Orchestrator.increment_automerge_failure_count t patch_id in
   let agent = Orchestrator.agent t patch_id in
-  if
-    agent.Patch_agent.automerge_failure_count >= automerge_max_failures
-    || not agent.Patch_agent.automerge_enabled
-  then t
+  if agent.Patch_agent.automerge_failure_count >= automerge_max_failures then
+    (* Clear any existing deadline so the persisted snapshot unambiguously
+       reflects the terminal state; the next reconcile would clear it anyway
+       via the non-candidate path, but leaving it in place between these two
+       events is misleading in traces and on-disk state. *)
+    Orchestrator.clear_automerge_deadline t patch_id
+  else if not agent.Patch_agent.automerge_enabled then
+    (* User disabled automerge while the call was in flight — toggling off
+       already cleared the deadline, so nothing more to do here. *)
+    t
   else
     Orchestrator.set_automerge_deadline t patch_id
       (now +. automerge_idle_timeout)
@@ -854,7 +860,7 @@ let%test "apply_automerge_failure bumps deadline one idle window out" =
   | Some d -> Float.( = ) d (now +. automerge_idle_timeout)
   | None -> false
 
-let%test "apply_automerge_failure does not re-arm once cap is reached" =
+let%test "apply_automerge_failure clears deadline once cap is reached" =
   let _patch, t = make_orchestrator ~patch_id:pid ~main_branch:main in
   let t = make_approved_agent t in
   (* Prime the counter so this failure hits the cap. *)
@@ -864,20 +870,15 @@ let%test "apply_automerge_failure does not re-arm once cap is reached" =
       (fun t -> Orchestrator.increment_automerge_failure_count t pid)
       t
   in
-  let pre_deadline = 1.0 in
-  let t = Orchestrator.set_automerge_deadline t pid pre_deadline in
+  (* Pre-arm a deadline so we can verify it's actively cleared, not just
+     skipped. *)
+  let t = Orchestrator.set_automerge_deadline t pid 1.0 in
   let t = Orchestrator.set_automerge_inflight t pid true in
-  let now = 1000.0 in
-  let t = apply_automerge_failure t ~now pid in
+  let t = apply_automerge_failure t ~now:1000.0 pid in
   let a = Orchestrator.agent t pid in
-  (* Deadline must not be bumped to [now +. idle_timeout]; the next reconcile
-     tick will clear it via the non-candidate path. *)
   a.Patch_agent.automerge_failure_count = automerge_max_failures
   && (not a.Patch_agent.automerge_inflight)
-  &&
-  match a.Patch_agent.automerge_deadline with
-  | None -> true
-  | Some d -> not (Float.( = ) d (now +. automerge_idle_timeout))
+  && Option.is_none a.Patch_agent.automerge_deadline
 
 let%test "apply_automerge_failure does not re-arm when automerge is disabled" =
   let _patch, t = make_orchestrator ~patch_id:pid ~main_branch:main in

--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -814,6 +814,10 @@ let%test "reconcile_automerge skips when inflight is true" =
 let%test "reconcile_automerge skips when failure cap is hit" =
   let _patch, t = make_orchestrator ~patch_id:pid ~main_branch:main in
   let t = make_approved_agent t in
+  (* Arm a deadline before hitting the cap so the (false, Some _) branch
+     actually fires and we verify the deadline gets cleared — otherwise the
+     test passes trivially via (false, None). *)
+  let t = Orchestrator.set_automerge_deadline t pid 1.0 in
   let t =
     Fn.apply_n_times ~n:automerge_max_failures
       (fun t -> Orchestrator.increment_automerge_failure_count t pid)

--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -451,9 +451,9 @@ let apply_github_effect_success t = function
 let automerge_idle_timeout = 300.0
 let automerge_max_failures = 3
 
-(** Pure predicate: a patch is a candidate for automerge merging when it is
-    approved, passing CI, has no queued work, and has not exceeded
-    [automerge_max_failures] consecutive failures. New feedback
+(** Pure predicate: a patch is a candidate for automerge merging when automerge
+    is enabled, the PR is approved, CI is passing, the queue is empty, and the
+    consecutive failure count is under [automerge_max_failures]. New feedback
     (Review_comments, Human, Ci, Merge_conflict, Pr_body) enqueues an operation,
     which fails this check and so resets the deadline. [checks_passing] is
     derived separately from [merge_ready] and captures CI conclusions that
@@ -467,7 +467,8 @@ let automerge_max_failures = 3
     and relies on this predicate returning [true] so long as the underlying
     candidacy still holds. *)
 let is_automerge_candidate (agent : Patch_agent.t) ~main_branch =
-  Patch_agent.is_approved agent ~main_branch
+  agent.Patch_agent.automerge_enabled
+  && Patch_agent.is_approved agent ~main_branch
   && agent.Patch_agent.checks_passing
   && List.is_empty agent.Patch_agent.queue
   && agent.Patch_agent.automerge_failure_count < automerge_max_failures
@@ -486,9 +487,11 @@ type automerge_decision = {
     - If the patch is [merged], clear any stale deadline/inflight flag — PRs
       merged outside [apply_automerge_success] (manual merge, replacement PR,
       etc.) must not keep a leftover timer in persisted state or the UI.
-    - If [automerge_enabled = false], nothing to do.
     - If [automerge_inflight = true], no-op. The executor owns the deadline and
       inflight transitions while a merge call is in progress.
+    - If [automerge_enabled = false], [is_automerge_candidate] returns false,
+      which funnels into the non-candidate branches below (clearing any stale
+      deadline). No separate early-return is needed.
     - If the patch is a candidate and has no deadline, set one at
       [now +. automerge_idle_timeout].
     - If the patch is not a candidate and has a deadline, clear it — any
@@ -516,7 +519,6 @@ let reconcile_automerge t ~now =
           else t
         in
         (t, decisions)
-      else if not agent.Patch_agent.automerge_enabled then (t, decisions)
       else if agent.Patch_agent.automerge_inflight then
         (* A merge is already in flight for this patch. Don't touch the
            deadline or issue a second decision — the caller clears the
@@ -791,6 +793,17 @@ let%test "reconcile_automerge clears inflight on merged agent" =
 let%test "reconcile_automerge skips when checks_passing is false" =
   let _patch, t = make_orchestrator ~patch_id:pid ~main_branch:main in
   let t = make_approved_agent t in
+  let t = Orchestrator.set_checks_passing t pid false in
+  let t, decisions = reconcile_automerge t ~now:1000.0 in
+  List.is_empty decisions
+  && Option.is_none (Orchestrator.agent t pid).Patch_agent.automerge_deadline
+
+let%test "reconcile_automerge clears deadline when checks_passing flips false" =
+  let _patch, t = make_orchestrator ~patch_id:pid ~main_branch:main in
+  let t = make_approved_agent t in
+  (* Pre-arm a deadline so the (false, Some _) clearing branch actually
+     fires. Without this the test passes trivially via (false, None). *)
+  let t = Orchestrator.set_automerge_deadline t pid 1300.0 in
   let t = Orchestrator.set_checks_passing t pid false in
   let t, decisions = reconcile_automerge t ~now:1000.0 in
   List.is_empty decisions

--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -451,29 +451,32 @@ let apply_github_effect_success t = function
 let automerge_idle_timeout = 300.0
 let automerge_max_failures = 3
 
-(** Pure predicate: a patch is a candidate for automerge merging when it is not
-    already merged, automerge is enabled, the PR is approved, CI is passing, the
-    queue is empty, and the consecutive failure count is under
-    [automerge_max_failures]. New feedback (Review_comments, Human, Ci,
-    Merge_conflict, Pr_body) enqueues an operation, which fails this check and
-    so resets the deadline. [checks_passing] is derived separately from
-    [merge_ready] and captures CI conclusions that GitHub's [mergeStateStatus]
-    may consider optional.
+(** Pure predicate: a patch is a candidate to START a new automerge call when it
+    is not already merged, no merge is currently in flight, automerge is
+    enabled, the PR is approved, CI is passing, the queue is empty, and the
+    consecutive failure count is under [automerge_max_failures]. New feedback
+    (Review_comments, Human, Ci, Merge_conflict, Pr_body) enqueues an operation,
+    which fails this check and so resets the deadline. [checks_passing] is
+    derived separately from [merge_ready] and captures CI conclusions that
+    GitHub's [mergeStateStatus] may consider optional.
 
     The [not merged] guard is included here because a merged PR can retain a
     stale [merge_ready = true] in the orchestrator snapshot (e.g. the poller
     hasn't yet observed the merge or the PR was merged out-of-band); without
     this guard such a PR would re-qualify as a candidate.
 
-    [automerge_inflight] is intentionally NOT checked here: that flag protects
-    the reconciler from double-claiming a decision, not the predicate's
-    definition of candidacy. Callers that must reject a concurrent claim (i.e.
-    [reconcile_automerge]) add the [not inflight] guard themselves; the executor
-    re-check in [reconcile_and_execute_automerge] runs while [inflight = true]
-    and relies on this predicate returning [true] so long as the underlying
-    candidacy still holds. *)
-let is_automerge_candidate (agent : Patch_agent.t) ~main_branch =
-  (not agent.Patch_agent.merged)
+    [?ignore_inflight] defaults to [false]: the safe default answers "is this
+    patch eligible to start a new merge call?". The only legitimate caller that
+    passes [~ignore_inflight:true] is the executor re-check in
+    [reconcile_and_execute_automerge], which runs while holding
+    [automerge_inflight = true] and needs the predicate to return [true] so long
+    as the underlying candidacy still holds (otherwise every merge call would be
+    short-circuited by its own inflight flag). Making the safe option the
+    default prevents a future caller from forgetting the inflight guard. *)
+let is_automerge_candidate ?(ignore_inflight = false) (agent : Patch_agent.t)
+    ~main_branch =
+  (ignore_inflight || not agent.Patch_agent.automerge_inflight)
+  && (not agent.Patch_agent.merged)
   && agent.Patch_agent.automerge_enabled
   && Patch_agent.is_approved agent ~main_branch
   && agent.Patch_agent.checks_passing

--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -448,6 +448,67 @@ let apply_github_effect_success t = function
   | Set_pr_base { patch_id; base; _ } ->
       Orchestrator.set_base_branch t patch_id base
 
+let automerge_idle_timeout = 300.0
+
+(** Pure predicate: a patch is a candidate for automerge merging when it is
+    approved AND has no queued work. New feedback (Review_comments, Human, Ci,
+    Merge_conflict, Pr_body) enqueues an operation, which fails this check and
+    so resets the deadline. *)
+let is_automerge_candidate (agent : Patch_agent.t) ~main_branch =
+  Patch_agent.is_approved agent ~main_branch && List.is_empty agent.queue
+
+type automerge_decision = {
+  merge_patch_id : Patch_id.t;
+  merge_pr_number : Pr_number.t;
+}
+[@@deriving show, eq, sexp_of]
+
+(** Reconcile the automerge deadline for every agent. Returns the updated
+    orchestrator and the list of patches whose deadline has now elapsed (the
+    caller is responsible for invoking the GitHub merge API for each).
+
+    For each agent with [automerge_enabled = true]:
+    - If the patch is a candidate and has no deadline, set one at
+      [now +. automerge_idle_timeout].
+    - If the patch is not a candidate and has a deadline, clear it — any
+      feedback resets the timer, so enabling again must wait out a fresh
+      5-minute window.
+    - If the patch is a candidate and the deadline has elapsed, include it in
+      the returned decision list. The deadline is left in place; clearing it is
+      the caller's responsibility after the merge side-effect completes (either
+      via [apply_automerge_success] on success or by re-reconciling on failure).
+*)
+let reconcile_automerge t ~now =
+  let agents = Orchestrator.all_agents t in
+  let main_branch = Orchestrator.main_branch t in
+  List.fold agents ~init:(t, []) ~f:(fun (t, decisions) agent ->
+      if agent.Patch_agent.merged || not agent.Patch_agent.automerge_enabled
+      then (t, decisions)
+      else
+        let candidate = is_automerge_candidate agent ~main_branch in
+        let patch_id = agent.Patch_agent.patch_id in
+        match (candidate, agent.Patch_agent.automerge_deadline) with
+        | false, Some _ ->
+            (Orchestrator.clear_automerge_deadline t patch_id, decisions)
+        | false, None -> (t, decisions)
+        | true, None ->
+            let deadline = now +. automerge_idle_timeout in
+            (Orchestrator.set_automerge_deadline t patch_id deadline, decisions)
+        | true, Some deadline ->
+            if Float.( >= ) now deadline then
+              match agent.Patch_agent.pr_number with
+              | Some pr_number ->
+                  ( t,
+                    { merge_patch_id = patch_id; merge_pr_number = pr_number }
+                    :: decisions )
+              | None -> (t, decisions)
+            else (t, decisions))
+  |> fun (t, decisions) -> (t, List.rev decisions)
+
+let apply_automerge_success t patch_id =
+  let t = Orchestrator.mark_merged t patch_id in
+  Orchestrator.clear_automerge_deadline t patch_id
+
 let make_orchestrator ~patch_id ~main_branch =
   let patch =
     {

--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -452,17 +452,24 @@ let automerge_idle_timeout = 300.0
 let automerge_max_failures = 3
 
 (** Pure predicate: a patch is a candidate for automerge merging when it is
-    approved, passing CI, has no queued work, has no merge call in flight, and
-    has not exceeded [automerge_max_failures] consecutive failures. New feedback
+    approved, passing CI, has no queued work, and has not exceeded
+    [automerge_max_failures] consecutive failures. New feedback
     (Review_comments, Human, Ci, Merge_conflict, Pr_body) enqueues an operation,
     which fails this check and so resets the deadline. [checks_passing] is
     derived separately from [merge_ready] and captures CI conclusions that
-    GitHub's [mergeStateStatus] may consider optional. *)
+    GitHub's [mergeStateStatus] may consider optional.
+
+    [automerge_inflight] is intentionally NOT checked here: that flag protects
+    the reconciler from double-claiming a decision, not the predicate's
+    definition of candidacy. Callers that must reject a concurrent claim (i.e.
+    [reconcile_automerge]) add the [not inflight] guard themselves; the executor
+    re-check in [reconcile_and_execute_automerge] runs while [inflight = true]
+    and relies on this predicate returning [true] so long as the underlying
+    candidacy still holds. *)
 let is_automerge_candidate (agent : Patch_agent.t) ~main_branch =
   Patch_agent.is_approved agent ~main_branch
   && agent.Patch_agent.checks_passing
   && List.is_empty agent.Patch_agent.queue
-  && (not agent.Patch_agent.automerge_inflight)
   && agent.Patch_agent.automerge_failure_count < automerge_max_failures
 
 type automerge_decision = {
@@ -480,6 +487,8 @@ type automerge_decision = {
       merged outside [apply_automerge_success] (manual merge, replacement PR,
       etc.) must not keep a leftover timer in persisted state or the UI.
     - If [automerge_enabled = false], nothing to do.
+    - If [automerge_inflight = true], no-op. The executor owns the deadline and
+      inflight transitions while a merge call is in progress.
     - If the patch is a candidate and has no deadline, set one at
       [now +. automerge_idle_timeout].
     - If the patch is not a candidate and has a deadline, clear it — any
@@ -508,10 +517,19 @@ let reconcile_automerge t ~now =
         in
         (t, decisions)
       else if not agent.Patch_agent.automerge_enabled then (t, decisions)
+      else if agent.Patch_agent.automerge_inflight then
+        (* A merge is already in flight for this patch. Don't touch the
+           deadline or issue a second decision — the caller clears the
+           inflight flag and advances state via apply_automerge_success /
+           apply_automerge_failure on resolution. *)
+        (t, decisions)
       else
         let candidate = is_automerge_candidate agent ~main_branch in
         match (candidate, agent.Patch_agent.automerge_deadline) with
         | false, Some _ ->
+            (* Feedback arrived, lost approval, CI flipped, or failure cap
+               hit: drop the deadline so the next reconcile re-arms a fresh
+               idle window once the patch becomes a candidate again. *)
             (Orchestrator.clear_automerge_deadline t patch_id, decisions)
         | false, None -> (t, decisions)
         | true, None ->
@@ -774,8 +792,12 @@ let%test "reconcile_automerge skips when inflight is true" =
   let t = Orchestrator.set_automerge_deadline t pid 1.0 in
   let t = Orchestrator.set_automerge_inflight t pid true in
   let t, decisions = reconcile_automerge t ~now:100.0 in
-  List.is_empty decisions
-  && Option.is_none (Orchestrator.agent t pid).Patch_agent.automerge_deadline
+  let a = Orchestrator.agent t pid in
+  (* No new decision while a merge is in flight, and reconcile leaves the
+     inflight flag and deadline alone — the caller owns both via
+     apply_automerge_success / apply_automerge_failure. *)
+  List.is_empty decisions && a.Patch_agent.automerge_inflight
+  && Option.is_some a.Patch_agent.automerge_deadline
 
 let%test "reconcile_automerge skips when failure cap is hit" =
   let _patch, t = make_orchestrator ~patch_id:pid ~main_branch:main in

--- a/lib/patch_controller.mli
+++ b/lib/patch_controller.mli
@@ -123,13 +123,14 @@ type automerge_decision = {
 [@@deriving show, eq, sexp_of]
 
 val is_automerge_candidate : Patch_agent.t -> main_branch:Branch.t -> bool
-(** A patch is a candidate for automerge when it is approved, passing CI, has no
-    queued work, and has not exceeded [automerge_max_failures]. Any queued
-    feedback (Review_comments, Human, Ci, Merge_conflict, Pr_body) resets the
-    deadline. [automerge_inflight] is deliberately out of scope: callers that
-    need to reject concurrent claims (i.e. [reconcile_automerge]) add the
-    inflight guard themselves; the executor re-check needs the predicate to
-    return [true] while holding the flag. *)
+(** A patch is a candidate for automerge when automerge is enabled, the PR is
+    approved, CI is passing, the queue is empty, and the consecutive failure
+    count is under [automerge_max_failures]. Any queued feedback
+    (Review_comments, Human, Ci, Merge_conflict, Pr_body) resets the deadline.
+    [automerge_inflight] is deliberately out of scope: callers that need to
+    reject concurrent claims (i.e. [reconcile_automerge]) add the inflight guard
+    themselves; the executor re-check needs the predicate to return [true] while
+    holding the flag. *)
 
 val reconcile_automerge :
   Orchestrator.t -> now:float -> Orchestrator.t * automerge_decision list

--- a/lib/patch_controller.mli
+++ b/lib/patch_controller.mli
@@ -157,11 +157,11 @@ val apply_automerge_success : Orchestrator.t -> Patch_id.t -> Orchestrator.t
 
 val apply_automerge_failure :
   Orchestrator.t -> now:float -> Patch_id.t -> Orchestrator.t
-(** Record a failed merge call: clear the inflight flag, increment the
-    consecutive failure counter, and push the deadline out to
+(** Record a failed merge call: clear the inflight flag and increment the
+    consecutive failure counter. Push the deadline out to
     [now +. automerge_idle_timeout] so the retry is at least one idle window
-    away. Without this explicit push-out, a persistent GitHub failure could
-    generate a burst of merge calls within a single poll cycle since the runner
-    re-reconciles every tick. If the failure cap is now hit the predicate skips
-    the patch regardless and the next reconcile clears the deadline via the
-    normal non-candidate path. *)
+    away (without this bound, a persistent GitHub failure could burst many merge
+    calls per poll cycle since the runner re-reconciles every tick). The
+    deadline is NOT re-armed when either (a) the failure cap has now been
+    reached (reconciliation will no longer issue merge calls for this patch), or
+    (b) the user disabled automerge while the call was in flight. *)

--- a/lib/patch_controller.mli
+++ b/lib/patch_controller.mli
@@ -122,20 +122,22 @@ type automerge_decision = {
 }
 [@@deriving show, eq, sexp_of]
 
-val is_automerge_candidate : Patch_agent.t -> main_branch:Branch.t -> bool
-(** A patch is a candidate for automerge when it is not already merged,
-    automerge is enabled, the PR is approved, CI is passing, the queue is empty,
-    and the consecutive failure count is under [automerge_max_failures]. Any
-    queued feedback (Review_comments, Human, Ci, Merge_conflict, Pr_body) resets
-    the deadline.
+val is_automerge_candidate :
+  ?ignore_inflight:bool -> Patch_agent.t -> main_branch:Branch.t -> bool
+(** A patch is a candidate to START a new automerge call when it is not already
+    merged, no merge is currently in flight, automerge is enabled, the PR is
+    approved, CI is passing, the queue is empty, and the consecutive failure
+    count is under [automerge_max_failures]. Any queued feedback
+    (Review_comments, Human, Ci, Merge_conflict, Pr_body) resets the deadline.
 
-    Warning: [automerge_inflight] is deliberately out of scope. Callers that
-    must guard against concurrent merge calls (e.g. [reconcile_automerge]) must
-    explicitly check [not agent.Patch_agent.automerge_inflight] themselves
-    before consulting this predicate — omitting that guard will issue
-    overlapping merge calls. The executor re-check in
-    [reconcile_and_execute_automerge] relies on the predicate returning [true]
-    while holding the flag, so the guard cannot live inside the predicate. *)
+    [?ignore_inflight] defaults to [false]; the default answers the
+    concurrency-safe question ("is this patch eligible to start a new merge
+    call?"). The only legitimate use of [~ignore_inflight:true] is the executor
+    re-check in [reconcile_and_execute_automerge], which runs while holding
+    [automerge_inflight = true] and needs the predicate to return [true] so long
+    as the underlying candidacy still holds. Do not pass [~ignore_inflight:true]
+    from any other caller — doing so opens the door to overlapping merge calls.
+*)
 
 val reconcile_automerge :
   Orchestrator.t -> now:float -> Orchestrator.t * automerge_decision list

--- a/lib/patch_controller.mli
+++ b/lib/patch_controller.mli
@@ -105,3 +105,30 @@ val tick :
 val apply_github_effect_success :
   Orchestrator.t -> github_effect -> Orchestrator.t
 (** Apply the durable state changes that follow a successful GitHub effect. *)
+
+val automerge_idle_timeout : float
+(** Seconds of idle time after approval before automerge fires. *)
+
+type automerge_decision = {
+  merge_patch_id : Patch_id.t;
+  merge_pr_number : Pr_number.t;
+}
+[@@deriving show, eq, sexp_of]
+
+val is_automerge_candidate : Patch_agent.t -> main_branch:Branch.t -> bool
+(** A patch is a candidate for automerge when it is approved AND has no queued
+    work. Any queued feedback (Review_comments, Human, Ci, Merge_conflict,
+    Pr_body) resets the deadline. *)
+
+val reconcile_automerge :
+  Orchestrator.t -> now:float -> Orchestrator.t * automerge_decision list
+(** Reconcile the automerge deadline for every agent and return decisions to
+    merge. For each agent with [automerge_enabled = true]:
+    - candidate + no deadline → set deadline at [now +. automerge_idle_timeout]
+    - not candidate + deadline → clear deadline (feedback arrived)
+    - candidate + deadline elapsed → include in decisions list. Deadline stays
+      in place; the caller clears it via [apply_automerge_success] on success,
+      or re-reconciles next tick on failure. *)
+
+val apply_automerge_success : Orchestrator.t -> Patch_id.t -> Orchestrator.t
+(** Mark the patch as merged and clear its automerge deadline. *)

--- a/lib/patch_controller.mli
+++ b/lib/patch_controller.mli
@@ -109,6 +109,13 @@ val apply_github_effect_success :
 val automerge_idle_timeout : float
 (** Seconds of idle time after approval before automerge fires. *)
 
+val automerge_max_failures : int
+(** Hard cap on consecutive automerge call failures per patch. Once a patch hits
+    this count it is no longer a candidate and reconciliation stops retrying
+    until automerge is toggled off/on (or a successful merge resets the count —
+    which cannot happen once the cap is hit, so the toggle is the only
+    recovery). *)
+
 type automerge_decision = {
   merge_patch_id : Patch_id.t;
   merge_pr_number : Pr_number.t;
@@ -116,19 +123,35 @@ type automerge_decision = {
 [@@deriving show, eq, sexp_of]
 
 val is_automerge_candidate : Patch_agent.t -> main_branch:Branch.t -> bool
-(** A patch is a candidate for automerge when it is approved AND has no queued
-    work. Any queued feedback (Review_comments, Human, Ci, Merge_conflict,
-    Pr_body) resets the deadline. *)
+(** A patch is a candidate for automerge when it is approved, passing CI, has no
+    queued work, is not currently inflight, and has not exceeded
+    [automerge_max_failures]. Any queued feedback (Review_comments, Human, Ci,
+    Merge_conflict, Pr_body) resets the deadline. *)
 
 val reconcile_automerge :
   Orchestrator.t -> now:float -> Orchestrator.t * automerge_decision list
 (** Reconcile the automerge deadline for every agent and return decisions to
-    merge. For each agent with [automerge_enabled = true]:
-    - candidate + no deadline → set deadline at [now +. automerge_idle_timeout]
-    - not candidate + deadline → clear deadline (feedback arrived)
-    - candidate + deadline elapsed → include in decisions list. Deadline stays
-      in place; the caller clears it via [apply_automerge_success] on success,
-      or re-reconciles next tick on failure. *)
+    merge. For each agent:
+    - merged → clear any stale deadline/inflight flag (no decision).
+    - not [automerge_enabled] → no-op.
+    - candidate + no deadline → set deadline at [now +. automerge_idle_timeout].
+    - not candidate + deadline → clear deadline (feedback arrived, CI flipped,
+      inflight, or failure cap hit).
+    - candidate + deadline elapsed → atomically mark the agent
+      [automerge_inflight = true] and include in decisions list. The caller MUST
+      clear the inflight flag on every exit path, and call either
+      [apply_automerge_success] (success) or [apply_automerge_failure]
+      (failure). A persistent-failure PR retries once per idle window until the
+      failure counter reaches [automerge_max_failures], after which
+      reconciliation stops issuing merge calls until the user disables and
+      re-enables automerge. *)
 
 val apply_automerge_success : Orchestrator.t -> Patch_id.t -> Orchestrator.t
-(** Mark the patch as merged and clear its automerge deadline. *)
+(** Mark the patch as merged, clear the automerge deadline, clear the inflight
+    flag, and reset the failure counter. *)
+
+val apply_automerge_failure : Orchestrator.t -> Patch_id.t -> Orchestrator.t
+(** Record a failed merge call: clear the inflight flag, increment the
+    consecutive failure counter, and drop the deadline so the next reconcile
+    starts a fresh idle window (unless the failure cap is now hit, in which case
+    reconciliation will keep the deadline cleared). *)

--- a/lib/patch_controller.mli
+++ b/lib/patch_controller.mli
@@ -123,26 +123,30 @@ type automerge_decision = {
 [@@deriving show, eq, sexp_of]
 
 val is_automerge_candidate : Patch_agent.t -> main_branch:Branch.t -> bool
-(** A patch is a candidate for automerge when automerge is enabled, the PR is
-    approved, CI is passing, the queue is empty, and the consecutive failure
-    count is under [automerge_max_failures]. Any queued feedback
-    (Review_comments, Human, Ci, Merge_conflict, Pr_body) resets the deadline.
-    [automerge_inflight] is deliberately out of scope: callers that need to
-    reject concurrent claims (i.e. [reconcile_automerge]) add the inflight guard
-    themselves; the executor re-check needs the predicate to return [true] while
-    holding the flag. *)
+(** A patch is a candidate for automerge when it is not already merged,
+    automerge is enabled, the PR is approved, CI is passing, the queue is empty,
+    and the consecutive failure count is under [automerge_max_failures]. Any
+    queued feedback (Review_comments, Human, Ci, Merge_conflict, Pr_body) resets
+    the deadline.
+
+    Warning: [automerge_inflight] is deliberately out of scope. Callers that
+    must guard against concurrent merge calls (e.g. [reconcile_automerge]) must
+    explicitly check [not agent.Patch_agent.automerge_inflight] themselves
+    before consulting this predicate — omitting that guard will issue
+    overlapping merge calls. The executor re-check in
+    [reconcile_and_execute_automerge] relies on the predicate returning [true]
+    while holding the flag, so the guard cannot live inside the predicate. *)
 
 val reconcile_automerge :
   Orchestrator.t -> now:float -> Orchestrator.t * automerge_decision list
 (** Reconcile the automerge deadline for every agent and return decisions to
     merge. For each agent:
     - merged → clear any stale deadline/inflight flag (no decision).
-    - not [automerge_enabled] → no-op.
     - [automerge_inflight] → no-op; the executor owns the deadline and inflight
       transitions via [apply_automerge_success] / [apply_automerge_failure].
     - candidate + no deadline → set deadline at [now +. automerge_idle_timeout].
     - not candidate + deadline → clear deadline (feedback arrived, CI flipped,
-      or failure cap hit).
+      automerge disabled, or failure cap hit).
     - candidate + deadline elapsed → atomically mark the agent
       [automerge_inflight = true] and include in decisions list. The caller MUST
       clear the inflight flag on every exit path, and call either

--- a/lib/patch_controller.mli
+++ b/lib/patch_controller.mli
@@ -150,8 +150,13 @@ val apply_automerge_success : Orchestrator.t -> Patch_id.t -> Orchestrator.t
 (** Mark the patch as merged, clear the automerge deadline, clear the inflight
     flag, and reset the failure counter. *)
 
-val apply_automerge_failure : Orchestrator.t -> Patch_id.t -> Orchestrator.t
+val apply_automerge_failure :
+  Orchestrator.t -> now:float -> Patch_id.t -> Orchestrator.t
 (** Record a failed merge call: clear the inflight flag, increment the
-    consecutive failure counter, and drop the deadline so the next reconcile
-    starts a fresh idle window (unless the failure cap is now hit, in which case
-    reconciliation will keep the deadline cleared). *)
+    consecutive failure counter, and push the deadline out to
+    [now +. automerge_idle_timeout] so the retry is at least one idle window
+    away. Without this explicit push-out, a persistent GitHub failure could
+    generate a burst of merge calls within a single poll cycle since the runner
+    re-reconciles every tick. If the failure cap is now hit the predicate skips
+    the patch regardless and the next reconcile clears the deadline via the
+    normal non-candidate path. *)

--- a/lib/patch_controller.mli
+++ b/lib/patch_controller.mli
@@ -124,9 +124,12 @@ type automerge_decision = {
 
 val is_automerge_candidate : Patch_agent.t -> main_branch:Branch.t -> bool
 (** A patch is a candidate for automerge when it is approved, passing CI, has no
-    queued work, is not currently inflight, and has not exceeded
-    [automerge_max_failures]. Any queued feedback (Review_comments, Human, Ci,
-    Merge_conflict, Pr_body) resets the deadline. *)
+    queued work, and has not exceeded [automerge_max_failures]. Any queued
+    feedback (Review_comments, Human, Ci, Merge_conflict, Pr_body) resets the
+    deadline. [automerge_inflight] is deliberately out of scope: callers that
+    need to reject concurrent claims (i.e. [reconcile_automerge]) add the
+    inflight guard themselves; the executor re-check needs the predicate to
+    return [true] while holding the flag. *)
 
 val reconcile_automerge :
   Orchestrator.t -> now:float -> Orchestrator.t * automerge_decision list
@@ -134,9 +137,11 @@ val reconcile_automerge :
     merge. For each agent:
     - merged → clear any stale deadline/inflight flag (no decision).
     - not [automerge_enabled] → no-op.
+    - [automerge_inflight] → no-op; the executor owns the deadline and inflight
+      transitions via [apply_automerge_success] / [apply_automerge_failure].
     - candidate + no deadline → set deadline at [now +. automerge_idle_timeout].
     - not candidate + deadline → clear deadline (feedback arrived, CI flipped,
-      inflight, or failure cap hit).
+      or failure cap hit).
     - candidate + deadline elapsed → atomically mark the agent
       [automerge_inflight = true] and include in decisions list. The caller MUST
       clear the inflight flag on every exit path, and call either

--- a/lib/persistence.ml
+++ b/lib/persistence.ml
@@ -96,7 +96,9 @@ let patch_agent_to_yojson (a : Patch_agent.t) =
       ("automerge_enabled", `Bool a.automerge_enabled);
       ( "automerge_deadline",
         match a.automerge_deadline with None -> `Null | Some f -> `Float f );
-      ("automerge_inflight", `Bool a.automerge_inflight);
+      (* [automerge_inflight] is intentionally not persisted: it guards an
+         in-flight GitHub call, which cannot still be running across a
+         supervisor restart. Deserialization hard-codes [false] to match. *)
       ("automerge_failure_count", `Int a.automerge_failure_count);
     ]
 

--- a/lib/persistence.ml
+++ b/lib/persistence.ml
@@ -93,6 +93,9 @@ let patch_agent_to_yojson (a : Patch_agent.t) =
       ("branch_blocked", `Bool a.branch_blocked);
       ( "llm_session_id",
         match a.llm_session_id with None -> `Null | Some s -> `String s );
+      ("automerge_enabled", `Bool a.automerge_enabled);
+      ( "automerge_deadline",
+        match a.automerge_deadline with None -> `Null | Some f -> `Float f );
     ]
 
 let patch_agent_of_yojson ~gameplan json =
@@ -215,7 +218,17 @@ let patch_agent_of_yojson ~gameplan json =
        ~generation:(int_member "generation" json)
        ~worktree_path:(string_member_opt "worktree_path" json)
        ~branch_blocked:(bool_member "branch_blocked" json)
-       ~llm_session_id:(string_member_opt "llm_session_id" json))
+       ~llm_session_id:(string_member_opt "llm_session_id" json)
+       ~automerge_enabled:
+         (Option.value
+            (bool_member_opt "automerge_enabled" json)
+            ~default:false)
+       ~automerge_deadline:
+         (match Yojson.Safe.Util.member "automerge_deadline" json with
+         | `Null -> None
+         | `Float f -> Some f
+         | `Int i -> Some (Float.of_int i)
+         | _ -> None))
 
 (* ---------- Activity_log ---------- *)
 

--- a/lib/persistence.ml
+++ b/lib/persistence.ml
@@ -240,7 +240,11 @@ let patch_agent_of_yojson ~gameplan json =
                 rather than raise — [reconcile_automerge] will re-arm a fresh
                 idle window on the next tick once the patch is a candidate. *)
              Float.of_string_opt s
-         | _ -> None)
+         | _ ->
+             (* Unexpected JSON shape (e.g. [`String], [`Bool], [`List]) — the
+                snapshot is corrupted or was written by an incompatible version.
+                Treat as absent; reconcile re-arms on the next tick. *)
+             None)
        ~automerge_inflight:
          (* Reset inflight on restore: any inflight flag persisted across a
             supervisor restart refers to a merge call that cannot still be

--- a/lib/persistence.ml
+++ b/lib/persistence.ml
@@ -232,7 +232,14 @@ let patch_agent_of_yojson ~gameplan json =
          | `Null -> None
          | `Float f -> Some f
          | `Int i -> Some (Float.of_int i)
-         | `Intlit s -> Float.of_string_opt s
+         | `Intlit s ->
+             (* Yojson emits [`Intlit] for integers that don't fit in an OCaml
+                int. Unix timestamps fit in a [float] on all supported
+                platforms, so conversion effectively always succeeds. If the
+                literal is malformed (corrupted snapshot), drop the deadline
+                rather than raise — [reconcile_automerge] will re-arm a fresh
+                idle window on the next tick once the patch is a candidate. *)
+             Float.of_string_opt s
          | _ -> None)
        ~automerge_inflight:
          (* Reset inflight on restore: any inflight flag persisted across a

--- a/lib/persistence.ml
+++ b/lib/persistence.ml
@@ -96,6 +96,8 @@ let patch_agent_to_yojson (a : Patch_agent.t) =
       ("automerge_enabled", `Bool a.automerge_enabled);
       ( "automerge_deadline",
         match a.automerge_deadline with None -> `Null | Some f -> `Float f );
+      ("automerge_inflight", `Bool a.automerge_inflight);
+      ("automerge_failure_count", `Int a.automerge_failure_count);
     ]
 
 let patch_agent_of_yojson ~gameplan json =
@@ -228,7 +230,17 @@ let patch_agent_of_yojson ~gameplan json =
          | `Null -> None
          | `Float f -> Some f
          | `Int i -> Some (Float.of_int i)
-         | _ -> None))
+         | `Intlit s -> Float.of_string_opt s
+         | _ -> None)
+       ~automerge_inflight:
+         (* Reset inflight on restore: any inflight flag persisted across a
+            supervisor restart refers to a merge call that cannot still be
+            running. Assuming [false] is the safe recovery default. *)
+         false
+       ~automerge_failure_count:
+         (Option.value
+            (int_member_opt "automerge_failure_count" json)
+            ~default:0))
 
 (* ---------- Activity_log ---------- *)
 

--- a/lib/tui.ml
+++ b/lib/tui.ml
@@ -846,7 +846,7 @@ let detail_info_rows (pv : patch_view) ~width ~now =
          then "enabled (failure cap reached — toggle off/on to retry)"
          else
            match pv.automerge_deadline with
-           | None -> "enabled"
+           | None -> "enabled (waiting: needs approval and passing CI)"
            | Some d ->
                let remaining = d -. now in
                if Float.( > ) remaining 0.0 then

--- a/lib/tui.ml
+++ b/lib/tui.ml
@@ -1204,8 +1204,9 @@ let render_manage_overlay ~width ~height ~automerge_enabled =
 
 (** Number of info lines render_detail produces for a patch. Derived from
     [detail_info_rows] so the two cannot drift. Width only affects truncation,
-    not line count, and [~now] only affects the automerge countdown text, so we
-    pass fixed values here. *)
+    not line count, and [~now] only affects the automerge countdown text (every
+    possible value fits on one line — "fires in Ns", "firing...", "enabled
+    (...)", "disabled"), so fixed dummy values here are safe. *)
 let detail_info_height (pv : patch_view) =
   List.length (detail_info_rows pv ~width:80 ~now:0.0)
 

--- a/lib/tui.ml
+++ b/lib/tui.ml
@@ -795,8 +795,10 @@ let render_activity (entries : activity_entry list) =
     header :: lines
 
 (** Build the info rows for a detail view. Shared between [render_detail] and
-    [detail_info_height] to keep them in sync. *)
-let detail_info_rows (pv : patch_view) ~width =
+    [detail_info_height] to keep them in sync. [~now] is the wall-clock time the
+    frame is rendered against — threaded in rather than read from
+    [Unix.gettimeofday] so the function stays pure and testable. *)
+let detail_info_rows (pv : patch_view) ~width ~now =
   let fit_value prefix value =
     prefix ^ Term.fit_width (Int.max 1 (width - String.length prefix)) value
   in
@@ -841,7 +843,7 @@ let detail_info_rows (pv : patch_view) ~width =
            match pv.automerge_deadline with
            | None -> "enabled (waiting for approval)"
            | Some d ->
-               let remaining = d -. Unix.gettimeofday () in
+               let remaining = d -. now in
                if Float.( > ) remaining 0.0 then
                  Printf.sprintf "fires in %.0fs" remaining
                else "firing...");
@@ -932,8 +934,8 @@ let detail_info_rows (pv : patch_view) ~width =
   in
   lines @ op_line @ intervention @ ci_section
 
-let render_detail (pv : patch_view) ~width ~scroll ?(transcript = "") () =
-  let info = detail_info_rows pv ~width in
+let render_detail (pv : patch_view) ~width ~scroll ~now ?(transcript = "") () =
+  let info = detail_info_rows pv ~width ~now in
   let transcript_content =
     if String.is_empty transcript then []
     else
@@ -1176,10 +1178,17 @@ let render_manage_overlay ~width ~height ~automerge_enabled =
     Printf.sprintf "    a   %s automerge (5-minute idle timer after approval)"
       (if automerge_enabled then "Disable" else "Enable")
   in
+  let automerge_item =
+    (* Highlight in green when automerge is currently on so the user can tell
+       at a glance, not just by reading the verb. *)
+    if automerge_enabled then
+      Term.styled [ Term.Sgr.bold; Term.Sgr.fg_green ] automerge_label
+    else Term.styled [ Term.Sgr.dim ] automerge_label
+  in
   let items =
     [
       Term.styled [ Term.Sgr.dim ] "    m   Force mark as merged (break glass)";
-      Term.styled [ Term.Sgr.dim ] automerge_label;
+      automerge_item;
     ]
   in
   let content = title :: "" :: items in
@@ -1190,9 +1199,10 @@ let render_manage_overlay ~width ~height ~automerge_enabled =
 
 (** Number of info lines render_detail produces for a patch. Derived from
     [detail_info_rows] so the two cannot drift. Width only affects truncation,
-    not line count, so we pass a dummy value. *)
+    not line count, and [~now] only affects the automerge countdown text, so we
+    pass fixed values here. *)
 let detail_info_height (pv : patch_view) =
-  List.length (detail_info_rows pv ~width:80)
+  List.length (detail_info_rows pv ~width:80 ~now:0.0)
 
 (** {1 Public API} *)
 
@@ -1249,7 +1259,7 @@ let views_of_orchestrator ~(orchestrator : Orchestrator.t)
       Int.compare idx_a idx_b)
 
 let render_frame ~width ~height ~selected ~scroll_offset ~view_mode
-    ~(activity : activity_entry list) ~project_name ~show_help ~show_manage
+    ~(activity : activity_entry list) ~project_name ~show_help ~show_manage ~now
     ?(transcript = "") ?status_msg ?prompt_line (views : patch_view list) =
   let no_patches =
     {
@@ -1301,7 +1311,7 @@ let render_frame ~width ~height ~selected ~scroll_offset ~view_mode
               { offset = scroll_offset; total = 0; visible = max_section }
             in
             let info, transcript_section, at_bottom, clamped_offset =
-              render_detail pv ~width ~scroll ~transcript ()
+              render_detail pv ~width ~scroll ~now ~transcript ()
             in
             let lines =
               header @ [ "" ] @ summary @ [ "" ] @ info @ transcript_section

--- a/lib/tui.ml
+++ b/lib/tui.ml
@@ -503,6 +503,8 @@ type patch_view = {
   base_branch : Branch.t option;
   worktree_path : string option;
   intervention_reason : string option;
+  automerge_enabled : bool;
+  automerge_deadline : float option;
 }
 [@@warning "-69"]
 
@@ -599,6 +601,8 @@ let patch_view_of_agent (agent : Patch_agent.t)
     base_branch = agent.base_branch;
     worktree_path = agent.worktree_path;
     intervention_reason = None;
+    automerge_enabled = agent.automerge_enabled;
+    automerge_deadline = agent.automerge_deadline;
   }
 
 (** {1 Render helpers} *)
@@ -1151,16 +1155,21 @@ let render_help_overlay ~width ~height =
   let pad_line line = if width <= 0 then "" else Term.fit_width width line in
   List.map visible ~f:pad_line
 
-let render_manage_overlay ~width ~height =
+let render_manage_overlay ~width ~height ~automerge_enabled =
   let dismiss = Term.styled [ Term.Sgr.dim ] "(esc to cancel)" in
   let title =
     Term.styled
       [ Term.Sgr.bold; Term.Sgr.fg_yellow ]
       (Printf.sprintf " Manage Patch  %s" dismiss)
   in
+  let automerge_label =
+    Printf.sprintf "    a   %s automerge (5-minute idle timer after approval)"
+      (if automerge_enabled then "Disable" else "Enable")
+  in
   let items =
     [
       Term.styled [ Term.Sgr.dim ] "    m   Force mark as merged (break glass)";
+      Term.styled [ Term.Sgr.dim ] automerge_label;
     ]
   in
   let content = title :: "" :: items in
@@ -1247,7 +1256,14 @@ let render_frame ~width ~height ~selected ~scroll_offset ~view_mode
     let overlay = render_help_overlay ~width ~height in
     { no_patches with lines = overlay }
   else if show_manage then
-    let overlay = render_manage_overlay ~width ~height in
+    let automerge_enabled =
+      match view_mode with
+      | Detail_view patch_id ->
+          List.find views ~f:(fun pv -> Patch_id.equal pv.patch_id patch_id)
+          |> Option.value_map ~default:false ~f:(fun pv -> pv.automerge_enabled)
+      | List_view | Timeline_view -> false
+    in
+    let overlay = render_manage_overlay ~width ~height ~automerge_enabled in
     { no_patches with lines = overlay; detail_scroll_offset = scroll_offset }
   else
     let header = render_header ~project_name ~width in

--- a/lib/tui.ml
+++ b/lib/tui.ml
@@ -1206,7 +1206,12 @@ let render_manage_overlay ~width ~height ~automerge_enabled =
     [detail_info_rows] so the two cannot drift. Width only affects truncation,
     not line count, and [~now] only affects the automerge countdown text (every
     possible value fits on one line — "fires in Ns", "firing...", "enabled
-    (...)", "disabled"), so fixed dummy values here are safe. *)
+    (...)", "disabled"), so fixed dummy values here are safe.
+
+    Invariant: automerge status strings must stay well under 70 chars so they
+    cannot wrap at the dummy [~width:80] used here. If a future string is long
+    enough to wrap, thread [~now] and the real terminal width through
+    [detail_info_height] instead of passing placeholders. *)
 let detail_info_height (pv : patch_view) =
   List.length (detail_info_rows pv ~width:80 ~now:0.0)
 

--- a/lib/tui.ml
+++ b/lib/tui.ml
@@ -852,7 +852,9 @@ let detail_info_rows (pv : patch_view) ~width ~now =
            | Some d ->
                let remaining = d -. now in
                if Float.( > ) remaining 0.0 then
-                 Printf.sprintf "fires in %.0fs" remaining
+                 (* Floor at 1s so sub-second remainders don't render as
+                    "fires in 0s" — transient but cosmetically odd. *)
+                 Printf.sprintf "fires in %.0fs" (Float.max 1.0 remaining)
                else "firing...");
     ]
   in

--- a/lib/tui.ml
+++ b/lib/tui.ml
@@ -846,7 +846,9 @@ let detail_info_rows (pv : patch_view) ~width ~now =
          then "enabled (failure cap reached — toggle off/on to retry)"
          else
            match pv.automerge_deadline with
-           | None -> "enabled (waiting: needs approval and passing CI)"
+           | None ->
+               if pv.queue_len > 0 then "enabled (waiting: queue must drain)"
+               else "enabled (waiting: needs approval and passing CI)"
            | Some d ->
                let remaining = d -. now in
                if Float.( > ) remaining 0.0 then

--- a/lib/tui.ml
+++ b/lib/tui.ml
@@ -835,6 +835,16 @@ let detail_info_rows (pv : patch_view) ~width =
       Printf.sprintf "  Conflict:    %s"
         (if pv.has_conflict then "yes" else "no");
       Printf.sprintf "  Messages:    %d queued" pv.human_messages;
+      Printf.sprintf "  Automerge:   %s"
+        (if not pv.automerge_enabled then "disabled"
+         else
+           match pv.automerge_deadline with
+           | None -> "enabled (waiting for approval)"
+           | Some d ->
+               let remaining = d -. Unix.gettimeofday () in
+               if Float.( > ) remaining 0.0 then
+                 Printf.sprintf "fires in %.0fs" remaining
+               else "firing...");
     ]
   in
   let op_line =

--- a/lib/tui.ml
+++ b/lib/tui.ml
@@ -505,6 +505,7 @@ type patch_view = {
   intervention_reason : string option;
   automerge_enabled : bool;
   automerge_deadline : float option;
+  automerge_failure_count : int;
 }
 [@@warning "-69"]
 
@@ -603,6 +604,7 @@ let patch_view_of_agent (agent : Patch_agent.t)
     intervention_reason = None;
     automerge_enabled = agent.automerge_enabled;
     automerge_deadline = agent.automerge_deadline;
+    automerge_failure_count = agent.automerge_failure_count;
   }
 
 (** {1 Render helpers} *)
@@ -839,9 +841,12 @@ let detail_info_rows (pv : patch_view) ~width ~now =
       Printf.sprintf "  Messages:    %d queued" pv.human_messages;
       Printf.sprintf "  Automerge:   %s"
         (if not pv.automerge_enabled then "disabled"
+         else if
+           pv.automerge_failure_count >= Patch_controller.automerge_max_failures
+         then "enabled (failure cap reached — toggle off/on to retry)"
          else
            match pv.automerge_deadline with
-           | None -> "enabled (waiting for approval)"
+           | None -> "enabled"
            | Some d ->
                let remaining = d -. now in
                if Float.( > ) remaining 0.0 then

--- a/lib/tui.mli
+++ b/lib/tui.mli
@@ -98,6 +98,7 @@ type patch_view = {
   intervention_reason : string option;
   automerge_enabled : bool;
   automerge_deadline : float option;
+  automerge_failure_count : int;
 }
 
 (** {2 Frame rendering} *)

--- a/lib/tui.mli
+++ b/lib/tui.mli
@@ -96,6 +96,8 @@ type patch_view = {
   base_branch : Branch.t option;
   worktree_path : string option;
   intervention_reason : string option;
+  automerge_enabled : bool;
+  automerge_deadline : float option;
 }
 
 (** {2 Frame rendering} *)
@@ -131,7 +133,9 @@ val views_of_orchestrator :
   patch_view list
 
 val render_help_overlay : width:int -> height:int -> string list
-val render_manage_overlay : width:int -> height:int -> string list
+
+val render_manage_overlay :
+  width:int -> height:int -> automerge_enabled:bool -> string list
 
 type prompt_info = { prompt_text : string; cursor_col : int }
 

--- a/lib/tui.mli
+++ b/lib/tui.mli
@@ -149,6 +149,7 @@ val render_frame :
   project_name:string ->
   show_help:bool ->
   show_manage:bool ->
+  now:float ->
   ?transcript:string ->
   ?status_msg:status_msg ->
   ?prompt_line:prompt_info ->

--- a/test/test_patch_agent.ml
+++ b/test/test_patch_agent.ml
@@ -681,7 +681,8 @@ let () =
               ~checks_passing:false ~current_op:None ~current_message_id:None
               ~generation:0 ~worktree_path:None ~branch_blocked:false
               ~llm_session_id:None ~automerge_enabled:false
-              ~automerge_deadline:None
+              ~automerge_deadline:None ~automerge_inflight:false
+              ~automerge_failure_count:0
           in
           let a = start a ~base_branch:br in
           List.is_empty a.ci_checks);
@@ -758,7 +759,8 @@ let () =
               ~checks_passing:false ~current_op:None ~current_message_id:None
               ~generation:0 ~worktree_path:None ~branch_blocked:false
               ~llm_session_id:None ~automerge_enabled:false
-              ~automerge_deadline:None
+              ~automerge_deadline:None ~automerge_inflight:false
+              ~automerge_failure_count:0
           in
           let a = enqueue a Operation_kind.Rebase in
           let a = rebase a ~base_branch:new_base in

--- a/test/test_patch_agent.ml
+++ b/test/test_patch_agent.ml
@@ -680,7 +680,8 @@ let () =
               ~no_commits_push_count:0 ~branch_rebased_onto:None
               ~checks_passing:false ~current_op:None ~current_message_id:None
               ~generation:0 ~worktree_path:None ~branch_blocked:false
-              ~llm_session_id:None
+              ~llm_session_id:None ~automerge_enabled:false
+              ~automerge_deadline:None
           in
           let a = start a ~base_branch:br in
           List.is_empty a.ci_checks);
@@ -756,7 +757,8 @@ let () =
               ~no_commits_push_count:0 ~branch_rebased_onto:None
               ~checks_passing:false ~current_op:None ~current_message_id:None
               ~generation:0 ~worktree_path:None ~branch_blocked:false
-              ~llm_session_id:None
+              ~llm_session_id:None ~automerge_enabled:false
+              ~automerge_deadline:None
           in
           let a = enqueue a Operation_kind.Rebase in
           let a = rebase a ~base_branch:new_base in

--- a/test/test_patch_controller.ml
+++ b/test/test_patch_controller.ml
@@ -53,7 +53,8 @@ let make_agent ~patch_id ~branch ~pr_number ~merged ~queue ~base_branch
     ~conflict_noop_count:0 ~no_commits_push_count:0 ~branch_rebased_onto:None
     ~checks_passing:false ~current_op:None ~current_message_id:None
     ~generation:0 ~worktree_path:None ~branch_blocked:false ~llm_session_id:None
-    ~automerge_enabled:false ~automerge_deadline:None
+    ~automerge_enabled:false ~automerge_deadline:None ~automerge_inflight:false
+    ~automerge_failure_count:0
 
 let has_draft_effect effects =
   List.exists effects ~f:(function
@@ -349,7 +350,8 @@ let () =
             ~checks_passing:false ~current_op:None ~current_message_id:None
             ~generation:0 ~worktree_path:None ~branch_blocked:false
             ~llm_session_id:None ~automerge_enabled:false
-            ~automerge_deadline:None
+            ~automerge_deadline:None ~automerge_inflight:false
+            ~automerge_failure_count:0
         in
         let orch = make_orch patch agent in
         (* Apply effects in a loop until convergence (max 5 rounds). *)
@@ -481,7 +483,8 @@ let () =
             ~checks_passing:false ~current_op:None ~current_message_id:None
             ~generation:0 ~worktree_path:None ~branch_blocked:false
             ~llm_session_id:None ~automerge_enabled:false
-            ~automerge_deadline:None
+            ~automerge_deadline:None ~automerge_inflight:false
+            ~automerge_failure_count:0
         in
         let orch = make_orch patch agent in
         let poll =
@@ -618,7 +621,8 @@ let () =
             ~checks_passing:false ~current_op:None ~current_message_id:None
             ~generation:0 ~worktree_path:None ~branch_blocked:false
             ~llm_session_id:None ~automerge_enabled:false
-            ~automerge_deadline:None
+            ~automerge_deadline:None ~automerge_inflight:false
+            ~automerge_failure_count:0
         in
         let orch = make_orch patch agent in
         begin try
@@ -819,7 +823,8 @@ let () =
             ~branch_rebased_onto:None ~checks_passing:false ~current_op:None
             ~current_message_id:None ~generation:0 ~worktree_path:None
             ~branch_blocked:false ~llm_session_id:None ~automerge_enabled:false
-            ~automerge_deadline:None
+            ~automerge_deadline:None ~automerge_inflight:false
+            ~automerge_failure_count:0
         in
         let orch =
           Orchestrator.restore
@@ -858,7 +863,8 @@ let () =
             ~checks_passing:false ~current_op:None ~current_message_id:None
             ~generation:0 ~worktree_path:None ~branch_blocked:false
             ~llm_session_id:None ~automerge_enabled:false
-            ~automerge_deadline:None
+            ~automerge_deadline:None ~automerge_inflight:false
+            ~automerge_failure_count:0
         in
         let orch =
           Orchestrator.restore

--- a/test/test_patch_controller.ml
+++ b/test/test_patch_controller.ml
@@ -53,6 +53,7 @@ let make_agent ~patch_id ~branch ~pr_number ~merged ~queue ~base_branch
     ~conflict_noop_count:0 ~no_commits_push_count:0 ~branch_rebased_onto:None
     ~checks_passing:false ~current_op:None ~current_message_id:None
     ~generation:0 ~worktree_path:None ~branch_blocked:false ~llm_session_id:None
+    ~automerge_enabled:false ~automerge_deadline:None
 
 let has_draft_effect effects =
   List.exists effects ~f:(function
@@ -347,7 +348,8 @@ let () =
             ~no_commits_push_count:0 ~branch_rebased_onto:None
             ~checks_passing:false ~current_op:None ~current_message_id:None
             ~generation:0 ~worktree_path:None ~branch_blocked:false
-            ~llm_session_id:None
+            ~llm_session_id:None ~automerge_enabled:false
+            ~automerge_deadline:None
         in
         let orch = make_orch patch agent in
         (* Apply effects in a loop until convergence (max 5 rounds). *)
@@ -478,7 +480,8 @@ let () =
             ~no_commits_push_count:0 ~branch_rebased_onto:None
             ~checks_passing:false ~current_op:None ~current_message_id:None
             ~generation:0 ~worktree_path:None ~branch_blocked:false
-            ~llm_session_id:None
+            ~llm_session_id:None ~automerge_enabled:false
+            ~automerge_deadline:None
         in
         let orch = make_orch patch agent in
         let poll =
@@ -614,7 +617,8 @@ let () =
             ~no_commits_push_count:0 ~branch_rebased_onto:None
             ~checks_passing:false ~current_op:None ~current_message_id:None
             ~generation:0 ~worktree_path:None ~branch_blocked:false
-            ~llm_session_id:None
+            ~llm_session_id:None ~automerge_enabled:false
+            ~automerge_deadline:None
         in
         let orch = make_orch patch agent in
         begin try
@@ -814,7 +818,8 @@ let () =
             ~conflict_noop_count:0 ~no_commits_push_count:0
             ~branch_rebased_onto:None ~checks_passing:false ~current_op:None
             ~current_message_id:None ~generation:0 ~worktree_path:None
-            ~branch_blocked:false ~llm_session_id:None
+            ~branch_blocked:false ~llm_session_id:None ~automerge_enabled:false
+            ~automerge_deadline:None
         in
         let orch =
           Orchestrator.restore
@@ -852,7 +857,8 @@ let () =
             ~no_commits_push_count:0 ~branch_rebased_onto:None
             ~checks_passing:false ~current_op:None ~current_message_id:None
             ~generation:0 ~worktree_path:None ~branch_blocked:false
-            ~llm_session_id:None
+            ~llm_session_id:None ~automerge_enabled:false
+            ~automerge_deadline:None
         in
         let orch =
           Orchestrator.restore

--- a/test/test_poll_log_properties.ml
+++ b/test/test_poll_log_properties.ml
@@ -51,6 +51,7 @@ let make_agent ~patch_id ~branch ~has_conflict ~ci_failure_count ~current_op
     ~branch_rebased_onto:None ~checks_passing ~current_op
     ~current_message_id:None ~generation:0 ~worktree_path ~branch_blocked
     ~llm_session_id:None ~automerge_enabled:false ~automerge_deadline:None
+    ~automerge_inflight:false ~automerge_failure_count:0
 
 let make_poll_observation ~branch_in_root ~worktree_path poll_result =
   Patch_controller.

--- a/test/test_poll_log_properties.ml
+++ b/test/test_poll_log_properties.ml
@@ -50,7 +50,7 @@ let make_agent ~patch_id ~branch ~has_conflict ~ci_failure_count ~current_op
     ~start_attempts_without_pr:0 ~conflict_noop_count:0 ~no_commits_push_count:0
     ~branch_rebased_onto:None ~checks_passing ~current_op
     ~current_message_id:None ~generation:0 ~worktree_path ~branch_blocked
-    ~llm_session_id:None
+    ~llm_session_id:None ~automerge_enabled:false ~automerge_deadline:None
 
 let make_poll_observation ~branch_in_root ~worktree_path poll_result =
   Patch_controller.


### PR DESCRIPTION
## Summary
- New **a**utomerge toggle on the patch detail manage overlay (`d` → `a`). When enabled on an approved patch with an empty queue, the supervisor arms a 5-minute deadline.
- Any new feedback (review comments, CI, human, merge conflict, pr_body) clears the deadline — the timer resets when the patch becomes a candidate again.
- On expiry, the supervisor squash-merges the PR via `PUT /repos/:owner/:repo/pulls/:number/merge`. Success marks the patch merged and clears the deadline; failure leaves state for retry next tick.
- Fields `automerge_enabled` and `automerge_deadline` persist through snapshots with backward-compat defaults.

## Test plan
- [ ] Open a PR, approve it, toggle automerge on from the manage overlay, verify it squashes ~5 minutes later.
- [ ] Approve + enable automerge, then post a review comment before the deadline — confirm the deadline clears and re-arms only after the comment is addressed.
- [ ] Toggle automerge off mid-timer — confirm the deadline clears.
- [ ] Restart the supervisor mid-timer — confirm persisted state restores the enabled flag (and that the deadline re-arms on the first tick).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per‑patch automerge with a 5‑minute idle timer after approval. Runs as a single long‑lived background daemon with bounded concurrency and clean shutdown, so one bad tick can’t kill automerge.

- **New Features**
  - TUI: Manage overlay adds an automerge toggle (`a`) with Enable/Disable; enabled state is bold‑green. Pressing `a` only toggles in Detail view.
  - Detail view shows “Automerge: fires in Xs” (floored at 1s), plus “enabled (waiting: queue must drain/needs approval and passing CI)” and “enabled (failure cap reached — toggle off/on to retry)”; events log enable/disable and outcomes.

- **Automerge Engine**
  - Candidates: not merged, automerge enabled, approved, checks passing, empty queue, and under cap; arms a 5‑minute deadline, cleared by any feedback; stale deadline/inflight clear if merged outside automerge.
  - Runs as a single long‑lived daemon (paced at 1s) decoupled from the runner; merges dispatch with a cap of 4; non‑cancel exceptions are logged and the loop continues; on cancellation the daemon exits via `Stop_daemon`.
  - On expiry, issues a squash‑merge via `PUT /repos/:owner/:repo/pulls/:number/merge`; decisions are claimed atomically with an `automerge_inflight` guard; the executor re‑reads state, confirms the PR number still matches, and uses an inflight‑safe candidate check (`~ignore_inflight:true`).
  - Parses 2xx bodies as `Merge_succeeded`, `Merge_queued msg`, or `Merge_unconfirmed`; queued/unconfirmed push the deadline out and clear inflight atomically (no failure count bump), preventing tight loops.
  - Failures increment a per‑patch counter and push the deadline out by 5 minutes (max 3 attempts); no re‑arm when the cap is hit or automerge was disabled mid‑flight; persistence stores `automerge_enabled`, `automerge_deadline`, and `automerge_failure_count` (back‑compat); `automerge_inflight` is not persisted.

<sup>Written for commit 4b637fb53fa3a67764e9ccf793089240909198e2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automerge: approved patches can auto-merge after an idle timeout with retries and a failure cap; background merging runs without delaying main ticks.
  * UI/manage: press "a" in Manage to toggle automerge for a patch; UI shows live automerge status, countdown, and failure-cap messaging.
* **Chores / Tests**
  * Automerge state persisted and tests extended to cover automerge scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->