### PR TITLE
Thread commit SHAs into review-comment prompts

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -3080,8 +3080,14 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                               failed_checks
                                       | Patch_decision.Review_payload
                                           { comments } ->
+                                          let current_head_sha =
+                                            Base.Option.bind fresh_pr_state
+                                              ~f:(fun ps ->
+                                                ps.Pr_state.head_oid)
+                                          in
                                           Prompt.render_review_prompt
-                                            ~project_name ?pr_number comments
+                                            ~project_name ?pr_number
+                                            ?current_head_sha comments
                                       | Patch_decision.Human_payload
                                           { messages } ->
                                           Prompt.render_human_message_prompt

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -130,6 +130,8 @@ let graphql_query =
         nodes {
           id
           isResolved
+          # [comments(first: 1)] only returns the thread opener. If a caller
+          # ever needs per-reply SHAs, raise this limit and add pagination.
           comments(first: 1) {
             nodes {
               databaseId

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -93,6 +93,7 @@ let graphql_query =
       mergeable
       mergeStateStatus
       headRefName
+      headRefOid
       baseRefName
       headRepositoryOwner { login }
       commits(last: 1) {
@@ -135,6 +136,8 @@ let graphql_query =
               body
               path
               line
+              commit { oid }
+              originalCommit { oid }
             }
           }
         }
@@ -206,7 +209,15 @@ let parse_comment_node ~thread_id node =
   let body = node |> member "body" |> to_string in
   let path = node |> member "path" |> to_string_option in
   let line = node |> member "line" |> to_int_option in
-  Types.Comment.{ id; thread_id; body; path; line }
+  let oid_of field =
+    match node |> member field with
+    | `Null -> None
+    | obj -> obj |> member "oid" |> to_string_option
+  in
+  let commit_sha = oid_of "commit" in
+  let original_commit_sha = oid_of "originalCommit" in
+  Types.Comment.
+    { id; thread_id; body; path; line; commit_sha; original_commit_sha }
 
 let parse_response_json ~owner json =
   let open Yojson.Safe.Util in
@@ -298,6 +309,7 @@ let parse_response_json ~owner json =
               pr |> member "headRefName" |> to_string_option
               |> Option.map ~f:Types.Branch.of_string
             in
+            let head_oid = pr |> member "headRefOid" |> to_string_option in
             let base_branch =
               pr |> member "baseRefName" |> to_string_option
               |> Option.map ~f:Types.Branch.of_string
@@ -323,6 +335,7 @@ let parse_response_json ~owner json =
                 comments;
                 unresolved_comment_count;
                 head_branch;
+                head_oid;
                 base_branch;
                 is_fork;
               })

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -209,6 +209,11 @@ let parse_comment_node ~thread_id node =
   let body = node |> member "body" |> to_string in
   let path = node |> member "path" |> to_string_option in
   let line = node |> member "line" |> to_int_option in
+  (* If [field] is absent or null we return [None]; if it's present but the
+     nested [oid] is missing/non-string, [to_string_option] also returns [None].
+     That second case is a GraphQL-schema-change red flag, but there's no
+     structured logger here — callers treat a [None] SHA as "no anchor info",
+     which is the safest fallback. *)
   let oid_of field =
     match node |> member field with
     | `Null -> None

--- a/lib/pr_state.ml
+++ b/lib/pr_state.ml
@@ -15,6 +15,7 @@ type t = {
   comments : Types.Comment.t list;
   unresolved_comment_count : int;
   head_branch : Types.Branch.t option;
+  head_oid : string option;
   base_branch : Types.Branch.t option;
   is_fork : bool;
 }

--- a/lib/pr_state.mli
+++ b/lib/pr_state.mli
@@ -21,6 +21,7 @@ type t = {
   comments : Comment.t list;
   unresolved_comment_count : int;
   head_branch : Branch.t option;
+  head_oid : string option;
   base_branch : Branch.t option;
   is_fork : bool;
 }

--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -493,7 +493,9 @@ Do not repeat information already in the description or specs above — add only
 Keep it concise — a few bullet points usually suffices. If you have nothing material to add (the patch is straightforward), write a single line acknowledging that.|}
         vars)
 
-let render_review_prompt ~(project_name : string) ?pr_number
+let short_sha s = if String.length s <= 7 then s else String.sub s ~pos:0 ~len:7
+
+let render_review_prompt ~(project_name : string) ?pr_number ?current_head_sha
     (comments : Comment.t list) =
   match comments with
   | [] -> "No review comments to address."
@@ -502,6 +504,17 @@ let render_review_prompt ~(project_name : string) ?pr_number
         match pr_number with
         | Some n -> Int.to_string (Pr_number.to_int n)
         | None -> "{pr_number}"
+      in
+      (* Only claim outdated-ness when GitHub has given us a signal. If
+         [commit] and [originalCommit] differ, GitHub re-anchored the comment
+         to a later commit (line moved). If [line] is null but we do have an
+         original SHA, GitHub detached the comment from the file. With no SHA
+         info at all, say nothing — matches pre-SHA behavior. *)
+      let is_outdated (c : Comment.t) =
+        match (c.Comment.commit_sha, c.Comment.original_commit_sha) with
+        | Some cur, Some orig when not (String.equal cur orig) -> true
+        | _, Some _ when Option.is_none c.Comment.line -> true
+        | _ -> false
       in
       let formatted =
         List.map comments ~f:(fun (c : Comment.t) ->
@@ -520,8 +533,14 @@ let render_review_prompt ~(project_name : string) ?pr_number
               | Some tid -> Printf.sprintf " [thread_id=%s]" tid
               | None -> ""
             in
-            Printf.sprintf "- **Comment**%s%s%s: %s" location db_id thread_ref
-              c.Comment.body)
+            let anchor =
+              match c.Comment.original_commit_sha with
+              | Some sha -> Printf.sprintf " [at=%s]" (short_sha sha)
+              | None -> ""
+            in
+            let outdated = if is_outdated c then " [outdated]" else "" in
+            Printf.sprintf "- **Comment**%s%s%s%s%s: %s" location db_id
+              thread_ref anchor outdated c.Comment.body)
         |> String.concat ~sep:"\n\n"
       in
       let pr_ctx =
@@ -529,18 +548,56 @@ let render_review_prompt ~(project_name : string) ?pr_number
         | Some n -> Printf.sprintf "\n\nPR: #%d\n" (Pr_number.to_int n)
         | None -> ""
       in
+      let reviewed_at_shas =
+        List.filter_map comments ~f:(fun (c : Comment.t) ->
+            c.Comment.original_commit_sha)
+        |> List.dedup_and_sort ~compare:String.compare
+      in
+      let sha_anchor =
+        match (current_head_sha, reviewed_at_shas) with
+        | Some head, (_ :: _ as shas) ->
+            let anchored =
+              match shas with
+              | [ sha ] -> Printf.sprintf "commit `%s`" (short_sha sha)
+              | many ->
+                  "commits "
+                  ^ (List.map many ~f:(fun s ->
+                         Printf.sprintf "`%s`" (short_sha s))
+                    |> String.concat ~sep:", ")
+            in
+            Printf.sprintf
+              "\n\n\
+               Review anchored at %s. Current branch HEAD is `%s`.\n\
+               If a comment is marked `[outdated]` or refers to code that no \
+               longer exists at HEAD, reply acknowledging it's addressed in a \
+               later commit and skip — do not re-do the change.\n"
+              anchored (short_sha head)
+        | _ -> ""
+      in
+      let reviewed_at_sha_var =
+        match reviewed_at_shas with
+        | [ sha ] -> short_sha sha
+        | _ :: _ as many -> List.map many ~f:short_sha |> String.concat ~sep:","
+        | [] -> ""
+      in
+      let current_head_sha_var =
+        match current_head_sha with Some s -> short_sha s | None -> ""
+      in
       let vars =
         [
           ("project_name", project_name);
           ("comments", formatted);
           ("count", Int.to_string (List.length comments));
           ("pr_number", pr_num_str);
+          ("reviewed_at_sha", reviewed_at_sha_var);
+          ("current_head_sha", current_head_sha_var);
+          ("sha_anchor", sha_anchor);
         ]
       in
       render_with_override ~project_name ~name:"review" ~vars
         ~default:(fun () ->
           Printf.sprintf
-            "# Review Comments%s\n\n\
+            "# Review Comments%s%s\n\n\
              The following review comments need to be addressed on your PR:\n\n\
              %s\n\n\
              For each comment:\n\
@@ -558,7 +615,7 @@ let render_review_prompt ~(project_name : string) ?pr_number
              { isResolved } } }'`\n\n\
              After addressing all comments, commit your changes. The \
              supervisor will push them for you — do not run `git push`."
-            pr_ctx formatted pr_num_str)
+            pr_ctx sha_anchor formatted pr_num_str)
 
 let render_ci_failure_prompt ~(project_name : string) ?pr_number
     (checks : Ci_check.t list) =
@@ -857,6 +914,8 @@ let%test "review prompt formats comments" =
           body = "Fix this function.";
           path = Some "lib/foo.ml";
           line = Some 42;
+          commit_sha = None;
+          original_commit_sha = None;
         };
       Comment.
         {
@@ -865,6 +924,8 @@ let%test "review prompt formats comments" =
           body = "General feedback.";
           path = None;
           line = None;
+          commit_sha = None;
+          original_commit_sha = None;
         };
     ]
   in
@@ -877,3 +938,73 @@ let%test "review prompt formats comments" =
   && String.is_substring result ~substring:"General feedback."
   && String.is_substring result ~substring:"resolveReviewThread"
   && String.is_substring result ~substring:"gh api repos/"
+  (* Back-compat: no SHAs → no preamble, no [at=…], no [outdated]. *)
+  && (not (String.is_substring result ~substring:"Review anchored at"))
+  && (not (String.is_substring result ~substring:"[at="))
+  && not (String.is_substring result ~substring:"[outdated]")
+
+let%expect_test "review prompt includes SHA preamble and per-bullet anchor" =
+  let comments : Comment.t list =
+    [
+      Comment.
+        {
+          id = Comment_id.of_int 1;
+          thread_id = Some "PRRT_thread1";
+          body = "Still relevant.";
+          path = Some "lib/foo.ml";
+          line = Some 10;
+          commit_sha = Some "47525fdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+          original_commit_sha = Some "47525fdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        };
+    ]
+  in
+  let result =
+    render_review_prompt ~project_name:"test"
+      ~current_head_sha:"da442c5bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" comments
+  in
+  Stdlib.print_endline result;
+  [%expect
+    {|
+    # Review Comments
+
+    Review anchored at commit `47525fd`. Current branch HEAD is `da442c5`.
+    If a comment is marked `[outdated]` or refers to code that no longer exists at HEAD, reply acknowledging it's addressed in a later commit and skip — do not re-do the change.
+
+
+    The following review comments need to be addressed on your PR:
+
+    - **Comment** on `lib/foo.ml` (line 10) [comment_id=1] [thread_id=PRRT_thread1] [at=47525fd]: Still relevant.
+
+    For each comment:
+    1. Implement the requested change, OR explain why the current approach is correct.
+    2. Reply to the comment thread:
+       `gh api repos/{owner}/{repo}/pulls/{pr_number}/comments/{comment_id}/replies -f body="your response"`
+       (`{owner}/{repo}` is resolved automatically by `gh` when run inside the repo)
+    3. Resolve the thread using the thread_id:
+       `gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "{thread_id}"}) { thread { isResolved } } }'`
+
+    After addressing all comments, commit your changes. The supervisor will push them for you — do not run `git push`.
+    |}]
+
+let%test "review prompt marks outdated comments" =
+  let comments : Comment.t list =
+    [
+      Comment.
+        {
+          id = Comment_id.of_int 1;
+          thread_id = Some "PRRT_outdated";
+          body = "This line moved.";
+          path = Some "lib/foo.ml";
+          line = None;
+          (* GitHub returns null line when the comment is outdated *)
+          commit_sha = Some "da442c5bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+          original_commit_sha = Some "47525fdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        };
+    ]
+  in
+  let result =
+    render_review_prompt ~project_name:"test"
+      ~current_head_sha:"da442c5bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" comments
+  in
+  String.is_substring result ~substring:"[at=47525fd]"
+  && String.is_substring result ~substring:"[outdated]"

--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -548,6 +548,10 @@ let render_review_prompt ~(project_name : string) ?pr_number ?current_head_sha
         | Some n -> Printf.sprintf "\n\nPR: #%d\n" (Pr_number.to_int n)
         | None -> ""
       in
+      (* Comments without [original_commit_sha] are dropped here. If the batch
+         mixes SHA-bearing and SHA-less comments, the preamble only lists the
+         SHA-bearing ones and the SHA-less entries simply omit the [at=…]
+         annotation — by design, since we'd be fabricating an anchor otherwise. *)
       let reviewed_at_shas =
         List.filter_map comments ~f:(fun (c : Comment.t) ->
             c.Comment.original_commit_sha)
@@ -1030,6 +1034,13 @@ let%test "review prompt does not mark file-level comments as outdated" =
     render_review_prompt ~project_name:"test"
       ~current_head_sha:"47525fdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" comments
   in
-  (* The preamble references "[outdated]" literally; the bullet-line marker is
-     distinguished by the trailing colon before the body. *)
-  not (String.is_substring result ~substring:"[outdated]:")
+  (* The preamble references "[outdated]" literally, so we can't just grep the
+     whole result. Assert directly on the bullet line that contains the comment
+     body — this stays correct even if the bullet format changes. *)
+  let lines = String.split_lines result in
+  match
+    List.find lines ~f:(fun l ->
+        String.is_substring l ~substring:"File-level feedback.")
+  with
+  | None -> false
+  | Some line -> not (String.is_substring line ~substring:"[outdated]")

--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -493,6 +493,7 @@ Do not repeat information already in the description or specs above — add only
 Keep it concise — a few bullet points usually suffices. If you have nothing material to add (the patch is straightforward), write a single line acknowledging that.|}
         vars)
 
+(* Private helper — truncates a Git SHA to 7 chars for prompt display. *)
 let short_sha s = if String.length s <= 7 then s else String.sub s ~pos:0 ~len:7
 
 let render_review_prompt ~(project_name : string) ?pr_number ?current_head_sha
@@ -569,19 +570,22 @@ let render_review_prompt ~(project_name : string) ?pr_number ?current_head_sha
                          Printf.sprintf "`%s`" (short_sha s))
                     |> String.concat ~sep:", ")
             in
+            (* No trailing newline — the format-string literal supplies the
+               \n\n separator before "The following review comments". *)
             Printf.sprintf
               "\n\n\
                Review anchored at %s. Current branch HEAD is `%s`.\n\
                If a comment is marked `[outdated]` or refers to code that no \
                longer exists at HEAD, reply acknowledging it's addressed in a \
-               later commit and skip — do not re-do the change.\n"
+               later commit and skip — do not re-do the change."
               anchored (short_sha head)
         | _ -> ""
       in
       let reviewed_at_sha_var =
         match reviewed_at_shas with
         | [ sha ] -> short_sha sha
-        | _ :: _ as many -> List.map many ~f:short_sha |> String.concat ~sep:","
+        | _ :: _ as many ->
+            List.map many ~f:short_sha |> String.concat ~sep:", "
         | [] -> ""
       in
       let current_head_sha_var =
@@ -945,6 +949,10 @@ let%test "review prompt formats comments" =
   (* Back-compat: no SHAs → no preamble, no [at=…], no [outdated]. *)
   && (not (String.is_substring result ~substring:"Review anchored at"))
   && (not (String.is_substring result ~substring:"[at="))
+  (* Safe substring check: sha_anchor is empty (no current_head_sha and no
+     comment SHAs), so the preamble text — which itself references the
+     literal `[outdated]` — is never emitted. If this test later adds SHAs,
+     switch to a bullet-line-scoped assertion like the file-level test below. *)
   && not (String.is_substring result ~substring:"[outdated]")
 
 let%expect_test "review prompt includes SHA preamble and per-bullet anchor" =
@@ -973,7 +981,6 @@ let%expect_test "review prompt includes SHA preamble and per-bullet anchor" =
 
     Review anchored at commit `47525fd`. Current branch HEAD is `da442c5`.
     If a comment is marked `[outdated]` or refers to code that no longer exists at HEAD, reply acknowledging it's addressed in a later commit and skip — do not re-do the change.
-
 
     The following review comments need to be addressed on your PR:
 

--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -505,15 +505,15 @@ let render_review_prompt ~(project_name : string) ?pr_number ?current_head_sha
         | Some n -> Int.to_string (Pr_number.to_int n)
         | None -> "{pr_number}"
       in
-      (* Only claim outdated-ness when GitHub has given us a signal. If
-         [commit] and [originalCommit] differ, GitHub re-anchored the comment
-         to a later commit (line moved). If [line] is null but we do have an
-         original SHA, GitHub detached the comment from the file. With no SHA
-         info at all, say nothing — matches pre-SHA behavior. *)
+      (* Only claim outdated-ness when GitHub has given us a strong signal:
+         [commit] and [originalCommit] differ, meaning GitHub re-anchored
+         the comment to a later commit (line moved or detached). A null
+         [line] alone is ambiguous — it also covers file-level comments,
+         which are not outdated. With no SHA info, say nothing — matches
+         pre-SHA behavior. *)
       let is_outdated (c : Comment.t) =
         match (c.Comment.commit_sha, c.Comment.original_commit_sha) with
         | Some cur, Some orig when not (String.equal cur orig) -> true
-        | _, Some _ when Option.is_none c.Comment.line -> true
         | _ -> false
       in
       let formatted =
@@ -1008,3 +1008,28 @@ let%test "review prompt marks outdated comments" =
   in
   String.is_substring result ~substring:"[at=47525fd]"
   && String.is_substring result ~substring:"[outdated]"
+
+let%test "review prompt does not mark file-level comments as outdated" =
+  let comments : Comment.t list =
+    [
+      Comment.
+        {
+          id = Comment_id.of_int 1;
+          thread_id = Some "PRRT_filelevel";
+          body = "File-level feedback.";
+          path = Some "lib/foo.ml";
+          line = None;
+          (* File-level comments have null line by design, and GitHub
+             leaves commit_sha equal to original_commit_sha. *)
+          commit_sha = Some "47525fdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+          original_commit_sha = Some "47525fdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        };
+    ]
+  in
+  let result =
+    render_review_prompt ~project_name:"test"
+      ~current_head_sha:"47525fdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" comments
+  in
+  (* The preamble references "[outdated]" literally; the bullet-line marker is
+     distinguished by the trailing colon before the body. *)
+  not (String.is_substring result ~substring:"[outdated]:")

--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -534,6 +534,11 @@ let render_review_prompt ~(project_name : string) ?pr_number ?current_head_sha
               | Some tid -> Printf.sprintf " [thread_id=%s]" tid
               | None -> ""
             in
+            (* [at=…] displays [original_commit_sha] — the SHA at which the
+               reviewer's diff view was anchored when they wrote the comment.
+               For an outdated comment, [commit_sha] holds the later commit
+               GitHub re-anchored to, but we still show the original so the
+               agent knows which diff the reviewer was looking at. *)
             let anchor =
               match c.Comment.original_commit_sha with
               | Some sha -> Printf.sprintf " [at=%s]" (short_sha sha)
@@ -544,9 +549,15 @@ let render_review_prompt ~(project_name : string) ?pr_number ?current_head_sha
               thread_ref anchor outdated c.Comment.body)
         |> String.concat ~sep:"\n\n"
       in
+      (* Both [pr_ctx] and [sha_anchor] are splatted into the
+         [Printf.sprintf "# Review Comments%s%s\n\n…"] format below. Each
+         owns its leading `\n\n` separator and no trailing newline, so
+         any subset of {pr_ctx, sha_anchor} renders with exactly one
+         blank line between each non-empty block (instead of two, which
+         is what happens if pr_ctx also ends in `\n`). *)
       let pr_ctx =
         match pr_number with
-        | Some n -> Printf.sprintf "\n\nPR: #%d\n" (Pr_number.to_int n)
+        | Some n -> Printf.sprintf "\n\nPR: #%d" (Pr_number.to_int n)
         | None -> ""
       in
       (* Comments without [original_commit_sha] are dropped here. If the batch
@@ -997,7 +1008,7 @@ let%expect_test "review prompt includes SHA preamble and per-bullet anchor" =
     After addressing all comments, commit your changes. The supervisor will push them for you — do not run `git push`.
     |}]
 
-let%test "review prompt marks outdated comments" =
+let%expect_test "review prompt marks outdated comments" =
   let comments : Comment.t list =
     [
       Comment.
@@ -1017,8 +1028,76 @@ let%test "review prompt marks outdated comments" =
     render_review_prompt ~project_name:"test"
       ~current_head_sha:"da442c5bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" comments
   in
-  String.is_substring result ~substring:"[at=47525fd]"
-  && String.is_substring result ~substring:"[outdated]"
+  Stdlib.print_endline result;
+  [%expect
+    {|
+    # Review Comments
+
+    Review anchored at commit `47525fd`. Current branch HEAD is `da442c5`.
+    If a comment is marked `[outdated]` or refers to code that no longer exists at HEAD, reply acknowledging it's addressed in a later commit and skip — do not re-do the change.
+
+    The following review comments need to be addressed on your PR:
+
+    - **Comment** on `lib/foo.ml` [comment_id=1] [thread_id=PRRT_outdated] [at=47525fd] [outdated]: This line moved.
+
+    For each comment:
+    1. Implement the requested change, OR explain why the current approach is correct.
+    2. Reply to the comment thread:
+       `gh api repos/{owner}/{repo}/pulls/{pr_number}/comments/{comment_id}/replies -f body="your response"`
+       (`{owner}/{repo}` is resolved automatically by `gh` when run inside the repo)
+    3. Resolve the thread using the thread_id:
+       `gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "{thread_id}"}) { thread { isResolved } } }'`
+
+    After addressing all comments, commit your changes. The supervisor will push them for you — do not run `git push`.
+    |}]
+
+let%expect_test
+    "review prompt with both pr_number and sha_anchor has single-blank \
+     separators" =
+  let comments : Comment.t list =
+    [
+      Comment.
+        {
+          id = Comment_id.of_int 1;
+          thread_id = Some "PRRT_thread1";
+          body = "Still relevant.";
+          path = Some "lib/foo.ml";
+          line = Some 10;
+          commit_sha = Some "47525fdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+          original_commit_sha = Some "47525fdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        };
+    ]
+  in
+  let result =
+    render_review_prompt ~project_name:"test" ~pr_number:(Pr_number.of_int 42)
+      ~current_head_sha:"da442c5bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" comments
+  in
+  Stdlib.print_endline result;
+  (* Exactly one blank line between "# Review Comments" / "PR: #42" /
+     the preamble / "The following" — not two. *)
+  [%expect
+    {|
+    # Review Comments
+
+    PR: #42
+
+    Review anchored at commit `47525fd`. Current branch HEAD is `da442c5`.
+    If a comment is marked `[outdated]` or refers to code that no longer exists at HEAD, reply acknowledging it's addressed in a later commit and skip — do not re-do the change.
+
+    The following review comments need to be addressed on your PR:
+
+    - **Comment** on `lib/foo.ml` (line 10) [comment_id=1] [thread_id=PRRT_thread1] [at=47525fd]: Still relevant.
+
+    For each comment:
+    1. Implement the requested change, OR explain why the current approach is correct.
+    2. Reply to the comment thread:
+       `gh api repos/{owner}/{repo}/pulls/42/comments/{comment_id}/replies -f body="your response"`
+       (`{owner}/{repo}` is resolved automatically by `gh` when run inside the repo)
+    3. Resolve the thread using the thread_id:
+       `gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "{thread_id}"}) { thread { isResolved } } }'`
+
+    After addressing all comments, commit your changes. The supervisor will push them for you — do not run `git push`.
+    |}]
 
 let%test "review prompt does not mark file-level comments as outdated" =
   let comments : Comment.t list =

--- a/lib/prompt.mli
+++ b/lib/prompt.mli
@@ -38,7 +38,11 @@ val render_pr_body_prompt :
   string
 
 val render_review_prompt :
-  project_name:string -> ?pr_number:Pr_number.t -> Comment.t list -> string
+  project_name:string ->
+  ?pr_number:Pr_number.t ->
+  ?current_head_sha:string ->
+  Comment.t list ->
+  string
 
 val render_ci_failure_prompt :
   project_name:string -> ?pr_number:Pr_number.t -> Ci_check.t list -> string

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -110,6 +110,8 @@ module Comment = struct
       body : string;
       path : string option;
       line : int option;
+      commit_sha : string option; [@yojson.default None]
+      original_commit_sha : string option; [@yojson.default None]
     }
     [@@deriving show, eq, sexp_of, compare, yojson]
   end

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -80,6 +80,8 @@ module Comment : sig
     body : string;
     path : string option;
     line : int option;
+    commit_sha : string option; [@yojson.default None]
+    original_commit_sha : string option; [@yojson.default None]
   }
   [@@deriving show, eq, sexp_of, compare, yojson]
 

--- a/lib_test/test_generators.ml
+++ b/lib_test/test_generators.ml
@@ -47,7 +47,16 @@ let gen_comment =
     let gen_line = option (int_range 1 500) in
     map4
       (fun id body path line ->
-        Comment.{ id; thread_id = None; body; path; line })
+        Comment.
+          {
+            id;
+            thread_id = None;
+            body;
+            path;
+            line;
+            commit_sha = None;
+            original_commit_sha = None;
+          })
       (* Use only synthetic (negative) IDs so content-based dedup governs in
          property tests, matching production behavior where real IDs are unique
          per GitHub comment. Real-ID duplicates with different content can't
@@ -265,6 +274,7 @@ let gen_pr_state =
           comments;
           unresolved_comment_count;
           head_branch;
+          head_oid = None;
           base_branch;
           is_fork;
         })


### PR DESCRIPTION
## Summary

- When the supervisor delivers review comments to the coding agent, the prompt now includes the SHA the review was anchored at and the current branch-tip SHA, plus per-bullet `[at=<short-sha>]` and `[outdated]` annotations. The agent can now distinguish stale feedback from live feedback mechanically instead of guessing.
- Motivation: we observed an agent reply with "already fixed in da442c5" / "you appear to be reviewing 9c759a1" — both wrong. The review had been generated at an earlier SHA; the agent had no anchor to reason against.
- Back-compat: when we have no SHA info (GraphQL returned null, no head fetched), the prompt renders identically to before.

## Changes

- `lib/github.ml`: GraphQL query adds `headRefOid` and per-comment `commit { oid }` / `originalCommit { oid }`; parsers surface them.
- `lib/types.{ml,mli}`: add `commit_sha` / `original_commit_sha` to `Comment.t`.
- `lib/pr_state.{ml,mli}`: add `head_oid` to `Pr_state.t`.
- `lib/prompt.{ml,mli}`: new `?current_head_sha` arg on `render_review_prompt`; emits SHA preamble and per-bullet annotations; adds short-SHA helper.
- `bin/main.ml`: threads `fresh_pr_state.head_oid` through the `Review_payload` render site.
- Tests: updated inline fixtures; added expect-test for the SHA-anchored rendering and a test for the outdated marker.

## Test plan

- [x] `dune build` clean
- [x] `dune runtest` — 18 suites pass; new expect-test captures the anchored output; back-compat test (no SHAs) unchanged
- [x] `dune fmt` clean
- [ ] Manual end-to-end check against a real PR with review comments — confirm rendered prompt contains `Review anchored at commit \`…\``, `[at=…]`, and (when GitHub considers a comment detached) `[outdated]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/201"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Review comments now show which commit each comment references (anchored-at short SHAs).
  * When a comment references an earlier commit than the current branch head, it is marked as [outdated].
  * When commit identifiers are missing, comment display and behavior remain unchanged (backward-compatible).
  * Prompt header now includes current branch HEAD when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds commit SHA anchoring to review-comment prompts so the agent can tell which commit feedback targets and when it’s stale. Handles mixed-SHA batches, avoids file-level false positives, and stays back-compatible with clean, single-blank-line formatting.

- **New Features**
  - Fetches `headRefOid` and per-comment `commit.oid` / `originalCommit.oid` via GraphQL (thread opener only).
  - Stores SHAs in `Pr_state.head_oid` and `Comment.commit_sha` / `original_commit_sha`.
  - `render_review_prompt` accepts `?current_head_sha`, emits a preamble for one or more commits, uses `original_commit_sha` for `[at=…]`, and marks `[outdated]` only when SHAs differ (file-level comments are not marked outdated).
  - Mixed-SHA batches: SHA-less comments omit `[at=…]` and are excluded from the preamble.

- **Refactors**
  - Ensures exactly one blank line between header, PR number, and preamble by stripping trailing newlines; normalizes multi-SHA list formatting (", ").
  - Tests converted to `expect_test`s and expanded to cover PR number + head SHA spacing; file-level test hardened; `short_sha` marked private and docs clarified.

<sup>Written for commit b537bd960b6a936e482eb22babffcca8cac5d0fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

