### PR TITLE
Fix 30-min stall and reap orphan grandchildren on LLM session end

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -951,6 +951,7 @@ let run_claude_and_handle ~runtime ~process_mgr ~clock ~fs ~project_name
                 {
                   exit_code = r.Llm_backend.exit_code;
                   got_events = r.Llm_backend.got_events;
+                  saw_final_result = r.Llm_backend.saw_final_result;
                   stderr = r.Llm_backend.stderr;
                   stream_errors = String.trim (Buffer.contents error_buf);
                   timed_out = r.Llm_backend.timed_out;

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -2291,17 +2291,51 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
     1800.0
     (* 30 minutes *)
   in
+  (* Locate the [onton-setsid-exec] shim so subprocesses can run in their
+     own process group; without it, tool-call grandchildren reparent to
+     PID 1 on exit and leak. We probe [$ONTON_SETSID_EXEC] first (for
+     tests that want direct spawn to compare behavior), then fall back
+     to a sibling of our own executable. A missing shim is not fatal —
+     we log and run without group isolation (Phase A early-exit still
+     ends the stall; only grandchild reaping is lost). *)
+  let setsid_exec =
+    let candidate =
+      match Sys.getenv_opt "ONTON_SETSID_EXEC" with
+      | Some "" -> None
+      | Some p -> Some p
+      | None ->
+          Some
+            (Filename.concat
+               (Filename.dirname Sys.executable_name)
+               "onton-setsid-exec")
+    in
+    match candidate with
+    | Some p when Sys.file_exists p -> Some p
+    | Some p ->
+        Eio.traceln
+          "onton-setsid-exec not found at %s; grandchildren will reparent to \
+           PID 1 on teardown"
+          p;
+        None
+    | None -> None
+  in
   let backend =
     match config.backend with
     | "claude" ->
         Claude_backend.create ~process_mgr ~clock ~timeout:session_timeout
+          ~setsid_exec
     | "codex" ->
         Codex_backend.create ~process_mgr ~clock ~timeout:session_timeout
+          ~setsid_exec
     | "opencode" ->
         Opencode_backend.create ~process_mgr ~clock ~timeout:session_timeout
-    | "pi" -> Pi_backend.create ~process_mgr ~clock ~timeout:session_timeout
+          ~setsid_exec
+    | "pi" ->
+        Pi_backend.create ~process_mgr ~clock ~timeout:session_timeout
+          ~setsid_exec
     | "gemini" ->
         Gemini_backend.create ~process_mgr ~clock ~timeout:session_timeout
+          ~setsid_exec
     | other ->
         invalid_arg
           (Printf.sprintf "Unsupported --backend=%S (expected %s)" other

--- a/bin/setsid_exec/dune
+++ b/bin/setsid_exec/dune
@@ -1,0 +1,5 @@
+(executable
+ (name main)
+ (public_name onton-setsid-exec)
+ (package onton)
+ (libraries unix))

--- a/bin/setsid_exec/main.ml
+++ b/bin/setsid_exec/main.ml
@@ -1,0 +1,17 @@
+(* Tiny launcher shim. Calls setsid(2) so the exec'd process becomes the
+   leader of a new session and process group, then execvp's its argv. Onton
+   uses this to put each LLM subprocess into its own group so that on
+   teardown we can kill(-pgid, SIG) the whole tree — otherwise tool-call
+   grandchildren (e.g. Bash-spawned shells) reparent to PID 1 and leak. *)
+
+let () =
+  if Array.length Sys.argv < 2 then (
+    prerr_endline "onton-setsid-exec: missing program to exec";
+    exit 2);
+  (try ignore (Unix.setsid () : int)
+   with Unix.Unix_error _ ->
+     (* Already a session leader: harmless, proceed. *)
+     ());
+  let prog = Sys.argv.(1) in
+  let argv = Array.sub Sys.argv 1 (Array.length Sys.argv - 1) in
+  Unix.execvp prog argv

--- a/lib/claude_backend.ml
+++ b/lib/claude_backend.ml
@@ -1,8 +1,8 @@
-let create ~process_mgr ~clock ~timeout : Llm_backend.t =
+let create ~process_mgr ~clock ~timeout ~setsid_exec : Llm_backend.t =
   {
     name = "Claude";
     run_streaming =
       (fun ~cwd ~patch_id ~prompt ~resume_session ~on_event ->
-        Claude_runner.run_streaming ~process_mgr ~clock ~timeout ~cwd ~patch_id
-          ~prompt ~resume_session ~on_event);
+        Claude_runner.run_streaming ~process_mgr ~clock ~timeout ~setsid_exec
+          ~cwd ~patch_id ~prompt ~resume_session ~on_event);
   }

--- a/lib/claude_backend.mli
+++ b/lib/claude_backend.mli
@@ -2,6 +2,10 @@ val create :
   process_mgr:_ Eio.Process.mgr ->
   clock:_ Eio.Time.clock ->
   timeout:float ->
+  setsid_exec:string option ->
   Llm_backend.t
 (** Create an LLM backend that uses the Claude CLI. [timeout] is the maximum
-    session duration in seconds before the process is killed. *)
+    session duration in seconds before the process is killed. [setsid_exec],
+    when [Some path], routes the subprocess through the [onton-setsid-exec] shim
+    so it leads its own process group and the whole tree can be reaped on
+    teardown. *)

--- a/lib/claude_runner.ml
+++ b/lib/claude_runner.ml
@@ -249,6 +249,7 @@ let run ~process_mgr ~cwd ~patch_id ~prompt ~resume_session =
     stdout = cleaned_stdout;
     stderr = stderr_content;
     got_events;
+    saw_final_result = false;
     timed_out = false;
   }
 

--- a/lib/claude_runner.ml
+++ b/lib/claude_runner.ml
@@ -253,16 +253,16 @@ let run ~process_mgr ~cwd ~patch_id ~prompt ~resume_session =
     timed_out = false;
   }
 
-let run_streaming ~process_mgr ~clock ~timeout ~cwd ~patch_id ~prompt
-    ~resume_session ~on_event =
+let run_streaming ~process_mgr ~clock ~timeout ~setsid_exec ~cwd ~patch_id
+    ~prompt ~resume_session ~on_event =
   ignore (patch_id : Types.Patch_id.t);
   let args = build_stream_args ~prompt ~resume_session in
   let process_line line =
     let trimmed = strip_ansi (String.strip line) in
     if String.is_empty trimmed then [] else parse_stream_events trimmed
   in
-  Llm_backend.spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~args
-    ~process_line ~on_event
+  Llm_backend.spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~setsid_exec
+    ~args ~process_line ~on_event
 
 let%test "build_args fresh (no resume)" =
   let args = build_args ~prompt:"do stuff" ~resume_session:None in

--- a/lib/claude_runner.mli
+++ b/lib/claude_runner.mli
@@ -38,6 +38,7 @@ val run_streaming :
   process_mgr:_ Eio.Process.mgr ->
   clock:_ Eio.Time.clock ->
   timeout:float ->
+  setsid_exec:string option ->
   cwd:Eio.Fs.dir_ty Eio.Path.t ->
   patch_id:Types.Patch_id.t ->
   prompt:string ->

--- a/lib/codex_backend.ml
+++ b/lib/codex_backend.ml
@@ -97,8 +97,8 @@ let parse_event (line : string) : Types.Stream_event.t list =
   | exception Yojson.Json_error _ -> []
   | exception Yojson.Safe.Util.Type_error _ -> []
 
-let run_streaming ~process_mgr ~clock ~timeout ~cwd ~patch_id ~prompt
-    ~resume_session ~on_event =
+let run_streaming ~process_mgr ~clock ~timeout ~setsid_exec ~cwd ~patch_id
+    ~prompt ~resume_session ~on_event =
   ignore (patch_id : Types.Patch_id.t);
   let cwd_path = snd cwd in
   let args = build_args ~cwd_path ~prompt ~resume_session in
@@ -106,16 +106,16 @@ let run_streaming ~process_mgr ~clock ~timeout ~cwd ~patch_id ~prompt
     let trimmed = String.strip line in
     if String.is_empty trimmed then [] else parse_event trimmed
   in
-  Llm_backend.spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~args
-    ~process_line ~on_event
+  Llm_backend.spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~setsid_exec
+    ~args ~process_line ~on_event
 
-let create ~process_mgr ~clock ~timeout : Llm_backend.t =
+let create ~process_mgr ~clock ~timeout ~setsid_exec : Llm_backend.t =
   {
     name = "Codex";
     run_streaming =
       (fun ~cwd ~patch_id ~prompt ~resume_session ~on_event ->
-        run_streaming ~process_mgr ~clock ~timeout ~cwd ~patch_id ~prompt
-          ~resume_session ~on_event);
+        run_streaming ~process_mgr ~clock ~timeout ~setsid_exec ~cwd ~patch_id
+          ~prompt ~resume_session ~on_event);
   }
 
 let%test "build_args fresh (no resume)" =

--- a/lib/codex_backend.mli
+++ b/lib/codex_backend.mli
@@ -2,9 +2,11 @@ val create :
   process_mgr:_ Eio.Process.mgr ->
   clock:_ Eio.Time.clock ->
   timeout:float ->
+  setsid_exec:string option ->
   Llm_backend.t
 (** Create an LLM backend that uses the Codex CLI. [timeout] is the maximum
-    session duration in seconds before the process is killed. *)
+    session duration in seconds before the process is killed. See
+    {!Claude_backend.create} for [setsid_exec] semantics. *)
 
 val parse_event : string -> Types.Stream_event.t list
 (** Parse a single NDJSON line from Codex's JSON output. Exposed for testing. *)

--- a/lib/gemini_backend.ml
+++ b/lib/gemini_backend.ml
@@ -71,24 +71,24 @@ let parse_event (line : string) : Types.Stream_event.t list =
   | exception Yojson.Json_error _ -> []
   | exception Yojson.Safe.Util.Type_error _ -> []
 
-let run_streaming ~process_mgr ~clock ~timeout ~cwd ~patch_id ~prompt
-    ~resume_session ~on_event =
+let run_streaming ~process_mgr ~clock ~timeout ~setsid_exec ~cwd ~patch_id
+    ~prompt ~resume_session ~on_event =
   ignore (patch_id : Types.Patch_id.t);
   let args = build_args ~prompt ~resume_session in
   let process_line line =
     let trimmed = String.strip line in
     if String.is_empty trimmed then [] else parse_event trimmed
   in
-  Llm_backend.spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~args
-    ~process_line ~on_event
+  Llm_backend.spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~setsid_exec
+    ~args ~process_line ~on_event
 
-let create ~process_mgr ~clock ~timeout : Llm_backend.t =
+let create ~process_mgr ~clock ~timeout ~setsid_exec : Llm_backend.t =
   {
     name = "Gemini";
     run_streaming =
       (fun ~cwd ~patch_id ~prompt ~resume_session ~on_event ->
-        run_streaming ~process_mgr ~clock ~timeout ~cwd ~patch_id ~prompt
-          ~resume_session ~on_event);
+        run_streaming ~process_mgr ~clock ~timeout ~setsid_exec ~cwd ~patch_id
+          ~prompt ~resume_session ~on_event);
   }
 
 let%test "build_args fresh (no resume)" =

--- a/lib/gemini_backend.mli
+++ b/lib/gemini_backend.mli
@@ -2,9 +2,11 @@ val create :
   process_mgr:_ Eio.Process.mgr ->
   clock:_ Eio.Time.clock ->
   timeout:float ->
+  setsid_exec:string option ->
   Llm_backend.t
 (** Create an LLM backend that uses the Gemini CLI. [timeout] is the maximum
-    session duration in seconds before the process is killed. *)
+    session duration in seconds before the process is killed. See
+    {!Claude_backend.create} for [setsid_exec] semantics. *)
 
 val parse_event : string -> Types.Stream_event.t list
 (** Parse a single NDJSON line from Gemini's stream-json output. Exposed for

--- a/lib/llm_backend.ml
+++ b/lib/llm_backend.ml
@@ -25,8 +25,9 @@ let spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~setsid_exec ~args
     match setsid_exec with Some path -> path :: args | None -> args
   in
   let saw_final_result_ref = ref false in
+  let got_events_ref = ref false in
   let run () =
-    let stderr_content, exit_code, got_events =
+    let stderr_content, exit_code =
       Eio.Switch.run @@ fun sw ->
       let stdin_r, stdin_w = Eio.Process.pipe ~sw process_mgr in
       let stdout_r, stdout_w = Eio.Process.pipe ~sw process_mgr in
@@ -54,7 +55,6 @@ let spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~setsid_exec ~args
       let stdout_buf = Eio.Buf_read.of_flow ~max_size:(1024 * 1024) stdout_r in
       let stderr_buf = Eio.Buf_read.of_flow ~max_size:(1024 * 1024) stderr_r in
       let err_ref = ref "" in
-      let got_events_ref = ref false in
       Eio.Fiber.both
         (fun () ->
           let rec read_lines () =
@@ -98,7 +98,7 @@ let spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~setsid_exec ~args
               with _ -> ())
           | _ -> ());
       let status =
-        if !saw_final_result_ref then (
+        if !saw_final_result_ref then
           (* SIGTERM was just delivered; cap the await so a child that
              ignores it doesn't stall us, then escalate to SIGKILL. *)
           match
@@ -106,20 +106,29 @@ let spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~setsid_exec ~args
                 Ok (Eio.Process.await child))
           with
           | Ok status -> status
-          | Error `Timeout ->
+          | Error `Timeout -> (
               signal_tree Stdlib.Sys.sigkill;
-              Eio.Process.await child)
+              (* SIGKILL is unconditional; 1s is more than enough for the
+                 kernel to deliver it. The outer session timeout is a final
+                 backstop, but it can be very long (e.g. 1800s), so we cap
+                 locally to keep the guarantee tight here. *)
+              match
+                Eio.Time.with_timeout clock 1.0 (fun () ->
+                    Ok (Eio.Process.await child))
+              with
+              | Ok status -> status
+              | Error `Timeout -> `Signaled 9)
         else Eio.Process.await child
       in
       let code = match status with `Exited c -> c | `Signaled s -> 128 + s in
-      (!err_ref, code, !got_events_ref)
+      (!err_ref, code)
     in
     Ok
       {
         exit_code;
         stdout = "";
         stderr = stderr_content;
-        got_events;
+        got_events = !got_events_ref;
         saw_final_result = !saw_final_result_ref;
         timed_out = false;
       }
@@ -131,7 +140,7 @@ let spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~setsid_exec ~args
         exit_code = 128 + 9 (* SIGKILL — sent via on_release hook *);
         stdout = "";
         stderr = "process timed out";
-        got_events = false;
+        got_events = !got_events_ref;
         saw_final_result = !saw_final_result_ref;
         timed_out = true;
       }

--- a/lib/llm_backend.ml
+++ b/lib/llm_backend.ml
@@ -5,12 +5,14 @@ type result = {
   stdout : string;
   stderr : string;
   got_events : bool;
+  saw_final_result : bool;
   timed_out : bool;
 }
 [@@deriving show, eq, sexp_of, compare]
 
 let spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~args
     ~(process_line : string -> Types.Stream_event.t list) ~on_event =
+  let saw_final_result_ref = ref false in
   let run () =
     let stderr_content, exit_code, got_events =
       Eio.Switch.run @@ fun sw ->
@@ -39,22 +41,53 @@ let spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~args
                 let events = process_line line in
                 if not (List.is_empty events) then got_events_ref := true;
                 List.iter events ~f:on_event;
-                read_lines ()
+                let saw_final =
+                  List.exists events ~f:(function
+                    | Types.Stream_event.Final_result _ -> true
+                    | Types.Stream_event.Text_delta _
+                    | Types.Stream_event.Tool_use _ | Types.Stream_event.Error _
+                    | Types.Stream_event.Session_init _ ->
+                        false)
+                in
+                if saw_final then saw_final_result_ref := true
+                else read_lines ()
             | exception End_of_file -> ()
           in
-          read_lines ())
+          read_lines ();
+          if !saw_final_result_ref then (
+            (* Tear down immediately: the model's turn is over. Descendants
+               of the child (e.g. Bash-tool zsh processes) may keep the
+               inherited stderr write-end open indefinitely, which would
+               leave the sibling [take_all] fiber blocked on EOF. Signal
+               the child and close our read end so the fiber unblocks. *)
+            (try Eio.Process.signal child Stdlib.Sys.sigterm with _ -> ());
+            try Eio.Flow.close stderr_r with _ -> ()))
         (fun () ->
-          try err_ref := Eio.Buf_read.take_all stderr_buf
-          with Eio.Buf_read.Buffer_limit_exceeded -> (
-            err_ref := "<stderr exceeded 1MB limit, truncated>";
-            let drain_buf = Bytes.create 4096 in
-            try
-              while true do
-                ignore
-                  (Eio.Flow.single_read stderr_r (Cstruct.of_bytes drain_buf))
-              done
-            with End_of_file -> ()));
-      let status = Eio.Process.await child in
+          try err_ref := Eio.Buf_read.take_all stderr_buf with
+          | Eio.Buf_read.Buffer_limit_exceeded -> (
+              err_ref := "<stderr exceeded 1MB limit, truncated>";
+              let drain_buf = Bytes.create 4096 in
+              try
+                while true do
+                  ignore
+                    (Eio.Flow.single_read stderr_r (Cstruct.of_bytes drain_buf))
+                done
+              with _ -> ())
+          | _ -> ());
+      let status =
+        if !saw_final_result_ref then (
+          (* SIGTERM was just delivered; cap the await so a child that
+             ignores it doesn't stall us, then escalate to SIGKILL. *)
+          match
+            Eio.Time.with_timeout clock 2.0 (fun () ->
+                Ok (Eio.Process.await child))
+          with
+          | Ok status -> status
+          | Error `Timeout ->
+              (try Eio.Process.signal child Stdlib.Sys.sigkill with _ -> ());
+              Eio.Process.await child)
+        else Eio.Process.await child
+      in
       let code = match status with `Exited c -> c | `Signaled s -> 128 + s in
       (!err_ref, code, !got_events_ref)
     in
@@ -64,6 +97,7 @@ let spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~args
         stdout = "";
         stderr = stderr_content;
         got_events;
+        saw_final_result = !saw_final_result_ref;
         timed_out = false;
       }
   in
@@ -75,6 +109,7 @@ let spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~args
         stdout = "";
         stderr = "process timed out";
         got_events = false;
+        saw_final_result = !saw_final_result_ref;
         timed_out = true;
       }
 

--- a/lib/llm_backend.ml
+++ b/lib/llm_backend.ml
@@ -10,8 +10,20 @@ type result = {
 }
 [@@deriving show, eq, sexp_of, compare]
 
-let spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~args
+(* Signal the whole process group led by [pid]. Requires the child to have
+   called [setsid()] at exec-time; otherwise [-pid] refers to onton's own
+   group and we'd signal ourselves, so we only call this when we spawned
+   through the setsid shim. ESRCH/EPERM are swallowed — they mean the group
+   is already gone or we lost the race. *)
+let kill_group ~pid ~signal =
+  try Unix.kill (-pid) signal
+  with Unix.Unix_error ((ESRCH | EPERM), _, _) -> ()
+
+let spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~setsid_exec ~args
     ~(process_line : string -> Types.Stream_event.t list) ~on_event =
+  let args =
+    match setsid_exec with Some path -> path :: args | None -> args
+  in
   let saw_final_result_ref = ref false in
   let run () =
     let stderr_content, exit_code, got_events =
@@ -23,8 +35,18 @@ let spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~args
         Eio.Process.spawn ~sw process_mgr ~cwd ~stdin:stdin_r ~stdout:stdout_w
           ~stderr:stderr_w args
       in
+      let pid = Eio.Process.pid child in
+      let have_group = Option.is_some setsid_exec in
+      let signal_tree signal =
+        if have_group then kill_group ~pid ~signal
+        else try Eio.Process.signal child signal with _ -> ()
+      in
       Eio.Switch.on_release sw (fun () ->
-          try Eio.Process.signal child Stdlib.Sys.sigterm with _ -> ());
+          (* Release path fires on timeout / cancellation / exception. Be
+             firm: SIGKILL the whole group (or just the direct child in the
+             no-shim fallback) rather than SIGTERM, since by this point
+             we've already given up on graceful exit. *)
+          signal_tree Stdlib.Sys.sigkill);
       Eio.Flow.close stdin_r;
       Eio.Flow.close stdin_w;
       Eio.Flow.close stdout_w;
@@ -59,8 +81,9 @@ let spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~args
                of the child (e.g. Bash-tool zsh processes) may keep the
                inherited stderr write-end open indefinitely, which would
                leave the sibling [take_all] fiber blocked on EOF. Signal
-               the child and close our read end so the fiber unblocks. *)
-            (try Eio.Process.signal child Stdlib.Sys.sigterm with _ -> ());
+               the whole group (when available) and close our read end so
+               the fiber unblocks. *)
+            signal_tree Stdlib.Sys.sigterm;
             try Eio.Flow.close stderr_r with _ -> ()))
         (fun () ->
           try err_ref := Eio.Buf_read.take_all stderr_buf with
@@ -84,7 +107,7 @@ let spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~args
           with
           | Ok status -> status
           | Error `Timeout ->
-              (try Eio.Process.signal child Stdlib.Sys.sigkill with _ -> ());
+              signal_tree Stdlib.Sys.sigkill;
               Eio.Process.await child)
         else Eio.Process.await child
       in
@@ -105,7 +128,7 @@ let spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~args
   | Ok result -> result
   | Error `Timeout ->
       {
-        exit_code = 128 + 15 (* SIGTERM — sent via on_release hook *);
+        exit_code = 128 + 9 (* SIGKILL — sent via on_release hook *);
         stdout = "";
         stderr = "process timed out";
         got_events = false;

--- a/lib/llm_backend.ml
+++ b/lib/llm_backend.ml
@@ -86,6 +86,12 @@ let spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~setsid_exec ~args
             signal_tree Stdlib.Sys.sigterm;
             try Eio.Flow.close stderr_r with _ -> ()))
         (fun () ->
+          (* Only swallow the expected teardown exceptions: Eio.Buf_read
+             raises when the buffer fills up; End_of_file and Eio.Exn.Io
+             fire when the stdout fiber closes stderr_r out from under us
+             after saw_final_result. Letting anything else propagate — in
+             particular Eio.Cancel.Cancelled — is required so this fiber
+             can honour cancellation and release Eio.Fiber.both. *)
           try err_ref := Eio.Buf_read.take_all stderr_buf with
           | Eio.Buf_read.Buffer_limit_exceeded -> (
               err_ref := "<stderr exceeded 1MB limit, truncated>";
@@ -95,8 +101,11 @@ let spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~setsid_exec ~args
                   ignore
                     (Eio.Flow.single_read stderr_r (Cstruct.of_bytes drain_buf))
                 done
-              with _ -> ())
-          | _ -> ());
+              with
+              | End_of_file -> ()
+              | Eio.Exn.Io _ -> ())
+          | End_of_file -> ()
+          | Eio.Exn.Io _ -> ());
       let status =
         if !saw_final_result_ref then
           (* SIGTERM was just delivered; cap the await so a child that

--- a/lib/llm_backend.mli
+++ b/lib/llm_backend.mli
@@ -21,6 +21,7 @@ val spawn_and_stream :
   clock:_ Eio.Time.clock ->
   timeout:float ->
   cwd:Eio.Fs.dir_ty Eio.Path.t ->
+  setsid_exec:string option ->
   args:string list ->
   process_line:(string -> Types.Stream_event.t list) ->
   on_event:(Types.Stream_event.t -> unit) ->
@@ -28,7 +29,13 @@ val spawn_and_stream :
 (** Spawn a subprocess, read NDJSON lines from stdout, and stream parsed events.
     Each stdout line is passed to [process_line] which returns events to forward
     to [on_event]. Handles pipe setup, stdin EOF, stderr capture, and exit code
-    extraction. The process is killed after [timeout] seconds. *)
+    extraction. The process is killed after [timeout] seconds.
+
+    When [setsid_exec] is supplied, [args] is prefixed with that path (a tiny
+    OCaml shim that calls [setsid(2)] before exec'ing). The child then leads its
+    own process group, and teardown sends [kill(2)] to the whole group so
+    tool-call grandchildren (e.g. Bash-spawned shells) are reaped rather than
+    reparented to PID 1. *)
 
 type t = {
   name : string;

--- a/lib/llm_backend.mli
+++ b/lib/llm_backend.mli
@@ -11,6 +11,7 @@ type result = {
   stdout : string;
   stderr : string;
   got_events : bool;
+  saw_final_result : bool;
   timed_out : bool;
 }
 [@@deriving show, eq, sexp_of, compare]

--- a/lib/opencode_backend.ml
+++ b/lib/opencode_backend.ml
@@ -92,8 +92,8 @@ let parse_event (line : string) : Types.Stream_event.t list =
   | exception Yojson.Json_error _ -> []
   | exception Yojson.Safe.Util.Type_error _ -> []
 
-let run_streaming ~process_mgr ~clock ~timeout ~cwd ~patch_id ~prompt
-    ~resume_session ~on_event =
+let run_streaming ~process_mgr ~clock ~timeout ~setsid_exec ~cwd ~patch_id
+    ~prompt ~resume_session ~on_event =
   ignore (patch_id : Types.Patch_id.t);
   let cwd_path = snd cwd in
   let args = build_args ~cwd_path ~prompt ~resume_session in
@@ -101,16 +101,16 @@ let run_streaming ~process_mgr ~clock ~timeout ~cwd ~patch_id ~prompt
     let trimmed = String.strip line in
     if String.is_empty trimmed then [] else parse_event trimmed
   in
-  Llm_backend.spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~args
-    ~process_line ~on_event
+  Llm_backend.spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~setsid_exec
+    ~args ~process_line ~on_event
 
-let create ~process_mgr ~clock ~timeout : Llm_backend.t =
+let create ~process_mgr ~clock ~timeout ~setsid_exec : Llm_backend.t =
   {
     name = "OpenCode";
     run_streaming =
       (fun ~cwd ~patch_id ~prompt ~resume_session ~on_event ->
-        run_streaming ~process_mgr ~clock ~timeout ~cwd ~patch_id ~prompt
-          ~resume_session ~on_event);
+        run_streaming ~process_mgr ~clock ~timeout ~setsid_exec ~cwd ~patch_id
+          ~prompt ~resume_session ~on_event);
   }
 
 let%test "build_args without continue" =

--- a/lib/opencode_backend.mli
+++ b/lib/opencode_backend.mli
@@ -2,9 +2,11 @@ val create :
   process_mgr:_ Eio.Process.mgr ->
   clock:_ Eio.Time.clock ->
   timeout:float ->
+  setsid_exec:string option ->
   Llm_backend.t
 (** Create an LLM backend that uses the OpenCode CLI. [timeout] is the maximum
-    session duration in seconds before the process is killed. *)
+    session duration in seconds before the process is killed. See
+    {!Claude_backend.create} for [setsid_exec] semantics. *)
 
 val parse_event : string -> Types.Stream_event.t list
 (** Parse a single NDJSON line from OpenCode's JSON output. Exposed for testing.

--- a/lib/pi_backend.ml
+++ b/lib/pi_backend.ml
@@ -50,8 +50,8 @@ let parse_event (line : string) : Types.Stream_event.t list =
   | exception Yojson.Json_error _ -> []
   | exception Yojson.Safe.Util.Type_error _ -> []
 
-let run_streaming ~process_mgr ~clock ~timeout ~cwd ~patch_id ~prompt
-    ~resume_session ~on_event =
+let run_streaming ~process_mgr ~clock ~timeout ~setsid_exec ~cwd ~patch_id
+    ~prompt ~resume_session ~on_event =
   let cwd_path = snd cwd in
   let patch_id_str = Types.Patch_id.to_string patch_id in
   let args =
@@ -61,16 +61,16 @@ let run_streaming ~process_mgr ~clock ~timeout ~cwd ~patch_id ~prompt
     let trimmed = String.strip line in
     if String.is_empty trimmed then [] else parse_event trimmed
   in
-  Llm_backend.spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~args
-    ~process_line ~on_event
+  Llm_backend.spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~setsid_exec
+    ~args ~process_line ~on_event
 
-let create ~process_mgr ~clock ~timeout : Llm_backend.t =
+let create ~process_mgr ~clock ~timeout ~setsid_exec : Llm_backend.t =
   {
     name = "Pi";
     run_streaming =
       (fun ~cwd ~patch_id ~prompt ~resume_session ~on_event ->
-        run_streaming ~process_mgr ~clock ~timeout ~cwd ~patch_id ~prompt
-          ~resume_session ~on_event);
+        run_streaming ~process_mgr ~clock ~timeout ~setsid_exec ~cwd ~patch_id
+          ~prompt ~resume_session ~on_event);
   }
 
 let%test "build_args without continue" =

--- a/lib/pi_backend.mli
+++ b/lib/pi_backend.mli
@@ -2,9 +2,11 @@ val create :
   process_mgr:_ Eio.Process.mgr ->
   clock:_ Eio.Time.clock ->
   timeout:float ->
+  setsid_exec:string option ->
   Llm_backend.t
 (** Create an LLM backend that uses the Pi CLI. [timeout] is the maximum session
-    duration in seconds before the process is killed. *)
+    duration in seconds before the process is killed. See
+    {!Claude_backend.create} for [setsid_exec] semantics. *)
 
 val parse_event : string -> Types.Stream_event.t list
 (** Parse a single NDJSON line from Pi's JSON output. Exposed for testing. *)

--- a/lib/run_classification.ml
+++ b/lib/run_classification.ml
@@ -29,8 +29,8 @@ let classify ~is_resume result =
   match result with
   | Error msg -> Process_error msg
   | Ok r when r.timed_out -> Timed_out
-  | Ok r when (not r.got_events) && is_resume -> No_session_to_resume
   | Ok r when r.saw_final_result -> Success { stream_errors = r.stream_errors }
+  | Ok r when (not r.got_events) && is_resume -> No_session_to_resume
   | Ok r when r.exit_code = 0 -> Success { stream_errors = r.stream_errors }
   | Ok r ->
       let stderr = String.strip r.stderr in

--- a/lib/run_classification.ml
+++ b/lib/run_classification.ml
@@ -8,6 +8,7 @@ open Base
 type run_outcome = {
   exit_code : int;
   got_events : bool;
+  saw_final_result : bool;
   stderr : string;
   stream_errors : string;
   timed_out : bool;
@@ -29,6 +30,7 @@ let classify ~is_resume result =
   | Error msg -> Process_error msg
   | Ok r when r.timed_out -> Timed_out
   | Ok r when (not r.got_events) && is_resume -> No_session_to_resume
+  | Ok r when r.saw_final_result -> Success { stream_errors = r.stream_errors }
   | Ok r when r.exit_code = 0 -> Success { stream_errors = r.stream_errors }
   | Ok r ->
       let stderr = String.strip r.stderr in

--- a/lib/run_classification.mli
+++ b/lib/run_classification.mli
@@ -8,6 +8,7 @@ open Base
 type run_outcome = {
   exit_code : int;
   got_events : bool;
+  saw_final_result : bool;
   stderr : string;
   stream_errors : string;
   timed_out : bool;

--- a/lib_test/test_generators.ml
+++ b/lib_test/test_generators.ml
@@ -586,10 +586,19 @@ let gen_run_outcome =
     let open Onton.Run_classification in
     let* exit_code = int_range (-1) 255 in
     let* got_events = bool in
+    let* saw_final_result = bool in
     let* stderr = string_size ~gen:printable (int_range 0 80) in
     let* stream_errors = string_size ~gen:printable (int_range 0 80) in
     let* timed_out = bool in
-    return { exit_code; got_events; stderr; stream_errors; timed_out })
+    return
+      {
+        exit_code;
+        got_events;
+        saw_final_result;
+        stderr;
+        stream_errors;
+        timed_out;
+      })
 
 let gen_porcelain_entry =
   QCheck2.Gen.(

--- a/test/dune
+++ b/test/dune
@@ -120,7 +120,12 @@
 
 (test
  (name test_backend_smoke)
- (libraries onton eio eio_main))
+ (libraries onton eio eio_main)
+ (deps (package onton))
+ (action
+  (setenv ONTON_SETSID_EXEC
+   %{bin:onton-setsid-exec}
+   (run %{test}))))
 
 (test
  (name test_user_config)

--- a/test/test_backend_smoke.ml
+++ b/test/test_backend_smoke.ml
@@ -9,14 +9,14 @@ open Onton
     full subprocess → line-reading → parsing → callback pipeline without
     requiring any LLM CLI to be installed. *)
 
-let smoke ~process_mgr ~clock ~cwd ~ndjson ~process_line =
+let smoke ?setsid_exec ~process_mgr ~clock ~cwd ~ndjson ~process_line () =
   let events = ref [] in
   let on_event ev = events := ev :: !events in
   let payload = String.concat ~sep:"\n" ndjson in
   let args = [ "printf"; "%s"; payload ] in
   let result =
-    Llm_backend.spawn_and_stream ~process_mgr ~clock ~timeout:60.0 ~cwd ~args
-      ~process_line ~on_event
+    Llm_backend.spawn_and_stream ~process_mgr ~clock ~timeout:60.0 ~cwd
+      ~setsid_exec ~args ~process_line ~on_event
   in
   (result, List.rev !events)
 
@@ -65,6 +65,7 @@ let () =
           {|{"type":"turn.completed"}|};
         ]
       ~process_line:(process_line_strip Codex_backend.parse_event)
+      ()
   in
   assert_smoke ~name:"codex" ~result ~got
     ~expected:
@@ -81,7 +82,7 @@ let () =
           {|{"type":"content_block_delta","delta":{"type":"text_delta","text":"hello"}}|};
           {|{"type":"result","result":"done","stop_reason":"end_turn"}|};
         ]
-      ~process_line:process_line_claude
+      ~process_line:process_line_claude ()
   in
   assert_smoke ~name:"claude" ~result ~got
     ~expected:
@@ -99,6 +100,7 @@ let () =
           {|{"type":"agent_end","messages":[]}|};
         ]
       ~process_line:(process_line_strip Pi_backend.parse_event)
+      ()
   in
   assert_smoke ~name:"pi" ~result ~got
     ~expected:
@@ -116,6 +118,7 @@ let () =
           {|{"type":"step_finish","part":{"type":"step-finish","reason":"stop"}}|};
         ]
       ~process_line:(process_line_strip Opencode_backend.parse_event)
+      ()
   in
   assert_smoke ~name:"opencode" ~result ~got
     ~expected:
@@ -135,6 +138,7 @@ let () =
           {|{"type":"step_finish","part":{"type":"step-finish","reason":"stop"}}|};
         ]
       ~process_line:(process_line_strip Opencode_backend.parse_event)
+      ()
   in
   assert_smoke ~name:"opencode tool_use pending" ~result ~got
     ~expected:
@@ -162,8 +166,8 @@ let () =
     in
     let started = Unix.gettimeofday () in
     let result =
-      Llm_backend.spawn_and_stream ~process_mgr ~clock ~timeout:30.0 ~cwd ~args
-        ~process_line:process_line_claude ~on_event
+      Llm_backend.spawn_and_stream ~process_mgr ~clock ~timeout:30.0 ~cwd
+        ~setsid_exec:None ~args ~process_line:process_line_claude ~on_event
     in
     let elapsed = Unix.gettimeofday () -. started in
     if not result.Llm_backend.saw_final_result then (
@@ -186,8 +190,8 @@ let () =
     let args = [ "sh"; "-c"; "sleep 30" ] in
     let started = Unix.gettimeofday () in
     let result =
-      Llm_backend.spawn_and_stream ~process_mgr ~clock ~timeout:1.0 ~cwd ~args
-        ~process_line:process_line_claude ~on_event
+      Llm_backend.spawn_and_stream ~process_mgr ~clock ~timeout:1.0 ~cwd
+        ~setsid_exec:None ~args ~process_line:process_line_claude ~on_event
     in
     let elapsed = Unix.gettimeofday () -. started in
     if not result.Llm_backend.timed_out then (
@@ -202,6 +206,74 @@ let () =
     else Stdio.printf "timeout regression: passed (%.2fs)\n" elapsed
   in
   timeout_test ();
+  (* --- Grandchild reap: with the setsid shim, killing the child on
+     Final_result takes the whole process group with it. Without the shim
+     a backgrounded [sleep] would reparent to PID 1 and outlive us. The
+     subprocess embeds its grandchild's pid in a text_delta so we can
+     probe for it after spawn_and_stream returns. *)
+  let grandchild_reap_test () =
+    match Stdlib.Sys.getenv_opt "ONTON_SETSID_EXEC" with
+    | None | Some "" ->
+        Stdio.printf
+          "grandchild reap: SKIPPED (ONTON_SETSID_EXEC not set — dune run only)\n"
+    | Some shim -> (
+        let grand_pid_ref = ref None in
+        let on_event ev =
+          match ev with
+          | Types.Stream_event.Text_delta t -> (
+              match String.chop_prefix t ~prefix:"GRAND:" with
+              | Some s -> (
+                  match Int.of_string_opt (String.strip s) with
+                  | Some pid -> grand_pid_ref := Some pid
+                  | None -> ())
+              | None -> ())
+          | Types.Stream_event.Tool_use _ | Types.Stream_event.Final_result _
+          | Types.Stream_event.Error _ | Types.Stream_event.Session_init _ ->
+              ()
+        in
+        let script =
+          {|sleep 30 &
+GRAND=$!
+printf '{"type":"content_block_delta","delta":{"type":"text_delta","text":"GRAND:%d"}}\n' "$GRAND"
+printf '{"type":"result","result":"done","stop_reason":"end_turn"}\n'
+# Don't wait — exit immediately so sleep is orphaned unless the shim's
+# setsid lets the parent's SIGKILL sweep it up.
+exit 0|}
+        in
+        let args = [ "sh"; "-c"; script ] in
+        let result =
+          Llm_backend.spawn_and_stream ~process_mgr ~clock ~timeout:30.0 ~cwd
+            ~setsid_exec:(Some shim) ~args ~process_line:process_line_claude
+            ~on_event
+        in
+        if not result.Llm_backend.saw_final_result then (
+          Stdio.printf "FAIL: grandchild reap: Final_result not seen\n";
+          Int.incr failures)
+        else
+          match !grand_pid_ref with
+          | None ->
+              Stdio.printf
+                "FAIL: grandchild reap: grandchild pid not captured\n";
+              Int.incr failures
+          | Some pid ->
+              (* Give the kernel a beat to deliver SIGKILL and reap. *)
+              Unix.sleepf 0.2;
+              let alive =
+                try
+                  Unix.kill pid 0;
+                  true
+                with Unix.Unix_error (Unix.ESRCH, _, _) -> false
+              in
+              if alive then (
+                Stdio.printf
+                  "FAIL: grandchild reap: pid %d still alive after \
+                   spawn_and_stream returned\n"
+                  pid;
+                (try Unix.kill pid Stdlib.Sys.sigkill with _ -> ());
+                Int.incr failures)
+              else Stdio.printf "grandchild reap: passed (pid %d reaped)\n" pid)
+  in
+  grandchild_reap_test ();
   if !failures > 0 then (
     Stdio.printf "%d backend smoke test(s) failed\n" !failures;
     Stdlib.exit 1)

--- a/test/test_backend_smoke.ml
+++ b/test/test_backend_smoke.ml
@@ -27,11 +27,15 @@ let assert_smoke ~name ~result ~got ~expected =
   (* Accept either a clean exit or any status when Final_result was seen:
      after [saw_final_result] we SIGTERM the child, so a short-lived process
      like [printf] may race and exit 143 instead of 0. Both are successful
-     runs from onton's perspective. *)
-  let exit_ok = result.exit_code = 0 || result.saw_final_result in
+     runs from onton's perspective. [timed_out] must always be false: a
+     run that also tripped the outer timeout is never a pass, even if we
+     managed to observe Final_result along the way. *)
+  let exit_ok =
+    (not result.timed_out) && (result.exit_code = 0 || result.saw_final_result)
+  in
   if not exit_ok then (
-    Stdio.printf "FAIL: %s exit_code=%d saw_final_result=%b\n" name
-      result.exit_code result.saw_final_result;
+    Stdio.printf "FAIL: %s timed_out=%b exit_code=%d saw_final_result=%b\n" name
+      result.timed_out result.exit_code result.saw_final_result;
     Int.incr failures)
   else if not result.got_events then (
     Stdio.printf "FAIL: %s got_events=false\n" name;

--- a/test/test_backend_smoke.ml
+++ b/test/test_backend_smoke.ml
@@ -148,6 +148,60 @@ let () =
         Types.Stream_event.Final_result
           { text = ""; stop_reason = Types.Stop_reason.End_turn };
       ];
+  (* --- Early exit on Final_result: the subprocess emits a terminal event
+     and then sleeps. spawn_and_stream must return without waiting the full
+     sleep, [saw_final_result] must be true, and [timed_out] must be false. *)
+  let early_exit_test () =
+    let payload =
+      {|{"type":"result","result":"done","stop_reason":"end_turn"}|}
+    in
+    let events = ref [] in
+    let on_event ev = events := ev :: !events in
+    let args =
+      [ "sh"; "-c"; Printf.sprintf "printf '%s\\n'; sleep 30" payload ]
+    in
+    let started = Unix.gettimeofday () in
+    let result =
+      Llm_backend.spawn_and_stream ~process_mgr ~clock ~timeout:30.0 ~cwd ~args
+        ~process_line:process_line_claude ~on_event
+    in
+    let elapsed = Unix.gettimeofday () -. started in
+    if not result.Llm_backend.saw_final_result then (
+      Stdio.printf "FAIL: early-exit saw_final_result=false\n";
+      Int.incr failures)
+    else if result.Llm_backend.timed_out then (
+      Stdio.printf "FAIL: early-exit timed_out=true\n";
+      Int.incr failures)
+    else if Float.(elapsed > 5.0) then (
+      Stdio.printf "FAIL: early-exit took %.2fs (expected < 5s)\n" elapsed;
+      Int.incr failures)
+    else Stdio.printf "early exit on Final_result: passed (%.2fs)\n" elapsed
+  in
+  early_exit_test ();
+  (* --- Timeout regression: a subprocess that never emits Final_result
+     still times out on schedule. *)
+  let timeout_test () =
+    let events = ref [] in
+    let on_event ev = events := ev :: !events in
+    let args = [ "sh"; "-c"; "sleep 30" ] in
+    let started = Unix.gettimeofday () in
+    let result =
+      Llm_backend.spawn_and_stream ~process_mgr ~clock ~timeout:1.0 ~cwd ~args
+        ~process_line:process_line_claude ~on_event
+    in
+    let elapsed = Unix.gettimeofday () -. started in
+    if not result.Llm_backend.timed_out then (
+      Stdio.printf "FAIL: timeout test timed_out=false\n";
+      Int.incr failures)
+    else if result.Llm_backend.saw_final_result then (
+      Stdio.printf "FAIL: timeout test saw_final_result=true\n";
+      Int.incr failures)
+    else if Float.(elapsed > 5.0) then (
+      Stdio.printf "FAIL: timeout test took %.2fs (expected < 5s)\n" elapsed;
+      Int.incr failures)
+    else Stdio.printf "timeout regression: passed (%.2fs)\n" elapsed
+  in
+  timeout_test ();
   if !failures > 0 then (
     Stdio.printf "%d backend smoke test(s) failed\n" !failures;
     Stdlib.exit 1)

--- a/test/test_backend_smoke.ml
+++ b/test/test_backend_smoke.ml
@@ -24,8 +24,14 @@ let failures = ref 0
 
 let assert_smoke ~name ~result ~got ~expected =
   let open Llm_backend in
-  if result.exit_code <> 0 then (
-    Stdio.printf "FAIL: %s exit_code=%d\n" name result.exit_code;
+  (* Accept either a clean exit or any status when Final_result was seen:
+     after [saw_final_result] we SIGTERM the child, so a short-lived process
+     like [printf] may race and exit 143 instead of 0. Both are successful
+     runs from onton's perspective. *)
+  let exit_ok = result.exit_code = 0 || result.saw_final_result in
+  if not exit_ok then (
+    Stdio.printf "FAIL: %s exit_code=%d saw_final_result=%b\n" name
+      result.exit_code result.saw_final_result;
     Int.incr failures)
   else if not result.got_events then (
     Stdio.printf "FAIL: %s got_events=false\n" name;

--- a/test/test_backend_smoke.ml
+++ b/test/test_backend_smoke.ml
@@ -167,8 +167,12 @@ let () =
     in
     let events = ref [] in
     let on_event ev = events := ev :: !events in
+    (* exec replaces sh with sleep, so the signal lands directly on
+       sleep rather than on a shell waiting for its child. Otherwise
+       SIGTERM would target sh and leave sleep orphaned until kernel
+       reparenting, which slows teardown on loaded machines. *)
     let args =
-      [ "sh"; "-c"; Printf.sprintf "printf '%s\\n'; sleep 30" payload ]
+      [ "sh"; "-c"; Printf.sprintf "printf '%s\\n'; exec sleep 30" payload ]
     in
     let started = Unix.gettimeofday () in
     let result =

--- a/test/test_run_classification.ml
+++ b/test/test_run_classification.ml
@@ -30,11 +30,20 @@ let () =
             false)
   in
 
-  (* Ok with no events + continue -> No_session_to_resume *)
+  (* Ok with no events + continue -> No_session_to_resume
+     (saw_final_result=false is required: a confirmed Final_result is
+     definitive success and short-circuits the no-events heuristic.) *)
   let prop_no_events_continue =
     Test.make ~name:"classify: no events + continue -> No_session_to_resume"
       ~count:500 gen_run_outcome (fun r ->
-        let r = { r with got_events = false; timed_out = false } in
+        let r =
+          {
+            r with
+            got_events = false;
+            saw_final_result = false;
+            timed_out = false;
+          }
+        in
         match classify ~is_resume:true (Ok r) with
         | No_session_to_resume -> true
         | Process_error _ | Timed_out | Success _ | Session_failed _ -> false)
@@ -92,23 +101,18 @@ let () =
             false)
   in
 
-  (* saw_final_result=true promotes non-zero exit codes to Success:
-     a child we SIGTERM'd after the model ended its turn exits 143,
-     but the run was successful from onton's perspective. *)
+  (* saw_final_result=true is definitive success: it short-circuits every
+     subsequent heuristic, including the no-events resume check and the
+     exit-code check. A child we SIGTERM'd after the model ended its turn
+     may exit 143, but the run was successful from onton's perspective. *)
   let prop_saw_final_is_success =
     Test.make
       ~name:"classify: saw_final_result=true -> Success regardless of exit"
-      ~count:500 gen_run_outcome (fun r ->
-        let r =
-          {
-            r with
-            exit_code = 143;
-            got_events = true;
-            saw_final_result = true;
-            timed_out = false;
-          }
-        in
-        match classify ~is_resume:false (Ok r) with
+      ~count:500
+      Gen.(pair gen_run_outcome bool)
+      (fun (r, is_resume) ->
+        let r = { r with saw_final_result = true; timed_out = false } in
+        match classify ~is_resume (Ok r) with
         | Success _ -> true
         | Process_error _ | No_session_to_resume | Timed_out | Session_failed _
           ->

--- a/test/test_run_classification.ml
+++ b/test/test_run_classification.ml
@@ -54,12 +54,18 @@ let () =
             false)
   in
 
-  (* Non-zero exit code -> Session_failed *)
+  (* Non-zero exit code -> Session_failed (when saw_final_result=false) *)
   let prop_nonzero_session_failed =
     Test.make ~name:"classify: non-zero exit -> Session_failed" ~count:500
       gen_run_outcome (fun r ->
         let r =
-          { r with exit_code = 1; got_events = true; timed_out = false }
+          {
+            r with
+            exit_code = 1;
+            got_events = true;
+            saw_final_result = false;
+            timed_out = false;
+          }
         in
         match classify ~is_resume:false (Ok r) with
         | Session_failed _ -> true
@@ -72,11 +78,52 @@ let () =
     Test.make ~name:"classify: detail string bounded" ~count:500 gen_run_outcome
       (fun r ->
         let r =
-          { r with exit_code = 1; got_events = true; timed_out = false }
+          {
+            r with
+            exit_code = 1;
+            got_events = true;
+            saw_final_result = false;
+            timed_out = false;
+          }
         in
         match classify ~is_resume:false (Ok r) with
         | Session_failed { detail; _ } -> String.length detail <= 503
         | Process_error _ | No_session_to_resume | Timed_out | Success _ ->
+            false)
+  in
+
+  (* saw_final_result=true promotes non-zero exit codes to Success:
+     a child we SIGTERM'd after the model ended its turn exits 143,
+     but the run was successful from onton's perspective. *)
+  let prop_saw_final_is_success =
+    Test.make
+      ~name:"classify: saw_final_result=true -> Success regardless of exit"
+      ~count:500 gen_run_outcome (fun r ->
+        let r =
+          {
+            r with
+            exit_code = 143;
+            got_events = true;
+            saw_final_result = true;
+            timed_out = false;
+          }
+        in
+        match classify ~is_resume:false (Ok r) with
+        | Success _ -> true
+        | Process_error _ | No_session_to_resume | Timed_out | Session_failed _
+          ->
+            false)
+  in
+
+  (* Timeout still wins over saw_final_result. *)
+  let prop_timeout_beats_saw_final =
+    Test.make ~name:"classify: timed_out overrides saw_final_result" ~count:500
+      gen_run_outcome (fun r ->
+        let r = { r with saw_final_result = true; timed_out = true } in
+        match classify ~is_resume:false (Ok r) with
+        | Timed_out -> true
+        | Process_error _ | No_session_to_resume | Success _ | Session_failed _
+          ->
             false)
   in
 
@@ -98,6 +145,8 @@ let () =
       prop_exit_zero_success;
       prop_nonzero_session_failed;
       prop_detail_bounded;
+      prop_saw_final_is_success;
+      prop_timeout_beats_saw_final;
       prop_no_continue_uses_exit_code;
     ]
   in


### PR DESCRIPTION
## Summary
Two defects around how onton runs LLM subprocesses — observed on patch 121, where the agent finished its turn at `14:34:40Z` but onton stayed in `responding-to-human` until `14:45:03Z` (exactly the 1800s `session_timeout`), and leaked two `zsh -c '… npm test …'` / `until grep …; sleep 3; done` processes reparented to launchd.

### Phase A — stop blocking 30 min after the model ends its turn
- `Llm_backend.spawn_and_stream` now breaks the stdout read loop on the first `Final_result` event, SIGTERM's the child, and closes our end of the stderr pipe so the sibling `take_all` fiber unblocks even when a descendant still holds the write end open.
- `Llm_backend.result` and `Run_classification.run_outcome` gain a `saw_final_result` field so `exit_code = 143` (from our SIGTERM) still classifies as `Success`. Timeout still wins.
- Post-SIGTERM `Eio.Process.await` is capped at 2s with a SIGKILL escalation.

### Phase B — reap orphan grandchildren
- New `onton-setsid-exec` shim (3-line OCaml binary under `bin/setsid_exec/`) that calls `setsid(2)` then `execvp`s its argv.
- Every LLM spawn routes through the shim so the child leads a new process group; `on_release` and the Final_result teardown now `Unix.kill (-pid) SIG` the whole group, which sweeps up Bash/Monitor tool-call grandchildren instead of leaving them to reparent to launchd.
- `Llm_backend.spawn_and_stream` takes `~setsid_exec:string option`. When `None`, we fall back to the old direct-child signaling so we don't accidentally kill onton's own group.
- `bin/main.ml` discovers the shim at startup via `Sys.executable_name` + `/onton-setsid-exec`, overrideable via `ONTON_SETSID_EXEC` (used by tests). Missing shim logs a trace and runs without group isolation.
- Threaded through Claude / Codex / OpenCode / Pi / Gemini backends (all five share `spawn_and_stream`).

## Test plan
- [x] `dune build` clean
- [x] `dune runtest` — all existing tests pass
- [x] New classifier property tests: `saw_final_result=true → Success`, `timed_out overrides saw_final_result`
- [x] New backend smoke test: subprocess emits `Final_result` then `sleep 30`; `spawn_and_stream` returns in **0.02s** (previously would have blocked 30s)
- [x] New backend smoke test: `sleep 30` via `sh -c` with `timeout=1.0` still `timed_out = true` at ~1.00s (no regression)
- [x] New grandchild-reap test: spawns `sh`, forks a background `sleep`, emits its pid + `Final_result`; after `spawn_and_stream` returns, `Unix.kill grand_pid 0` raises `ESRCH` (grandchild reaped)
- [ ] Live run: point onton at a project, send a `/say` that ends cleanly, confirm the TUI flips out of "responding-to-*" within seconds of `stop_reason: end_turn` rather than after 30 min, and that `ps -eo pid,ppid …` afterwards shows no leaked `zsh -c` / `sleep` / `tail -15` descendants

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional process-group shim (onton-setsid-exec) to run subprocesses in their own session for improved lifecycle control
  * Early-success detection when LLM backends emit a final result to shorten run time

* **Bug Fixes**
  * More robust subprocess teardown with SIGTERM→SIGKILL escalation and better process-tree reaping
  * Timeouts and outcome reporting updated to reflect observed final-result behavior

* **Tests**
  * Added regressions for early-exit, timeout, and grandchild-reap scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->