### PR TITLE
Add scripts/ for global skill install + port DB migration guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,18 @@ The `skills/` directory contains Claude Code skills for the planning layers:
   test maps, and a dependency graph. Designed so it's 5-10x easier to review
   the gameplan than the code it produces.
 
+To make these skills available to Claude Code from any project on your
+machine, run:
+
+```sh
+./scripts/install-hooks.sh
+```
+
+This symlinks each skill into `~/.claude/skills/` and installs a git
+`post-checkout` hook that keeps the symlinks pointed at the current checkout
+after branch switches. Running `./scripts/sync-skills.sh` directly has the
+same effect without installing the hook.
+
 ## Onton: the orchestrator
 
 Onton parses a structured gameplan, builds a dependency graph, and spawns

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# install-hooks — install onton's git hooks into .git/hooks/
+#
+# Currently installs:
+#   - post-checkout: runs sync-skills.sh after branch switches so ~/.claude/skills
+#     always points at the current checkout
+#
+# Safe to run repeatedly. Overwrites any existing post-checkout hook. Also runs
+# sync-skills.sh once immediately so skills are available without switching
+# branches.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+HOOKS_DIR="$REPO_ROOT/.git/hooks"
+
+if [ ! -d "$HOOKS_DIR" ]; then
+  echo "error: $HOOKS_DIR not found — is this a git clone of onton?" >&2
+  exit 1
+fi
+
+cat > "$HOOKS_DIR/post-checkout" <<HOOK
+#!/bin/sh
+[ -x "$SCRIPT_DIR/sync-skills.sh" ] && "$SCRIPT_DIR/sync-skills.sh"
+HOOK
+chmod +x "$HOOKS_DIR/post-checkout"
+echo "[installed] post-checkout hook"
+
+"$SCRIPT_DIR/sync-skills.sh"

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,30 +1,54 @@
 #!/bin/sh
-# install-hooks — install onton's git hooks into .git/hooks/
+# install-hooks — install onton's git hooks into the repo's hooks dir
 #
 # Currently installs:
 #   - post-checkout: runs sync-skills.sh after branch switches so ~/.claude/skills
 #     always points at the current checkout
 #
-# Safe to run repeatedly. Overwrites any existing post-checkout hook. Also runs
-# sync-skills.sh once immediately so skills are available without switching
-# branches.
+# Safe to run repeatedly. Refuses to overwrite a pre-existing post-checkout hook
+# that isn't onton's own. Also runs sync-skills.sh once immediately so skills
+# are available without switching branches.
 
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-HOOKS_DIR="$REPO_ROOT/.git/hooks"
 
-if [ ! -d "$HOOKS_DIR" ]; then
-  echo "error: $HOOKS_DIR not found — is this a git clone of onton?" >&2
+# Use `git rev-parse --git-path hooks` so linked worktrees install into their
+# own hooks directory rather than the main checkout's.
+HOOKS_DIR="$(git -C "$REPO_ROOT" rev-parse --git-path hooks 2>/dev/null)" || HOOKS_DIR=""
+
+if [ -z "$HOOKS_DIR" ]; then
+  echo "error: could not resolve git hooks directory — is this a git clone of onton?" >&2
   exit 1
 fi
 
-cat > "$HOOKS_DIR/post-checkout" <<HOOK
+# `--git-path` may return a path relative to REPO_ROOT; anchor it.
+case "$HOOKS_DIR" in
+  /*) ;;
+  *)  HOOKS_DIR="$REPO_ROOT/$HOOKS_DIR" ;;
+esac
+
+mkdir -p "$HOOKS_DIR"
+
+HOOK_PATH="$HOOKS_DIR/post-checkout"
+
+if [ -e "$HOOK_PATH" ] && ! grep -q 'sync-skills.sh' "$HOOK_PATH"; then
+  echo "error: $HOOK_PATH already exists and is not onton's hook." >&2
+  echo "       Merge the following into it manually, then re-run:" >&2
+  echo "         REPO_ROOT=\"\$(git rev-parse --show-toplevel 2>/dev/null)\" || exit 0" >&2
+  echo "         [ -x \"\$REPO_ROOT/scripts/sync-skills.sh\" ] && \"\$REPO_ROOT/scripts/sync-skills.sh\"" >&2
+  exit 1
+fi
+
+# Single-quoted heredoc delimiter so $REPO_ROOT is resolved at hook runtime,
+# not baked in at install time (the repo may later be moved or cloned elsewhere).
+cat > "$HOOK_PATH" <<'HOOK'
 #!/bin/sh
-[ -x "$SCRIPT_DIR/sync-skills.sh" ] && "$SCRIPT_DIR/sync-skills.sh"
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+[ -x "$REPO_ROOT/scripts/sync-skills.sh" ] && "$REPO_ROOT/scripts/sync-skills.sh"
 HOOK
-chmod +x "$HOOKS_DIR/post-checkout"
-echo "[installed] post-checkout hook"
+chmod +x "$HOOK_PATH"
+echo "[installed] post-checkout hook at $HOOK_PATH"
 
 "$SCRIPT_DIR/sync-skills.sh"

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -33,7 +33,12 @@ mkdir -p "$HOOKS_DIR"
 
 HOOK_PATH="$HOOKS_DIR/post-checkout"
 
-if [ -e "$HOOK_PATH" ] && ! grep -q 'sync-skills.sh' "$HOOK_PATH"; then
+# Detect onton-installed hooks via a sentinel comment so renaming sync-skills.sh
+# doesn't break re-installation, and a third-party hook that merely mentions
+# sync-skills.sh in a comment isn't mistaken for ours.
+ONTON_HOOK_SENTINEL='onton-managed-post-checkout'
+
+if [ -e "$HOOK_PATH" ] && ! grep -q "$ONTON_HOOK_SENTINEL" "$HOOK_PATH"; then
   echo "error: $HOOK_PATH already exists and is not onton's hook." >&2
   echo "       Merge the following into it manually, then re-run:" >&2
   echo "         REPO_ROOT=\"\$(git rev-parse --show-toplevel 2>/dev/null)\" || exit 0" >&2
@@ -45,6 +50,8 @@ fi
 # not baked in at install time (the repo may later be moved or cloned elsewhere).
 cat > "$HOOK_PATH" <<'HOOK'
 #!/bin/sh
+# onton-managed-post-checkout — do not edit this line; install-hooks.sh uses it
+# to detect that this hook is owned by onton and may be safely overwritten.
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
 [ -x "$REPO_ROOT/scripts/sync-skills.sh" ] && "$REPO_ROOT/scripts/sync-skills.sh"
 HOOK

--- a/scripts/sync-skills.sh
+++ b/scripts/sync-skills.sh
@@ -5,6 +5,14 @@
 # globally available to Claude Code regardless of which repo you're working in.
 # Also invoked automatically by the post-checkout hook installed via
 # scripts/install-hooks.sh.
+#
+# Per-skill behavior:
+#   - no entry: create a symlink pointing at this checkout
+#   - broken symlink: replace it
+#   - symlink already pointing at this checkout: leave alone
+#   - symlink pointing at a different onton checkout: SKIP (do not hijack —
+#     another worktree may be actively using it)
+#   - regular file or directory: SKIP
 
 set -e
 
@@ -32,15 +40,21 @@ for skill_path in "$SKILLS_DIR"/*/SKILL.md; do
     ln -s "$skill_dir" "$target_link"
     echo "[new] $skill_name → $skill_dir"
   elif [ -L "$target_link" ]; then
-    link_target="$(readlink "$target_link")"
+    # Resolve the stored symlink target to an absolute path before comparing.
+    # `readlink` (without -f, which isn't portable) returns the raw stored
+    # target; relative targets must be interpreted relative to the symlink's
+    # own directory.
+    link_raw="$(readlink "$target_link")"
+    case "$link_raw" in
+      /*) link_target="$link_raw" ;;
+      *)  link_target="$(cd "$TARGET_DIR" && cd "$(dirname "$link_raw")" 2>/dev/null && pwd)/$(basename "$link_raw")" ;;
+    esac
     if [ "$link_target" = "$skill_dir" ]; then
       echo "[ok] $skill_name"
     else
-      rm "$target_link"
-      ln -s "$skill_dir" "$target_link"
-      echo "[update] $skill_name → $skill_dir (was $link_target)"
+      echo "[skip] $skill_name — already linked to $link_target (owned by another checkout)"
     fi
   else
-    echo "[SKIP] $skill_name — exists as regular directory at $target_link"
+    echo "[skip] $skill_name — exists as regular file/directory at $target_link"
   fi
 done

--- a/scripts/sync-skills.sh
+++ b/scripts/sync-skills.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+# sync-skills — symlink repo skills/ into ~/.claude/skills/ for cross-project discovery
+#
+# Run once after cloning (or whenever onton's skills change) to make the skills
+# globally available to Claude Code regardless of which repo you're working in.
+# Also invoked automatically by the post-checkout hook installed via
+# scripts/install-hooks.sh.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SKILLS_DIR="$REPO_ROOT/skills"
+TARGET_DIR="$HOME/.claude/skills"
+
+[ -d "$SKILLS_DIR" ] || exit 0
+
+mkdir -p "$TARGET_DIR"
+
+for skill_path in "$SKILLS_DIR"/*/SKILL.md; do
+  [ -f "$skill_path" ] || continue
+
+  skill_dir="$(dirname "$skill_path")"
+  skill_name="$(basename "$skill_dir")"
+  target_link="$TARGET_DIR/$skill_name"
+
+  if [ -L "$target_link" ] && [ ! -e "$target_link" ]; then
+    rm "$target_link"
+    ln -s "$skill_dir" "$target_link"
+    echo "[fix] $skill_name → $skill_dir (replaced broken symlink)"
+  elif [ ! -e "$target_link" ] && [ ! -L "$target_link" ]; then
+    ln -s "$skill_dir" "$target_link"
+    echo "[new] $skill_name → $skill_dir"
+  elif [ -L "$target_link" ]; then
+    link_target="$(readlink "$target_link")"
+    if [ "$link_target" = "$skill_dir" ]; then
+      echo "[ok] $skill_name"
+    else
+      rm "$target_link"
+      ln -s "$skill_dir" "$target_link"
+      echo "[update] $skill_name → $skill_dir (was $link_target)"
+    fi
+  else
+    echo "[SKIP] $skill_name — exists as regular directory at $target_link"
+  fi
+done

--- a/scripts/sync-skills.sh
+++ b/scripts/sync-skills.sh
@@ -41,14 +41,19 @@ for skill_path in "$SKILLS_DIR"/*/SKILL.md; do
     echo "[new] $skill_name → $skill_dir"
   elif [ -L "$target_link" ]; then
     # Resolve the stored symlink target to an absolute path before comparing.
-    # `readlink` (without -f, which isn't portable) returns the raw stored
-    # target; relative targets must be interpreted relative to the symlink's
-    # own directory.
-    link_raw="$(readlink "$target_link")"
-    case "$link_raw" in
-      /*) link_target="$link_raw" ;;
-      *)  link_target="$(cd "$TARGET_DIR" && cd "$(dirname "$link_raw")" 2>/dev/null && pwd)/$(basename "$link_raw")" ;;
-    esac
+    # Prefer `readlink -f` (macOS 12.3+ and GNU coreutils); fall back to manual
+    # resolution against the symlink's own directory ($TARGET_DIR) on older
+    # systems. The fallback would silently return a wrong path if the relative
+    # target's parent directory no longer exists, hence the `-f` preference.
+    if link_target="$(readlink -f "$target_link" 2>/dev/null)" && [ -n "$link_target" ]; then
+      :
+    else
+      link_raw="$(readlink "$target_link")"
+      case "$link_raw" in
+        /*) link_target="$link_raw" ;;
+        *)  link_target="$(cd "$TARGET_DIR/$(dirname "$link_raw")" 2>/dev/null && pwd)/$(basename "$link_raw")" ;;
+      esac
+    fi
     if [ "$link_target" = "$skill_dir" ]; then
       echo "[ok] $skill_name"
     else

--- a/skills/write-gameplan/SKILL.md
+++ b/skills/write-gameplan/SKILL.md
@@ -128,6 +128,20 @@ Order patches to ship non-functional changes early:
 - **Middle** (`GATED`): Business logic behind flags, new gated endpoints
 - **Late** (`BEHAVIOR`): Wire up UI/API, enable flags, remove old code
 
+### Database Migration Rules
+
+**Co-location**: Any patch that modifies a database schema must also include generating/writing the corresponding migration in that same patch. Never defer migration generation to a later patch — each patch must leave the DB schema and migration files in sync so it is independently mergeable.
+
+**Sequential execution**: Patches that include database migrations MUST be ordered sequentially in the dependency graph — they cannot be parallelized. Migration files typically have sequential numbering, and parallel branches that each generate migrations will produce numbering conflicts that cause merge failures. This negates the benefit of parallelization.
+
+**Practical guidance**: If a gameplan requires multiple schema changes, either:
+1. Bundle them into one patch (if they're related), or
+2. Chain the migration-containing patches sequentially in the dependency graph
+
+Reserve parallelization for patches that don't touch database schemas/migrations.
+
+Different projects may use different migration tools and workflows. When planning patches that involve schema changes, research how migrations work in the relevant part of the codebase and include explicit migration instructions (commands to run, files to create/generate) in those patches. The implementing agent will follow the gameplan as-written — do not assume it will discover the migration workflow on its own.
+
 ## Test-First Pattern
 
 Write test stubs with skip/pending markers BEFORE implementation:


### PR DESCRIPTION
## Summary

- `scripts/sync-skills.sh` symlinks each `skills/*` directory into `~/.claude/skills/` so Claude Code can invoke `/write-gameplan` and `/write-workstream` from any repo on the host — not just from inside onton. The script is safe to re-run; it replaces broken symlinks and skip-fixes ones pointing at other checkouts.
- `scripts/install-hooks.sh` does a one-time setup: installs a `post-checkout` git hook that re-runs `sync-skills.sh` after branch switches, then performs an initial sync. README updated with the one-liner.
- `skills/write-gameplan/SKILL.md` gains a **Database Migration Rules** subsection under "Mergability Strategy" — back-ported from flowglad-pay's fork ([PR #1983](https://github.com/flowglad/provisioning-agent/pull/1983) there), with project-specific wording generalized. Captures co-location (migration lives in the same patch as the schema change) and sequential-execution (migration-bearing patches can't be parallelized because of numbering collisions).

Pairs with https://github.com/flowglad/provisioning-agent/pull/2146, which deletes the now-redundant skill copies from flowglad-pay and points its docs at this repo.

## Test plan

- [ ] `dune build` / `dune runtest` / `dune fmt` (pre-commit verified)
- [ ] Run `./scripts/install-hooks.sh` in a fresh clone and confirm `~/.claude/skills/write-gameplan` and `~/.claude/skills/write-workstream` resolve to onton
- [ ] Switch branches and confirm `post-checkout` hook re-syncs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/198"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `scripts/sync-skills.sh` and `scripts/install-hooks.sh` to expose repo skills globally via `~/.claude/skills/` and auto-sync on branch switches, with hardened hook detection and link resolution. Also adds Database Migration Rules to `write-gameplan`.

- **New Features**
  - `scripts/sync-skills.sh`: symlinks `skills/*` into `~/.claude/skills/`; safe to re-run; fixes broken links; skips links owned by another checkout; prefers `readlink -f` and normalizes targets for correct `[ok]` detection.
  - `scripts/install-hooks.sh`: installs a `post-checkout` hook and runs an initial sync; uses `git rev-parse --git-path hooks` for worktrees; resolves repo root at runtime; detects onton-owned hooks via an `onton-managed-post-checkout` sentinel and refuses to overwrite others. README adds a one-liner.
  - `skills/write-gameplan/SKILL.md`: new Database Migration Rules (co-location, sequential execution, practical guidance) with generalized wording.

- **Migration**
  - Run `./scripts/install-hooks.sh`.
  - Confirm `~/.claude/skills/write-gameplan` and `~/.claude/skills/write-workstream` point to this repo. Branch switches auto-sync.

<sup>Written for commit 569f743c2bf1127d071fbc3d67f56045ec5d4477. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added installation instructions for development environment setup with automated skill synchronization.
  * Updated database migration rules for gameplan patch planning.

* **New Features**
  * Automated skill synchronization with git hook installation capability.
  * Direct sync script available for manual execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->