### PR TITLE
CI: lint and format-check shell scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,16 +156,23 @@ jobs:
 
       - name: Install shfmt
         if: steps.discover.outputs.count != '0'
+        # Checksums pin the exact binary for SHFMT_VERSION; bumping the version
+        # requires regenerating both. Computed via:
+        #   sha256sum shfmt_v3.13.1_linux_{amd64,arm64}
+        env:
+          SHFMT_SHA256_LINUX_AMD64: fb096c5d1ac6beabbdbaa2874d025badb03ee07929f0c9ff67563ce8c75398b1
+          SHFMT_SHA256_LINUX_ARM64: 32d92acaa5cd8abb29fc49dac123dc412442d5713967819d8af2c29f1b3857c7
         run: |
           set -euo pipefail
           arch=$(uname -m)
           case "$arch" in
-            x86_64)  shfmt_arch="linux_amd64" ;;
-            aarch64) shfmt_arch="linux_arm64" ;;
+            x86_64)  shfmt_arch="linux_amd64"; expected_sha="$SHFMT_SHA256_LINUX_AMD64" ;;
+            aarch64) shfmt_arch="linux_arm64"; expected_sha="$SHFMT_SHA256_LINUX_ARM64" ;;
             *) echo "Unsupported architecture: $arch" >&2; exit 1 ;;
           esac
           curl -fsSL -o "$RUNNER_TEMP/shfmt" \
             "https://github.com/mvdan/sh/releases/download/${SHFMT_VERSION}/shfmt_${SHFMT_VERSION}_${shfmt_arch}"
+          echo "${expected_sha}  ${RUNNER_TEMP}/shfmt" | sha256sum -c -
           chmod +x "$RUNNER_TEMP/shfmt"
           sudo mv "$RUNNER_TEMP/shfmt" /usr/local/bin/shfmt
           shfmt --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
               case "$f" in *.sh|*.bash) continue ;; esac
               # Only read the first line; skip binaries and large files cheaply.
               if head -c 128 -- "$f" 2>/dev/null | head -n 1 \
-                  | grep -Eq '^#![[:space:]]*(/usr/bin/env[[:space:]]+)?(bash|dash|ksh|sh)([[:space:]]|$)'; then
+                  | grep -Eq '^#![[:space:]]*((/usr/bin/env[[:space:]]+)?|/usr/bin/|/bin/)(bash|dash|ksh|sh)([[:space:]]|$)'; then
                 printf '%s\0' "$f"
               fi
             done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,3 +117,63 @@ jobs:
         run: opam option 'archive-mirrors=["https://opam.ocaml.org/cache"]'
 
       - uses: ocaml/setup-ocaml/lint-fmt@e32b06a3e831ff2fbc6f08cf35be2085e3918014 # v3.6.1
+
+  shell-lint:
+    name: Shell Lint & Format
+    runs-on: ubuntu-latest
+    env:
+      SHFMT_VERSION: v3.13.1
+      # 2-space indent + case-item indent matches the existing scripts/ style.
+      SHFMT_FLAGS: "-i 2 -ci"
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Discover shell scripts
+        id: discover
+        # Match by extension *and* by shebang so files like git hooks or
+        # scripts without a `.sh` suffix still get checked. `git ls-files -z`
+        # respects .gitignore and avoids globbing surprises.
+        run: |
+          set -euo pipefail
+          # `if … fi` (not `&&`) so a non-matching grep doesn't fail the
+          # subshell under `set -e` and abort the whole pipeline.
+          {
+            git ls-files -z '*.sh' '*.bash'
+            git ls-files -z | while IFS= read -r -d '' f; do
+              [ -f "$f" ] || continue
+              case "$f" in *.sh|*.bash) continue ;; esac
+              # Only read the first line; skip binaries and large files cheaply.
+              if head -c 128 -- "$f" 2>/dev/null | head -n 1 \
+                  | grep -Eq '^#![[:space:]]*(/usr/bin/env[[:space:]]+)?(bash|dash|ksh|sh)([[:space:]]|$)'; then
+                printf '%s\0' "$f"
+              fi
+            done
+          } | sort -zu | tee /tmp/shell-files.nul >/dev/null
+          count=$(tr -cd '\0' < /tmp/shell-files.nul | wc -c | tr -d ' ')
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+          echo "Discovered $count shell script(s):"
+          tr '\0' '\n' < /tmp/shell-files.nul
+
+      - name: Install shfmt
+        if: steps.discover.outputs.count != '0'
+        run: |
+          set -euo pipefail
+          curl -fsSL -o /tmp/shfmt \
+            "https://github.com/mvdan/sh/releases/download/${SHFMT_VERSION}/shfmt_${SHFMT_VERSION}_linux_amd64"
+          chmod +x /tmp/shfmt
+          sudo mv /tmp/shfmt /usr/local/bin/shfmt
+          shfmt --version
+
+      - name: shellcheck
+        if: steps.discover.outputs.count != '0'
+        run: |
+          set -euo pipefail
+          shellcheck --version
+          xargs -0 shellcheck < /tmp/shell-files.nul
+
+      - name: shfmt --diff
+        if: steps.discover.outputs.count != '0'
+        run: |
+          set -euo pipefail
+          # shellcheck disable=SC2086 # SHFMT_FLAGS intentionally word-splits
+          xargs -0 shfmt $SHFMT_FLAGS -d < /tmp/shell-files.nul

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,20 +148,26 @@ jobs:
                 printf '%s\0' "$f"
               fi
             done
-          } | sort -zu | tee /tmp/shell-files.nul >/dev/null
-          count=$(tr -cd '\0' < /tmp/shell-files.nul | wc -c | tr -d ' ')
+          } | sort -zu | tee "$RUNNER_TEMP/shell-files.nul" >/dev/null
+          count=$(tr -cd '\0' < "$RUNNER_TEMP/shell-files.nul" | wc -c | tr -d ' ')
           echo "count=$count" >> "$GITHUB_OUTPUT"
           echo "Discovered $count shell script(s):"
-          tr '\0' '\n' < /tmp/shell-files.nul
+          tr '\0' '\n' < "$RUNNER_TEMP/shell-files.nul"
 
       - name: Install shfmt
         if: steps.discover.outputs.count != '0'
         run: |
           set -euo pipefail
-          curl -fsSL -o /tmp/shfmt \
-            "https://github.com/mvdan/sh/releases/download/${SHFMT_VERSION}/shfmt_${SHFMT_VERSION}_linux_amd64"
-          chmod +x /tmp/shfmt
-          sudo mv /tmp/shfmt /usr/local/bin/shfmt
+          arch=$(uname -m)
+          case "$arch" in
+            x86_64)  shfmt_arch="linux_amd64" ;;
+            aarch64) shfmt_arch="linux_arm64" ;;
+            *) echo "Unsupported architecture: $arch" >&2; exit 1 ;;
+          esac
+          curl -fsSL -o "$RUNNER_TEMP/shfmt" \
+            "https://github.com/mvdan/sh/releases/download/${SHFMT_VERSION}/shfmt_${SHFMT_VERSION}_${shfmt_arch}"
+          chmod +x "$RUNNER_TEMP/shfmt"
+          sudo mv "$RUNNER_TEMP/shfmt" /usr/local/bin/shfmt
           shfmt --version
 
       - name: shellcheck
@@ -169,11 +175,11 @@ jobs:
         run: |
           set -euo pipefail
           shellcheck --version
-          xargs -0 shellcheck < /tmp/shell-files.nul
+          xargs -0 shellcheck < "$RUNNER_TEMP/shell-files.nul"
 
       - name: shfmt --diff
         if: steps.discover.outputs.count != '0'
         run: |
           set -euo pipefail
           # shellcheck disable=SC2086 # SHFMT_FLAGS intentionally word-splits
-          xargs -0 shfmt $SHFMT_FLAGS -d < /tmp/shell-files.nul
+          xargs -0 shfmt $SHFMT_FLAGS -d < "$RUNNER_TEMP/shell-files.nul"

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -28,7 +28,7 @@ fi
 # `--git-path` may return a path relative to REPO_ROOT; anchor it.
 case "$HOOKS_DIR" in
   /*) ;;
-  *)  HOOKS_DIR="$REPO_ROOT/$HOOKS_DIR" ;;
+  *) HOOKS_DIR="$REPO_ROOT/$HOOKS_DIR" ;;
 esac
 
 mkdir -p "$HOOKS_DIR"
@@ -62,7 +62,7 @@ fi
 install_hook() {
   hook_name="$1"
   hook_path="$HOOKS_DIR/$hook_name"
-  cat > "$hook_path"
+  cat >"$hook_path"
   chmod +x "$hook_path"
   echo "[installed] $hook_name hook at $hook_path"
 }

--- a/scripts/sync-skills.sh
+++ b/scripts/sync-skills.sh
@@ -51,7 +51,7 @@ for skill_path in "$SKILLS_DIR"/*/SKILL.md; do
       link_raw="$(readlink "$target_link")"
       case "$link_raw" in
         /*) link_target="$link_raw" ;;
-        *)  link_target="$(cd "$TARGET_DIR/$(dirname "$link_raw")" 2>/dev/null && pwd)/$(basename "$link_raw")" ;;
+        *) link_target="$(cd "$TARGET_DIR/$(dirname "$link_raw")" 2>/dev/null && pwd)/$(basename "$link_raw")" ;;
       esac
     fi
     if [ "$link_target" = "$skill_dir" ]; then


### PR DESCRIPTION
## Summary
- New `shell-lint` CI job runs `shellcheck` and `shfmt -i 2 -ci -d` against repo shell scripts.
- Discovers scripts via `git ls-files '*.sh' '*.bash'` plus shebang sniffing on extensionless files (so future git hooks etc. get covered).
- Pinned `shfmt` v3.13.1 (downloaded from GitHub releases); `shellcheck` is preinstalled on `ubuntu-latest`.
- Reformats `scripts/install-hooks.sh` and `scripts/sync-skills.sh` to match `shfmt -i 2 -ci` so the new check passes on `main`.

## Test plan
- [ ] CI `shell-lint` job passes on this PR.
- [ ] OCaml jobs (`build-and-test`, `property-tests`, `format`) still pass — workflow file changed but their steps are untouched.
- [ ] Locally: `shellcheck scripts/*.sh` and `shfmt -i 2 -ci -d scripts/*.sh` exit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/220"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a CI job to lint and format-check shell scripts with `shellcheck` and `shfmt` to catch issues early and keep scripts consistent. Discovery covers `.sh`/`.bash` files and env or direct-path shebangs; existing scripts are reformatted to pass.

- **New Features**
  - Adds `shell-lint` job running `shellcheck` and `shfmt -i 2 -ci -d`.
  - Finds scripts via `git ls-files -z` plus shebang sniffing for `/usr/bin/env` and direct `/bin/*`/`/usr/bin/*` shells; writes a null-delimited list to `$RUNNER_TEMP` and runs with `xargs -0`.
  - Installs arch-appropriate `shfmt` v3.13.1 and verifies the download against pinned SHA256; uses preinstalled `shellcheck` on `ubuntu-latest`.

- **Refactors**
  - Formats `scripts/install-hooks.sh` and `scripts/sync-skills.sh` to match `shfmt` rules.

<sup>Written for commit 18af13c33069561851404832ac9f9f39c6ab7a56. Summary will update on new commits. <a href="https://cubic.dev/pr/flowglad/onton/pull/220?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated shell script linting and formatting in the continuous integration pipeline
  * Updated script formatting for consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->