### PR TITLE
Let orchestrator-run Rebase bypass needs_intervention

### DIFF
--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -418,6 +418,10 @@ type rebase_effect = Push_branch [@@deriving show, eq, sexp_of]
 let apply_rebase_result t patch_id rebase_result new_base =
   match rebase_result with
   | Worktree.Ok ->
+      (* TODO: consider calling [reset_intervention_state] on a successful
+         rebase — a fresh base may well have resolved the CI failure, noop
+         cycle, or other condition that latched [needs_intervention]. Left
+         conservative for now: rebase only clears conflict-specific state. *)
       let t = set_base_branch t patch_id new_base in
       let t =
         update_agent t patch_id ~f:(fun a ->

--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -318,10 +318,16 @@ let plan_action_for_patch t ~branch_map patch_id =
     in
     Some (Orchestrator.Start (patch_id, base))
   else if
+    (* Rebase is exempt from [needs_intervention] because it is
+       orchestrator-executed (no LLM session) and does not mutate the
+       counters that triggered intervention. Otherwise a [needs-help] patch
+       would sit on a stale base until a human message happened to land and
+       flip the Human exemption inside [Patch_agent.needs_intervention]. A
+       conflict outcome still enqueues [Merge_conflict], which keeps the
+       patch blocked until an LLM session can run. *)
     Patch_agent.has_pr agent
     && (not agent.Patch_agent.merged)
     && (not agent.Patch_agent.busy)
-    && (not (Patch_agent.needs_intervention agent))
     && (not agent.Patch_agent.branch_blocked)
     && List.mem agent.Patch_agent.queue Operation_kind.Rebase
          ~equal:Operation_kind.equal

--- a/test/test_patch_controller.ml
+++ b/test/test_patch_controller.ml
@@ -350,7 +350,8 @@ let () =
             ~notified_base_branch:(Some branch) ~ci_failure_count:3
             ~session_fallback:Patch_agent.Fresh_available ~human_messages:[]
             ~inflight_human_messages:[] ~ci_checks:[] ~merge_ready:false
-            ~is_draft:false ~pr_body_delivered:true ~start_attempts_without_pr:0
+            ~is_draft:false ~pr_body_delivered:true
+            ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
             ~conflict_noop_count:0 ~no_commits_push_count:0
             ~branch_rebased_onto:None ~checks_passing:false ~current_op:None
             ~current_message_id:None ~generation:0 ~worktree_path:None
@@ -389,7 +390,8 @@ let () =
             ~notified_base_branch:(Some branch) ~ci_failure_count:3
             ~session_fallback:Patch_agent.Fresh_available ~human_messages:[]
             ~inflight_human_messages:[] ~ci_checks:[] ~merge_ready:false
-            ~is_draft:false ~pr_body_delivered:true ~start_attempts_without_pr:0
+            ~is_draft:false ~pr_body_delivered:true
+            ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
             ~conflict_noop_count:0 ~no_commits_push_count:0
             ~branch_rebased_onto:None ~checks_passing:false ~current_op:None
             ~current_message_id:None ~generation:0 ~worktree_path:None

--- a/test/test_patch_controller.ml
+++ b/test/test_patch_controller.ml
@@ -326,6 +326,89 @@ let () =
                | Orchestrator.Respond _ | Orchestrator.Rebase _ -> false)))
   in
 
+  (* Dual of prop_reconcile_all_blocks_restart_after_intervention: the
+     Respond/Start arms of [plan_action_for_patch] gate on
+     [needs_intervention], but the Rebase arm does not — Rebase is
+     orchestrator-executed and must continue tracking the base branch even
+     for patches latched into needs-help. Regression guard: this held even
+     before the fix if Human was in the queue (exemption inside
+     [needs_intervention]), so the property explicitly keeps Human out to
+     exercise the needs-intervention-true path. *)
+  let prop_rebase_not_blocked_by_needs_intervention =
+    Test.make ~name:"patch_controller: needs_intervention does not block Rebase"
+      ~count:200
+      Gen.(pair gen_patch_id gen_branch)
+      (fun (pid, branch) ->
+        let patch = make_patch pid branch in
+        let gameplan = make_gameplan patch in
+        let agent =
+          Patch_agent.restore ~patch_id:pid ~branch
+            ~pr_number:(Some (Pr_number.of_int 42))
+            ~has_session:true ~busy:false ~merged:false
+            ~queue:[ Operation_kind.Rebase ] ~satisfies:false ~changed:false
+            ~has_conflict:false ~base_branch:(Some branch)
+            ~notified_base_branch:(Some branch) ~ci_failure_count:3
+            ~session_fallback:Patch_agent.Fresh_available ~human_messages:[]
+            ~inflight_human_messages:[] ~ci_checks:[] ~merge_ready:false
+            ~is_draft:false ~pr_body_delivered:true ~start_attempts_without_pr:0
+            ~conflict_noop_count:0 ~no_commits_push_count:0
+            ~branch_rebased_onto:None ~checks_passing:false ~current_op:None
+            ~current_message_id:None ~generation:0 ~worktree_path:None
+            ~branch_blocked:false ~llm_session_id:None ~automerge_enabled:false
+            ~automerge_deadline:None ~automerge_inflight:false
+            ~automerge_failure_count:0 ~delivered_ci_run_ids:[]
+        in
+        let orch = make_orch patch agent in
+        let actions =
+          Patch_controller.plan_actions orch ~patches:gameplan.patches
+        in
+        Patch_agent.needs_intervention (Orchestrator.agent orch pid)
+        && List.exists actions ~f:(function
+          | Orchestrator.Rebase (action_pid, _) -> Patch_id.equal action_pid pid
+          | Orchestrator.Start _ | Orchestrator.Respond _ -> false))
+  in
+
+  (* Complement of the above: Respond must still be blocked under
+     needs_intervention. Identical agent except the queue holds a
+     non-Rebase feedback op, so the Rebase arm of [plan_action_for_patch]
+     doesn't apply and the Respond arm's [needs_intervention] guard is
+     what matters. *)
+  let prop_respond_still_blocked_by_needs_intervention =
+    Test.make ~name:"patch_controller: needs_intervention still blocks Respond"
+      ~count:200
+      Gen.(pair gen_patch_id gen_branch)
+      (fun (pid, branch) ->
+        let patch = make_patch pid branch in
+        let gameplan = make_gameplan patch in
+        let agent =
+          Patch_agent.restore ~patch_id:pid ~branch
+            ~pr_number:(Some (Pr_number.of_int 42))
+            ~has_session:true ~busy:false ~merged:false
+            ~queue:[ Operation_kind.Ci ] ~satisfies:false ~changed:false
+            ~has_conflict:false ~base_branch:(Some branch)
+            ~notified_base_branch:(Some branch) ~ci_failure_count:3
+            ~session_fallback:Patch_agent.Fresh_available ~human_messages:[]
+            ~inflight_human_messages:[] ~ci_checks:[] ~merge_ready:false
+            ~is_draft:false ~pr_body_delivered:true ~start_attempts_without_pr:0
+            ~conflict_noop_count:0 ~no_commits_push_count:0
+            ~branch_rebased_onto:None ~checks_passing:false ~current_op:None
+            ~current_message_id:None ~generation:0 ~worktree_path:None
+            ~branch_blocked:false ~llm_session_id:None ~automerge_enabled:false
+            ~automerge_deadline:None ~automerge_inflight:false
+            ~automerge_failure_count:0 ~delivered_ci_run_ids:[]
+        in
+        let orch = make_orch patch agent in
+        let actions =
+          Patch_controller.plan_actions orch ~patches:gameplan.patches
+        in
+        Patch_agent.needs_intervention (Orchestrator.agent orch pid)
+        && not
+             (List.exists actions ~f:(function
+               | Orchestrator.Respond (action_pid, _) ->
+                   Patch_id.equal action_pid pid
+               | Orchestrator.Start _ | Orchestrator.Rebase _ -> false)))
+  in
+
   let prop_reconcile_all_converges_after_acknowledged_effects =
     Test.make
       ~name:
@@ -887,6 +970,8 @@ let () =
       prop_intervention_stable_after_threshold;
       prop_reconcile_all_exposes_pr_body_as_next_action;
       prop_reconcile_all_blocks_restart_after_intervention;
+      prop_rebase_not_blocked_by_needs_intervention;
+      prop_respond_still_blocked_by_needs_intervention;
       prop_reconcile_all_converges_after_acknowledged_effects;
       prop_poll_to_controller_promotes_ready_after_pr_body;
       prop_poll_ci_failure_never_erases_pr_body_followup;


### PR DESCRIPTION
## Summary

- A reconciler-enqueued Rebase used to sit indefinitely in the queue once a patch latched into needs-help (`ci_failure_count >= 3`, `conflict_noop_count >= 2`, `no_commits_push_count >= 2`, or `Given_up`). The only unblock path was a human message landing in the queue — that flipped the Human exemption inside `Patch_agent.needs_intervention` off, which in turn let the higher-priority Rebase run.
- Drop the `needs_intervention` guard on the Rebase arm of `plan_action_for_patch`. Rebase is purely orchestrator-executed (no LLM session), doesn't mutate the counters that triggered intervention, and a conflict outcome enqueues `Merge_conflict` which keeps the patch blocked until an LLM session can run. Start and Respond still honor the guard.
- Two targeted property tests (200 shrinks each) codify the new behavior and its complement:
  - `needs_intervention does not block Rebase` — positive regression guard; sanity-checked to fail in 8 shrink steps against the pre-fix `plan_action_for_patch`.
  - `needs_intervention still blocks Respond` — keeps us honest about not over-fixing.
- TODO planted at `apply_rebase_result Worktree.Ok` for a future enhancement: call `reset_intervention_state` on a successful rebase, since a fresh base can legitimately resolve the condition that latched needs-help in the first place. Left conservative for this PR.

## Test plan

- [x] `dune build` clean
- [x] `dune runtest` green (including the two new properties)
- [x] Verified the positive property fails against the pre-fix code (shrinks to a minimal counterexample in 8 steps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/206"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Rebase operations in patch orchestration now proceed correctly even when intervention is required, eliminating unnecessary blocking of automated rebase tasks.

* **Tests**
  * Added regression tests to ensure rebase operations remain executable regardless of intervention state, and that other operation types remain appropriately blocked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let orchestrator-run Rebases bypass `needs_intervention` so needs-help patches keep tracking the base without waiting for a human message. Start and Respond still honor intervention.

- **Bug Fixes**
  - Removed the `needs_intervention` guard for the Rebase arm in `plan_action_for_patch`.
  - Conflict outcomes still enqueue `Merge_conflict`, keeping the patch blocked until an LLM session runs.
  - Added property tests: “needs_intervention does not block Rebase” and “needs_intervention still blocks Respond” (200 runs each).
  - TODO in `apply_rebase_result`: consider `reset_intervention_state` on successful rebase.

<sup>Written for commit eb463723ef2e1a9368baff437e122bdd548d3fdd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

