### PR TITLE
Harden Pr_body response handling against silent tool-call disconnects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         # erratique.ch (upstream for cmdliner, mtime, fpath, logs, uutf, ...)
         # is frequently flaky; the community cache mirrors opam-repository
         # archives behind a CDN, so opam only falls back to upstream on a miss.
-        run: opam option archive-mirrors=https://opam.ocaml.org/cache
+        run: opam option 'archive-mirrors=["https://opam.ocaml.org/cache"]'
 
       - name: Install dependencies
         run: opam install . --deps-only --with-test -y
@@ -82,7 +82,7 @@ jobs:
           dune-cache: true
 
       - name: Use opam.ocaml.org archive cache
-        run: opam option archive-mirrors=https://opam.ocaml.org/cache
+        run: opam option 'archive-mirrors=["https://opam.ocaml.org/cache"]'
 
       - name: Install dependencies
         run: opam install . --deps-only --with-test -y
@@ -114,6 +114,6 @@ jobs:
           ocaml-compiler: '5.4.0'
 
       - name: Use opam.ocaml.org archive cache
-        run: opam option archive-mirrors=https://opam.ocaml.org/cache
+        run: opam option 'archive-mirrors=["https://opam.ocaml.org/cache"]'
 
       - uses: ocaml/setup-ocaml/lint-fmt@dec6499fef64fc5d7ed43d43a87251b7b1c306f5 # v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,12 @@ jobs:
           ocaml-compiler: '5.4.0'
           dune-cache: true
 
+      - name: Use opam.ocaml.org archive cache
+        # erratique.ch (upstream for cmdliner, mtime, fpath, logs, uutf, ...)
+        # is frequently flaky; the community cache mirrors opam-repository
+        # archives behind a CDN, so opam only falls back to upstream on a miss.
+        run: opam option archive-mirrors=https://opam.ocaml.org/cache
+
       - name: Install dependencies
         run: opam install . --deps-only --with-test -y
 
@@ -75,6 +81,9 @@ jobs:
           ocaml-compiler: '5.4.0'
           dune-cache: true
 
+      - name: Use opam.ocaml.org archive cache
+        run: opam option archive-mirrors=https://opam.ocaml.org/cache
+
       - name: Install dependencies
         run: opam install . --deps-only --with-test -y
 
@@ -103,5 +112,8 @@ jobs:
       - uses: ocaml/setup-ocaml@dec6499fef64fc5d7ed43d43a87251b7b1c306f5 # v3
         with:
           ocaml-compiler: '5.4.0'
+
+      - name: Use opam.ocaml.org archive cache
+        run: opam option archive-mirrors=https://opam.ocaml.org/cache
 
       - uses: ocaml/setup-ocaml/lint-fmt@dec6499fef64fc5d7ed43d43a87251b7b1c306f5 # v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,13 @@ jobs:
           ocaml-compiler: '5.4.0'
           dune-cache: true
 
+      - name: Use opam.ocaml.org archive cache
+        if: steps.cache-opam.outputs.cache-hit != 'true'
+        # erratique.ch (upstream for cmdliner, mtime, fpath, logs, uutf, ...)
+        # is frequently flaky; the community cache mirrors opam-repository
+        # archives behind a CDN, so opam only falls back to upstream on a miss.
+        run: opam option archive-mirrors=https://opam.ocaml.org/cache
+
       - name: Install dependencies
         if: steps.cache-opam.outputs.cache-hit != 'true'
         run: opam install . --deps-only --with-test -y

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
         # erratique.ch (upstream for cmdliner, mtime, fpath, logs, uutf, ...)
         # is frequently flaky; the community cache mirrors opam-repository
         # archives behind a CDN, so opam only falls back to upstream on a miss.
-        run: opam option archive-mirrors=https://opam.ocaml.org/cache
+        run: opam option 'archive-mirrors=["https://opam.ocaml.org/cache"]'
 
       - name: Install dependencies
         if: steps.cache-opam.outputs.cache-hit != 'true'

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -3166,6 +3166,19 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                           Project_store.ensure_dir
                                             (Stdlib.Filename.dirname
                                                artifact_path);
+                                          (* Clear any stale artifact from a
+                                             prior Pr_body session. The path
+                                             is stable per-patch, so without
+                                             this the classifier could read
+                                             outdated notes when the current
+                                             session doesn't write (blocked,
+                                             no-op, or legitimately chose not
+                                             to). *)
+                                          (try Unix.unlink artifact_path
+                                           with
+                                           | Unix.Unix_error (Unix.ENOENT, _, _)
+                                           ->
+                                             ());
                                           Prompt.render_pr_body_prompt
                                             ~project_name
                                             ~pr_number:

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -3328,10 +3328,15 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                    (Patch_id.to_string patch_id))
                               ()
                       | Orchestrator.Respond_pr_body_miss ->
-                          (* Blocked mid-Write (e.g. sandbox rejection). The
-                             reconciler will re-enqueue Pr_body; at cap (>=2)
-                             needs_intervention fires and the TUI surfaces the
-                             stuck patch. *)
+                          (* Triggered by classify_pr_body_respond for either
+                             [`Patch_failed] (notes written, GitHub PATCH call
+                             failed) or [`Missing | `Empty] + observed Write
+                             tool failure (blocked mid-Write). The specific
+                             cause is already logged by apply_pr_body_artifact;
+                             keep this line cause-agnostic so it doesn't
+                             mislabel a [`Patch_failed] miss as a Write
+                             failure. The reconciler re-enqueues Pr_body; at
+                             cap (>=2) needs_intervention fires. *)
                           let agent =
                             Runtime.read runtime (fun snap ->
                                 Orchestrator.agent snap.Runtime.orchestrator
@@ -3339,9 +3344,11 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                           in
                           log_event runtime ~patch_id
                             (Printf.sprintf
-                               "pr-body: retrying — artifact missing with \
-                                observed Write failure (miss count: %d)"
-                               agent.Patch_agent.pr_body_artifact_miss_count);
+                               "pr-body: miss recorded (miss count: %d)%s"
+                               agent.Patch_agent.pr_body_artifact_miss_count
+                               (if Patch_agent.needs_intervention agent then
+                                  "; escalating to human review"
+                                else "; will re-enqueue"));
                           if Patch_agent.needs_intervention agent then
                             set_status ~level:Tui.Error
                               ~text:

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -834,10 +834,24 @@ let run_claude_and_handle ~runtime ~process_mgr ~fs ~project_name ~patch_id
                   | None -> ())
             | Types.Stream_event.Tool_use { name; input; status } ->
                 tool_count := !tool_count + 1;
+                (* OpenCode emits pending → running → completed for a single
+                   tool call. Track only the latest unresolved status per tool
+                   name: clear on completed, replace on any other status.
+                   Otherwise a normal pending → completed lifecycle would leave
+                   a stale (name, "pending") entry that
+                   [classify_pr_body_respond] would misread as a blocked Write. *)
                 (match status with
-                | Some s when not (String.equal s "completed") ->
-                    tool_failures := (name, s) :: !tool_failures
-                | Some _ | None -> ());
+                | Some s when String.equal s "completed" ->
+                    tool_failures :=
+                      Base.List.filter !tool_failures ~f:(fun (n, _) ->
+                          not (String.equal n name))
+                | Some s ->
+                    let without =
+                      Base.List.filter !tool_failures ~f:(fun (n, _) ->
+                          not (String.equal n name))
+                    in
+                    tool_failures := (name, s) :: without
+                | None -> ());
                 let summary =
                   try
                     let json = Yojson.Safe.from_string input in

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -464,10 +464,12 @@ let read_artifact_file path =
 
 (** Apply the agent-authored notes artifact to the PR. Composes the final body
     as: gameplan description + specs + Implementation Notes (from artifact).
-    Falls back to keeping the existing PR body if the artifact is missing or
-    empty. *)
+    Returns a tag describing the outcome so the caller can correlate with
+    session-level signals (e.g. a Missing artifact alongside a failed Write tool
+    call indicates the agent was blocked mid-call, not that it chose to skip
+    notes). *)
 let apply_pr_body_artifact ~runtime ~net ~github ~project_name ~patch_id
-    ~pr_number ~patch ~gameplan =
+    ~pr_number ~patch ~gameplan : [ `Ok | `Missing | `Empty | `Patch_failed ] =
   let artifact_path =
     Project_store.pr_body_artifact_path ~project_name ~patch_id
   in
@@ -476,10 +478,12 @@ let apply_pr_body_artifact ~runtime ~net ~github ~project_name ~patch_id
       log_event runtime ~patch_id
         (Printf.sprintf
            "pr-body: artifact missing at %s; keeping initial PR body"
-           artifact_path)
+           artifact_path);
+      `Missing
   | Some notes when String.length (String.trim notes) = 0 ->
       log_event runtime ~patch_id
-        "pr-body: artifact empty; keeping initial PR body"
+        "pr-body: artifact empty; keeping initial PR body";
+      `Empty
   | Some notes -> (
       let description =
         Prompt.render_pr_description ~project_name patch gameplan
@@ -493,10 +497,12 @@ let apply_pr_body_artifact ~runtime ~net ~github ~project_name ~patch_id
       | Ok () ->
           log_event runtime ~patch_id
             (Printf.sprintf "pr-body: PATCHed PR #%d"
-               (Pr_number.to_int pr_number))
+               (Pr_number.to_int pr_number));
+          `Ok
       | Error e ->
           log_event runtime ~patch_id
-            (Printf.sprintf "pr-body: PATCH failed — %s" (Github.show_error e)))
+            (Printf.sprintf "pr-body: PATCH failed — %s" (Github.show_error e));
+          `Patch_failed)
 
 (** Terminal failure — forces [Given_up] so [complete] raises intervention. Used
     for non-retryable errors (patch not found, PR discovery failed). *)
@@ -739,7 +745,7 @@ let run_claude_and_handle ~runtime ~process_mgr ~fs ~project_name ~patch_id
       Runtime.update_orchestrator runtime (fun orch ->
           Orchestrator.apply_session_result orch patch_id
             Orchestrator.Session_give_up);
-      `Failed
+      (`Failed, [])
   | (`Resume _ | `Fresh) as mode -> (
       let resume_session, is_fresh =
         match mode with `Resume id -> (Some id, false) | `Fresh -> (None, true)
@@ -752,7 +758,7 @@ let run_claude_and_handle ~runtime ~process_mgr ~fs ~project_name ~patch_id
           Runtime.update_orchestrator runtime (fun orch ->
               Orchestrator.apply_session_result orch patch_id
                 Orchestrator.Session_worktree_missing);
-          `Failed
+          (`Failed, [])
       | Some worktree_path ->
           let cwd = Eio.Path.(fs / worktree_path) in
           let text_buf =
@@ -784,6 +790,13 @@ let run_claude_and_handle ~runtime ~process_mgr ~fs ~project_name ~patch_id
           in
           let error_buf = Buffer.create 256 in
           let tool_count = ref 0 in
+          (* Accumulates (tool_name, status) for Tool_use events that report a
+             non-"completed" status (OpenCode surfaces [pending]/[running] or
+             error states; other backends do not populate [status] and so never
+             contribute here). Propagated to the caller so artifact-backed
+             phases like Pr_body can tell "agent chose not to write" apart
+             from "a tool call was announced but never executed". *)
+          let tool_failures = ref [] in
           let pr_found = ref false in
           let needle_len =
             String.length (Printf.sprintf "github.com/%s/%s/pull/" owner repo)
@@ -819,8 +832,12 @@ let run_claude_and_handle ~runtime ~process_mgr ~fs ~project_name ~patch_id
                               (Pr_number.to_int pr_number)));
                       on_pr_detected pr_number
                   | None -> ())
-            | Types.Stream_event.Tool_use { name; input } ->
+            | Types.Stream_event.Tool_use { name; input; status } ->
                 tool_count := !tool_count + 1;
+                (match status with
+                | Some s when not (String.equal s "completed") ->
+                    tool_failures := (name, s) :: !tool_failures
+                | Some _ | None -> ());
                 let summary =
                   try
                     let json = Yojson.Safe.from_string input in
@@ -936,6 +953,22 @@ let run_claude_and_handle ~runtime ~process_mgr ~fs ~project_name ~patch_id
                      backend.Llm_backend.name exit_code detail);
                 (Orchestrator.Session_failed { is_fresh }, `Failed)
           in
+          (* Observability: if any tool_use events reported a non-"completed"
+             status (OpenCode's sandbox/rejection/pending states), summarize
+             them so the disconnect is visible in the activity log even when
+             the session otherwise looks healthy. *)
+          (match !tool_failures with
+          | [] -> ()
+          | failures ->
+              let rendered =
+                List.rev failures
+                |> List.map (fun (n, s) -> Printf.sprintf "%s[%s]" n s)
+                |> String.concat ", "
+              in
+              log_event runtime ~patch_id
+                (Printf.sprintf
+                   "Session ended with %d non-completed tool call(s) (%s): %s"
+                   (List.length failures) backend.Llm_backend.name rendered));
           (* Supervisor-owned push: agent commits locally; we push every
              local commit to the remote at session end. force_push_with_lease
              is idempotent (Push_up_to_date when nothing new), and lease-safe
@@ -1019,7 +1052,7 @@ let run_claude_and_handle ~runtime ~process_mgr ~fs ~project_name ~patch_id
           in
           Event_log.log_complete event_log ~patch_id
             ~result:final_session_result ~agent_before ~agent_after;
-          final_user_result)
+          (final_user_result, List.rev !tool_failures))
 
 (** {1 Fibers} *)
 
@@ -2404,14 +2437,18 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                      REST API (Github.list_prs) after Claude
                                      finishes *)
                                       let on_pr_detected _pr_number = () in
-                                      run_claude_and_handle ~runtime
-                                        ~process_mgr ~fs ~project_name ~patch_id
-                                        ~repo_root:config.repo_root ~prompt
-                                        ~agent ~owner:config.github_owner
-                                        ~repo:config.github_repo ~on_pr_detected
-                                        ~transcripts
-                                        ~user_config:config.user_config
-                                        ~worktree_mutex ~backend ~event_log)
+                                      let r, _tool_failures =
+                                        run_claude_and_handle ~runtime
+                                          ~process_mgr ~fs ~project_name
+                                          ~patch_id ~repo_root:config.repo_root
+                                          ~prompt ~agent
+                                          ~owner:config.github_owner
+                                          ~repo:config.github_repo
+                                          ~on_pr_detected ~transcripts
+                                          ~user_config:config.user_config
+                                          ~worktree_mutex ~backend ~event_log
+                                      in
+                                      r)
                           in
                           let start_outcome =
                             match result with
@@ -2862,7 +2899,7 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                         else base_changed_prefix ^ "\n" ^ raw
                                       in
                                       let on_pr_detected _pr_number = () in
-                                      let result =
+                                      let result, _tool_failures =
                                         run_claude_and_handle ~runtime
                                           ~process_mgr ~fs ~project_name
                                           ~patch_id ~repo_root:config.repo_root
@@ -3163,7 +3200,7 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                     | Patch_decision.Pr_body_payload
                                     | Patch_decision.Merge_conflict_payload ->
                                         ());
-                                    let result =
+                                    let result, tool_failures =
                                       run_claude_and_handle ~runtime
                                         ~process_mgr ~fs ~project_name ~patch_id
                                         ~repo_root:config.repo_root ~prompt
@@ -3184,37 +3221,56 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                     | _ -> ());
                                     (* Artifact-driven phase (Pr_body): read
                                    the agent's artifact and PATCH the PR body.
-                                   Falls back gracefully if the artifact is
-                                   missing — pr_body_delivered flips true via
-                                   apply_respond_outcome on Respond_ok
-                                   regardless, so we don't loop. *)
+                                   When the artifact is missing AND we saw a
+                                   Write tool call that did not complete, the
+                                   agent was likely blocked mid-call (e.g. by
+                                   OpenCode's --dir sandbox) — signal retry
+                                   via Respond_pr_body_miss so the reconciler
+                                   re-enqueues Pr_body once before escalating
+                                   to needs_intervention. When the artifact is
+                                   missing but we saw no Write failure, the
+                                   agent legitimately chose not to add notes:
+                                   fall through to Respond_ok as before. *)
                                     let session_ok =
                                       match result with
                                       | `Ok -> true
                                       | _ -> false
                                     in
-                                    (if session_ok then
-                                       match payload with
-                                       | Patch_decision.Pr_body_payload ->
-                                           let pr =
-                                             Base.Option.value_exn pr_number
-                                           in
-                                           let patch =
-                                             Base.List.find_exn
-                                               gameplan.Gameplan.patches
-                                               ~f:(fun (p : Patch.t) ->
-                                                 Patch_id.equal p.Patch.id
-                                                   patch_id)
-                                           in
-                                           apply_pr_body_artifact ~runtime ~net
-                                             ~github ~project_name ~patch_id
-                                             ~pr_number:pr ~patch ~gameplan
-                                       | Patch_decision.Human_payload _
-                                       | Patch_decision.Ci_payload _
-                                       | Patch_decision.Review_payload _
-                                       | Patch_decision.Merge_conflict_payload
-                                         ->
-                                           ());
+                                    let result =
+                                      if session_ok then
+                                        match payload with
+                                        | Patch_decision.Pr_body_payload -> (
+                                            let pr =
+                                              Base.Option.value_exn pr_number
+                                            in
+                                            let patch =
+                                              Base.List.find_exn
+                                                gameplan.Gameplan.patches
+                                                ~f:(fun (p : Patch.t) ->
+                                                  Patch_id.equal p.Patch.id
+                                                    patch_id)
+                                            in
+                                            let artifact_outcome =
+                                              apply_pr_body_artifact ~runtime
+                                                ~net ~github ~project_name
+                                                ~patch_id ~pr_number:pr ~patch
+                                                ~gameplan
+                                            in
+                                            match
+                                              Patch_decision
+                                              .classify_pr_body_respond
+                                                ~artifact_outcome ~tool_failures
+                                            with
+                                            | `Pr_body_miss -> `Pr_body_miss
+                                            | `Ok -> result)
+                                        | Patch_decision.Human_payload _
+                                        | Patch_decision.Ci_payload _
+                                        | Patch_decision.Review_payload _
+                                        | Patch_decision.Merge_conflict_payload
+                                          ->
+                                            result
+                                      else result
+                                    in
                                     result)
                       in
                       let respond_outcome =
@@ -3223,6 +3279,7 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                         | `Skip_empty -> Orchestrator.Respond_skip_empty
                         | `Failed -> Orchestrator.Respond_failed
                         | `Retry_push -> Orchestrator.Respond_retry_push
+                        | `Pr_body_miss -> Orchestrator.Respond_pr_body_miss
                         | `Ok -> Orchestrator.Respond_ok
                       in
                       Runtime.update_orchestrator runtime (fun orch ->
@@ -3241,6 +3298,29 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                 (Printf.sprintf
                                    "Patch %s: session failed — human review \
                                     needed"
+                                   (Patch_id.to_string patch_id))
+                              ()
+                      | Orchestrator.Respond_pr_body_miss ->
+                          (* Blocked mid-Write (e.g. sandbox rejection). The
+                             reconciler will re-enqueue Pr_body; at cap (>=2)
+                             needs_intervention fires and the TUI surfaces the
+                             stuck patch. *)
+                          let agent =
+                            Runtime.read runtime (fun snap ->
+                                Orchestrator.agent snap.Runtime.orchestrator
+                                  patch_id)
+                          in
+                          log_event runtime ~patch_id
+                            (Printf.sprintf
+                               "pr-body: retrying — artifact missing with \
+                                observed Write failure (miss count: %d)"
+                               agent.Patch_agent.pr_body_artifact_miss_count);
+                          if Patch_agent.needs_intervention agent then
+                            set_status ~level:Tui.Error
+                              ~text:
+                                (Printf.sprintf
+                                   "Patch %s: pr-body artifact repeatedly \
+                                    missing — human review needed"
                                    (Patch_id.to_string patch_id))
                               ()
                       | Orchestrator.Respond_ok ->

--- a/lib/claude_runner.ml
+++ b/lib/claude_runner.ml
@@ -90,7 +90,9 @@ let parse_stream_events (line : string) : Types.Stream_event.t list =
                 member "name" content_block
                 |> to_string_option |> Option.value ~default:""
               in
-              [ Types.Stream_event.Tool_use { name; input = "" } ]
+              [
+                Types.Stream_event.Tool_use { name; input = ""; status = None };
+              ]
           | _ -> [])
       | Some "assistant" ->
           (* --verbose format: assistant event contains message.content array *)
@@ -112,7 +114,8 @@ let parse_stream_events (line : string) : Types.Stream_event.t list =
                     | `Null -> ""
                     | v -> Yojson.Safe.to_string v
                   in
-                  Some (Types.Stream_event.Tool_use { name; input })
+                  Some
+                    (Types.Stream_event.Tool_use { name; input; status = None })
               | Some "text" ->
                   let text =
                     member "text" block |> to_string_option
@@ -348,7 +351,9 @@ let%test "parse_stream_event tool_use" =
     {|{"type":"content_block_start","content_block":{"type":"tool_use","name":"write_file"}}|}
   in
   Option.equal Types.Stream_event.equal (parse_stream_event line)
-    (Some (Types.Stream_event.Tool_use { name = "write_file"; input = "" }))
+    (Some
+       (Types.Stream_event.Tool_use
+          { name = "write_file"; input = ""; status = None }))
 
 let%test "parse_stream_event error" =
   let line = {|{"type":"error","error":{"message":"rate limited"}}|} in

--- a/lib/codex_backend.ml
+++ b/lib/codex_backend.ml
@@ -71,7 +71,10 @@ let parse_event (line : string) : Types.Stream_event.t list =
                   let input =
                     Yojson.Safe.to_string (`Assoc [ ("command", `String cmd) ])
                   in
-                  [ Types.Stream_event.Tool_use { name = "Bash"; input } ]
+                  [
+                    Types.Stream_event.Tool_use
+                      { name = "Bash"; input; status = None };
+                  ]
               | _ -> [])
           | _ -> [])
       | Some "thread.started" -> (
@@ -183,7 +186,7 @@ let%test "parse_event command_execution started encodes input as JSON" =
   List.equal Types.Stream_event.equal (parse_event line)
     [
       Types.Stream_event.Tool_use
-        { name = "Bash"; input = {|{"command":"ls -la"}|} };
+        { name = "Bash"; input = {|{"command":"ls -la"}|}; status = None };
     ]
 
 let%test "parse_event command_execution input survives JSON parse + extract" =
@@ -196,7 +199,10 @@ let%test "parse_event command_execution input survives JSON parse + extract" =
     Yojson.Safe.to_string (`Assoc [ ("command", `String {|echo "hi" && ls|}) ])
   in
   List.equal Types.Stream_event.equal (parse_event line)
-    [ Types.Stream_event.Tool_use { name = "Bash"; input = expected } ]
+    [
+      Types.Stream_event.Tool_use
+        { name = "Bash"; input = expected; status = None };
+    ]
 
 let%test "parse_event command_execution completed is ignored" =
   let line =

--- a/lib/gemini_backend.ml
+++ b/lib/gemini_backend.ml
@@ -43,7 +43,7 @@ let parse_event (line : string) : Types.Stream_event.t list =
             | `Null -> ""
             | v -> Yojson.Safe.to_string v
           in
-          [ Types.Stream_event.Tool_use { name; input } ]
+          [ Types.Stream_event.Tool_use { name; input; status = None } ]
       | Some "result" -> (
           let status = member "status" json |> to_string_option in
           match status with
@@ -137,7 +137,7 @@ let%test "parse_event tool_use" =
   List.equal Types.Stream_event.equal (parse_event line)
     [
       Types.Stream_event.Tool_use
-        { name = "list_directory"; input = {|{"dir_path":"."}|} };
+        { name = "list_directory"; input = {|{"dir_path":"."}|}; status = None };
     ]
 
 let%test "parse_event tool_result is ignored" =

--- a/lib/opencode_backend.ml
+++ b/lib/opencode_backend.ml
@@ -65,9 +65,10 @@ let parse_event (line : string) : Types.Stream_event.t list =
             | `Null -> ""
             | v -> Yojson.Safe.to_string (normalize_input_json ~tool:raw_tool v)
           in
+          let status = member "status" state |> to_string_option in
           [
             Types.Stream_event.Tool_use
-              { name = normalize_tool_name raw_tool; input };
+              { name = normalize_tool_name raw_tool; input; status };
           ]
       | Some "step_finish" -> (
           let part = member "part" json in
@@ -149,7 +150,11 @@ let%test "parse_event tool_use bash normalizes name" =
   List.equal Types.Stream_event.equal (parse_event line)
     [
       Types.Stream_event.Tool_use
-        { name = "Bash"; input = {|{"command":"ls -la"}|} };
+        {
+          name = "Bash";
+          input = {|{"command":"ls -la"}|};
+          status = Some "completed";
+        };
     ]
 
 let%test "parse_event tool_use read normalizes name and filePath key" =
@@ -159,7 +164,11 @@ let%test "parse_event tool_use read normalizes name and filePath key" =
   List.equal Types.Stream_event.equal (parse_event line)
     [
       Types.Stream_event.Tool_use
-        { name = "Read"; input = {|{"file_path":"/tmp/foo.txt"}|} };
+        {
+          name = "Read";
+          input = {|{"file_path":"/tmp/foo.txt"}|};
+          status = Some "completed";
+        };
     ]
 
 let%test "parse_event tool_use edit normalizes filePath, leaves other keys" =
@@ -172,6 +181,7 @@ let%test "parse_event tool_use edit normalizes filePath, leaves other keys" =
         {
           name = "Edit";
           input = {|{"file_path":"/tmp/a","oldString":"x","newString":"y"}|};
+          status = Some "completed";
         };
     ]
 
@@ -185,7 +195,50 @@ let%test "parse_event tool_use write normalizes filePath key" =
         {
           name = "Write";
           input = {|{"file_path":"/tmp/b.txt","content":"hello"}|};
+          status = Some "completed";
         };
+    ]
+
+let%test "parse_event tool_use pending status survives parse" =
+  (* OpenCode emits tool_use events with status=pending before the tool runs
+     (e.g. while awaiting sandbox approval). We surface the status so the
+     supervisor can distinguish a tool call that completed from one that
+     was announced but never executed. *)
+  let line =
+    {|{"type":"tool_use","part":{"type":"tool","tool":"write","state":{"status":"pending","input":{"filePath":"/tmp/b.txt","content":"hello"}}}}|}
+  in
+  List.equal Types.Stream_event.equal (parse_event line)
+    [
+      Types.Stream_event.Tool_use
+        {
+          name = "Write";
+          input = {|{"file_path":"/tmp/b.txt","content":"hello"}|};
+          status = Some "pending";
+        };
+    ]
+
+let%test "parse_event tool_use running status survives parse" =
+  let line =
+    {|{"type":"tool_use","part":{"type":"tool","tool":"bash","state":{"status":"running","input":{"command":"sleep 10"}}}}|}
+  in
+  List.equal Types.Stream_event.equal (parse_event line)
+    [
+      Types.Stream_event.Tool_use
+        {
+          name = "Bash";
+          input = {|{"command":"sleep 10"}|};
+          status = Some "running";
+        };
+    ]
+
+let%test "parse_event tool_use missing status parses as None" =
+  let line =
+    {|{"type":"tool_use","part":{"type":"tool","tool":"bash","state":{"input":{"command":"ls"}}}}|}
+  in
+  List.equal Types.Stream_event.equal (parse_event line)
+    [
+      Types.Stream_event.Tool_use
+        { name = "Bash"; input = {|{"command":"ls"}|}; status = None };
     ]
 
 let%test "parse_event step_start emits session_init" =

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -692,5 +692,6 @@ let apply_respond_outcome t patch_id kind outcome =
         else t
       in
       if Operation_kind.equal kind Operation_kind.Pr_body then
-        set_pr_body_delivered t patch_id true
+        let t = set_pr_body_delivered t patch_id true in
+        update_agent t patch_id ~f:Patch_agent.reset_pr_body_artifact_miss_count
       else t

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -657,12 +657,17 @@ type respond_outcome =
   | Respond_stale
   | Respond_skip_empty
   | Respond_pr_body_miss
-      (** Pr_body session finished cleanly but the artifact was missing/empty
-          AND we observed a Write tool_use that did not complete — evidence the
-          agent was blocked mid-call rather than choosing to skip notes. Does
-          NOT flip [pr_body_delivered]; instead increments
-          [pr_body_artifact_miss_count] and lets the reconciler re-enqueue. At
-          cap (>=2) the agent surfaces via [needs_intervention]. *)
+      (** Pr_body session finished cleanly but the PR body was not durably
+          delivered. Two cases:
+          - artifact outcome [`Missing | `Empty] AND a Write tool_use did not
+            complete — evidence the agent was blocked mid-call (e.g. OpenCode's
+            [--dir] sandbox rejecting a write outside the worktree); or
+          - artifact outcome [`Patch_failed] — the notes were written but the
+            subsequent GitHub [update_pr_body] call failed, leaving the PR
+            description stale. Does NOT flip [pr_body_delivered]; instead
+            increments [pr_body_artifact_miss_count] and lets the reconciler
+            re-enqueue. At cap (>=2) the agent surfaces via
+            [needs_intervention]. *)
 [@@deriving show, eq, sexp_of]
 
 let apply_respond_outcome t patch_id kind outcome =

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -656,6 +656,13 @@ type respond_outcome =
   | Respond_retry_push
   | Respond_stale
   | Respond_skip_empty
+  | Respond_pr_body_miss
+      (** Pr_body session finished cleanly but the artifact was missing/empty
+          AND we observed a Write tool_use that did not complete — evidence the
+          agent was blocked mid-call rather than choosing to skip notes. Does
+          NOT flip [pr_body_delivered]; instead increments
+          [pr_body_artifact_miss_count] and lets the reconciler re-enqueue. At
+          cap (>=2) the agent surfaces via [needs_intervention]. *)
 [@@deriving show, eq, sexp_of]
 
 let apply_respond_outcome t patch_id kind outcome =
@@ -664,6 +671,10 @@ let apply_respond_outcome t patch_id kind outcome =
   | Respond_failed -> complete_failed t patch_id
   | Respond_retry_push -> complete t patch_id
   | Respond_skip_empty -> complete t patch_id
+  | Respond_pr_body_miss ->
+      let t = complete t patch_id in
+      update_agent t patch_id
+        ~f:Patch_agent.increment_pr_body_artifact_miss_count
   | Respond_ok ->
       let t = complete t patch_id in
       (* Only count CI fix attempts that actually delivered a payload with

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -201,10 +201,11 @@ val apply_respond_outcome :
   t -> Patch_id.t -> Operation_kind.t -> respond_outcome -> t
 (** Apply the outcome of a Respond action fiber. [Respond_ok] -> complete +
     kind-specific transitions (Merge_conflict -> clear_has_conflict +
-    reset_conflict_noop_count; Pr_body -> set_pr_body_delivered).
-    [Respond_failed] -> complete_failed (restores inflight human messages).
-    [Respond_skip_empty] -> complete. [Respond_retry_push] -> complete.
-    [Respond_stale] -> identity. [Respond_pr_body_miss] -> complete +
+    reset_conflict_noop_count; Pr_body -> set_pr_body_delivered +
+    reset_pr_body_artifact_miss_count so the cap counts only consecutive
+    misses). [Respond_failed] -> complete_failed (restores inflight human
+    messages). [Respond_skip_empty] -> complete. [Respond_retry_push] ->
+    complete. [Respond_stale] -> identity. [Respond_pr_body_miss] -> complete +
     increment_pr_body_artifact_miss_count (does NOT set_pr_body_delivered — the
     reconciler re-enqueues Pr_body naturally). *)
 

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -194,6 +194,7 @@ type respond_outcome =
   | Respond_retry_push
   | Respond_stale
   | Respond_skip_empty
+  | Respond_pr_body_miss
 [@@deriving show, eq, sexp_of]
 
 val apply_respond_outcome :
@@ -203,7 +204,9 @@ val apply_respond_outcome :
     reset_conflict_noop_count; Pr_body -> set_pr_body_delivered).
     [Respond_failed] -> complete_failed (restores inflight human messages).
     [Respond_skip_empty] -> complete. [Respond_retry_push] -> complete.
-    [Respond_stale] -> identity. *)
+    [Respond_stale] -> identity. [Respond_pr_body_miss] -> complete +
+    increment_pr_body_artifact_miss_count (does NOT set_pr_body_delivered — the
+    reconciler re-enqueues Pr_body naturally). *)
 
 (** Side effects emitted by rebase result application. The runner is responsible
     for executing these (e.g. force-pushing the branch to the remote). Modeled

--- a/lib/patch_agent.ml
+++ b/lib/patch_agent.ml
@@ -26,6 +26,11 @@ type t = {
   merge_ready : bool;
   is_draft : bool;
   pr_body_delivered : bool;
+  pr_body_artifact_miss_count : int;
+      (** Consecutive Pr_body sessions that ended with evidence the agent was
+          blocked mid-write (see [Orchestrator.Respond_pr_body_miss]). At >=2
+          contributes to [needs_intervention]. Reset by
+          [reset_intervention_state]. *)
   start_attempts_without_pr : int;
   conflict_noop_count : int;
   no_commits_push_count : int;
@@ -88,7 +93,8 @@ let needs_intervention t =
         && (t.ci_failure_count >= 3
            || ((not (has_pr t)) && t.start_attempts_without_pr >= 2)
            || t.conflict_noop_count >= 2
-           || t.no_commits_push_count >= 2))
+           || t.no_commits_push_count >= 2
+           || t.pr_body_artifact_miss_count >= 2))
 
 let create ~branch patch_id =
   {
@@ -112,6 +118,7 @@ let create ~branch patch_id =
     merge_ready = false;
     is_draft = false;
     pr_body_delivered = false;
+    pr_body_artifact_miss_count = 0;
     start_attempts_without_pr = 0;
     conflict_noop_count = 0;
     no_commits_push_count = 0;
@@ -152,6 +159,7 @@ let create_adhoc ~patch_id ~branch ~pr_number =
     merge_ready = false;
     is_draft = false;
     pr_body_delivered = true;
+    pr_body_artifact_miss_count = 0;
     start_attempts_without_pr = 0;
     conflict_noop_count = 0;
     no_commits_push_count = 0;
@@ -221,6 +229,12 @@ let increment_no_commits_push_count t =
   { t with no_commits_push_count = t.no_commits_push_count + 1 }
 
 let reset_no_commits_push_count t = { t with no_commits_push_count = 0 }
+
+let increment_pr_body_artifact_miss_count t =
+  { t with pr_body_artifact_miss_count = t.pr_body_artifact_miss_count + 1 }
+
+let reset_pr_body_artifact_miss_count t =
+  { t with pr_body_artifact_miss_count = 0 }
 
 let set_base_branch t branch =
   let notified =
@@ -324,6 +338,7 @@ let reset_intervention_state t =
     start_attempts_without_pr = 0;
     conflict_noop_count = 0;
     no_commits_push_count = 0;
+    pr_body_artifact_miss_count = 0;
   }
 
 let reset_busy t = if not t.busy then t else { t with busy = false }
@@ -332,10 +347,10 @@ let restore ~patch_id ~branch ~pr_number ~has_session ~busy ~merged ~queue
     ~satisfies ~changed ~has_conflict ~base_branch ~notified_base_branch
     ~ci_failure_count ~session_fallback ~human_messages ~inflight_human_messages
     ~ci_checks ~merge_ready ~is_draft ~pr_body_delivered
-    ~start_attempts_without_pr ~conflict_noop_count ~no_commits_push_count
-    ~branch_rebased_onto ~checks_passing ~current_op ~current_message_id
-    ~generation ~worktree_path ~branch_blocked ~llm_session_id
-    ~automerge_enabled ~automerge_deadline ~automerge_inflight
+    ~pr_body_artifact_miss_count ~start_attempts_without_pr ~conflict_noop_count
+    ~no_commits_push_count ~branch_rebased_onto ~checks_passing ~current_op
+    ~current_message_id ~generation ~worktree_path ~branch_blocked
+    ~llm_session_id ~automerge_enabled ~automerge_deadline ~automerge_inflight
     ~automerge_failure_count ~delivered_ci_run_ids =
   {
     patch_id;
@@ -358,6 +373,7 @@ let restore ~patch_id ~branch ~pr_number ~has_session ~busy ~merged ~queue
     merge_ready;
     is_draft;
     pr_body_delivered;
+    pr_body_artifact_miss_count;
     start_attempts_without_pr;
     conflict_noop_count;
     no_commits_push_count;

--- a/lib/patch_agent.mli
+++ b/lib/patch_agent.mli
@@ -31,12 +31,13 @@ type t = private {
   is_draft : bool;
   pr_body_delivered : bool;
   pr_body_artifact_miss_count : int;
-      (** Consecutive Pr_body sessions that ended with a missing artifact AND
-          evidence of a non-completed Write tool call (see
-          [Orchestrator.Respond_pr_body_miss]). Contributes to
+      (** Consecutive Pr_body sessions that produced [Respond_pr_body_miss]:
+          either the artifact was missing/empty AND a Write tool call did not
+          complete (agent blocked mid-call), or the GitHub [update_pr_body]
+          PATCH call failed ([`Patch_failed]). Contributes to
           [needs_intervention] at [>= 2]. Zero in fresh snapshots and older
           snapshots that didn't persist the field. Reset by
-          [reset_intervention_state]. *)
+          [reset_intervention_state] and by [Respond_ok] for [Pr_body]. *)
   start_attempts_without_pr : int;
   conflict_noop_count : int;
   no_commits_push_count : int;

--- a/lib/patch_agent.mli
+++ b/lib/patch_agent.mli
@@ -211,10 +211,13 @@ val reset_no_commits_push_count : t -> t
     push, because the agent has demonstrated it can commit. *)
 
 val increment_pr_body_artifact_miss_count : t -> t
-(** Record a Pr_body session that ended with a missing/empty artifact AND an
-    observed non-completed Write tool call. After 2 such sessions,
-    [needs_intervention] triggers. Called from
-    [Orchestrator.apply_respond_outcome] on [Respond_pr_body_miss]. *)
+(** Record a Pr_body session that ended without durable PR body delivery. Called
+    from [Orchestrator.apply_respond_outcome] on [Respond_pr_body_miss], which
+    covers two cases: (a) missing/empty artifact AND an observed non-completed
+    Write tool call (agent blocked mid-call); (b)
+    [artifact_outcome = `Patch_failed] (notes written but the GitHub
+    [update_pr_body] call failed). After 2 such sessions, [needs_intervention]
+    triggers. *)
 
 val reset_pr_body_artifact_miss_count : t -> t
 (** Reset [pr_body_artifact_miss_count] to 0. *)

--- a/lib/patch_agent.mli
+++ b/lib/patch_agent.mli
@@ -30,6 +30,13 @@ type t = private {
   merge_ready : bool;
   is_draft : bool;
   pr_body_delivered : bool;
+  pr_body_artifact_miss_count : int;
+      (** Consecutive Pr_body sessions that ended with a missing artifact AND
+          evidence of a non-completed Write tool call (see
+          [Orchestrator.Respond_pr_body_miss]). Contributes to
+          [needs_intervention] at [>= 2]. Zero in fresh snapshots and older
+          snapshots that didn't persist the field. Reset by
+          [reset_intervention_state]. *)
   start_attempts_without_pr : int;
   conflict_noop_count : int;
   no_commits_push_count : int;
@@ -75,7 +82,8 @@ val needs_intervention : t -> bool
 (** Derived predicate: true when [Human] is not in [queue] and any of:
     [ci_failure_count >= 3], [session_fallback = Given_up],
     [(not has_pr) && start_attempts_without_pr >= 2],
-    [conflict_noop_count >= 2], or [no_commits_push_count >= 2]. *)
+    [conflict_noop_count >= 2], [no_commits_push_count >= 2], or
+    [pr_body_artifact_miss_count >= 2]. *)
 
 (** {2 Spec actions} *)
 
@@ -200,6 +208,15 @@ val increment_no_commits_push_count : t -> t
 val reset_no_commits_push_count : t -> t
 (** Reset [no_commits_push_count] to 0. Called on [Session_ok] with a successful
     push, because the agent has demonstrated it can commit. *)
+
+val increment_pr_body_artifact_miss_count : t -> t
+(** Record a Pr_body session that ended with a missing/empty artifact AND an
+    observed non-completed Write tool call. After 2 such sessions,
+    [needs_intervention] triggers. Called from
+    [Orchestrator.apply_respond_outcome] on [Respond_pr_body_miss]. *)
+
+val reset_pr_body_artifact_miss_count : t -> t
+(** Reset [pr_body_artifact_miss_count] to 0. *)
 
 val set_checks_passing : t -> bool -> t
 (** Set the checks_passing flag from GitHub CI status. *)
@@ -334,6 +351,7 @@ val restore :
   merge_ready:bool ->
   is_draft:bool ->
   pr_body_delivered:bool ->
+  pr_body_artifact_miss_count:int ->
   start_attempts_without_pr:int ->
   conflict_noop_count:int ->
   no_commits_push_count:int ->

--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -68,7 +68,14 @@ let discovery_intents orch =
       else None)
 
 let enqueue_pr_body_if_needed t patch_id (agent : Patch_agent.t) =
-  if (not (Patch_agent.has_pr agent)) || agent.merged || agent.pr_body_delivered
+  (* [needs_intervention] guard: without it, after two Respond_pr_body_miss
+     outcomes push [pr_body_artifact_miss_count] to the cap, the reconciler
+     would re-enqueue Pr_body on every tick and immediately override the
+     escalation — defeating the retry-once-then-intervene contract. *)
+  if
+    (not (Patch_agent.has_pr agent))
+    || agent.merged || agent.pr_body_delivered
+    || Patch_agent.needs_intervention agent
   then t
   else
     let already_queued =

--- a/lib/patch_decision.ml
+++ b/lib/patch_decision.ml
@@ -184,3 +184,39 @@ let respond_delivery ~(agent : Patch_agent.t) ~(kind : Operation_kind.t)
             assert false
       in
       Deliver { payload; base_change }
+
+(** Post-session classification for a successful Pr_body session.
+
+    Pure. Inputs are the three observations produced upstream by the session
+    runner and the artifact PATCHer:
+    - [artifact_outcome]: result of reading the agent-authored notes file and
+      PATCHing the PR body (from [apply_pr_body_artifact]).
+    - [tool_failures]: [(name, status)] pairs for every Tool_use event whose
+      status was not ["completed"] (OpenCode's pending/running/error states;
+      other backends do not populate status and so contribute nothing).
+
+    Correlation rule: artifact outcome in [`Missing | `Empty] together with at
+    least one Write-named tool_use that did not complete is evidence the agent
+    was blocked mid-call (e.g. OpenCode's [--dir] sandbox rejecting a write to a
+    path outside the worktree). Return [`Pr_body_miss] so the caller maps to
+    [Orchestrator.Respond_pr_body_miss] (reconciler re-enqueues Pr_body; counter
+    increments; cap at [>=2] fires [needs_intervention]).
+
+    Everything else → [`Ok]: a missing/empty artifact with no Write tool_failure
+    is the agent's deliberate choice not to add notes; artifact [`Ok] and
+    [`Patch_failed] both mean the session's intent was delivered (or attempted)
+    as expected.
+
+    Tool name match is case-sensitive on ["Write"]. OpenCode's [parse_event]
+    normalizes lowercase tool names to Claude-style PascalCase before emitting,
+    and other backends already emit PascalCase — so by the time a Tool_use
+    reaches this function, "Write" is the canonical form. *)
+let classify_pr_body_respond
+    ~(artifact_outcome : [ `Ok | `Missing | `Empty | `Patch_failed ])
+    ~(tool_failures : (string * string) list) : [ `Ok | `Pr_body_miss ] =
+  let observed_write_failure =
+    List.exists tool_failures ~f:(fun (name, _) -> String.equal name "Write")
+  in
+  match (artifact_outcome, observed_write_failure) with
+  | (`Missing | `Empty), true -> `Pr_body_miss
+  | (`Ok | `Missing | `Empty | `Patch_failed), _ -> `Ok

--- a/lib/patch_decision.ml
+++ b/lib/patch_decision.ml
@@ -195,17 +195,20 @@ let respond_delivery ~(agent : Patch_agent.t) ~(kind : Operation_kind.t)
       status was not ["completed"] (OpenCode's pending/running/error states;
       other backends do not populate status and so contribute nothing).
 
-    Correlation rule: artifact outcome in [`Missing | `Empty] together with at
-    least one Write-named tool_use that did not complete is evidence the agent
-    was blocked mid-call (e.g. OpenCode's [--dir] sandbox rejecting a write to a
-    path outside the worktree). Return [`Pr_body_miss] so the caller maps to
-    [Orchestrator.Respond_pr_body_miss] (reconciler re-enqueues Pr_body; counter
-    increments; cap at [>=2] fires [needs_intervention]).
+    Correlation rules that produce [`Pr_body_miss]:
+    - artifact outcome in [`Missing | `Empty] with at least one Write-named
+      tool_use that did not complete — evidence the agent was blocked mid-call
+      (e.g. OpenCode's [--dir] sandbox rejecting a write to a path outside the
+      worktree);
+    - artifact outcome [`Patch_failed] — the notes were authored but the
+      subsequent [Github.update_pr_body] call failed, so the PR body is stale.
+      Returning [`Pr_body_miss] lets the reconciler re-enqueue Pr_body; at cap
+      ([>=2]) the agent surfaces via [needs_intervention] so a persistent
+      delivery failure does not silently leave the PR description wrong.
 
     Everything else → [`Ok]: a missing/empty artifact with no Write tool_failure
-    is the agent's deliberate choice not to add notes; artifact [`Ok] and
-    [`Patch_failed] both mean the session's intent was delivered (or attempted)
-    as expected.
+    is the agent's deliberate choice not to add notes, and [`Ok] means delivery
+    succeeded.
 
     Tool name match is case-sensitive on ["Write"]. OpenCode's [parse_event]
     normalizes lowercase tool names to Claude-style PascalCase before emitting,
@@ -218,5 +221,6 @@ let classify_pr_body_respond
     List.exists tool_failures ~f:(fun (name, _) -> String.equal name "Write")
   in
   match (artifact_outcome, observed_write_failure) with
+  | `Patch_failed, _ -> `Pr_body_miss
   | (`Missing | `Empty), true -> `Pr_body_miss
-  | (`Ok | `Missing | `Empty | `Patch_failed), _ -> `Ok
+  | (`Ok | `Missing | `Empty), _ -> `Ok

--- a/lib/patch_decision.mli
+++ b/lib/patch_decision.mli
@@ -114,9 +114,13 @@ val classify_pr_body_respond :
   artifact_outcome:[ `Ok | `Missing | `Empty | `Patch_failed ] ->
   tool_failures:(string * string) list ->
   [ `Ok | `Pr_body_miss ]
-(** Pure post-session rule for Pr_body. Returns [`Pr_body_miss] iff the artifact
-    was [`Missing] or [`Empty] AND at least one [(name, status)] pair in
-    [tool_failures] has [name = "Write"]. Any other combination returns [`Ok].
+(** Pure post-session rule for Pr_body. Returns [`Pr_body_miss] when:
+    - artifact is [`Patch_failed] (GitHub [update_pr_body] call failed, PR body
+      is stale and the runner must retry rather than mark delivered); or
+    - artifact is [`Missing] or [`Empty] AND at least one [(name, status)] pair
+      in [tool_failures] has [name = "Write"] (agent blocked mid-write).
+
+    Any other combination returns [`Ok].
 
     Only invoked after a successful session — session-level failures
     (stale/failed/retry_push) short-circuit upstream in the handler and never

--- a/lib/patch_decision.mli
+++ b/lib/patch_decision.mli
@@ -107,3 +107,17 @@ val respond_delivery :
     re-polls GitHub before delivery and writes the fresh list into
     [agent.ci_checks] via [Orchestrator.set_ci_checks], then skips the call
     entirely if no failures remain. *)
+
+(** {2 Pr_body post-session classification} *)
+
+val classify_pr_body_respond :
+  artifact_outcome:[ `Ok | `Missing | `Empty | `Patch_failed ] ->
+  tool_failures:(string * string) list ->
+  [ `Ok | `Pr_body_miss ]
+(** Pure post-session rule for Pr_body. Returns [`Pr_body_miss] iff the artifact
+    was [`Missing] or [`Empty] AND at least one [(name, status)] pair in
+    [tool_failures] has [name = "Write"]. Any other combination returns [`Ok].
+
+    Only invoked after a successful session — session-level failures
+    (stale/failed/retry_push) short-circuit upstream in the handler and never
+    reach this function. *)

--- a/lib/persistence.ml
+++ b/lib/persistence.ml
@@ -71,6 +71,7 @@ let patch_agent_to_yojson (a : Patch_agent.t) =
       ("merge_ready", `Bool a.merge_ready);
       ("is_draft", `Bool a.is_draft);
       ("pr_body_delivered", `Bool a.pr_body_delivered);
+      ("pr_body_artifact_miss_count", `Int a.pr_body_artifact_miss_count);
       ("start_attempts_without_pr", `Int a.start_attempts_without_pr);
       ("conflict_noop_count", `Int a.conflict_noop_count);
       ("no_commits_push_count", `Int a.no_commits_push_count);
@@ -194,6 +195,10 @@ let patch_agent_of_yojson ~gameplan json =
        ~is_draft:(bool_member "is_draft" json)
        ~pr_body_delivered:
          (Option.value (bool_member_opt "pr_body_delivered" json) ~default:true)
+       ~pr_body_artifact_miss_count:
+         (Option.value
+            (int_member_opt "pr_body_artifact_miss_count" json)
+            ~default:0)
        ~start_attempts_without_pr:(int_member "start_attempts_without_pr" json)
        ~conflict_noop_count:
          (Option.value (int_member_opt "conflict_noop_count" json) ~default:0)

--- a/lib/pi_backend.ml
+++ b/lib/pi_backend.ml
@@ -39,7 +39,7 @@ let parse_event (line : string) : Types.Stream_event.t list =
                 | `Null -> ""
                 | v -> Yojson.Safe.to_string v
               in
-              [ Types.Stream_event.Tool_use { name; input } ]
+              [ Types.Stream_event.Tool_use { name; input; status = None } ]
           | _ -> [])
       | Some "agent_end" ->
           [
@@ -121,7 +121,7 @@ let%test "parse_event toolcall_end" =
   List.equal Types.Stream_event.equal (parse_event line)
     [
       Types.Stream_event.Tool_use
-        { name = "bash"; input = {|{"command":"ls -la"}|} };
+        { name = "bash"; input = {|{"command":"ls -la"}|}; status = None };
     ]
 
 let%test "parse_event agent_end" =

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -218,7 +218,7 @@ end
 module Stream_event = struct
   type t =
     | Text_delta of string
-    | Tool_use of { name : string; input : string }
+    | Tool_use of { name : string; input : string; status : string option }
     | Final_result of { text : string; stop_reason : Stop_reason.t }
     | Error of string
     | Session_init of { session_id : string }

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -166,7 +166,17 @@ end
 module Stream_event : sig
   type t =
     | Text_delta of string
-    | Tool_use of { name : string; input : string }
+    | Tool_use of {
+        name : string;
+        input : string;
+        status : string option;
+            (** Tool-call lifecycle status from the backend stream, when
+                exposed. [Some "completed"] means the tool returned a result;
+                any other [Some _] (e.g. [Some "pending"], [Some "running"],
+                backend-specific error states) indicates the tool was announced
+                but did not finish normally. [None] for backends that do not
+                surface per-tool state (all non-OpenCode backends today). *)
+      }
     | Final_result of { text : string; stop_reason : Stop_reason.t }
     | Error of string
     | Session_init of { session_id : string }

--- a/test/test_action_outcome_properties.ml
+++ b/test/test_action_outcome_properties.ml
@@ -71,6 +71,7 @@ let () =
       Orchestrator.Respond_failed;
       Orchestrator.Respond_retry_push;
       Orchestrator.Respond_skip_empty;
+      Orchestrator.Respond_pr_body_miss;
     ]
   in
   let respond_kinds =
@@ -276,6 +277,7 @@ let () =
       Orchestrator.Respond_skip_empty;
       Orchestrator.Respond_retry_push;
       Orchestrator.Respond_stale;
+      Orchestrator.Respond_pr_body_miss;
     ]
   in
   let prop =
@@ -296,3 +298,30 @@ let () =
   in
   QCheck2.Test.check_exn prop;
   Stdlib.print_endline "AO-9 passed"
+
+(* ========== AO-10: Respond_pr_body_miss semantics ========== *)
+
+(* Respond_pr_body_miss must: (a) clear busy so the reconciler can re-enqueue,
+   (b) leave pr_body_delivered=false so the re-enqueue actually happens,
+   (c) increment pr_body_artifact_miss_count by exactly 1 each call. This
+   encodes the retry-once-then-intervene contract. *)
+let () =
+  let prop =
+    QCheck2.Test.make ~name:"AO-10: Respond_pr_body_miss retry semantics"
+      (QCheck2.Gen.return ()) (fun () ->
+        let orch, patches, gameplan, pid = bootstrap_one () in
+        let orch = make_busy orch patches gameplan pid Operation_kind.Pr_body in
+        let before =
+          (Orchestrator.agent orch pid).Patch_agent.pr_body_artifact_miss_count
+        in
+        let orch =
+          Orchestrator.apply_respond_outcome orch pid Operation_kind.Pr_body
+            Orchestrator.Respond_pr_body_miss
+        in
+        let a = Orchestrator.agent orch pid in
+        (not a.Patch_agent.busy)
+        && (not a.Patch_agent.pr_body_delivered)
+        && a.Patch_agent.pr_body_artifact_miss_count = before + 1)
+  in
+  QCheck2.Test.check_exn prop;
+  Stdlib.print_endline "AO-10 passed"

--- a/test/test_action_outcome_properties.ml
+++ b/test/test_action_outcome_properties.ml
@@ -330,3 +330,40 @@ let () =
   in
   QCheck2.Test.check_exn prop;
   Stdlib.print_endline "AO-10 passed"
+
+(* ========== AO-11: Respond_ok + Pr_body resets miss count ========== *)
+
+(* The cap [pr_body_artifact_miss_count >= 2] must count consecutive misses,
+   not lifetime misses. A successful delivery resets the counter so a stale
+   miss from earlier in the patch's lifecycle cannot combine with a later
+   single miss to trigger intervention. *)
+let () =
+  let prop =
+    QCheck2.Test.make ~name:"AO-11: Respond_ok + Pr_body resets miss count"
+      (QCheck2.Gen.return ()) (fun () ->
+        try
+          let orch, patches, gameplan, pid = bootstrap_one () in
+          let orch =
+            make_busy orch patches gameplan pid Operation_kind.Pr_body
+          in
+          let orch =
+            Orchestrator.apply_respond_outcome orch pid Operation_kind.Pr_body
+              Orchestrator.Respond_pr_body_miss
+          in
+          assert (
+            (Orchestrator.agent orch pid)
+              .Patch_agent.pr_body_artifact_miss_count = 1);
+          let orch =
+            make_busy orch patches gameplan pid Operation_kind.Pr_body
+          in
+          let orch =
+            Orchestrator.apply_respond_outcome orch pid Operation_kind.Pr_body
+              Orchestrator.Respond_ok
+          in
+          let a = Orchestrator.agent orch pid in
+          a.Patch_agent.pr_body_delivered
+          && a.Patch_agent.pr_body_artifact_miss_count = 0
+        with _ -> false)
+  in
+  QCheck2.Test.check_exn prop;
+  Stdlib.print_endline "AO-11 passed"

--- a/test/test_action_outcome_properties.ml
+++ b/test/test_action_outcome_properties.ml
@@ -309,19 +309,24 @@ let () =
   let prop =
     QCheck2.Test.make ~name:"AO-10: Respond_pr_body_miss retry semantics"
       (QCheck2.Gen.return ()) (fun () ->
-        let orch, patches, gameplan, pid = bootstrap_one () in
-        let orch = make_busy orch patches gameplan pid Operation_kind.Pr_body in
-        let before =
-          (Orchestrator.agent orch pid).Patch_agent.pr_body_artifact_miss_count
-        in
-        let orch =
-          Orchestrator.apply_respond_outcome orch pid Operation_kind.Pr_body
-            Orchestrator.Respond_pr_body_miss
-        in
-        let a = Orchestrator.agent orch pid in
-        (not a.Patch_agent.busy)
-        && (not a.Patch_agent.pr_body_delivered)
-        && a.Patch_agent.pr_body_artifact_miss_count = before + 1)
+        try
+          let orch, patches, gameplan, pid = bootstrap_one () in
+          let orch =
+            make_busy orch patches gameplan pid Operation_kind.Pr_body
+          in
+          let before =
+            (Orchestrator.agent orch pid)
+              .Patch_agent.pr_body_artifact_miss_count
+          in
+          let orch =
+            Orchestrator.apply_respond_outcome orch pid Operation_kind.Pr_body
+              Orchestrator.Respond_pr_body_miss
+          in
+          let a = Orchestrator.agent orch pid in
+          (not a.Patch_agent.busy)
+          && (not a.Patch_agent.pr_body_delivered)
+          && a.Patch_agent.pr_body_artifact_miss_count = before + 1
+        with _ -> false)
   in
   QCheck2.Test.check_exn prop;
   Stdlib.print_endline "AO-10 passed"

--- a/test/test_backend_smoke.ml
+++ b/test/test_backend_smoke.ml
@@ -124,6 +124,30 @@ let () =
         Types.Stream_event.Final_result
           { text = ""; stop_reason = Types.Stop_reason.End_turn };
       ];
+  (* --- OpenCode: tool_use status survives the full subprocess pipeline.
+     Regression guard for the silent-disconnect bug where a pending Write was
+     mistaken for a completed one because the parser discarded state.status. *)
+  let result, got =
+    smoke ~process_mgr ~clock ~cwd
+      ~ndjson:
+        [
+          {|{"type":"tool_use","part":{"type":"tool","tool":"write","state":{"status":"pending","input":{"filePath":"/tmp/x","content":"y"}}}}|};
+          {|{"type":"step_finish","part":{"type":"step-finish","reason":"stop"}}|};
+        ]
+      ~process_line:(process_line_strip Opencode_backend.parse_event)
+  in
+  assert_smoke ~name:"opencode tool_use pending" ~result ~got
+    ~expected:
+      [
+        Types.Stream_event.Tool_use
+          {
+            name = "Write";
+            input = {|{"file_path":"/tmp/x","content":"y"}|};
+            status = Some "pending";
+          };
+        Types.Stream_event.Final_result
+          { text = ""; stop_reason = Types.Stop_reason.End_turn };
+      ];
   if !failures > 0 then (
     Stdio.printf "%d backend smoke test(s) failed\n" !failures;
     Stdlib.exit 1)

--- a/test/test_patch_agent.ml
+++ b/test/test_patch_agent.ml
@@ -630,40 +630,46 @@ let () =
       Test.make ~name:"1 pr_body miss no intervention (boundary)" ~count:1
         Gen.(pure (pid0, br0))
         (fun (pid, br) ->
-          let a =
-            create ~branch:br pid |> fun a -> start_with_pr a ~base_branch:br
-          in
-          let a = complete a in
-          let a = increment_pr_body_artifact_miss_count a in
-          not (needs_intervention a));
+          try
+            let a =
+              create ~branch:br pid |> fun a -> start_with_pr a ~base_branch:br
+            in
+            let a = complete a in
+            let a = increment_pr_body_artifact_miss_count a in
+            not (needs_intervention a)
+          with _ -> false);
       (* -- 2 pr_body misses triggers needs_intervention -- *)
       Test.make ~name:"2 pr_body misses triggers intervention" ~count:1
         Gen.(pure (pid0, br0))
         (fun (pid, br) ->
-          let a =
-            create ~branch:br pid |> fun a -> start_with_pr a ~base_branch:br
-          in
-          let a = complete a in
-          let a = increment_pr_body_artifact_miss_count a in
-          let a = increment_pr_body_artifact_miss_count a in
-          needs_intervention a);
+          try
+            let a =
+              create ~branch:br pid |> fun a -> start_with_pr a ~base_branch:br
+            in
+            let a = complete a in
+            let a = increment_pr_body_artifact_miss_count a in
+            let a = increment_pr_body_artifact_miss_count a in
+            needs_intervention a
+          with _ -> false);
       (* -- reset_intervention_state zeros the pr_body miss counter -- *)
       Test.make
         ~name:"reset_intervention_state clears pr_body_artifact_miss_count"
         ~count:1
         Gen.(pure (pid0, br0))
         (fun (pid, br) ->
-          let a =
-            create ~branch:br pid |> fun a -> start_with_pr a ~base_branch:br
-          in
-          let a = complete a in
-          let a = increment_pr_body_artifact_miss_count a in
-          let a = increment_pr_body_artifact_miss_count a in
-          let triggered = needs_intervention a in
-          let a = reset_intervention_state a in
-          triggered
-          && (not (needs_intervention a))
-          && a.pr_body_artifact_miss_count = 0);
+          try
+            let a =
+              create ~branch:br pid |> fun a -> start_with_pr a ~base_branch:br
+            in
+            let a = complete a in
+            let a = increment_pr_body_artifact_miss_count a in
+            let a = increment_pr_body_artifact_miss_count a in
+            let triggered = needs_intervention a in
+            let a = reset_intervention_state a in
+            triggered
+            && (not (needs_intervention a))
+            && a.pr_body_artifact_miss_count = 0
+          with _ -> false);
       (* -- reset_intervention_state clears derived intervention -- *)
       Test.make ~name:"reset_intervention_state clears intervention" ~count:1
         Gen.(pure (pid0, br0))

--- a/test/test_patch_agent.ml
+++ b/test/test_patch_agent.ml
@@ -626,6 +626,44 @@ let () =
           let a = rebase a ~base_branch:(Branch.of_string "new-base") in
           let a = complete a in
           not (needs_intervention a));
+      (* -- 1 pr_body miss does NOT trigger needs_intervention (boundary) -- *)
+      Test.make ~name:"1 pr_body miss no intervention (boundary)" ~count:1
+        Gen.(pure (pid0, br0))
+        (fun (pid, br) ->
+          let a =
+            create ~branch:br pid |> fun a -> start_with_pr a ~base_branch:br
+          in
+          let a = complete a in
+          let a = increment_pr_body_artifact_miss_count a in
+          not (needs_intervention a));
+      (* -- 2 pr_body misses triggers needs_intervention -- *)
+      Test.make ~name:"2 pr_body misses triggers intervention" ~count:1
+        Gen.(pure (pid0, br0))
+        (fun (pid, br) ->
+          let a =
+            create ~branch:br pid |> fun a -> start_with_pr a ~base_branch:br
+          in
+          let a = complete a in
+          let a = increment_pr_body_artifact_miss_count a in
+          let a = increment_pr_body_artifact_miss_count a in
+          needs_intervention a);
+      (* -- reset_intervention_state zeros the pr_body miss counter -- *)
+      Test.make
+        ~name:"reset_intervention_state clears pr_body_artifact_miss_count"
+        ~count:1
+        Gen.(pure (pid0, br0))
+        (fun (pid, br) ->
+          let a =
+            create ~branch:br pid |> fun a -> start_with_pr a ~base_branch:br
+          in
+          let a = complete a in
+          let a = increment_pr_body_artifact_miss_count a in
+          let a = increment_pr_body_artifact_miss_count a in
+          let triggered = needs_intervention a in
+          let a = reset_intervention_state a in
+          triggered
+          && (not (needs_intervention a))
+          && a.pr_body_artifact_miss_count = 0);
       (* -- reset_intervention_state clears derived intervention -- *)
       Test.make ~name:"reset_intervention_state clears intervention" ~count:1
         Gen.(pure (pid0, br0))
@@ -679,13 +717,14 @@ let () =
               ~session_fallback:Fresh_available ~human_messages:[]
               ~inflight_human_messages:[] ~ci_checks:a.ci_checks
               ~merge_ready:false ~is_draft:false ~pr_body_delivered:false
-              ~start_attempts_without_pr:0 ~conflict_noop_count:0
-              ~no_commits_push_count:0 ~branch_rebased_onto:None
-              ~checks_passing:false ~current_op:None ~current_message_id:None
-              ~generation:0 ~worktree_path:None ~branch_blocked:false
-              ~llm_session_id:None ~automerge_enabled:false
-              ~automerge_deadline:None ~automerge_inflight:false
-              ~automerge_failure_count:0 ~delivered_ci_run_ids:[]
+              ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
+              ~conflict_noop_count:0 ~no_commits_push_count:0
+              ~branch_rebased_onto:None ~checks_passing:false ~current_op:None
+              ~current_message_id:None ~generation:0 ~worktree_path:None
+              ~branch_blocked:false ~llm_session_id:None
+              ~automerge_enabled:false ~automerge_deadline:None
+              ~automerge_inflight:false ~automerge_failure_count:0
+              ~delivered_ci_run_ids:[]
           in
           let a = start a ~base_branch:br in
           List.is_empty a.ci_checks);
@@ -758,13 +797,14 @@ let () =
               ~ci_failure_count:0 ~session_fallback:Fresh_available
               ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
               ~merge_ready:false ~is_draft:false ~pr_body_delivered:false
-              ~start_attempts_without_pr:0 ~conflict_noop_count:0
-              ~no_commits_push_count:0 ~branch_rebased_onto:None
-              ~checks_passing:false ~current_op:None ~current_message_id:None
-              ~generation:0 ~worktree_path:None ~branch_blocked:false
-              ~llm_session_id:None ~automerge_enabled:false
-              ~automerge_deadline:None ~automerge_inflight:false
-              ~automerge_failure_count:0 ~delivered_ci_run_ids:[]
+              ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
+              ~conflict_noop_count:0 ~no_commits_push_count:0
+              ~branch_rebased_onto:None ~checks_passing:false ~current_op:None
+              ~current_message_id:None ~generation:0 ~worktree_path:None
+              ~branch_blocked:false ~llm_session_id:None
+              ~automerge_enabled:false ~automerge_deadline:None
+              ~automerge_inflight:false ~automerge_failure_count:0
+              ~delivered_ci_run_ids:[]
           in
           let a = enqueue a Operation_kind.Rebase in
           let a = rebase a ~base_branch:new_base in

--- a/test/test_patch_controller.ml
+++ b/test/test_patch_controller.ml
@@ -49,7 +49,8 @@ let make_agent ~patch_id ~branch ~pr_number ~merged ~queue ~base_branch
     ~has_conflict:false ~base_branch ~notified_base_branch:base_branch
     ~ci_failure_count:0 ~session_fallback:Patch_agent.Fresh_available
     ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
-    ~merge_ready:false ~is_draft ~pr_body_delivered ~start_attempts_without_pr
+    ~merge_ready:false ~is_draft ~pr_body_delivered
+    ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr
     ~conflict_noop_count:0 ~no_commits_push_count:0 ~branch_rebased_onto:None
     ~checks_passing:false ~current_op:None ~current_message_id:None
     ~generation:0 ~worktree_path:None ~branch_blocked:false ~llm_session_id:None
@@ -345,11 +346,11 @@ let () =
             ~ci_failure_count:0 ~session_fallback:Patch_agent.Fresh_available
             ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
             ~merge_ready:false ~is_draft:true ~pr_body_delivered:false
-            ~start_attempts_without_pr:0 ~conflict_noop_count:0
-            ~no_commits_push_count:0 ~branch_rebased_onto:None
-            ~checks_passing:false ~current_op:None ~current_message_id:None
-            ~generation:0 ~worktree_path:None ~branch_blocked:false
-            ~llm_session_id:None ~automerge_enabled:false
+            ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
+            ~conflict_noop_count:0 ~no_commits_push_count:0
+            ~branch_rebased_onto:None ~checks_passing:false ~current_op:None
+            ~current_message_id:None ~generation:0 ~worktree_path:None
+            ~branch_blocked:false ~llm_session_id:None ~automerge_enabled:false
             ~automerge_deadline:None ~automerge_inflight:false
             ~automerge_failure_count:0 ~delivered_ci_run_ids:[]
         in
@@ -478,11 +479,11 @@ let () =
             ~ci_failure_count:1 ~session_fallback:Patch_agent.Fresh_available
             ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
             ~merge_ready:false ~is_draft:false ~pr_body_delivered:true
-            ~start_attempts_without_pr:0 ~conflict_noop_count:0
-            ~no_commits_push_count:0 ~branch_rebased_onto:None
-            ~checks_passing:false ~current_op:None ~current_message_id:None
-            ~generation:0 ~worktree_path:None ~branch_blocked:false
-            ~llm_session_id:None ~automerge_enabled:false
+            ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
+            ~conflict_noop_count:0 ~no_commits_push_count:0
+            ~branch_rebased_onto:None ~checks_passing:false ~current_op:None
+            ~current_message_id:None ~generation:0 ~worktree_path:None
+            ~branch_blocked:false ~llm_session_id:None ~automerge_enabled:false
             ~automerge_deadline:None ~automerge_inflight:false
             ~automerge_failure_count:0 ~delivered_ci_run_ids:[]
         in
@@ -616,11 +617,11 @@ let () =
             ~ci_failure_count:0 ~session_fallback:Patch_agent.Fresh_available
             ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
             ~merge_ready:false ~is_draft:true ~pr_body_delivered:false
-            ~start_attempts_without_pr:0 ~conflict_noop_count:0
-            ~no_commits_push_count:0 ~branch_rebased_onto:None
-            ~checks_passing:false ~current_op:None ~current_message_id:None
-            ~generation:0 ~worktree_path:None ~branch_blocked:false
-            ~llm_session_id:None ~automerge_enabled:false
+            ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
+            ~conflict_noop_count:0 ~no_commits_push_count:0
+            ~branch_rebased_onto:None ~checks_passing:false ~current_op:None
+            ~current_message_id:None ~generation:0 ~worktree_path:None
+            ~branch_blocked:false ~llm_session_id:None ~automerge_enabled:false
             ~automerge_deadline:None ~automerge_inflight:false
             ~automerge_failure_count:0 ~delivered_ci_run_ids:[]
         in
@@ -818,7 +819,8 @@ let () =
             ~base_branch:None ~notified_base_branch:None ~ci_failure_count:0
             ~session_fallback:Patch_agent.Fresh_available ~human_messages:[]
             ~inflight_human_messages:[] ~ci_checks:[] ~merge_ready:false
-            ~is_draft:false ~pr_body_delivered:true ~start_attempts_without_pr:0
+            ~is_draft:false ~pr_body_delivered:true
+            ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
             ~conflict_noop_count:0 ~no_commits_push_count:0
             ~branch_rebased_onto:None ~checks_passing:false ~current_op:None
             ~current_message_id:None ~generation:0 ~worktree_path:None
@@ -858,11 +860,11 @@ let () =
             ~ci_failure_count:0 ~session_fallback:Patch_agent.Fresh_available
             ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
             ~merge_ready:false ~is_draft:false ~pr_body_delivered:true
-            ~start_attempts_without_pr:0 ~conflict_noop_count:0
-            ~no_commits_push_count:0 ~branch_rebased_onto:None
-            ~checks_passing:false ~current_op:None ~current_message_id:None
-            ~generation:0 ~worktree_path:None ~branch_blocked:false
-            ~llm_session_id:None ~automerge_enabled:false
+            ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
+            ~conflict_noop_count:0 ~no_commits_push_count:0
+            ~branch_rebased_onto:None ~checks_passing:false ~current_op:None
+            ~current_message_id:None ~generation:0 ~worktree_path:None
+            ~branch_blocked:false ~llm_session_id:None ~automerge_enabled:false
             ~automerge_deadline:None ~automerge_inflight:false
             ~automerge_failure_count:0 ~delivered_ci_run_ids:[]
         in

--- a/test/test_patch_decision.ml
+++ b/test/test_patch_decision.ml
@@ -595,4 +595,161 @@ let () =
     Stdlib.print_endline "RD-10 passed"
   in
 
-  ignore main_branch
+  ignore main_branch;
+
+  (* ========== classify_pr_body_respond property tests ==========
+
+     The correlation rule is small enough to exhaustively enumerate over the
+     4 artifact_outcomes × {Write-present, no-Write} × sample tool_failure
+     shapes. Properties assert the invariants that matter for the
+     retry-once-then-intervene contract. *)
+  let () =
+    let all_artifact_outcomes = [ `Ok; `Missing; `Empty; `Patch_failed ] in
+    let write_failure = ("Write", "pending") in
+    let non_write_failures = [ ("Bash", "pending"); ("Read", "error") ] in
+
+    (* PB-1: artifact = Ok → Ok regardless of tool_failures. *)
+    List.iter
+      [ []; [ write_failure ]; write_failure :: non_write_failures ]
+      ~f:(fun tool_failures ->
+        let r = classify_pr_body_respond ~artifact_outcome:`Ok ~tool_failures in
+        match r with
+        | `Ok -> ()
+        | `Pr_body_miss ->
+            failwith "PB-1: artifact=Ok must not classify as Pr_body_miss");
+    Stdlib.print_endline "PB-1 passed";
+
+    (* PB-2: artifact = Patch_failed → Ok regardless of tool_failures.
+       Rationale: the agent wrote the artifact successfully; only the PR
+       PATCH call failed, which is a transient network error unrelated to
+       a sandbox-blocked write. *)
+    List.iter
+      [ []; [ write_failure ]; write_failure :: non_write_failures ]
+      ~f:(fun tool_failures ->
+        let r =
+          classify_pr_body_respond ~artifact_outcome:`Patch_failed
+            ~tool_failures
+        in
+        match r with
+        | `Ok -> ()
+        | `Pr_body_miss ->
+            failwith "PB-2: Patch_failed must not classify as Pr_body_miss");
+    Stdlib.print_endline "PB-2 passed";
+
+    (* PB-3: artifact = Missing + Write tool_failure → Pr_body_miss. *)
+    let r =
+      classify_pr_body_respond ~artifact_outcome:`Missing
+        ~tool_failures:[ write_failure ]
+    in
+    (match r with
+    | `Pr_body_miss -> ()
+    | `Ok -> failwith "PB-3: Missing + Write failure must be Pr_body_miss");
+    Stdlib.print_endline "PB-3 passed";
+
+    (* PB-4: artifact = Empty + Write tool_failure → Pr_body_miss. *)
+    let r =
+      classify_pr_body_respond ~artifact_outcome:`Empty
+        ~tool_failures:[ write_failure ]
+    in
+    (match r with
+    | `Pr_body_miss -> ()
+    | `Ok -> failwith "PB-4: Empty + Write failure must be Pr_body_miss");
+    Stdlib.print_endline "PB-4 passed";
+
+    (* PB-5: artifact = Missing|Empty + no Write tool_failure → Ok.
+       Agent legitimately chose not to add notes. *)
+    List.iter [ `Missing; `Empty ] ~f:(fun artifact_outcome ->
+        List.iter [ []; non_write_failures ] ~f:(fun tool_failures ->
+            match classify_pr_body_respond ~artifact_outcome ~tool_failures with
+            | `Ok -> ()
+            | `Pr_body_miss ->
+                failwith "PB-5: Missing|Empty with no Write failure must be Ok"));
+    Stdlib.print_endline "PB-5 passed";
+
+    (* PB-6: case-sensitive match on "Write" — lowercase "write" does NOT
+       trigger, because OpenCode's normalize_tool_name converts to PascalCase
+       upstream and the correlation rule matches only the canonical form.
+       Regression guard for future backends that surface status without
+       normalizing. *)
+    let r =
+      classify_pr_body_respond ~artifact_outcome:`Missing
+        ~tool_failures:[ ("write", "pending") ]
+    in
+    (match r with
+    | `Ok -> ()
+    | `Pr_body_miss ->
+        failwith "PB-6: lowercase 'write' must not trigger Pr_body_miss");
+    Stdlib.print_endline "PB-6 passed";
+
+    (* PB-7: property — Write failure mixed with any number of non-Write
+       failures still classifies as Pr_body_miss when artifact is
+       Missing|Empty. *)
+    let prop =
+      QCheck2.Test.make ~name:"PB-7: Write+noise in failures still Pr_body_miss"
+        QCheck2.Gen.(
+          pair
+            (oneof_list [ `Missing; `Empty ])
+            (list_small
+               (pair
+                  (oneof_list [ "Bash"; "Read"; "Grep"; "Edit"; "Glob" ])
+                  (oneof_list [ "pending"; "running"; "error" ]))))
+        (fun (artifact_outcome, noise) ->
+          try
+            let tool_failures = write_failure :: noise in
+            match classify_pr_body_respond ~artifact_outcome ~tool_failures with
+            | `Pr_body_miss -> true
+            | `Ok -> false
+          with _ -> false)
+    in
+    QCheck2.Test.check_exn prop;
+    Stdlib.print_endline "PB-7 passed";
+
+    (* PB-8: property — all combinations of artifact_outcome × non-Write
+       failure list classify as Ok (the correlation never fires without a
+       Write failure). *)
+    let prop =
+      QCheck2.Test.make ~name:"PB-8: no Write failure → never Pr_body_miss"
+        QCheck2.Gen.(
+          pair
+            (oneof_list all_artifact_outcomes)
+            (list_small
+               (pair
+                  (oneof_list [ "Bash"; "Read"; "Grep"; "Edit"; "Glob" ])
+                  (oneof_list [ "pending"; "running"; "error" ]))))
+        (fun (artifact_outcome, non_write) ->
+          try
+            match
+              classify_pr_body_respond ~artifact_outcome
+                ~tool_failures:non_write
+            with
+            | `Ok -> true
+            | `Pr_body_miss -> false
+          with _ -> false)
+    in
+    QCheck2.Test.check_exn prop;
+    Stdlib.print_endline "PB-8 passed";
+
+    (* PB-9: property — Write failure anywhere in the list (not just head)
+       triggers Pr_body_miss when artifact is Missing|Empty. Guards against
+       a regression that only checks the head of the list. *)
+    let prop =
+      QCheck2.Test.make ~name:"PB-9: Write failure position independence"
+        QCheck2.Gen.(
+          pair
+            (oneof_list [ `Missing; `Empty ])
+            (list_small
+               (pair
+                  (oneof_list [ "Bash"; "Read"; "Grep"; "Edit"; "Glob" ])
+                  (oneof_list [ "pending"; "running"; "error" ]))))
+        (fun (artifact_outcome, prefix) ->
+          try
+            let tool_failures = prefix @ [ write_failure ] in
+            match classify_pr_body_respond ~artifact_outcome ~tool_failures with
+            | `Pr_body_miss -> true
+            | `Ok -> false
+          with _ -> false)
+    in
+    QCheck2.Test.check_exn prop;
+    Stdlib.print_endline "PB-9 passed"
+  in
+  ()

--- a/test/test_patch_decision.ml
+++ b/test/test_patch_decision.ml
@@ -604,7 +604,6 @@ let () =
      shapes. Properties assert the invariants that matter for the
      retry-once-then-intervene contract. *)
   let () =
-    let all_artifact_outcomes = [ `Ok; `Missing; `Empty; `Patch_failed ] in
     let write_failure = ("Write", "pending") in
     let non_write_failures = [ ("Bash", "pending"); ("Read", "error") ] in
 
@@ -619,10 +618,10 @@ let () =
             failwith "PB-1: artifact=Ok must not classify as Pr_body_miss");
     Stdlib.print_endline "PB-1 passed";
 
-    (* PB-2: artifact = Patch_failed → Ok regardless of tool_failures.
-       Rationale: the agent wrote the artifact successfully; only the PR
-       PATCH call failed, which is a transient network error unrelated to
-       a sandbox-blocked write. *)
+    (* PB-2: artifact = Patch_failed → Pr_body_miss regardless of
+       tool_failures. Rationale: the PR body update call failed, so the
+       description is stale; bubble out as Pr_body_miss so the reconciler
+       re-enqueues rather than marking delivery complete. *)
     List.iter
       [ []; [ write_failure ]; write_failure :: non_write_failures ]
       ~f:(fun tool_failures ->
@@ -631,9 +630,8 @@ let () =
             ~tool_failures
         in
         match r with
-        | `Ok -> ()
-        | `Pr_body_miss ->
-            failwith "PB-2: Patch_failed must not classify as Pr_body_miss");
+        | `Pr_body_miss -> ()
+        | `Ok -> failwith "PB-2: Patch_failed must classify as Pr_body_miss");
     Stdlib.print_endline "PB-2 passed";
 
     (* PB-3: artifact = Missing + Write tool_failure → Pr_body_miss. *)
@@ -704,14 +702,15 @@ let () =
     QCheck2.Test.check_exn prop;
     Stdlib.print_endline "PB-7 passed";
 
-    (* PB-8: property — all combinations of artifact_outcome × non-Write
-       failure list classify as Ok (the correlation never fires without a
-       Write failure). *)
+    (* PB-8: property — for non-failing artifact outcomes (Ok/Missing/Empty),
+       a non-Write failure list always classifies as Ok. The correlation
+       never fires without a Write failure. Patch_failed is excluded because
+       it classifies as Pr_body_miss regardless of tool_failures (see PB-2). *)
     let prop =
       QCheck2.Test.make ~name:"PB-8: no Write failure → never Pr_body_miss"
         QCheck2.Gen.(
           pair
-            (oneof_list all_artifact_outcomes)
+            (oneof_list [ `Ok; `Missing; `Empty ])
             (list_small
                (pair
                   (oneof_list [ "Bash"; "Read"; "Grep"; "Edit"; "Glob" ])

--- a/test/test_poll_log_properties.ml
+++ b/test/test_poll_log_properties.ml
@@ -47,12 +47,12 @@ let make_agent ~patch_id ~branch ~has_conflict ~ci_failure_count ~current_op
     ~ci_failure_count ~session_fallback:Patch_agent.Fresh_available
     ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
     ~merge_ready:false ~is_draft ~pr_body_delivered:true
-    ~start_attempts_without_pr:0 ~conflict_noop_count:0 ~no_commits_push_count:0
-    ~branch_rebased_onto:None ~checks_passing ~current_op
-    ~current_message_id:None ~generation:0 ~worktree_path ~branch_blocked
-    ~llm_session_id:None ~automerge_enabled:false ~automerge_deadline:None
-    ~automerge_inflight:false ~automerge_failure_count:0
-    ~delivered_ci_run_ids:[]
+    ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
+    ~conflict_noop_count:0 ~no_commits_push_count:0 ~branch_rebased_onto:None
+    ~checks_passing ~current_op ~current_message_id:None ~generation:0
+    ~worktree_path ~branch_blocked ~llm_session_id:None ~automerge_enabled:false
+    ~automerge_deadline:None ~automerge_inflight:false
+    ~automerge_failure_count:0 ~delivered_ci_run_ids:[]
 
 let make_poll_observation ~branch_in_root ~worktree_path poll_result =
   Patch_controller.

--- a/test/test_stream_parser.ml
+++ b/test/test_stream_parser.ml
@@ -63,7 +63,7 @@ let gen_tool_use_pair =
             {|{"type":"content_block_start","content_block":{"type":"tool_use","name":"%s"}}|}
             name
         in
-        (json, Stream_event.Tool_use { name; input = "" }))
+        (json, Stream_event.Tool_use { name; input = ""; status = None }))
       gen_tool_name)
 
 let gen_result_pair =


### PR DESCRIPTION
## Summary

Closes the class of bug where a Pr_body session reports success while the agent was actually blocked mid-write. The trigger: OpenCode emits `tool_use` events with a `state.status` field (`pending`/`running`/`completed`/error states), but the parser discarded it. When OpenCode's `--dir` sandbox rejected a `Write` to the out-of-worktree artifact path, the tool_use emitted as `pending` and never completed; the supervisor saw a clean exit, the missing-artifact fallback logged and moved on, and `pr_body_delivered` flipped true — so nothing surfaced.

Two layers land together:

- **Observability**: `Types.Stream_event.Tool_use` gains `status : string option`. OpenCode extracts `state.status` (`lib/opencode_backend.ml`); other backends pass `None`. The session runner accumulates `(name, status)` for every non-`"completed"` tool_use and logs a structured summary at session end (`bin/main.ml`).
- **Retry-once-then-intervene**: `apply_pr_body_artifact` returns a tagged outcome. New `Orchestrator.Respond_pr_body_miss` variant + persistent `Patch_agent.pr_body_artifact_miss_count` with a cap at `>= 2` wired into `needs_intervention` and `reset_intervention_state`. Persistence reads with `~default:0` so existing snapshots roll forward cleanly.

The correlation rule — artifact `Missing|Empty` **AND** any tool_failure with `name = "Write"` → `Pr_body_miss`; otherwise → `Ok` — is isolated as a pure `Patch_decision.classify_pr_body_respond`, with nine property tests (`PB-1..9` in `test/test_patch_decision.ml`) covering all 4 artifact outcomes × Write-present/absent, case sensitivity, position independence, and QCheck2 noise mixing. An `opencode tool_use pending` smoke test locks in the end-to-end status-survives-parsing contract.

The `--dir` sandbox issue itself is out of scope — this PR closes the *class* of disconnect, not the specific sandbox mismatch.

## Test plan

- [x] `dune build` — clean, zero non-exempt warnings
- [x] `dune runtest` — all existing + 9 new PB-* + AO-10 + opencode-tool-use-pending smoke pass
- [x] `dune fmt` — no diff
- [ ] Manual scenario replay: force a Pr_body with a blocked Write and confirm: session-end log emits `"N tool call(s) ended in non-completed state: Write[pending]"`, counter increments to 1, reconciler re-enqueues, second miss triggers `needs_intervention`
- [ ] Happy-path regression: Pr_body with a successful write still flips `pr_body_delivered=true` with no counter increment
- [ ] Benign no-notes regression: Pr_body where the agent deliberately writes nothing (no Write failures in the session) still classifies as `Ok` — today's fallback preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/204"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents false “PR body delivered” when a `Write` tool call never completes or the PR body PATCH fails. Clears stale artifacts before each run, correlates non‑completed tool calls with artifact outcomes, retries once, then escalates.

- **Bug Fixes**
  - Track per‑tool status end‑to‑end, keep only unresolved entries per tool name, log a session‑end summary, and return `tool_failures` to the caller.
  - Pr_body: tag artifact outcome; classify `(Missing|Empty && non‑completed "Write")` or `Patch_failed` as `Pr_body_miss`; clear the Pr_body artifact before each session to avoid stale notes.
  - Retry once, then escalate at `>= 2`; successful delivery resets `pr_body_artifact_miss_count`; guard `enqueue_pr_body_if_needed` with `needs_intervention` so Pr_body isn’t re‑enqueued after escalation.
  - Docs: cover both `Respond_pr_body_miss` causes in `patch_agent.mli` and `increment_pr_body_artifact_miss_count`.

- **Dependencies**
  - CI/Release: use the `opam.ocaml.org` archive cache mirror (with proper list syntax) to avoid flaky upstream archive fetches.

<sup>Written for commit b940c65c4d68dc17d6bb40945fe740334ab27a9c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable detection and handling of missing/empty PR descriptions by correlating incomplete tool runs with artifact outcomes; avoids falsely marking PRs as delivered.

* **New Features**
  * Tracks consecutive PR-body delivery misses and escalates to a human-review error after repeated failures; counts and resets missed attempts.

* **Tests**
  * Expanded coverage for per-tool status handling, PR-body miss classification, and recovery paths.

* **Chores**
  * CI configured to prefer the package archive cache for faster, more stable builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->