### PR TITLE
Strip squash-merged ancestor commits during rebase --onto

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -688,7 +688,7 @@ let ensure_worktree ~runtime ~process_mgr ~fs ~repo_root ~project_name ~patch_id
     for follow-on effects like [Worktree.force_push_with_lease]. *)
 let execute_worktree_plan ~runtime ~process_mgr ~fs ~repo_root ~project_name
     ~patch_id ~(agent : Patch_agent.t) ~user_config ~worktree_mutex ~fetch_lock
-    ~fail_label (plan : Worktree_plan.t) =
+    ~fail_label ~ancestor_ids (plan : Worktree_plan.t) =
   let default_path = Worktree.worktree_dir ~project_name ~patch_id in
   let rec loop ~path = function
     | [] -> (Worktree.Ok, path)
@@ -716,7 +716,10 @@ let execute_worktree_plan ~runtime ~process_mgr ~fs ~repo_root ~project_name
                 (Printf.sprintf "fetch before rebase failed: %s" msg),
               path ))
     | Worktree_plan.Rebase_onto target :: rest -> (
-        match Worktree.rebase_onto ~process_mgr ~path ~target with
+        match
+          Worktree.rebase_onto ~process_mgr ~path ~target ~project_name
+            ~ancestor_ids
+        with
         | Worktree.Ok -> loop ~path rest
         | (Worktree.Noop | Worktree.Conflict | Worktree.Error _) as r ->
             (r, path))
@@ -2564,11 +2567,18 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                             Orchestrator.agent snap.Runtime.orchestrator
                               patch_id)
                       in
+                      let ancestor_ids =
+                        Runtime.read runtime (fun snap ->
+                            Graph.transitive_ancestors
+                              (Orchestrator.graph snap.Runtime.orchestrator)
+                              patch_id)
+                      in
                       let rebase_result, wt_path =
                         execute_worktree_plan ~runtime ~process_mgr ~fs
                           ~repo_root:config.repo_root ~project_name ~patch_id
                           ~agent ~user_config:config.user_config ~worktree_mutex
                           ~fetch_lock:fetch_mutex ~fail_label:"rebase"
+                          ~ancestor_ids
                           (Worktree_plan.for_rebase ~new_base)
                       in
                       (match rebase_result with
@@ -2892,6 +2902,13 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                      target origin/<base> so we rebase
                                      against fresh refs, not the stale
                                      local tracking ref. *)
+                                      let ancestor_ids =
+                                        Runtime.read runtime (fun snap ->
+                                            Graph.transitive_ancestors
+                                              (Orchestrator.graph
+                                                 snap.Runtime.orchestrator)
+                                              patch_id)
+                                      in
                                       let rebase_result, _wt_path =
                                         execute_worktree_plan ~runtime
                                           ~process_mgr ~fs
@@ -2901,6 +2918,7 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                           ~worktree_mutex
                                           ~fetch_lock:fetch_mutex
                                           ~fail_label:"merge-conflict rebase"
+                                          ~ancestor_ids
                                           (Worktree_plan.for_merge_conflict
                                              ~base:(Types.Branch.of_string base))
                                       in

--- a/lib/graph.ml
+++ b/lib/graph.ml
@@ -37,13 +37,16 @@ let depends_on t patch_id ~dep =
   List.mem (deps t patch_id) dep ~equal:Patch_id.equal
 
 (** All patches reachable by walking [deps] transitively from [patch_id],
-    excluding [patch_id] itself. Missing IDs in [deps_map] act as leaves. *)
+    excluding [patch_id] itself. Missing IDs in [deps_map] act as leaves.
+    Dependency cycles that point back to [patch_id] do not re-add it. *)
 let transitive_ancestors t patch_id =
   let rec visit seen pid =
     List.fold (deps t pid) ~init:seen ~f:(fun seen dep ->
         if Set.mem seen dep then seen else visit (Set.add seen dep) dep)
   in
-  visit (Set.empty (module Patch_id)) patch_id |> Set.to_list
+  visit (Set.singleton (module Patch_id) patch_id) patch_id
+  |> Fn.flip Set.remove patch_id
+  |> Set.to_list
 
 let open_pr_deps t patch_id ~has_merged =
   deps t patch_id |> List.filter ~f:(fun d -> not (has_merged d))

--- a/lib/graph.ml
+++ b/lib/graph.ml
@@ -36,6 +36,15 @@ let deps t patch_id = Map.find t.deps_map patch_id |> Option.value ~default:[]
 let depends_on t patch_id ~dep =
   List.mem (deps t patch_id) dep ~equal:Patch_id.equal
 
+(** All patches reachable by walking [deps] transitively from [patch_id],
+    excluding [patch_id] itself. Missing IDs in [deps_map] act as leaves. *)
+let transitive_ancestors t patch_id =
+  let rec visit seen pid =
+    List.fold (deps t pid) ~init:seen ~f:(fun seen dep ->
+        if Set.mem seen dep then seen else visit (Set.add seen dep) dep)
+  in
+  visit (Set.empty (module Patch_id)) patch_id |> Set.to_list
+
 let open_pr_deps t patch_id ~has_merged =
   deps t patch_id |> List.filter ~f:(fun d -> not (has_merged d))
 

--- a/lib/graph.mli
+++ b/lib/graph.mli
@@ -22,9 +22,9 @@ val depends_on : t -> Types.Patch_id.t -> dep:Types.Patch_id.t -> bool
 
 val transitive_ancestors : t -> Types.Patch_id.t -> Types.Patch_id.t list
 (** [transitive_ancestors t p] returns every patch reachable by walking [deps]
-    from [p], excluding [p] itself. The list is sorted by [Patch_id.compare] and
-    has no duplicates. Cycle-safe: back-edges to [p] are silently ignored, and
-    any other cycle terminates via a [seen]-set guard. *)
+    from [p], excluding [p] itself. The list is sorted in ascending order by
+    [Patch_id.compare] and has no duplicates. Cycle-safe: back-edges to [p] are
+    silently ignored, and any other cycle terminates via a [seen]-set guard. *)
 
 val open_pr_deps :
   t ->

--- a/lib/graph.mli
+++ b/lib/graph.mli
@@ -20,6 +20,11 @@ val deps : t -> Types.Patch_id.t -> Types.Patch_id.t list
 val depends_on : t -> Types.Patch_id.t -> dep:Types.Patch_id.t -> bool
 (** [depends_on t p d] is true iff [d] is in [deps t p]. *)
 
+val transitive_ancestors : t -> Types.Patch_id.t -> Types.Patch_id.t list
+(** [transitive_ancestors t p] returns every patch reachable by walking [deps]
+    from [p], excluding [p] itself. Order is unspecified; the list has no
+    duplicates. *)
+
 val open_pr_deps :
   t ->
   Types.Patch_id.t ->

--- a/lib/graph.mli
+++ b/lib/graph.mli
@@ -22,8 +22,9 @@ val depends_on : t -> Types.Patch_id.t -> dep:Types.Patch_id.t -> bool
 
 val transitive_ancestors : t -> Types.Patch_id.t -> Types.Patch_id.t list
 (** [transitive_ancestors t p] returns every patch reachable by walking [deps]
-    from [p], excluding [p] itself. Order is unspecified; the list has no
-    duplicates. *)
+    from [p], excluding [p] itself. The list is sorted by [Patch_id.compare] and
+    has no duplicates. Cycle-safe: back-edges to [p] are silently ignored, and
+    any other cycle terminates via a [seen]-set guard. *)
 
 val open_pr_deps :
   t ->

--- a/lib/worktree.ml
+++ b/lib/worktree.ml
@@ -403,6 +403,11 @@ let oldest_non_ancestor_commit ~project_name ~ancestor_ids log_output =
         else
           match String.lsplit2 line ~on:' ' with
           | None -> None
+          | Some ("", _) ->
+              (* Leading space: no sha at start of line. Cannot arise from
+                 [git log --format=%H %s] but guard in case of wrapper
+                 indentation so we don't pass [""] to [git rev-parse]. *)
+              None
           | Some (sha, subject) ->
               if is_ancestor_patch_subject ~project_name ~ancestor_ids subject
               then None

--- a/lib/worktree.ml
+++ b/lib/worktree.ml
@@ -365,30 +365,80 @@ let oldest_unique_commit rev_list_output =
     let lines = String.split_lines trimmed in
     Result.Ok (List.last_exn lines)
 
+(** Pure: does [subject] match the conventional "[<project>] Patch <N>:"
+    commit-subject format for some [N] in [ancestor_ids]? The patch id segment
+    is everything between "Patch " and the first non-id character (':', ' ', or
+    end of string). We compare literally against [Patch_id.to_string], which is
+    the same form rendered into PR titles at commit time. *)
+let is_ancestor_patch_subject ~project_name ~ancestor_ids subject =
+  let prefix = Printf.sprintf "[%s] Patch " project_name in
+  match String.chop_prefix subject ~prefix with
+  | None -> false
+  | Some rest ->
+      let id_end =
+        String.lfindi rest ~f:(fun _ c ->
+            not (Char.is_alphanum c || Char.equal c '-' || Char.equal c '_'))
+      in
+      let id_str =
+        match id_end with
+        | None -> rest
+        | Some i -> String.sub rest ~pos:0 ~len:i
+      in
+      (not (String.is_empty id_str))
+      && List.mem ancestor_ids
+           (Types.Patch_id.of_string id_str)
+           ~equal:Types.Patch_id.equal
+
+(** Pure: parse [git log --format=%H %s] output into (sha, subject) pairs, then
+    drop those whose subject matches an ancestor patch. Returns the oldest
+    remaining SHA, or [Error] when the filtered list is empty. Split out so the
+    subject-pattern fallback to [--cherry-pick] can be property-tested. *)
+let oldest_non_ancestor_commit ~project_name ~ancestor_ids log_output =
+  let trimmed = String.strip log_output in
+  if String.is_empty trimmed then Result.Error "no unique commits found"
+  else
+    let lines = String.split_lines trimmed in
+    let kept =
+      List.filter_map lines ~f:(fun line ->
+          match String.lsplit2 line ~on:' ' with
+          | None -> if String.is_empty line then None else Some line
+          | Some (sha, subject) ->
+              if is_ancestor_patch_subject ~project_name ~ancestor_ids subject
+              then None
+              else Some sha)
+    in
+    match List.last kept with
+    | Some sha -> Result.Ok sha
+    | None -> Result.Error "no unique commits found"
+
 (** Find the old base commit for [--onto] rebase by identifying which commits on
-    our branch are unique (not in target by patch-id). Returns the parent of the
-    oldest unique commit — i.e., the last dependency commit in our branch's
-    history. *)
-let find_old_base ~process_mgr ~path ~target =
+    our branch are unique (not in target). Uses patch-id matching via
+    [git log --cherry-pick], and additionally strips commits whose subject
+    matches [[<project>] Patch N:] for any transitive ancestor N. The subject
+    fallback handles squash-merged ancestors whose patch-ids no longer match
+    (squash collapses multiple commits into one with a fresh patch-id). Returns
+    the parent of the oldest commit that survives both filters. *)
+let find_old_base ~process_mgr ~path ~target ~project_name ~ancestor_ids =
   let code, stdout, stderr =
     run_git_exit_code ~process_mgr
       [
         "git";
         "-C";
         path;
-        "rev-list";
+        "log";
         "--cherry-pick";
         "--right-only";
         "--no-merges";
+        "--format=%H %s";
         Printf.sprintf "%s...HEAD" target;
       ]
   in
   if code <> 0 then
     Result.Error
-      (Printf.sprintf "rev-list cherry-pick failed (exit %d): %s" code
+      (Printf.sprintf "log cherry-pick failed (exit %d): %s" code
          (String.strip stderr))
   else
-    match oldest_unique_commit stdout with
+    match oldest_non_ancestor_commit ~project_name ~ancestor_ids stdout with
     | Result.Error _ as e -> e
     | Result.Ok oldest_sha ->
         let code, stdout, stderr =
@@ -448,7 +498,7 @@ let conflict_diff ~process_mgr ~path =
     (* Truncate to avoid blowing up the prompt *)
     if String.length s > 4000 then String.prefix s 4000 ^ "\n[truncated]" else s
 
-let rebase_onto ~process_mgr ~path ~target =
+let rebase_onto ~process_mgr ~path ~target ~project_name ~ancestor_ids =
   let target = Types.Branch.to_string target in
   let ancestor_code, _, ancestor_stderr =
     run_git_exit_code ~process_mgr
@@ -462,7 +512,9 @@ let rebase_onto ~process_mgr ~path ~target =
          ancestor_code
          (String.strip ancestor_stderr))
   else
-    match find_old_base ~process_mgr ~path ~target with
+    match
+      find_old_base ~process_mgr ~path ~target ~project_name ~ancestor_ids
+    with
     | Result.Error msg ->
         (* If we can't find unique commits, fall back to plain rebase *)
         let rebase_code, _, rebase_stderr =

--- a/lib/worktree.ml
+++ b/lib/worktree.ml
@@ -357,11 +357,11 @@ let run_git_exit_code ~process_mgr args =
 
 (** Pure: does [subject] match the conventional "[<project>] Patch <N>:"
     commit-subject format for some [N] in [ancestor_ids]? The patch-id segment
-    is terminated by the first whitespace or ':' (or end of string), so any
-    [Patch_id.to_string] value that doesn't itself contain whitespace or ':'
-    round-trips correctly. Empty [project_name] or [ancestor_ids] always returns
-    false: callers must supply the real project name for this match to be
-    meaningful. *)
+    is terminated by the first character that satisfies [Char.is_whitespace] or
+    equals [':'] (or end of string), so any [Patch_id.to_string] value that
+    doesn't itself contain such a character round-trips correctly. Empty
+    [project_name] or [ancestor_ids] always returns false: callers must supply
+    the real project name for this match to be meaningful. *)
 let is_ancestor_patch_subject ~project_name ~ancestor_ids subject =
   if String.is_empty project_name || List.is_empty ancestor_ids then false
   else
@@ -430,6 +430,10 @@ let find_old_base ~process_mgr ~path ~target ~project_name ~ancestor_ids =
         "--cherry-pick";
         "--right-only";
         "--no-merges";
+        (* Defeat log.showSignature=true in the user's gitconfig — otherwise
+           [gpg: Signature made ...] lines would appear in the output and be
+           misinterpreted by [oldest_non_ancestor_commit] as SHAs. *)
+        "--no-signature";
         "--format=%H %s";
         Printf.sprintf "%s...HEAD" target;
       ]

--- a/lib/worktree.ml
+++ b/lib/worktree.ml
@@ -395,9 +395,13 @@ let oldest_non_ancestor_commit ~project_name ~ancestor_ids log_output =
   let lines = String.split_lines log_output in
   let kept =
     List.filter_map lines ~f:(fun line ->
-        (* Strip only trailing [\r] so CRLF line endings don't leak into the
-           sha; a legitimate trailing space on empty-subject lines ([<sha> ])
-           must survive intact. *)
+        (* [rstrip ~drop:\r] removes only trailing [\r] (CRLF); the full
+           [String.strip] gate below handles lines that are only spaces (e.g.
+           blank separator lines that some git configs emit). Both are needed:
+           a bare "\r" becomes "" after rstrip and is skipped; "  \r" becomes
+           "  " and is skipped by the strip gate; "<sha> " (empty subject)
+           survives rstrip and the gate because the trailing space is a
+           content-bearing separator. *)
         let line = String.rstrip line ~drop:(Char.equal '\r') in
         if String.is_empty (String.strip line) then None
         else

--- a/lib/worktree.ml
+++ b/lib/worktree.ml
@@ -357,49 +357,56 @@ let run_git_exit_code ~process_mgr args =
 
 (** Pure: does [subject] match the conventional "[<project>] Patch <N>:"
     commit-subject format for some [N] in [ancestor_ids]? The patch-id segment
-    is terminated by the first character that is not alphanumeric, '-', or '_'
-    (or end of string). We compare literally against [Patch_id.to_string], which
-    is the same form rendered into PR titles at commit time. *)
+    is terminated by the first whitespace or ':' (or end of string), so any
+    [Patch_id.to_string] value that doesn't itself contain whitespace or ':'
+    round-trips correctly. Empty [project_name] or [ancestor_ids] always returns
+    false: callers must supply the real project name for this match to be
+    meaningful. *)
 let is_ancestor_patch_subject ~project_name ~ancestor_ids subject =
-  let prefix = Printf.sprintf "[%s] Patch " project_name in
-  match String.chop_prefix subject ~prefix with
-  | None -> false
-  | Some rest ->
-      let id_end =
-        String.lfindi rest ~f:(fun _ c ->
-            not (Char.is_alphanum c || Char.equal c '-' || Char.equal c '_'))
-      in
-      let id_str =
-        match id_end with
-        | None -> rest
-        | Some i -> String.sub rest ~pos:0 ~len:i
-      in
-      (not (String.is_empty id_str))
-      && List.mem ancestor_ids
-           (Types.Patch_id.of_string id_str)
-           ~equal:Types.Patch_id.equal
+  if String.is_empty project_name || List.is_empty ancestor_ids then false
+  else
+    let prefix = Printf.sprintf "[%s] Patch " project_name in
+    match String.chop_prefix subject ~prefix with
+    | None -> false
+    | Some rest ->
+        let id_end =
+          String.lfindi rest ~f:(fun _ c ->
+              Char.is_whitespace c || Char.equal c ':')
+        in
+        let id_str =
+          match id_end with
+          | None -> rest
+          | Some i -> String.sub rest ~pos:0 ~len:i
+        in
+        (not (String.is_empty id_str))
+        && List.mem ancestor_ids
+             (Types.Patch_id.of_string id_str)
+             ~equal:Types.Patch_id.equal
 
 (** Pure: parse [git log --format=%H %s] output into (sha, subject) pairs, then
     drop those whose subject matches an ancestor patch. Returns the oldest
     remaining SHA, or [Error] when the filtered list is empty. Split out so the
-    subject-pattern fallback to [--cherry-pick] can be property-tested. *)
+    subject-pattern fallback to [--cherry-pick] can be property-tested. Does not
+    [String.strip] the input: a commit with an empty subject still emits "<sha>
+    " (trailing space) from [%H %s], so stripping would erase the separator and
+    cause the SHA to be dropped. Blank lines (all whitespace) are ignored
+    explicitly. *)
 let oldest_non_ancestor_commit ~project_name ~ancestor_ids log_output =
-  let trimmed = String.strip log_output in
-  if String.is_empty trimmed then Result.Error "no unique commits found"
-  else
-    let lines = String.split_lines trimmed in
-    let kept =
-      List.filter_map lines ~f:(fun line ->
+  let lines = String.split_lines log_output in
+  let kept =
+    List.filter_map lines ~f:(fun line ->
+        if String.is_empty (String.strip line) then None
+        else
           match String.lsplit2 line ~on:' ' with
           | None -> None
           | Some (sha, subject) ->
               if is_ancestor_patch_subject ~project_name ~ancestor_ids subject
               then None
               else Some sha)
-    in
-    match List.last kept with
-    | Some sha -> Result.Ok sha
-    | None -> Result.Error "no unique commits found"
+  in
+  match List.last kept with
+  | Some sha -> Result.Ok sha
+  | None -> Result.Error "no unique commits found"
 
 (** Find the old base commit for [--onto] rebase by identifying which commits on
     our branch are unique (not in target). Uses patch-id matching via

--- a/lib/worktree.ml
+++ b/lib/worktree.ml
@@ -355,21 +355,11 @@ let run_git_exit_code ~process_mgr args =
   in
   (code, Buffer.contents stdout_buf, Buffer.contents stderr_buf)
 
-(** Pure: extract the oldest unique commit SHA from [rev-list --cherry-pick]
-    output. Returns [Error] when the output is empty (all commits already in
-    target). The output is newest-first, so the last line is the oldest. *)
-let oldest_unique_commit rev_list_output =
-  let trimmed = String.strip rev_list_output in
-  if String.is_empty trimmed then Result.Error "no unique commits found"
-  else
-    let lines = String.split_lines trimmed in
-    Result.Ok (List.last_exn lines)
-
 (** Pure: does [subject] match the conventional "[<project>] Patch <N>:"
-    commit-subject format for some [N] in [ancestor_ids]? The patch id segment
-    is everything between "Patch " and the first non-id character (':', ' ', or
-    end of string). We compare literally against [Patch_id.to_string], which is
-    the same form rendered into PR titles at commit time. *)
+    commit-subject format for some [N] in [ancestor_ids]? The patch-id segment
+    is terminated by the first character that is not alphanumeric, '-', or '_'
+    (or end of string). We compare literally against [Patch_id.to_string], which
+    is the same form rendered into PR titles at commit time. *)
 let is_ancestor_patch_subject ~project_name ~ancestor_ids subject =
   let prefix = Printf.sprintf "[%s] Patch " project_name in
   match String.chop_prefix subject ~prefix with
@@ -401,7 +391,7 @@ let oldest_non_ancestor_commit ~project_name ~ancestor_ids log_output =
     let kept =
       List.filter_map lines ~f:(fun line ->
           match String.lsplit2 line ~on:' ' with
-          | None -> if String.is_empty line then None else Some line
+          | None -> None
           | Some (sha, subject) ->
               if is_ancestor_patch_subject ~project_name ~ancestor_ids subject
               then None

--- a/lib/worktree.ml
+++ b/lib/worktree.ml
@@ -395,6 +395,10 @@ let oldest_non_ancestor_commit ~project_name ~ancestor_ids log_output =
   let lines = String.split_lines log_output in
   let kept =
     List.filter_map lines ~f:(fun line ->
+        (* Strip only trailing [\r] so CRLF line endings don't leak into the
+           sha; a legitimate trailing space on empty-subject lines ([<sha> ])
+           must survive intact. *)
+        let line = String.rstrip line ~drop:(Char.equal '\r') in
         if String.is_empty (String.strip line) then None
         else
           match String.lsplit2 line ~on:' ' with

--- a/lib/worktree.ml
+++ b/lib/worktree.ml
@@ -433,7 +433,7 @@ let find_old_base ~process_mgr ~path ~target ~project_name ~ancestor_ids =
         (* Defeat log.showSignature=true in the user's gitconfig — otherwise
            [gpg: Signature made ...] lines would appear in the output and be
            misinterpreted by [oldest_non_ancestor_commit] as SHAs. *)
-        "--no-signature";
+        "--no-show-signature";
         "--format=%H %s";
         Printf.sprintf "%s...HEAD" target;
       ]

--- a/lib/worktree.mli
+++ b/lib/worktree.mli
@@ -61,9 +61,13 @@ val oldest_non_ancestor_commit :
   ancestor_ids:Types.Patch_id.t list ->
   string ->
   (string, string) Result.t
-(** Pure: parse [git log --cherry-pick --right-only --format=%H %s] output and
-    return the oldest SHA whose subject is not [is_ancestor_patch_subject].
-    Returns [Error] when the filtered list is empty. *)
+(** Pure: parse
+    [git log --cherry-pick --right-only --no-merges --no-show-signature
+     --format=%H %s] output and return the oldest SHA whose subject is not
+    [is_ancestor_patch_subject]. Returns [Error] when the filtered list is
+    empty. [--no-merges] keeps merge-commit lines out of the input; callers
+    emitting raw [git log] should also pass [--no-show-signature] so GPG
+    annotation lines aren't mistaken for SHAs. *)
 
 val git_status : process_mgr:_ Eio.Process.mgr -> path:string -> string
 (** Run [git status] in the worktree and return its output. Returns empty string

--- a/lib/worktree.mli
+++ b/lib/worktree.mli
@@ -65,9 +65,12 @@ val oldest_non_ancestor_commit :
     [git log --cherry-pick --right-only --no-merges --no-show-signature
      --format=%H %s] output and return the oldest SHA whose subject is not
     [is_ancestor_patch_subject]. Returns [Error] when the filtered list is
-    empty. [--no-merges] keeps merge-commit lines out of the input; callers
-    emitting raw [git log] should also pass [--no-show-signature] so GPG
-    annotation lines aren't mistaken for SHAs. *)
+    empty. Both [--no-merges] and [--no-show-signature] are load-bearing for
+    callers who build their own [git log] invocation: [--no-merges] prevents a
+    merge-commit line like [<sha> Merge branch 'x'] from being picked as the
+    oldest SHA (its [~1] parent is the wrong side of the merge), and
+    [--no-show-signature] keeps GPG annotation lines from being mistaken for
+    SHAs. *)
 
 val git_status : process_mgr:_ Eio.Process.mgr -> path:string -> string
 (** Run [git status] in the worktree and return its output. Returns empty string

--- a/lib/worktree.mli
+++ b/lib/worktree.mli
@@ -105,7 +105,7 @@ val rebase_onto :
   project_name:string ->
   ancestor_ids:Types.Patch_id.t list ->
   rebase_result
-(** Rebase HEAD onto [target]. Uses [git rev-list --cherry-pick] to detect
+(** Rebase HEAD onto [target]. Uses [git log --cherry-pick] to detect
     already-applied commits, and supplements that with subject-pattern matching
     against [[<project_name>] Patch N:] for every [N] in [ancestor_ids] — the
     fallback is load-bearing when [target] is a squash-merging trunk like

--- a/lib/worktree.mli
+++ b/lib/worktree.mli
@@ -49,11 +49,6 @@ val list_with_branches :
   repo_root:string ->
   (string * Types.Branch.t) list
 
-val oldest_unique_commit : string -> (string, string) Result.t
-(** Pure: extract the oldest unique commit SHA from
-    [git rev-list --cherry-pick --right-only] output (newest-first). Returns
-    [Error] when the output is empty (all commits already in target). *)
-
 val is_ancestor_patch_subject :
   project_name:string -> ancestor_ids:Types.Patch_id.t list -> string -> bool
 (** Pure: does a commit subject match the convention

--- a/lib/worktree.mli
+++ b/lib/worktree.mli
@@ -54,6 +54,22 @@ val oldest_unique_commit : string -> (string, string) Result.t
     [git rev-list --cherry-pick --right-only] output (newest-first). Returns
     [Error] when the output is empty (all commits already in target). *)
 
+val is_ancestor_patch_subject :
+  project_name:string -> ancestor_ids:Types.Patch_id.t list -> string -> bool
+(** Pure: does a commit subject match the convention
+    [[<project_name>] Patch <N>:] for some [N] in [ancestor_ids]? Used to strip
+    squash-merged ancestor commits whose patch-ids no longer match any commit on
+    [main]. *)
+
+val oldest_non_ancestor_commit :
+  project_name:string ->
+  ancestor_ids:Types.Patch_id.t list ->
+  string ->
+  (string, string) Result.t
+(** Pure: parse [git log --cherry-pick --right-only --format=%H %s] output and
+    return the oldest SHA whose subject is not [is_ancestor_patch_subject].
+    Returns [Error] when the filtered list is empty. *)
+
 val git_status : process_mgr:_ Eio.Process.mgr -> path:string -> string
 (** Run [git status] in the worktree and return its output. Returns empty string
     on failure. *)
@@ -91,7 +107,15 @@ val rebase_onto :
   process_mgr:_ Eio.Process.mgr ->
   path:string ->
   target:Types.Branch.t ->
+  project_name:string ->
+  ancestor_ids:Types.Patch_id.t list ->
   rebase_result
+(** Rebase HEAD onto [target]. Uses [git rev-list --cherry-pick] to detect
+    already-applied commits, and supplements that with subject-pattern matching
+    against [[<project_name>] Patch N:] for every [N] in [ancestor_ids] — the
+    fallback is load-bearing when [target] is a squash-merging trunk like
+    [main], because squash-merged ancestor commits carry a fresh patch-id that
+    cherry-pick cannot equate with the original feature-branch commits. *)
 
 val parse_push_porcelain : string -> char option
 (** Pure: extract the status flag character from [git push --porcelain] stdout.

--- a/lib/worktree.mli
+++ b/lib/worktree.mli
@@ -114,7 +114,9 @@ val rebase_onto :
     against [[<project_name>] Patch N:] for every [N] in [ancestor_ids] — the
     fallback is load-bearing when [target] is a squash-merging trunk like
     [main], because squash-merged ancestor commits carry a fresh patch-id that
-    cherry-pick cannot equate with the original feature-branch commits. *)
+    cherry-pick cannot equate with the original feature-branch commits. Pass
+    [~project_name:""] or [~ancestor_ids:[]] to opt out of the subject filter
+    entirely; cherry-pick deduplication still applies. *)
 
 val parse_push_porcelain : string -> char option
 (** Pure: extract the status flag character from [git push --porcelain] stdout.

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -162,7 +162,17 @@ let () =
    let anc_a = sort (Graph.transitive_ancestors g a) in
    let anc_b = sort (Graph.transitive_ancestors g b) in
    assert (List.equal Types.Patch_id.equal anc_a (sort [ b ]));
-   assert (List.equal Types.Patch_id.equal anc_b (sort [ a ])));
+   assert (List.equal Types.Patch_id.equal anc_b (sort [ a ]));
+   (* Three-node cycle A→B→C→A: exercises the non-adjacent back-edge path
+      through the [seen]-set guard. When visiting from B we reach C, then
+      C's dep A triggers the termination guard ([A] is already in [seen]). *)
+   let c = Types.Patch_id.of_string "C" in
+   let g3 =
+     Graph.of_patches
+       [ make_patch a [ b ]; make_patch b [ c ]; make_patch c [ a ] ]
+   in
+   let anc3_a = sort (Graph.transitive_ancestors g3 a) in
+   assert (List.equal Types.Patch_id.equal anc3_a (sort [ b; c ])));
 
   let prop_initial_base_all_merged_returns_main =
     Test.make ~name:"graph: initial_base returns main when all deps merged"

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -134,6 +134,35 @@ let () =
       prop_transitive_ancestors_transitive;
     ];
 
+  (* Hand-crafted cycle test: gen_patch_dag only produces DAGs, so the
+     [Set.mem seen] termination guard in [transitive_ancestors] is never
+     exercised by the property tests above. Build A ↔ B directly and
+     confirm the walk terminates and excludes the root. *)
+  (let make_patch pid deps =
+     Types.Patch.
+       {
+         id = pid;
+         title = "";
+         description = "";
+         branch = Types.Branch.of_string ("b-" ^ Types.Patch_id.to_string pid);
+         dependencies = deps;
+         spec = "";
+         acceptance_criteria = [];
+         files = [];
+         classification = "";
+         changes = [];
+         test_stubs_introduced = [];
+         test_stubs_implemented = [];
+       }
+   in
+   let a = Types.Patch_id.of_string "A" in
+   let b = Types.Patch_id.of_string "B" in
+   let g = Graph.of_patches [ make_patch a [ b ]; make_patch b [ a ] ] in
+   let anc_a = Graph.transitive_ancestors g a in
+   let anc_b = Graph.transitive_ancestors g b in
+   assert (List.equal Types.Patch_id.equal anc_a [ b ]);
+   assert (List.equal Types.Patch_id.equal anc_b [ a ]));
+
   let prop_initial_base_all_merged_returns_main =
     Test.make ~name:"graph: initial_base returns main when all deps merged"
       Onton_test_support.Test_generators.gen_patch_list_unique (fun patches ->

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -115,7 +115,10 @@ let () =
               let ancestors = Graph.transitive_ancestors g p.id in
               List.for_all ancestors ~f:(fun anc ->
                   List.for_all (Graph.deps g anc) ~f:(fun grand ->
-                      List.mem ancestors grand ~equal:Types.Patch_id.equal)))
+                      (* A back-edge to the root is permitted: the root
+                         is deliberately excluded from its own ancestors. *)
+                      Types.Patch_id.equal grand p.id
+                      || List.mem ancestors grand ~equal:Types.Patch_id.equal)))
         with _ -> false)
   in
   List.iter

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -158,10 +158,11 @@ let () =
    let a = Types.Patch_id.of_string "A" in
    let b = Types.Patch_id.of_string "B" in
    let g = Graph.of_patches [ make_patch a [ b ]; make_patch b [ a ] ] in
-   let anc_a = Graph.transitive_ancestors g a in
-   let anc_b = Graph.transitive_ancestors g b in
-   assert (List.equal Types.Patch_id.equal anc_a [ b ]);
-   assert (List.equal Types.Patch_id.equal anc_b [ a ]));
+   let sort = List.sort ~compare:Types.Patch_id.compare in
+   let anc_a = sort (Graph.transitive_ancestors g a) in
+   let anc_b = sort (Graph.transitive_ancestors g b) in
+   assert (List.equal Types.Patch_id.equal anc_a (sort [ b ]));
+   assert (List.equal Types.Patch_id.equal anc_b (sort [ a ])));
 
   let prop_initial_base_all_merged_returns_main =
     Test.make ~name:"graph: initial_base returns main when all deps merged"

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -80,6 +80,44 @@ let () =
                   Graph.depends_on g p.id ~dep))
         with _ -> false)
   in
+  let prop_transitive_ancestors_excludes_self =
+    Test.make ~name:"graph: transitive_ancestors excludes the patch itself"
+      Onton_test_support.Test_generators.gen_patch_list_unique (fun patches ->
+        try
+          let g = Graph.of_patches patches in
+          List.for_all patches ~f:(fun (p : Types.Patch.t) ->
+              not
+                (List.mem
+                   (Graph.transitive_ancestors g p.id)
+                   p.id ~equal:Types.Patch_id.equal))
+        with _ -> false)
+  in
+  let prop_transitive_ancestors_includes_direct_deps =
+    Test.make
+      ~name:"graph: transitive_ancestors includes every direct dependency"
+      Onton_test_support.Test_generators.gen_patch_list_unique (fun patches ->
+        try
+          let g = Graph.of_patches patches in
+          List.for_all patches ~f:(fun (p : Types.Patch.t) ->
+              let ancestors = Graph.transitive_ancestors g p.id in
+              List.for_all (Graph.deps g p.id) ~f:(fun dep ->
+                  List.mem ancestors dep ~equal:Types.Patch_id.equal))
+        with _ -> false)
+  in
+  let prop_transitive_ancestors_transitive =
+    Test.make
+      ~name:
+        "graph: transitive_ancestors is closed under deps (grand-deps included)"
+      Onton_test_support.Test_generators.gen_patch_list_unique (fun patches ->
+        try
+          let g = Graph.of_patches patches in
+          List.for_all patches ~f:(fun (p : Types.Patch.t) ->
+              let ancestors = Graph.transitive_ancestors g p.id in
+              List.for_all ancestors ~f:(fun anc ->
+                  List.for_all (Graph.deps g anc) ~f:(fun grand ->
+                      List.mem ancestors grand ~equal:Types.Patch_id.equal)))
+        with _ -> false)
+  in
   List.iter
     ~f:(fun t -> QCheck2.Test.check_exn t)
     [
@@ -88,6 +126,9 @@ let () =
       prop_dependents_inverse;
       prop_no_dep_satisfiable;
       prop_depends_on_consistent;
+      prop_transitive_ancestors_excludes_self;
+      prop_transitive_ancestors_includes_direct_deps;
+      prop_transitive_ancestors_transitive;
     ];
 
   let prop_initial_base_all_merged_returns_main =

--- a/test/test_rebase_onto.ml
+++ b/test/test_rebase_onto.ml
@@ -791,7 +791,11 @@ let () =
    git ~process_mgr ~dir [ "checkout"; "feat" ] |> ignore;
    (* Sanity: the cherry-pick filter alone keeps the drifted Patch 1 commit,
       so the positive end-state assertion below is specifically exercising
-      the subject-filter code path. *)
+      the subject-filter code path. We verify both that the log contains
+      both commits (not just Patch 7) *and* that the oldest kept SHA is
+      Patch 1, so a future git version that patch-id-equates the drift with
+      the squash surfaces as a line-count mismatch rather than a confusing
+      SHA mismatch. *)
    let raw_log =
      git ~process_mgr ~dir
        [
@@ -804,6 +808,12 @@ let () =
          "main...HEAD";
        ]
    in
+   let log_lines =
+     List.filter (String.split_lines raw_log) ~f:(fun l ->
+         not (String.is_empty (String.strip l)))
+   in
+   assert_eq "test10: cherry-pick log has 2 commits (sanity)" "2"
+     (Int.to_string (List.length log_lines));
    (match
       Worktree.oldest_non_ancestor_commit ~project_name:"proj" ~ancestor_ids:[]
         raw_log

--- a/test/test_rebase_onto.ml
+++ b/test/test_rebase_onto.ml
@@ -39,8 +39,14 @@ let () =
         | Result.Error _ -> false)
   in
   let prop_trailing_whitespace =
-    Test.make ~name:"oldest_non_ancestor_commit: trailing whitespace stripped"
-      ~count:1 Gen.unit (fun () ->
+    (* Trailing spaces on the subject side don't bleed into the SHA —
+       [lsplit2 ~on:' '] splits at the first space, so the SHA is always
+       the leading non-space run regardless of what follows the first
+       separator. The second all-whitespace line must also be skipped. *)
+    Test.make
+      ~name:
+        "oldest_non_ancestor_commit: trailing whitespace on subject doesn't \
+         corrupt SHA" ~count:1 Gen.unit (fun () ->
         match oldest "abc123 subj  \n  " with
         | Result.Ok sha -> String.equal sha "abc123"
         | Result.Error _ -> false)

--- a/test/test_rebase_onto.ml
+++ b/test/test_rebase_onto.ml
@@ -2,44 +2,46 @@ open Base
 open Onton
 
 (* ───────────────────────────────────────────────────────────────────────
-   Pure tests for [Worktree.oldest_unique_commit]
+   Pure tests for [Worktree.oldest_non_ancestor_commit] with no ancestors
+   (subsumes the behaviour of the former [oldest_unique_commit]).
    ─────────────────────────────────────────────────────────────────────── *)
 
 let () =
   let open QCheck2 in
+  let oldest =
+    Worktree.oldest_non_ancestor_commit ~project_name:"" ~ancestor_ids:[]
+  in
   let prop_empty =
-    Test.make ~name:"oldest_unique_commit: empty -> Error" ~count:1 Gen.unit
-      (fun () ->
-        match Worktree.oldest_unique_commit "" with
-        | Result.Error _ -> true
-        | Result.Ok _ -> false)
+    Test.make ~name:"oldest_non_ancestor_commit: empty -> Error" ~count:1
+      Gen.unit (fun () ->
+        match oldest "" with Result.Error _ -> true | Result.Ok _ -> false)
   in
   let prop_whitespace_only =
-    Test.make ~name:"oldest_unique_commit: whitespace-only -> Error" ~count:1
-      Gen.unit (fun () ->
-        match Worktree.oldest_unique_commit "  \n  \n" with
+    Test.make ~name:"oldest_non_ancestor_commit: whitespace-only -> Error"
+      ~count:1 Gen.unit (fun () ->
+        match oldest "  \n  \n" with
         | Result.Error _ -> true
         | Result.Ok _ -> false)
   in
   let prop_single_sha =
-    Test.make ~name:"oldest_unique_commit: single SHA -> that SHA" ~count:1
-      Gen.unit (fun () ->
-        match Worktree.oldest_unique_commit "abc123\n" with
+    Test.make ~name:"oldest_non_ancestor_commit: single line -> that SHA"
+      ~count:1 Gen.unit (fun () ->
+        match oldest "abc123 subj\n" with
         | Result.Ok sha -> String.equal sha "abc123"
         | Result.Error _ -> false)
   in
   let prop_multiple_shas =
-    Test.make ~name:"oldest_unique_commit: multiple -> last line (oldest)"
+    Test.make ~name:"oldest_non_ancestor_commit: multiple -> last line (oldest)"
       ~count:1 Gen.unit (fun () ->
-        let output = "newest111\nmiddle222\noldest333\n" in
-        match Worktree.oldest_unique_commit output with
+        let output = "newest111 a\nmiddle222 b\noldest333 c\n" in
+        match oldest output with
         | Result.Ok sha -> String.equal sha "oldest333"
         | Result.Error _ -> false)
   in
   let prop_trailing_whitespace =
-    Test.make ~name:"oldest_unique_commit: trailing whitespace stripped"
+    Test.make ~name:"oldest_non_ancestor_commit: trailing whitespace stripped"
       ~count:1 Gen.unit (fun () ->
-        match Worktree.oldest_unique_commit "abc123  \n  " with
+        match oldest "abc123 subj  \n  " with
         | Result.Ok sha -> String.equal sha "abc123"
         | Result.Error _ -> false)
   in
@@ -48,12 +50,16 @@ let () =
     Gen.string_size ~gen:(Gen.char_range 'a' 'f') (Gen.int_range 6 40)
   in
   let prop_always_last =
-    Test.make ~name:"oldest_unique_commit: always returns last line" ~count:200
+    Test.make ~name:"oldest_non_ancestor_commit: always returns last line"
+      ~count:200
       Gen.(list_size (int_range 1 20) sha_gen)
       (fun shas ->
         try
-          let output = String.concat ~sep:"\n" shas ^ "\n" in
-          match Worktree.oldest_unique_commit output with
+          let output =
+            String.concat ~sep:"\n" (List.map shas ~f:(fun s -> s ^ " subj"))
+            ^ "\n"
+          in
+          match oldest output with
           | Result.Ok sha -> String.equal sha (List.last_exn shas)
           | Result.Error _ -> false
         with _ -> false)

--- a/test/test_rebase_onto.ml
+++ b/test/test_rebase_onto.ml
@@ -744,11 +744,11 @@ let () =
   (* ── Test 10: ancestor-subject filter strips drifted dep commits ─── *)
   (* Regression for the trigger-only-execution / patch-7 case. A dep's
      commit survives on our branch with the conventional
-     [<project>] Patch N: prefix but with *modified* content (a trailing
-     whitespace edit) — so git rev-list --cherry-pick cannot equate it with
-     the squash on main by patch-id. Without the ancestor_ids fallback, the
-     old dep commit would be replayed onto main; with ancestor_ids=["1"]
-     find_old_base picks a newer old_base and only our own commit survives. *)
+     [<project>] Patch N: prefix but with *modified* content — so
+     git log --cherry-pick cannot equate it with the squash on main by
+     patch-id. Without the ancestor_ids fallback, the old dep commit
+     would be replayed onto main; with ancestor_ids=["1"] find_old_base
+     picks a newer old_base and only our own commit survives. *)
   (let dir = init_repo ~process_mgr in
    commit_file ~process_mgr ~dir ~filename:"a.txt" ~content:"a" ~msg:"A"
    |> ignore;
@@ -757,14 +757,13 @@ let () =
      ~msg:"[proj] Patch 1: add dep.txt"
    |> ignore;
    git ~process_mgr ~dir [ "checkout"; "-b"; "feat" ] |> ignore;
-   (* Simulate the drift: rewrite dep.txt identically but with a trailing
-      newline difference so patch-id on feat's dep-commit ≠ patch-id on
-      main's squash. The simplest way is to amend the Patch 1 commit on
-      feat with slightly different content. *)
+   (* Simulate the drift: rewrite dep.txt with content-level differences
+      (not just whitespace — git patch-id normalizes trailing whitespace)
+      so the patch-id of feat's amended dep commit ≠ the patch-id of
+      main's squash. Amend the Patch 1 commit with different content. *)
    let dep_path = Stdlib.Filename.concat dir "dep.txt" in
    let oc = Stdlib.open_out dep_path in
-   Stdlib.output_string oc "dep-v1\n";
-   (* note trailing newline *)
+   Stdlib.output_string oc "dep-v1-drift";
    Stdlib.close_out oc;
    git ~process_mgr ~dir [ "add"; "dep.txt" ] |> ignore;
    git ~process_mgr ~dir [ "commit"; "--amend"; "--no-edit" ] |> ignore;
@@ -773,6 +772,33 @@ let () =
    |> ignore;
    squash_merge ~process_mgr ~dir ~branch:"dep";
    git ~process_mgr ~dir [ "checkout"; "feat" ] |> ignore;
+   (* Sanity: the cherry-pick filter alone keeps the drifted Patch 1 commit,
+      so the positive end-state assertion below is specifically exercising
+      the subject-filter code path. *)
+   let raw_log =
+     git ~process_mgr ~dir
+       [
+         "log";
+         "--cherry-pick";
+         "--right-only";
+         "--no-merges";
+         "--no-show-signature";
+         "--format=%H %s";
+         "main...HEAD";
+       ]
+   in
+   (match
+      Worktree.oldest_non_ancestor_commit ~project_name:"proj" ~ancestor_ids:[]
+        raw_log
+    with
+   | Result.Ok sha ->
+       let patch1_sha = git ~process_mgr ~dir [ "rev-parse"; "HEAD~1" ] in
+       assert_eq "test10: cherry-pick alone keeps drifted Patch 1" patch1_sha
+         sha
+   | Result.Error msg ->
+       failwith
+         (Printf.sprintf
+            "test10: cherry-pick-only unexpectedly filtered all commits: %s" msg));
    let result =
      Worktree.rebase_onto ~process_mgr ~path:dir
        ~target:(Types.Branch.of_string "main")

--- a/test/test_rebase_onto.ml
+++ b/test/test_rebase_onto.ml
@@ -45,6 +45,16 @@ let () =
         | Result.Ok sha -> String.equal sha "abc123"
         | Result.Error _ -> false)
   in
+  let prop_single_line_empty_subject =
+    (* %H %s for an empty-subject commit emits "<sha> " — lsplit2 must
+       still parse sha and subject separately (the trailing space is a
+       content-bearing separator, not stripable whitespace). *)
+    Test.make ~name:"oldest_non_ancestor_commit: single empty-subject line kept"
+      ~count:1 Gen.unit (fun () ->
+        match oldest "abc123 \n" with
+        | Result.Ok sha -> String.equal sha "abc123"
+        | Result.Error _ -> false)
+  in
   (* Property: for any non-empty list of SHAs, returns the last one *)
   let sha_gen =
     Gen.string_size ~gen:(Gen.char_range 'a' 'f') (Gen.int_range 6 40)
@@ -71,6 +81,7 @@ let () =
       prop_single_sha;
       prop_multiple_shas;
       prop_trailing_whitespace;
+      prop_single_line_empty_subject;
       prop_always_last;
     ]
   in

--- a/test/test_rebase_onto.ml
+++ b/test/test_rebase_onto.ml
@@ -819,6 +819,10 @@ let () =
         raw_log
     with
    | Result.Ok sha ->
+       (* With [~ancestor_ids:[]] the subject filter is inactive, so both
+          log lines survive; [oldest_non_ancestor_commit] returns the last
+          line (oldest = Patch 1 = HEAD~1). [git] above already strips its
+          subprocess output, so [patch1_sha] is the bare 40-char SHA. *)
        let patch1_sha = git ~process_mgr ~dir [ "rev-parse"; "HEAD~1" ] in
        assert_eq "test10: cherry-pick alone keeps drifted Patch 1" patch1_sha
          sha

--- a/test/test_rebase_onto.ml
+++ b/test/test_rebase_onto.ml
@@ -72,6 +72,100 @@ let () =
   if errcode <> 0 then Stdlib.exit errcode
 
 (* ───────────────────────────────────────────────────────────────────────
+   Pure tests for [Worktree.is_ancestor_patch_subject] and
+   [Worktree.oldest_non_ancestor_commit]
+   ─────────────────────────────────────────────────────────────────────── *)
+
+let () =
+  let open QCheck2 in
+  let pid = Types.Patch_id.of_string in
+  let ancestor_ids = [ pid "1"; pid "2"; pid "6" ] in
+  let matches s =
+    Worktree.is_ancestor_patch_subject ~project_name:"proj" ~ancestor_ids s
+  in
+  let prop_matches_bare =
+    Test.make ~name:"is_ancestor_patch_subject: matches '[proj] Patch 1: title'"
+      ~count:1 Gen.unit (fun () -> matches "[proj] Patch 1: add foo")
+  in
+  let prop_matches_squash =
+    Test.make
+      ~name:
+        "is_ancestor_patch_subject: matches squash suffix '[proj] Patch 2: … \
+         (#42)'" ~count:1 Gen.unit (fun () ->
+        matches "[proj] Patch 2: bar (#42)")
+  in
+  let prop_current_not_matched =
+    Test.make
+      ~name:"is_ancestor_patch_subject: current patch id not in ancestors"
+      ~count:1 Gen.unit (fun () -> not (matches "[proj] Patch 7: impl"))
+  in
+  let prop_wrong_project =
+    Test.make
+      ~name:"is_ancestor_patch_subject: wrong project tag does not match"
+      ~count:1 Gen.unit (fun () -> not (matches "[other] Patch 1: add foo"))
+  in
+  let prop_non_convention =
+    Test.make ~name:"is_ancestor_patch_subject: agent's ad-hoc subject is safe"
+      ~count:1 Gen.unit (fun () -> not (matches "docs: fix typo"))
+  in
+  let prop_missing_colon =
+    Test.make ~name:"is_ancestor_patch_subject: missing colon still parses id"
+      ~count:1 Gen.unit (fun () -> matches "[proj] Patch 6 (HEAD -> main)")
+  in
+  let oldest =
+    Worktree.oldest_non_ancestor_commit ~project_name:"proj" ~ancestor_ids
+  in
+  let prop_filter_drops_ancestors =
+    Test.make ~name:"oldest_non_ancestor_commit: drops ancestor-subject commits"
+      ~count:1 Gen.unit (fun () ->
+        let input =
+          "feat01 [proj] Patch 7: the real work\n\
+           anc002 [proj] Patch 2: drop duplicate migration\n\
+           anc001 [proj] Patch 1: add schema\n"
+        in
+        match oldest input with
+        | Result.Ok sha -> String.equal sha "feat01"
+        | Result.Error _ -> false)
+  in
+  let prop_filter_empty_when_all_ancestors =
+    Test.make
+      ~name:"oldest_non_ancestor_commit: Error when every commit is ancestor"
+      ~count:1 Gen.unit (fun () ->
+        let input =
+          "anc002 [proj] Patch 2: bar\nanc001 [proj] Patch 1: foo\n"
+        in
+        match oldest input with Result.Error _ -> true | Result.Ok _ -> false)
+  in
+  let prop_filter_passthrough_no_ancestors =
+    Test.make
+      ~name:"oldest_non_ancestor_commit: empty ancestor list -> oldest as-is"
+      ~count:1 Gen.unit (fun () ->
+        let no_filter =
+          Worktree.oldest_non_ancestor_commit ~project_name:"proj"
+            ~ancestor_ids:[]
+        in
+        let input = "newer111 subj A\nolder222 subj B\n" in
+        match no_filter input with
+        | Result.Ok sha -> String.equal sha "older222"
+        | Result.Error _ -> false)
+  in
+  let suite =
+    [
+      prop_matches_bare;
+      prop_matches_squash;
+      prop_current_not_matched;
+      prop_wrong_project;
+      prop_non_convention;
+      prop_missing_colon;
+      prop_filter_drops_ancestors;
+      prop_filter_empty_when_all_ancestors;
+      prop_filter_passthrough_no_ancestors;
+    ]
+  in
+  let errcode = QCheck_base_runner.run_tests ~verbose:true suite in
+  if errcode <> 0 then Stdlib.exit errcode
+
+(* ───────────────────────────────────────────────────────────────────────
    Pure tests for [Worktree.parse_push_porcelain]
    ─────────────────────────────────────────────────────────────────────── *)
 
@@ -331,6 +425,7 @@ let () =
    let result =
      Worktree.rebase_onto ~process_mgr ~path:dir
        ~target:(Types.Branch.of_string "main")
+       ~project_name:"" ~ancestor_ids:[]
    in
    assert_rebase_ok "test1: simple rebase" result;
    (* C should now be on top of B *)
@@ -371,6 +466,7 @@ let () =
    let result =
      Worktree.rebase_onto ~process_mgr ~path:dir
        ~target:(Types.Branch.of_string "main")
+       ~project_name:"" ~ancestor_ids:[]
    in
    assert_rebase_ok "test2: onto after squash" result;
    let log = git ~process_mgr ~dir [ "log"; "--oneline"; "--format=%s" ] in
@@ -409,6 +505,7 @@ let () =
    let result =
      Worktree.rebase_onto ~process_mgr ~path:dir
        ~target:(Types.Branch.of_string "main")
+       ~project_name:"" ~ancestor_ids:[]
    in
    assert_rebase_ok "test3: multi-commit" result;
    let log = git ~process_mgr ~dir [ "log"; "--oneline"; "--format=%s" ] in
@@ -430,6 +527,7 @@ let () =
    let result =
      Worktree.rebase_onto ~process_mgr ~path:dir
        ~target:(Types.Branch.of_string "main")
+       ~project_name:"" ~ancestor_ids:[]
    in
    assert_rebase_noop "test4: already up-to-date" result;
    Stdlib.Sys.command (Printf.sprintf "rm -rf %s" dir) |> ignore);
@@ -455,6 +553,7 @@ let () =
    let result =
      Worktree.rebase_onto ~process_mgr ~path:dir
        ~target:(Types.Branch.of_string "main")
+       ~project_name:"" ~ancestor_ids:[]
    in
    assert_rebase_conflict "test5: conflict" result;
    (* Rebase should be left in progress for the agent to resolve *)
@@ -490,6 +589,7 @@ let () =
    let result =
      Worktree.rebase_onto ~process_mgr ~path:dir
        ~target:(Types.Branch.of_string "dep2")
+       ~project_name:"" ~ancestor_ids:[]
    in
    assert_rebase_noop "test6: dep2 already ancestor" result;
    Stdlib.Sys.command (Printf.sprintf "rm -rf %s" dir) |> ignore);
@@ -516,6 +616,7 @@ let () =
    let result =
      Worktree.rebase_onto ~process_mgr ~path:dir
        ~target:(Types.Branch.of_string "main")
+       ~project_name:"" ~ancestor_ids:[]
    in
    (* With a real merge, D1 is in main's history so cherry-pick should
       identify only F1 as unique. Result should be Ok or Noop depending
@@ -547,6 +648,7 @@ let () =
    let result =
      Worktree.rebase_onto ~process_mgr ~path:dir
        ~target:(Types.Branch.of_string "main")
+       ~project_name:"" ~ancestor_ids:[]
    in
    (* find_old_base returns Error "no unique commits found" so we fall
       back to plain rebase. Plain rebase should produce Ok or conflict
@@ -577,6 +679,7 @@ let () =
    let result =
      Worktree.rebase_onto ~process_mgr ~path:dir
        ~target:(Types.Branch.of_string "main")
+       ~project_name:"" ~ancestor_ids:[]
    in
    assert_rebase_ok "test9: modify dep file" result;
    let log = git ~process_mgr ~dir [ "log"; "--oneline"; "--format=%s" ] in
@@ -587,6 +690,56 @@ let () =
    (* x.txt should contain feat's version *)
    let content = read_file ~dir ~filename:"x.txt" in
    assert_eq "test9: x.txt content" "v2" content;
+   Stdlib.Sys.command (Printf.sprintf "rm -rf %s" dir) |> ignore);
+
+  (* ── Test 10: ancestor-subject filter strips drifted dep commits ─── *)
+  (* Regression for the trigger-only-execution / patch-7 case. A dep's
+     commit survives on our branch with the conventional
+     [<project>] Patch N: prefix but with *modified* content (a trailing
+     whitespace edit) — so git rev-list --cherry-pick cannot equate it with
+     the squash on main by patch-id. Without the ancestor_ids fallback, the
+     old dep commit would be replayed onto main; with ancestor_ids=["1"]
+     find_old_base picks a newer old_base and only our own commit survives. *)
+  (let dir = init_repo ~process_mgr in
+   commit_file ~process_mgr ~dir ~filename:"a.txt" ~content:"a" ~msg:"A"
+   |> ignore;
+   git ~process_mgr ~dir [ "checkout"; "-b"; "dep" ] |> ignore;
+   commit_file ~process_mgr ~dir ~filename:"dep.txt" ~content:"dep-v1"
+     ~msg:"[proj] Patch 1: add dep.txt"
+   |> ignore;
+   git ~process_mgr ~dir [ "checkout"; "-b"; "feat" ] |> ignore;
+   (* Simulate the drift: rewrite dep.txt identically but with a trailing
+      newline difference so patch-id on feat's dep-commit ≠ patch-id on
+      main's squash. The simplest way is to amend the Patch 1 commit on
+      feat with slightly different content. *)
+   let dep_path = Stdlib.Filename.concat dir "dep.txt" in
+   let oc = Stdlib.open_out dep_path in
+   Stdlib.output_string oc "dep-v1\n";
+   (* note trailing newline *)
+   Stdlib.close_out oc;
+   git ~process_mgr ~dir [ "add"; "dep.txt" ] |> ignore;
+   git ~process_mgr ~dir [ "commit"; "--amend"; "--no-edit" ] |> ignore;
+   commit_file ~process_mgr ~dir ~filename:"mine.txt" ~content:"mine"
+     ~msg:"[proj] Patch 7: add mine.txt"
+   |> ignore;
+   squash_merge ~process_mgr ~dir ~branch:"dep";
+   git ~process_mgr ~dir [ "checkout"; "feat" ] |> ignore;
+   let result =
+     Worktree.rebase_onto ~process_mgr ~path:dir
+       ~target:(Types.Branch.of_string "main")
+       ~project_name:"proj"
+       ~ancestor_ids:[ Types.Patch_id.of_string "1" ]
+   in
+   assert_rebase_ok "test10: subject-filter strips drifted dep" result;
+   let log = git ~process_mgr ~dir [ "log"; "--oneline"; "--format=%s" ] in
+   let lines = String.split_lines log in
+   (* Only our Patch 7 commit should sit on top of main's squash. *)
+   assert_eq "test10: head is Patch 7" "[proj] Patch 7: add mine.txt"
+     (List.hd_exn lines);
+   assert_eq "test10: parent is squash" "squash-merge dep"
+     (List.nth_exn lines 1);
+   assert_eq "test10: grandparent is A" "A" (List.nth_exn lines 2);
+   assert_eq "test10: exactly 3 commits" "3" (Int.to_string (List.length lines));
    Stdlib.Sys.command (Printf.sprintf "rm -rf %s" dir) |> ignore);
 
   Stdlib.print_endline "All rebase_onto integration tests passed."

--- a/test/test_rebase_onto.ml
+++ b/test/test_rebase_onto.ml
@@ -181,6 +181,20 @@ let () =
              ~ancestor_ids:[ pid "1" ]
              "[] Patch 1: boom"))
   in
+  let prop_crlf_line_endings =
+    (* Regression: CRLF (core.autocrlf=true on Windows) leaves a trailing
+       \r on each split line. The sha must not carry the \r, or the
+       downstream rev-parse would fail. *)
+    Test.make ~name:"oldest_non_ancestor_commit: CRLF trailing \\r stripped"
+      ~count:1 Gen.unit (fun () ->
+        let no_filter =
+          Worktree.oldest_non_ancestor_commit ~project_name:"proj"
+            ~ancestor_ids:[]
+        in
+        match no_filter "newer111 subj A\r\nolder222 subj B\r\n" with
+        | Result.Ok sha -> String.equal sha "older222"
+        | Result.Error _ -> false)
+  in
   let suite =
     [
       prop_matches_bare;
@@ -194,6 +208,7 @@ let () =
       prop_filter_passthrough_no_ancestors;
       prop_empty_subject_preserved;
       prop_empty_project_never_matches;
+      prop_crlf_line_endings;
     ]
   in
   let errcode = QCheck_base_runner.run_tests ~verbose:true suite in

--- a/test/test_rebase_onto.ml
+++ b/test/test_rebase_onto.ml
@@ -155,6 +155,32 @@ let () =
         | Result.Ok sha -> String.equal sha "older222"
         | Result.Error _ -> false)
   in
+  let prop_empty_subject_preserved =
+    (* Regression: %H %s for an empty-subject commit emits "<sha> ", and the
+       oldest line may have no content after the space. Stripping the full
+       input would erase that separator and drop the SHA. *)
+    Test.make
+      ~name:"oldest_non_ancestor_commit: oldest with empty subject is kept"
+      ~count:1 Gen.unit (fun () ->
+        let no_filter =
+          Worktree.oldest_non_ancestor_commit ~project_name:"proj"
+            ~ancestor_ids:[]
+        in
+        match no_filter "newer111 subj A\nolder222 \n" with
+        | Result.Ok sha -> String.equal sha "older222"
+        | Result.Error _ -> false)
+  in
+  let prop_empty_project_never_matches =
+    (* Regression: empty project_name would otherwise produce the prefix
+       "[] Patch " and match any subject that starts that way. *)
+    Test.make
+      ~name:"is_ancestor_patch_subject: empty project_name never matches"
+      ~count:1 Gen.unit (fun () ->
+        not
+          (Worktree.is_ancestor_patch_subject ~project_name:""
+             ~ancestor_ids:[ pid "1" ]
+             "[] Patch 1: boom"))
+  in
   let suite =
     [
       prop_matches_bare;
@@ -166,6 +192,8 @@ let () =
       prop_filter_drops_ancestors;
       prop_filter_empty_when_all_ancestors;
       prop_filter_passthrough_no_ancestors;
+      prop_empty_subject_preserved;
+      prop_empty_project_never_matches;
     ]
   in
   let errcode = QCheck_base_runner.run_tests ~verbose:true suite in


### PR DESCRIPTION
## Summary

- `Worktree.find_old_base` now reads each candidate commit's subject alongside its SHA (via `git log --format='%H %s'`) and filters out commits matching `[<project>] Patch N:` for any transitive ancestor `N`, in addition to the existing `git rev-list --cherry-pick` patch-id filter.
- The subject-based fallback is load-bearing against squash-merging trunks: a squash collapses a PR's commits into a single new commit with a fresh patch-id, so cherry-pick can't match the ancestor's original commit on a descendant feature branch. We saw this on `trigger-only-execution/patch-7` — the auto `--onto main` replayed merged Patch 1 and Patch 2 back onto main because their feature-branch patch-ids had drifted from the squashes.
- `Graph.transitive_ancestors` exposes the ancestor set; both rebase call sites in `bin/main.ml` (the `Rebase` op and merge-conflict rebase) thread it through `execute_worktree_plan` → `Worktree.rebase_onto ~project_name ~ancestor_ids`.

## Test plan

- [x] `dune build` (fatal-warnings clean)
- [x] `dune runtest --force` — full suite passes, including:
  - 9 new pure tests for `is_ancestor_patch_subject` and `oldest_non_ancestor_commit` (covers squash `(#42)` suffix, wrong-project tag, ad-hoc agent subjects, missing-colon form, empty-ancestor passthrough)
  - 3 new property tests for `Graph.transitive_ancestors` (self-exclusion, direct-deps coverage, deps-closure)
  - New integration test 10 in `test_rebase_onto.ml`: reproduces the patch-7 drift — an ancestor commit with the `[proj] Patch 1:` subject whose content was touched (so its patch-id no longer matches main's squash) is correctly stripped when `ancestor_ids=[1]`; only the current patch's commit sits on top of the squash
- [x] Existing 9 `rebase_onto` integration tests keep passing by threading `~project_name:""` and `~ancestor_ids:[]` (no-op filter preserves pre-change behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops rebase --onto from replaying squash-merged ancestor commits by reading `git log` subjects and skipping `[<project>] Patch N:` for transitive ancestors. Picks the correct old base on squash-merging trunks and hardens log parsing.

- **Bug Fixes**
  - `Worktree.find_old_base` now uses `git log --cherry-pick --format='%H %s' --no-show-signature --no-merges`, returns the oldest SHA after dropping lines whose subjects match `[<project>] Patch N:` for any `ancestor_ids`; strips trailing `\r`, skips blank/malformed/empty-SHA lines, and supports opt-out via `project_name=""` or `ancestor_ids=[]`. Docs clarify why `--no-merges` and `--no-show-signature` are required.
  - Added `Graph.transitive_ancestors` (cycle-safe, ascending order) and threaded its result into `Worktree.rebase_onto ~project_name ~ancestor_ids` at both rebase call sites; tests include a line-count sanity check to prove the subject-filter path.

- **Refactors**
  - Replaced `oldest_unique_commit` with `oldest_non_ancestor_commit`, which subsumes the old behavior.

<sup>Written for commit 32b2a315534163d24154c57395f97b52c64bf14c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rebase now computes transitive ancestor info and recognizes project-tagged commit subjects to avoid replaying ancestor patches.

* **Bug Fixes**
  * More robust base selection for rebases: skips ancestor-tagged commits, preserves commit-subject separators, and handles empty/whitespace and CRLF edge cases.

* **Tests**
  * Added property and integration tests covering transitive-ancestor discovery, cycle safety, and ancestor-aware rebase/subject-parsing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->