### PR TITLE
Capture stdout in run_hook so failures are diagnosable

### DIFF
--- a/lib/user_config.ml
+++ b/lib/user_config.ml
@@ -19,6 +19,7 @@ let load ~github_owner ~github_repo =
   { on_worktree_create }
 
 let run_hook ~process_mgr ~script ~cwd ~env =
+  let stdout_buf = Buffer.create 256 in
   let stderr_buf = Buffer.create 256 in
   try
     let env_array =
@@ -29,11 +30,21 @@ let run_hook ~process_mgr ~script ~cwd ~env =
       Array.of_list (List.append inherited (Array.to_list env_array))
     in
     Eio.Process.run process_mgr ~env:merged ~cwd
+      ~stdout:(Eio.Flow.buffer_sink stdout_buf)
       ~stderr:(Eio.Flow.buffer_sink stderr_buf)
       [ script ];
     Ok ()
   with exn ->
+    let stdout = String.strip (Buffer.contents stdout_buf) in
     let stderr = String.strip (Buffer.contents stderr_buf) in
-    let msg = Stdlib.Printexc.to_string exn in
-    if String.is_empty stderr then Error msg
-    else Error (Printf.sprintf "%s\nstderr: %s" msg stderr)
+    let sections =
+      List.filter_opt
+        [
+          Some (Stdlib.Printexc.to_string exn);
+          (if String.is_empty stdout then None
+           else Some (Printf.sprintf "stdout:\n%s" stdout));
+          (if String.is_empty stderr then None
+           else Some (Printf.sprintf "stderr:\n%s" stderr));
+        ]
+    in
+    Error (String.concat ~sep:"\n" sections)

--- a/lib/user_config.mli
+++ b/lib/user_config.mli
@@ -15,5 +15,7 @@ val run_hook :
   cwd:_ Eio.Path.t ->
   env:(string * string) list ->
   (unit, string) Result.t
-(** Execute a hook script in [cwd] with the given environment variables. Returns
-    [Error msg] if the script fails. *)
+(** Execute a hook script in [cwd] with the given environment variables. Both
+    stdout and stderr are captured; on failure the returned [Error msg] embeds
+    the underlying exception followed by non-empty stdout/stderr sections so the
+    caller can surface them (e.g. to the activity log). *)

--- a/test/dune
+++ b/test/dune
@@ -121,3 +121,7 @@
 (test
  (name test_backend_smoke)
  (libraries onton eio eio_main))
+
+(test
+ (name test_user_config)
+ (libraries onton eio eio_main eio.unix unix))

--- a/test/test_user_config.ml
+++ b/test/test_user_config.ml
@@ -1,0 +1,92 @@
+open Base
+open Onton
+
+(** Write [body] to a fresh executable script in a tmp dir and return its
+    absolute path plus the dir. Caller is responsible for cleanup. *)
+let make_script body =
+  let dir = Stdlib.Filename.temp_dir "onton_user_config_" "" in
+  let path = Stdlib.Filename.concat dir "hook" in
+  let oc = Stdlib.open_out path in
+  Stdlib.output_string oc body;
+  Stdlib.close_out oc;
+  Unix.chmod path 0o755;
+  (dir, path)
+
+let assert_contains ~label ~needle haystack =
+  if not (String.is_substring haystack ~substring:needle) then
+    failwith
+      (Printf.sprintf "%s: expected output to contain %S, got:\n%s" label needle
+         haystack)
+
+let assert_not_contains ~label ~needle haystack =
+  if String.is_substring haystack ~substring:needle then
+    failwith
+      (Printf.sprintf "%s: expected output NOT to contain %S, got:\n%s" label
+         needle haystack)
+
+let () =
+  Eio_main.run @@ fun env ->
+  let process_mgr = Eio.Stdenv.process_mgr env in
+  let fs = Eio.Stdenv.fs env in
+
+  (* ── Success: exit 0, stdout ignored by caller ────────────────────── *)
+  (let dir, script = make_script "#!/bin/sh\necho hello\n" in
+   let cwd = Eio.Path.(fs / dir) in
+   match User_config.run_hook ~process_mgr ~script ~cwd ~env:[] with
+   | Ok () -> ()
+   | Error msg -> failwith (Printf.sprintf "expected Ok, got Error: %s" msg));
+
+  (* ── Failure: hook writes a diagnostic to STDOUT (the real-world case
+        we hit — `echo ERROR:...; exit 1` — where previously only stderr
+        was captured and the error reason was silently dropped). ───── *)
+  (let dir, script =
+     make_script "#!/bin/sh\necho 'ERROR: no opam switch' >&1\nexit 1\n"
+   in
+   let cwd = Eio.Path.(fs / dir) in
+   match User_config.run_hook ~process_mgr ~script ~cwd ~env:[] with
+   | Ok () -> failwith "expected Error when hook exits 1"
+   | Error msg ->
+       assert_contains ~label:"stdout-on-failure" ~needle:"stdout:" msg;
+       assert_contains ~label:"stdout-on-failure"
+         ~needle:"ERROR: no opam switch" msg;
+       assert_not_contains ~label:"stdout-on-failure" ~needle:"stderr:" msg);
+
+  (* ── Failure: hook writes to STDERR only. ─────────────────────────── *)
+  (let dir, script = make_script "#!/bin/sh\necho 'boom' >&2\nexit 2\n" in
+   let cwd = Eio.Path.(fs / dir) in
+   match User_config.run_hook ~process_mgr ~script ~cwd ~env:[] with
+   | Ok () -> failwith "expected Error when hook exits 2"
+   | Error msg ->
+       assert_contains ~label:"stderr-only" ~needle:"stderr:" msg;
+       assert_contains ~label:"stderr-only" ~needle:"boom" msg;
+       assert_not_contains ~label:"stderr-only" ~needle:"stdout:" msg);
+
+  (* ── Failure: both streams populated — both must appear. ──────────── *)
+  (let dir, script =
+     make_script "#!/bin/sh\necho out-line\necho err-line >&2\nexit 3\n"
+   in
+   let cwd = Eio.Path.(fs / dir) in
+   match User_config.run_hook ~process_mgr ~script ~cwd ~env:[] with
+   | Ok () -> failwith "expected Error when hook exits 3"
+   | Error msg ->
+       assert_contains ~label:"both-streams" ~needle:"stdout:" msg;
+       assert_contains ~label:"both-streams" ~needle:"out-line" msg;
+       assert_contains ~label:"both-streams" ~needle:"stderr:" msg;
+       assert_contains ~label:"both-streams" ~needle:"err-line" msg);
+
+  (* ── Env vars are passed through to the hook. ─────────────────────── *)
+  (let dir, script =
+     make_script
+       "#!/bin/sh\n\
+        if [ \"$ONTON_PATCH_ID\" != \"42\" ]; then\n\
+       \  echo \"missing ONTON_PATCH_ID (got '$ONTON_PATCH_ID')\" >&2\n\
+       \  exit 1\n\
+        fi\n"
+   in
+   let cwd = Eio.Path.(fs / dir) in
+   let env = [ ("ONTON_PATCH_ID", "42") ] in
+   match User_config.run_hook ~process_mgr ~script ~cwd ~env with
+   | Ok () -> ()
+   | Error msg -> failwith (Printf.sprintf "expected Ok, got Error: %s" msg));
+
+  Stdlib.print_endline "test_user_config: OK"


### PR DESCRIPTION
## Summary

- `User_config.run_hook` previously captured only stderr, so a hook that emitted its diagnostic via `echo` to stdout left the activity log with just `Eio.Io Process Child_error Exited (code 1), running command: ...` — no hint of what went wrong. (Concrete case today: `on_worktree_create` logged from the `subsetpark/pantagruel` project had no clue that the real message was `ERROR: No opam switch found at '/Users/zax/code-src/pantagruel'`.)
- Capture both streams, and on failure build the error string as `exception\nstdout:\n…\nstderr:\n…`, omitting empty sections. `Activity_log.Event.message` round-trips multi-line strings through JSON, so no storage changes are needed.
- Add `test/test_user_config.ml` covering success, stdout-only failure (regression for this incident), stderr-only failure, both-streams failure, and env-var passthrough.

## Test plan

- [x] `dune build` (pre-commit hook)
- [x] `dune runtest` — all suites green, including new `test_user_config`
- [x] `dune fmt` clean
- [ ] Manually re-trigger a failing hook (e.g. uninstall a dep, let onton re-create a worktree) and confirm the activity-log entry now names the missing tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/203"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hook execution now captures stdout in addition to stderr, with error messages providing both captured outputs for enhanced debugging.

* **Documentation**
  * Updated hook documentation to clearly specify that both stdout and stderr are captured during execution, with non-empty outputs embedded in error messages.

* **Tests**
  * Added test suite validating hook execution success cases, non-zero exit handling with proper output capture, and environment variable passing to hook processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Capture stdout in run_hook so failing hooks show real diagnostics in the activity log. Errors now include the exception plus non-empty stdout/stderr sections for easier debugging.

- **Bug Fixes**
  - Capture stdout in `User_config.run_hook` and include stdout/stderr in error messages when non-empty.
  - Multi-line error text is supported by `Activity_log`, so no storage changes needed.
  - Added tests for success, stdout-only failure, stderr-only failure, both-streams failure, and env var passthrough.

<sup>Written for commit 93c00037cbec18c0172aa43c2b292b6d940599b2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

