### PR TITLE
Add Claude model-specific backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ of these must be installed and configured before onton can run.
 |------|---------|---------|
 | `git` | Worktree CRUD, branch detection, rebase | `brew install git` (or system package manager) |
 | `gh` (GitHub CLI) | Token resolution, PR discovery (`gh pr list`), and the main vehicle agents use to interact with GitHub (`gh pr create`, `gh pr edit`, `gh pr view`, `gh api`, `gh api graphql`) | `brew install gh`, then `gh auth login` |
-| Coding-agent CLI | Drives the actual patches. One of: `claude` ([Claude Code](https://docs.anthropic.com/en/docs/claude-code)), `codex` ([OpenAI Codex CLI](https://github.com/openai/codex)), `opencode`, `pi`. Selected via `--backend` (default `claude`) and must be on `PATH` | See each tool's docs |
+| Coding-agent CLI | Drives the actual patches. One of: `claude-opus` or `claude-sonnet` ([Claude Code](https://docs.anthropic.com/en/docs/claude-code)), `codex` ([OpenAI Codex CLI](https://github.com/openai/codex)), `opencode`, `pi`, `gemini`. Selected via `--backend` (default `claude-opus`) and must be on `PATH` | See each tool's docs |
 
 Onton is built and tested on macOS (ARM64 and x86_64). Linux should work but is
 not part of the release pipeline.
@@ -423,12 +423,15 @@ GitHub Actions runs on every push and PR:
 
 Backend selection uses `--backend`:
 
-- `onton --backend claude`
+- `onton --backend claude-opus`
+- `onton --backend claude-sonnet`
 - `onton --backend codex`
 - `onton --backend opencode`
 - `onton --backend pi`
+- `onton --backend gemini`
 
-If omitted for a new project, `claude` is the default. The selected backend is
+If omitted for a new project, `claude-opus` is the default. Existing stored
+`claude` configs are migrated to `claude-opus`. The selected backend is
 persisted in project config and reused on resume unless you pass `--backend`
 again to override it.
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ of these must be installed and configured before onton can run.
 |------|---------|---------|
 | `git` | Worktree CRUD, branch detection, rebase | `brew install git` (or system package manager) |
 | `gh` (GitHub CLI) | Token resolution, PR discovery (`gh pr list`), and the main vehicle agents use to interact with GitHub (`gh pr create`, `gh pr edit`, `gh pr view`, `gh api`, `gh api graphql`) | `brew install gh`, then `gh auth login` |
-| Coding-agent CLI | Drives the actual patches. One of: `claude-opus` or `claude-sonnet` ([Claude Code](https://docs.anthropic.com/en/docs/claude-code)), `codex` ([OpenAI Codex CLI](https://github.com/openai/codex)), `opencode`, `pi`, `gemini`. Selected via `--backend` (default `claude-opus`) and must be on `PATH` | See each tool's docs |
+| Coding-agent CLI | Drives the actual patches. One of: `claude` ([Claude Code](https://docs.anthropic.com/en/docs/claude-code); selected as `claude-opus` or `claude-sonnet` via `--backend`), `codex` ([OpenAI Codex CLI](https://github.com/openai/codex)), `opencode`, `pi`, `gemini`. Selected via `--backend` (default `claude-opus`) and must be on `PATH` | See each tool's docs |
 
 Onton is built and tested on macOS (ARM64 and x86_64). Linux should work but is
 not part of the release pipeline.

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -122,10 +122,17 @@ let infer_default_branch ~repo_root =
           | Some _ -> "master"
           | None -> "main"))
 
-let known_backends = [ "claude"; "codex"; "opencode"; "pi"; "gemini" ]
+let default_backend = "claude-opus"
+
+let normalize_backend backend =
+  match backend with "claude" -> default_backend | other -> other
+
+let known_backends =
+  [ "claude-sonnet"; "claude-opus"; "codex"; "opencode"; "pi"; "gemini" ]
 
 let validate_resolved_config ~backend ~github_token ~github_owner ~github_repo
     ~main_branch ~poll_interval ~max_concurrency =
+  let backend = normalize_backend backend in
   let errors =
     Base.List.filter_map
       [
@@ -2350,10 +2357,13 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
     | None -> None
   in
   let backend =
-    match config.backend with
-    | "claude" ->
-        Claude_backend.create ~process_mgr ~clock ~timeout:session_timeout
-          ~setsid_exec
+    match normalize_backend config.backend with
+    | "claude-sonnet" ->
+        Claude_backend.create ~name:"Claude Sonnet" ~model:"sonnet" ~process_mgr
+          ~clock ~timeout:session_timeout ~setsid_exec
+    | "claude-opus" ->
+        Claude_backend.create ~name:"Claude Opus" ~model:"opus" ~process_mgr
+          ~clock ~timeout:session_timeout ~setsid_exec
     | "codex" ->
         Codex_backend.create ~process_mgr ~clock ~timeout:session_timeout
           ~setsid_exec
@@ -3635,7 +3645,8 @@ let resolve_config ~project ~gameplan_path ~github_token ~backend ~main_branch
           }
       in
       let backend =
-        if Base.String.is_empty backend then "claude" else backend
+        if Base.String.is_empty backend then default_backend
+        else backend |> normalize_backend
       in
       let main_branch = resolve_branch ~repo_root main_branch in
       Project_store.save_config ~project_name ~github_token:token
@@ -3673,7 +3684,8 @@ let resolve_config ~project ~gameplan_path ~github_token ~backend ~main_branch
             resolve_github_credentials ~github_token ~repo_root
           in
           let backend =
-            if Base.String.is_empty backend then "claude" else backend
+            if Base.String.is_empty backend then default_backend
+            else backend |> normalize_backend
           in
           let main_branch = resolve_branch ~repo_root main_branch in
           Project_store.save_config ~project_name ~github_token:token
@@ -3729,6 +3741,7 @@ let resolve_config ~project ~gameplan_path ~github_token ~backend ~main_branch
                   in
                   let backend =
                     merge_cli_stored backend stored.Project_store.backend
+                    |> normalize_backend
                   in
                   let token_from_stored =
                     merge_cli_stored github_token
@@ -4076,7 +4089,9 @@ let backend_arg =
   Arg.(
     value & opt string ""
     & info [ "backend" ] ~docv:"BACKEND"
-        ~doc:"LLM backend to use: claude, codex, opencode, pi, or gemini.")
+        ~doc:
+          "LLM backend to use: claude-sonnet, claude-opus, codex, opencode, \
+           pi, or gemini.")
 
 let repo_arg =
   let open Cmdliner in

--- a/lib/claude_backend.ml
+++ b/lib/claude_backend.ml
@@ -1,8 +1,9 @@
-let create ~process_mgr ~clock ~timeout ~setsid_exec : Llm_backend.t =
+let create ~name ~model ~process_mgr ~clock ~timeout ~setsid_exec :
+    Llm_backend.t =
   {
-    name = "Claude";
+    name;
     run_streaming =
       (fun ~cwd ~patch_id ~prompt ~resume_session ~on_event ->
-        Claude_runner.run_streaming ~process_mgr ~clock ~timeout ~setsid_exec
-          ~cwd ~patch_id ~prompt ~resume_session ~on_event);
+        Claude_runner.run_streaming ~model ~process_mgr ~clock ~timeout
+          ~setsid_exec ~cwd ~patch_id ~prompt ~resume_session ~on_event);
   }

--- a/lib/claude_backend.mli
+++ b/lib/claude_backend.mli
@@ -1,4 +1,6 @@
 val create :
+  name:string ->
+  model:string ->
   process_mgr:_ Eio.Process.mgr ->
   clock:_ Eio.Time.clock ->
   timeout:float ->

--- a/lib/claude_runner.ml
+++ b/lib/claude_runner.ml
@@ -39,17 +39,28 @@ let ansi_re =
 (** Strip ANSI escape sequences and stray control characters. *)
 let strip_ansi s = Re.replace_string ansi_re ~by:"" s
 
-let build_args ~prompt ~resume_session =
-  let base = [ "claude"; "-p"; prompt; "--output-format"; "text" ] in
+let build_args ~model ~prompt ~resume_session =
+  let base =
+    [ "claude"; "--model"; model; "-p"; prompt; "--output-format"; "text" ]
+  in
   let session_args =
     match resume_session with Some id -> [ "--resume"; id ] | None -> []
   in
   let flags = [ "--dangerously-skip-permissions"; "--max-turns"; "200" ] in
   base @ session_args @ flags
 
-let build_stream_args ~prompt ~resume_session =
+let build_stream_args ~model ~prompt ~resume_session =
   let base =
-    [ "claude"; "-p"; prompt; "--output-format"; "stream-json"; "--verbose" ]
+    [
+      "claude";
+      "--model";
+      model;
+      "-p";
+      prompt;
+      "--output-format";
+      "stream-json";
+      "--verbose";
+    ]
   in
   let session_args =
     match resume_session with Some id -> [ "--resume"; id ] | None -> []
@@ -197,9 +208,9 @@ let parse_stream_events (line : string) : Types.Stream_event.t list =
 let parse_stream_event (line : string) : Types.Stream_event.t option =
   match parse_stream_events line with [] -> None | e :: _ -> Some e
 
-let run ~process_mgr ~cwd ~patch_id ~prompt ~resume_session =
+let run ~model ~process_mgr ~cwd ~patch_id ~prompt ~resume_session =
   ignore (patch_id : Types.Patch_id.t);
-  let args = build_args ~prompt ~resume_session in
+  let args = build_args ~model ~prompt ~resume_session in
   let stdout_content, stderr_content, exit_code =
     Eio.Switch.run @@ fun sw ->
     let stdin_r, stdin_w = Eio.Process.pipe ~sw process_mgr in
@@ -253,10 +264,10 @@ let run ~process_mgr ~cwd ~patch_id ~prompt ~resume_session =
     timed_out = false;
   }
 
-let run_streaming ~process_mgr ~clock ~timeout ~setsid_exec ~cwd ~patch_id
-    ~prompt ~resume_session ~on_event =
+let run_streaming ~model ~process_mgr ~clock ~timeout ~setsid_exec ~cwd
+    ~patch_id ~prompt ~resume_session ~on_event =
   ignore (patch_id : Types.Patch_id.t);
-  let args = build_stream_args ~prompt ~resume_session in
+  let args = build_stream_args ~model ~prompt ~resume_session in
   let process_line line =
     let trimmed = strip_ansi (String.strip line) in
     if String.is_empty trimmed then [] else parse_stream_events trimmed
@@ -265,10 +276,14 @@ let run_streaming ~process_mgr ~clock ~timeout ~setsid_exec ~cwd ~patch_id
     ~args ~process_line ~on_event
 
 let%test "build_args fresh (no resume)" =
-  let args = build_args ~prompt:"do stuff" ~resume_session:None in
+  let args =
+    build_args ~model:"sonnet" ~prompt:"do stuff" ~resume_session:None
+  in
   List.equal String.equal args
     [
       "claude";
+      "--model";
+      "sonnet";
       "-p";
       "do stuff";
       "--output-format";
@@ -279,10 +294,14 @@ let%test "build_args fresh (no resume)" =
     ]
 
 let%test "build_args with resume session" =
-  let args = build_args ~prompt:"do stuff" ~resume_session:(Some "abc-123") in
+  let args =
+    build_args ~model:"opus" ~prompt:"do stuff" ~resume_session:(Some "abc-123")
+  in
   List.equal String.equal args
     [
       "claude";
+      "--model";
+      "opus";
       "-p";
       "do stuff";
       "--output-format";
@@ -295,10 +314,14 @@ let%test "build_args with resume session" =
     ]
 
 let%test "build_stream_args fresh (no resume)" =
-  let args = build_stream_args ~prompt:"do stuff" ~resume_session:None in
+  let args =
+    build_stream_args ~model:"sonnet" ~prompt:"do stuff" ~resume_session:None
+  in
   List.equal String.equal args
     [
       "claude";
+      "--model";
+      "sonnet";
       "-p";
       "do stuff";
       "--output-format";
@@ -311,11 +334,14 @@ let%test "build_stream_args fresh (no resume)" =
 
 let%test "build_stream_args with resume session" =
   let args =
-    build_stream_args ~prompt:"do stuff" ~resume_session:(Some "abc-123")
+    build_stream_args ~model:"opus" ~prompt:"do stuff"
+      ~resume_session:(Some "abc-123")
   in
   List.equal String.equal args
     [
       "claude";
+      "--model";
+      "opus";
       "-p";
       "do stuff";
       "--output-format";

--- a/lib/claude_runner.mli
+++ b/lib/claude_runner.mli
@@ -15,6 +15,7 @@ open Base
     busy patches don't get new work. *)
 
 val run :
+  model:string ->
   process_mgr:_ Eio.Process.mgr ->
   cwd:Eio.Fs.dir_ty Eio.Path.t ->
   patch_id:Types.Patch_id.t ->
@@ -35,6 +36,7 @@ val run :
     {!run_streaming} carries [~clock] and [~timeout] for this purpose. *)
 
 val run_streaming :
+  model:string ->
   process_mgr:_ Eio.Process.mgr ->
   clock:_ Eio.Time.clock ->
   timeout:float ->
@@ -62,10 +64,11 @@ val strip_ansi : string -> string
 (** Strip ANSI escape sequences and stray control characters from a line.
     Exposed for testing. *)
 
-val build_args : prompt:string -> resume_session:string option -> string list
+val build_args :
+  model:string -> prompt:string -> resume_session:string option -> string list
 (** Build the CLI argument list for the Claude process. Exposed for testing. *)
 
 val build_stream_args :
-  prompt:string -> resume_session:string option -> string list
+  model:string -> prompt:string -> resume_session:string option -> string list
 (** Build the CLI argument list for stream-json output mode. Exposed for
     testing. *)

--- a/lib/project_store.ml
+++ b/lib/project_store.ml
@@ -108,7 +108,7 @@ let load_config ~project_name =
     | `Assoc fields ->
         let fields =
           if List.Assoc.mem fields "backend" ~equal:String.equal then fields
-          else ("backend", `String "claude") :: fields
+          else ("backend", `String "claude-opus") :: fields
         in
         Ok (stored_config_of_yojson (`Assoc fields))
     | _ -> Ok (stored_config_of_yojson json)

--- a/lib/project_store.ml
+++ b/lib/project_store.ml
@@ -107,8 +107,14 @@ let load_config ~project_name =
     match json with
     | `Assoc fields ->
         let fields =
-          if List.Assoc.mem fields "backend" ~equal:String.equal then fields
-          else ("backend", `String "claude-opus") :: fields
+          let fields =
+            if List.Assoc.mem fields "backend" ~equal:String.equal then fields
+            else ("backend", `String "claude-opus") :: fields
+          in
+          List.map fields ~f:(fun (key, value) ->
+              match (key, value) with
+              | "backend", `String "claude" -> (key, `String "claude-opus")
+              | _ -> (key, value))
         in
         Ok (stored_config_of_yojson (`Assoc fields))
     | _ -> Ok (stored_config_of_yojson json)


### PR DESCRIPTION
## Summary
- add separate `claude-opus` and `claude-sonnet` backend selections
- make `claude-opus` the default and normalize legacy `claude` configs to it
- pass the selected Claude model through to the Claude CLI with `--model`
- update README backend documentation

## Verification
- `dune build @fmt`
- `dune build`
- `git diff --check`
- `dune runtest` fails on existing TUI ANSI assertions in `lib/tui.ml:429` and `lib/tui.ml:446`; backend smoke tests pass

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/216"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add model-specific Claude backends: `claude-opus` and `claude-sonnet`. `claude-opus` is now the default, legacy `claude` is normalized to it, and the selected model is passed to the `claude` CLI via `--model`.

- **New Features**
  - Choose `--backend claude-opus` or `--backend claude-sonnet`.
  - Runner forwards `--model` (`opus` or `sonnet`) to the `claude` CLI in both sync and streaming modes.
  - Updated README and CLI help; known backends now list both and include `gemini`.

- **Migration**
  - Default backend is `claude-opus` (missing backend fields default to it).
  - Existing `backend: claude` in project config and `--backend claude` are auto-migrated/normalized to `claude-opus`.

<sup>Written for commit 0b0280530aa0ffbc7ca81db6a34207cd8ebf9d07. Summary will update on new commits. <a href="https://cubic.dev/pr/flowglad/onton/pull/216?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for `claude-sonnet` and `gemini`
  * CLI now lists `claude-opus` / `claude-sonnet` as explicit backend options

* **Chores**
  * Default backend changed from `claude` to `claude-opus`
  * Stored projects originally using `claude` are migrated to `claude-opus`
  * Selected backend is persisted across resume unless overridden via CLI
<!-- end of auto-generated comment: release notes by coderabbit.ai -->