### PR TITLE
write-gameplan: refresh Pantagruel guidance for pant 0.22

### DIFF
--- a/skills/write-gameplan/SKILL.md
+++ b/skills/write-gameplan/SKILL.md
@@ -182,7 +182,7 @@ The `spec` and `finalStateSpec` fields contain source code in a formal specifica
 We use [Pantagruel](https://github.com/subsetpark/pantagruel) — a language for writing formal specifications with domains, rules, and invariants organized into progressive-disclosure chapters.
 
 - **Language reference**: `https://raw.githubusercontent.com/subsetpark/pantagruel/refs/heads/master/REFERENCE.md` — fetch this for syntax details
-- **Validation (parse + type-check)**: extract spec strings to `.pant` files and run `pant <file.pant>`. Bare `pant` type-checks; exit code 0 and empty output mean the spec is well-formed. If `pant` is not installed, install via Homebrew: `brew tap subsetpark/pantagruel https://github.com/subsetpark/pantagruel && brew install pantagruel`
+- **Validation (parse + type-check)**: extract spec strings to `.pant` files and run `pant <file.pant>`. Bare `pant` type-checks; exit code 0 means the spec is well-formed (pant 0.22 is quiet on success — no stdout or stderr). If `pant` is not installed, install via Homebrew: `brew tap subsetpark/pantagruel https://github.com/subsetpark/pantagruel && brew install pantagruel`
 - **SMT verification (optional)**: `pant --check <file.pant>` runs SMT-based invariant/precondition checks (requires `z3` or `cvc5`). Use this to catch contradictions, unreachable states, and violated invariants — not a replacement for the parse check. `--bound N` sets the domain-element bound (default 3); `--solver z3|cvc5` picks a solver
 - **Module naming**: final-state spec uses `<PROJECT_NAME>` (e.g., `EXTRACT_DECISION`); per-patch specs use `<PROJECT_NAME>_PATCH_<N>`
 - **Style**:

--- a/skills/write-gameplan/SKILL.md
+++ b/skills/write-gameplan/SKILL.md
@@ -182,7 +182,7 @@ The `spec` and `finalStateSpec` fields contain source code in a formal specifica
 We use [Pantagruel](https://github.com/subsetpark/pantagruel) — a language for writing formal specifications with domains, rules, and invariants organized into progressive-disclosure chapters.
 
 - **Language reference**: `https://raw.githubusercontent.com/subsetpark/pantagruel/refs/heads/master/REFERENCE.md` — fetch this for syntax details
-- **Validation (parse + type-check)**: extract spec strings to `.pant` files and run `pant <file.pant>`. Bare `pant` type-checks; exit code 0 means the spec is well-formed (pant 0.22 is quiet on success — no stdout or stderr). If `pant` is not installed, install via Homebrew: `brew tap subsetpark/pantagruel https://github.com/subsetpark/pantagruel && brew install pantagruel`
+- **Validation (parse + type-check)**: extract spec strings to `.pant` files and run `pant <file.pant>`. Bare `pant` type-checks; exit code 0 means the spec is well-formed. On pant 0.22, success produces no output. If `pant` is not installed, install via Homebrew: `brew tap subsetpark/pantagruel https://github.com/subsetpark/pantagruel && brew install pantagruel`
 - **SMT verification (optional)**: `pant --check <file.pant>` runs SMT-based invariant/precondition checks (requires `z3` or `cvc5`). Use this to catch contradictions, unreachable states, and violated invariants — not a replacement for the parse check. `--bound N` sets the domain-element bound (default 3); `--solver z3|cvc5` picks a solver
 - **Module naming**: final-state spec uses `<PROJECT_NAME>` (e.g., `EXTRACT_DECISION`); per-patch specs use `<PROJECT_NAME>_PATCH_<N>`
 - **Style**:

--- a/skills/write-gameplan/SKILL.md
+++ b/skills/write-gameplan/SKILL.md
@@ -182,9 +182,15 @@ The `spec` and `finalStateSpec` fields contain source code in a formal specifica
 We use [Pantagruel](https://github.com/subsetpark/pantagruel) — a language for writing formal specifications with domains, rules, and invariants organized into progressive-disclosure chapters.
 
 - **Language reference**: `https://raw.githubusercontent.com/subsetpark/pantagruel/refs/heads/master/REFERENCE.md` — fetch this for syntax details
-- **Validation**: extract spec strings to `.pant` files and run `pant --check <file.pant>`. If `pant` is not installed, run `opam install pantagruel`
+- **Validation (parse + type-check)**: extract spec strings to `.pant` files and run `pant <file.pant>`. Bare `pant` type-checks; exit code 0 and empty output mean the spec is well-formed. If `pant` is not installed, install via Homebrew: `brew tap subsetpark/pantagruel https://github.com/subsetpark/pantagruel && brew install pantagruel`
+- **SMT verification (optional)**: `pant --check <file.pant>` runs SMT-based invariant/precondition checks (requires `z3` or `cvc5`). Use this to catch contradictions, unreachable states, and violated invariants — not a replacement for the parse check. `--bound N` sets the domain-element bound (default 3); `--solver z3|cvc5` picks a solver
 - **Module naming**: final-state spec uses `<PROJECT_NAME>` (e.g., `EXTRACT_DECISION`); per-patch specs use `<PROJECT_NAME>_PATCH_<N>`
-- **Style**: use progressive disclosure (top-down chapter structure), keep per-patch specs self-contained (redeclare referenced domains/rules rather than importing)
+- **Style**:
+  - Progressive disclosure (top-down chapter structure); keep per-patch specs self-contained (redeclare referenced domains/rules rather than importing)
+  - **Uppercase** identifiers are domains/types (`Patch`, `Disposition`); **lowercase** identifiers are rules/values (`disposition`, `skip`), optionally suffixed with `?` or `!`
+  - Enum-like values are best modelled as nullary lowercase rules returning the domain: `skip => Disposition.` (not `Skip => Disposition.` — uppercase rule names will not parse)
+  - Rules with multiple parameters use **comma-separated typed params**, not arrows: `inline-decisions rf: RunnerFiber, p: Patch => Nat0.` (not `rf: RunnerFiber -> Patch => Nat0.`)
+  - Every chapter needs at least one declaration in its head before the `---` separator; if a patch introduces no new invariants, redeclare the prior chapter's domains/rules so the module is self-contained
 
 ### Using a different spec language
 

--- a/skills/write-gameplan/references/example.json
+++ b/skills/write-gameplan/references/example.json
@@ -152,9 +152,9 @@
         }
       ],
       "changes": [
-        "Implement disposition: merged -> Skip, busy -> Queue, else -> Deliver",
-        "Implement on_ci_failure: merged -> Reject, ci_failure_count >= 3 -> Cap_reached, busy -> Queue, else -> Deliver",
-        "Implement on_merge_conflict: merged -> Noop, busy -> Queue, else -> Deliver",
+        "Implement disposition: merged -> skip, busy -> queue, else -> deliver",
+        "Implement on_ci_failure: merged -> reject, ci_failure_count >= 3 -> cap_reached, busy -> queue, else -> deliver",
+        "Implement on_merge_conflict: merged -> noop, busy -> queue, else -> deliver",
         "Enable all QCheck2 tests from Patch 2"
       ],
       "testStubsIntroduced": null,

--- a/skills/write-gameplan/references/example.json
+++ b/skills/write-gameplan/references/example.json
@@ -27,7 +27,7 @@
       "file": "lib/patch_decision.ml",
       "line": null,
       "description": "New module: pure decision functions for patch lifecycle",
-      "signature": "val disposition : merged:bool -> busy:bool -> [ `Skip | `Queue | `Deliver ]"
+      "signature": "val disposition : merged:bool -> busy:bool -> disposition"
     },
     {
       "file": "lib/patch_decision.mli",

--- a/skills/write-gameplan/references/example.json
+++ b/skills/write-gameplan/references/example.json
@@ -101,7 +101,7 @@
       ],
       "testStubsIntroduced": null,
       "testStubsImplemented": null,
-      "spec": "module EXTRACT_DECISION_PATCH_1.\n\n> Patch 1 introduces type declarations only.\n> No behavioral invariants — the contribution is the type structure itself.\n\nDisposition.\nskip => Disposition.\nqueue => Disposition.\ndeliver => Disposition.\n---\n"
+      "spec": "module EXTRACT_DECISION_PATCH_1.\n\n> Patch 1 introduces type declarations only.\n> No behavioral invariants — the contribution is the type structure itself.\n\nDisposition.\nskip => Disposition.\nqueue => Disposition.\ndeliver => Disposition.\n---\ntrue.\n"
     },
     {
       "number": 2,

--- a/skills/write-gameplan/references/example.json
+++ b/skills/write-gameplan/references/example.json
@@ -125,14 +125,12 @@
       "changes": [
         "Add pending test: merged patch is always skipped (spec: merged? p -> disposition p = skip)",
         "Add pending test: busy patch is never delivered (spec: busy? p -> disposition p ~= deliver)",
-        "Add pending test: CI failure count >= 3 yields Cap_reached (spec: ci-failure-count p >= 3 -> needs-intervention? p)",
-        "Add pending test: merged patch conflict is Noop (spec: merged? p -> on-conflict p = noop)"
+        "Add pending test: CI failure count >= 3 yields Cap_reached (spec: ci-failure-count p >= 3 -> needs-intervention? p)"
       ],
       "testStubsIntroduced": [
         "Patch_decision > merged patch is always skipped",
         "Patch_decision > busy patch is never delivered",
-        "Patch_decision > CI failure cap at 3",
-        "Patch_decision > merged patch conflict is Noop"
+        "Patch_decision > CI failure cap at 3"
       ],
       "testStubsImplemented": null,
       "spec": "module EXTRACT_DECISION_PATCH_2.\n\n> Patch 2 introduces test stubs only. No new invariants are\n> declared — stubs are pending markers implemented in Patch 3.\n> Redeclare Patch 1's types here so the module is self-contained.\n\nDisposition.\nskip => Disposition.\nqueue => Disposition.\ndeliver => Disposition.\n---\ntrue.\n"
@@ -163,8 +161,7 @@
       "testStubsImplemented": [
         "Patch_decision > merged patch is always skipped",
         "Patch_decision > busy patch is never delivered",
-        "Patch_decision > CI failure cap at 3",
-        "Patch_decision > merged patch conflict is Noop"
+        "Patch_decision > CI failure cap at 3"
       ],
       "spec": "module EXTRACT_DECISION_PATCH_3.\n\n> Patch 3 implements the pure decision logic.\n> These invariants are derived from the Pantagruel spec.\n\nPatch.\nDisposition.\nskip => Disposition.\nqueue => Disposition.\ndeliver => Disposition.\n\nmerged? p: Patch => Bool.\nbusy? p: Patch => Bool.\nci-failure-count p: Patch => Nat0.\nneeds-intervention? p: Patch => Bool.\n\ndisposition p: Patch => Disposition.\n---\n> Merged patches are always skipped.\nall p: Patch, merged? p | disposition p = skip.\n\n> Busy patches are never delivered.\nall p: Patch, busy? p | disposition p ~= deliver.\n\n> CI failure cap triggers intervention.\nall p: Patch, ci-failure-count p >= 3 | needs-intervention? p.\n"
     },
@@ -206,12 +203,6 @@
     },
     {
       "testName": "Patch_decision > CI failure cap at 3",
-      "file": "test/test_patch_decision.ml",
-      "stubPatch": 2,
-      "implPatch": 3
-    },
-    {
-      "testName": "Patch_decision > merged patch conflict is Noop",
       "file": "test/test_patch_decision.ml",
       "stubPatch": 2,
       "implPatch": 3

--- a/skills/write-gameplan/references/example.json
+++ b/skills/write-gameplan/references/example.json
@@ -104,7 +104,7 @@
       ],
       "testStubsIntroduced": null,
       "testStubsImplemented": null,
-      "spec": "module EXTRACT_DECISION_PATCH_1.\n\n> Patch 1 introduces type declarations only.\n> No behavioral invariants — the contribution is the type structure itself.\n\nDisposition.\nSkip => Disposition.\nQueue => Disposition.\nDeliver => Disposition.\n\nCiAction.\nCap_reached => CiAction.\n\nConflictAction.\nNoop => ConflictAction.\n---\n"
+      "spec": "module EXTRACT_DECISION_PATCH_1.\n\n> Patch 1 introduces type declarations only.\n> No behavioral invariants — the contribution is the type structure itself.\n\nDisposition.\nskip => Disposition.\nqueue => Disposition.\ndeliver => Disposition.\n---\n"
     },
     {
       "number": 2,
@@ -123,10 +123,10 @@
         }
       ],
       "changes": [
-        "Add pending test: merged patch is always skipped (spec: merged p -> disposition p = Skip)",
-        "Add pending test: busy patch is never delivered (spec: busy p -> disposition p /= Deliver)",
-        "Add pending test: CI failure count >= 3 yields Cap_reached (spec: ci-failure-count >= 3 -> needs-intervention)",
-        "Add pending test: merged patch conflict is Noop (spec: merged p -> on-conflict p = Noop)"
+        "Add pending test: merged patch is always skipped (spec: merged? p -> disposition p = skip)",
+        "Add pending test: busy patch is never delivered (spec: busy? p -> disposition p ~= deliver)",
+        "Add pending test: CI failure count >= 3 yields Cap_reached (spec: ci-failure-count p >= 3 -> needs-intervention? p)",
+        "Add pending test: merged patch conflict is Noop (spec: merged? p -> on-conflict p = noop)"
       ],
       "testStubsIntroduced": [
         "Patch_decision > merged patch is always skipped",
@@ -135,7 +135,7 @@
         "Patch_decision > merged patch conflict is Noop"
       ],
       "testStubsImplemented": null,
-      "spec": "module EXTRACT_DECISION_PATCH_2.\n\n> Patch 2 introduces test stubs only.\n> No new invariants — stubs are pending markers implemented in Patch 3.\n\n---\n"
+      "spec": "module EXTRACT_DECISION_PATCH_2.\n\n> Patch 2 introduces test stubs only. No new invariants are\n> declared — stubs are pending markers implemented in Patch 3.\n> Redeclare Patch 1's types here so the module is self-contained.\n\nDisposition.\nskip => Disposition.\nqueue => Disposition.\ndeliver => Disposition.\n---\ntrue.\n"
     },
     {
       "number": 3,
@@ -166,7 +166,7 @@
         "Patch_decision > CI failure cap at 3",
         "Patch_decision > merged patch conflict is Noop"
       ],
-      "spec": "module EXTRACT_DECISION_PATCH_3.\n\n> Patch 3 implements the pure decision logic.\n> These invariants are derived from the Pantagruel spec.\n\nPatch.\nDisposition.\nSkip => Disposition.\nQueue => Disposition.\nDeliver => Disposition.\n\nmerged? p: Patch => Bool.\nbusy? p: Patch => Bool.\nci-failure-count p: Patch => Nat0.\n\ndisposition p: Patch => Disposition.\n\n> Merged patches are always skipped.\nall p: Patch, merged? p | disposition p = Skip.\n\n> Busy patches are never delivered.\nall p: Patch, busy? p | disposition p /= Deliver.\n\n> CI failure cap triggers intervention.\nall p: Patch, ci-failure-count p >= 3 | needs-intervention? p.\n\nwhere\n\nneeds-intervention? p: Patch => Bool.\n---\n"
+      "spec": "module EXTRACT_DECISION_PATCH_3.\n\n> Patch 3 implements the pure decision logic.\n> These invariants are derived from the Pantagruel spec.\n\nPatch.\nDisposition.\nskip => Disposition.\nqueue => Disposition.\ndeliver => Disposition.\n\nmerged? p: Patch => Bool.\nbusy? p: Patch => Bool.\nci-failure-count p: Patch => Nat0.\nneeds-intervention? p: Patch => Bool.\n\ndisposition p: Patch => Disposition.\n---\n> Merged patches are always skipped.\nall p: Patch, merged? p | disposition p = skip.\n\n> Busy patches are never delivered.\nall p: Patch, busy? p | disposition p ~= deliver.\n\n> CI failure cap triggers intervention.\nall p: Patch, ci-failure-count p >= 3 | needs-intervention? p.\n"
     },
     {
       "number": 4,
@@ -187,7 +187,7 @@
       ],
       "testStubsIntroduced": null,
       "testStubsImplemented": null,
-      "spec": "module EXTRACT_DECISION_PATCH_4.\n\n> Patch 4 wires the pure decision module into main.ml.\n> The behavioral invariant: main.ml delegates all lifecycle\n> decisions to Patch_decision — no inline decision logic remains.\n\nPatch.\nRunnerFiber.\n\n> All decision points in runner_fiber use Patch_decision.\nall p: Patch, rf: RunnerFiber |\n  inline-decisions rf p = 0.\n\nwhere\n\ninline-decisions rf: RunnerFiber -> Patch => Nat0.\n---\n"
+      "spec": "module EXTRACT_DECISION_PATCH_4.\n\n> Patch 4 wires the pure decision module into main.ml.\n> The behavioral invariant: main.ml delegates all lifecycle\n> decisions to Patch_decision — no inline decision logic remains.\n\nPatch.\nRunnerFiber.\ninline-decisions rf: RunnerFiber, p: Patch => Nat0.\n---\n> All decision points in runner_fiber use Patch_decision.\nall rf: RunnerFiber, p: Patch | inline-decisions rf p = 0.\n"
     }
   ],
 
@@ -239,5 +239,5 @@
 
   "mergabilityInsight": "3 of 4 patches are INFRA and can ship without changing observable behavior. Only Patch 4 changes behavior (wiring).",
 
-  "finalStateSpec": "module EXTRACT_DECISION.\n\n> ══════════════════════════════════════════\n> THE GUARANTEE\n> ══════════════════════════════════════════\n> After this gameplan, all patch lifecycle decisions are made\n> by the pure Patch_decision module. Decision logic is fully\n> testable via QCheck2 properties derived from the spec.\n\nPatch.\nDisposition.\nSkip => Disposition.\nQueue => Disposition.\nDeliver => Disposition.\n\nmerged? p: Patch => Bool.\nbusy? p: Patch => Bool.\nci-failure-count p: Patch => Nat0.\n\ndisposition p: Patch => Disposition.\n\n> Merged patches are always skipped.\nall p: Patch, merged? p | disposition p = Skip.\n\n> Busy patches are never delivered.\nall p: Patch, busy? p | disposition p /= Deliver.\n\n> CI failure cap triggers intervention.\nall p: Patch, ci-failure-count p >= 3 | needs-intervention? p.\n\nwhere\n\n> ══════════════════════════════════════════\n> SEPARATION OF CONCERNS\n> ══════════════════════════════════════════\n> main.ml delegates all decisions to Patch_decision.\n> No inline decision logic remains in I/O code.\n\nRunnerFiber.\n\nall p: Patch, rf: RunnerFiber |\n  inline-decisions rf p = 0.\n\nneeds-intervention? p: Patch => Bool.\ninline-decisions rf: RunnerFiber -> Patch => Nat0.\n---\n"
+  "finalStateSpec": "module EXTRACT_DECISION.\n\n> ══════════════════════════════════════════\n> THE GUARANTEE\n> ══════════════════════════════════════════\n> After this gameplan, all patch lifecycle decisions are made\n> by the pure Patch_decision module. Decision logic is fully\n> testable via QCheck2 properties derived from the spec.\n\nPatch.\nDisposition.\nskip => Disposition.\nqueue => Disposition.\ndeliver => Disposition.\n\nmerged? p: Patch => Bool.\nbusy? p: Patch => Bool.\nci-failure-count p: Patch => Nat0.\nneeds-intervention? p: Patch => Bool.\n\ndisposition p: Patch => Disposition.\n---\n> Merged patches are always skipped.\nall p: Patch, merged? p | disposition p = skip.\n\n> Busy patches are never delivered.\nall p: Patch, busy? p | disposition p ~= deliver.\n\n> CI failure cap triggers intervention.\nall p: Patch, ci-failure-count p >= 3 | needs-intervention? p.\n\nwhere\n\n> ══════════════════════════════════════════\n> SEPARATION OF CONCERNS\n> ══════════════════════════════════════════\n> main.ml delegates all decisions to Patch_decision.\n> No inline decision logic remains in I/O code.\n\nRunnerFiber.\ninline-decisions rf: RunnerFiber, p: Patch => Nat0.\n---\nall rf: RunnerFiber, p: Patch | inline-decisions rf p = 0.\n"
 }

--- a/skills/write-gameplan/references/example.json
+++ b/skills/write-gameplan/references/example.json
@@ -12,7 +12,7 @@
 
   "problemStatement": "Decision logic for patch lifecycle (should we deliver an operation? skip it? queue it?) is tangled with I/O in main.ml's 1500-line runner_fiber. This makes it impossible to property-test the decision rules that the formal spec defines. The decision logic should be extracted into a pure module.",
 
-  "solutionSummary": "Extract a pure Patch_decision module with functions like `disposition`, `on_review_comments`, `on_ci_failure`, and `on_merge_conflict`. Each function takes the patch's current state and returns an algebraic type describing the action. Wire main.ml to call these functions instead of inlining the logic. Add QCheck2 property tests derived from the formal spec's preconditions and postconditions.",
+  "solutionSummary": "Extract a pure Patch_decision module with functions like `disposition` (algebraic return) and `needs_intervention` (predicate). Each mirrors how the spec models its invariant: actions as domains, cap conditions as predicates. Wire main.ml to call these functions instead of inlining the logic. Add QCheck2 property tests derived from the formal spec's preconditions and postconditions.",
 
   "mergabilityStrategy": {
     "featureFlagStrategy": "No feature flag needed. This is a refactoring of internal decision logic. External behavior is unchanged — the same decisions are made, just in a different module.",
@@ -96,11 +96,8 @@
       ],
       "changes": [
         "Define type disposition = Skip | Queue | Deliver with [@@deriving show, eq]",
-        "Define type ci_action = Queue | Deliver | Cap_reached | Reject with [@@deriving show, eq]",
-        "Define type conflict_action = Queue | Deliver | Noop with [@@deriving show, eq]",
         "Add val disposition : merged:bool -> busy:bool -> disposition (placeholder)",
-        "Add val on_ci_failure : merged:bool -> busy:bool -> ci_failure_count:int -> ci_action (placeholder)",
-        "Add val on_merge_conflict : merged:bool -> busy:bool -> conflict_action (placeholder)"
+        "Add val needs_intervention : ci_failure_count:int -> bool (placeholder)"
       ],
       "testStubsIntroduced": null,
       "testStubsImplemented": null,
@@ -125,7 +122,7 @@
       "changes": [
         "Add pending test: merged patch is always skipped (spec: merged? p -> disposition p = skip)",
         "Add pending test: busy patch is never delivered (spec: busy? p -> disposition p ~= deliver)",
-        "Add pending test: CI failure count >= 3 yields Cap_reached (spec: ci-failure-count p >= 3 -> needs-intervention? p)"
+        "Add pending test: CI failure count >= 3 requires intervention (spec: ci-failure-count p >= 3 -> needs-intervention? p)"
       ],
       "testStubsIntroduced": [
         "Patch_decision > merged patch is always skipped",
@@ -153,8 +150,7 @@
       ],
       "changes": [
         "Implement disposition: merged -> skip, busy -> queue, else -> deliver",
-        "Implement on_ci_failure: merged -> reject, ci_failure_count >= 3 -> cap_reached, busy -> queue, else -> deliver",
-        "Implement on_merge_conflict: merged -> noop, busy -> queue, else -> deliver",
+        "Implement needs_intervention: ci_failure_count >= 3 -> true, else -> false",
         "Enable all QCheck2 tests from Patch 2"
       ],
       "testStubsIntroduced": null,
@@ -178,8 +174,7 @@
       ],
       "changes": [
         "In runner_fiber poll handler (~line 960): replace inline merged/busy checks with Patch_decision.disposition",
-        "In CI failure handler (~line 1050): replace inline ci_failure_count check with Patch_decision.on_ci_failure",
-        "In merge conflict handler (~line 1110): replace inline logic with Patch_decision.on_merge_conflict",
+        "In CI failure handler (~line 1050): replace inline ci_failure_count >= 3 check with Patch_decision.needs_intervention",
         "Remove now-dead local helper functions that duplicated decision logic"
       ],
       "testStubsIntroduced": null,

--- a/skills/write-gameplan/references/example.json
+++ b/skills/write-gameplan/references/example.json
@@ -95,7 +95,7 @@
         }
       ],
       "changes": [
-        "Define type disposition = Skip | Queue | Deliver with [@@deriving show, eq]",
+        "Define type disposition = Skip | Queue | Deliver with [@@deriving show, eq] (Skip/Queue/Deliver correspond to spec rules skip/queue/deliver; OCaml requires capitalised regular-variant constructors)",
         "Add val disposition : merged:bool -> busy:bool -> disposition (placeholder)",
         "Add val needs_intervention : ci_failure_count:int -> bool (placeholder)"
       ],


### PR DESCRIPTION
## Summary

- The write-gameplan skill's Pantagruel guidance had drifted from the current language/CLI. Audit uncovered three concrete staleness issues:
  1. `pant --check <file>` no longer means "parse/type-check" — in 0.22 it runs SMT-based invariant verification. Our skill told users to use it for validation.
  2. `opam install pantagruel` is not the upstream-recommended install path; Homebrew tap is.
  3. All 5 `spec`/`finalStateSpec` strings in `references/example.json` fail to parse against `pant 0.22.0` (uppercase rule names, arrow-typed multi-arg params, empty chapter heads).
- `SKILL.md` updated: split validation into parse-check (`pant <file>`) vs. SMT (`pant --check`); new Homebrew install command; added concrete style rules derived from the samples in `subsetpark/pantagruel`.
- `references/example.json`: rewrote every spec string so they all parse cleanly **and** pass `pant --check` against locally-installed pant 0.22.0. The illustrative example now focuses on `Disposition` (drops the colliding `CiAction`/`ConflictAction` enums that broke in-module). Example still validates against `gameplan-schema.json` (verified with ajv-cli draft 2020).

## Test plan

- [x] `pant <file>` parses each of patch 1-4 and final-state spec extracted from `example.json`
- [x] `pant --check <file>` succeeds (or "No verification queries generated." for spec 1) on each of the 5 specs
- [x] `ajv-cli validate --spec=draft2020 -s gameplan-schema.json -d example.json` reports valid
- [x] Pre-commit hook (`dune build` + `dune runtest` + format check) passed locally
- [x] REFERENCE.md URL fetched successfully (link is live)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/199"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes Pantagruel guidance for `pant` 0.22, updates the example specs to parse and verify with the new CLI, and removes the unbacked test stub. Switches the example API to the nominal `disposition` type and clarifies OCaml vs. spec casing for `disposition` constructors.

- **Bug Fixes**
  - Validation: `pant <file>` for parse/type-check; `pant --check` for SMT. Exit code 0 signals success (quiet on success in 0.22). Documented `--bound` and `--solver`.
  - Install: switch to Homebrew tap `brew tap subsetpark/pantagruel https://github.com/subsetpark/pantagruel && brew install pantagruel`.
  - Example updates: modeled CI cap with a `needs_intervention` predicate; dropped `on_merge_conflict`/`conflict_action` and the orphan “merged patch conflict is Noop” stub; redeclared Patch 1 types in Patch 2; normalized invariant-free bodies to `true.`; updated the `disposition` function signature to use the nominal `disposition` type; added an inline note that OCaml constructors `Skip`/`Queue`/`Deliver` map to spec rules `skip`/`queue`/`deliver`. All five specs parse and pass `pant --check` on 0.22.0.
  - Style: added concise rules in `SKILL.md` (uppercase domains vs. lowercase rules/values; enum values as nullary lowercase rules; comma-separated typed params; non-empty chapter heads). Aligned Patch 3 “changes” text to lowercase names to match the spec.

<sup>Written for commit 836981f332eae5d3cb6963d17fd6507bed35daae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

