### PR TITLE
Stop FD churn and tighten exception-path closes

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -24,10 +24,10 @@ let read_process_capture open_ic =
   match open_ic () with
   | exception _ -> None
   | ic ->
-      let closed = ref false in
+      let status = ref None in
       Stdlib.Fun.protect
         ~finally:(fun () ->
-          if not !closed then
+          if Option.is_none !status then
             try ignore (Unix.close_process_in ic) with _ -> ())
         (fun () ->
           let buf = Buffer.create 128 in
@@ -36,9 +36,9 @@ let read_process_capture open_ic =
                Buffer.add_char buf (input_char ic)
              done
            with End_of_file -> ());
-          let status = Unix.close_process_in ic in
-          closed := true;
-          Some (status, Buffer.contents buf))
+          let s = Unix.close_process_in ic in
+          status := Some s;
+          Some (s, Buffer.contents buf))
 
 (** Infer GitHub owner/repo from [git remote get-url origin] in [repo_root].
     Parses both HTTPS and SSH remote URLs. Uses argv (no shell). *)

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -17,31 +17,52 @@ type config = {
   user_config : User_config.t;
 }
 
+(** Run a subprocess, capture stdout, and guarantee the pipe is closed on any
+    exception path. Returns the exit status and captured output, or [None] if
+    opening the pipe itself raised. *)
+let read_process_capture open_ic =
+  match open_ic () with
+  | exception _ -> None
+  | ic ->
+      let closed = ref false in
+      Stdlib.Fun.protect
+        ~finally:(fun () ->
+          if not !closed then
+            try ignore (Unix.close_process_in ic) with _ -> ())
+        (fun () ->
+          let buf = Buffer.create 128 in
+          (try
+             while true do
+               Buffer.add_char buf (input_char ic)
+             done
+           with End_of_file -> ());
+          let status = Unix.close_process_in ic in
+          closed := true;
+          Some (status, Buffer.contents buf))
+
 (** Infer GitHub owner/repo from [git remote get-url origin] in [repo_root].
     Parses both HTTPS and SSH remote URLs. Uses argv (no shell). *)
 let infer_owner_repo ~repo_root =
-  let buf = Buffer.create 128 in
   try
-    let ic =
-      Unix.open_process_args_in "git"
-        [| "git"; "-C"; repo_root; "remote"; "get-url"; "origin" |]
-    in
-    (try
-       while true do
-         Buffer.add_char buf (input_char ic)
-       done
-     with End_of_file -> ());
-    (match Unix.close_process_in ic with
-    | Unix.WEXITED 0 -> ()
-    | Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> raise Exit);
-    let url = Base.String.strip (Buffer.contents buf) in
-    let re =
-      Re.Pcre.re {|github\.com[:/]([^/]+)/([^/\s]+?)(?:\.git)?/?$|}
-      |> Re.compile
-    in
-    match Re.exec_opt re url with
-    | Some g -> Some (Re.Group.get g 1, Re.Group.get g 2)
-    | None -> None
+    match
+      read_process_capture (fun () ->
+          Unix.open_process_args_in "git"
+            [| "git"; "-C"; repo_root; "remote"; "get-url"; "origin" |])
+    with
+    | Some (Unix.WEXITED 0, out) -> (
+        let url = Base.String.strip out in
+        let re =
+          Re.Pcre.re {|github\.com[:/]([^/]+)/([^/\s]+?)(?:\.git)?/?$|}
+          |> Re.compile
+        in
+        match Re.exec_opt re url with
+        | Some g -> Some (Re.Group.get g 1, Re.Group.get g 2)
+        | None -> None)
+    | Some (Unix.WEXITED _, _)
+    | Some (Unix.WSIGNALED _, _)
+    | Some (Unix.WSTOPPED _, _)
+    | None ->
+        None
   with _ -> None
 
 (** Resolve GitHub token: check GITHUB_TOKEN env var, then try [gh auth token].
@@ -51,19 +72,19 @@ let infer_github_token () =
   | Some t when not (Base.String.is_empty (Base.String.strip t)) ->
       Base.String.strip t
   | _ -> (
-      let buf = Buffer.create 128 in
       try
-        let ic = Unix.open_process_args_in "gh" [| "gh"; "auth"; "token" |] in
-        (try
-           while true do
-             Buffer.add_char buf (input_char ic)
-           done
-         with End_of_file -> ());
-        (match Unix.close_process_in ic with
-        | Unix.WEXITED 0 -> ()
-        | Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> raise Exit);
-        let t = Base.String.strip (Buffer.contents buf) in
-        if Base.String.is_empty t then "" else t
+        match
+          read_process_capture (fun () ->
+              Unix.open_process_args_in "gh" [| "gh"; "auth"; "token" |])
+        with
+        | Some (Unix.WEXITED 0, out) ->
+            let t = Base.String.strip out in
+            if Base.String.is_empty t then "" else t
+        | Some (Unix.WEXITED _, _)
+        | Some (Unix.WSIGNALED _, _)
+        | Some (Unix.WSTOPPED _, _)
+        | None ->
+            ""
       with _ -> "")
 
 (** Detect the default branch of a git repository. Tries: 1.
@@ -72,21 +93,19 @@ let infer_github_token () =
     [git rev-parse --verify refs/heads/master] → "master" 4. Fallback: "main" *)
 let infer_default_branch ~repo_root =
   let run_git cmd =
-    let buf = Buffer.create 128 in
     try
-      let ic =
-        Unix.open_process_in
-          (Printf.sprintf "git -C %s %s 2>/dev/null" (Filename.quote repo_root)
-             cmd)
-      in
-      (try
-         while true do
-           Buffer.add_char buf (input_char ic)
-         done
-       with End_of_file -> ());
-      match Unix.close_process_in ic with
-      | Unix.WEXITED 0 -> Some (Base.String.strip (Buffer.contents buf))
-      | Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> None
+      match
+        read_process_capture (fun () ->
+            Unix.open_process_in
+              (Printf.sprintf "git -C %s %s 2>/dev/null"
+                 (Filename.quote repo_root) cmd))
+      with
+      | Some (Unix.WEXITED 0, out) -> Some (Base.String.strip out)
+      | Some (Unix.WEXITED _, _)
+      | Some (Unix.WSIGNALED _, _)
+      | Some (Unix.WSTOPPED _, _)
+      | None ->
+          None
     with _ -> None
   in
   match run_git "symbolic-ref refs/remotes/origin/HEAD" with
@@ -452,13 +471,15 @@ let reconcile_and_execute_automerge ~runtime ~net ~github =
     readable, [None] otherwise. *)
 let read_artifact_file path =
   try
-    if Stdlib.Sys.file_exists path then (
+    if Stdlib.Sys.file_exists path then
       let ic = Stdlib.open_in path in
-      let len = Stdlib.in_channel_length ic in
-      let s = Bytes.create len in
-      Stdlib.really_input ic s 0 len;
-      Stdlib.close_in ic;
-      Some (Bytes.to_string s))
+      Stdlib.Fun.protect
+        ~finally:(fun () -> Stdlib.close_in_noerr ic)
+        (fun () ->
+          let len = Stdlib.in_channel_length ic in
+          let s = Bytes.create len in
+          Stdlib.really_input ic s 0 len;
+          Some (Bytes.to_string s))
     else None
   with _ -> None
 

--- a/lib/debug_upload.ml
+++ b/lib/debug_upload.ml
@@ -12,13 +12,15 @@ let eprintf fmt = Stdlib.Printf.eprintf fmt
 
 (** Read a file to string, returning [None] if it doesn't exist. *)
 let read_file_opt path =
-  if Stdlib.Sys.file_exists path then (
+  if Stdlib.Sys.file_exists path then
     let ic = Stdlib.open_in path in
-    let n = Stdlib.in_channel_length ic in
-    let s = Bytes.create n in
-    Stdlib.really_input ic s 0 n;
-    Stdlib.close_in ic;
-    Some (Bytes.to_string s))
+    Stdlib.Fun.protect
+      ~finally:(fun () -> Stdlib.close_in_noerr ic)
+      (fun () ->
+        let n = Stdlib.in_channel_length ic in
+        let s = Bytes.create n in
+        Stdlib.really_input ic s 0 n;
+        Some (Bytes.to_string s))
   else None
 
 (** Replace known GitHub token patterns with [<REDACTED>]. *)

--- a/lib/term.ml
+++ b/lib/term.ml
@@ -335,8 +335,10 @@ let measure_size () =
         match In_channel.input_line ic with
         | Some s -> (
             match String.split s ~on:' ' with
-            | [ rows; cols ] ->
-                Some { rows = Int.of_string rows; cols = Int.of_string cols }
+            | [ rows; cols ] -> (
+                match (Int.of_string_opt rows, Int.of_string_opt cols) with
+                | Some r, Some c -> Some { rows = r; cols = c }
+                | _ -> None)
             | _ -> None)
         | None -> None)
   with _ -> None
@@ -350,7 +352,7 @@ let get_size () =
   | None ->
       let measured = measure_size () in
       (match measured with
-      | Some _ -> Atomic.set _size_cache measured
+      | Some _ -> ignore (Atomic.compare_and_set _size_cache None measured)
       | None -> ());
       measured
 

--- a/lib/term.ml
+++ b/lib/term.ml
@@ -313,10 +313,6 @@ let%test "repeat" = String.equal (repeat 3 "ab") "ababab"
 type size = { rows : int; cols : int } [@@deriving show, eq]
 (** Terminal size as rows × cols. *)
 
-(* SIGWINCH is not exposed by [Stdlib.Sys]. The value is 28 on both Linux and
-   macOS, the only platforms this project targets. *)
-let sigwinch = 28
-
 (** Cached terminal size. Cleared by the SIGWINCH handler installed via
     {!Raw.install_suspend_handlers}, and refilled on the next {!get_size} call.
     [Atomic.t] because the SIGWINCH handler runs in an async-signal context. *)
@@ -468,7 +464,7 @@ module Raw = struct
     in
     _saved_handlers := Some (prev_tstp, prev_cont);
     let prev_winch =
-      Stdlib.Sys.signal sigwinch
+      Stdlib.Sys.signal Stdlib.Sys.sigwinch
         (Stdlib.Sys.Signal_handle
            (fun _signum ->
              invalidate_size_cache ();
@@ -487,7 +483,8 @@ module Raw = struct
     _saved_handlers := None;
     (match !_saved_winch_handler with
     | None -> ()
-    | Some prev_winch -> ignore (Stdlib.Sys.signal sigwinch prev_winch));
+    | Some prev_winch ->
+        ignore (Stdlib.Sys.signal Stdlib.Sys.sigwinch prev_winch));
     _saved_winch_handler := None;
     match Atomic.exchange _saved_state None with
     | Some state -> leave state

--- a/lib/term.ml
+++ b/lib/term.ml
@@ -313,21 +313,46 @@ let%test "repeat" = String.equal (repeat 3 "ab") "ababab"
 type size = { rows : int; cols : int } [@@deriving show, eq]
 (** Terminal size as rows × cols. *)
 
-(** Query terminal size via stty. Returns None if the terminal size cannot be
-    determined. *)
-let get_size () =
+(* SIGWINCH is not exposed by [Stdlib.Sys]. The value is 28 on both Linux and
+   macOS, the only platforms this project targets. *)
+let sigwinch = 28
+
+(** Cached terminal size. Cleared by the SIGWINCH handler installed via
+    {!Raw.install_suspend_handlers}, and refilled on the next {!get_size} call.
+    [Atomic.t] because the SIGWINCH handler runs in an async-signal context. *)
+let _size_cache : size option Atomic.t = Atomic.make None
+
+let invalidate_size_cache () = Atomic.set _size_cache None
+
+(** Run [stty size] and parse the result. Always closes the pipe, even if the
+    intermediate reads raise. *)
+let measure_size () =
   try
     let ic = Unix.open_process_in "stty size 2>/dev/null </dev/tty" in
-    let line = In_channel.input_line ic in
-    let _ = Unix.close_process_in ic in
-    match line with
-    | Some s -> (
-        match String.split s ~on:' ' with
-        | [ rows; cols ] ->
-            Some { rows = Int.of_string rows; cols = Int.of_string cols }
-        | _ -> None)
-    | None -> None
+    Stdlib.Fun.protect
+      ~finally:(fun () -> try ignore (Unix.close_process_in ic) with _ -> ())
+      (fun () ->
+        match In_channel.input_line ic with
+        | Some s -> (
+            match String.split s ~on:' ' with
+            | [ rows; cols ] ->
+                Some { rows = Int.of_string rows; cols = Int.of_string cols }
+            | _ -> None)
+        | None -> None)
   with _ -> None
+
+(** Query terminal size. Returns a cached value when available, repopulating
+    from [stty] on first call and after each SIGWINCH. Returns [None] if the
+    size cannot be determined. *)
+let get_size () =
+  match Atomic.get _size_cache with
+  | Some _ as cached -> cached
+  | None ->
+      let measured = measure_size () in
+      (match measured with
+      | Some _ -> Atomic.set _size_cache measured
+      | None -> ());
+      measured
 
 (** Raw mode management. Saves/restores original termios settings. *)
 module Raw = struct
@@ -362,6 +387,8 @@ module Raw = struct
   let _saved_handlers :
       (Stdlib.Sys.signal_behavior * Stdlib.Sys.signal_behavior) option ref =
     ref None
+
+  let _saved_winch_handler : Stdlib.Sys.signal_behavior option ref = ref None
 
   (** Flag set by the SIGCONT handler to request an immediate TUI redraw. The
       TUI render loop should check and clear this each iteration. *)
@@ -428,7 +455,15 @@ module Raw = struct
                  (Clear.screen ^ Cursor.move_to ~row:1 ~col:1 ^ Cursor.hide);
                Atomic.set redraw_needed true)))
     in
-    _saved_handlers := Some (prev_tstp, prev_cont)
+    _saved_handlers := Some (prev_tstp, prev_cont);
+    let prev_winch =
+      Stdlib.Sys.signal sigwinch
+        (Stdlib.Sys.Signal_handle
+           (fun _signum ->
+             invalidate_size_cache ();
+             Atomic.set redraw_needed true))
+    in
+    _saved_winch_handler := Some prev_winch
 
   (** Clean up suspend handlers, restoring previous handlers and clearing saved
       state. *)
@@ -439,6 +474,10 @@ module Raw = struct
         ignore (Stdlib.Sys.signal Stdlib.Sys.sigtstp prev_tstp);
         ignore (Stdlib.Sys.signal Stdlib.Sys.sigcont prev_cont));
     _saved_handlers := None;
+    (match !_saved_winch_handler with
+    | None -> ()
+    | Some prev_winch -> ignore (Stdlib.Sys.signal sigwinch prev_winch));
+    _saved_winch_handler := None;
     match Atomic.exchange _saved_state None with
     | Some state -> leave state
     | None -> ()

--- a/lib/term.ml
+++ b/lib/term.ml
@@ -324,23 +324,32 @@ let _size_cache : size option Atomic.t = Atomic.make None
 
 let invalidate_size_cache () = Atomic.set _size_cache None
 
-(** Run [stty size] and parse the result. Always closes the pipe, even if the
-    intermediate reads raise. *)
+(** Run [stty size] and parse the result. Closes the pipe in the body so the
+    exit status can be checked; [finally] guards against the body raising before
+    the close. Returns [None] unless [stty] exits 0 with parseable output. *)
 let measure_size () =
   try
     let ic = Unix.open_process_in "stty size 2>/dev/null </dev/tty" in
+    let status = ref None in
     Stdlib.Fun.protect
-      ~finally:(fun () -> try ignore (Unix.close_process_in ic) with _ -> ())
+      ~finally:(fun () ->
+        if Option.is_none !status then
+          try ignore (Unix.close_process_in ic) with _ -> ())
       (fun () ->
         match In_channel.input_line ic with
+        | None -> None
         | Some s -> (
-            match String.split s ~on:' ' with
-            | [ rows; cols ] -> (
-                match (Int.of_string_opt rows, Int.of_string_opt cols) with
-                | Some r, Some c -> Some { rows = r; cols = c }
+            let st = Unix.close_process_in ic in
+            status := Some st;
+            match st with
+            | Unix.WEXITED 0 -> (
+                match String.split s ~on:' ' with
+                | [ rows; cols ] -> (
+                    match (Int.of_string_opt rows, Int.of_string_opt cols) with
+                    | Some r, Some c -> Some { rows = r; cols = c }
+                    | _ -> None)
                 | _ -> None)
-            | _ -> None)
-        | None -> None)
+            | Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> None))
   with _ -> None
 
 (** Query terminal size. Returns a cached value when available, repopulating


### PR DESCRIPTION
## Summary

- **`Term.get_size` no longer forks per redraw.** The TUI called `stty size` via `Unix.open_process_in` on every render frame (`bin/main.ml:1075`) and every click event (`bin/main.ml:1611`, `bin/main.ml:1737`). At TUI refresh rates that's thousands of short-lived subprocesses and pipes per minute — high concurrent FD pressure and a plausible contributor to a recent machine-wide "too many open files" incident. `get_size` now returns a cached value invalidated by a SIGWINCH handler installed alongside the existing TSTP/CONT handlers in `Raw.install_suspend_handlers` / `clear_suspend_handlers`.
- **Cache-miss path hardened.** `measure_size` wraps `Unix.open_process_in` in `Fun.protect` so the pipe closes even if `input_line` raises.
- **Three subprocess probes stop leaking on non-`End_of_file` exceptions.** `infer_owner_repo`, `infer_github_token`, and `infer_default_branch` now route through a new local `read_process_capture` helper that guarantees `close_process_in` on every exception path. Matches on `Unix.process_status` are now exhaustive (warning 4 is fatal in this build).
- **Two unprotected file reads wrapped in `Fun.protect`.** `read_file_opt` in `lib/debug_upload.ml` and `read_artifact_file` in `bin/main.ml` would leak the channel if `in_channel_length` or `really_input` raised.

Context: plan at `~/.claude/plans/yes-let-s-plan-all-composed-axolotl.md`. Already-safe sites (`event_log.ml`, `persistence.ml`, `project_store.ml`, `prompt.ml`, and Eio-switch-owned pipes in `claude_runner.ml` / `llm_backend.ml`) were inspected and left untouched.

## Test plan

- [x] `dune build` clean with fatal warnings config
- [x] `dune runtest` all green
- [ ] Manual TUI smoke: launch `onton`, resize the terminal a few times, confirm the layout reflows (SIGWINCH path fires) and `ps` shows no `stty size` children in steady state (cache path works)
- [ ] `lsof -p <onton-pid>` before and after a few minutes of TUI activity — FD count should be flat

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cache terminal size and invalidate on SIGWINCH to stop per-frame `stty` forks and reduce FD churn. Validate `stty` exit status and harden subprocess and file reads to always close FDs on errors.

- **Bug Fixes**
  - Subprocess probes (`infer_owner_repo`, `infer_github_token`, `infer_default_branch`) now use a `read_process_capture` helper that always closes pipes, avoids double-closing, and matches `Unix.process_status` exhaustively.
  - `read_artifact_file` and `debug_upload.read_file_opt` use `Fun.protect` with `close_in_noerr` to close channels on errors.
  - Terminal size reads: `measure_size` checks `stty` exit status before parsing and uses `Int.of_string_opt` so bad output returns `None` without raising.

- **Refactors**
  - `Term.get_size` returns a cached value; the cache is invalidated by a new SIGWINCH handler installed/restored in `Raw.install_suspend_handlers`/`clear_suspend_handlers`, and published via `Atomic.compare_and_set` to keep updates single-writer.
  - Use `Stdlib.Sys.sigwinch` instead of a hard-coded 28.

<sup>Written for commit ab7250091e7d034d8846db3d3b699d47a984b453. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

