### PR TITLE
Fix Codex human delivery replay after backend acceptance

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -864,6 +864,8 @@ let run_claude_and_handle ~(kind : Operation_kind.t option) ~runtime
           in
           let on_event (event : Types.Stream_event.t) =
             match event with
+            (* Turn_started is the preferred signal; the arms below are
+               fallbacks for backends that do not emit it. *)
             | Types.Stream_event.Turn_started -> mark_backend_accepted_turn ()
             | Types.Stream_event.Text_delta text -> (
                 mark_backend_accepted_turn ();

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -845,9 +845,28 @@ let run_claude_and_handle ~(kind : Operation_kind.t option) ~runtime
               sync_transcript ())
           in
           let captured_session_id = ref None in
+          let backend_accepted_turn = ref false in
+          let mark_backend_accepted_turn () =
+            if not !backend_accepted_turn then (
+              backend_accepted_turn := true;
+              match kind with
+              | Some Operation_kind.Human ->
+                  Runtime.update_orchestrator runtime (fun orch ->
+                      Orchestrator.mark_inflight_human_messages_delivered orch
+                        patch_id)
+              | Some Operation_kind.Ci
+              | Some Operation_kind.Review_comments
+              | Some Operation_kind.Pr_body
+              | Some Operation_kind.Merge_conflict
+              | Some Operation_kind.Rebase
+              | None ->
+                  ())
+          in
           let on_event (event : Types.Stream_event.t) =
             match event with
+            | Types.Stream_event.Turn_started -> mark_backend_accepted_turn ()
             | Types.Stream_event.Text_delta text -> (
+                mark_backend_accepted_turn ();
                 let prev_len = Buffer.length text_buf in
                 Buffer.add_string text_buf text;
                 maybe_sync_transcript ();
@@ -866,6 +885,7 @@ let run_claude_and_handle ~(kind : Operation_kind.t option) ~runtime
                       on_pr_detected pr_number
                   | None -> ())
             | Types.Stream_event.Tool_use { name; input; status } ->
+                mark_backend_accepted_turn ();
                 tool_count := !tool_count + 1;
                 (* OpenCode emits pending → running → completed for a single
                    tool call. Track only the latest unresolved status per tool
@@ -924,6 +944,7 @@ let run_claude_and_handle ~(kind : Operation_kind.t option) ~runtime
                 log_stream_entry runtime ~patch_id
                   (Activity_log.Stream_entry.Tool_use (name, summary))
             | Types.Stream_event.Final_result { stop_reason; _ } ->
+                mark_backend_accepted_turn ();
                 sync_transcript ();
                 let reason = Types.Stop_reason.to_display stop_reason in
                 log_stream_entry runtime ~patch_id

--- a/lib/codex_backend.ml
+++ b/lib/codex_backend.ml
@@ -82,6 +82,7 @@ let parse_event (line : string) : Types.Stream_event.t list =
           | Some id when not (String.is_empty id) ->
               [ Types.Stream_event.Session_init { session_id = id } ]
           | _ -> [])
+      | Some "turn.started" -> [ Types.Stream_event.Turn_started ]
       | Some "turn.completed" ->
           [
             Types.Stream_event.Final_result
@@ -164,6 +165,11 @@ let%test "parse_event thread.started emits Session_init" =
 let%test "parse_event thread.started without thread_id is ignored" =
   let line = {|{"type":"thread.started"}|} in
   List.is_empty (parse_event line)
+
+let%test "parse_event turn.started emits Turn_started" =
+  let line = {|{"type":"turn.started"}|} in
+  List.equal Types.Stream_event.equal (parse_event line)
+    [ Types.Stream_event.Turn_started ]
 
 let%test "parse_event agent_message (content-array schema)" =
   let line =

--- a/lib/llm_backend.ml
+++ b/lib/llm_backend.ml
@@ -54,8 +54,12 @@ let spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~setsid_exec ~args
       Eio.Flow.close stdin_w;
       Eio.Flow.close stdout_w;
       Eio.Flow.close stderr_w;
-      let stdout_buf = Eio.Buf_read.of_flow ~max_size:stdout_max_size stdout_r in
-      let stderr_buf = Eio.Buf_read.of_flow ~max_size:stderr_max_size stderr_r in
+      let stdout_buf =
+        Eio.Buf_read.of_flow ~max_size:stdout_max_size stdout_r
+      in
+      let stderr_buf =
+        Eio.Buf_read.of_flow ~max_size:stderr_max_size stderr_r
+      in
       let err_ref = ref "" in
       Eio.Fiber.both
         (fun () ->
@@ -68,6 +72,7 @@ let spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~setsid_exec ~args
                 let saw_final =
                   List.exists events ~f:(function
                     | Types.Stream_event.Final_result _ -> true
+                    | Types.Stream_event.Turn_started
                     | Types.Stream_event.Text_delta _
                     | Types.Stream_event.Tool_use _ | Types.Stream_event.Error _
                     | Types.Stream_event.Session_init _ ->

--- a/lib/llm_backend.ml
+++ b/lib/llm_backend.ml
@@ -24,6 +24,8 @@ let spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~setsid_exec ~args
   let args =
     match setsid_exec with Some path -> path :: args | None -> args
   in
+  let stdout_max_size = 64 * 1024 * 1024 in
+  let stderr_max_size = 1024 * 1024 in
   let saw_final_result_ref = ref false in
   let got_events_ref = ref false in
   let run () =
@@ -52,8 +54,8 @@ let spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~setsid_exec ~args
       Eio.Flow.close stdin_w;
       Eio.Flow.close stdout_w;
       Eio.Flow.close stderr_w;
-      let stdout_buf = Eio.Buf_read.of_flow ~max_size:(1024 * 1024) stdout_r in
-      let stderr_buf = Eio.Buf_read.of_flow ~max_size:(1024 * 1024) stderr_r in
+      let stdout_buf = Eio.Buf_read.of_flow ~max_size:stdout_max_size stdout_r in
+      let stderr_buf = Eio.Buf_read.of_flow ~max_size:stderr_max_size stderr_r in
       let err_ref = ref "" in
       Eio.Fiber.both
         (fun () ->
@@ -105,7 +107,7 @@ let spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~setsid_exec ~args
               | End_of_file -> ()
               | Eio.Exn.Io _ -> ())
           | End_of_file -> ()
-          | Eio.Exn.Io _ -> ());
+          | Eio.Exn.Io _ | Invalid_argument _ -> ());
       let status =
         if !saw_final_result_ref then
           (* SIGTERM was just delivered; cap the await so a child that

--- a/lib/llm_backend.ml
+++ b/lib/llm_backend.ml
@@ -110,9 +110,9 @@ let spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~setsid_exec ~args
                 done
               with
               | End_of_file -> ()
-              | Eio.Exn.Io _ -> ())
+              | Eio.Exn.Io _ | Invalid_argument _ -> ())
           | End_of_file -> ()
-          | Eio.Exn.Io _ | Invalid_argument _ -> ());
+          | Eio.Exn.Io _ -> ());
       let status =
         if !saw_final_result_ref then
           (* SIGTERM was just delivered; cap the await so a child that

--- a/lib/llm_backend.mli
+++ b/lib/llm_backend.mli
@@ -29,7 +29,9 @@ val spawn_and_stream :
 (** Spawn a subprocess, read NDJSON lines from stdout, and stream parsed events.
     Each stdout line is passed to [process_line] which returns events to forward
     to [on_event]. Handles pipe setup, stdin EOF, stderr capture, and exit code
-    extraction. The process is killed after [timeout] seconds.
+    extraction. Stdout allows large single-line JSON events from CLIs such as
+    Codex; stderr is capped and truncated. The process is killed after
+    [timeout] seconds.
 
     When [setsid_exec] is supplied, [args] is prefixed with that path (a tiny
     OCaml shim that calls [setsid(2)] before exec'ing). The child then leads its

--- a/lib/llm_backend.mli
+++ b/lib/llm_backend.mli
@@ -30,8 +30,8 @@ val spawn_and_stream :
     Each stdout line is passed to [process_line] which returns events to forward
     to [on_event]. Handles pipe setup, stdin EOF, stderr capture, and exit code
     extraction. Stdout allows large single-line JSON events from CLIs such as
-    Codex; stderr is capped and truncated. The process is killed after
-    [timeout] seconds.
+    Codex; stderr is capped and truncated. The process is killed after [timeout]
+    seconds.
 
     When [setsid_exec] is supplied, [args] is prefixed with that path (a tiny
     OCaml shim that calls [setsid(2)] before exec'ing). The child then leads its

--- a/lib/opencode_backend.ml
+++ b/lib/opencode_backend.ml
@@ -45,7 +45,10 @@ let parse_event (line : string) : Types.Stream_event.t list =
       | Some "step_start" -> (
           match member "sessionID" json |> to_string_option with
           | Some id when not (String.is_empty id) ->
-              [ Types.Stream_event.Session_init { session_id = id } ]
+              [
+                Types.Stream_event.Turn_started;
+                Types.Stream_event.Session_init { session_id = id };
+              ]
           | _ -> [])
       | Some "text" ->
           let part = member "part" json in
@@ -246,7 +249,10 @@ let%test "parse_event step_start emits session_init" =
     {|{"type":"step_start","sessionID":"ses_abc","part":{"type":"step-start"}}|}
   in
   List.equal Types.Stream_event.equal (parse_event line)
-    [ Types.Stream_event.Session_init { session_id = "ses_abc" } ]
+    [
+      Types.Stream_event.Turn_started;
+      Types.Stream_event.Session_init { session_id = "ses_abc" };
+    ]
 
 let%test "parse_event step_finish stop" =
   let line =

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -374,6 +374,9 @@ let set_llm_session_id t patch_id session_id =
   update_agent t patch_id ~f:(fun a ->
       Patch_agent.set_llm_session_id a session_id)
 
+let mark_inflight_human_messages_delivered t patch_id =
+  update_agent t patch_id ~f:Patch_agent.mark_inflight_human_messages_delivered
+
 let set_automerge_enabled t patch_id v =
   update_agent t patch_id ~f:(fun a -> Patch_agent.set_automerge_enabled a v)
 
@@ -572,10 +575,10 @@ type session_result =
   | Session_no_commits
 [@@deriving show, eq, sexp_of]
 
-(** Complete a failed session, restoring inflight human messages to the inbox.
-    On failure the messages were NOT delivered, so we prepend
-    [inflight_human_messages] back to [human_messages] before [complete] clears
-    the inflight slot. *)
+(** Complete a failed session, restoring only still-inflight human messages to
+    the inbox. Human messages are cleared from the inflight slot as soon as the
+    backend accepts the turn, so anything remaining here was not delivered and
+    should be retried. *)
 let complete_failed t patch_id =
   let a = agent t patch_id in
   let inflight = a.Patch_agent.inflight_human_messages in

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -106,6 +106,11 @@ val clear_branch_blocked : t -> Patch_id.t -> t
 val reset_busy : t -> Patch_id.t -> t
 val set_worktree_path : t -> Patch_id.t -> string -> t
 val set_llm_session_id : t -> Patch_id.t -> string option -> t
+
+val mark_inflight_human_messages_delivered : t -> Patch_id.t -> t
+(** Clear inflight Human messages after backend turn acceptance. See
+    {!Patch_agent.mark_inflight_human_messages_delivered}. *)
+
 val set_automerge_enabled : t -> Patch_id.t -> bool -> t
 val set_automerge_deadline : t -> Patch_id.t -> float -> t
 val clear_automerge_deadline : t -> Patch_id.t -> t

--- a/lib/patch_agent.ml
+++ b/lib/patch_agent.ml
@@ -300,6 +300,11 @@ let set_current_message_id t current_message_id = { t with current_message_id }
 let bump_generation t = { t with generation = t.generation + 1 }
 let set_llm_session_id t llm_session_id = { t with llm_session_id }
 
+let mark_inflight_human_messages_delivered t =
+  if Option.equal Operation_kind.equal t.current_op (Some Operation_kind.Human)
+  then { t with inflight_human_messages = [] }
+  else t
+
 let set_automerge_enabled t v =
   if Bool.equal t.automerge_enabled v then t
   else

--- a/lib/patch_agent.mli
+++ b/lib/patch_agent.mli
@@ -283,6 +283,11 @@ val set_llm_session_id : t -> string option -> t
     after intervention. Cleared on start-path fresh-failure reset (clean retry)
     and when the session is known dead (no-resume, give-up). *)
 
+val mark_inflight_human_messages_delivered : t -> t
+(** Clear [inflight_human_messages] for an active Human response once the
+    backend has emitted evidence that it accepted the turn. Does not complete
+    the session or change fallback state. No-op for non-Human operations. *)
+
 val set_automerge_enabled : t -> bool -> t
 (** Enable or disable automerge for this patch. When the value actually changes,
     the inflight flag is cleared and [automerge_failure_count] is reset;

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -218,6 +218,7 @@ end
    (--output-format stream-json), not the raw Anthropic streaming API. *)
 module Stream_event = struct
   type t =
+    | Turn_started
     | Text_delta of string
     | Tool_use of { name : string; input : string; status : string option }
     | Final_result of { text : string; stop_reason : Stop_reason.t }

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -166,6 +166,11 @@ end
     the raw Anthropic streaming API. *)
 module Stream_event : sig
   type t =
+    | Turn_started
+        (** Backend emitted an event indicating it accepted/started processing
+            the current turn. This is stronger than session initialization:
+            session IDs can be created or resumed without proving that the
+            prompt was processed. *)
     | Text_delta of string
     | Tool_use of {
         name : string;

--- a/test/test_action_outcome_properties.ml
+++ b/test/test_action_outcome_properties.ml
@@ -118,8 +118,7 @@ let () =
     QCheck2.Test.make
       ~name:
         "AO-2b: delivered Human message is cleared before next Human delivery"
-      distinct_human_messages_gen
-      (fun (first_msg, second_msg) ->
+      distinct_human_messages_gen (fun (first_msg, second_msg) ->
         try
           let orch, _patches, _gameplan, pid = bootstrap_one () in
           let orch = Orchestrator.send_human_message orch pid first_msg in

--- a/test/test_action_outcome_properties.ml
+++ b/test/test_action_outcome_properties.ml
@@ -129,11 +129,15 @@ let () =
               (Orchestrator.Respond (pid, Operation_kind.Human))
           in
           let orch =
+            Orchestrator.mark_inflight_human_messages_delivered orch pid
+          in
+          let mid = Orchestrator.agent orch pid in
+          if not (List.is_empty mid.Patch_agent.inflight_human_messages) then
+            QCheck2.Test.fail_reportf
+              "mark_inflight did not clear inflight slot";
+          let orch =
             Orchestrator.apply_respond_outcome orch pid Operation_kind.Human
               Orchestrator.Respond_ok
-          in
-          let orch =
-            Orchestrator.mark_inflight_human_messages_delivered orch pid
           in
           let after_first = Orchestrator.agent orch pid in
           if not (List.is_empty after_first.Patch_agent.human_messages) then

--- a/test/test_action_outcome_properties.ml
+++ b/test/test_action_outcome_properties.ml
@@ -262,13 +262,15 @@ let () =
           let orch = make_busy orch patches gameplan pid Operation_kind.Human in
           let before = Orchestrator.agent orch pid in
           if List.is_empty before.Patch_agent.inflight_human_messages then
-            failwith "expected inflight Human messages";
+            QCheck2.Test.fail_reportf "expected inflight Human messages";
           let orch =
             Orchestrator.mark_inflight_human_messages_delivered orch pid
           in
           let accepted = Orchestrator.agent orch pid in
           if not (List.is_empty accepted.Patch_agent.inflight_human_messages)
-          then failwith "accepted Human messages should be drained";
+          then
+            QCheck2.Test.fail_reportf
+              "accepted Human messages should be drained";
           let orch = Orchestrator.apply_session_result orch pid result in
           let after = Orchestrator.agent orch pid in
           List.is_empty after.Patch_agent.human_messages
@@ -276,7 +278,13 @@ let () =
           && not
                (List.mem after.Patch_agent.queue Operation_kind.Human
                   ~equal:Operation_kind.equal)
-        with _ -> false)
+        with
+        | e
+          when String.equal
+                 (Stdlib.Printexc.exn_slot_name e)
+                 "QCheck2.Test.User_fail" ->
+            raise e
+        | _ -> false)
   in
   QCheck2.Test.check_exn prop;
   Stdlib.print_endline "AO-6b passed"

--- a/test/test_action_outcome_properties.ml
+++ b/test/test_action_outcome_properties.ml
@@ -132,11 +132,14 @@ let () =
             Orchestrator.apply_respond_outcome orch pid Operation_kind.Human
               Orchestrator.Respond_ok
           in
+          let orch =
+            Orchestrator.mark_inflight_human_messages_delivered orch pid
+          in
           let after_first = Orchestrator.agent orch pid in
           if not (List.is_empty after_first.Patch_agent.human_messages) then
-            failwith "first message remained in inbox";
+            QCheck2.Test.fail_reportf "first message remained in inbox";
           if not (List.is_empty after_first.Patch_agent.inflight_human_messages)
-          then failwith "first message remained inflight";
+          then QCheck2.Test.fail_reportf "first message remained inflight";
           let orch = Orchestrator.send_human_message orch pid second_msg in
           let second_pre = Orchestrator.agent orch pid in
           let orch =
@@ -161,7 +164,9 @@ let () =
               | Patch_decision.Merge_conflict_payload ->
                   false)
           | Patch_decision.Skip_empty | Patch_decision.Respond_stale -> false
-        with _ -> false)
+        with
+        | QCheck2.Test.Test_fail _ as e -> raise e
+        | _ -> false)
   in
   QCheck2.Test.check_exn prop;
   Stdlib.print_endline "AO-2b passed"

--- a/test/test_action_outcome_properties.ml
+++ b/test/test_action_outcome_properties.ml
@@ -126,9 +126,7 @@ let () =
           let after_first = Orchestrator.agent orch pid in
           if not (List.is_empty after_first.Patch_agent.human_messages) then
             failwith "first message remained in inbox";
-          if
-            not
-              (List.is_empty after_first.Patch_agent.inflight_human_messages)
+          if not (List.is_empty after_first.Patch_agent.inflight_human_messages)
           then failwith "first message remained inflight";
           let orch = Orchestrator.send_human_message orch pid second_msg in
           let second_pre = Orchestrator.agent orch pid in
@@ -146,11 +144,10 @@ let () =
               match payload with
               | Patch_decision.Human_payload { messages } ->
                   List.equal String.equal messages [ second_msg ]
-                  && not (List.mem messages first_msg ~equal:String.equal)
+                  && (not (List.mem messages first_msg ~equal:String.equal))
                   && List.mem first_pre.Patch_agent.human_messages first_msg
                        ~equal:String.equal
-              | Patch_decision.Ci_payload _
-              | Patch_decision.Review_payload _
+              | Patch_decision.Ci_payload _ | Patch_decision.Review_payload _
               | Patch_decision.Pr_body_payload
               | Patch_decision.Merge_conflict_payload ->
                   false)
@@ -240,6 +237,49 @@ let () =
   assert (List.is_empty agent.Patch_agent.inflight_human_messages);
   assert (not agent.Patch_agent.busy);
   Stdlib.print_endline "AO-6 passed"
+
+(* ========== AO-6b: accepted Human delivery is not restored on failure ========== *)
+
+let () =
+  let failed_results =
+    [
+      Orchestrator.Session_process_error { is_fresh = false };
+      Orchestrator.Session_process_error { is_fresh = true };
+      Orchestrator.Session_no_resume;
+      Orchestrator.Session_failed { is_fresh = false };
+      Orchestrator.Session_failed { is_fresh = true };
+      Orchestrator.Session_give_up;
+    ]
+  in
+  let prop =
+    QCheck2.Test.make
+      ~name:
+        "AO-6b: backend-accepted Human delivery is not restored on session \
+         failure" (QCheck2.Gen.oneof_list failed_results) (fun result ->
+        try
+          let orch, patches, gameplan, pid = bootstrap_one () in
+          let orch = Orchestrator.send_human_message orch pid "fix this" in
+          let orch = make_busy orch patches gameplan pid Operation_kind.Human in
+          let before = Orchestrator.agent orch pid in
+          if List.is_empty before.Patch_agent.inflight_human_messages then
+            failwith "expected inflight Human messages";
+          let orch =
+            Orchestrator.mark_inflight_human_messages_delivered orch pid
+          in
+          let accepted = Orchestrator.agent orch pid in
+          if not (List.is_empty accepted.Patch_agent.inflight_human_messages)
+          then failwith "accepted Human messages should be drained";
+          let orch = Orchestrator.apply_session_result orch pid result in
+          let after = Orchestrator.agent orch pid in
+          List.is_empty after.Patch_agent.human_messages
+          && List.is_empty after.Patch_agent.inflight_human_messages
+          && not
+               (List.mem after.Patch_agent.queue Operation_kind.Human
+                  ~equal:Operation_kind.equal)
+        with _ -> false)
+  in
+  QCheck2.Test.check_exn prop;
+  Stdlib.print_endline "AO-6b passed"
 
 (* ========== AO-7: Ci respond counter is bumped only on Respond_ok ========== *)
 

--- a/test/test_action_outcome_properties.ml
+++ b/test/test_action_outcome_properties.ml
@@ -265,35 +265,37 @@ let () =
       ~name:
         "AO-6b: backend-accepted Human delivery is not restored on session \
          failure" (QCheck2.Gen.oneof_list failed_results) (fun result ->
-        try
-          let orch, patches, gameplan, pid = bootstrap_one () in
-          let orch = Orchestrator.send_human_message orch pid "fix this" in
-          let orch = make_busy orch patches gameplan pid Operation_kind.Human in
-          let before = Orchestrator.agent orch pid in
-          if List.is_empty before.Patch_agent.inflight_human_messages then
-            QCheck2.Test.fail_reportf "expected inflight Human messages";
-          let orch =
-            Orchestrator.mark_inflight_human_messages_delivered orch pid
-          in
-          let accepted = Orchestrator.agent orch pid in
-          if not (List.is_empty accepted.Patch_agent.inflight_human_messages)
-          then
-            QCheck2.Test.fail_reportf
-              "accepted Human messages should be drained";
-          let orch = Orchestrator.apply_session_result orch pid result in
-          let after = Orchestrator.agent orch pid in
-          List.is_empty after.Patch_agent.human_messages
-          && List.is_empty after.Patch_agent.inflight_human_messages
-          && not
-               (List.mem after.Patch_agent.queue Operation_kind.Human
-                  ~equal:Operation_kind.equal)
+        match
+          try
+            let orch, patches, gameplan, pid = bootstrap_one () in
+            let orch = Orchestrator.send_human_message orch pid "fix this" in
+            let orch =
+              make_busy orch patches gameplan pid Operation_kind.Human
+            in
+            let before = Orchestrator.agent orch pid in
+            if List.is_empty before.Patch_agent.inflight_human_messages then
+              Error "expected inflight Human messages"
+            else
+              let orch =
+                Orchestrator.mark_inflight_human_messages_delivered orch pid
+              in
+              let accepted = Orchestrator.agent orch pid in
+              if
+                not (List.is_empty accepted.Patch_agent.inflight_human_messages)
+              then Error "accepted Human messages should be drained"
+              else
+                let orch = Orchestrator.apply_session_result orch pid result in
+                let after = Orchestrator.agent orch pid in
+                Ok
+                  (List.is_empty after.Patch_agent.human_messages
+                  && List.is_empty after.Patch_agent.inflight_human_messages
+                  && not
+                       (List.mem after.Patch_agent.queue Operation_kind.Human
+                          ~equal:Operation_kind.equal))
+          with _ -> Ok false
         with
-        | e
-          when String.equal
-                 (Stdlib.Printexc.exn_slot_name e)
-                 "QCheck2.Test.User_fail" ->
-            raise e
-        | _ -> false)
+        | Ok passed -> passed
+        | Error msg -> QCheck2.Test.fail_reportf "%s" msg)
   in
   QCheck2.Test.check_exn prop;
   Stdlib.print_endline "AO-6b passed"

--- a/test/test_action_outcome_properties.ml
+++ b/test/test_action_outcome_properties.ml
@@ -166,7 +166,9 @@ let () =
           | Patch_decision.Skip_empty | Patch_decision.Respond_stale -> false
         with
         | QCheck2.Test.Test_fail _ as e -> raise e
-        | _ -> false)
+        | exn ->
+            QCheck2.Test.fail_reportf "unexpected exception: %s"
+              (Exn.to_string exn))
   in
   QCheck2.Test.check_exn prop;
   Stdlib.print_endline "AO-2b passed"
@@ -297,7 +299,7 @@ let () =
                   && not
                        (List.mem after.Patch_agent.queue Operation_kind.Human
                           ~equal:Operation_kind.equal))
-          with _ -> Ok false
+          with exn -> Error (Exn.to_string exn)
         with
         | Ok passed -> passed
         | Error msg -> QCheck2.Test.fail_reportf "%s" msg)

--- a/test/test_action_outcome_properties.ml
+++ b/test/test_action_outcome_properties.ml
@@ -103,13 +103,22 @@ let () =
 (* ========== AO-2b: delivered Human messages are not replayed ========== *)
 
 let () =
+  let human_message_gen =
+    QCheck2.Gen.string_size (QCheck2.Gen.int_range 1 80)
+  in
+  let distinct_human_messages_gen =
+    QCheck2.Gen.map2
+      (fun first_msg second_msg ->
+        if String.equal first_msg second_msg then
+          (first_msg, second_msg ^ " (next)")
+        else (first_msg, second_msg))
+      human_message_gen human_message_gen
+  in
   let prop =
     QCheck2.Test.make
       ~name:
         "AO-2b: delivered Human message is cleared before next Human delivery"
-      (QCheck2.Gen.pair
-         (QCheck2.Gen.string_size (QCheck2.Gen.int_range 1 80))
-         (QCheck2.Gen.string_size (QCheck2.Gen.int_range 1 80)))
+      distinct_human_messages_gen
       (fun (first_msg, second_msg) ->
         try
           let orch, _patches, _gameplan, pid = bootstrap_one () in

--- a/test/test_action_outcome_properties.ml
+++ b/test/test_action_outcome_properties.ml
@@ -100,6 +100,66 @@ let () =
   QCheck2.Test.check_exn prop;
   Stdlib.print_endline "AO-2 passed"
 
+(* ========== AO-2b: delivered Human messages are not replayed ========== *)
+
+let () =
+  let prop =
+    QCheck2.Test.make
+      ~name:
+        "AO-2b: delivered Human message is cleared before next Human delivery"
+      (QCheck2.Gen.pair
+         (QCheck2.Gen.string_size (QCheck2.Gen.int_range 1 80))
+         (QCheck2.Gen.string_size (QCheck2.Gen.int_range 1 80)))
+      (fun (first_msg, second_msg) ->
+        try
+          let orch, _patches, _gameplan, pid = bootstrap_one () in
+          let orch = Orchestrator.send_human_message orch pid first_msg in
+          let first_pre = Orchestrator.agent orch pid in
+          let orch =
+            Orchestrator.fire orch
+              (Orchestrator.Respond (pid, Operation_kind.Human))
+          in
+          let orch =
+            Orchestrator.apply_respond_outcome orch pid Operation_kind.Human
+              Orchestrator.Respond_ok
+          in
+          let after_first = Orchestrator.agent orch pid in
+          if not (List.is_empty after_first.Patch_agent.human_messages) then
+            failwith "first message remained in inbox";
+          if
+            not
+              (List.is_empty after_first.Patch_agent.inflight_human_messages)
+          then failwith "first message remained inflight";
+          let orch = Orchestrator.send_human_message orch pid second_msg in
+          let second_pre = Orchestrator.agent orch pid in
+          let orch =
+            Orchestrator.fire orch
+              (Orchestrator.Respond (pid, Operation_kind.Human))
+          in
+          let agent = Orchestrator.agent orch pid in
+          match
+            Patch_decision.respond_delivery ~agent ~kind:Operation_kind.Human
+              ~pre_fire_agent:(Some second_pre) ~prefetched_comments:[]
+              ~main_branch:(Branch.to_string main)
+          with
+          | Patch_decision.Deliver { payload; _ } -> (
+              match payload with
+              | Patch_decision.Human_payload { messages } ->
+                  List.equal String.equal messages [ second_msg ]
+                  && not (List.mem messages first_msg ~equal:String.equal)
+                  && List.mem first_pre.Patch_agent.human_messages first_msg
+                       ~equal:String.equal
+              | Patch_decision.Ci_payload _
+              | Patch_decision.Review_payload _
+              | Patch_decision.Pr_body_payload
+              | Patch_decision.Merge_conflict_payload ->
+                  false)
+          | Patch_decision.Skip_empty | Patch_decision.Respond_stale -> false
+        with _ -> false)
+  in
+  QCheck2.Test.check_exn prop;
+  Stdlib.print_endline "AO-2b passed"
+
 (* ========== AO-3: Respond_ok + Merge_conflict clears has_conflict ========== *)
 
 let () =

--- a/test/test_backend_smoke.ml
+++ b/test/test_backend_smoke.ml
@@ -134,10 +134,7 @@ let () =
   let perl_available =
     match Unix.system "perl -e 1 >/dev/null 2>&1" with
     | Unix.WEXITED 0 -> true
-    | Unix.WEXITED _
-    | Unix.WSIGNALED _
-    | Unix.WSTOPPED _ ->
-        false
+    | Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> false
   in
   if perl_available then large_codex_line_test ()
   else Stdio.printf "codex large stdout line: skipped (perl not found)\n";

--- a/test/test_backend_smoke.ml
+++ b/test/test_backend_smoke.ml
@@ -98,11 +98,9 @@ let () =
       [
         "sh";
         "-c";
-        Printf.sprintf "perl -e 'print q!%s!; print q!x! x %d; print q!%s!;'"
+        Printf.sprintf "perl -e 'print q!%s!; print q!x! x %d; print qq!%s!;'"
           {|{"type":"item.completed","item":{"type":"agent_message","text":"|}
-          (String.length large_text) {|"}}
-{"type":"turn.completed"}
-|};
+          (String.length large_text) {|"}}\n{"type":"turn.completed"}\n|};
       ]
     in
     let result =

--- a/test/test_backend_smoke.ml
+++ b/test/test_backend_smoke.ml
@@ -71,6 +71,7 @@ let () =
     smoke ~process_mgr ~clock ~cwd
       ~ndjson:
         [
+          {|{"type":"turn.started"}|};
           {|{"type":"item.completed","item":{"type":"agent_message","content":[{"type":"output_text","text":"hello"}]}}|};
           {|{"type":"turn.completed"}|};
         ]
@@ -80,6 +81,7 @@ let () =
   assert_smoke ~name:"codex" ~result ~got
     ~expected:
       [
+        Types.Stream_event.Turn_started;
         Types.Stream_event.Text_delta "hello";
         Types.Stream_event.Final_result
           { text = ""; stop_reason = Types.Stop_reason.End_turn };
@@ -96,11 +98,9 @@ let () =
       [
         "sh";
         "-c";
-        Printf.sprintf
-          "perl -e 'print q!%s!; print q!x! x %d; print q!%s!;'"
+        Printf.sprintf "perl -e 'print q!%s!; print q!x! x %d; print q!%s!;'"
           {|{"type":"item.completed","item":{"type":"agent_message","text":"|}
-          (String.length large_text)
-          {|"}}
+          (String.length large_text) {|"}}
 {"type":"turn.completed"}
 |};
       ]
@@ -126,12 +126,12 @@ let () =
       && result.Llm_backend.got_events && result.Llm_backend.saw_final_result
     then Stdio.printf "codex large stdout line: passed\n"
     else (
-        Stdio.printf
-          "FAIL: codex large stdout line timed_out=%b got_events=%b \
-           saw_final_result=%b events=%d\n"
-          result.Llm_backend.timed_out result.Llm_backend.got_events
-          result.Llm_backend.saw_final_result (List.length got);
-        Int.incr failures)
+      Stdio.printf
+        "FAIL: codex large stdout line timed_out=%b got_events=%b \
+         saw_final_result=%b events=%d\n"
+        result.Llm_backend.timed_out result.Llm_backend.got_events
+        result.Llm_backend.saw_final_result (List.length got);
+      Int.incr failures)
   in
   large_codex_line_test ();
   (* --- Claude --- *)
@@ -292,7 +292,8 @@ let () =
                   | None -> ())
               | None -> ())
           | Types.Stream_event.Tool_use _ | Types.Stream_event.Final_result _
-          | Types.Stream_event.Error _ | Types.Stream_event.Session_init _ ->
+          | Types.Stream_event.Error _ | Types.Stream_event.Session_init _
+          | Types.Stream_event.Turn_started ->
               ()
         in
         let script =

--- a/test/test_backend_smoke.ml
+++ b/test/test_backend_smoke.ml
@@ -84,6 +84,56 @@ let () =
         Types.Stream_event.Final_result
           { text = ""; stop_reason = Types.Stop_reason.End_turn };
       ];
+  (* Codex can emit very large single-line JSON events. This used to exceed
+     the shared 1 MiB stdout line buffer, bubble out as
+     [Eio__Buf_read.Buffer_limit_exceeded], and make the orchestrator restore
+     inflight Human messages as though delivery had failed. *)
+  let large_codex_line_test () =
+    let large_text = String.make ((1024 * 1024) + 1024) 'x' in
+    let events = ref [] in
+    let on_event ev = events := ev :: !events in
+    let args =
+      [
+        "sh";
+        "-c";
+        Printf.sprintf
+          "perl -e 'print q!%s!; print q!x! x %d; print q!%s!;'"
+          {|{"type":"item.completed","item":{"type":"agent_message","text":"|}
+          (String.length large_text)
+          {|"}}
+{"type":"turn.completed"}
+|};
+      ]
+    in
+    let result =
+      Llm_backend.spawn_and_stream ~process_mgr ~clock ~timeout:60.0 ~cwd
+        ~setsid_exec:None ~args
+        ~process_line:(process_line_strip Codex_backend.parse_event)
+        ~on_event
+    in
+    let got = List.rev !events in
+    let expected =
+      [
+        Types.Stream_event.Text_delta large_text;
+        Types.Stream_event.Final_result
+          { text = ""; stop_reason = Types.Stop_reason.End_turn };
+      ]
+    in
+    let event_ok = List.equal Types.Stream_event.equal got expected in
+    if
+      event_ok
+      && (not result.Llm_backend.timed_out)
+      && result.Llm_backend.got_events && result.Llm_backend.saw_final_result
+    then Stdio.printf "codex large stdout line: passed\n"
+    else (
+        Stdio.printf
+          "FAIL: codex large stdout line timed_out=%b got_events=%b \
+           saw_final_result=%b events=%d\n"
+          result.Llm_backend.timed_out result.Llm_backend.got_events
+          result.Llm_backend.saw_final_result (List.length got);
+        Int.incr failures)
+  in
+  large_codex_line_test ();
   (* --- Claude --- *)
   let result, got =
     smoke ~process_mgr ~clock ~cwd

--- a/test/test_backend_smoke.ml
+++ b/test/test_backend_smoke.ml
@@ -133,7 +133,16 @@ let () =
         result.Llm_backend.saw_final_result (List.length got);
       Int.incr failures)
   in
-  large_codex_line_test ();
+  let perl_available =
+    match Unix.system "perl -e 1 >/dev/null 2>&1" with
+    | Unix.WEXITED 0 -> true
+    | Unix.WEXITED _
+    | Unix.WSIGNALED _
+    | Unix.WSTOPPED _ ->
+        false
+  in
+  if perl_available then large_codex_line_test ()
+  else Stdio.printf "codex large stdout line: skipped (perl not found)\n";
   (* --- Claude --- *)
   let result, got =
     smoke ~process_mgr ~clock ~cwd


### PR DESCRIPTION
## Summary
- raise Codex stdout line buffering and harden stderr teardown handling
- add a backend turn-start event and clear Human inflight messages after backend acceptance
- keep resume enabled while preventing accepted Human prompts from being restored after later backend/session failures
- add regression coverage for large Codex JSON lines and accepted Human delivery failures

## Tests
- dune runtest

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents replay of backend-accepted Human messages and fixes `Codex` streaming for very large stdout lines. Detects backend turn acceptance earlier and tightens stderr handling.

- **Bug Fixes**
  - Emit `Turn_started` for `Codex` (turn.started) and `OpenCode` (step_start); on first `Turn_started`/`Text_delta`/`Tool_use`/`Final_result`, clear inflight Human messages.
  - Do not restore backend-accepted Human prompts after later session/backend failures; resume stays enabled.
  - Raise stdout buffer to 64 MiB; cap stderr at 1 MiB; handle buffer-limit/Invalid_argument errors during teardown.
  - Add smoke/property tests for large `Codex` lines and no Human replay; fix generator to ensure distinct messages and preserve diagnostics.

<sup>Written for commit 7edf781d79612404cd20eb4c73c88f232db0caf2. Summary will update on new commits. <a href="https://cubic.dev/pr/flowglad/onton/pull/217?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detects backend "turn accepted" signals and clears delivered human messages.
  * Surfaces a new "turn started" streaming event.

* **Improvements**
  * Increased stdout buffer to handle very large single-line streaming payloads; stderr remains size-limited.
  * Broader stream error handling and refined final-event recognition.

* **Tests**
  * Added unit, property, and smoke tests for turn-started parsing, large-line streaming, and delivery invariants.

* **Documentation**
  * Updated notes on spawn/stream behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->