### PR TITLE
Infer dep edge for ad-hoc patches stacked on tracked branches

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1450,8 +1450,12 @@ let input_fiber ~runtime ~process_mgr ~net ~github ~list_selected ~detail_scroll
                                 Pr_registry.register pr_registry ~patch_id
                                   ~pr_number;
                                 Runtime.update_orchestrator runtime (fun orch ->
+                                    let base_branch =
+                                      Option.value pr_state.Pr_state.base_branch
+                                        ~default:(Orchestrator.main_branch orch)
+                                    in
                                     Orchestrator.add_agent orch ~patch_id
-                                      ~branch ~pr_number);
+                                      ~branch ~base_branch ~pr_number);
                                 log_event runtime ~patch_id
                                   (Printf.sprintf "Ad-hoc PR #%d added (%s)" n
                                      (Branch.to_string branch))))

--- a/lib/graph.ml
+++ b/lib/graph.ml
@@ -94,6 +94,22 @@ let add_patch_with_deps t patch_id ~deps =
 
 let add_patch t patch_id = add_patch_with_deps t patch_id ~deps:[]
 
+let add_dependency t patch_id ~dep =
+  if Patch_id.equal patch_id dep then t
+  else if not (Map.mem t.deps_map patch_id) then t
+  else if not (Map.mem t.deps_map dep) then t
+  else
+    let existing = Map.find t.deps_map patch_id |> Option.value ~default:[] in
+    if List.mem existing dep ~equal:Patch_id.equal then t
+    else
+      {
+        deps_map = Map.set t.deps_map ~key:patch_id ~data:(dep :: existing);
+        dependents_map =
+          Map.update t.dependents_map dep ~f:(fun existing ->
+              patch_id :: Option.value existing ~default:[]);
+        all_ids = t.all_ids;
+      }
+
 let remove_patch t patch_id =
   {
     deps_map = Map.remove t.deps_map patch_id;

--- a/lib/graph.ml
+++ b/lib/graph.ml
@@ -112,6 +112,9 @@ let add_dependency t patch_id ~dep =
 
 let remove_patch t patch_id =
   let deps = Map.find t.deps_map patch_id |> Option.value ~default:[] in
+  let dependents =
+    Map.find t.dependents_map patch_id |> Option.value ~default:[]
+  in
   let dependents_map =
     List.fold deps ~init:t.dependents_map ~f:(fun acc dep_id ->
         Map.change acc dep_id ~f:(function
@@ -122,8 +125,18 @@ let remove_patch t patch_id =
               in
               if List.is_empty lst' then None else Some lst'))
   in
+  let deps_map =
+    List.fold dependents ~init:t.deps_map ~f:(fun acc dependent_id ->
+        Map.change acc dependent_id ~f:(function
+          | None -> None
+          | Some lst ->
+              let lst' =
+                List.filter lst ~f:(fun d -> not (Patch_id.equal d patch_id))
+              in
+              Some lst'))
+  in
   {
-    deps_map = Map.remove t.deps_map patch_id;
+    deps_map = Map.remove deps_map patch_id;
     dependents_map = Map.remove dependents_map patch_id;
     all_ids =
       List.filter t.all_ids ~f:(fun id -> not (Patch_id.equal id patch_id));

--- a/lib/graph.ml
+++ b/lib/graph.ml
@@ -73,14 +73,26 @@ let dependents t patch_id =
 
 let all_patch_ids t = t.all_ids
 
-let add_patch t patch_id =
+let add_patch_with_deps t patch_id ~deps =
   if Map.mem t.deps_map patch_id then t
   else
+    let deps =
+      List.filter deps ~f:(Map.mem t.deps_map)
+      |> dedup_deps
+      |> List.filter ~f:(fun d -> not (Patch_id.equal d patch_id))
+    in
+    let dependents_map =
+      List.fold deps ~init:t.dependents_map ~f:(fun acc dep_id ->
+          Map.update acc dep_id ~f:(fun existing ->
+              patch_id :: Option.value existing ~default:[]))
+    in
     {
-      deps_map = Map.set t.deps_map ~key:patch_id ~data:[];
-      dependents_map = t.dependents_map;
+      deps_map = Map.set t.deps_map ~key:patch_id ~data:deps;
+      dependents_map;
       all_ids = t.all_ids @ [ patch_id ];
     }
+
+let add_patch t patch_id = add_patch_with_deps t patch_id ~deps:[]
 
 let remove_patch t patch_id =
   {

--- a/lib/graph.ml
+++ b/lib/graph.ml
@@ -111,9 +111,20 @@ let add_dependency t patch_id ~dep =
       }
 
 let remove_patch t patch_id =
+  let deps = Map.find t.deps_map patch_id |> Option.value ~default:[] in
+  let dependents_map =
+    List.fold deps ~init:t.dependents_map ~f:(fun acc dep_id ->
+        Map.change acc dep_id ~f:(function
+          | None -> None
+          | Some lst ->
+              let lst' =
+                List.filter lst ~f:(fun d -> not (Patch_id.equal d patch_id))
+              in
+              if List.is_empty lst' then None else Some lst'))
+  in
   {
     deps_map = Map.remove t.deps_map patch_id;
-    dependents_map = Map.remove t.dependents_map patch_id;
+    dependents_map = Map.remove dependents_map patch_id;
     all_ids =
       List.filter t.all_ids ~f:(fun id -> not (Patch_id.equal id patch_id));
   }

--- a/lib/graph.mli
+++ b/lib/graph.mli
@@ -88,6 +88,12 @@ val add_patch_with_deps :
     the existing rebase machinery (detect_rebases, initial_base, …) treats the
     patch like any other stacked patch. *)
 
+val add_dependency : t -> Types.Patch_id.t -> dep:Types.Patch_id.t -> t
+(** [add_dependency t pid ~dep] adds an edge [pid -> dep] to the graph. No-op if
+    either endpoint is absent, if [pid = dep], or if the edge already exists.
+    Intended for snapshot restore, where ad-hoc patches are first added as bare
+    nodes and then linked once all nodes are present. *)
+
 val remove_patch : t -> Types.Patch_id.t -> t
 (** [remove_patch t pid] removes an ad-hoc patch from the graph. The patch must
     have no dependents — removing a patch that others depend on is not

--- a/lib/graph.mli
+++ b/lib/graph.mli
@@ -95,6 +95,6 @@ val add_dependency : t -> Types.Patch_id.t -> dep:Types.Patch_id.t -> t
     nodes and then linked once all nodes are present. *)
 
 val remove_patch : t -> Types.Patch_id.t -> t
-(** [remove_patch t pid] removes an ad-hoc patch from the graph. The patch must
-    have no dependents — removing a patch that others depend on is not
-    supported. *)
+(** [remove_patch t pid] removes an ad-hoc patch from the graph. Any edges
+    pointing at [pid] from its dependents are also dropped, so the resulting
+    graph is consistent (no dangling edges to a removed patch). *)

--- a/lib/graph.mli
+++ b/lib/graph.mli
@@ -73,7 +73,20 @@ val all_patch_ids : t -> Types.Patch_id.t list
 
 val add_patch : t -> Types.Patch_id.t -> t
 (** [add_patch t pid] registers an ad-hoc patch with no dependencies. No-op if
-    [pid] is already in the graph. Per spec: "Added patches have no deps." *)
+    [pid] is already in the graph. Equivalent to
+    [add_patch_with_deps t pid ~deps:[]]. *)
+
+val add_patch_with_deps :
+  t -> Types.Patch_id.t -> deps:Types.Patch_id.t list -> t
+(** [add_patch_with_deps t pid ~deps] registers an ad-hoc patch with inferred
+    dependency edges. Deps not already present in [t] are silently dropped
+    (defensive — unknown ids cannot introduce dangling edges). Self-edges are
+    dropped. No-op if [pid] is already in the graph.
+
+    Used when an ad-hoc patch's PR base branch matches an already-tracked
+    patch's branch: the observed stacking is recorded as a real graph edge so
+    the existing rebase machinery (detect_rebases, initial_base, …) treats the
+    patch like any other stacked patch. *)
 
 val remove_patch : t -> Types.Patch_id.t -> t
 (** [remove_patch t pid] removes an ad-hoc patch from the graph. The patch must

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -406,11 +406,29 @@ let main_branch t = t.main_branch
 let set_main_branch t branch = { t with main_branch = branch }
 let agents_map t = t.agents
 
-let add_agent t ~patch_id ~branch ~pr_number =
+let find_patch_by_branch t branch =
+  Map.to_alist t.agents
+  |> List.find ~f:(fun (_, a) -> Branch.equal a.Patch_agent.branch branch)
+  |> Option.map ~f:fst
+
+let add_agent t ~patch_id ~branch ~base_branch ~pr_number =
   if Map.mem t.agents patch_id then t
   else
+    let deps =
+      if Branch.equal base_branch t.main_branch then []
+      else
+        match find_patch_by_branch t base_branch with
+        | Some dep_pid -> (
+            match find_agent t dep_pid with
+            | Some a when not a.Patch_agent.merged -> [ dep_pid ]
+            | _ -> [])
+        | None -> []
+    in
+    (* Do not seed agent.base_branch: persistence infers branch_rebased_onto
+       from base_branch when the former is absent, which would fabricate a
+       stale-rebase state on round-trip. The poller populates it next tick. *)
     let agent = Patch_agent.create_adhoc ~patch_id ~branch ~pr_number in
-    let graph = Graph.add_patch t.graph patch_id in
+    let graph = Graph.add_patch_with_deps t.graph patch_id ~deps in
     { t with graph; agents = Map.set t.agents ~key:patch_id ~data:agent }
 
 type rebase_effect = Push_branch [@@deriving show, eq, sexp_of]

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -124,10 +124,24 @@ val set_main_branch : t -> Branch.t -> t
 val agents_map : t -> Patch_agent.t Map.M(Patch_id).t
 
 val add_agent :
-  t -> patch_id:Patch_id.t -> branch:Branch.t -> pr_number:Pr_number.t -> t
+  t ->
+  patch_id:Patch_id.t ->
+  branch:Branch.t ->
+  base_branch:Branch.t ->
+  pr_number:Pr_number.t ->
+  t
 (** Add an ad-hoc agent for a PR not in the gameplan. No-op if the patch_id
-    already exists. The agent starts with [has_pr = true] and no dependencies.
-    Corresponds to the spec's Add action. *)
+    already exists. The agent starts with [has_pr = true] and no deps by
+    default.
+
+    [base_branch] is inspected only for dependency-edge inference: if it matches
+    the [branch] of another unmerged tracked patch, a graph edge from the new
+    patch to that patch is recorded so the existing rebase machinery
+    (detect_rebases, initial_base) treats the stacked ad-hoc PR like any other
+    stacked patch. If [base_branch] is the main branch, an unknown branch, or a
+    merged patch's branch, no edge is inferred. The agent's own [base_branch]
+    field is populated by the poller on the next tick. Corresponds to the spec's
+    Add action. *)
 
 (** {2 Persistence support} *)
 

--- a/lib/persistence.ml
+++ b/lib/persistence.ml
@@ -465,10 +465,17 @@ let orchestrator_of_yojson ~gameplan json =
              Mirrors the inference in [Orchestrator.add_agent] so a snapshot
              restored after a stacked ad-hoc PR was added retains the edge
              that drives detect_rebases on the dep's merge. *)
+          let branch_to_pid =
+            Map.fold agents_map
+              ~init:(Hashtbl.create (module String))
+              ~f:(fun ~key:pid ~data:ag acc ->
+                Hashtbl.set acc
+                  ~key:(Branch.to_string ag.Patch_agent.branch)
+                  ~data:pid;
+                acc)
+          in
           let find_by_branch br =
-            Map.to_alist agents_map
-            |> List.find ~f:(fun (_, a) -> Branch.equal a.Patch_agent.branch br)
-            |> Option.map ~f:fst
+            Hashtbl.find branch_to_pid (Branch.to_string br)
           in
           let graph =
             Set.fold adhoc_pids ~init:graph ~f:(fun g pid ->

--- a/lib/persistence.ml
+++ b/lib/persistence.ml
@@ -458,10 +458,35 @@ let orchestrator_of_yojson ~gameplan json =
         if not (Set.is_empty missing_agent_pids) then
           Error "snapshot missing agent state for one or more gameplan patches"
         else
+          let adhoc_pids = Set.diff agent_pids graph_pids in
+          let graph = Set.fold adhoc_pids ~init:graph ~f:Graph.add_patch in
+          (* Infer stacking edges for ad-hoc patches whose persisted
+             base_branch matches another tracked unmerged agent's branch.
+             Mirrors the inference in [Orchestrator.add_agent] so a snapshot
+             restored after a stacked ad-hoc PR was added retains the edge
+             that drives detect_rebases on the dep's merge. *)
+          let find_by_branch br =
+            Map.to_alist agents_map
+            |> List.find ~f:(fun (_, a) -> Branch.equal a.Patch_agent.branch br)
+            |> Option.map ~f:fst
+          in
           let graph =
-            Set.fold
-              (Set.diff agent_pids graph_pids)
-              ~init:graph ~f:Graph.add_patch
+            Set.fold adhoc_pids ~init:graph ~f:(fun g pid ->
+                match Map.find agents_map pid with
+                | None -> g
+                | Some ag -> (
+                    match ag.Patch_agent.base_branch with
+                    | None -> g
+                    | Some base when Branch.equal base main_branch -> g
+                    | Some base -> (
+                        match find_by_branch base with
+                        | None -> g
+                        | Some dep_pid when Patch_id.equal dep_pid pid -> g
+                        | Some dep_pid -> (
+                            match Map.find agents_map dep_pid with
+                            | Some dep_ag when not dep_ag.Patch_agent.merged ->
+                                Graph.add_dependency g pid ~dep:dep_pid
+                            | _ -> g))))
           in
           Ok
             (Orchestrator.restore ~graph ~agents:agents_map ~outbox ~main_branch))

--- a/lib/persistence.ml
+++ b/lib/persistence.ml
@@ -467,13 +467,20 @@ let orchestrator_of_yojson ~gameplan json =
              that drives detect_rebases on the dep's merge. *)
           let branch_to_pid =
             Map.fold agents_map
-              ~init:(Hashtbl.create (module String))
+              ~init:(Ok (Hashtbl.create (module String)))
               ~f:(fun ~key:pid ~data:ag acc ->
-                Hashtbl.set acc
-                  ~key:(Branch.to_string ag.Patch_agent.branch)
-                  ~data:pid;
-                acc)
+                match acc with
+                | Error _ as e -> e
+                | Ok tbl -> (
+                    let key = Branch.to_string ag.Patch_agent.branch in
+                    match Hashtbl.add tbl ~key ~data:pid with
+                    | `Ok -> Ok tbl
+                    | `Duplicate ->
+                        Error
+                          (Printf.sprintf "duplicate branch %s across agents"
+                             key)))
           in
+          let* branch_to_pid = branch_to_pid in
           let find_by_branch br =
             Hashtbl.find branch_to_pid (Branch.to_string br)
           in

--- a/test/test_interleaving_properties.ml
+++ b/test/test_interleaving_properties.ml
@@ -485,7 +485,7 @@ let rec apply_command orch patches cmd =
       with Invalid_argument _ -> orch)
   | Add_adhoc i ->
       Orchestrator.add_agent orch ~patch_id:(adhoc_pid i)
-        ~branch:(adhoc_branch i) ~pr_number:(adhoc_pr i)
+        ~branch:(adhoc_branch i) ~base_branch:main ~pr_number:(adhoc_pr i)
   | Remove_adhoc i -> Orchestrator.remove_agent orch (adhoc_pid i)
   | Discover_pr patch_idx -> (
       let pid = resolve_pid patches patch_idx in
@@ -1333,7 +1333,7 @@ let () =
         let pid = adhoc_pid 0 in
         let orch =
           Orchestrator.add_agent orch ~patch_id:pid ~branch:(adhoc_branch 0)
-            ~pr_number:(adhoc_pr 0)
+            ~base_branch:main ~pr_number:(adhoc_pr 0)
         in
         (* Poll conflict to enqueue Merge_conflict on the ad-hoc patch *)
         let poll_result =
@@ -2351,3 +2351,170 @@ let () =
   in
   QCheck2.Test.check_exn prop_cv5;
   Stdlib.print_endline "CV-5 passed"
+
+(** PI-AH-1..5: Ad-hoc stacking inference.
+
+    When an ad-hoc patch B is added with [base_branch] matching an already-
+    tracked, unmerged patch A's branch, the graph must record a B→A dep edge so
+    the existing rebase machinery fires on A's merge. base = main, an unknown
+    branch, or an already-merged patch's branch must NOT create an edge. *)
+
+let reconcile_views_of orch =
+  let agents = Orchestrator.all_agents orch in
+  List.map agents ~f:(fun (ag : Patch_agent.t) ->
+      Reconciler.
+        {
+          id = ag.Patch_agent.patch_id;
+          has_pr = Patch_agent.has_pr ag;
+          merged = ag.Patch_agent.merged;
+          busy = ag.Patch_agent.busy;
+          needs_intervention = Patch_agent.needs_intervention ag;
+          branch_blocked = ag.Patch_agent.branch_blocked;
+          queue = ag.Patch_agent.queue;
+          base_branch = Option.value ag.Patch_agent.base_branch ~default:main;
+          branch_rebased_onto = ag.Patch_agent.branch_rebased_onto;
+        })
+
+let () =
+  let prop =
+    QCheck2.Test.make
+      ~name:"PI-AH-1: ad-hoc stacked on gameplan patch rebases on merge"
+      ~count:1 (QCheck2.Gen.return ()) (fun () ->
+        let patches = mk_patches 1 in
+        let orch = bootstrap patches in
+        let pid_a = pid_of_idx patches 0 in
+        let a = Orchestrator.agent orch pid_a in
+        let pid_b = adhoc_pid 0 in
+        let orch =
+          Orchestrator.add_agent orch ~patch_id:pid_b ~branch:(adhoc_branch 0)
+            ~base_branch:a.Patch_agent.branch ~pr_number:(adhoc_pr 0)
+        in
+        let graph = Orchestrator.graph orch in
+        if not (List.mem (Graph.deps graph pid_b) pid_a ~equal:Patch_id.equal)
+        then failwith "expected inferred dep B->A";
+        if
+          not
+            (List.mem
+               (Graph.dependents graph pid_a)
+               pid_b ~equal:Patch_id.equal)
+        then failwith "expected reverse dependent A->B";
+        (* Poller observes A's PR merged: pass pid_a in merged_pr_patches
+           while agent is still unmerged so detect_merges fires Mark_merged
+           and detect_rebases sees newly_merged=[A]. *)
+        let branch_of pid =
+          match Orchestrator.find_agent orch pid with
+          | Some ag -> ag.Patch_agent.branch
+          | None -> main
+        in
+        let views = reconcile_views_of orch in
+        let actions =
+          Reconciler.reconcile ~graph:(Orchestrator.graph orch) ~main
+            ~merged_pr_patches:[ pid_a ] ~branch_of views
+        in
+        List.exists actions ~f:(function
+          | Reconciler.Enqueue_rebase p -> Patch_id.equal p pid_b
+          | Reconciler.Mark_merged _ | Reconciler.Start_operation _ -> false))
+  in
+  QCheck2.Test.check_exn prop;
+  Stdlib.print_endline "PI-AH-1 passed"
+
+let () =
+  let prop =
+    QCheck2.Test.make ~name:"PI-AH-2: ad-hoc stacked on ad-hoc rebases on merge"
+      ~count:1 (QCheck2.Gen.return ()) (fun () ->
+        let patches = mk_patches 1 in
+        let orch = bootstrap patches in
+        (* Add ad-hoc A on main *)
+        let pid_a_ah = adhoc_pid 0 in
+        let orch =
+          Orchestrator.add_agent orch ~patch_id:pid_a_ah
+            ~branch:(adhoc_branch 0) ~base_branch:main ~pr_number:(adhoc_pr 0)
+        in
+        (* Add ad-hoc B on A's branch *)
+        let pid_b_ah = adhoc_pid 1 in
+        let orch =
+          Orchestrator.add_agent orch ~patch_id:pid_b_ah
+            ~branch:(adhoc_branch 1) ~base_branch:(adhoc_branch 0)
+            ~pr_number:(adhoc_pr 1)
+        in
+        let graph = Orchestrator.graph orch in
+        if
+          not
+            (List.mem
+               (Graph.deps graph pid_b_ah)
+               pid_a_ah ~equal:Patch_id.equal)
+        then failwith "expected inferred dep B->A(ad-hoc)";
+        (* Poller observes ad-hoc A's PR merged. *)
+        let branch_of pid =
+          match Orchestrator.find_agent orch pid with
+          | Some ag -> ag.Patch_agent.branch
+          | None -> main
+        in
+        let views = reconcile_views_of orch in
+        let actions =
+          Reconciler.reconcile ~graph:(Orchestrator.graph orch) ~main
+            ~merged_pr_patches:[ pid_a_ah ] ~branch_of views
+        in
+        List.exists actions ~f:(function
+          | Reconciler.Enqueue_rebase p -> Patch_id.equal p pid_b_ah
+          | Reconciler.Mark_merged _ | Reconciler.Start_operation _ -> false))
+  in
+  QCheck2.Test.check_exn prop;
+  Stdlib.print_endline "PI-AH-2 passed"
+
+let () =
+  let prop =
+    QCheck2.Test.make ~name:"PI-AH-3: ad-hoc on main has no inferred dep"
+      ~count:1 (QCheck2.Gen.return ()) (fun () ->
+        let patches = mk_patches 1 in
+        let orch = bootstrap patches in
+        let pid_b = adhoc_pid 0 in
+        let orch =
+          Orchestrator.add_agent orch ~patch_id:pid_b ~branch:(adhoc_branch 0)
+            ~base_branch:main ~pr_number:(adhoc_pr 0)
+        in
+        let graph = Orchestrator.graph orch in
+        List.is_empty (Graph.deps graph pid_b))
+  in
+  QCheck2.Test.check_exn prop;
+  Stdlib.print_endline "PI-AH-3 passed"
+
+let () =
+  let prop =
+    QCheck2.Test.make
+      ~name:"PI-AH-4: ad-hoc on unknown external branch has no inferred dep"
+      ~count:1 (QCheck2.Gen.return ()) (fun () ->
+        let patches = mk_patches 1 in
+        let orch = bootstrap patches in
+        let pid_b = adhoc_pid 0 in
+        let orch =
+          Orchestrator.add_agent orch ~patch_id:pid_b ~branch:(adhoc_branch 0)
+            ~base_branch:(Branch.of_string "some-external-branch")
+            ~pr_number:(adhoc_pr 0)
+        in
+        let graph = Orchestrator.graph orch in
+        List.is_empty (Graph.deps graph pid_b))
+  in
+  QCheck2.Test.check_exn prop;
+  Stdlib.print_endline "PI-AH-4 passed"
+
+let () =
+  let prop =
+    QCheck2.Test.make
+      ~name:"PI-AH-5: ad-hoc based on already-merged patch has no inferred dep"
+      ~count:1 (QCheck2.Gen.return ()) (fun () ->
+        let patches = mk_patches 1 in
+        let orch = bootstrap patches in
+        let pid_a = pid_of_idx patches 0 in
+        let a = Orchestrator.agent orch pid_a in
+        let orch = Orchestrator.mark_merged orch pid_a in
+        let pid_b = adhoc_pid 0 in
+        let orch =
+          Orchestrator.add_agent orch ~patch_id:pid_b ~branch:(adhoc_branch 0)
+            ~base_branch:a.Patch_agent.branch ~pr_number:(adhoc_pr 0)
+        in
+        let graph = Orchestrator.graph orch in
+        List.is_empty (Graph.deps graph pid_b))
+  in
+  QCheck2.Test.check_exn prop;
+  Stdlib.print_endline "PI-AH-5 passed"

--- a/test/test_persistence_properties.ml
+++ b/test/test_persistence_properties.ml
@@ -282,6 +282,72 @@ let () =
           | Error _msg -> false
         with _ -> false)
   in
+  (* Restore of a snapshot whose ad-hoc agents encode a stack (B's
+     base_branch = A's branch) must re-infer the dep edge B→A so
+     detect_rebases can fire on A's merge post-restart. Mirrors the
+     real subsetpark-pantagruel PRs 118-on-119 case. *)
+  let adhoc_stack_restore_infers_edge =
+    QCheck2.Test.make ~name:"restore re-infers ad-hoc stack edge" ~count:1
+      (QCheck2.Gen.return ()) (fun () ->
+        try
+          let gameplan =
+            Gameplan.
+              {
+                project_name = "adhoc-stack";
+                problem_statement = "";
+                solution_summary = "";
+                final_state_spec = "";
+                patches = [];
+                current_state_analysis = "";
+                explicit_opinions = "";
+                acceptance_criteria = [];
+                open_questions = [];
+              }
+          in
+          let main_branch = Branch.of_string "main" in
+          let orch = Onton.Orchestrator.create ~patches:[] ~main_branch in
+          (* Add A first (base = main, no edge) *)
+          let pid_a = Patch_id.of_string "a" in
+          let branch_a = Branch.of_string "feature-a" in
+          let orch =
+            Onton.Orchestrator.add_agent orch ~patch_id:pid_a ~branch:branch_a
+              ~base_branch:main_branch ~pr_number:(Pr_number.of_int 100)
+          in
+          (* Seed A's persisted base_branch to main so it survives the
+             round-trip. Without this A.base_branch stays None and the
+             restore has no signal that A is a valid dep target. *)
+          let orch =
+            Onton.Orchestrator.set_base_branch orch pid_a main_branch
+          in
+          (* Add B stacked on A *)
+          let pid_b = Patch_id.of_string "b" in
+          let branch_b = Branch.of_string "feature-b" in
+          let orch =
+            Onton.Orchestrator.add_agent orch ~patch_id:pid_b ~branch:branch_b
+              ~base_branch:branch_a ~pr_number:(Pr_number.of_int 101)
+          in
+          (* Seed B's persisted base_branch — this is what the poller would
+             have done; without it the restore has no basis to infer. *)
+          let orch = Onton.Orchestrator.set_base_branch orch pid_b branch_a in
+          let snap =
+            {
+              Onton.Runtime.orchestrator = orch;
+              activity_log = Onton.Activity_log.empty;
+              gameplan;
+              transcripts = Base.Hashtbl.create (module Patch_id);
+            }
+          in
+          let json = Onton.Persistence.snapshot_to_yojson snap in
+          match Onton.Persistence.snapshot_of_yojson json with
+          | Error _ -> false
+          | Ok snap' ->
+              let g = Onton.Orchestrator.graph snap'.orchestrator in
+              let deps_b = Onton.Graph.deps g pid_b in
+              let dependents_a = Onton.Graph.dependents g pid_a in
+              List.mem deps_b pid_a ~equal:Patch_id.equal
+              && List.mem dependents_a pid_b ~equal:Patch_id.equal
+        with _ -> false)
+  in
   let exit_code =
     QCheck_base_runner.run_tests
       [
@@ -294,6 +360,7 @@ let () =
         missing_pr_number_defaults_none;
         missing_branch_falls_back_to_gameplan;
         adhoc_snapshot_roundtrip;
+        adhoc_stack_restore_infers_edge;
       ]
   in
   if exit_code <> 0 then Stdlib.exit exit_code

--- a/test/test_persistence_properties.ml
+++ b/test/test_persistence_properties.ml
@@ -265,7 +265,8 @@ let () =
                 let branch =
                   Branch.of_string ("feature/pr-" ^ Int.to_string n)
                 in
-                Onton.Orchestrator.add_agent orch ~patch_id ~branch ~pr_number)
+                Onton.Orchestrator.add_agent orch ~patch_id ~branch
+                  ~base_branch:main_branch ~pr_number)
           in
           let snap =
             {


### PR DESCRIPTION
## Summary

- Ad-hoc patches added with a PR base branch matching another tracked, unmerged patch's branch now record a graph dependency edge, so `Reconciler.detect_rebases` fires on the dep's merge.
- Previously only `detect_notified_base_drift` could catch this, and only if GitHub had already auto-retargeted the dependent PR — fragile and scenario-dependent.
- New `Graph.add_patch_with_deps` is the only graph-mutation change; existing `add_patch` is now a `~deps:[]` wrapper.
- `Orchestrator.add_agent` gains `~base_branch` and uses a small inline `find_patch_by_branch` reverse lookup. `base_branch = main`, unknown branches, and already-merged patches infer no edge.
- The agent's own `base_branch` is deliberately NOT seeded at creation — persistence's `branch_rebased_onto` fallback would fabricate a stale-rebase state on round-trip. The poller populates it on the next tick from GitHub state.

## Test plan

- [x] `dune build` — no warnings
- [x] `dune runtest` — all tests pass, including 5 new property tests (PI-AH-1..5):
  - ad-hoc stacked on gameplan patch: edge inferred, rebase enqueued on dep merge
  - ad-hoc stacked on ad-hoc: same
  - ad-hoc on main: no edge
  - ad-hoc on unknown external branch: no edge, no crash
  - ad-hoc on already-merged patch: no edge
- [x] `dune fmt` — clean (two pre-existing unrelated odoc warnings left alone)
- [ ] End-to-end manual (not done in this PR): open PR A on main, PR B on branch A in a test repo; add both as ad-hoc; merge A on GitHub; confirm Rebase fires on B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/207"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ad‑hoc patches now infer a dependency when their PR base matches a tracked, unmerged patch’s branch, and snapshot restore re‑infers these edges so stacks auto‑rebase across restarts. Restore is faster with a branch→pid index and now fails on duplicate agent branches.

- **New Features**
  - Infer a dep when an ad‑hoc PR’s base branch matches another unmerged tracked patch’s branch; skip when base is main, unknown, or merged.
  - Re‑infer stacking edges on snapshot restore from persisted base branches so rebases still trigger after a restart.

- **Bug Fixes**
  - Removing a patch now cleans up edges in both directions to avoid dangling deps.
  - Snapshot restore rejects snapshots with duplicate agent branches to prevent spurious edges.

<sup>Written for commit 632ea25fc92df140b8ae7801782c31c0f53dbc2f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ad-hoc patches now record an explicit base-branch when created, inferring stacking dependencies to existing unmerged patches on that base and enqueuing rebases for dependents when base patches merge.
  * Snapshot restore now re-inferrs and reconstructs stacking edges from persisted base-branch information.

* **Tests**
  * Added property tests covering ad-hoc stacking inference, snapshot persistence/restore of inferred edges, and automatic rebase behavior for stacked patches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->