### PR TITLE
Use GitHub's isOutdated flag instead of SHA heuristic

### DIFF
--- a/lib/github.ml
+++ b/lib/github.ml
@@ -131,6 +131,7 @@ let graphql_query =
         nodes {
           id
           isResolved
+          isOutdated
           # [comments(first: 1)] only returns the thread opener. If a caller
           # ever needs per-reply SHAs, raise this limit and add pagination.
           comments(first: 1) {
@@ -210,7 +211,7 @@ let parse_check_context_node node =
               })
   | _ -> None
 
-let parse_comment_node ~thread_id node =
+let parse_comment_node ~thread_id ~outdated node =
   let open Yojson.Safe.Util in
   let id =
     match node |> member "databaseId" |> to_int_option with
@@ -233,7 +234,16 @@ let parse_comment_node ~thread_id node =
   let commit_sha = oid_of "commit" in
   let original_commit_sha = oid_of "originalCommit" in
   Types.Comment.
-    { id; thread_id; body; path; line; commit_sha; original_commit_sha }
+    {
+      id;
+      thread_id;
+      body;
+      path;
+      line;
+      commit_sha;
+      original_commit_sha;
+      outdated;
+    }
 
 let parse_response_json ~owner json =
   let open Yojson.Safe.Util in
@@ -314,8 +324,20 @@ let parse_response_json ~owner json =
                   if thread |> member "isResolved" |> to_bool then []
                   else
                     let thread_id = thread |> member "id" |> to_string_option in
+                    (* [isOutdated] is the authoritative signal from GitHub:
+                       the thread's anchored lines were changed by a later
+                       commit (or the file was deleted). Do not infer this
+                       from [commit] vs [originalCommit] — GitHub advances
+                       [commit] to whatever commit still contains the line,
+                       including commits that touched unrelated files, so
+                       that comparison flags false positives. *)
+                    let outdated =
+                      match thread |> member "isOutdated" with
+                      | `Bool b -> b
+                      | _ -> false
+                    in
                     thread |> member "comments" |> member "nodes" |> to_list
-                    |> List.map ~f:(parse_comment_node ~thread_id))
+                    |> List.map ~f:(parse_comment_node ~thread_id ~outdated))
             in
             let unresolved_comment_count =
               List.count review_threads ~f:(fun thread ->

--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -506,17 +506,13 @@ let render_review_prompt ~(project_name : string) ?pr_number ?current_head_sha
         | Some n -> Int.to_string (Pr_number.to_int n)
         | None -> "{pr_number}"
       in
-      (* Only claim outdated-ness when GitHub has given us a strong signal:
-         [commit] and [originalCommit] differ, meaning GitHub re-anchored
-         the comment to a later commit (line moved or detached). A null
-         [line] alone is ambiguous — it also covers file-level comments,
-         which are not outdated. With no SHA info, say nothing — matches
-         pre-SHA behavior. *)
-      let is_outdated (c : Comment.t) =
-        match (c.Comment.commit_sha, c.Comment.original_commit_sha) with
-        | Some cur, Some orig when not (String.equal cur orig) -> true
-        | _ -> false
-      in
+      (* [outdated] is GitHub's own [isOutdated] on the thread — the line
+         the comment anchors to was changed by a later commit (or the file
+         was deleted). Do not infer from [commit] vs [originalCommit]:
+         GitHub advances [commit] to any later commit that still contains
+         the anchored line, including commits that touched unrelated
+         files, so that comparison produces false positives. *)
+      let is_outdated (c : Comment.t) = c.Comment.outdated in
       let formatted =
         List.map comments ~f:(fun (c : Comment.t) ->
             let location =
@@ -935,6 +931,7 @@ let%test "review prompt formats comments" =
           line = Some 42;
           commit_sha = None;
           original_commit_sha = None;
+          outdated = false;
         };
       Comment.
         {
@@ -945,6 +942,7 @@ let%test "review prompt formats comments" =
           line = None;
           commit_sha = None;
           original_commit_sha = None;
+          outdated = false;
         };
     ]
   in
@@ -978,6 +976,7 @@ let%expect_test "review prompt includes SHA preamble and per-bullet anchor" =
           line = Some 10;
           commit_sha = Some "47525fdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
           original_commit_sha = Some "47525fdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+          outdated = false;
         };
     ]
   in
@@ -1018,9 +1017,12 @@ let%expect_test "review prompt marks outdated comments" =
           body = "This line moved.";
           path = Some "lib/foo.ml";
           line = None;
-          (* GitHub returns null line when the comment is outdated *)
+          (* GitHub returns null line when the comment is outdated.
+             [commit_sha] may or may not equal [original_commit_sha] —
+             what matters is the authoritative [outdated] flag. *)
           commit_sha = Some "da442c5bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
           original_commit_sha = Some "47525fdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+          outdated = true;
         };
     ]
   in
@@ -1065,6 +1067,7 @@ let%expect_test
           line = Some 10;
           commit_sha = Some "47525fdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
           original_commit_sha = Some "47525fdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+          outdated = false;
         };
     ]
   in
@@ -1109,10 +1112,11 @@ let%test "review prompt does not mark file-level comments as outdated" =
           body = "File-level feedback.";
           path = Some "lib/foo.ml";
           line = None;
-          (* File-level comments have null line by design, and GitHub
-             leaves commit_sha equal to original_commit_sha. *)
+          (* File-level comments have null line by design, and the
+             thread's isOutdated is false because the file still exists. *)
           commit_sha = Some "47525fdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
           original_commit_sha = Some "47525fdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+          outdated = false;
         };
     ]
   in

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -112,6 +112,7 @@ module Comment = struct
       line : int option;
       commit_sha : string option; [@yojson.default None]
       original_commit_sha : string option; [@yojson.default None]
+      outdated : bool; [@yojson.default false]
     }
     [@@deriving show, eq, sexp_of, compare, yojson]
   end

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -82,6 +82,7 @@ module Comment : sig
     line : int option;
     commit_sha : string option; [@yojson.default None]
     original_commit_sha : string option; [@yojson.default None]
+    outdated : bool; [@yojson.default false]
   }
   [@@deriving show, eq, sexp_of, compare, yojson]
 

--- a/lib_test/test_generators.ml
+++ b/lib_test/test_generators.ml
@@ -45,25 +45,27 @@ let gen_comment =
       option (string_size ~gen:(char_range 'a' 'z') (int_range 3 30))
     in
     let gen_line = option (int_range 1 500) in
-    map4
-      (fun id body path line ->
-        Comment.
-          {
-            id;
-            thread_id = None;
-            body;
-            path;
-            line;
-            commit_sha = None;
-            original_commit_sha = None;
-            outdated = false;
-          })
-      (* Use only synthetic (negative) IDs so content-based dedup governs in
-         property tests, matching production behavior where real IDs are unique
-         per GitHub comment. Real-ID duplicates with different content can't
-         arise in production but would bypass content-match dedup. *)
-      (map Comment_id.of_int (int_range (-1_000_000) (-1)))
-      gen_body gen_path gen_line)
+    (* Use only synthetic (negative) IDs so content-based dedup governs in
+       property tests, matching production behavior where real IDs are unique
+       per GitHub comment. Real-ID duplicates with different content can't
+       arise in production but would bypass content-match dedup. *)
+    let* id = map Comment_id.of_int (int_range (-1_000_000) (-1)) in
+    let* body = gen_body in
+    let* path = gen_path in
+    let* line = gen_line in
+    let* outdated = bool in
+    return
+      Comment.
+        {
+          id;
+          thread_id = None;
+          body;
+          path;
+          line;
+          commit_sha = None;
+          original_commit_sha = None;
+          outdated;
+        })
 
 let gen_patch =
   QCheck2.Gen.(

--- a/lib_test/test_generators.ml
+++ b/lib_test/test_generators.ml
@@ -56,6 +56,7 @@ let gen_comment =
             line;
             commit_sha = None;
             original_commit_sha = None;
+            outdated = false;
           })
       (* Use only synthetic (negative) IDs so content-based dedup governs in
          property tests, matching production behavior where real IDs are unique


### PR DESCRIPTION
## Summary

- `render_review_prompt`'s `is_outdated` inferred outdatedness from `commit_sha != original_commit_sha`. GitHub advances a comment's `commit` to any later commit that still contains the anchored line, including commits that didn't touch the commented-on file, so this heuristic mis-stamped `[outdated]` on every open comment as soon as any unrelated commit landed.
- Query `PullRequestReviewThread.isOutdated` in the GraphQL comment fetch, thread it through `parse_comment_node`, and add `outdated : bool` to `Types.Comment.t` (yojson default `false` for snapshot back-compat).
- `is_outdated c = c.outdated` — no more heuristic.

## Motivation

Observed in patch 119 of the `subsetpark-pantagruel` project: a workflow-only commit (`a61d102`) was the only commit between the review anchor and HEAD, yet every review comment arrived with `[outdated]` appended. Claude had to cross-check the diff to confirm the marker was a false positive, which is exactly the verification the marker is supposed to obviate.

## Test plan

- [x] `dune build`
- [x] `dune runtest` — existing expect tests updated; new fixtures set `outdated` explicitly.
- [x] `dune build @fmt`
- [ ] Verify on a live PR that a comment only renders `[outdated]` when GitHub's UI also shows the Outdated badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use GitHub’s isOutdated flag to mark review comments as outdated instead of comparing commit SHAs. This removes false “[outdated]” tags when unrelated commits land.

- **Bug Fixes**
  - Query `PullRequestReviewThread.isOutdated` in the GraphQL fetch and pass it through `parse_comment_node`.
  - Add `outdated: bool` to `Types.Comment.t` (yojson default `false`) and use it in `render_review_prompt`.
  - Remove the SHA comparison heuristic and update tests/fixtures to set `outdated` explicitly.
  - Randomize `outdated` in `gen_comment` to exercise both states in property tests.

<sup>Written for commit 8deb624e1b0af82a139316735c23a28114ac92e1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

