### PR TITLE
Normalize OpenCode tool events to match display layer

### DIFF
--- a/lib/opencode_backend.ml
+++ b/lib/opencode_backend.ml
@@ -175,6 +175,19 @@ let%test "parse_event tool_use edit normalizes filePath, leaves other keys" =
         };
     ]
 
+let%test "parse_event tool_use write normalizes filePath key" =
+  let line =
+    {|{"type":"tool_use","part":{"type":"tool","tool":"write","state":{"status":"completed","input":{"filePath":"/tmp/b.txt","content":"hello"}}}}|}
+  in
+  List.equal Types.Stream_event.equal (parse_event line)
+    [
+      Types.Stream_event.Tool_use
+        {
+          name = "Write";
+          input = {|{"file_path":"/tmp/b.txt","content":"hello"}|};
+        };
+    ]
+
 let%test "parse_event step_start emits session_init" =
   let line =
     {|{"type":"step_start","sessionID":"ses_abc","part":{"type":"step-start"}}|}

--- a/lib/opencode_backend.ml
+++ b/lib/opencode_backend.ml
@@ -9,12 +9,44 @@ let build_args ~cwd_path ~prompt ~resume_session =
   in
   base @ resume_args @ [ prompt ]
 
+(* OpenCode emits lowercase tool names and camelCase input keys, while the
+   downstream summary extractor in [bin/main.ml] expects the PascalCase names
+   and snake_case keys used by Claude Code. Normalize here so tool-use details
+   (file paths, commands, patterns) render consistently across backends. *)
+let normalize_tool_name = function
+  | "read" -> "Read"
+  | "write" -> "Write"
+  | "edit" -> "Edit"
+  | "bash" -> "Bash"
+  | "grep" -> "Grep"
+  | "glob" -> "Glob"
+  | "webfetch" -> "WebFetch"
+  | "list" -> "List"
+  | "task" -> "Task"
+  | "todowrite" -> "TodoWrite"
+  | "todoread" -> "TodoRead"
+  | other -> other
+
+let normalize_input_json ~tool (json : Yojson.Safe.t) : Yojson.Safe.t =
+  match (tool, json) with
+  | ("read" | "write" | "edit"), `Assoc fields ->
+      `Assoc
+        (List.map fields ~f:(fun (k, v) ->
+             let k' = if String.equal k "filePath" then "file_path" else k in
+             (k', v)))
+  | _ -> json
+
 let parse_event (line : string) : Types.Stream_event.t list =
   match Yojson.Safe.from_string line with
   | json -> (
       let open Yojson.Safe.Util in
       let typ = member "type" json |> to_string_option in
       match typ with
+      | Some "step_start" -> (
+          match member "sessionID" json |> to_string_option with
+          | Some id when not (String.is_empty id) ->
+              [ Types.Stream_event.Session_init { session_id = id } ]
+          | _ -> [])
       | Some "text" ->
           let part = member "part" json in
           let text =
@@ -24,16 +56,19 @@ let parse_event (line : string) : Types.Stream_event.t list =
           else [ Types.Stream_event.Text_delta text ]
       | Some "tool_use" ->
           let part = member "part" json in
-          let tool =
+          let raw_tool =
             member "tool" part |> to_string_option |> Option.value ~default:""
           in
           let state = member "state" part in
           let input =
             match member "input" state with
             | `Null -> ""
-            | v -> Yojson.Safe.to_string v
+            | v -> Yojson.Safe.to_string (normalize_input_json ~tool:raw_tool v)
           in
-          [ Types.Stream_event.Tool_use { name = tool; input } ]
+          [
+            Types.Stream_event.Tool_use
+              { name = normalize_tool_name raw_tool; input };
+          ]
       | Some "step_finish" -> (
           let part = member "part" json in
           let reason =
@@ -107,15 +142,45 @@ let%test "parse_event text" =
   List.equal Types.Stream_event.equal (parse_event line)
     [ Types.Stream_event.Text_delta "hello" ]
 
-let%test "parse_event tool_use" =
+let%test "parse_event tool_use bash normalizes name" =
   let line =
     {|{"type":"tool_use","part":{"type":"tool","tool":"bash","state":{"status":"completed","input":{"command":"ls -la"}}}}|}
   in
   List.equal Types.Stream_event.equal (parse_event line)
     [
       Types.Stream_event.Tool_use
-        { name = "bash"; input = {|{"command":"ls -la"}|} };
+        { name = "Bash"; input = {|{"command":"ls -la"}|} };
     ]
+
+let%test "parse_event tool_use read normalizes name and filePath key" =
+  let line =
+    {|{"type":"tool_use","part":{"type":"tool","tool":"read","state":{"status":"completed","input":{"filePath":"/tmp/foo.txt"}}}}|}
+  in
+  List.equal Types.Stream_event.equal (parse_event line)
+    [
+      Types.Stream_event.Tool_use
+        { name = "Read"; input = {|{"file_path":"/tmp/foo.txt"}|} };
+    ]
+
+let%test "parse_event tool_use edit normalizes filePath, leaves other keys" =
+  let line =
+    {|{"type":"tool_use","part":{"type":"tool","tool":"edit","state":{"status":"completed","input":{"filePath":"/tmp/a","oldString":"x","newString":"y"}}}}|}
+  in
+  List.equal Types.Stream_event.equal (parse_event line)
+    [
+      Types.Stream_event.Tool_use
+        {
+          name = "Edit";
+          input = {|{"file_path":"/tmp/a","oldString":"x","newString":"y"}|};
+        };
+    ]
+
+let%test "parse_event step_start emits session_init" =
+  let line =
+    {|{"type":"step_start","sessionID":"ses_abc","part":{"type":"step-start"}}|}
+  in
+  List.equal Types.Stream_event.equal (parse_event line)
+    [ Types.Stream_event.Session_init { session_id = "ses_abc" } ]
 
 let%test "parse_event step_finish stop" =
   let line =
@@ -133,7 +198,7 @@ let%test "parse_event step_finish tool-calls is ignored" =
   in
   List.is_empty (parse_event line)
 
-let%test "parse_event step_start is ignored" =
+let%test "parse_event step_start without sessionID is ignored" =
   let line = {|{"type":"step_start","part":{"type":"step-start"}}|} in
   List.is_empty (parse_event line)
 


### PR DESCRIPTION
## Summary
- OpenCode's JSON stream uses lowercase tool names (`read`, `bash`) and camelCase input keys (`filePath`), but the tool-use summary extractor in `bin/main.ml` expects Claude Code's PascalCase names and snake_case keys — so OpenCode tool events render as bare `[tool: read]` with no file path/command/pattern detail.
- Normalize tool names to PascalCase and rewrite `filePath` → `file_path` for `read`/`write`/`edit` in `lib/opencode_backend.ml`. `bash`/`grep`/`glob` input schemas already match Claude's and need no rewrite.
- Emit `Session_init` from `step_start` events (OpenCode puts `sessionID` at the top level of every event) so `--resume` across turns can capture the session id — previously it was never captured.

## Test plan
- [x] `dune build` — passes
- [x] `dune runtest` — passes (4 new inline tests cover bash-name normalization, filePath→file_path rename for `read`/`edit`, and `step_start` session-init emission; existing `step_start`-ignored test updated to cover the no-sessionID case)
- [ ] Manual: run a patch through the OpenCode backend and confirm tool events render as `[tool: Read /path/to/file]` instead of `[tool: read]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session initialization tracking for step-start events.
  * Standardized tool name normalization for consistent downstream display.
  * Normalized file path field naming in tool inputs for reliable processing.
  * Enhanced event parsing reliability and consistency to reduce missed or malformed events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize OpenCode tool events so the display layer shows correct tool names and details, and make session resume work across turns. Converts lowercase tool names and camelCase inputs to the expected formats.

- **Bug Fixes**
  - Map tool names to PascalCase (e.g., `read` → `Read`, `bash` → `Bash`; includes `webfetch` → `WebFetch`).
  - Rename `filePath` to `file_path` for `read`/`write`/`edit`; leave `bash`/`grep`/`glob` as-is.
  - Emit `Session_init` on `step_start` to capture `sessionID` for `--resume`.
  - Add inline test for `write` `filePath` normalization.

<sup>Written for commit 612709351f82ea7904880b6c221431defbbdf869. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

