### PR TITLE
write-gameplan: resolve open questions interactively after construction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: ocaml/setup-ocaml@dec6499fef64fc5d7ed43d43a87251b7b1c306f5 # v3
+      - uses: ocaml/setup-ocaml@e32b06a3e831ff2fbc6f08cf35be2085e3918014 # v3.6.1
         with:
           ocaml-compiler: '5.4.0'
           dune-cache: true
@@ -76,7 +76,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: ocaml/setup-ocaml@dec6499fef64fc5d7ed43d43a87251b7b1c306f5 # v3
+      - uses: ocaml/setup-ocaml@e32b06a3e831ff2fbc6f08cf35be2085e3918014 # v3.6.1
         with:
           ocaml-compiler: '5.4.0'
           dune-cache: true
@@ -109,11 +109,11 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: ocaml/setup-ocaml@dec6499fef64fc5d7ed43d43a87251b7b1c306f5 # v3
+      - uses: ocaml/setup-ocaml@e32b06a3e831ff2fbc6f08cf35be2085e3918014 # v3.6.1
         with:
           ocaml-compiler: '5.4.0'
 
       - name: Use opam.ocaml.org archive cache
         run: opam option 'archive-mirrors=["https://opam.ocaml.org/cache"]'
 
-      - uses: ocaml/setup-ocaml/lint-fmt@dec6499fef64fc5d7ed43d43a87251b7b1c306f5 # v3
+      - uses: ocaml/setup-ocaml/lint-fmt@e32b06a3e831ff2fbc6f08cf35be2085e3918014 # v3.6.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
           path: _opam
           key: opam-macos-14-ocaml-5.4.0-${{ hashFiles('*.opam') }}
 
-      - uses: ocaml/setup-ocaml@fefd9c240b9d934d5d25aa9c2a8caae6c7b40079 # v3
+      - uses: ocaml/setup-ocaml@e32b06a3e831ff2fbc6f08cf35be2085e3918014 # v3.6.1
         if: steps.cache-opam.outputs.cache-hit != 'true'
         with:
           ocaml-compiler: '5.4.0'

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -33,22 +33,35 @@ esac
 
 mkdir -p "$HOOKS_DIR"
 
-# install_hook <hook_name> <sentinel> reads the hook body from stdin.
-# Detects onton-installed hooks via the sentinel so renaming the body
-# doesn't break re-installation, and a third-party hook that merely
-# mentions onton in a comment isn't mistaken for ours.
-install_hook() {
+# Detect onton-installed hooks via a sentinel so renaming the body doesn't
+# break re-installation, and a third-party hook that merely mentions onton
+# in a comment isn't mistaken for ours.
+check_hook_writable() {
   hook_name="$1"
   sentinel="$2"
   hook_path="$HOOKS_DIR/$hook_name"
 
   if [ -e "$hook_path" ] && ! grep -q "$sentinel" "$hook_path"; then
     echo "error: $hook_path already exists and is not onton's hook." >&2
-    echo "       Back it up and remove it, then re-run install-hooks.sh." >&2
-    echo "       The desired body is inlined in scripts/install-hooks.sh." >&2
-    exit 1
+    return 1
   fi
+}
 
+# Validate all hook paths up front so a conflict on the second hook doesn't
+# leave the first one already written to disk in a partial-install state.
+conflicts=0
+check_hook_writable post-checkout 'onton-managed-post-checkout' || conflicts=1
+check_hook_writable pre-commit 'onton-managed-pre-commit' || conflicts=1
+if [ "$conflicts" -ne 0 ]; then
+  echo "       Back up the conflicting file(s) and remove them, then re-run install-hooks.sh." >&2
+  echo "       The desired hook bodies are inlined in scripts/install-hooks.sh." >&2
+  exit 1
+fi
+
+# install_hook <hook_name> reads the hook body from stdin.
+install_hook() {
+  hook_name="$1"
+  hook_path="$HOOKS_DIR/$hook_name"
   cat > "$hook_path"
   chmod +x "$hook_path"
   echo "[installed] $hook_name hook at $hook_path"
@@ -57,7 +70,7 @@ install_hook() {
 # Single-quoted heredoc delimiters so $vars are resolved at hook runtime,
 # not baked in at install time (the repo may later be moved or cloned elsewhere).
 
-install_hook post-checkout 'onton-managed-post-checkout' <<'HOOK'
+install_hook post-checkout <<'HOOK'
 #!/bin/sh
 # onton-managed-post-checkout — do not edit this line; install-hooks.sh uses it
 # to detect that this hook is owned by onton and may be safely overwritten.
@@ -65,7 +78,7 @@ REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
 [ -x "$REPO_ROOT/scripts/sync-skills.sh" ] && "$REPO_ROOT/scripts/sync-skills.sh"
 HOOK
 
-install_hook pre-commit 'onton-managed-pre-commit' <<'HOOK'
+install_hook pre-commit <<'HOOK'
 #!/bin/sh
 # onton-managed-pre-commit — do not edit this line; install-hooks.sh uses it
 # to detect that this hook is owned by onton and may be safely overwritten.

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -75,7 +75,7 @@ set -e
 # user's default switch happens to be. git-common-dir resolves to the main
 # repo's .git from any worktree; its parent is the project root that holds _opam.
 PROJECT_ROOT=$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")
-eval $(opam env --switch="$PROJECT_ROOT" --set-switch)
+eval "$(opam env --switch="$PROJECT_ROOT" --set-switch)"
 
 echo "==> dune build"
 dune build 2>&1
@@ -84,7 +84,7 @@ echo "==> dune runtest"
 dune runtest 2>&1
 
 echo "==> format check"
-dune fmt 2>&1
+dune build @fmt 2>&1
 HOOK
 
 "$SCRIPT_DIR/sync-skills.sh"

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -74,7 +74,7 @@ set -e
 # Activate the project's local opam switch (5.4.0) rather than whatever the
 # user's default switch happens to be. git-common-dir resolves to the main
 # repo's .git from any worktree; its parent is the project root that holds _opam.
-PROJECT_ROOT=$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")
+PROJECT_ROOT="$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")"
 eval "$(opam env --switch="$PROJECT_ROOT" --set-switch)"
 
 echo "==> dune build"

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -78,13 +78,13 @@ PROJECT_ROOT="$(dirname "$(git rev-parse --path-format=absolute --git-common-dir
 eval "$(opam env --switch="$PROJECT_ROOT" --set-switch)"
 
 echo "==> dune build"
-dune build 2>&1
+dune build
 
 echo "==> dune runtest"
-dune runtest 2>&1
+dune runtest
 
 echo "==> format check"
-dune build @fmt 2>&1
+dune build @fmt
 HOOK
 
 "$SCRIPT_DIR/sync-skills.sh"

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -4,10 +4,12 @@
 # Currently installs:
 #   - post-checkout: runs sync-skills.sh after branch switches so ~/.claude/skills
 #     always points at the current checkout
+#   - pre-commit: runs dune build / runtest / fmt against the project's local
+#     opam switch (5.4.0), not whatever the user's default switch happens to be
 #
-# Safe to run repeatedly. Refuses to overwrite a pre-existing post-checkout hook
-# that isn't onton's own. Also runs sync-skills.sh once immediately so skills
-# are available without switching branches.
+# Safe to run repeatedly. Refuses to overwrite a pre-existing hook that isn't
+# onton's own (detected via a sentinel comment). Also runs sync-skills.sh once
+# immediately so skills are available without switching branches.
 
 set -e
 
@@ -31,31 +33,58 @@ esac
 
 mkdir -p "$HOOKS_DIR"
 
-HOOK_PATH="$HOOKS_DIR/post-checkout"
+# install_hook <hook_name> <sentinel> reads the hook body from stdin.
+# Detects onton-installed hooks via the sentinel so renaming the body
+# doesn't break re-installation, and a third-party hook that merely
+# mentions onton in a comment isn't mistaken for ours.
+install_hook() {
+  hook_name="$1"
+  sentinel="$2"
+  hook_path="$HOOKS_DIR/$hook_name"
 
-# Detect onton-installed hooks via a sentinel comment so renaming sync-skills.sh
-# doesn't break re-installation, and a third-party hook that merely mentions
-# sync-skills.sh in a comment isn't mistaken for ours.
-ONTON_HOOK_SENTINEL='onton-managed-post-checkout'
+  if [ -e "$hook_path" ] && ! grep -q "$sentinel" "$hook_path"; then
+    echo "error: $hook_path already exists and is not onton's hook." >&2
+    echo "       Back it up and remove it, then re-run install-hooks.sh." >&2
+    echo "       The desired body is inlined in scripts/install-hooks.sh." >&2
+    exit 1
+  fi
 
-if [ -e "$HOOK_PATH" ] && ! grep -q "$ONTON_HOOK_SENTINEL" "$HOOK_PATH"; then
-  echo "error: $HOOK_PATH already exists and is not onton's hook." >&2
-  echo "       Merge the following into it manually, then re-run:" >&2
-  echo "         REPO_ROOT=\"\$(git rev-parse --show-toplevel 2>/dev/null)\" || exit 0" >&2
-  echo "         [ -x \"\$REPO_ROOT/scripts/sync-skills.sh\" ] && \"\$REPO_ROOT/scripts/sync-skills.sh\"" >&2
-  exit 1
-fi
+  cat > "$hook_path"
+  chmod +x "$hook_path"
+  echo "[installed] $hook_name hook at $hook_path"
+}
 
-# Single-quoted heredoc delimiter so $REPO_ROOT is resolved at hook runtime,
+# Single-quoted heredoc delimiters so $vars are resolved at hook runtime,
 # not baked in at install time (the repo may later be moved or cloned elsewhere).
-cat > "$HOOK_PATH" <<'HOOK'
+
+install_hook post-checkout 'onton-managed-post-checkout' <<'HOOK'
 #!/bin/sh
 # onton-managed-post-checkout — do not edit this line; install-hooks.sh uses it
 # to detect that this hook is owned by onton and may be safely overwritten.
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
 [ -x "$REPO_ROOT/scripts/sync-skills.sh" ] && "$REPO_ROOT/scripts/sync-skills.sh"
 HOOK
-chmod +x "$HOOK_PATH"
-echo "[installed] post-checkout hook at $HOOK_PATH"
+
+install_hook pre-commit 'onton-managed-pre-commit' <<'HOOK'
+#!/bin/sh
+# onton-managed-pre-commit — do not edit this line; install-hooks.sh uses it
+# to detect that this hook is owned by onton and may be safely overwritten.
+set -e
+
+# Activate the project's local opam switch (5.4.0) rather than whatever the
+# user's default switch happens to be. git-common-dir resolves to the main
+# repo's .git from any worktree; its parent is the project root that holds _opam.
+PROJECT_ROOT=$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")
+eval $(opam env --switch="$PROJECT_ROOT" --set-switch)
+
+echo "==> dune build"
+dune build 2>&1
+
+echo "==> dune runtest"
+dune runtest 2>&1
+
+echo "==> format check"
+dune fmt 2>&1
+HOOK
 
 "$SCRIPT_DIR/sync-skills.sh"

--- a/skills/write-gameplan/SKILL.md
+++ b/skills/write-gameplan/SKILL.md
@@ -189,7 +189,7 @@ For each open question, in order:
 3. **Wait for the programmer's decision** before moving on. If they ask for deeper analysis, provide it. If they pick an option you didn't list, accept it. If their resolution conflicts with the spec file or workstream constraints, flag the conflict explicitly and offer to regenerate the gameplan with updated assumptions before proceeding.
 4. **Record the resolution** by:
    - Editing the gameplan to reflect the chosen path — update affected patches (`changes`, `spec`, `files`, signatures), `acceptanceCriteria`, `finalStateSpec`, `dependencyGraph`, and any other fields the decision touches.
-   - Appending an entry to `explicitOpinions` capturing the decision and the rationale, so the reasoning is preserved in the gameplan itself.
+   - Appending an entry to `explicitOpinions` — an object with non-empty `opinion` (the chosen resolution) and `rationale` (why it was chosen) keys — so the reasoning is preserved in the gameplan itself.
    - Removing the question from `openQuestions`.
 5. **Move to the next question.** Do not batch — questions are presented sequentially because later questions often depend on earlier answers, and batching prevents the programmer from reasoning about each decision in isolation.
 

--- a/skills/write-gameplan/SKILL.md
+++ b/skills/write-gameplan/SKILL.md
@@ -175,7 +175,7 @@ After writing the gameplan JSON, verify:
 
 ## Resolving Open Questions
 
-After the gameplan is written and verified, work through the `openQuestions` array with the programmer **one question at a time** until the array is empty.
+After the gameplan is written and verified, automatically proceed to this step without waiting for an additional prompt — work through the `openQuestions` array with the programmer **one question at a time** until the array is empty.
 
 Why this step is mandatory:
 
@@ -186,7 +186,7 @@ For each open question, in order:
 
 1. **Present the question** with the context needed to decide it: which patches it affects, the entities/invariants it touches, and any constraints from the spec file or workstream that bear on it.
 2. **Propose 2-4 candidate resolutions** with brief tradeoffs. State your own recommendation and why; do not hide behind false neutrality. If you genuinely have no preference, say so.
-3. **Wait for the programmer's decision** before moving on. If they ask for deeper analysis, provide it. If they pick an option you didn't list, accept it.
+3. **Wait for the programmer's decision** before moving on. If they ask for deeper analysis, provide it. If they pick an option you didn't list, accept it. If their resolution conflicts with the spec file or workstream constraints, flag the conflict explicitly and offer to regenerate the gameplan with updated assumptions before proceeding.
 4. **Record the resolution** by:
    - Editing the gameplan to reflect the chosen path — update affected patches (`changes`, `spec`, `files`, signatures), `acceptanceCriteria`, `finalStateSpec`, `dependencyGraph`, and any other fields the decision touches.
    - Appending an entry to `explicitOpinions` capturing the decision and the rationale, so the reasoning is preserved in the gameplan itself.

--- a/skills/write-gameplan/SKILL.md
+++ b/skills/write-gameplan/SKILL.md
@@ -173,6 +173,30 @@ After writing the gameplan JSON, verify:
 4. All test stubs have corresponding implementations
 5. The mergability checklist passes
 
+## Resolving Open Questions
+
+After the gameplan is written and verified, work through the `openQuestions` array with the programmer **one question at a time** until the array is empty.
+
+Why this step is mandatory:
+
+- **Gating**: onton will refuse to begin executing a gameplan whose `openQuestions` array is non-empty. Leaving questions unresolved blocks the entire plan.
+- **Control**: this dialogue ensures the programmer understands and has direct authority over the most consequential and thorny design decisions before any code is written.
+
+For each open question, in order:
+
+1. **Present the question** with the context needed to decide it: which patches it affects, the entities/invariants it touches, and any constraints from the spec file or workstream that bear on it.
+2. **Propose 2-4 candidate resolutions** with brief tradeoffs. State your own recommendation and why; do not hide behind false neutrality. If you genuinely have no preference, say so.
+3. **Wait for the programmer's decision** before moving on. If they ask for deeper analysis, provide it. If they pick an option you didn't list, accept it.
+4. **Record the resolution** by:
+   - Editing the gameplan to reflect the chosen path — update affected patches (`changes`, `spec`, `files`, signatures), `acceptanceCriteria`, `finalStateSpec`, `dependencyGraph`, and any other fields the decision touches.
+   - Appending an entry to `explicitOpinions` capturing the decision and the rationale, so the reasoning is preserved in the gameplan itself.
+   - Removing the question from `openQuestions`.
+5. **Move to the next question.** Do not batch — questions are presented sequentially because later questions often depend on earlier answers, and batching prevents the programmer from reasoning about each decision in isolation.
+
+After the last question is resolved, **re-run verification** (schema validation and spec parsing) since edits made during this dialogue may have introduced regressions.
+
+The end state is a gameplan with `openQuestions: []` and an `explicitOpinions` array that captures every decision made during the dialogue.
+
 ## Specification Language
 
 The `spec` and `finalStateSpec` fields contain source code in a formal specification language. The language is a project-level choice — the gameplan structure is the same regardless of which language you use.


### PR DESCRIPTION
## Summary
- Adds a "Resolving Open Questions" step to the `write-gameplan` skill: after the gameplan is written and verified, the agent walks the programmer through `openQuestions` one at a time, presenting context and 2-4 candidate resolutions per question.
- Each resolution edits the affected patches/specs/criteria, appends an entry to `explicitOpinions`, and removes the question from `openQuestions`. After the last question, schema + spec validation re-runs to catch regressions.
- Motivated by two constraints: onton refuses to begin executing a gameplan whose `openQuestions` array is non-empty, and the programmer should have direct authority over the thorniest design decisions before any code is written.

## Test plan
- [ ] Generate a gameplan with `/write-gameplan` and confirm the agent enters the open-questions dialogue after writing the JSON
- [ ] Confirm questions are presented one at a time (no batching) and that each resolution is reflected in `explicitOpinions` and removed from `openQuestions`
- [ ] Confirm the final gameplan has `openQuestions: []` and re-validates against the schema and spec toolchain

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/213"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR, just tag <code>@codesmith</code> or enable autofix. <a href="https://app.blacksmith.sh/flowglad/settings?tab=codesmith">Settings</a>.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an automatic “Resolving Open Questions” step to `write-gameplan` and a managed `pre-commit` hook tied to the repo’s local `opam` switch. This unblocks execution and makes pre-commit checks consistent and reliable across machines.

- **New Features**
  - Auto-starts the open-questions dialogue after verification; presents 2–4 options with a recommendation, accepts custom choices, and flags spec/workstream conflicts.
  - Applies the chosen resolution, records it in `explicitOpinions` with `opinion` and `rationale`, removes the question, and re-validates; final state `openQuestions: []`.

- **Bug Fixes**
  - `scripts/install-hooks.sh` now manages both `post-checkout` and `pre-commit` via per-hook sentinels; activates the project’s local switch from any worktree.
  - `pre-commit`: runs dune build/test/read-only fmt (`dune build`, `dune runtest`, `dune build @fmt`); quotes `eval "$(opam env …)"` and `PROJECT_ROOT`; drops no-op `2>&1` to preserve output order.
  - `install-hooks`: validates all hook paths before writing any; hook installation is atomic.
  - CI: pin `ocaml/setup-ocaml` to `v3.6.1` in CI and Release workflows to avoid failures when the latest `opam` binaries are missing.

<sup>Written for commit 2a102735c6ba3cbb61961accba90462c26177082. Summary will update on new commits. <a href="https://cubic.dev/pr/flowglad/onton/pull/213?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a mandatory interactive question-resolution flow for the write-gameplan skill: sequentially handle open questions with full context, present 2–4 candidate resolutions plus a recommendation, record chosen resolution and rationale in the decision log, update the gameplan state, re-run validation, and block execution until all questions are resolved.
* **Chores**
  * Generalized repo hook installation and added a pre-commit hook to initialize the project environment and run build, tests, and formatting.
  * Updated CI tooling pins for the OCaml setup and formatting checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->