### PR TITLE
Distinguish queued from running for in-flight ops

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -2564,8 +2564,6 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                       with_busy_guard ~patch_id (fun () ->
                           let result =
                             with_claude_slot (fun () ->
-                                Runtime.update_orchestrator runtime (fun orch ->
-                                    Orchestrator.mark_running orch patch_id);
                                 let agent =
                                   Runtime.read runtime (fun snap ->
                                       Orchestrator.agent
@@ -2581,7 +2579,10 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                     "Skipping action — became stale during \
                                      semaphore wait";
                                   `Stale)
-                                else
+                                else (
+                                  Runtime.update_orchestrator runtime
+                                    (fun orch ->
+                                      Orchestrator.mark_running orch patch_id);
                                   match
                                     ensure_worktree ~runtime ~process_mgr ~clock
                                       ~fs ~repo_root:config.repo_root
@@ -2625,7 +2626,7 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                           ~worktree_mutex ~hook_mutex ~backend
                                           ~event_log
                                       in
-                                      r)
+                                      r))
                           in
                           let start_outcome =
                             match result with

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -2564,6 +2564,8 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                       with_busy_guard ~patch_id (fun () ->
                           let result =
                             with_claude_slot (fun () ->
+                                Runtime.update_orchestrator runtime (fun orch ->
+                                    Orchestrator.mark_running orch patch_id);
                                 let agent =
                                   Runtime.read runtime (fun snap ->
                                       Orchestrator.agent
@@ -2774,6 +2776,10 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
               Some
                 (fun () ->
                   with_busy_guard ~patch_id (fun () ->
+                      (* Rebase is orchestrator-executed (no Claude slot), so
+                         work begins immediately under the busy guard. *)
+                      Runtime.update_orchestrator runtime (fun orch ->
+                          Orchestrator.mark_running orch patch_id);
                       let agent =
                         Runtime.read runtime (fun snap ->
                             Orchestrator.agent snap.Runtime.orchestrator
@@ -2956,6 +2962,8 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                             `Skip_empty
                         | None ->
                             with_claude_slot (fun () ->
+                                Runtime.update_orchestrator runtime (fun orch ->
+                                    Orchestrator.mark_running orch patch_id);
                                 (* Write fresh ci_checks under the busy guard
                                    so the write can't race with the poller or
                                    land after a concurrent complete/merge.

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -367,6 +367,9 @@ let clear_branch_blocked t patch_id =
 
 let reset_busy t patch_id = update_agent t patch_id ~f:Patch_agent.reset_busy
 
+let mark_running t patch_id =
+  update_agent t patch_id ~f:Patch_agent.mark_running
+
 let set_worktree_path t patch_id path =
   update_agent t patch_id ~f:(fun a -> Patch_agent.set_worktree_path a path)
 

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -104,6 +104,13 @@ val reset_intervention_state : t -> Patch_id.t -> t
 val set_branch_blocked : t -> Patch_id.t -> t
 val clear_branch_blocked : t -> Patch_id.t -> t
 val reset_busy : t -> Patch_id.t -> t
+
+val mark_running : t -> Patch_id.t -> t
+(** Transition the patch's [current_op_state] from [Queued] to [Running]. Called
+    from action fibers right after the Claude semaphore has been acquired so the
+    TUI can distinguish queued (waiting on slot) from running. No-op if the
+    agent is no longer busy. *)
+
 val set_worktree_path : t -> Patch_id.t -> string -> t
 val set_llm_session_id : t -> Patch_id.t -> string option -> t
 

--- a/lib/patch_agent.ml
+++ b/lib/patch_agent.ml
@@ -5,6 +5,9 @@ open Operation_kind
 type session_fallback = Fresh_available | Tried_fresh | Given_up
 [@@deriving show, eq, sexp_of, compare, yojson]
 
+type op_state = Queued | Running
+[@@deriving show, eq, sexp_of, compare, yojson]
+
 type t = {
   patch_id : Patch_id.t;
   branch : Branch.t;
@@ -37,6 +40,13 @@ type t = {
   branch_rebased_onto : Branch.t option;
   checks_passing : bool;
   current_op : Operation_kind.t option;
+  current_op_state : op_state;
+      (** Sub-state of [current_op]. [Queued] when the action fiber is alive but
+          the actual work has not begun (waiting on the Claude semaphore, or in
+          pre-work setup). [Running] once the work has started. Meaningful only
+          when [busy] is true; reset to [Queued] on [complete]. Drives the TUI
+          "(queued)" suffix so a saturated semaphore is distinguishable from an
+          actively-running session. *)
   current_message_id : Message_id.t option;
   generation : int;
   worktree_path : string option;
@@ -125,6 +135,7 @@ let create ~branch patch_id =
     branch_rebased_onto = None;
     checks_passing = false;
     current_op = None;
+    current_op_state = Queued;
     current_message_id = None;
     generation = 0;
     worktree_path = None;
@@ -166,6 +177,7 @@ let create_adhoc ~patch_id ~branch ~pr_number =
     branch_rebased_onto = None;
     checks_passing = false;
     current_op = None;
+    current_op_state = Queued;
     current_message_id = None;
     generation = 0;
     worktree_path = None;
@@ -333,7 +345,16 @@ let increment_automerge_failure_count t =
 let reset_automerge_failure_count t = { t with automerge_failure_count = 0 }
 
 let resume_current_message t ~op =
-  { t with busy = true; has_session = true; current_op = op }
+  {
+    t with
+    busy = true;
+    has_session = true;
+    current_op = op;
+    current_op_state = Queued;
+  }
+
+let mark_running t =
+  if not t.busy then t else { t with current_op_state = Running }
 
 let reset_intervention_state t =
   {
@@ -354,9 +375,9 @@ let restore ~patch_id ~branch ~pr_number ~has_session ~busy ~merged ~queue
     ~ci_checks ~merge_ready ~is_draft ~pr_body_delivered
     ~pr_body_artifact_miss_count ~start_attempts_without_pr ~conflict_noop_count
     ~no_commits_push_count ~branch_rebased_onto ~checks_passing ~current_op
-    ~current_message_id ~generation ~worktree_path ~branch_blocked
-    ~llm_session_id ~automerge_enabled ~automerge_deadline ~automerge_inflight
-    ~automerge_failure_count ~delivered_ci_run_ids =
+    ~current_op_state ~current_message_id ~generation ~worktree_path
+    ~branch_blocked ~llm_session_id ~automerge_enabled ~automerge_deadline
+    ~automerge_inflight ~automerge_failure_count ~delivered_ci_run_ids =
   {
     patch_id;
     branch;
@@ -385,6 +406,7 @@ let restore ~patch_id ~branch ~pr_number ~has_session ~busy ~merged ~queue
     branch_rebased_onto;
     checks_passing;
     current_op;
+    current_op_state;
     current_message_id;
     generation;
     worktree_path;
@@ -428,6 +450,7 @@ let start t ~base_branch =
     has_session = true;
     busy = true;
     current_op = None;
+    current_op_state = Queued;
     current_message_id = None;
     satisfies = true;
     base_branch = Some base_branch;
@@ -461,6 +484,7 @@ let rebase t ~base_branch =
     has_session = true;
     busy = true;
     current_op = Some Rebase;
+    current_op_state = Queued;
     current_message_id = None;
     queue;
     base_branch = Some base_branch;
@@ -507,6 +531,7 @@ let respond t k =
     has_session = true;
     busy = true;
     current_op = Some k;
+    current_op_state = Queued;
     current_message_id = None;
     queue;
     satisfies;
@@ -527,6 +552,7 @@ let complete t =
       t with
       busy = false;
       current_op = None;
+      current_op_state = Queued;
       current_message_id = None;
       inflight_human_messages = [];
     }

--- a/lib/patch_agent.mli
+++ b/lib/patch_agent.mli
@@ -9,6 +9,9 @@ open Base
 type session_fallback = Fresh_available | Tried_fresh | Given_up
 [@@deriving show, eq, sexp_of, compare, yojson]
 
+type op_state = Queued | Running
+[@@deriving show, eq, sexp_of, compare, yojson]
+
 type t = private {
   patch_id : Types.Patch_id.t;
   branch : Types.Branch.t;
@@ -44,6 +47,13 @@ type t = private {
   branch_rebased_onto : Types.Branch.t option;
   checks_passing : bool;
   current_op : Types.Operation_kind.t option;
+  current_op_state : op_state;
+      (** Sub-state of [current_op]. [Queued] when the action fiber is alive but
+          its work has not begun (typically waiting on the Claude semaphore).
+          [Running] once the work has actually started. Meaningful only when
+          [busy] is true; reset to [Queued] on [complete]. Drives the TUI
+          "(queued)" suffix so a saturated semaphore can be told apart from an
+          actively-running session. *)
   current_message_id : Types.Message_id.t option;
   generation : int;
   worktree_path : string option;
@@ -322,7 +332,14 @@ val reset_automerge_failure_count : t -> t
 val resume_current_message : t -> op:Types.Operation_kind.t option -> t
 (** Resume execution of an already accepted message without reapplying its
     queue-consuming state transition. [~op] restores [current_op] from the
-    outbox so that [complete] can clear [human_messages] correctly. *)
+    outbox so that [complete] can clear [human_messages] correctly. Resets
+    [current_op_state] to [Queued] — the resumed fiber must call [mark_running]
+    when it actually begins work. *)
+
+val mark_running : t -> t
+(** Transition [current_op_state] from [Queued] to [Running]. Called from the
+    action fiber once the Claude semaphore has been acquired and real work is
+    about to begin. No-op when [busy] is false (fiber already exited). *)
 
 (** {2 Queries} *)
 
@@ -367,6 +384,7 @@ val restore :
   branch_rebased_onto:Types.Branch.t option ->
   checks_passing:bool ->
   current_op:Types.Operation_kind.t option ->
+  current_op_state:op_state ->
   current_message_id:Types.Message_id.t option ->
   generation:int ->
   worktree_path:string option ->

--- a/lib/persistence.ml
+++ b/lib/persistence.ml
@@ -84,6 +84,7 @@ let patch_agent_to_yojson (a : Patch_agent.t) =
         match a.current_op with
         | None -> `Null
         | Some op -> Operation_kind.yojson_of_t op );
+      ("current_op_state", Patch_agent.yojson_of_op_state a.current_op_state);
       ( "current_message_id",
         match a.current_message_id with
         | None -> `Null
@@ -223,6 +224,16 @@ let patch_agent_of_yojson ~gameplan json =
              match try_of_yojson Operation_kind.t_of_yojson_compat v with
              | Ok op -> Some op
              | Error _ -> None))
+       ~current_op_state:
+         (* Default to [Queued] for snapshots written before this field
+            existed. A live agent will be re-promoted to [Running] when its
+            fiber resumes after restart. *)
+         (match Yojson.Safe.Util.member "current_op_state" json with
+         | `Null -> Patch_agent.Queued
+         | v -> (
+             match try_of_yojson Patch_agent.op_state_of_yojson v with
+             | Ok s -> s
+             | Error _ -> Patch_agent.Queued))
        ~current_message_id:
          (string_member_opt "current_message_id" json
          |> Option.map ~f:Message_id.of_string)

--- a/lib/persistence.ml
+++ b/lib/persistence.ml
@@ -225,11 +225,14 @@ let patch_agent_of_yojson ~gameplan json =
              | Ok op -> Some op
              | Error _ -> None))
        ~current_op_state:
-         (* Default to [Queued] for snapshots written before this field
-            existed. A live agent will be re-promoted to [Running] when its
-            fiber resumes after restart. *)
          (match Yojson.Safe.Util.member "current_op_state" json with
-         | `Null -> Patch_agent.Queued
+         | `Null ->
+             (* Field absent in snapshots predating this feature (missing key
+                returns [`Null]) — default to [Queued]. A live agent will be
+                re-promoted to [Running] when its fiber resumes after restart.
+                An explicit JSON [null] would also land here and is treated
+                the same way. *)
+             Patch_agent.Queued
          | v -> (
              match try_of_yojson Patch_agent.op_state_of_yojson v with
              | Ok s -> s

--- a/lib/tui.ml
+++ b/lib/tui.ml
@@ -493,6 +493,10 @@ type patch_view = {
   status : display_status;
   queue_len : int;
   current_op : Operation_kind.t option;
+  current_op_state : Patch_agent.op_state;
+      (** Carries the agent's queued/running sub-state for the current op. Used
+          to render a "(queued)" suffix on busy statuses so a saturated Claude
+          semaphore can be told apart from an actively running session. *)
   ci_failures : int;
   dep_ids : (Patch_id.t * display_status) list;
   has_pr : bool;
@@ -592,6 +596,7 @@ let patch_view_of_agent (agent : Patch_agent.t)
     status;
     queue_len = List.length agent.queue;
     current_op;
+    current_op_state = agent.Patch_agent.current_op_state;
     ci_failures = agent.ci_failure_count;
     dep_ids;
     has_pr = Patch_agent.has_pr agent;
@@ -613,10 +618,19 @@ let patch_view_of_agent (agent : Patch_agent.t)
 
 let styled_status status text = Term.styled (status_style status) text
 
-let render_status_badge status =
+let render_status_badge ?(queued = false) status =
   let ind = status_indicator status in
   let lbl = label status in
-  styled_status status (Printf.sprintf "%s %s" ind lbl)
+  let suffix = if queued then " (queued)" else "" in
+  styled_status status (Printf.sprintf "%s %s%s" ind lbl suffix)
+
+let is_running_status = function
+  | Fixing_ci | Addressing_review | Resolving_conflict | Responding_to_human
+  | Writing_pr_body | Rebasing | Starting | Updating | Approved_running ->
+      true
+  | Merged | Needs_help | Approved_idle | Ci_queued | Review_queued
+  | Awaiting_ci | Awaiting_review | Blocked_by_dep | Pending ->
+      false
 
 (** {1 Frame rendering} *)
 
@@ -648,8 +662,12 @@ let short_op_name = function
   | Operation_kind.Pr_body -> "pr-body"
   | Operation_kind.Rebase -> "rebase"
 
+let pv_queued (pv : patch_view) =
+  is_running_status pv.status
+  && Patch_agent.equal_op_state pv.current_op_state Patch_agent.Queued
+
 let render_patch_row ~width ~selected (pv : patch_view) =
-  let badge = render_status_badge pv.status in
+  let badge = render_status_badge ~queued:(pv_queued pv) pv.status in
   let patch_label =
     let id_str = Patch_id.to_string pv.patch_id in
     let id_short =
@@ -744,21 +762,18 @@ let render_summary (views : patch_view list) =
   in
   let total = List.length views in
   let merged = count Merged in
-  let is_running status =
-    match status with
-    | Fixing_ci | Addressing_review | Resolving_conflict | Responding_to_human
-    | Writing_pr_body | Rebasing | Starting | Updating | Approved_running ->
-        true
-    | Merged | Needs_help | Approved_idle | Ci_queued | Review_queued
-    | Awaiting_ci | Awaiting_review | Blocked_by_dep | Pending ->
-        false
+  let busy_views = List.filter views ~f:(fun v -> is_running_status v.status) in
+  let queued =
+    List.count busy_views ~f:(fun v ->
+        Patch_agent.equal_op_state v.current_op_state Patch_agent.Queued)
   in
-  let running = List.count views ~f:(fun v -> is_running v.status) in
+  let running = List.length busy_views - queued in
   let needs_help = count Needs_help in
   let parts =
     [
       Printf.sprintf "%d/%d merged" merged total;
       (if running > 0 then Printf.sprintf "%d running" running else "");
+      (if queued > 0 then Printf.sprintf "%d queued" queued else "");
       (if needs_help > 0 then
          Term.styled [ Term.Sgr.fg_red ]
            (Printf.sprintf "%d need help" needs_help)
@@ -805,7 +820,7 @@ let detail_info_rows (pv : patch_view) ~width ~now =
       (Term.fit_width (Int.max 1 (width - 1)) (" " ^ pv.title))
   in
   let rule = Term.hrule width in
-  let badge = render_status_badge pv.status in
+  let badge = render_status_badge ~queued:(pv_queued pv) pv.status in
   let lines =
     [
       header;

--- a/lib/tui.mli
+++ b/lib/tui.mli
@@ -84,6 +84,7 @@ type patch_view = {
   status : display_status;
   queue_len : int;
   current_op : Operation_kind.t option;
+  current_op_state : Patch_agent.op_state;
   ci_failures : int;
   dep_ids : (Patch_id.t * display_status) list;
   has_pr : bool;

--- a/test/test_patch_agent.ml
+++ b/test/test_patch_agent.ml
@@ -726,6 +726,7 @@ let () =
               ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
               ~conflict_noop_count:0 ~no_commits_push_count:0
               ~branch_rebased_onto:None ~checks_passing:false ~current_op:None
+              ~current_op_state:Onton.Patch_agent.Queued
               ~current_message_id:None ~generation:0 ~worktree_path:None
               ~branch_blocked:false ~llm_session_id:None
               ~automerge_enabled:false ~automerge_deadline:None
@@ -806,6 +807,7 @@ let () =
               ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
               ~conflict_noop_count:0 ~no_commits_push_count:0
               ~branch_rebased_onto:None ~checks_passing:false ~current_op:None
+              ~current_op_state:Onton.Patch_agent.Queued
               ~current_message_id:None ~generation:0 ~worktree_path:None
               ~branch_blocked:false ~llm_session_id:None
               ~automerge_enabled:false ~automerge_deadline:None

--- a/test/test_patch_controller.ml
+++ b/test/test_patch_controller.ml
@@ -52,9 +52,10 @@ let make_agent ~patch_id ~branch ~pr_number ~merged ~queue ~base_branch
     ~merge_ready:false ~is_draft ~pr_body_delivered
     ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr
     ~conflict_noop_count:0 ~no_commits_push_count:0 ~branch_rebased_onto:None
-    ~checks_passing:false ~current_op:None ~current_message_id:None
-    ~generation:0 ~worktree_path:None ~branch_blocked:false ~llm_session_id:None
-    ~automerge_enabled:false ~automerge_deadline:None ~automerge_inflight:false
+    ~checks_passing:false ~current_op:None ~current_op_state:Patch_agent.Queued
+    ~current_message_id:None ~generation:0 ~worktree_path:None
+    ~branch_blocked:false ~llm_session_id:None ~automerge_enabled:false
+    ~automerge_deadline:None ~automerge_inflight:false
     ~automerge_failure_count:0 ~delivered_ci_run_ids:[]
 
 let has_draft_effect effects =
@@ -354,8 +355,9 @@ let () =
             ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
             ~conflict_noop_count:0 ~no_commits_push_count:0
             ~branch_rebased_onto:None ~checks_passing:false ~current_op:None
-            ~current_message_id:None ~generation:0 ~worktree_path:None
-            ~branch_blocked:false ~llm_session_id:None ~automerge_enabled:false
+            ~current_op_state:Patch_agent.Queued ~current_message_id:None
+            ~generation:0 ~worktree_path:None ~branch_blocked:false
+            ~llm_session_id:None ~automerge_enabled:false
             ~automerge_deadline:None ~automerge_inflight:false
             ~automerge_failure_count:0 ~delivered_ci_run_ids:[]
         in
@@ -394,8 +396,9 @@ let () =
             ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
             ~conflict_noop_count:0 ~no_commits_push_count:0
             ~branch_rebased_onto:None ~checks_passing:false ~current_op:None
-            ~current_message_id:None ~generation:0 ~worktree_path:None
-            ~branch_blocked:false ~llm_session_id:None ~automerge_enabled:false
+            ~current_op_state:Patch_agent.Queued ~current_message_id:None
+            ~generation:0 ~worktree_path:None ~branch_blocked:false
+            ~llm_session_id:None ~automerge_enabled:false
             ~automerge_deadline:None ~automerge_inflight:false
             ~automerge_failure_count:0 ~delivered_ci_run_ids:[]
         in
@@ -434,8 +437,9 @@ let () =
             ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
             ~conflict_noop_count:0 ~no_commits_push_count:0
             ~branch_rebased_onto:None ~checks_passing:false ~current_op:None
-            ~current_message_id:None ~generation:0 ~worktree_path:None
-            ~branch_blocked:false ~llm_session_id:None ~automerge_enabled:false
+            ~current_op_state:Patch_agent.Queued ~current_message_id:None
+            ~generation:0 ~worktree_path:None ~branch_blocked:false
+            ~llm_session_id:None ~automerge_enabled:false
             ~automerge_deadline:None ~automerge_inflight:false
             ~automerge_failure_count:0 ~delivered_ci_run_ids:[]
         in
@@ -567,8 +571,9 @@ let () =
             ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
             ~conflict_noop_count:0 ~no_commits_push_count:0
             ~branch_rebased_onto:None ~checks_passing:false ~current_op:None
-            ~current_message_id:None ~generation:0 ~worktree_path:None
-            ~branch_blocked:false ~llm_session_id:None ~automerge_enabled:false
+            ~current_op_state:Patch_agent.Queued ~current_message_id:None
+            ~generation:0 ~worktree_path:None ~branch_blocked:false
+            ~llm_session_id:None ~automerge_enabled:false
             ~automerge_deadline:None ~automerge_inflight:false
             ~automerge_failure_count:0 ~delivered_ci_run_ids:[]
         in
@@ -705,8 +710,9 @@ let () =
             ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
             ~conflict_noop_count:0 ~no_commits_push_count:0
             ~branch_rebased_onto:None ~checks_passing:false ~current_op:None
-            ~current_message_id:None ~generation:0 ~worktree_path:None
-            ~branch_blocked:false ~llm_session_id:None ~automerge_enabled:false
+            ~current_op_state:Patch_agent.Queued ~current_message_id:None
+            ~generation:0 ~worktree_path:None ~branch_blocked:false
+            ~llm_session_id:None ~automerge_enabled:false
             ~automerge_deadline:None ~automerge_inflight:false
             ~automerge_failure_count:0 ~delivered_ci_run_ids:[]
         in
@@ -908,8 +914,9 @@ let () =
             ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
             ~conflict_noop_count:0 ~no_commits_push_count:0
             ~branch_rebased_onto:None ~checks_passing:false ~current_op:None
-            ~current_message_id:None ~generation:0 ~worktree_path:None
-            ~branch_blocked:false ~llm_session_id:None ~automerge_enabled:false
+            ~current_op_state:Patch_agent.Queued ~current_message_id:None
+            ~generation:0 ~worktree_path:None ~branch_blocked:false
+            ~llm_session_id:None ~automerge_enabled:false
             ~automerge_deadline:None ~automerge_inflight:false
             ~automerge_failure_count:0 ~delivered_ci_run_ids:[]
         in
@@ -948,8 +955,9 @@ let () =
             ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
             ~conflict_noop_count:0 ~no_commits_push_count:0
             ~branch_rebased_onto:None ~checks_passing:false ~current_op:None
-            ~current_message_id:None ~generation:0 ~worktree_path:None
-            ~branch_blocked:false ~llm_session_id:None ~automerge_enabled:false
+            ~current_op_state:Patch_agent.Queued ~current_message_id:None
+            ~generation:0 ~worktree_path:None ~branch_blocked:false
+            ~llm_session_id:None ~automerge_enabled:false
             ~automerge_deadline:None ~automerge_inflight:false
             ~automerge_failure_count:0 ~delivered_ci_run_ids:[]
         in

--- a/test/test_poll_log_properties.ml
+++ b/test/test_poll_log_properties.ml
@@ -49,10 +49,12 @@ let make_agent ~patch_id ~branch ~has_conflict ~ci_failure_count ~current_op
     ~merge_ready:false ~is_draft ~pr_body_delivered:true
     ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
     ~conflict_noop_count:0 ~no_commits_push_count:0 ~branch_rebased_onto:None
-    ~checks_passing ~current_op ~current_message_id:None ~generation:0
-    ~worktree_path ~branch_blocked ~llm_session_id:None ~automerge_enabled:false
-    ~automerge_deadline:None ~automerge_inflight:false
-    ~automerge_failure_count:0 ~delivered_ci_run_ids:[]
+    ~checks_passing ~current_op
+    ~current_op_state:(if busy then Patch_agent.Running else Patch_agent.Queued)
+    ~current_message_id:None ~generation:0 ~worktree_path ~branch_blocked
+    ~llm_session_id:None ~automerge_enabled:false ~automerge_deadline:None
+    ~automerge_inflight:false ~automerge_failure_count:0
+    ~delivered_ci_run_ids:[]
 
 let make_poll_observation ~branch_in_root ~worktree_path poll_result =
   Patch_controller.


### PR DESCRIPTION
## Summary
- Adds a `Queued | Running` sub-state to `Patch_agent.current_op_state` so a fiber waiting on the Claude semaphore is distinguishable from one actually running. `Orchestrator.mark_running` is called from each action fiber (Start, Respond) right after `with_claude_slot` acquires; Rebase marks Running immediately (no slot).
- Persisted across snapshots (defaults to `Queued` for older snapshots).
- TUI: status badges append `" (queued)"` while waiting; summary line reports running and queued counts separately. No new `display_status` variants — keeps existing tests untouched.

## Why
Saw a Pr_body op stuck in "writing pr body" for 7 minutes with an empty transcript. Root cause: 5 fibers landed in the same tick at `max_concurrency=5`, so the Pr_body fiber sat in the semaphore queue before the prompt was ever rendered. The agent was already `busy=true` / `current_op=Pr_body` from `Patch_agent.respond` (called synchronously in `Orchestrator.fire`), so the TUI showed it as actively writing the body — indistinguishable from a real hang.

## Test plan
- [x] `dune build` clean
- [x] `dune runtest` all green (existing tests updated for new `restore` param)
- [x] `dune build @fmt` clean
- [ ] Run on a real gameplan with `max_concurrency` low enough to saturate; confirm queued/running labels flip as expected

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/219"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a queued vs running sub-state for in-flight ops so the UI can tell when a patch is waiting on a Claude slot vs actively working. Prevents sessions from looking hung when max concurrency is saturated.

- **New Features**
  - Added `Queued | Running` `current_op_state` to `Patch_agent`.
  - Introduced `Orchestrator.mark_running`, called after acquiring the Claude slot; `Rebase` marks immediately.
  - Persisted across snapshots; missing/`null` field defaults to `Queued`.
  - `TUI` appends "(queued)" to busy statuses and splits summary into running vs queued.
  - No new `display_status` variants; tests updated.

- **Bug Fixes**
  - Gated `mark_running` behind the stale check in Start so actions that become stale during semaphore wait stay `Queued` and don’t briefly show as Running.

<sup>Written for commit 44092ee8c177f578ff8b0dbdb4aeecf7ab2bf09e. Summary will update on new commits. <a href="https://cubic.dev/pr/flowglad/onton/pull/219?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

