### PR TITLE
Defenses against FD exhaustion (#209)

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -618,9 +618,9 @@ let resolve_worktree_path ~process_mgr ~repo_root ~project_name ~patch_id
     existing worktrees for the branch, creates one if needed, and persists the
     path. Returns [Some path] on success or [None] if the branch is unknown and
     no worktree can be created yet. *)
-let ensure_worktree ~runtime ~process_mgr ~fs ~repo_root ~project_name ~patch_id
-    ~(agent : Patch_agent.t) ~(user_config : User_config.t) ~worktree_mutex
-    ?branch ?base_ref () =
+let ensure_worktree ~runtime ~process_mgr ~clock ~fs ~repo_root ~project_name
+    ~patch_id ~(agent : Patch_agent.t) ~(user_config : User_config.t)
+    ~worktree_mutex ~hook_mutex ?branch ?base_ref () =
   let path =
     resolve_worktree_path ~process_mgr ~repo_root ~project_name ~patch_id ~agent
       ?branch ()
@@ -686,7 +686,15 @@ let ensure_worktree ~runtime ~process_mgr ~fs ~repo_root ~project_name ~patch_id
                   ]
                 in
                 let cwd = Eio.Path.(fs / path) in
-                match User_config.run_hook ~process_mgr ~script ~cwd ~env with
+                (* [hook_mutex] serializes hook invocations across patch
+                   fibers — npm/dune/bun aren't parallelism-safe across
+                   shared caches, and per-hook fan-out is the dominant
+                   subprocess multiplier (see issue #209). *)
+                match
+                  Eio.Mutex.use_ro hook_mutex (fun () ->
+                      User_config.run_hook ~process_mgr ~clock ~script ~cwd ~env
+                        ())
+                with
                 | Ok () ->
                     log_event runtime ~patch_id "Ran on_worktree_create hook"
                 | Error msg ->
@@ -713,16 +721,18 @@ let ensure_worktree ~runtime ~process_mgr ~fs ~repo_root ~project_name ~patch_id
 
     Returns the final result paired with the worktree path so callers can use it
     for follow-on effects like [Worktree.force_push_with_lease]. *)
-let execute_worktree_plan ~runtime ~process_mgr ~fs ~repo_root ~project_name
-    ~patch_id ~(agent : Patch_agent.t) ~user_config ~worktree_mutex ~fetch_lock
-    ~fail_label ~ancestor_ids (plan : Worktree_plan.t) =
+let execute_worktree_plan ~runtime ~process_mgr ~clock ~fs ~repo_root
+    ~project_name ~patch_id ~(agent : Patch_agent.t) ~user_config
+    ~worktree_mutex ~hook_mutex ~fetch_lock ~fail_label ~ancestor_ids
+    (plan : Worktree_plan.t) =
   let default_path = Worktree.worktree_dir ~project_name ~patch_id in
   let rec loop ~path = function
     | [] -> (Worktree.Ok, path)
     | Worktree_plan.Ensure_worktree :: rest -> (
         match
-          ensure_worktree ~runtime ~process_mgr ~fs ~repo_root ~project_name
-            ~patch_id ~agent ~user_config ~worktree_mutex ()
+          ensure_worktree ~runtime ~process_mgr ~clock ~fs ~repo_root
+            ~project_name ~patch_id ~agent ~user_config ~worktree_mutex
+            ~hook_mutex ()
         with
         | Some p -> loop ~path:p rest
         | None ->
@@ -755,9 +765,10 @@ let execute_worktree_plan ~runtime ~process_mgr ~fs ~repo_root ~project_name
 
 let truncate s n = if String.length s <= n then s else String.sub s 0 n ^ "..."
 
-let run_claude_and_handle ~runtime ~process_mgr ~fs ~project_name ~patch_id
-    ~repo_root ~prompt ~(agent : Patch_agent.t) ~owner ~repo ~on_pr_detected
-    ~transcripts ~user_config ~worktree_mutex ~backend ~event_log =
+let run_claude_and_handle ~runtime ~process_mgr ~clock ~fs ~project_name
+    ~patch_id ~repo_root ~prompt ~(agent : Patch_agent.t) ~owner ~repo
+    ~on_pr_detected ~transcripts ~user_config ~worktree_mutex ~hook_mutex
+    ~backend ~event_log =
   match session_mode agent with
   | `Give_up ->
       log_event runtime ~patch_id
@@ -772,8 +783,9 @@ let run_claude_and_handle ~runtime ~process_mgr ~fs ~project_name ~patch_id
         match mode with `Resume id -> (Some id, false) | `Fresh -> (None, true)
       in
       match
-        ensure_worktree ~runtime ~process_mgr ~fs ~repo_root ~project_name
-          ~patch_id ~agent ~user_config ~worktree_mutex ()
+        ensure_worktree ~runtime ~process_mgr ~clock ~fs ~repo_root
+          ~project_name ~patch_id ~agent ~user_config ~worktree_mutex
+          ~hook_mutex ()
       with
       | None ->
           Runtime.update_orchestrator runtime (fun orch ->
@@ -2308,6 +2320,12 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
   (* Serializes [git fetch origin] across worktrees to avoid ref-lock races on
      the shared [refs/remotes/origin/*] store. See [Worktree.fetch_origin]. *)
   let fetch_mutex = Eio.Mutex.create () in
+  (* Serializes [on_worktree_create] invocations across patch fibers. The
+     hook runs user build commands ([npm install], [dune build], …) which
+     aren't parallelism-safe across shared caches AND fan out into dozens
+     of short-lived children. Running 10 hooks in parallel is how issue
+     #209 blew through the system FD table. *)
+  let hook_mutex = Eio.Mutex.create () in
   let with_busy_guard ~patch_id f =
     Fun.protect
       ~finally:(fun () ->
@@ -2447,11 +2465,12 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                   `Stale)
                                 else
                                   match
-                                    ensure_worktree ~runtime ~process_mgr ~fs
-                                      ~repo_root:config.repo_root ~project_name
-                                      ~patch_id ~agent
+                                    ensure_worktree ~runtime ~process_mgr ~clock
+                                      ~fs ~repo_root:config.repo_root
+                                      ~project_name ~patch_id ~agent
                                       ~user_config:config.user_config
-                                      ~worktree_mutex ~branch:patch.Patch.branch
+                                      ~worktree_mutex ~hook_mutex
+                                      ~branch:patch.Patch.branch
                                       ~base_ref:(Branch.to_string base_branch)
                                       ()
                                   with
@@ -2478,14 +2497,15 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                       let on_pr_detected _pr_number = () in
                                       let r, _tool_failures =
                                         run_claude_and_handle ~runtime
-                                          ~process_mgr ~fs ~project_name
+                                          ~process_mgr ~clock ~fs ~project_name
                                           ~patch_id ~repo_root:config.repo_root
                                           ~prompt ~agent
                                           ~owner:config.github_owner
                                           ~repo:config.github_repo
                                           ~on_pr_detected ~transcripts
                                           ~user_config:config.user_config
-                                          ~worktree_mutex ~backend ~event_log
+                                          ~worktree_mutex ~hook_mutex ~backend
+                                          ~event_log
                                       in
                                       r)
                           in
@@ -2650,11 +2670,11 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                               patch_id)
                       in
                       let rebase_result, wt_path =
-                        execute_worktree_plan ~runtime ~process_mgr ~fs
+                        execute_worktree_plan ~runtime ~process_mgr ~clock ~fs
                           ~repo_root:config.repo_root ~project_name ~patch_id
                           ~agent ~user_config:config.user_config ~worktree_mutex
-                          ~fetch_lock:fetch_mutex ~fail_label:"rebase"
-                          ~ancestor_ids
+                          ~hook_mutex ~fetch_lock:fetch_mutex
+                          ~fail_label:"rebase" ~ancestor_ids
                           (Worktree_plan.for_rebase ~new_base)
                       in
                       (match rebase_result with
@@ -2885,11 +2905,11 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                       render_base_changed_prefix base_change
                                     in
                                     let wt_path_opt =
-                                      ensure_worktree ~runtime ~process_mgr ~fs
-                                        ~repo_root:config.repo_root
+                                      ensure_worktree ~runtime ~process_mgr
+                                        ~clock ~fs ~repo_root:config.repo_root
                                         ~project_name ~patch_id ~agent
                                         ~user_config:config.user_config
-                                        ~worktree_mutex ()
+                                        ~worktree_mutex ~hook_mutex ()
                                     in
                                     let wt_path =
                                       match wt_path_opt with
@@ -2940,14 +2960,15 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                       let on_pr_detected _pr_number = () in
                                       let result, _tool_failures =
                                         run_claude_and_handle ~runtime
-                                          ~process_mgr ~fs ~project_name
+                                          ~process_mgr ~clock ~fs ~project_name
                                           ~patch_id ~repo_root:config.repo_root
                                           ~prompt ~agent
                                           ~owner:config.github_owner
                                           ~repo:config.github_repo
                                           ~on_pr_detected ~transcripts
                                           ~user_config:config.user_config
-                                          ~worktree_mutex ~backend ~event_log
+                                          ~worktree_mutex ~hook_mutex ~backend
+                                          ~event_log
                                       in
                                       (match result with
                                       | `Ok
@@ -2987,11 +3008,11 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                       in
                                       let rebase_result, _wt_path =
                                         execute_worktree_plan ~runtime
-                                          ~process_mgr ~fs
+                                          ~process_mgr ~clock ~fs
                                           ~repo_root:config.repo_root
                                           ~project_name ~patch_id ~agent
                                           ~user_config:config.user_config
-                                          ~worktree_mutex
+                                          ~worktree_mutex ~hook_mutex
                                           ~fetch_lock:fetch_mutex
                                           ~fail_label:"merge-conflict rebase"
                                           ~ancestor_ids
@@ -3254,13 +3275,15 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                         ());
                                     let result, tool_failures =
                                       run_claude_and_handle ~runtime
-                                        ~process_mgr ~fs ~project_name ~patch_id
-                                        ~repo_root:config.repo_root ~prompt
-                                        ~agent ~owner:config.github_owner
+                                        ~process_mgr ~clock ~fs ~project_name
+                                        ~patch_id ~repo_root:config.repo_root
+                                        ~prompt ~agent
+                                        ~owner:config.github_owner
                                         ~repo:config.github_repo ~on_pr_detected
                                         ~transcripts
                                         ~user_config:config.user_config
-                                        ~worktree_mutex ~backend ~event_log
+                                        ~worktree_mutex ~hook_mutex ~backend
+                                        ~event_log
                                     in
                                     (match result with
                                     | `Ok when Base.Option.is_some base_change
@@ -3510,14 +3533,10 @@ let with_snapshot_load ~project_name config gameplan =
       project name.
     - [PROJECT] only: load stored config + gameplan. CLI flags override stored
       values. *)
-let normalize_repo_root rr =
-  if Filename.is_relative rr then Filename.concat (Stdlib.Sys.getcwd ()) rr
-  else rr
-
 let resolve_config ~project ~gameplan_path ~github_token ~backend ~main_branch
     ~poll_interval ~(repo_root : string option) ~max_concurrency ~headless =
   let repo_root_for_fresh =
-    normalize_repo_root (Base.Option.value repo_root ~default:".")
+    Repo_root.normalize (Base.Option.value repo_root ~default:".")
   in
   let resolve_branch ~repo_root mb_opt =
     match mb_opt with
@@ -3648,10 +3667,13 @@ let resolve_config ~project ~gameplan_path ~github_token ~backend ~main_branch
                     merge_cli_stored github_token
                       stored.Project_store.github_token
                   in
+                  (* Always route through [Repo_root.normalize] — including
+                     the stored value — so legacy configs that persisted a
+                     worktree path (or a trailing [/.]) self-heal on load. *)
                   let repo_root =
                     match repo_root with
-                    | Some rr -> normalize_repo_root rr
-                    | None -> stored.Project_store.repo_root
+                    | Some rr -> Repo_root.normalize rr
+                    | None -> Repo_root.normalize stored.Project_store.repo_root
                   in
                   let token, inferred_owner, inferred_repo =
                     resolve_github_credentials ~github_token:token_from_stored
@@ -3699,7 +3721,7 @@ let resolve_config ~project ~gameplan_path ~github_token ~backend ~main_branch
                   in
                   with_snapshot_load ~project_name:proj config gameplan))
 
-let run_with_config (config : config) gameplan existing_snapshot =
+let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
   let project_name =
     match config.project with Some p -> p | None -> assert false
   in
@@ -3714,6 +3736,53 @@ let run_with_config (config : config) gameplan existing_snapshot =
       Base.List.iter errs ~f:(fun e -> Printf.eprintf "Error: %s\n" e);
       Stdlib.exit 1
   | Ok () ->
+      (* Preflight: ensure RLIMIT_NOFILE is high enough for [max_concurrency]
+         long-lived Claude subprocesses (each holding 3 pipes = 6 FDs),
+         parallel git subprocesses, HTTPS connections, the activity log,
+         snapshot files, and the project lock. Budget 256 FDs/slot plus 512
+         headroom. Auto-raise the soft limit to the hard cap silently; fail
+         fast with an actionable [ulimit -n] message only if the effective
+         limit is still insufficient. See issue #209. *)
+      let () =
+        let open Onton.Rlimit in
+        let required = (config.max_concurrency * 256) + 512 in
+        let cur = get_nofile () in
+        if cur.soft < required then begin
+          let after = try_raise_nofile_soft ~target:required in
+          if after.soft < required then begin
+            Printf.eprintf
+              "onton: soft FD limit %d is below the required %d (hard cap %d).\n\
+              \       Raise it with: ulimit -n %d\n\
+              \       macOS system ceiling: sudo launchctl limit maxfiles \
+               <soft> <hard>.\n\
+               %!"
+              after.soft required after.hard required;
+            Stdlib.exit 1
+          end
+        end
+      in
+      let lock =
+        if no_lock then None
+        else
+          let project_dir = Project_store.project_dir project_name in
+          match
+            Project_lock.acquire ~project_dir ~on_stale:(fun stale_pid ->
+                if stale_pid > 0 then
+                  Printf.eprintf "onton: reclaiming stale lock from pid %d\n%!"
+                    stale_pid)
+          with
+          | Ok l -> Some l
+          | Error e ->
+              Printf.eprintf "onton: %s\n"
+                (Format.asprintf "%a" Project_lock.pp_error e);
+              Printf.eprintf
+                "       pass --no-lock (or set ONTON_NO_LOCK=1) to bypass.\n%!";
+              (* 75 = EX_TEMPFAIL from sysexits(3): transient, try again. *)
+              Stdlib.exit 75
+      in
+      Stdlib.Fun.protect ~finally:(fun () ->
+          Base.Option.iter lock ~f:Project_lock.release)
+      @@ fun () ->
       Eio_main.run @@ fun env ->
       if config.headless then
         Sys.set_signal Sys.sigint
@@ -3898,7 +3967,7 @@ let run_with_config (config : config) gameplan existing_snapshot =
 
 let run ~project ~gameplan_path ~github_token ~backend
     ~(main_branch : Branch.t option) ~poll_interval ~(repo_root : string option)
-    ~max_concurrency ~headless =
+    ~max_concurrency ~headless ~no_lock =
   match
     resolve_config ~project ~gameplan_path ~github_token ~backend ~main_branch
       ~poll_interval ~repo_root ~max_concurrency ~headless
@@ -3907,7 +3976,7 @@ let run ~project ~gameplan_path ~github_token ~backend
       Base.List.iter errs ~f:(fun e -> Printf.eprintf "Error: %s\n" e);
       Stdlib.exit 1
   | Ok (config, gameplan, existing_snapshot) ->
-      run_with_config config gameplan existing_snapshot
+      run_with_config ~no_lock config gameplan existing_snapshot
 
 (** {1 CLI via Cmdliner} *)
 
@@ -3988,10 +4057,20 @@ let upload_debug_arg =
           "Upload project debug state for troubleshooting. Requires a project \
            name.")
 
+let no_lock_arg =
+  let open Cmdliner in
+  Arg.(
+    value & flag
+    & info [ "no-lock" ]
+        ~doc:
+          "Bypass the per-project advisory lock. Only use when a stale lock \
+           cannot be reclaimed automatically."
+        ~env:(Cmd.Env.info "ONTON_NO_LOCK"))
+
 let main_cmd =
   let open Cmdliner in
   let run_cmd project gameplan_path github_token backend main_branch
-      poll_interval repo_root max_concurrency headless upload_debug =
+      poll_interval repo_root max_concurrency headless upload_debug no_lock =
     if upload_debug then (
       match project with
       | None ->
@@ -4016,12 +4095,13 @@ let main_cmd =
       run ~project ~gameplan_path ~github_token
         ~backend:(Base.String.strip backend)
         ~main_branch ~poll_interval ~repo_root ~max_concurrency ~headless
+        ~no_lock
   in
   let term =
     Term.(
       const run_cmd $ project_arg $ gameplan_path_arg $ github_token_arg
       $ backend_arg $ main_branch_arg $ poll_interval_arg $ repo_arg
-      $ max_concurrency_arg $ headless_arg $ upload_debug_arg)
+      $ max_concurrency_arg $ headless_arg $ upload_debug_arg $ no_lock_arg)
   in
   let info =
     Cmd.info "onton" ~version:Version.s

--- a/lib/dune
+++ b/lib/dune
@@ -1,6 +1,9 @@
 (library
  (name onton)
  (libraries base unix eio eio_main eio.unix yojson ppx_yojson_conv_lib cohttp-eio tls-eio mirage-crypto-rng.unix ca-certs cmarkit)
+ (foreign_stubs
+  (language c)
+  (names rlimit_stubs))
  (inline_tests)
  (ocamlopt_flags (:standard -w -40-42))
  (ocamlc_flags (:standard -w -40-42))

--- a/lib/project_lock.ml
+++ b/lib/project_lock.ml
@@ -1,0 +1,109 @@
+open Base
+
+type t = { fd : Unix.file_descr }
+type error = Held_by of { pid : int; path : string } | Io_error of string
+
+let path_for ~project_dir = Stdlib.Filename.concat project_dir "onton.lock"
+
+(** Rewind [fd], read up to [cap] bytes, return the trimmed contents as an
+    integer if parseable. *)
+let read_pid fd =
+  try
+    let _ = Unix.lseek fd 0 Unix.SEEK_SET in
+    let buf = Bytes.create 32 in
+    let n = Unix.read fd buf 0 (Bytes.length buf) in
+    let s = Stdlib.Bytes.sub_string buf 0 n |> String.strip in
+    Int.of_string_opt s
+  with _ -> None
+
+(** Does [pid] name a running process? [kill(pid, 0)] returns:
+    - ok → process exists and we could signal it
+    - [EPERM] → exists, different user: still counts as alive
+    - [ESRCH] → does not exist → stale *)
+let pid_alive pid =
+  if pid <= 0 then false
+  else
+    try
+      Unix.kill pid 0;
+      true
+    with
+    | Unix.Unix_error (Unix.ESRCH, _, _) -> false
+    | Unix.Unix_error (Unix.EPERM, _, _) -> true
+    | _ -> false
+
+let write_self_pid fd =
+  try
+    let _ = Unix.lseek fd 0 Unix.SEEK_SET in
+    Unix.ftruncate fd 0;
+    let s = Printf.sprintf "%d\n" (Unix.getpid ()) in
+    let _ = Unix.single_write_substring fd s 0 (String.length s) in
+    ()
+  with _ -> ()
+
+let try_lock fd =
+  try
+    Unix.lockf fd Unix.F_TLOCK 0;
+    `Acquired
+  with
+  | Unix.Unix_error ((Unix.EAGAIN | Unix.EACCES), _, _) -> `Busy
+  | Unix.Unix_error (e, _, _) -> `Error (Unix.error_message e)
+
+let ensure_dir dir =
+  let rec mkdir_p p =
+    if not (Stdlib.Sys.file_exists p) then (
+      mkdir_p (Stdlib.Filename.dirname p);
+      try Stdlib.Sys.mkdir p 0o755 with Sys_error _ -> ())
+  in
+  mkdir_p dir
+
+let acquire ~project_dir ~on_stale =
+  let path = path_for ~project_dir in
+  ensure_dir project_dir;
+  match
+    Unix.openfile path [ Unix.O_CREAT; Unix.O_RDWR; Unix.O_CLOEXEC ] 0o644
+  with
+  | exception Unix.Unix_error (e, _, _) ->
+      Error (Io_error (Unix.error_message e))
+  | fd -> (
+      match try_lock fd with
+      | `Acquired ->
+          write_self_pid fd;
+          Ok { fd }
+      | `Error msg ->
+          (try Unix.close fd with _ -> ());
+          Error (Io_error msg)
+      | `Busy -> (
+          let recorded = read_pid fd in
+          match recorded with
+          | Some pid when pid_alive pid ->
+              (try Unix.close fd with _ -> ());
+              Error (Held_by { pid; path })
+          | _ -> (
+              (* No PID recorded, or recorded PID is dead → stale. *)
+              on_stale (Option.value recorded ~default:(-1));
+              match try_lock fd with
+              | `Acquired ->
+                  write_self_pid fd;
+                  Ok { fd }
+              | `Busy ->
+                  (* A third process raced in between our check and retry. *)
+                  let pid = Option.value (read_pid fd) ~default:(-1) in
+                  (try Unix.close fd with _ -> ());
+                  Error (Held_by { pid; path })
+              | `Error msg ->
+                  (try Unix.close fd with _ -> ());
+                  Error (Io_error msg))))
+
+let release t =
+  (try
+     let _ = Unix.lseek t.fd 0 Unix.SEEK_SET in
+     Unix.ftruncate t.fd 0
+   with _ -> ());
+  (try Unix.lockf t.fd Unix.F_ULOCK 0 with _ -> ());
+  try Unix.close t.fd with _ -> ()
+
+let pp_error ppf = function
+  | Held_by { pid; path } ->
+      Stdlib.Format.fprintf ppf
+        "another onton is already running (pid %d, lock %s)" pid path
+  | Io_error s -> Stdlib.Format.fprintf ppf "lock i/o error: %s" s

--- a/lib/project_lock.mli
+++ b/lib/project_lock.mli
@@ -1,0 +1,34 @@
+(** Process-level advisory lock on a project data directory.
+
+    At most one onton process may hold the lock for a given project at a time.
+    Uses [Unix.lockf] on [<project_dir>/onton.lock]; the lock stays held for the
+    process lifetime and is released via [Fun.protect] by the caller.
+
+    The lock file records the holder's PID so [acquire] can render actionable
+    error messages. A stale lock (PID no longer running) is reclaimed
+    automatically — the caller is notified via [~on_stale]. *)
+
+type t
+
+type error =
+  | Held_by of { pid : int; path : string }
+      (** Another onton is alive and holds the lock. *)
+  | Io_error of string  (** Opening or locking the file failed. *)
+
+val acquire : project_dir:string -> on_stale:(int -> unit) -> (t, error) result
+(** [acquire ~project_dir ~on_stale] creates [<project_dir>/onton.lock] if
+    needed, obtains [F_TLOCK], and writes the current PID.
+
+    On contention, reads the PID stored in the file:
+    - If [Unix.kill pid 0] confirms the holder is alive → [Error (Held_by ...)].
+    - If [Unix.kill] raises [ESRCH] → [on_stale pid] is called and the lock is
+      reclaimed.
+
+    [on_stale] is invoked with the stale PID (or [-1] if no PID was recorded in
+    the file). *)
+
+val release : t -> unit
+(** Truncate the PID file and release the lock. Idempotent; never raises. *)
+
+val pp_error : Format.formatter -> error -> unit
+(** Human-readable error rendering for CLI diagnostics. *)

--- a/lib/repo_root.ml
+++ b/lib/repo_root.ml
@@ -1,0 +1,63 @@
+open Base
+
+(** Run [git -C path rev-parse --path-format=absolute --git-common-dir] and
+    return the parent directory of the reported common dir — i.e. the main
+    working tree. Returns [None] if [path] is not inside a git repository or the
+    command fails for any reason. *)
+let resolve_main_working_tree path =
+  let env = Unix.environment () in
+  let argv =
+    [|
+      "git";
+      "-C";
+      path;
+      "rev-parse";
+      "--path-format=absolute";
+      "--git-common-dir";
+    |]
+  in
+  match Unix.open_process_args_full "git" argv env with
+  | exception _ -> None
+  | in_ch, out_ch, err_ch -> (
+      let buf = Buffer.create 128 in
+      let status = ref None in
+      Stdlib.Fun.protect
+        ~finally:(fun () ->
+          if Option.is_none !status then
+            try ignore (Unix.close_process_full (in_ch, out_ch, err_ch))
+            with _ -> ())
+        (fun () ->
+          (try
+             while true do
+               Buffer.add_char buf (Stdlib.input_char in_ch)
+             done
+           with End_of_file -> ());
+          (* Drain stderr to keep it off the terminal (git prints
+             "not a git repository" when [path] is outside any repo). *)
+          (try
+             while true do
+               ignore (Stdlib.input_char err_ch)
+             done
+           with End_of_file -> ());
+          status := Some (Unix.close_process_full (in_ch, out_ch, err_ch)));
+      match !status with
+      | Some (Unix.WEXITED 0) ->
+          let common_dir = String.strip (Buffer.contents buf) in
+          if String.is_empty common_dir then None
+          else Some (Stdlib.Filename.dirname common_dir)
+      | Some (Unix.WEXITED _)
+      | Some (Unix.WSIGNALED _)
+      | Some (Unix.WSTOPPED _)
+      | None ->
+          None)
+
+let normalize rr =
+  let absolute =
+    if Stdlib.Filename.is_relative rr then
+      Stdlib.Filename.concat (Stdlib.Sys.getcwd ()) rr
+    else rr
+  in
+  let normalized = Worktree.normalize_path absolute in
+  match resolve_main_working_tree normalized with
+  | Some main -> Worktree.normalize_path main
+  | None -> normalized

--- a/lib/repo_root.ml
+++ b/lib/repo_root.ml
@@ -44,7 +44,14 @@ let resolve_main_working_tree path =
       | Some (Unix.WEXITED 0) ->
           let common_dir = String.strip (Buffer.contents buf) in
           if String.is_empty common_dir then None
-          else Some (Stdlib.Filename.dirname common_dir)
+          else
+            let parent = Stdlib.Filename.dirname common_dir in
+            (* [--path-format=absolute] requires git >= 2.31; older git
+               silently ignores the flag and returns a path relative to the
+               worktree's CWD. Treat that as failure rather than resolving
+               against the worktree and re-introducing the very bug this
+               module is meant to fix. *)
+            if Stdlib.Filename.is_relative parent then None else Some parent
       | Some (Unix.WEXITED _)
       | Some (Unix.WSIGNALED _)
       | Some (Unix.WSTOPPED _)

--- a/lib/repo_root.mli
+++ b/lib/repo_root.mli
@@ -1,0 +1,16 @@
+(** Normalize a user-supplied repo-root path to the absolute main working tree.
+
+    Users may invoke [onton] from any directory inside a git repository,
+    including a worktree. This module resolves the main working tree via
+    [git rev-parse --git-common-dir] so the persisted [repo_root] is always the
+    main checkout, never a worktree path. *)
+
+val normalize : string -> string
+(** [normalize path] returns an absolute path to the main working tree of
+    [path]'s git repository.
+
+    - Relative paths are resolved against the current working directory.
+    - Trailing slashes and [/.] suffixes are stripped.
+    - If [path] is inside any worktree, the main checkout is returned.
+    - If [path] is not inside any git repository, the absolute-but-unresolved
+      path is returned — downstream code surfaces the non-repo error. *)

--- a/lib/rlimit.ml
+++ b/lib/rlimit.ml
@@ -1,7 +1,7 @@
 type limits = { soft : int; hard : int }
 
 external get_nofile_stub : unit -> int * int = "caml_onton_getrlimit_nofile"
-external set_nofile_stub : int -> int -> unit = "caml_onton_setrlimit_nofile"
+external set_nofile_soft_stub : int -> unit = "caml_onton_setrlimit_nofile_soft"
 
 let get_nofile () =
   let soft, hard = get_nofile_stub () in
@@ -13,5 +13,5 @@ let try_raise_nofile_soft ~target =
   if target <= cur.soft then cur
   else
     let desired_soft = min target cur.hard in
-    (try set_nofile_stub desired_soft cur.hard with _ -> ());
+    (try set_nofile_soft_stub desired_soft with _ -> ());
     get_nofile ()

--- a/lib/rlimit.ml
+++ b/lib/rlimit.ml
@@ -1,0 +1,17 @@
+type limits = { soft : int; hard : int }
+
+external get_nofile_stub : unit -> int * int = "caml_onton_getrlimit_nofile"
+external set_nofile_stub : int -> int -> unit = "caml_onton_setrlimit_nofile"
+
+let get_nofile () =
+  let soft, hard = get_nofile_stub () in
+  { soft; hard }
+
+let try_raise_nofile_soft ~target =
+  let cur = get_nofile () in
+  (* Never lower — this is [raise], not [set]. *)
+  if target <= cur.soft then cur
+  else
+    let desired_soft = min target cur.hard in
+    (try set_nofile_stub desired_soft cur.hard with _ -> ());
+    get_nofile ()

--- a/lib/rlimit.mli
+++ b/lib/rlimit.mli
@@ -1,0 +1,17 @@
+(** Thin POSIX bindings for [RLIMIT_NOFILE] (per-process open-file cap).
+
+    onton needs a generous FD limit because it opens many pipes (per-LLM and
+    per-git subprocess), HTTPS sockets to GitHub, log and snapshot files, and
+    the project lock. Too-low a soft limit surfaces as obscure "too many open
+    files" failures mid-run — see issue #209. Preflight- check at startup and
+    auto-raise to the hard cap where possible. *)
+
+type limits = { soft : int; hard : int }
+
+val get_nofile : unit -> limits
+(** Current RLIMIT_NOFILE. Raises [Failure] on syscall error. *)
+
+val try_raise_nofile_soft : target:int -> limits
+(** Best-effort: attempt to raise soft to [min target hard]. Never raises — on
+    failure, returns the (possibly unchanged) current limits so the caller can
+    decide whether the effective value is sufficient. *)

--- a/lib/rlimit_stubs.c
+++ b/lib/rlimit_stubs.c
@@ -1,0 +1,51 @@
+/* POSIX getrlimit/setrlimit bindings for RLIMIT_NOFILE only.
+ *
+ * We care about the file-descriptor limit because onton opens many pipes
+ * and sockets (per-LLM-subprocess pipes, per-git-subprocess pipes, GitHub
+ * HTTPS connections, the activity log, snapshot files, the project lock).
+ * A low soft limit surfaces as "too many open files" mid-run, long after
+ * enough state is committed to make recovery painful. Checking at startup
+ * lets us fail fast with an actionable message instead.
+ *
+ * See issue #209. */
+
+#define CAML_NAME_SPACE
+#include <caml/mlvalues.h>
+#include <caml/alloc.h>
+#include <caml/memory.h>
+#include <caml/fail.h>
+
+#include <sys/resource.h>
+#include <errno.h>
+#include <string.h>
+
+/* Returns (soft, hard) as an OCaml int pair. */
+CAMLprim value caml_onton_getrlimit_nofile(value unit) {
+  CAMLparam1(unit);
+  CAMLlocal1(pair);
+  struct rlimit rl;
+  if (getrlimit(RLIMIT_NOFILE, &rl) != 0) {
+    caml_failwith(strerror(errno));
+  }
+  pair = caml_alloc_tuple(2);
+  /* RLIM_INFINITY may exceed OCaml's int range on some platforms; clamp
+   * to max_int. For RLIMIT_NOFILE this is defensive — no real system ships
+   * with more than a few million allowed FDs. */
+  long soft = (rl.rlim_cur > (rlim_t)Max_long) ? Max_long : (long)rl.rlim_cur;
+  long hard = (rl.rlim_max > (rlim_t)Max_long) ? Max_long : (long)rl.rlim_max;
+  Store_field(pair, 0, Val_long(soft));
+  Store_field(pair, 1, Val_long(hard));
+  CAMLreturn(pair);
+}
+
+/* Sets the soft and hard limits. Raises Failure on error. */
+CAMLprim value caml_onton_setrlimit_nofile(value v_soft, value v_hard) {
+  CAMLparam2(v_soft, v_hard);
+  struct rlimit rl;
+  rl.rlim_cur = (rlim_t)Long_val(v_soft);
+  rl.rlim_max = (rlim_t)Long_val(v_hard);
+  if (setrlimit(RLIMIT_NOFILE, &rl) != 0) {
+    caml_failwith(strerror(errno));
+  }
+  CAMLreturn(Val_unit);
+}

--- a/lib/rlimit_stubs.c
+++ b/lib/rlimit_stubs.c
@@ -38,12 +38,18 @@ CAMLprim value caml_onton_getrlimit_nofile(value unit) {
   CAMLreturn(pair);
 }
 
-/* Sets the soft and hard limits. Raises Failure on error. */
-CAMLprim value caml_onton_setrlimit_nofile(value v_soft, value v_hard) {
-  CAMLparam2(v_soft, v_hard);
+/* Raises only the soft RLIMIT_NOFILE to [v_soft]; re-reads the kernel's
+ * current hard limit so we preserve RLIM_INFINITY instead of sending back
+ * the Max_long-clamped value from the getter (which setrlimit would treat
+ * as a hard-limit lowering, rejected EPERM on some platforms).
+ * Raises Failure on error. */
+CAMLprim value caml_onton_setrlimit_nofile_soft(value v_soft) {
+  CAMLparam1(v_soft);
   struct rlimit rl;
+  if (getrlimit(RLIMIT_NOFILE, &rl) != 0) {
+    caml_failwith(strerror(errno));
+  }
   rl.rlim_cur = (rlim_t)Long_val(v_soft);
-  rl.rlim_max = (rlim_t)Long_val(v_hard);
   if (setrlimit(RLIMIT_NOFILE, &rl) != 0) {
     caml_failwith(strerror(errno));
   }

--- a/lib/user_config.ml
+++ b/lib/user_config.ml
@@ -94,40 +94,39 @@ let run_hook ~process_mgr ~clock ~script ~cwd ~env ?(timeout : float option)
             ~stderr:(Eio.Flow.buffer_sink stderr_buf)
             cmd
         in
-        match
-          Eio.Time.with_timeout clock timeout (fun () ->
-              Ok (Eio.Process.await child))
-        with
-        | Ok (`Exited 0) -> Ok ()
-        | Ok (`Exited code) ->
-            build_error
-              ~status_msg:(Printf.sprintf "hook exited with code %d" code)
-              stdout_buf stderr_buf
-        | Ok (`Signaled signal) ->
-            build_error
-              ~status_msg:(Printf.sprintf "hook killed by signal %d" signal)
-              stdout_buf stderr_buf
-        | Error `Timeout ->
-            (* SIGKILL reaches the direct child (our [/bin/sh -c]). If the
-               hook forked grandchildren (e.g. [npm install] spawning node
-               subprocesses), those orphans may keep running past the
-               timeout until they notice their parent is gone. Killing the
-               whole process tree requires [setpgid] (not in OCaml's
-               Stdlib.Unix) or a fork-action pre-exec hook (Eio private
-               API); both are out of scope here. The timeout still bounds
-               *our* blocking on the hook, which is the property the
-               orchestrator needs. *)
+        (* [Fun.protect] guarantees SIGKILL + await run on *every* exit path,
+           including cancellation from the outer fiber while we're blocked in
+           [Eio.Process.await] on the normal-exit branch. Signalling an
+           already-exited child is harmless (ESRCH), and [Eio.Process.await]
+           is idempotent, so the cleanup is safe even when the timeout arm
+           already handled things. SIGKILL only reaches the direct child
+           ([/bin/sh -c]); grandchildren from [npm install]/etc may outlive
+           the hook — killing the whole process tree needs [setpgid] or an
+           Eio fork-action pre-exec, both out of scope here. *)
+        Stdlib.Fun.protect
+          ~finally:(fun () ->
             (try Eio.Process.signal child Stdlib.Sys.sigkill with _ -> ());
-            (* Await the child synchronously before returning — otherwise
-               the caller's [hook_mutex] is released while the kernel is
-               still finishing SIGKILL delivery, and a second hook can
-               start running concurrently with the dying first one. *)
-            (try ignore (Eio.Process.await child) with _ -> ());
-            build_error
-              ~status_msg:
-                (Printf.sprintf
-                   "hook timed out after %.1fs (ONTON_HOOK_TIMEOUT)" timeout)
-              stdout_buf stderr_buf)
+            try ignore (Eio.Process.await child) with _ -> ())
+          (fun () ->
+            match
+              Eio.Time.with_timeout clock timeout (fun () ->
+                  Ok (Eio.Process.await child))
+            with
+            | Ok (`Exited 0) -> Ok ()
+            | Ok (`Exited code) ->
+                build_error
+                  ~status_msg:(Printf.sprintf "hook exited with code %d" code)
+                  stdout_buf stderr_buf
+            | Ok (`Signaled signal) ->
+                build_error
+                  ~status_msg:(Printf.sprintf "hook killed by signal %d" signal)
+                  stdout_buf stderr_buf
+            | Error `Timeout ->
+                build_error
+                  ~status_msg:
+                    (Printf.sprintf
+                       "hook timed out after %.1fs (ONTON_HOOK_TIMEOUT)" timeout)
+                  stdout_buf stderr_buf))
   with
   | Eio.Cancel.Cancelled _ as exn ->
       (* Cancellation must propagate to the caller — never format it as a

--- a/lib/user_config.ml
+++ b/lib/user_config.ml
@@ -50,16 +50,16 @@ let build_error ~status_msg stdout_buf stderr_buf =
     invocation. [ulimit -n] lowers the child's [RLIMIT_NOFILE] before the script
     runs, so runaway subtree fan-out (npm install spawning node, dune spawning
     ocamlc, etc.) can't exhaust the shared file-descriptor table on the host. We
-    clamp the requested limit against the current hard cap at runtime —
-    otherwise on shells like dash where [ulimit -n N] fails when [N] exceeds the
-    hard limit, the builtin error leaks into the captured stderr even with
-    [2>/dev/null]. *)
+    clamp the requested target against both the hard and soft caps — the hard
+    cap prevents shells like dash from printing an error when the target exceeds
+    it, and the soft cap prevents us from accidentally *raising* a parent who
+    already ran [ulimit -n] to something below our default. *)
 let wrap_with_ulimit ~fd_limit script =
   [
     "/bin/sh";
     "-c";
     Printf.sprintf
-      {|limit=$(ulimit -Hn); target=%d; if [ "$limit" = unlimited ] || [ "$target" -lt "$limit" ]; then ulimit -n "$target"; else ulimit -n "$limit"; fi; exec %s|}
+      {|hlimit=$(ulimit -Hn); slimit=$(ulimit -Sn); target=%d; [ "$hlimit" != unlimited ] && [ "$target" -gt "$hlimit" ] && target=$hlimit; [ "$slimit" != unlimited ] && [ "$target" -gt "$slimit" ] && target=$slimit; ulimit -n "$target"; exec %s|}
       fd_limit
       (Stdlib.Filename.quote script);
   ]

--- a/lib/user_config.ml
+++ b/lib/user_config.ml
@@ -18,33 +18,98 @@ let load ~github_owner ~github_repo =
   in
   { on_worktree_create }
 
-let run_hook ~process_mgr ~script ~cwd ~env =
+let env_float name default =
+  match Stdlib.Sys.getenv_opt name with
+  | Some s -> ( try Float.of_string s with _ -> default)
+  | None -> default
+
+let env_int name default =
+  match Stdlib.Sys.getenv_opt name with
+  | Some s -> ( try Int.of_string s with _ -> default)
+  | None -> default
+
+let default_timeout () = env_float "ONTON_HOOK_TIMEOUT" 600.0
+let default_fd_limit () = env_int "ONTON_HOOK_FD_LIMIT" 256
+
+let build_error ~status_msg stdout_buf stderr_buf =
+  let stdout = String.strip (Buffer.contents stdout_buf) in
+  let stderr = String.strip (Buffer.contents stderr_buf) in
+  let sections =
+    List.filter_opt
+      [
+        Some status_msg;
+        (if String.is_empty stdout then None
+         else Some (Printf.sprintf "stdout:\n%s" stdout));
+        (if String.is_empty stderr then None
+         else Some (Printf.sprintf "stderr:\n%s" stderr));
+      ]
+  in
+  Error (String.concat ~sep:"\n" sections)
+
+(** Wrap the user's script in a [/bin/sh -c "ulimit -n N; exec SCRIPT"]
+    invocation. [ulimit -n] lowers the child's [RLIMIT_NOFILE] before the script
+    runs, so runaway subtree fan-out (npm install spawning node, dune spawning
+    ocamlc, etc.) can't exhaust the shared file-descriptor table on the host.
+    The [2>/dev/null] suppresses a noisy error if the current hard limit is
+    below the target — we still want [exec] to run either way. *)
+let wrap_with_ulimit ~fd_limit script =
+  [
+    "/bin/sh";
+    "-c";
+    Printf.sprintf "ulimit -n %d 2>/dev/null; exec %s" fd_limit
+      (Stdlib.Filename.quote script);
+  ]
+
+let run_hook ~process_mgr ~clock ~script ~cwd ~env ?(timeout : float option)
+    ?(fd_limit : int option) () : (unit, string) Result.t =
+  let timeout = Option.value timeout ~default:(default_timeout ()) in
+  let fd_limit = Option.value fd_limit ~default:(default_fd_limit ()) in
   let stdout_buf = Buffer.create 256 in
   let stderr_buf = Buffer.create 256 in
-  try
-    let env_array =
-      Array.of_list (List.map env ~f:(fun (k, v) -> Printf.sprintf "%s=%s" k v))
-    in
+  let env_array =
     let inherited = Unix.environment () |> Array.to_list in
-    let merged =
-      Array.of_list (List.append inherited (Array.to_list env_array))
-    in
-    Eio.Process.run process_mgr ~env:merged ~cwd
-      ~stdout:(Eio.Flow.buffer_sink stdout_buf)
-      ~stderr:(Eio.Flow.buffer_sink stderr_buf)
-      [ script ];
-    Ok ()
+    let overlay = List.map env ~f:(fun (k, v) -> Printf.sprintf "%s=%s" k v) in
+    Array.of_list (List.append inherited overlay)
+  in
+  let cmd = wrap_with_ulimit ~fd_limit script in
+  try
+    Eio.Switch.run (fun sw ->
+        let child =
+          Eio.Process.spawn ~sw process_mgr ~cwd ~env:env_array
+            ~stdout:(Eio.Flow.buffer_sink stdout_buf)
+            ~stderr:(Eio.Flow.buffer_sink stderr_buf)
+            cmd
+        in
+        match
+          Eio.Time.with_timeout clock timeout (fun () ->
+              Ok (Eio.Process.await child))
+        with
+        | Ok (`Exited 0) -> Ok ()
+        | Ok (`Exited code) ->
+            build_error
+              ~status_msg:(Printf.sprintf "hook exited with code %d" code)
+              stdout_buf stderr_buf
+        | Ok (`Signaled signal) ->
+            build_error
+              ~status_msg:(Printf.sprintf "hook killed by signal %d" signal)
+              stdout_buf stderr_buf
+        | Error `Timeout ->
+            (* SIGKILL reaches the direct child (our [/bin/sh -c]). If the
+               hook forked grandchildren (e.g. [npm install] spawning node
+               subprocesses), those orphans may keep running past the
+               timeout until they notice their parent is gone. Killing the
+               whole process tree requires [setpgid] (not in OCaml's
+               Stdlib.Unix) or a fork-action pre-exec hook (Eio private
+               API); both are out of scope here. The timeout still bounds
+               *our* blocking on the hook, which is the property the
+               orchestrator needs. *)
+            (try Eio.Process.signal child Stdlib.Sys.sigkill with _ -> ());
+            build_error
+              ~status_msg:
+                (Printf.sprintf
+                   "hook timed out after %.1fs (ONTON_HOOK_TIMEOUT)" timeout)
+              stdout_buf stderr_buf)
   with exn ->
-    let stdout = String.strip (Buffer.contents stdout_buf) in
-    let stderr = String.strip (Buffer.contents stderr_buf) in
-    let sections =
-      List.filter_opt
-        [
-          Some (Stdlib.Printexc.to_string exn);
-          (if String.is_empty stdout then None
-           else Some (Printf.sprintf "stdout:\n%s" stdout));
-          (if String.is_empty stderr then None
-           else Some (Printf.sprintf "stderr:\n%s" stderr));
-        ]
-    in
-    Error (String.concat ~sep:"\n" sections)
+    build_error
+      ~status_msg:(Stdlib.Printexc.to_string exn)
+      stdout_buf stderr_buf

--- a/lib/user_config.ml
+++ b/lib/user_config.ml
@@ -18,18 +18,30 @@ let load ~github_owner ~github_repo =
   in
   { on_worktree_create }
 
-let env_float name default =
+(* Positive-only parsers: zero/negative/NaN/infinity in these env vars would
+   either break the hook (ulimit -n 0 makes the child unable to open anything)
+   or weaken containment (negative timeout, infinite timeout). Fall back to
+   the default rather than propagating a footgun. *)
+let env_positive_float name default =
   match Stdlib.Sys.getenv_opt name with
-  | Some s -> ( try Float.of_string s with _ -> default)
+  | Some s -> (
+      try
+        let v = Float.of_string s in
+        if Float.is_finite v && Float.(v > 0.) then v else default
+      with _ -> default)
   | None -> default
 
-let env_int name default =
+let env_positive_int name default =
   match Stdlib.Sys.getenv_opt name with
-  | Some s -> ( try Int.of_string s with _ -> default)
+  | Some s -> (
+      try
+        let v = Int.of_string s in
+        if v > 0 then v else default
+      with _ -> default)
   | None -> default
 
-let default_timeout () = env_float "ONTON_HOOK_TIMEOUT" 600.0
-let default_fd_limit () = env_int "ONTON_HOOK_FD_LIMIT" 256
+let default_timeout () = env_positive_float "ONTON_HOOK_TIMEOUT" 600.0
+let default_fd_limit () = env_positive_int "ONTON_HOOK_FD_LIMIT" 256
 
 let build_error ~status_msg stdout_buf stderr_buf =
   let stdout = String.strip (Buffer.contents stdout_buf) in
@@ -59,7 +71,7 @@ let wrap_with_ulimit ~fd_limit script =
     "/bin/sh";
     "-c";
     Printf.sprintf
-      {|hlimit=$(ulimit -Hn); slimit=$(ulimit -Sn); target=%d; [ "$hlimit" != unlimited ] && [ "$target" -gt "$hlimit" ] && target=$hlimit; [ "$slimit" != unlimited ] && [ "$target" -gt "$slimit" ] && target=$slimit; ulimit -n "$target"; exec %s|}
+      {|hlimit=$(ulimit -Hn); slimit=$(ulimit -Sn); target=%d; [ "$hlimit" != unlimited ] && [ "$target" -gt "$hlimit" ] && target=$hlimit; [ "$slimit" != unlimited ] && [ "$target" -gt "$slimit" ] && target=$slimit; ulimit -n "$target" && exec %s|}
       fd_limit
       (Stdlib.Filename.quote script);
   ]

--- a/lib/user_config.ml
+++ b/lib/user_config.ml
@@ -71,7 +71,17 @@ let run_hook ~process_mgr ~clock ~script ~cwd ~env ?(timeout : float option)
   let stdout_buf = Buffer.create 256 in
   let stderr_buf = Buffer.create 256 in
   let env_array =
+    (* Overlay keys must override inherited ones. [execve] accepts duplicate
+       keys but [getenv] returns the first match on glibc, so we filter
+       inherited entries whose key is in [overlay] before appending. *)
     let inherited = Unix.environment () |> Array.to_list in
+    let override_keys = Set.of_list (module String) (List.map env ~f:fst) in
+    let inherited =
+      List.filter inherited ~f:(fun binding ->
+          match String.lsplit2 binding ~on:'=' with
+          | Some (k, _) -> not (Set.mem override_keys k)
+          | None -> true)
+    in
     let overlay = List.map env ~f:(fun (k, v) -> Printf.sprintf "%s=%s" k v) in
     Array.of_list (List.append inherited overlay)
   in
@@ -118,7 +128,12 @@ let run_hook ~process_mgr ~clock ~script ~cwd ~env ?(timeout : float option)
                 (Printf.sprintf
                    "hook timed out after %.1fs (ONTON_HOOK_TIMEOUT)" timeout)
               stdout_buf stderr_buf)
-  with exn ->
-    build_error
-      ~status_msg:(Stdlib.Printexc.to_string exn)
-      stdout_buf stderr_buf
+  with
+  | Eio.Cancel.Cancelled _ as exn ->
+      (* Cancellation must propagate to the caller — never format it as a
+         hook failure. See Eio.Cancel docs. *)
+      raise exn
+  | exn ->
+      build_error
+        ~status_msg:(Stdlib.Printexc.to_string exn)
+        stdout_buf stderr_buf

--- a/lib/user_config.ml
+++ b/lib/user_config.ml
@@ -49,14 +49,18 @@ let build_error ~status_msg stdout_buf stderr_buf =
 (** Wrap the user's script in a [/bin/sh -c "ulimit -n N; exec SCRIPT"]
     invocation. [ulimit -n] lowers the child's [RLIMIT_NOFILE] before the script
     runs, so runaway subtree fan-out (npm install spawning node, dune spawning
-    ocamlc, etc.) can't exhaust the shared file-descriptor table on the host.
-    The [2>/dev/null] suppresses a noisy error if the current hard limit is
-    below the target — we still want [exec] to run either way. *)
+    ocamlc, etc.) can't exhaust the shared file-descriptor table on the host. We
+    clamp the requested limit against the current hard cap at runtime —
+    otherwise on shells like dash where [ulimit -n N] fails when [N] exceeds the
+    hard limit, the builtin error leaks into the captured stderr even with
+    [2>/dev/null]. *)
 let wrap_with_ulimit ~fd_limit script =
   [
     "/bin/sh";
     "-c";
-    Printf.sprintf "ulimit -n %d 2>/dev/null; exec %s" fd_limit
+    Printf.sprintf
+      {|limit=$(ulimit -Hn); target=%d; if [ "$limit" = unlimited ] || [ "$target" -lt "$limit" ]; then ulimit -n "$target"; else ulimit -n "$limit"; fi; exec %s|}
+      fd_limit
       (Stdlib.Filename.quote script);
   ]
 
@@ -104,6 +108,11 @@ let run_hook ~process_mgr ~clock ~script ~cwd ~env ?(timeout : float option)
                *our* blocking on the hook, which is the property the
                orchestrator needs. *)
             (try Eio.Process.signal child Stdlib.Sys.sigkill with _ -> ());
+            (* Await the child synchronously before returning — otherwise
+               the caller's [hook_mutex] is released while the kernel is
+               still finishing SIGKILL delivery, and a second hook can
+               start running concurrently with the dying first one. *)
+            (try ignore (Eio.Process.await child) with _ -> ());
             build_error
               ~status_msg:
                 (Printf.sprintf

--- a/lib/user_config.mli
+++ b/lib/user_config.mli
@@ -11,11 +11,30 @@ val config_dir : github_owner:string -> github_repo:string -> string
 
 val run_hook :
   process_mgr:_ Eio.Process.mgr ->
+  clock:_ Eio.Time.clock ->
   script:string ->
-  cwd:_ Eio.Path.t ->
+  cwd:Eio.Fs.dir_ty Eio.Path.t ->
   env:(string * string) list ->
+  ?timeout:float ->
+  ?fd_limit:int ->
+  unit ->
   (unit, string) Result.t
-(** Execute a hook script in [cwd] with the given environment variables. Both
-    stdout and stderr are captured; on failure the returned [Error msg] embeds
-    the underlying exception followed by non-empty stdout/stderr sections so the
-    caller can surface them (e.g. to the activity log). *)
+(** Execute a hook script in [cwd] with the given environment variables.
+
+    The hook is invoked through
+    [/bin/sh -c "ulimit -n <fd_limit>; exec <script>"] so the child's
+    file-descriptor limit is capped independently of the parent. This prevents a
+    runaway hook (e.g. [npm install] fanning into hundreds of node subprocesses,
+    or [dune build] spawning many compilers) from exhausting the shared host FD
+    table — see issue #209.
+
+    A wall-clock [timeout] bounds the hook; on expiry the child is sent
+    [SIGKILL] and an [Error] is returned carrying any captured output.
+
+    Defaults (override per call or via env):
+    - [timeout]: 600.0 seconds ([ONTON_HOOK_TIMEOUT])
+    - [fd_limit]: 256 ([ONTON_HOOK_FD_LIMIT])
+
+    Both stdout and stderr are captured; on failure (non-zero exit, signal,
+    timeout) the returned [Error msg] embeds a status summary followed by
+    non-empty stdout/stderr sections so the caller can surface them. *)

--- a/test/dune
+++ b/test/dune
@@ -125,3 +125,15 @@
 (test
  (name test_user_config)
  (libraries onton eio eio_main eio.unix unix))
+
+(test
+ (name test_repo_root)
+ (libraries onton unix))
+
+(test
+ (name test_project_lock)
+ (libraries onton unix))
+
+(test
+ (name test_rlimit)
+ (libraries onton))

--- a/test/test_project_lock.ml
+++ b/test/test_project_lock.ml
@@ -1,0 +1,208 @@
+(** Tests for [Onton.Project_lock]: per-project advisory lock using
+    [Unix.lockf]. Verifies contention, stale reclamation, release, and
+    re-acquire semantics without spinning up Eio. *)
+
+open Onton
+
+let ( // ) = Filename.concat
+
+let mktempdir prefix =
+  let base = Filename.get_temp_dir_name () in
+  let rec loop n =
+    let dir = base // Printf.sprintf "%s-%d-%d" prefix (Unix.getpid ()) n in
+    try
+      Unix.mkdir dir 0o755;
+      dir
+    with Unix.Unix_error (Unix.EEXIST, _, _) -> loop (n + 1)
+  in
+  loop 0
+
+let rm_rf dir =
+  ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote dir)))
+
+let fail_if cond msg = if cond then failwith msg
+
+let must_ok = function
+  | Ok v -> v
+  | Error (Project_lock.Held_by { pid; _ }) ->
+      failwith (Printf.sprintf "expected Ok, got Held_by pid=%d" pid)
+  | Error (Project_lock.Io_error s) ->
+      failwith (Printf.sprintf "expected Ok, got Io_error %s" s)
+
+let must_held_by = function
+  | Error (Project_lock.Held_by { pid; _ }) -> pid
+  | Ok _ -> failwith "expected Held_by, got Ok"
+  | Error (Project_lock.Io_error s) ->
+      failwith (Printf.sprintf "expected Held_by, got Io_error %s" s)
+
+let on_stale_noop _pid = ()
+
+let test_happy_path () =
+  let dir = mktempdir "onton-lock-happy" in
+  Fun.protect
+    ~finally:(fun () -> rm_rf dir)
+    (fun () ->
+      let lock =
+        must_ok (Project_lock.acquire ~project_dir:dir ~on_stale:on_stale_noop)
+      in
+      let path = dir // "onton.lock" in
+      fail_if (not (Sys.file_exists path)) "lock file not created";
+      let ic = open_in path in
+      let content = In_channel.input_all ic in
+      close_in ic;
+      let pid = int_of_string (String.trim content) in
+      fail_if
+        (pid <> Unix.getpid ())
+        (Printf.sprintf "PID mismatch: %d vs %d" pid (Unix.getpid ()));
+      Project_lock.release lock)
+
+let test_release_is_idempotent () =
+  let dir = mktempdir "onton-lock-release" in
+  Fun.protect
+    ~finally:(fun () -> rm_rf dir)
+    (fun () ->
+      let lock =
+        must_ok (Project_lock.acquire ~project_dir:dir ~on_stale:on_stale_noop)
+      in
+      Project_lock.release lock;
+      Project_lock.release lock;
+      (* After release, re-acquisition must succeed. *)
+      let lock2 =
+        must_ok (Project_lock.acquire ~project_dir:dir ~on_stale:on_stale_noop)
+      in
+      Project_lock.release lock2)
+
+(** Fork a child that acquires the lock and pauses. Wait until the PID file is
+    populated, then the parent attempts to acquire and must see
+    [Held_by child_pid]. *)
+let test_contention () =
+  let dir = mktempdir "onton-lock-contention" in
+  Fun.protect
+    ~finally:(fun () -> rm_rf dir)
+    (fun () ->
+      let sync_fd, child_resume = Unix.pipe () in
+      match Unix.fork () with
+      | 0 ->
+          Unix.close child_resume;
+          let lock =
+            match
+              Project_lock.acquire ~project_dir:dir ~on_stale:on_stale_noop
+            with
+            | Ok l -> l
+            | Error _ -> exit 2
+          in
+          (* Signal ready by writing the PID file (acquire already did).
+             Block until parent closes [child_resume]. *)
+          let buf = Bytes.create 1 in
+          (try
+             let _ = Unix.read sync_fd buf 0 1 in
+             ()
+           with _ -> ());
+          Project_lock.release lock;
+          exit 0
+      | child_pid ->
+          Unix.close sync_fd;
+          (* Wait for child's lock file to appear with a non-empty PID. *)
+          let lock_path = dir // "onton.lock" in
+          let deadline = Unix.gettimeofday () +. 5.0 in
+          let rec wait () =
+            let populated =
+              Sys.file_exists lock_path
+              &&
+                try
+                  let ic = open_in lock_path in
+                  let s = In_channel.input_all ic in
+                  close_in ic;
+                  String.length (String.trim s) > 0
+                with _ -> false
+            in
+            if populated then ()
+            else if Unix.gettimeofday () > deadline then
+              failwith "child never populated lock file"
+            else (
+              ignore (Unix.select [] [] [] 0.01);
+              wait ())
+          in
+          wait ();
+          let held_pid =
+            must_held_by
+              (Project_lock.acquire ~project_dir:dir ~on_stale:on_stale_noop)
+          in
+          fail_if (held_pid <> child_pid)
+            (Printf.sprintf "held-by pid mismatch: %d vs child %d" held_pid
+               child_pid);
+          (* Release child. *)
+          Unix.close child_resume;
+          let _, _ = Unix.waitpid [] child_pid in
+          (* Now the parent can acquire. *)
+          let lock =
+            must_ok
+              (Project_lock.acquire ~project_dir:dir ~on_stale:on_stale_noop)
+          in
+          Project_lock.release lock)
+
+(** Crash recovery: if the previous holder died (SIGKILL), the kernel releases
+    its F_TLOCK automatically — so a fresh [acquire] just succeeds. This
+    verifies the practical "onton crashed, user restarts" case. The explicit
+    stale-PID path in [project_lock.ml] is a defensive safety net for rarer
+    cases (FD inherited across fork, dying holder with FDs still open
+    elsewhere); those are difficult to reach from userspace and aren't tested.
+*)
+let test_crash_recovery () =
+  let dir = mktempdir "onton-lock-crash" in
+  Fun.protect
+    ~finally:(fun () -> rm_rf dir)
+    (fun () ->
+      match Unix.fork () with
+      | 0 ->
+          let _ =
+            match
+              Project_lock.acquire ~project_dir:dir ~on_stale:on_stale_noop
+            with
+            | Ok l -> l
+            | Error _ -> exit 2
+          in
+          (* Hang until parent kills us; never release. *)
+          let rec spin () =
+            ignore (Unix.select [] [] [] 10.0);
+            spin ()
+          in
+          spin ()
+      | child_pid ->
+          let lock_path = dir // "onton.lock" in
+          let deadline = Unix.gettimeofday () +. 5.0 in
+          let rec wait () =
+            let populated =
+              Sys.file_exists lock_path
+              &&
+                try
+                  let ic = open_in lock_path in
+                  let s = In_channel.input_all ic in
+                  close_in ic;
+                  String.length (String.trim s) > 0
+                with _ -> false
+            in
+            if populated then ()
+            else if Unix.gettimeofday () > deadline then
+              failwith "child never populated lock file"
+            else (
+              ignore (Unix.select [] [] [] 0.01);
+              wait ())
+          in
+          wait ();
+          (* Simulate crash: SIGKILL. Kernel releases the lock when the FD
+             is auto-closed on process death. *)
+          Unix.kill child_pid Sys.sigkill;
+          let _, _ = Unix.waitpid [] child_pid in
+          let lock =
+            must_ok
+              (Project_lock.acquire ~project_dir:dir ~on_stale:on_stale_noop)
+          in
+          Project_lock.release lock)
+
+let () =
+  test_happy_path ();
+  test_release_is_idempotent ();
+  test_contention ();
+  test_crash_recovery ();
+  print_endline "test_project_lock: OK"

--- a/test/test_project_lock.ml
+++ b/test/test_project_lock.ml
@@ -72,18 +72,22 @@ let test_release_is_idempotent () =
       in
       Project_lock.release lock2)
 
-(** Fork a child that acquires the lock and pauses. Wait until the PID file is
-    populated, then the parent attempts to acquire and must see
-    [Held_by child_pid]. *)
+(** Fork a child that acquires the lock and pauses. The child signals readiness
+    over a pipe *after* [acquire] has finished its ftruncate+write, so the
+    parent never observes the file mid-write. Then the parent attempts to
+    acquire and must see [Held_by child_pid]. *)
 let test_contention () =
   let dir = mktempdir "onton-lock-contention" in
   Fun.protect
     ~finally:(fun () -> rm_rf dir)
     (fun () ->
-      let sync_fd, child_resume = Unix.pipe () in
+      (* Pipe A: child → parent "ready". Pipe B: parent → child "resume". *)
+      let ready_r, ready_w = Unix.pipe () in
+      let resume_r, resume_w = Unix.pipe () in
       match Unix.fork () with
       | 0 ->
-          Unix.close child_resume;
+          Unix.close ready_r;
+          Unix.close resume_w;
           let lock =
             match
               Project_lock.acquire ~project_dir:dir ~on_stale:on_stale_noop
@@ -91,39 +95,21 @@ let test_contention () =
             | Ok l -> l
             | Error _ -> exit 2
           in
-          (* Signal ready by writing the PID file (acquire already did).
-             Block until parent closes [child_resume]. *)
+          (* Signal readiness *after* acquire's ftruncate+write is done. *)
+          let _ = Unix.write ready_w (Bytes.create 1) 0 1 in
+          Unix.close ready_w;
+          (* Block until parent closes [resume_w] (EOF on read). *)
           let buf = Bytes.create 1 in
-          (try
-             let _ = Unix.read sync_fd buf 0 1 in
-             ()
-           with _ -> ());
+          (try ignore (Unix.read resume_r buf 0 1) with _ -> ());
           Project_lock.release lock;
           exit 0
       | child_pid ->
-          Unix.close sync_fd;
-          (* Wait for child's lock file to appear with a non-empty PID. *)
-          let lock_path = dir // "onton.lock" in
-          let deadline = Unix.gettimeofday () +. 5.0 in
-          let rec wait () =
-            let populated =
-              Sys.file_exists lock_path
-              &&
-                try
-                  let ic = open_in lock_path in
-                  let s = In_channel.input_all ic in
-                  close_in ic;
-                  String.length (String.trim s) > 0
-                with _ -> false
-            in
-            if populated then ()
-            else if Unix.gettimeofday () > deadline then
-              failwith "child never populated lock file"
-            else (
-              ignore (Unix.select [] [] [] 0.01);
-              wait ())
-          in
-          wait ();
+          Unix.close ready_w;
+          Unix.close resume_r;
+          (* Deterministic wait: blocks until child writes one byte. *)
+          let buf = Bytes.create 1 in
+          let _ = Unix.read ready_r buf 0 1 in
+          Unix.close ready_r;
           let held_pid =
             must_held_by
               (Project_lock.acquire ~project_dir:dir ~on_stale:on_stale_noop)
@@ -132,7 +118,7 @@ let test_contention () =
             (Printf.sprintf "held-by pid mismatch: %d vs child %d" held_pid
                child_pid);
           (* Release child. *)
-          Unix.close child_resume;
+          Unix.close resume_w;
           let _, _ = Unix.waitpid [] child_pid in
           (* Now the parent can acquire. *)
           let lock =
@@ -153,8 +139,10 @@ let test_crash_recovery () =
   Fun.protect
     ~finally:(fun () -> rm_rf dir)
     (fun () ->
+      let ready_r, ready_w = Unix.pipe () in
       match Unix.fork () with
       | 0 ->
+          Unix.close ready_r;
           let _ =
             match
               Project_lock.acquire ~project_dir:dir ~on_stale:on_stale_noop
@@ -162,6 +150,8 @@ let test_crash_recovery () =
             | Ok l -> l
             | Error _ -> exit 2
           in
+          let _ = Unix.write ready_w (Bytes.create 1) 0 1 in
+          Unix.close ready_w;
           (* Hang until parent kills us; never release. *)
           let rec spin () =
             ignore (Unix.select [] [] [] 10.0);
@@ -169,27 +159,10 @@ let test_crash_recovery () =
           in
           spin ()
       | child_pid ->
-          let lock_path = dir // "onton.lock" in
-          let deadline = Unix.gettimeofday () +. 5.0 in
-          let rec wait () =
-            let populated =
-              Sys.file_exists lock_path
-              &&
-                try
-                  let ic = open_in lock_path in
-                  let s = In_channel.input_all ic in
-                  close_in ic;
-                  String.length (String.trim s) > 0
-                with _ -> false
-            in
-            if populated then ()
-            else if Unix.gettimeofday () > deadline then
-              failwith "child never populated lock file"
-            else (
-              ignore (Unix.select [] [] [] 0.01);
-              wait ())
-          in
-          wait ();
+          Unix.close ready_w;
+          let buf = Bytes.create 1 in
+          let _ = Unix.read ready_r buf 0 1 in
+          Unix.close ready_r;
           (* Simulate crash: SIGKILL. Kernel releases the lock when the FD
              is auto-closed on process death. *)
           Unix.kill child_pid Sys.sigkill;

--- a/test/test_repo_root.ml
+++ b/test/test_repo_root.ml
@@ -1,0 +1,124 @@
+(** Tests for [Onton.Repo_root.normalize]: running [onton] from any directory
+    inside a git repository — including a worktree — should resolve to the main
+    working tree, never to a worktree path. *)
+
+open Onton
+
+let ( // ) = Filename.concat
+
+(** Create a unique temp directory. *)
+let mktempdir prefix =
+  let base = Filename.get_temp_dir_name () in
+  let rec loop n =
+    let dir = base // Printf.sprintf "%s-%d-%d" prefix (Unix.getpid ()) n in
+    try
+      Unix.mkdir dir 0o755;
+      dir
+    with Unix.Unix_error (Unix.EEXIST, _, _) -> loop (n + 1)
+  in
+  loop 0
+
+(** Remove [dir] recursively. Best-effort; swallows errors. *)
+let rm_rf dir =
+  let cmd = Printf.sprintf "rm -rf %s" (Filename.quote dir) in
+  ignore (Sys.command cmd)
+
+(** Run a command from [cwd] and assert it succeeded. *)
+let sh_at cwd cmd =
+  let full =
+    Printf.sprintf "cd %s && %s >/dev/null 2>&1" (Filename.quote cwd) cmd
+  in
+  match Sys.command full with
+  | 0 -> ()
+  | n -> failwith (Printf.sprintf "command failed (%d): %s" n cmd)
+
+(** Initialize a git repo at [dir] with a single commit. *)
+let init_repo dir =
+  sh_at dir "git init -q -b main";
+  sh_at dir "git config user.email test@example.com";
+  sh_at dir "git config user.name test";
+  sh_at dir "git commit -q --allow-empty -m init"
+
+let with_main_and_worktree f =
+  let main = mktempdir "onton-repo-root-main" in
+  let wt_parent = mktempdir "onton-repo-root-wt" in
+  let wt = wt_parent // "patch-1" in
+  Fun.protect
+    ~finally:(fun () ->
+      rm_rf main;
+      rm_rf wt_parent)
+    (fun () ->
+      init_repo main;
+      sh_at main
+        (Printf.sprintf "git worktree add -b feat %s" (Filename.quote wt));
+      f ~main ~wt)
+
+let with_chdir dir f =
+  let saved = Sys.getcwd () in
+  Fun.protect
+    ~finally:(fun () -> try Unix.chdir saved with _ -> ())
+    (fun () ->
+      Unix.chdir dir;
+      f ())
+
+let real_path p =
+  (* Resolve symlinks — macOS /tmp → /private/tmp — so path comparisons hold
+     regardless of how [Sys.getcwd] vs the [git] binary render the prefix. *)
+  let ic =
+    Unix.open_process_in (Printf.sprintf "cd %s && pwd -P" (Filename.quote p))
+  in
+  let line = input_line ic in
+  ignore (Unix.close_process_in ic);
+  line
+
+let assert_eq ~ctx expected actual =
+  if String.equal expected actual then ()
+  else
+    failwith (Printf.sprintf "[%s] expected=%s actual=%s" ctx expected actual)
+
+let test_main_from_main_repo () =
+  with_main_and_worktree (fun ~main ~wt:_ ->
+      with_chdir main (fun () ->
+          let got = Repo_root.normalize "." in
+          assert_eq ~ctx:"main-from-main" (real_path main) got))
+
+let test_main_from_worktree () =
+  with_main_and_worktree (fun ~main ~wt ->
+      with_chdir wt (fun () ->
+          let got = Repo_root.normalize "." in
+          assert_eq ~ctx:"main-from-worktree" (real_path main) got))
+
+let test_absolute_worktree_path_resolves () =
+  with_main_and_worktree (fun ~main ~wt ->
+      let got = Repo_root.normalize wt in
+      assert_eq ~ctx:"absolute-worktree" (real_path main) got)
+
+let test_trailing_dot_stripped () =
+  with_main_and_worktree (fun ~main ~wt:_ ->
+      let got = Repo_root.normalize (main // ".") in
+      assert_eq ~ctx:"trailing-dot" (real_path main) got)
+
+let test_trailing_slash_stripped () =
+  with_main_and_worktree (fun ~main ~wt:_ ->
+      let got = Repo_root.normalize (main ^ "/") in
+      assert_eq ~ctx:"trailing-slash" (real_path main) got)
+
+let test_non_repo_passthrough () =
+  (* Outside any git repo: return absolute-but-unresolved, so downstream
+     error paths surface the non-repo case rather than masking it. *)
+  let tmp = mktempdir "onton-repo-root-nonrepo" in
+  Fun.protect
+    ~finally:(fun () -> rm_rf tmp)
+    (fun () ->
+      let got = Repo_root.normalize tmp in
+      (* No git repo here, so the resolved path equals the input. *)
+      assert_eq ~ctx:"non-repo" tmp got)
+
+let () =
+  test_main_from_main_repo ();
+  test_main_from_worktree ();
+  test_absolute_worktree_path_resolves ();
+  test_trailing_dot_stripped ();
+  test_trailing_slash_stripped ();
+  test_non_repo_passthrough ();
+  print_endline "test_repo_root: OK"

--- a/test/test_rlimit.ml
+++ b/test/test_rlimit.ml
@@ -15,10 +15,12 @@ let test_get_returns_sane_limits () =
     (Printf.sprintf "hard=%d must be ≥ soft=%d" lim.hard lim.soft)
 
 let test_try_raise_is_capped_at_hard () =
-  (* Ask for something far beyond the hard cap. Must not raise, and must
-     return a soft that does not exceed hard. *)
-  let before = get_nofile () in
-  let after = try_raise_nofile_soft ~target:((before.hard * 2) + 1_000_000) in
+  (* Ask for something far beyond any plausible hard cap. Using [max_int]
+     avoids overflow when the kernel hard cap is [RLIM_INFINITY] and the C
+     getter has clamped it to [Max_long] — [hard * 2 + N] would wrap to a
+     negative value, short-circuit the raise, and make the assertion
+     trivially true. *)
+  let after = try_raise_nofile_soft ~target:Int.max_int in
   fail_if (after.soft > after.hard)
     (Printf.sprintf "soft=%d must be ≤ hard=%d after raise" after.soft
        after.hard)

--- a/test/test_rlimit.ml
+++ b/test/test_rlimit.ml
@@ -1,0 +1,38 @@
+(** Tests for [Onton.Rlimit]: POSIX RLIMIT_NOFILE bindings.
+
+    We exercise [get_nofile] and [try_raise_nofile_soft] in-process; we do not
+    test the preflight integration in [bin/main.ml] because that would require
+    spawning the full [onton] binary under different ulimit values. *)
+
+open Onton.Rlimit
+
+let fail_if cond msg = if cond then failwith msg
+
+let test_get_returns_sane_limits () =
+  let lim = get_nofile () in
+  fail_if (lim.soft <= 0) (Printf.sprintf "soft=%d must be > 0" lim.soft);
+  fail_if (lim.hard < lim.soft)
+    (Printf.sprintf "hard=%d must be ≥ soft=%d" lim.hard lim.soft)
+
+let test_try_raise_is_capped_at_hard () =
+  (* Ask for something far beyond the hard cap. Must not raise, and must
+     return a soft that does not exceed hard. *)
+  let before = get_nofile () in
+  let after = try_raise_nofile_soft ~target:((before.hard * 2) + 1_000_000) in
+  fail_if (after.soft > after.hard)
+    (Printf.sprintf "soft=%d must be ≤ hard=%d after raise" after.soft
+       after.hard)
+
+let test_try_raise_noop_when_already_sufficient () =
+  let before = get_nofile () in
+  (* Asking for the current soft or lower must not reduce it — the function
+     promises to *raise*, not to lower. *)
+  let after = try_raise_nofile_soft ~target:1 in
+  fail_if (after.soft < before.soft)
+    (Printf.sprintf "soft unexpectedly reduced %d → %d" before.soft after.soft)
+
+let () =
+  test_get_returns_sane_limits ();
+  test_try_raise_is_capped_at_hard ();
+  test_try_raise_noop_when_already_sufficient ();
+  print_endline "test_rlimit: OK"

--- a/test/test_user_config.ml
+++ b/test/test_user_config.ml
@@ -27,12 +27,13 @@ let assert_not_contains ~label ~needle haystack =
 let () =
   Eio_main.run @@ fun env ->
   let process_mgr = Eio.Stdenv.process_mgr env in
+  let clock = Eio.Stdenv.clock env in
   let fs = Eio.Stdenv.fs env in
 
   (* ── Success: exit 0, stdout ignored by caller ────────────────────── *)
   (let dir, script = make_script "#!/bin/sh\necho hello\n" in
    let cwd = Eio.Path.(fs / dir) in
-   match User_config.run_hook ~process_mgr ~script ~cwd ~env:[] with
+   match User_config.run_hook ~process_mgr ~clock ~script ~cwd ~env:[] () with
    | Ok () -> ()
    | Error msg -> failwith (Printf.sprintf "expected Ok, got Error: %s" msg));
 
@@ -43,7 +44,7 @@ let () =
      make_script "#!/bin/sh\necho 'ERROR: no opam switch' >&1\nexit 1\n"
    in
    let cwd = Eio.Path.(fs / dir) in
-   match User_config.run_hook ~process_mgr ~script ~cwd ~env:[] with
+   match User_config.run_hook ~process_mgr ~clock ~script ~cwd ~env:[] () with
    | Ok () -> failwith "expected Error when hook exits 1"
    | Error msg ->
        assert_contains ~label:"stdout-on-failure" ~needle:"stdout:" msg;
@@ -54,7 +55,7 @@ let () =
   (* ── Failure: hook writes to STDERR only. ─────────────────────────── *)
   (let dir, script = make_script "#!/bin/sh\necho 'boom' >&2\nexit 2\n" in
    let cwd = Eio.Path.(fs / dir) in
-   match User_config.run_hook ~process_mgr ~script ~cwd ~env:[] with
+   match User_config.run_hook ~process_mgr ~clock ~script ~cwd ~env:[] () with
    | Ok () -> failwith "expected Error when hook exits 2"
    | Error msg ->
        assert_contains ~label:"stderr-only" ~needle:"stderr:" msg;
@@ -66,7 +67,7 @@ let () =
      make_script "#!/bin/sh\necho out-line\necho err-line >&2\nexit 3\n"
    in
    let cwd = Eio.Path.(fs / dir) in
-   match User_config.run_hook ~process_mgr ~script ~cwd ~env:[] with
+   match User_config.run_hook ~process_mgr ~clock ~script ~cwd ~env:[] () with
    | Ok () -> failwith "expected Error when hook exits 3"
    | Error msg ->
        assert_contains ~label:"both-streams" ~needle:"stdout:" msg;
@@ -85,8 +86,48 @@ let () =
    in
    let cwd = Eio.Path.(fs / dir) in
    let env = [ ("ONTON_PATCH_ID", "42") ] in
-   match User_config.run_hook ~process_mgr ~script ~cwd ~env with
+   match User_config.run_hook ~process_mgr ~clock ~script ~cwd ~env () with
    | Ok () -> ()
    | Error msg -> failwith (Printf.sprintf "expected Ok, got Error: %s" msg));
+
+  (* ── Timeout: hook that runs longer than [~timeout] must be killed
+        with SIGKILL and return an Error whose message names the timeout.
+
+        NOTE: SIGKILL is only delivered to the [child] PID we spawned
+        (the outer [/bin/sh -c] that exec'd the hook). Grandchild processes
+        the hook itself forked are not killed by this signal — mitigating
+        that requires setpgid + killing the whole group, which is a
+        follow-up. For this test we exec [sleep] directly so no grandchild
+        is created. *)
+  (let dir, script = make_script "#!/bin/sh\nexec sleep 5\n" in
+   let cwd = Eio.Path.(fs / dir) in
+   let t0 = Unix.gettimeofday () in
+   (match
+      User_config.run_hook ~process_mgr ~clock ~script ~cwd ~env:[] ~timeout:0.3
+        ()
+    with
+   | Ok () -> failwith "expected timeout Error"
+   | Error msg -> assert_contains ~label:"timeout" ~needle:"timed out" msg);
+   let elapsed = Unix.gettimeofday () -. t0 in
+   if Float.(elapsed > 3.0) then
+     failwith
+       (Printf.sprintf "timeout took %.1fs — SIGKILL likely didn't fire in time"
+          elapsed));
+
+  (* ── FD cap: the [ulimit -n N] prefix must reach the child so a runaway
+        hook can't exhaust the shared FD table. The hook echoes its own
+        [ulimit -n] then exits non-zero so the captured stdout surfaces via
+        the Error message. ────────────────────────────────────────────── *)
+  (let dir, script =
+     make_script
+       "#!/bin/sh\nlimit=$(ulimit -n)\necho \"limit=$limit\"\nexit 1\n"
+   in
+   let cwd = Eio.Path.(fs / dir) in
+   match
+     User_config.run_hook ~process_mgr ~clock ~script ~cwd ~env:[] ~fd_limit:128
+       ()
+   with
+   | Ok () -> failwith "expected Error (exit 1)"
+   | Error msg -> assert_contains ~label:"fd-cap" ~needle:"limit=128" msg);
 
   Stdlib.print_endline "test_user_config: OK"

--- a/test/test_user_config.ml
+++ b/test/test_user_config.ml
@@ -117,17 +117,32 @@ let () =
   (* ── FD cap: the [ulimit -n N] prefix must reach the child so a runaway
         hook can't exhaust the shared FD table. The hook echoes its own
         [ulimit -n] then exits non-zero so the captured stdout surfaces via
-        the Error message. ────────────────────────────────────────────── *)
+        the Error message.
+
+        [wrap_with_ulimit] clamps the requested limit against the test
+        runner's own soft cap, so if the CI runner is already at [ulimit -Sn]
+        < 128 (exactly the scenario this PR is meant to help with), the child
+        sees the clamped value, not 128. Expect [min fd_limit parent_soft]. *)
   (let dir, script =
      make_script
        "#!/bin/sh\nlimit=$(ulimit -n)\necho \"limit=$limit\"\nexit 1\n"
    in
    let cwd = Eio.Path.(fs / dir) in
+   let parent_soft =
+     let ic = Unix.open_process_in "ulimit -Sn" in
+     let s = String.strip (Stdlib.input_line ic) in
+     ignore (Unix.close_process_in ic);
+     if String.equal s "unlimited" then Int.max_value else Int.of_string s
+   in
+   let fd_limit = 128 in
+   let expected = min fd_limit parent_soft in
    match
-     User_config.run_hook ~process_mgr ~clock ~script ~cwd ~env:[] ~fd_limit:128
-       ()
+     User_config.run_hook ~process_mgr ~clock ~script ~cwd ~env:[] ~fd_limit ()
    with
    | Ok () -> failwith "expected Error (exit 1)"
-   | Error msg -> assert_contains ~label:"fd-cap" ~needle:"limit=128" msg);
+   | Error msg ->
+       assert_contains ~label:"fd-cap"
+         ~needle:(Printf.sprintf "limit=%d" expected)
+         msg);
 
   Stdlib.print_endline "test_user_config: OK"


### PR DESCRIPTION
## Summary

Four independent, locally-scoped fixes for the blast-radius defects surfaced by the postmortem in #209. Each can be reverted on its own; each has dedicated unit tests. Keeping them in one PR for atomic review — split on request.

**RCA recap** (full chain in #209):
- Multiple onton instances running simultaneously (no singleton guard) compounded the damage.
- `on_worktree_create` hook had no timeout, FD cap, or concurrency gate — `npm install` + `dune build` + `bun install` per worktree × N worktrees × M instances = system-wide `kern.maxfiles` exhaustion.
- Separately: `repo_root` was silently persisting the *worktree* path when onton was invoked from inside a worktree (see #209 comment trail), which is a latent correctness bug worth fixing in the same pass.

## The four fixes

### 1. Resolve `repo_root` via `git rev-parse --git-common-dir`

`bin/main.ml`'s `normalize_repo_root` just absolutized CWD, so invoking onton from any worktree persisted that worktree path as the canonical `repo_root`. Evidence: the affected project's `config.json` had `repo_root: "/Users/…/worktrees/…/patch-120/."` — the trailing `/.` is precisely `Filename.concat cwd "."`.

- New `lib/repo_root.{ml,mli}` calls `git rev-parse --path-format=absolute --git-common-dir | dirname` (via `Unix.open_process_args_full`, since this runs before `Eio_main.run`). Reuses `Worktree.normalize_path` for slash/`/.` stripping.
- On resume, the stored `repo_root` is routed through the same normalizer — **legacy configs self-heal on next launch**, no user action needed.
- `test/test_repo_root.ml` covers main-from-main, main-from-worktree, absolute worktree, trailing `/.`, trailing `/`, non-repo passthrough.

### 2. Project-scoped advisory lockfile

Collapses the N→1 instance multiplier. `Unix.lockf F_TLOCK` on `<project_dir>/onton.lock`, PID recorded for diagnostics, acquired before `Eio_main.run`, released via `Fun.protect`.

- Exits `75` (EX_TEMPFAIL) on contention with a readable error naming the holder PID and lock path.
- Crashed holder → kernel releases `F_TLOCK` when FD auto-closes → next acquire just succeeds. Verified by unit test (fork → SIGKILL → re-acquire).
- New `--no-lock` CLI flag + `ONTON_NO_LOCK` env for recovery scenarios.
- `test/test_project_lock.ml`: happy path, release idempotent + re-acquire, contention (fork), crash recovery.

### 3. `on_worktree_create` hook containment

Three defenses in `lib/user_config.ml`:
- **Timeout** via `Eio.Time.with_timeout` (default `600s`, override `ONTON_HOOK_TIMEOUT`). SIGKILL on expiry.
- **FD cap** via `/bin/sh -c "ulimit -n N; exec <script>"` (default `256`, override `ONTON_HOOK_FD_LIMIT`). Child process tree can't exhaust the shared table.
- **Concurrency gate**: new `hook_mutex : Eio.Mutex.t` alongside the existing `worktree_mutex`/`fetch_mutex`. npm/dune/bun aren't parallelism-safe across shared caches anyway, and serial execution bounds fan-out by construction.

`clock` + `hook_mutex` are threaded through `ensure_worktree` → `execute_worktree_plan` → `run_claude_and_handle`.

**Known limitation** (documented in the source): SIGKILL reaches our direct child (`/bin/sh`), not grandchildren the hook itself forked. Killing the whole tree requires `setpgid` (not in OCaml's `Stdlib.Unix`) or an Eio private fork-action preexec hook. Deferred — the timeout still bounds *onton's* blocking wait, which is the orchestrator-level property we need.

`test/test_user_config.ml` gets two new cases (timeout, fd-cap) on top of the existing five.

### 4. `RLIMIT_NOFILE` preflight

At startup (before the lock): require `(max_concurrency * 256) + 512` FDs. Auto-raise soft → hard cap silently; fail fast with an actionable `ulimit -n` / `launchctl limit maxfiles` message only if the effective limit is still insufficient.

- `lib/rlimit.{ml,mli}` + `lib/rlimit_stubs.c` (30 lines of C binding `getrlimit`/`setrlimit` for `RLIMIT_NOFILE` only). Zero new opam deps; uses `dune foreign_stubs`.
- `test/test_rlimit.ml` caught and fixed a bug in the first cut of `try_raise_nofile_soft` — it was *lowering* when asked for a smaller target. Now no-ops when `target ≤ current_soft`.

## Out of scope (called out in plan, deferred)

- Master global spawn semaphore (throttling all LLM + git + hook spawns behind a single counter). Not load-bearing once items 1–4 land.
- `Fun.protect`-based pipe cleanup rewrap in `llm_backend.ml` / `claude_runner.ml`. Eio's Switch already closes pipes on exit; revisit if profiling shows leaks.
- Process-group kill of hook grandchildren (see §3 limitation).
- Separate concern surfaced during RCA: project configs persist real GitHub tokens in plaintext (`config.json`) — followup, not addressed here.

## Test plan

- [x] `dune build` clean (fatal-warnings enabled)
- [x] `dune runtest` — all existing tests pass, 14 new test cases pass
- [x] `dune build @fmt` clean
- [x] `onton --help` shows `--no-lock` with env fallback documented
- [ ] Manual: `cd` into an existing worktree, run `onton <project>`, confirm persisted `repo_root` points at the main repo (fix #1)
- [ ] Manual: `for i in {1..10}; do onton <project> & done; wait` — one proceeds, rest exit 75 with holder PID (fix #2)
- [ ] Manual: `ulimit -n 64 && onton <project>` — exits with actionable message (fix #4)
- [ ] Manual: craft a hook containing `sleep 99999` and confirm it's killed at the configured timeout (fix #3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/210"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents FD exhaustion and fixes incorrect `repo_root` persistence. Adds a per-project lock, bounds and serializes hook execution (with fail-closed FD capping), and preflights FD limits with auto-raise. Addresses #209.

- **New Features**
  - Per-project advisory lock `onton.lock` with PID; exits 75 on contention. `--no-lock` and `ONTON_NO_LOCK` to bypass.
  - `on_worktree_create` containment: timeout (600s via `ONTON_HOOK_TIMEOUT`), per-hook FD cap (256 via `ONTON_HOOK_FD_LIMIT`, clamped to soft+hard), serialized via a hook mutex; cleanup SIGKILL + await on all paths. Env parsers reject non-positive/NaN/∞ values; `ulimit` uses `&& exec` to fail closed.
  - Startup `RLIMIT_NOFILE` preflight: require `(max_concurrency*256)+512`, auto-raise soft to hard; fail fast with an actionable message.

- **Bug Fixes**
  - Persist main repo root via `git rev-parse --path-format=absolute --git-common-dir`; reject relative outputs; legacy configs self-heal.
  - Hook env overlays now override inherited vars; `Eio.Cancel.Cancelled` propagates instead of being reported as a hook error.
  - Tests cover lock contention/crash recovery, repo-root normalization, RLIMIT behavior; fd-cap assertion accounts for clamping; RLIMIT test avoids overflow.

<sup>Written for commit 28684e2eef3576757c7ddcefb047e3c853dbcfb3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add --no-lock / ONTON_NO_LOCK to opt out of per-project advisory locking.
  * Per-project advisory locking by default to prevent concurrent operations.

* **Improvements**
  * Hooks accept timeout and FD-limit controls, run with enforced FD limits, and return richer errors including captured stdout/stderr and timeout messages.
  * Startup attempts to raise the process file-descriptor limit and exits with an actionable message if insufficient.
  * Repository-root resolution improved to map worktree paths back to the main checkout.

* **Tests**
  * New/expanded tests for repo-root normalization, project locking, and RLIMIT_NOFILE behavior; hook tests cover timeouts and FD limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->