### PR TITLE
Dedup CI feedback delivery by CheckRun id

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -3131,6 +3131,32 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                         ~default:(Branch.to_string main)
                                         ~f:Branch.to_string
                                     in
+                                    (* Lock in CI run dedup before firing the
+                                       session. Recording pre-flight (rather
+                                       than post-) means a session that starts
+                                       but later fails still counts as
+                                       "delivered", so we don't re-nag the
+                                       agent with the same failing run on the
+                                       next tick. *)
+                                    (match payload with
+                                    | Patch_decision.Ci_payload
+                                        { failed_checks } ->
+                                        let ids =
+                                          Base.List.filter_map failed_checks
+                                            ~f:(fun (c : Ci_check.t) ->
+                                              c.Ci_check.id)
+                                        in
+                                        if not (Base.List.is_empty ids) then
+                                          Runtime.update_orchestrator runtime
+                                            (fun orch ->
+                                              Orchestrator
+                                              .record_delivered_ci_run_ids orch
+                                                patch_id ids)
+                                    | Patch_decision.Human_payload _
+                                    | Patch_decision.Review_payload _
+                                    | Patch_decision.Pr_body_payload
+                                    | Patch_decision.Merge_conflict_payload ->
+                                        ());
                                     let result =
                                       run_claude_and_handle ~runtime
                                         ~process_mgr ~fs ~project_name ~patch_id

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -105,6 +105,7 @@ let graphql_query =
                 nodes {
                   ... on CheckRun {
                     __typename
+                    databaseId
                     name
                     conclusion
                     detailsUrl
@@ -176,9 +177,10 @@ let parse_check_context_node node =
           let details_url = node |> member "detailsUrl" |> to_string_option in
           let description = node |> member "text" |> to_string_option in
           let started_at = node |> member "startedAt" |> to_string_option in
+          let id = node |> member "databaseId" |> to_int_option in
           Some
             Types.Ci_check.
-              { name; conclusion; details_url; description; started_at })
+              { name; conclusion; details_url; description; started_at; id })
   | Some "StatusContext" -> (
       match node |> member "context" |> to_string_option with
       | None -> None
@@ -193,7 +195,14 @@ let parse_check_context_node node =
           let started_at = node |> member "createdAt" |> to_string_option in
           Some
             Types.Ci_check.
-              { name; conclusion; details_url; description; started_at })
+              {
+                name;
+                conclusion;
+                details_url;
+                description;
+                started_at;
+                id = None;
+              })
   | _ -> None
 
 let parse_comment_node ~thread_id node =

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -333,6 +333,10 @@ let reset_ci_failure_count t patch_id =
 let set_ci_checks t patch_id checks =
   update_agent t patch_id ~f:(fun a -> Patch_agent.set_ci_checks a checks)
 
+let record_delivered_ci_run_ids t patch_id ids =
+  update_agent t patch_id ~f:(fun a ->
+      Patch_agent.record_delivered_ci_run_ids a ids)
+
 let set_checks_passing t patch_id v =
   update_agent t patch_id ~f:(fun a -> Patch_agent.set_checks_passing a v)
 

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -89,6 +89,12 @@ val set_notified_base_branch : t -> Patch_id.t -> Branch.t -> t
 val increment_ci_failure_count : t -> Patch_id.t -> t
 val reset_ci_failure_count : t -> Patch_id.t -> t
 val set_ci_checks : t -> Patch_id.t -> Ci_check.t list -> t
+
+val record_delivered_ci_run_ids : t -> Patch_id.t -> int list -> t
+(** Record CheckRun [databaseId]s as delivered to the agent for this patch so
+    subsequent CI deliveries do not re-deliver the same runs. See
+    {!Patch_agent.record_delivered_ci_run_ids}. *)
+
 val set_checks_passing : t -> Patch_id.t -> bool -> t
 val set_merge_ready : t -> Patch_id.t -> bool -> t
 val set_is_draft : t -> Patch_id.t -> bool -> t

--- a/lib/patch_agent.ml
+++ b/lib/patch_agent.ml
@@ -51,6 +51,13 @@ type t = {
       (** Consecutive merge-call failures. After [automerge_max_failures] the
           patch is no longer an automerge candidate until the user re-toggles
           automerge or a successful merge resets the counter. *)
+  delivered_ci_run_ids : int list;
+      (** CheckRun [databaseId]s that have already been delivered to the agent
+          as CI feedback. Maintained sorted and deduplicated. Used so a single
+          failing run is only delivered once, even if [generation] bumps or
+          other state changes cause the Ci payload to be recomposed with the
+          same underlying failures. Cleared on [clear_pr]. Checks without a
+          stable id (StatusContext entries) bypass this dedup. *)
 }
 [@@deriving eq, sexp_of, compare]
 
@@ -120,6 +127,7 @@ let create ~branch patch_id =
     automerge_deadline = None;
     automerge_inflight = false;
     automerge_failure_count = 0;
+    delivered_ci_run_ids = [];
   }
 
 let create_adhoc ~patch_id ~branch ~pr_number =
@@ -159,6 +167,7 @@ let create_adhoc ~patch_id ~branch ~pr_number =
     automerge_deadline = None;
     automerge_inflight = false;
     automerge_failure_count = 0;
+    delivered_ci_run_ids = [];
   }
 
 let highest_priority t =
@@ -260,6 +269,17 @@ let increment_ci_failure_count t =
 
 let reset_ci_failure_count t = { t with ci_failure_count = 0 }
 let set_ci_checks t checks = { t with ci_checks = checks }
+
+let record_delivered_ci_run_ids t ids =
+  (* Maintain sorted + deduplicated list. Small enough (tens of entries per
+     patch lifetime) that a list is fine; sorting keeps equality checks stable
+     across serialization round-trips. *)
+  let combined = List.rev_append ids t.delivered_ci_run_ids in
+  let deduped =
+    List.dedup_and_sort combined ~compare:(fun a b -> Int.compare a b)
+  in
+  { t with delivered_ci_run_ids = deduped }
+
 let set_branch_blocked t = { t with branch_blocked = true }
 let clear_branch_blocked t = { t with branch_blocked = false }
 let set_current_message_id t current_message_id = { t with current_message_id }
@@ -316,7 +336,7 @@ let restore ~patch_id ~branch ~pr_number ~has_session ~busy ~merged ~queue
     ~branch_rebased_onto ~checks_passing ~current_op ~current_message_id
     ~generation ~worktree_path ~branch_blocked ~llm_session_id
     ~automerge_enabled ~automerge_deadline ~automerge_inflight
-    ~automerge_failure_count =
+    ~automerge_failure_count ~delivered_ci_run_ids =
   {
     patch_id;
     branch;
@@ -353,6 +373,7 @@ let restore ~patch_id ~branch ~pr_number ~has_session ~busy ~merged ~queue
     automerge_deadline;
     automerge_inflight;
     automerge_failure_count;
+    delivered_ci_run_ids;
   }
 
 let set_pr_number t pr_number =
@@ -375,6 +396,7 @@ let clear_pr t =
     ci_failure_count = 0;
     base_branch = None;
     notified_base_branch = None;
+    delivered_ci_run_ids = [];
   }
 
 let start t ~base_branch =

--- a/lib/patch_agent.mli
+++ b/lib/patch_agent.mli
@@ -45,6 +45,11 @@ type t = private {
   automerge_deadline : float option;
   automerge_inflight : bool;
   automerge_failure_count : int;
+  delivered_ci_run_ids : int list;
+      (** CheckRun [databaseId]s already delivered as CI feedback. Sorted and
+          deduplicated. Drives per-run deduplication in the CI delivery path so
+          a single failing run is never delivered twice. Cleared on [clear_pr].
+      *)
 }
 [@@deriving show, eq, sexp_of, compare]
 
@@ -235,6 +240,12 @@ val clear_branch_blocked : t -> t
 val set_ci_checks : t -> Types.Ci_check.t list -> t
 (** Replace the stored CI check details. *)
 
+val record_delivered_ci_run_ids : t -> int list -> t
+(** Mark the given CheckRun [databaseId]s as delivered so the CI feedback path
+    will not re-deliver them. Merges with the existing set, sorts, and dedups.
+    [ids] should contain only CheckRuns that carried an id (StatusContext
+    entries without stable numeric ids cannot be deduped). *)
+
 val reset_busy : t -> t
 (** Reset a stale [busy] flag from a crashed session. If [busy], clears it.
     [needs_intervention] is derived automatically. No-op if not busy. *)
@@ -338,6 +349,7 @@ val restore :
   automerge_deadline:float option ->
   automerge_inflight:bool ->
   automerge_failure_count:int ->
+  delivered_ci_run_ids:int list ->
   t
 (** Reconstruct agent state from persisted field values. Bypasses precondition
     checks — use only for deserialization. *)

--- a/lib/patch_decision.ml
+++ b/lib/patch_decision.ml
@@ -109,6 +109,19 @@ type respond_delivery =
   | Respond_stale
 [@@deriving show, eq, sexp_of, compare]
 
+(** Keep only failing CI checks that haven't already been delivered to the
+    agent. Checks without a stable [id] (StatusContext entries, legacy
+    snapshots) bypass the dedup — they can't be keyed reliably, and the
+    conservative choice is to deliver rather than silently drop. *)
+let filter_undelivered_ci_failures (agent : Patch_agent.t) : Ci_check.t list =
+  List.filter agent.ci_checks ~f:(fun (c : Ci_check.t) ->
+      if not (Ci_check.is_failure c) then false
+      else
+        match c.id with
+        | None -> true
+        | Some id ->
+            not (List.mem agent.delivered_ci_run_ids id ~equal:Int.equal))
+
 let respond_delivery ~(agent : Patch_agent.t) ~(kind : Operation_kind.t)
     ~(pre_fire_agent : Patch_agent.t option)
     ~(prefetched_comments : Comment.t list) ~(main_branch : string) :
@@ -120,6 +133,11 @@ let respond_delivery ~(agent : Patch_agent.t) ~(kind : Operation_kind.t)
   then Respond_stale
   else
     let source = Option.value pre_fire_agent ~default:agent in
+    (* Precompute the CI failure list once so emptiness and payload agree.
+       Filtering against [delivered_ci_run_ids] is what prevents a second
+       delivery of the same underlying run after an unrelated [generation]
+       bump. *)
+    let ci_undelivered = filter_undelivered_ci_failures agent in
     let is_empty =
       match kind with
       | Operation_kind.Review_comments -> List.is_empty prefetched_comments
@@ -129,8 +147,10 @@ let respond_delivery ~(agent : Patch_agent.t) ~(kind : Operation_kind.t)
              and skips delivery before calling us when the failure is
              already resolved. This is a belt-and-suspenders guard so the
              pure function never emits an empty [Ci_payload] in isolation
-             (e.g. if a future caller forgets the freshness hop). *)
-          not (List.exists agent.ci_checks ~f:Ci_check.is_failure)
+             (e.g. if a future caller forgets the freshness hop). Also
+             catches the case where every fresh failure has already been
+             delivered — no new information to send. *)
+          List.is_empty ci_undelivered
       | Operation_kind.Merge_conflict | Operation_kind.Pr_body
       | Operation_kind.Rebase ->
           false
@@ -154,12 +174,7 @@ let respond_delivery ~(agent : Patch_agent.t) ~(kind : Operation_kind.t)
         match kind with
         | Operation_kind.Human ->
             Human_payload { messages = List.rev source.human_messages }
-        | Operation_kind.Ci ->
-            let failed =
-              List.filter agent.ci_checks ~f:(fun (c : Ci_check.t) ->
-                  List.mem failure_conclusions c.conclusion ~equal:String.equal)
-            in
-            Ci_payload { failed_checks = failed }
+        | Operation_kind.Ci -> Ci_payload { failed_checks = ci_undelivered }
         | Operation_kind.Review_comments ->
             Review_payload { comments = prefetched_comments }
         | Operation_kind.Pr_body -> Pr_body_payload

--- a/lib/persistence.ml
+++ b/lib/persistence.ml
@@ -100,6 +100,8 @@ let patch_agent_to_yojson (a : Patch_agent.t) =
          in-flight GitHub call, which cannot still be running across a
          supervisor restart. Deserialization hard-codes [false] to match. *)
       ("automerge_failure_count", `Int a.automerge_failure_count);
+      ( "delivered_ci_run_ids",
+        `List (List.map a.delivered_ci_run_ids ~f:(fun i -> `Int i)) );
     ]
 
 let patch_agent_of_yojson ~gameplan json =
@@ -253,7 +255,14 @@ let patch_agent_of_yojson ~gameplan json =
        ~automerge_failure_count:
          (Option.value
             (int_member_opt "automerge_failure_count" json)
-            ~default:0))
+            ~default:0)
+       ~delivered_ci_run_ids:
+         (match Yojson.Safe.Util.member "delivered_ci_run_ids" json with
+         | `List items ->
+             List.filter_map items ~f:(fun j ->
+                 Yojson.Safe.Util.to_int_option j)
+             |> List.dedup_and_sort ~compare:Int.compare
+         | _ -> []))
 
 (* ---------- Activity_log ---------- *)
 

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -143,6 +143,11 @@ module Ci_check = struct
     details_url : string option;
     description : string option;
     started_at : string option;
+    id : int option; [@yojson.default None]
+        (** GitHub CheckRun [databaseId] when available, [None] for legacy
+            StatusContext entries (which have no stable numeric ID). Used as the
+            dedup key for CI feedback delivery so a single failing run is only
+            delivered once even if [generation] bumps for other reasons. *)
   }
   [@@deriving show, eq, sexp_of, compare, yojson]
 

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -111,6 +111,11 @@ module Ci_check : sig
     details_url : string option;
     description : string option;
     started_at : string option;
+    id : int option;
+        (** GitHub CheckRun [databaseId] when available, [None] for legacy
+            StatusContext entries (which expose no stable numeric ID). Used as
+            the dedup key for CI feedback delivery so a single failing run is
+            only delivered once. *)
   }
   [@@deriving show, eq, sexp_of, compare, yojson]
 

--- a/lib_test/test_generators.ml
+++ b/lib_test/test_generators.ml
@@ -111,7 +111,14 @@ let gen_ci_check =
     map4
       (fun name conclusion details_url description ->
         Ci_check.
-          { name; conclusion; details_url; description; started_at = None })
+          {
+            name;
+            conclusion;
+            details_url;
+            description;
+            started_at = None;
+            id = None;
+          })
       gen_name gen_conclusion gen_url gen_desc)
 
 let gen_patch_list_linear =

--- a/test/test_patch_agent.ml
+++ b/test/test_patch_agent.ml
@@ -469,6 +469,7 @@ let () =
                       details_url = None;
                       description = None;
                       started_at = None;
+                      id = None;
                     })
             in
             let a = set_ci_checks a checks in
@@ -515,6 +516,7 @@ let () =
                       details_url = None;
                       description = None;
                       started_at = None;
+                      id = None;
                     })
             in
             let a = set_ci_checks a checks in
@@ -663,6 +665,7 @@ let () =
                 details_url = None;
                 description = None;
                 started_at = None;
+                id = None;
               }
           in
           let a = set_ci_checks a [ check ] in
@@ -682,7 +685,7 @@ let () =
               ~generation:0 ~worktree_path:None ~branch_blocked:false
               ~llm_session_id:None ~automerge_enabled:false
               ~automerge_deadline:None ~automerge_inflight:false
-              ~automerge_failure_count:0
+              ~automerge_failure_count:0 ~delivered_ci_run_ids:[]
           in
           let a = start a ~base_branch:br in
           List.is_empty a.ci_checks);
@@ -699,6 +702,7 @@ let () =
                 details_url = None;
                 description = None;
                 started_at = None;
+                id = None;
               }
           in
           let a = set_ci_checks a [ check ] in
@@ -760,7 +764,7 @@ let () =
               ~generation:0 ~worktree_path:None ~branch_blocked:false
               ~llm_session_id:None ~automerge_enabled:false
               ~automerge_deadline:None ~automerge_inflight:false
-              ~automerge_failure_count:0
+              ~automerge_failure_count:0 ~delivered_ci_run_ids:[]
           in
           let a = enqueue a Operation_kind.Rebase in
           let a = rebase a ~base_branch:new_base in

--- a/test/test_patch_controller.ml
+++ b/test/test_patch_controller.ml
@@ -54,7 +54,7 @@ let make_agent ~patch_id ~branch ~pr_number ~merged ~queue ~base_branch
     ~checks_passing:false ~current_op:None ~current_message_id:None
     ~generation:0 ~worktree_path:None ~branch_blocked:false ~llm_session_id:None
     ~automerge_enabled:false ~automerge_deadline:None ~automerge_inflight:false
-    ~automerge_failure_count:0
+    ~automerge_failure_count:0 ~delivered_ci_run_ids:[]
 
 let has_draft_effect effects =
   List.exists effects ~f:(function
@@ -351,7 +351,7 @@ let () =
             ~generation:0 ~worktree_path:None ~branch_blocked:false
             ~llm_session_id:None ~automerge_enabled:false
             ~automerge_deadline:None ~automerge_inflight:false
-            ~automerge_failure_count:0
+            ~automerge_failure_count:0 ~delivered_ci_run_ids:[]
         in
         let orch = make_orch patch agent in
         (* Apply effects in a loop until convergence (max 5 rounds). *)
@@ -484,7 +484,7 @@ let () =
             ~generation:0 ~worktree_path:None ~branch_blocked:false
             ~llm_session_id:None ~automerge_enabled:false
             ~automerge_deadline:None ~automerge_inflight:false
-            ~automerge_failure_count:0
+            ~automerge_failure_count:0 ~delivered_ci_run_ids:[]
         in
         let orch = make_orch patch agent in
         let poll =
@@ -622,7 +622,7 @@ let () =
             ~generation:0 ~worktree_path:None ~branch_blocked:false
             ~llm_session_id:None ~automerge_enabled:false
             ~automerge_deadline:None ~automerge_inflight:false
-            ~automerge_failure_count:0
+            ~automerge_failure_count:0 ~delivered_ci_run_ids:[]
         in
         let orch = make_orch patch agent in
         begin try
@@ -824,7 +824,7 @@ let () =
             ~current_message_id:None ~generation:0 ~worktree_path:None
             ~branch_blocked:false ~llm_session_id:None ~automerge_enabled:false
             ~automerge_deadline:None ~automerge_inflight:false
-            ~automerge_failure_count:0
+            ~automerge_failure_count:0 ~delivered_ci_run_ids:[]
         in
         let orch =
           Orchestrator.restore
@@ -864,7 +864,7 @@ let () =
             ~generation:0 ~worktree_path:None ~branch_blocked:false
             ~llm_session_id:None ~automerge_enabled:false
             ~automerge_deadline:None ~automerge_inflight:false
-            ~automerge_failure_count:0
+            ~automerge_failure_count:0 ~delivered_ci_run_ids:[]
         in
         let orch =
           Orchestrator.restore

--- a/test/test_patch_decision.ml
+++ b/test/test_patch_decision.ml
@@ -303,6 +303,7 @@ let () =
             details_url = None;
             description = None;
             started_at = None;
+            id = None;
           };
         ]
     in
@@ -431,6 +432,7 @@ let () =
                 details_url = None;
                 description = None;
                 started_at = None;
+                id = None;
               };
             ]
         in
@@ -475,6 +477,122 @@ let () =
                  (Operation_kind.to_label kind))
         | Deliver _ | Respond_stale -> ());
     Stdlib.print_endline "RD-7 passed"
+  in
+
+  (* RD-8: Ci with all failing run ids already delivered -> Skip_empty *)
+  let () =
+    let pid = Patch_id.of_string "rd8" in
+    let br = Branch.of_string "b" in
+    let failing_check id =
+      {
+        Ci_check.name = Printf.sprintf "check-%d" id;
+        conclusion = "failure";
+        details_url = None;
+        description = None;
+        started_at = None;
+        id = Some id;
+      }
+    in
+    let pre_fire =
+      with_pr pid br |> fun a ->
+      set_ci_checks a [ failing_check 101; failing_check 202 ] |> fun a ->
+      record_delivered_ci_run_ids a [ 101; 202 ]
+    in
+    let a = enqueue pre_fire Operation_kind.Ci in
+    let a = respond a Operation_kind.Ci in
+    (match
+       respond_delivery ~agent:a ~kind:Operation_kind.Ci
+         ~pre_fire_agent:(Some pre_fire) ~prefetched_comments:[] ~main_branch
+     with
+    | Skip_empty -> ()
+    | Deliver _ | Respond_stale ->
+        failwith "RD-8: expected Skip_empty when all run ids already delivered");
+    Stdlib.print_endline "RD-8 passed"
+  in
+
+  (* RD-9: Ci with one delivered and one undelivered failing run -> Deliver
+     with only the undelivered check. *)
+  let () =
+    let pid = Patch_id.of_string "rd9" in
+    let br = Branch.of_string "b" in
+    let failing_check id =
+      {
+        Ci_check.name = Printf.sprintf "check-%d" id;
+        conclusion = "failure";
+        details_url = None;
+        description = None;
+        started_at = None;
+        id = Some id;
+      }
+    in
+    let pre_fire =
+      with_pr pid br |> fun a ->
+      set_ci_checks a [ failing_check 11; failing_check 22 ] |> fun a ->
+      record_delivered_ci_run_ids a [ 11 ]
+    in
+    let a = enqueue pre_fire Operation_kind.Ci in
+    let a = respond a Operation_kind.Ci in
+    (match
+       respond_delivery ~agent:a ~kind:Operation_kind.Ci
+         ~pre_fire_agent:(Some pre_fire) ~prefetched_comments:[] ~main_branch
+     with
+    | Deliver { payload = Ci_payload { failed_checks }; _ } ->
+        let ids =
+          List.filter_map failed_checks ~f:(fun (c : Ci_check.t) ->
+              c.Ci_check.id)
+        in
+        assert (List.equal Int.equal ids [ 22 ])
+    | Deliver
+        {
+          payload =
+            ( Human_payload _ | Review_payload _ | Pr_body_payload
+            | Merge_conflict_payload );
+          _;
+        }
+    | Skip_empty | Respond_stale ->
+        failwith "RD-9: expected Deliver with only id=22");
+    Stdlib.print_endline "RD-9 passed"
+  in
+
+  (* RD-10: checks with id=None (StatusContext) bypass dedup and always
+     deliver. *)
+  let () =
+    let pid = Patch_id.of_string "rd10" in
+    let br = Branch.of_string "b" in
+    let no_id_check =
+      {
+        Ci_check.name = "legacy-status";
+        conclusion = "failure";
+        details_url = None;
+        description = None;
+        started_at = None;
+        id = None;
+      }
+    in
+    let pre_fire =
+      with_pr pid br |> fun a ->
+      set_ci_checks a [ no_id_check ]
+      (* recording unrelated ids does not suppress an id=None check *)
+      |> fun a -> record_delivered_ci_run_ids a [ 999 ]
+    in
+    let a = enqueue pre_fire Operation_kind.Ci in
+    let a = respond a Operation_kind.Ci in
+    (match
+       respond_delivery ~agent:a ~kind:Operation_kind.Ci
+         ~pre_fire_agent:(Some pre_fire) ~prefetched_comments:[] ~main_branch
+     with
+    | Deliver { payload = Ci_payload { failed_checks }; _ } ->
+        assert (List.length failed_checks = 1)
+    | Deliver
+        {
+          payload =
+            ( Human_payload _ | Review_payload _ | Pr_body_payload
+            | Merge_conflict_payload );
+          _;
+        }
+    | Skip_empty | Respond_stale ->
+        failwith "RD-10: expected Deliver for id=None check");
+    Stdlib.print_endline "RD-10 passed"
   in
 
   ignore main_branch

--- a/test/test_poll_log_properties.ml
+++ b/test/test_poll_log_properties.ml
@@ -52,6 +52,7 @@ let make_agent ~patch_id ~branch ~has_conflict ~ci_failure_count ~current_op
     ~current_message_id:None ~generation:0 ~worktree_path ~branch_blocked
     ~llm_session_id:None ~automerge_enabled:false ~automerge_deadline:None
     ~automerge_inflight:false ~automerge_failure_count:0
+    ~delivered_ci_run_ids:[]
 
 let make_poll_observation ~branch_in_root ~worktree_path poll_result =
   Patch_controller.

--- a/test/test_poller_properties.ml
+++ b/test/test_poller_properties.ml
@@ -67,6 +67,7 @@ let () =
                      details_url;
                      description;
                      started_at = None;
+                     id = None;
                    })
                (triple
                   (string_size ~gen:(char_range 'a' 'z') (int_range 3 10))


### PR DESCRIPTION
## Summary
- Track CheckRun `databaseId` of CI failures already delivered per patch in `Patch_agent.delivered_ci_run_ids` (persisted in the JSON snapshot)
- Filter `Patch_decision.respond_delivery` CI payloads to only undelivered runs; return `Skip_empty` when every current failure has already been delivered
- Record delivered ids pre-flight in `bin/main.ml` so a session that fails still counts as delivered — no re-nagging on the next tick

StatusContext checks carry no stable numeric id and bypass the dedup (conservative: deliver rather than silently drop).

## Test plan
- [x] `dune build` clean
- [x] `dune runtest` — full suite passes, including three new `RD-8/9/10` tests covering: all-delivered → Skip_empty, partial-delivered → Deliver with only undelivered, id=None bypasses dedup
- [x] `dune fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/200"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dedup CI feedback by CheckRun `databaseId` so each failing run is delivered once. Delivered run ids are recorded pre-flight and persisted per patch to prevent re-nagging on retries or generation bumps.

- **New Features**
  - Track delivered CI run ids in `Patch_agent.delivered_ci_run_ids` and persist in the JSON snapshot.
  - Store CheckRun id on each check (`Ci_check.id`) and include `databaseId` in the GraphQL query.
  - Filter CI payloads to only undelivered failures; return `Skip_empty` when all current failures were already delivered.
  - Keep StatusContext entries (no stable id) out of the dedup for safety.

<sup>Written for commit 5eb641e54e7e3241e1c56b2c5e9947417ecf4d46. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

