### PR TITLE
Treat no-commits as success for Human deliveries

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -765,10 +765,10 @@ let execute_worktree_plan ~runtime ~process_mgr ~clock ~fs ~repo_root
 
 let truncate s n = if String.length s <= n then s else String.sub s 0 n ^ "..."
 
-let run_claude_and_handle ~runtime ~process_mgr ~clock ~fs ~project_name
-    ~patch_id ~repo_root ~prompt ~(agent : Patch_agent.t) ~owner ~repo
-    ~on_pr_detected ~transcripts ~user_config ~worktree_mutex ~hook_mutex
-    ~backend ~event_log =
+let run_claude_and_handle ~(kind : Operation_kind.t option) ~runtime
+    ~process_mgr ~clock ~fs ~project_name ~patch_id ~repo_root ~prompt
+    ~(agent : Patch_agent.t) ~owner ~repo ~on_pr_detected ~transcripts
+    ~user_config ~worktree_mutex ~hook_mutex ~backend ~event_log =
   match session_mode agent with
   | `Give_up ->
       log_event runtime ~patch_id
@@ -1057,10 +1057,40 @@ let run_claude_and_handle ~runtime ~process_mgr ~clock ~fs ~project_name
              session_result via the pure decision in
              [Orchestrator.combine_session_and_push]. user_result mirrors:
              same Ok/Failed disposition unless the combination promoted us
-             to Session_push_failed (which is always Failed). *)
+             to Session_push_failed (which is always Failed).
+
+             Special case: when the agent is responding to a human message,
+             the human may have asked a question or made a request that
+             requires no code changes. Absence of new commits is therefore
+             not a failure — override Session_no_commits to Session_ok so
+             the no_commits_push_count counter does not march toward
+             needs_intervention and the operation completes cleanly. *)
+          let no_commits_is_ok =
+            match kind with
+            | Some Operation_kind.Human -> true
+            | Some Operation_kind.Ci
+            | Some Operation_kind.Review_comments
+            | Some Operation_kind.Pr_body
+            | Some Operation_kind.Merge_conflict
+            | Some Operation_kind.Rebase
+            | None ->
+                false
+          in
           let final_session_result =
-            Orchestrator.combine_session_and_push ~session:session_result
-              ~push:push_outcome
+            let combined =
+              Orchestrator.combine_session_and_push ~session:session_result
+                ~push:push_outcome
+            in
+            match combined with
+            | Orchestrator.Session_no_commits when no_commits_is_ok ->
+                Orchestrator.Session_ok
+            | Orchestrator.Session_ok | Orchestrator.Session_no_commits
+            | Orchestrator.Session_process_error _
+            | Orchestrator.Session_no_resume | Orchestrator.Session_failed _
+            | Orchestrator.Session_give_up
+            | Orchestrator.Session_worktree_missing
+            | Orchestrator.Session_push_failed ->
+                combined
           in
           let final_user_result =
             match final_session_result with
@@ -2531,11 +2561,11 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                      finishes *)
                                       let on_pr_detected _pr_number = () in
                                       let r, _tool_failures =
-                                        run_claude_and_handle ~runtime
-                                          ~process_mgr ~clock ~fs ~project_name
-                                          ~patch_id ~repo_root:config.repo_root
-                                          ~prompt ~agent
-                                          ~owner:config.github_owner
+                                        run_claude_and_handle ~kind:None
+                                          ~runtime ~process_mgr ~clock ~fs
+                                          ~project_name ~patch_id
+                                          ~repo_root:config.repo_root ~prompt
+                                          ~agent ~owner:config.github_owner
                                           ~repo:config.github_repo
                                           ~on_pr_detected ~transcripts
                                           ~user_config:config.user_config
@@ -2994,11 +3024,13 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                       in
                                       let on_pr_detected _pr_number = () in
                                       let result, _tool_failures =
-                                        run_claude_and_handle ~runtime
-                                          ~process_mgr ~clock ~fs ~project_name
-                                          ~patch_id ~repo_root:config.repo_root
-                                          ~prompt ~agent
-                                          ~owner:config.github_owner
+                                        run_claude_and_handle
+                                          ~kind:
+                                            (Some Operation_kind.Merge_conflict)
+                                          ~runtime ~process_mgr ~clock ~fs
+                                          ~project_name ~patch_id
+                                          ~repo_root:config.repo_root ~prompt
+                                          ~agent ~owner:config.github_owner
                                           ~repo:config.github_repo
                                           ~on_pr_detected ~transcripts
                                           ~user_config:config.user_config
@@ -3309,11 +3341,11 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                     | Patch_decision.Merge_conflict_payload ->
                                         ());
                                     let result, tool_failures =
-                                      run_claude_and_handle ~runtime
-                                        ~process_mgr ~clock ~fs ~project_name
-                                        ~patch_id ~repo_root:config.repo_root
-                                        ~prompt ~agent
-                                        ~owner:config.github_owner
+                                      run_claude_and_handle ~kind:(Some kind)
+                                        ~runtime ~process_mgr ~clock ~fs
+                                        ~project_name ~patch_id
+                                        ~repo_root:config.repo_root ~prompt
+                                        ~agent ~owner:config.github_owner
                                         ~repo:config.github_repo ~on_pr_detected
                                         ~transcripts
                                         ~user_config:config.user_config


### PR DESCRIPTION
## Summary
- After a Human-kind session, override `Session_no_commits` to `Session_ok` so a human asking a question (no code change required) doesn't bump `no_commits_push_count` or march toward `needs_intervention`.
- Plumbed `~kind:Operation_kind.t option` through `run_claude_and_handle`; Start passes `None`, the merge-conflict path passes `Some Merge_conflict`, and the Respond path passes the in-scope `kind`.
- Other operation kinds keep the existing semantics. Supervisor-owned push behavior is unchanged — `force_push_with_lease` already short-circuits when there are no commits ahead of base; this just stops treating that as a partial failure for Human deliveries.

## Test plan
- [x] dune build clean (no warnings)
- [x] dune runtest passes
- [ ] Manually exercise: send a human "thanks, looks good" style message to a patch and confirm the orchestrator returns to idle without bumping `no_commits_push_count`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat no-commit pushes during Human operations as success so conversational replies don’t escalate to intervention. This stops incrementing `no_commits_push_count` and lets the orchestrator idle when no code changes are needed.

- **Bug Fixes**
  - When `kind = Human`, map `Session_no_commits` to `Session_ok`; other kinds keep existing semantics. Supervisor-owned push behavior is unchanged.

- **Refactors**
  - Plumbed `Operation_kind.t option` into `run_claude_and_handle`: `None` for Start, `Some Merge_conflict` for merge-conflict path, and the in-scope `kind` for Respond.

<sup>Written for commit 2106d42f3fa986b8abccc9a68c46f6c36566326b. Summary will update on new commits. <a href="https://cubic.dev/pr/flowglad/onton/pull/214?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of operation outcomes when responses result in no commits, ensuring accurate status reporting for user-initiated messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->