### PR TITLE
Fix Codex clean empty resume fallback

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1008,6 +1008,24 @@ let run_claude_and_handle ~(kind : Operation_kind.t option) ~runtime
                      backend.Llm_backend.name);
                 (Orchestrator.Session_failed { is_fresh }, `Failed)
             | Success { stream_errors } ->
+                (match (resume_session, result) with
+                | Some _, Ok r when not r.Llm_backend.got_events ->
+                    let stdout = String.trim r.Llm_backend.stdout in
+                    let stderr = String.trim r.Llm_backend.stderr in
+                    log_event runtime ~patch_id
+                      (Printf.sprintf
+                         "Resume exited 0 (%s) with no parsed stream events — \
+                          stdout=%s stderr=%s"
+                         backend.Llm_backend.name
+                         (if String.equal stdout "" then "empty"
+                          else
+                            Printf.sprintf "%d chars: %s" (String.length stdout)
+                              (truncate stdout 500))
+                         (if String.equal stderr "" then "empty"
+                          else
+                            Printf.sprintf "%d chars: %s" (String.length stderr)
+                              (truncate stderr 500)))
+                | Some _, (Ok _ | Error _) | None, _ -> ());
                 if String.length stream_errors > 0 then
                   log_event runtime ~patch_id
                     (Printf.sprintf

--- a/lib/llm_backend.ml
+++ b/lib/llm_backend.ml
@@ -26,8 +26,28 @@ let spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~setsid_exec ~args
   in
   let stdout_max_size = 64 * 1024 * 1024 in
   let stderr_max_size = 1024 * 1024 in
+  let stdout_capture_max_size = 64 * 1024 in
   let saw_final_result_ref = ref false in
   let got_events_ref = ref false in
+  let stdout_capture = Buffer.create 4096 in
+  let stdout_capture_truncated = ref false in
+  let capture_stdout_line line =
+    let remaining = stdout_capture_max_size - Buffer.length stdout_capture in
+    if remaining <= 0 then stdout_capture_truncated := true
+    else
+      let text = line ^ "\n" in
+      let len = String.length text in
+      if len <= remaining then Buffer.add_string stdout_capture text
+      else (
+        Buffer.add_substring stdout_capture text ~pos:0 ~len:remaining;
+        stdout_capture_truncated := true)
+  in
+  let captured_stdout () =
+    let s = Buffer.contents stdout_capture in
+    if !stdout_capture_truncated then
+      s ^ "\n<stdout exceeded 64KB capture limit, truncated>"
+    else s
+  in
   let run () =
     let stderr_content, exit_code =
       Eio.Switch.run @@ fun sw ->
@@ -66,6 +86,7 @@ let spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~setsid_exec ~args
           let rec read_lines () =
             match Eio.Buf_read.line stdout_buf with
             | line ->
+                capture_stdout_line line;
                 let events = process_line line in
                 if not (List.is_empty events) then got_events_ref := true;
                 List.iter events ~f:on_event;
@@ -142,7 +163,7 @@ let spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~setsid_exec ~args
     Ok
       {
         exit_code;
-        stdout = "";
+        stdout = captured_stdout ();
         stderr = stderr_content;
         got_events = !got_events_ref;
         saw_final_result = !saw_final_result_ref;
@@ -154,7 +175,7 @@ let spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~setsid_exec ~args
   | Error `Timeout ->
       {
         exit_code = 128 + 9 (* SIGKILL — sent via on_release hook *);
-        stdout = "";
+        stdout = captured_stdout ();
         stderr = "process timed out";
         got_events = !got_events_ref;
         saw_final_result = !saw_final_result_ref;

--- a/lib/llm_backend.mli
+++ b/lib/llm_backend.mli
@@ -9,6 +9,9 @@ open Base
 type result = {
   exit_code : int;
   stdout : string;
+      (** Bounded raw stdout capture from streaming backends. This is retained
+          for diagnostics when a backend exits cleanly without parseable events;
+          it may be truncated. *)
   stderr : string;
   got_events : bool;
   saw_final_result : bool;

--- a/lib/run_classification.ml
+++ b/lib/run_classification.ml
@@ -30,8 +30,8 @@ let classify ~is_resume result =
   | Error msg -> Process_error msg
   | Ok r when r.timed_out -> Timed_out
   | Ok r when r.saw_final_result -> Success { stream_errors = r.stream_errors }
-  | Ok r when (not r.got_events) && is_resume -> No_session_to_resume
   | Ok r when r.exit_code = 0 -> Success { stream_errors = r.stream_errors }
+  | Ok r when (not r.got_events) && is_resume -> No_session_to_resume
   | Ok r ->
       let stderr = String.strip r.stderr in
       let stream_errors = String.strip r.stream_errors in

--- a/lib/run_classification.mli
+++ b/lib/run_classification.mli
@@ -25,5 +25,5 @@ type classification =
 
 val classify :
   is_resume:bool -> (run_outcome, string) Result.t -> classification
-(** Classify a Claude runner result into a pure decision value. [is_resume]
+(** Classify an LLM runner result into a pure decision value. [is_resume]
     indicates whether this was a --resume session (explicit session ID). *)

--- a/lib/tui.ml
+++ b/lib/tui.ml
@@ -431,7 +431,8 @@ let%test "render_status_msg Error contains red ANSI" =
     render_status_msg ~width:80
       (Some { level = Error; text = "oops"; expires_at = None })
   in
-  String.is_substring s ~substring:"\027[31m"
+  (not (Lazy.force Term.color_enabled))
+  || String.is_substring s ~substring:"\027[31m"
   || String.is_substring s ~substring:"\027[1;31m"
   || String.is_substring s ~substring:"\027[31;1m"
 
@@ -449,7 +450,8 @@ let%test "render_status_msg Info is styled dim" =
       (Some { level = Info; text = "hello"; expires_at = None })
   in
   String.is_substring s ~substring:"hello"
-  && String.is_substring s ~substring:"\027[2m"
+  && ((not (Lazy.force Term.color_enabled))
+     || String.is_substring s ~substring:"\027[2m")
 
 let%test "msg_expired true when past" =
   msg_expired ~now:100.0 { level = Info; text = "x"; expires_at = Some 50.0 }

--- a/test/test_backend_smoke.ml
+++ b/test/test_backend_smoke.ml
@@ -138,6 +138,28 @@ let () =
   in
   if perl_available then large_codex_line_test ()
   else Stdio.printf "codex large stdout line: skipped (perl not found)\n";
+  let stdout_capture_test () =
+    let events = ref [] in
+    let on_event ev = events := ev :: !events in
+    let result =
+      Llm_backend.spawn_and_stream ~process_mgr ~clock ~timeout:60.0 ~cwd
+        ~setsid_exec:None
+        ~args:[ "printf"; "%s"; "not-json\n" ]
+        ~process_line:(fun _ -> [])
+        ~on_event
+    in
+    if
+      result.Llm_backend.exit_code = 0
+      && (not result.Llm_backend.got_events)
+      && String.equal result.Llm_backend.stdout "not-json\n"
+    then Stdio.printf "stdout capture: passed\n"
+    else (
+      Stdio.printf "FAIL: stdout capture exit=%d got_events=%b stdout=%S\n"
+        result.Llm_backend.exit_code result.Llm_backend.got_events
+        result.Llm_backend.stdout;
+      Int.incr failures)
+  in
+  stdout_capture_test ();
   (* --- Claude --- *)
   let result, got =
     smoke ~process_mgr ~clock ~cwd

--- a/test/test_run_classification.ml
+++ b/test/test_run_classification.ml
@@ -30,15 +30,19 @@ let () =
             false)
   in
 
-  (* Ok with no events + continue -> No_session_to_resume
+  (* Ok with no events + resume + nonzero exit -> No_session_to_resume
      (saw_final_result=false is required: a confirmed Final_result is
-     definitive success and short-circuits the no-events heuristic.) *)
-  let prop_no_events_continue =
-    Test.make ~name:"classify: no events + continue -> No_session_to_resume"
+     definitive success and short-circuits the no-events heuristic. A clean
+     exit is also success: some backends can produce an empty successful
+     resumed turn, and retrying fresh would duplicate the delivered prompt.) *)
+  let prop_no_events_resume_nonzero =
+    Test.make
+      ~name:"classify: no events + resume + nonzero -> No_session_to_resume"
       ~count:500 gen_run_outcome (fun r ->
         let r =
           {
             r with
+            exit_code = 1;
             got_events = false;
             saw_final_result = false;
             timed_out = false;
@@ -47,6 +51,26 @@ let () =
         match classify ~is_resume:true (Ok r) with
         | No_session_to_resume -> true
         | Process_error _ | Timed_out | Success _ | Session_failed _ -> false)
+  in
+
+  (* Ok with no events + resume + exit_code=0 -> Success *)
+  let prop_no_events_resume_zero_success =
+    Test.make ~name:"classify: no events + resume + exit_code=0 -> Success"
+      ~count:500 gen_run_outcome (fun r ->
+        let r =
+          {
+            r with
+            exit_code = 0;
+            got_events = false;
+            saw_final_result = false;
+            timed_out = false;
+          }
+        in
+        match classify ~is_resume:true (Ok r) with
+        | Success _ -> true
+        | Process_error _ | No_session_to_resume | Timed_out | Session_failed _
+          ->
+            false)
   in
 
   (* Ok with exit_code=0 -> Success *)
@@ -145,7 +169,8 @@ let () =
     [
       prop_error_is_process_error;
       prop_timed_out;
-      prop_no_events_continue;
+      prop_no_events_resume_nonzero;
+      prop_no_events_resume_zero_success;
       prop_exit_zero_success;
       prop_nonzero_session_failed;
       prop_detail_bounded;


### PR DESCRIPTION
## Summary
- treat clean exit code 0 as success even when a resumed backend emits no parsed stream events
- keep no-events resume fallback for nonzero runs
- make TUI ANSI status-message tests respect color-disabled environments

## Tests
- dune runtest

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/218"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix resume classification to mark clean (exit_code=0) empty resumes as Success, avoiding retries and duplicated prompts. Add stdout capture and diagnostics to make these resumes easier to debug.

- **Bug Fixes**
  - Resume runs with exit_code=0 and no events now classify as Success; nonzero stays No_session_to_resume. `classify` order updated and property tests added.
  - Capture up to 64KB of raw stdout from streaming backends and log it (with stderr) when a resume exits 0 with no events; includes a smoke test.
  - TUI ANSI status-message tests skip when `Term.color_enabled` is disabled.

<sup>Written for commit cff58d361db98e89b3ba91207f2574220064dac0. Summary will update on new commits. <a href="https://cubic.dev/pr/flowglad/onton/pull/218?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected resume-session classification so successful completions with no events are reported as Success.

* **New Features**
  * Capture and retain bounded raw stdout for streaming backends to aid diagnostics; surfaced in observability logs when resumed sessions produce no events.

* **Tests**
  * Made status-message tests tolerant of environments with color disabled.

* **Documentation**
  * Generalized runner terminology in the classify function's interface docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->