### PR TITLE
Sync pr-body artifact updates from any patch-agent session

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -3391,6 +3391,18 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                     | Patch_decision.Pr_body_payload
                                     | Patch_decision.Merge_conflict_payload ->
                                         ());
+                                    (* Snapshot the pr-body artifact before
+                                       the session so the post-session sync
+                                       step (after run_claude_and_handle) can
+                                       detect content changes from any kind
+                                       of session, not only Pr_body. For
+                                       Pr_body the artifact was just unlinked
+                                       above, so the snapshot is None. *)
+                                    let pr_body_pre_snapshot =
+                                      read_artifact_file
+                                        (Project_store.pr_body_artifact_path
+                                           ~project_name ~patch_id)
+                                    in
                                     let result, tool_failures =
                                       run_claude_and_handle ~kind:(Some kind)
                                         ~runtime ~process_mgr ~clock ~fs
@@ -3464,6 +3476,71 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                             result
                                       else result
                                     in
+                                    (* Opportunistic pr-body sync. If the
+                                       agent updated the artifact during a
+                                       non-Pr_body session, PATCH the PR.
+                                       Pure planner returns Sync_skip for
+                                       kind=Pr_body (its delivery path is
+                                       owned by classify_pr_body_respond),
+                                       so this block is a no-op for that
+                                       kind and never double-PATCHes. *)
+                                    let pr_body_post_snapshot =
+                                      read_artifact_file
+                                        (Project_store.pr_body_artifact_path
+                                           ~project_name ~patch_id)
+                                    in
+                                    let plan =
+                                      Patch_decision.plan_artifact_sync ~kind
+                                        ~session_ok ~pre:pr_body_pre_snapshot
+                                        ~post:pr_body_post_snapshot
+                                    in
+                                    let patch_result =
+                                      match plan with
+                                      | Patch_decision.Sync_skip -> None
+                                      | Patch_decision.Sync_attempt_pr_body ->
+                                          let pr =
+                                            Base.Option.value_exn pr_number
+                                          in
+                                          let patch =
+                                            Base.List.find_exn
+                                              gameplan.Gameplan.patches
+                                              ~f:(fun (p : Patch.t) ->
+                                                Patch_id.equal p.Patch.id
+                                                  patch_id)
+                                          in
+                                          Some
+                                            (apply_pr_body_artifact ~runtime
+                                               ~net ~github ~project_name
+                                               ~patch_id ~pr_number:pr ~patch
+                                               ~gameplan)
+                                    in
+                                    (match
+                                       Patch_decision
+                                       .classify_artifact_sync_outcome ~plan
+                                         ~patch_result
+                                     with
+                                    | Patch_decision.Sync_no_op -> ()
+                                    | Patch_decision.Sync_delivered ->
+                                        log_event runtime ~patch_id
+                                          (Printf.sprintf
+                                             "pr-body: synced \
+                                              opportunistically from %s \
+                                              session"
+                                             (Operation_kind.to_label kind));
+                                        Runtime.update_orchestrator runtime
+                                          (fun orch ->
+                                            let orch =
+                                              Orchestrator.set_pr_body_delivered
+                                                orch patch_id true
+                                            in
+                                            Orchestrator
+                                            .reset_pr_body_artifact_miss_count
+                                              orch patch_id)
+                                    | Patch_decision.Sync_patch_failed ->
+                                        log_event runtime ~patch_id
+                                          "pr-body: opportunistic sync PATCH \
+                                           failed; leaving state — next \
+                                           Pr_body cycle will retry");
                                     result)
                       in
                       let respond_outcome =

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -3499,7 +3499,21 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                       | Patch_decision.Sync_skip -> None
                                       | Patch_decision.Sync_attempt_pr_body ->
                                           let pr =
-                                            Base.Option.value_exn pr_number
+                                            match pr_number with
+                                            | Some n -> n
+                                            | None ->
+                                                (* Invariant: Sync_attempt_pr_body
+                                                   is only reachable inside the
+                                                   Deliver arm, which requires a
+                                                   PR to exist. *)
+                                                failwith
+                                                  (Printf.sprintf
+                                                     "BUG: \
+                                                      Sync_attempt_pr_body \
+                                                      reached with no \
+                                                      pr_number for %s"
+                                                     (Patch_id.to_string
+                                                        patch_id))
                                           in
                                           let patch =
                                             Base.List.find_exn

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -3506,7 +3506,7 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                     let patch_result =
                                       match plan with
                                       | Patch_decision.Sync_skip -> None
-                                      | Patch_decision.Sync_attempt_pr_body ->
+                                      | Patch_decision.Sync_attempt_pr_body -> (
                                           let pr =
                                             match pr_number with
                                             | Some n -> n
@@ -3524,30 +3524,35 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                                      (Patch_id.to_string
                                                         patch_id))
                                           in
-                                          let patch =
-                                            match
-                                              Base.List.find
-                                                gameplan.Gameplan.patches
-                                                ~f:(fun (p : Patch.t) ->
-                                                  Patch_id.equal p.Patch.id
-                                                    patch_id)
-                                            with
-                                            | Some p -> p
-                                            | None ->
-                                                failwith
-                                                  (Printf.sprintf
-                                                     "BUG: \
-                                                      Sync_attempt_pr_body: \
-                                                      patch %s not found in \
-                                                      gameplan"
-                                                     (Patch_id.to_string
-                                                        patch_id))
-                                          in
-                                          Some
-                                            (apply_pr_body_artifact ~runtime
-                                               ~net ~github ~project_name
-                                               ~patch_id ~pr_number:pr ~patch
-                                               ~gameplan)
+                                          (* Ad-hoc agents (added via
+                                             Orchestrator.add_agent) have a
+                                             pr_number but no gameplan entry,
+                                             so a missing patch here is not a
+                                             bug — skip the opportunistic
+                                             sync and let
+                                             classify_artifact_sync_outcome
+                                             map patch_result=None to
+                                             Sync_no_op. *)
+                                          match
+                                            Base.List.find
+                                              gameplan.Gameplan.patches
+                                              ~f:(fun (p : Patch.t) ->
+                                                Patch_id.equal p.Patch.id
+                                                  patch_id)
+                                          with
+                                          | Some patch ->
+                                              Some
+                                                (apply_pr_body_artifact ~runtime
+                                                   ~net ~github ~project_name
+                                                   ~patch_id ~pr_number:pr
+                                                   ~patch ~gameplan)
+                                          | None ->
+                                              log_event runtime ~patch_id
+                                                "pr-body: skipping \
+                                                 opportunistic sync — patch \
+                                                 has no gameplan entry (likely \
+                                                 ad-hoc)";
+                                              None)
                                     in
                                     (match
                                        Patch_decision

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -3484,6 +3484,15 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                        owned by classify_pr_body_respond),
                                        so this block is a no-op for that
                                        kind and never double-PATCHes. *)
+                                    (* Re-derive session_ok from the (possibly
+                                       rebound) result so the planner sees the
+                                       final outcome — the Pr_body_payload arm
+                                       above can flip result to Pr_body_miss. *)
+                                    let session_ok =
+                                      match result with
+                                      | `Ok -> true
+                                      | _ -> false
+                                    in
                                     let pr_body_post_snapshot =
                                       read_artifact_file
                                         (Project_store.pr_body_artifact_path

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -3516,11 +3516,23 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
                                                         patch_id))
                                           in
                                           let patch =
-                                            Base.List.find_exn
-                                              gameplan.Gameplan.patches
-                                              ~f:(fun (p : Patch.t) ->
-                                                Patch_id.equal p.Patch.id
-                                                  patch_id)
+                                            match
+                                              Base.List.find
+                                                gameplan.Gameplan.patches
+                                                ~f:(fun (p : Patch.t) ->
+                                                  Patch_id.equal p.Patch.id
+                                                    patch_id)
+                                            with
+                                            | Some p -> p
+                                            | None ->
+                                                failwith
+                                                  (Printf.sprintf
+                                                     "BUG: \
+                                                      Sync_attempt_pr_body: \
+                                                      patch %s not found in \
+                                                      gameplan"
+                                                     (Patch_id.to_string
+                                                        patch_id))
                                           in
                                           Some
                                             (apply_pr_body_artifact ~runtime

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -349,6 +349,9 @@ let set_is_draft t patch_id v =
 let set_pr_body_delivered t patch_id v =
   update_agent t patch_id ~f:(fun a -> Patch_agent.set_pr_body_delivered a v)
 
+let reset_pr_body_artifact_miss_count t patch_id =
+  update_agent t patch_id ~f:Patch_agent.reset_pr_body_artifact_miss_count
+
 let increment_conflict_noop_count t patch_id =
   update_agent t patch_id ~f:Patch_agent.increment_conflict_noop_count
 

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -99,6 +99,7 @@ val set_checks_passing : t -> Patch_id.t -> bool -> t
 val set_merge_ready : t -> Patch_id.t -> bool -> t
 val set_is_draft : t -> Patch_id.t -> bool -> t
 val set_pr_body_delivered : t -> Patch_id.t -> bool -> t
+val reset_pr_body_artifact_miss_count : t -> Patch_id.t -> t
 val increment_start_attempts_without_pr : t -> Patch_id.t -> t
 val reset_intervention_state : t -> Patch_id.t -> t
 val set_branch_blocked : t -> Patch_id.t -> t

--- a/lib/patch_decision.ml
+++ b/lib/patch_decision.ml
@@ -228,9 +228,12 @@ let classify_pr_body_respond
 (** {2 Opportunistic pr-body artifact sync from any session} *)
 
 (* Treat empty and whitespace-only contents as "no artifact present" so a
-   truncating write is not classified as a "change". Mirrors the existing
-   apply_pr_body_artifact rule that returns [`Empty] for blank artifacts and
-   keeps the initial PR body. *)
+   blank post is equivalent to None. A truncation from non-empty to empty
+   (Some "x" -> Some "") still differs from pre after normalization (post' =
+   None vs pre' = Some "x"), so plan_artifact_sync will return
+   Sync_attempt_pr_body. apply_pr_body_artifact then returns `Empty (keeps
+   the initial PR body), and classify_artifact_sync_outcome maps that to
+   Sync_no_op — defensive handling rather than silent skip. *)
 let normalize_artifact = function
   | None -> None
   | Some s when String.is_empty (String.strip s) -> None

--- a/lib/patch_decision.ml
+++ b/lib/patch_decision.ml
@@ -224,3 +224,48 @@ let classify_pr_body_respond
   | `Patch_failed, _ -> `Pr_body_miss
   | (`Missing | `Empty), true -> `Pr_body_miss
   | (`Ok | `Missing | `Empty), _ -> `Ok
+
+(** {2 Opportunistic pr-body artifact sync from any session} *)
+
+(* Treat empty and whitespace-only contents as "no artifact present" so a
+   truncating write is not classified as a "change". Mirrors the existing
+   apply_pr_body_artifact rule that returns [`Empty] for blank artifacts and
+   keeps the initial PR body. *)
+let normalize_artifact = function
+  | None -> None
+  | Some s when String.is_empty (String.strip s) -> None
+  | Some _ as x -> x
+
+let pr_body_artifact_changed ~(pre : string option) ~(post : string option) :
+    bool =
+  let pre' = normalize_artifact pre in
+  let post' = normalize_artifact post in
+  not (Option.equal String.equal pre' post')
+
+type artifact_sync_plan = Sync_skip | Sync_attempt_pr_body
+[@@deriving show, eq, sexp_of, compare]
+
+let plan_artifact_sync ~(kind : Operation_kind.t) ~(session_ok : bool)
+    ~(pre : string option) ~(post : string option) : artifact_sync_plan =
+  if not session_ok then Sync_skip
+  else
+    match kind with
+    | Operation_kind.Pr_body -> Sync_skip
+    | Operation_kind.Rebase | Operation_kind.Human
+    | Operation_kind.Merge_conflict | Operation_kind.Ci
+    | Operation_kind.Review_comments ->
+        if pr_body_artifact_changed ~pre ~post then Sync_attempt_pr_body
+        else Sync_skip
+
+type artifact_sync_outcome = Sync_no_op | Sync_delivered | Sync_patch_failed
+[@@deriving show, eq, sexp_of, compare]
+
+let classify_artifact_sync_outcome ~(plan : artifact_sync_plan)
+    ~(patch_result : [ `Ok | `Missing | `Empty | `Patch_failed ] option) :
+    artifact_sync_outcome =
+  match (plan, patch_result) with
+  | Sync_skip, _ -> Sync_no_op
+  | Sync_attempt_pr_body, Some `Ok -> Sync_delivered
+  | Sync_attempt_pr_body, Some `Patch_failed -> Sync_patch_failed
+  | Sync_attempt_pr_body, Some (`Missing | `Empty) -> Sync_no_op
+  | Sync_attempt_pr_body, None -> Sync_no_op

--- a/lib/patch_decision.mli
+++ b/lib/patch_decision.mli
@@ -125,3 +125,71 @@ val classify_pr_body_respond :
     Only invoked after a successful session — session-level failures
     (stale/failed/retry_push) short-circuit upstream in the handler and never
     reach this function. *)
+
+(** {2 Opportunistic pr-body artifact sync from any session}
+
+    The patch agent can in principle update [pr-body.md] during any session (CI,
+    Review_comments, Human, Merge_conflict, Rebase) — not only [Pr_body]. The
+    runner takes a content snapshot before launching the agent and another after
+    the session, then asks these pure functions whether to PATCH the PR and what
+    state changes to apply.
+
+    [Pr_body] sessions are deliberately excluded here: their delivery path is
+    owned by [classify_pr_body_respond] (with its own miss-counter and
+    intervention semantics). [plan_artifact_sync] returns [Sync_skip] for
+    [Pr_body] so the opportunistic block is a no-op for that kind. *)
+
+val pr_body_artifact_changed : pre:string option -> post:string option -> bool
+(** Pure: did the effective body change between the pre- and post-session
+    snapshots? Whitespace-only and empty strings collapse to [None] before
+    comparison, so truncation and whitespace-only writes are not "changes" —
+    matching the existing "Empty → keep initial PR body" branch in
+    [apply_pr_body_artifact]. *)
+
+type artifact_sync_plan =
+  | Sync_skip
+      (** No PATCH attempt; no state change. Used when (a) the session failed,
+          (b) [kind = Pr_body] (which has its own classify path), or (c) the
+          artifact was unchanged. *)
+  | Sync_attempt_pr_body
+      (** Caller should run [apply_pr_body_artifact] and feed the result into
+          [classify_artifact_sync_outcome]. *)
+[@@deriving show, eq, sexp_of, compare]
+
+val plan_artifact_sync :
+  kind:Operation_kind.t ->
+  session_ok:bool ->
+  pre:string option ->
+  post:string option ->
+  artifact_sync_plan
+(** Pure pre-PATCH planner. Returns [Sync_attempt_pr_body] only when the session
+    succeeded, the operation kind is not [Pr_body], and the artifact actually
+    changed. Otherwise [Sync_skip]. *)
+
+type artifact_sync_outcome =
+  | Sync_no_op
+  | Sync_delivered
+      (** PATCH succeeded — caller should set [pr_body_delivered = true] and
+          reset [pr_body_artifact_miss_count] to 0. *)
+  | Sync_patch_failed
+      (** PATCH failed — caller should log only; do NOT mutate
+          [pr_body_delivered] or the miss count. The next [Pr_body] cycle will
+          retry through the regular classifier path. *)
+[@@deriving show, eq, sexp_of, compare]
+
+val classify_artifact_sync_outcome :
+  plan:artifact_sync_plan ->
+  patch_result:[ `Ok | `Missing | `Empty | `Patch_failed ] option ->
+  artifact_sync_outcome
+(** Pure post-PATCH classifier. Total over every (plan, patch_result)
+    combination so it is safe to apply over arbitrary generators in property
+    tests, even on inputs the runner never produces.
+
+    - [plan = Sync_skip] → [Sync_no_op] regardless of [patch_result].
+    - [plan = Sync_attempt_pr_body], [patch_result = Some `Ok] →
+      [Sync_delivered].
+    - [plan = Sync_attempt_pr_body], [patch_result = Some `Patch_failed] →
+      [Sync_patch_failed].
+    - [plan = Sync_attempt_pr_body], [patch_result = Some (`Missing | `Empty)]
+      or [None] → [Sync_no_op] (defensive — unreachable when the planner gates
+      on [pr_body_artifact_changed]). *)

--- a/lib/patch_decision.mli
+++ b/lib/patch_decision.mli
@@ -142,9 +142,12 @@ val classify_pr_body_respond :
 val pr_body_artifact_changed : pre:string option -> post:string option -> bool
 (** Pure: did the effective body change between the pre- and post-session
     snapshots? Whitespace-only and empty strings collapse to [None] before
-    comparison, so truncation and whitespace-only writes are not "changes" —
-    matching the existing "Empty → keep initial PR body" branch in
-    [apply_pr_body_artifact]. *)
+    comparison, so a whitespace-only post is equivalent to no artifact at all.
+    Truncation from non-empty content to empty (e.g. [Some "x" -> Some ""])
+    collapses post to [None] but pre stays [Some "x"], so it is treated as a
+    change and is later mapped to [Sync_no_op] by
+    [classify_artifact_sync_outcome] (since [apply_pr_body_artifact] returns
+    [`Empty] and keeps the initial PR body). *)
 
 type artifact_sync_plan =
   | Sync_skip

--- a/lib/patch_decision.mli
+++ b/lib/patch_decision.mli
@@ -194,5 +194,10 @@ val classify_artifact_sync_outcome :
     - [plan = Sync_attempt_pr_body], [patch_result = Some `Patch_failed] →
       [Sync_patch_failed].
     - [plan = Sync_attempt_pr_body], [patch_result = Some (`Missing | `Empty)]
-      or [None] → [Sync_no_op] (defensive — unreachable when the planner gates
-      on [pr_body_artifact_changed]). *)
+      or [None] → [Sync_no_op]. The [`Empty] arm is reachable when a file
+      changes from non-empty to empty: [normalize_artifact] (planner) and
+      [apply_pr_body_artifact]'s [String.trim] check are independent, so both
+      can fire on the same content change. [`Missing] is reachable if the file
+      is deleted between the post-snapshot and the [apply_pr_body_artifact]
+      call. [None] is reachable when the caller skips the PATCH despite the plan
+      (e.g. an ad-hoc patch with no gameplan entry). *)

--- a/test/dune
+++ b/test/dune
@@ -1,125 +1,150 @@
 (test
  (name test_onton)
+ (modules test_onton)
  (libraries onton))
 
 (test
  (name test_patch_agent)
+ (modules test_patch_agent)
  (libraries onton qcheck-core))
 
 (test
  (name test_properties)
+ (modules test_properties)
  (libraries onton onton_test_support qcheck-core)
  (ocamlopt_flags (:standard -w -40-42))
  (ocamlc_flags (:standard -w -40-42)))
 
 (test
  (name test_reconciler_properties)
+ (modules test_reconciler_properties)
  (libraries onton onton_test_support qcheck-core)
  (ocamlopt_flags (:standard -w -40-42))
  (ocamlc_flags (:standard -w -40-42)))
 
 (test
  (name test_orchestrator_properties)
+ (modules test_orchestrator_properties)
  (libraries onton onton_test_support qcheck-core))
 
 (test
  (name test_state_machine_properties)
+ (modules test_state_machine_properties)
  (libraries onton onton_test_support qcheck-core)
  (ocamlopt_flags (:standard -w -40-42))
  (ocamlc_flags (:standard -w -40-42)))
 
 (test
  (name test_tui_input)
+ (modules test_tui_input)
  (libraries onton))
 
 (test
  (name test_stream_parser)
+ (modules test_stream_parser)
  (libraries onton qcheck-core))
 
 (test
  (name test_persistence_properties)
+ (modules test_persistence_properties)
  (libraries onton onton_test_support qcheck-core qcheck-core.runner yojson)
  (ocamlopt_flags (:standard -w -40-42))
  (ocamlc_flags (:standard -w -40-42)))
 
 (test
  (name test_runtime_create)
+ (modules test_runtime_create)
  (libraries onton))
 
 (test
  (name test_poller_properties)
+ (modules test_poller_properties)
  (libraries onton onton_test_support qcheck-core))
 
 (test
  (name test_tui_scheduling)
+ (modules test_tui_scheduling)
  (libraries onton eio eio_main eio.unix unix))
 
 (test
  (name test_patch_decision)
+ (modules test_patch_decision)
  (libraries onton qcheck-core))
 
 (test
  (name test_worktree_plan)
+ (modules test_worktree_plan)
  (libraries onton qcheck-core))
 
 (test
  (name test_spawn_logic)
+ (modules test_spawn_logic)
  (libraries onton onton_test_support qcheck-core))
 
 (test
  (name test_worktree_parser)
+ (modules test_worktree_parser)
  (libraries onton qcheck-core qcheck-core.runner)
  (ocamlopt_flags (:standard -w -40-42))
  (ocamlc_flags (:standard -w -40-42)))
 
 (test
  (name test_rebase_onto)
+ (modules test_rebase_onto)
  (libraries onton qcheck-core qcheck-core.runner eio eio_main eio.unix)
  (ocamlopt_flags (:standard -w -40-42))
  (ocamlc_flags (:standard -w -40-42)))
 
 (test
  (name test_run_classification)
+ (modules test_run_classification)
  (libraries onton onton_test_support qcheck-core qcheck-core.runner)
  (ocamlopt_flags (:standard -w -40-42))
  (ocamlc_flags (:standard -w -40-42)))
 
 (test
  (name test_patch_controller)
+ (modules test_patch_controller)
  (libraries onton onton_test_support qcheck-core qcheck-core.runner)
  (ocamlopt_flags (:standard -w -40-42))
  (ocamlc_flags (:standard -w -40-42)))
 
 (test
  (name test_patch_controller_state_machine)
+ (modules test_patch_controller_state_machine)
  (libraries onton onton_test_support qcheck-core qcheck-core.runner)
  (ocamlopt_flags (:standard -w -40-42))
  (ocamlc_flags (:standard -w -40-42)))
 
 (test
  (name test_poll_log_properties)
+ (modules test_poll_log_properties)
  (libraries onton onton_test_support qcheck-core qcheck-core.runner)
  (ocamlopt_flags (:standard -w -40-42))
  (ocamlc_flags (:standard -w -40-42)))
 
 (test
  (name test_interleaving_properties)
+ (modules test_interleaving_properties)
  (libraries onton onton_test_support qcheck-core)
  (ocamlopt_flags (:standard -w -40-42))
  (ocamlc_flags (:standard -w -40-42)))
 
 (test
  (name test_misc_pure_properties)
+ (modules test_misc_pure_properties)
  (libraries onton onton_test_support qcheck-core qcheck-core.runner)
  (ocamlopt_flags (:standard -w -40-42))
  (ocamlc_flags (:standard -w -40-42)))
 
 (test
  (name test_action_outcome_properties)
+ (modules test_action_outcome_properties)
  (libraries onton onton_test_support qcheck-core))
 
 (test
  (name test_backend_smoke)
+ (modules test_backend_smoke)
  (libraries onton eio eio_main)
  (deps (package onton))
  (action
@@ -129,16 +154,20 @@
 
 (test
  (name test_user_config)
+ (modules test_user_config)
  (libraries onton eio eio_main eio.unix unix))
 
 (test
  (name test_repo_root)
+ (modules test_repo_root)
  (libraries onton unix))
 
 (test
  (name test_project_lock)
+ (modules test_project_lock)
  (libraries onton unix))
 
 (test
  (name test_rlimit)
+ (modules test_rlimit)
  (libraries onton))

--- a/test/test_interleaving_properties.ml
+++ b/test/test_interleaving_properties.ml
@@ -74,6 +74,13 @@ type push_result_kind =
   | Push_rejected_k
   | Push_error_k
 
+(* Outcome of an opportunistic pr-body artifact sync, mirroring
+   Patch_decision.artifact_sync_outcome. The runner produces these only for
+   non-Pr_body kinds (kind=Pr_body always yields Sync_no_op_k via the
+   planner). The interleaving generator preserves that contract — see
+   [gen_sync_outcome_command] below. *)
+type sync_outcome_kind = Sync_no_op_k | Sync_delivered_k | Sync_patch_failed_k
+
 type command =
   | Apply_poll of { patch_idx : int; poll_kind : poll_kind }
   | Reconcile
@@ -92,6 +99,11 @@ type command =
   | Add_adhoc of int
   | Remove_adhoc of int
   | Discover_pr of int
+  | Apply_sync_outcome of {
+      patch_idx : int;
+      kind : Operation_kind.t;
+      outcome : sync_outcome_kind;
+    }
 
 let show_poll_kind = function
   | Poll_normal -> "Normal"
@@ -123,6 +135,11 @@ let show_push_result_kind = function
   | Push_rejected_k -> "Push_rejected"
   | Push_error_k -> "Push_error"
 
+let show_sync_outcome_kind = function
+  | Sync_no_op_k -> "No_op"
+  | Sync_delivered_k -> "Delivered"
+  | Sync_patch_failed_k -> "Patch_failed"
+
 let show_command = function
   | Apply_poll { patch_idx; poll_kind } ->
       Printf.sprintf "Apply_poll(%d, %s)" patch_idx (show_poll_kind poll_kind)
@@ -149,6 +166,10 @@ let show_command = function
   | Add_adhoc i -> Printf.sprintf "Add_adhoc(%d)" i
   | Remove_adhoc i -> Printf.sprintf "Remove_adhoc(%d)" i
   | Discover_pr i -> Printf.sprintf "Discover_pr(%d)" i
+  | Apply_sync_outcome { patch_idx; kind; outcome } ->
+      Printf.sprintf "Apply_sync_outcome(%d, %s, %s)" patch_idx
+        (Operation_kind.to_label kind)
+        (show_sync_outcome_kind outcome)
 
 (* -- Ad-hoc patch helpers -- *)
 
@@ -213,6 +234,27 @@ let gen_push_result_kind =
   QCheck2.Gen.oneof_list
     [ Push_ok_k; Push_up_to_date_k; Push_rejected_k; Push_error_k ]
 
+(** Generate an [Apply_sync_outcome] command. Honors INV-C: when [kind] is
+    [Pr_body], the outcome is forced to [Sync_no_op_k] because the runner's
+    planner returns [Sync_skip] for that kind, so [Sync_delivered_k] or
+    [Sync_patch_failed_k] for [Pr_body] would be unreachable in practice. *)
+let gen_sync_outcome_command ~gen_idx =
+  QCheck2.Gen.(
+    let gen_kind =
+      oneof_list
+        Operation_kind.
+          [ Rebase; Human; Merge_conflict; Ci; Review_comments; Pr_body ]
+    in
+    let gen_outcome_for kind =
+      if Operation_kind.equal kind Operation_kind.Pr_body then
+        return Sync_no_op_k
+      else oneof_list [ Sync_no_op_k; Sync_delivered_k; Sync_patch_failed_k ]
+    in
+    let* patch_idx = gen_idx in
+    let* kind = gen_kind in
+    let* outcome = gen_outcome_for kind in
+    return (Apply_sync_outcome { patch_idx; kind; outcome }))
+
 let gen_command ~n =
   let total = n + max_adhoc in
   QCheck2.Gen.(
@@ -243,6 +285,7 @@ let gen_command ~n =
         map (fun i -> Add_adhoc i) (int_range 0 (max_adhoc - 1));
         map (fun i -> Remove_adhoc i) (int_range 0 (max_adhoc - 1));
         map (fun i -> Discover_pr i) gen_idx;
+        gen_sync_outcome_command ~gen_idx;
       ])
 
 let gen_command_seq ~n ~len =
@@ -278,6 +321,7 @@ let gen_atomic_command ~n =
         map (fun i -> Add_adhoc i) (int_range 0 (max_adhoc - 1));
         map (fun i -> Remove_adhoc i) (int_range 0 (max_adhoc - 1));
         map (fun i -> Discover_pr i) gen_idx;
+        gen_sync_outcome_command ~gen_idx;
       ])
 
 let gen_atomic_command_seq ~n ~len =
@@ -510,6 +554,21 @@ let rec apply_command orch patches cmd =
           let orch = Orchestrator.set_pr_number orch pid pr in
           Orchestrator.set_base_branch orch pid base
       | _ -> orch)
+  | Apply_sync_outcome { patch_idx; kind = _; outcome } -> (
+      (* Mirror the runner's state transition on Patch_decision outcomes from
+         the opportunistic pr-body sync. Sync_no_op_k and Sync_patch_failed_k
+         are pure no-ops (the runner only logs); Sync_delivered_k flips
+         pr_body_delivered=true and resets the miss counter, exactly as
+         bin/main.ml does on Sync_delivered. *)
+      let pid = resolve_pid patches patch_idx in
+      match Orchestrator.find_agent orch pid with
+      | None -> orch
+      | Some _ -> (
+          match outcome with
+          | Sync_no_op_k | Sync_patch_failed_k -> orch
+          | Sync_delivered_k ->
+              let orch = Orchestrator.set_pr_body_delivered orch pid true in
+              Orchestrator.reset_pr_body_artifact_miss_count orch pid))
 
 type poll_log_info = {
   agent_before : Patch_agent.t;
@@ -561,7 +620,7 @@ let rec apply_command_with_logs orch patches cmd =
   | Reconcile | Runner_tick | Complete _ | Apply_session_result _
   | Apply_rebase_result _ | Send_human_message _ | Reset_intervention _
   | Apply_conflict_rebase_result _ | Apply_rebase_push_result _ | Add_adhoc _
-  | Remove_adhoc _ | Discover_pr _ ->
+  | Remove_adhoc _ | Discover_pr _ | Apply_sync_outcome _ ->
       (apply_command orch patches cmd, None)
 
 (* ========== Log invariant checks ========== *)
@@ -829,6 +888,83 @@ let check_human_messages_preserved ~(prev : Patch_agent.t)
          (Patch_id.to_string curr.patch_id)
          prev_total curr_total)
 
+(** INV-A: After [Apply_sync_outcome { outcome = Sync_delivered_k; _ }], the
+    affected agent has [pr_body_delivered = true] AND
+    [pr_body_artifact_miss_count = 0]. Holds across arbitrary interleavings —
+    e.g. a prior [Respond_pr_body_miss] sequence that pushed the miss count just
+    below the cap is rescued by an opportunistic sync.
+
+    INV-B: After
+    [Apply_sync_outcome { outcome = Sync_no_op_k | Sync_patch_failed_k; _ }],
+    the affected agent's [pr_body_delivered] and [pr_body_artifact_miss_count]
+    are unchanged from before the command. The runner only logs in those
+    branches; no state mutation. *)
+let check_sync_outcome_invariants ~prev_agents ~curr_orch cmd =
+  match cmd with
+  | Apply_sync_outcome { patch_idx = _; kind; outcome } ->
+      (* INV-C is enforced by the generator: kind=Pr_body always gets
+         Sync_no_op_k. Cross-check here so a regression in the generator
+         surfaces as a test failure rather than silently exercising
+         unreachable runner state. *)
+      (if Operation_kind.equal kind Operation_kind.Pr_body then
+         match outcome with
+         | Sync_no_op_k -> ()
+         | Sync_delivered_k | Sync_patch_failed_k ->
+             failwith
+               "INV-C generator contract violated: Apply_sync_outcome with \
+                kind=Pr_body must yield Sync_no_op_k");
+      List.iter (Orchestrator.all_agents curr_orch)
+        ~f:(fun (a : Patch_agent.t) ->
+          match Map.find prev_agents a.Patch_agent.patch_id with
+          | None ->
+              () (* agent appeared this step — not an Apply_sync_outcome *)
+          | Some (prev : Patch_agent.t) -> (
+              match outcome with
+              | Sync_delivered_k ->
+                  (* INV-A only applies to the targeted agent. We can't
+                     identify "the targeted agent" precisely here without
+                     plumbing the patch_idx, but every agent's pr_body
+                     fields must remain coherent: if the post-state has
+                     pr_body_delivered but prev didn't, the miss count must
+                     be 0 (since the sync resets it). For untouched
+                     agents, both fields are unchanged (Sync_delivered_k
+                     mutates only the targeted pid). *)
+                  if
+                    a.Patch_agent.pr_body_delivered
+                    && (not prev.Patch_agent.pr_body_delivered)
+                    && a.Patch_agent.pr_body_artifact_miss_count <> 0
+                  then
+                    failwith
+                      (Printf.sprintf
+                         "INV-A sync_delivered_resets_miss_count violated for \
+                          %s: pr_body_delivered flipped true but miss_count = \
+                          %d"
+                         (Patch_id.to_string a.Patch_agent.patch_id)
+                         a.Patch_agent.pr_body_artifact_miss_count)
+              | Sync_no_op_k | Sync_patch_failed_k ->
+                  (* INV-B: no mutation. *)
+                  if
+                    Bool.( <> ) a.Patch_agent.pr_body_delivered
+                      prev.Patch_agent.pr_body_delivered
+                    || a.Patch_agent.pr_body_artifact_miss_count
+                       <> prev.Patch_agent.pr_body_artifact_miss_count
+                  then
+                    failwith
+                      (Printf.sprintf
+                         "INV-B sync_no_mutation violated for %s on %s: \
+                          delivered %b -> %b, miss_count %d -> %d"
+                         (Patch_id.to_string a.Patch_agent.patch_id)
+                         (show_sync_outcome_kind outcome)
+                         prev.Patch_agent.pr_body_delivered
+                         a.Patch_agent.pr_body_delivered
+                         prev.Patch_agent.pr_body_artifact_miss_count
+                         a.Patch_agent.pr_body_artifact_miss_count)))
+  | Apply_poll _ | Reconcile | Runner_tick | Complete _ | Apply_session_result _
+  | Apply_rebase_result _ | Send_human_message _ | Reset_intervention _
+  | Atomic_poll_reconcile _ | Apply_conflict_rebase_result _
+  | Apply_rebase_push_result _ | Add_adhoc _ | Remove_adhoc _ | Discover_pr _ ->
+      ()
+
 (* ========== Combined check ========== *)
 
 let merged_set_of orch =
@@ -878,7 +1014,8 @@ let delivered_pid_of_cmd cmd patches =
   | Apply_poll _ | Reconcile | Runner_tick | Apply_session_result _
   | Apply_rebase_result _ | Send_human_message _ | Reset_intervention _
   | Atomic_poll_reconcile _ | Apply_conflict_rebase_result _
-  | Apply_rebase_push_result _ | Add_adhoc _ | Remove_adhoc _ | Discover_pr _ ->
+  | Apply_rebase_push_result _ | Add_adhoc _ | Remove_adhoc _ | Discover_pr _
+  | Apply_sync_outcome _ ->
       None
 
 let removed_pids_of_cmd cmd prev_removed =
@@ -888,7 +1025,7 @@ let removed_pids_of_cmd cmd prev_removed =
   | Apply_session_result _ | Apply_rebase_result _ | Send_human_message _
   | Reset_intervention _ | Atomic_poll_reconcile _
   | Apply_conflict_rebase_result _ | Apply_rebase_push_result _ | Discover_pr _
-    ->
+  | Apply_sync_outcome _ ->
       prev_removed
 
 let run_sequence ?(debug = false) orch patches cmds =
@@ -913,7 +1050,7 @@ let run_sequence ?(debug = false) orch patches cmds =
           | Apply_session_result _ | Apply_rebase_result _
           | Send_human_message _ | Reset_intervention _
           | Atomic_poll_reconcile _ | Apply_conflict_rebase_result _
-          | Apply_rebase_push_result _ | Discover_pr _ ->
+          | Apply_rebase_push_result _ | Discover_pr _ | Apply_sync_outcome _ ->
               merged_logged
         in
         let curr_merged = merged_set_of o in
@@ -931,6 +1068,7 @@ let run_sequence ?(debug = false) orch patches cmds =
         let delivered_pid = delivered_pid_of_cmd cmd patches in
         check_all_invariants o patches ~prev_agents ~prev_merged ~curr_merged
           ~removed_pids ~delivered_pid;
+        check_sync_outcome_invariants ~prev_agents ~curr_orch:o cmd;
         let merged_logged =
           match log_info with
           | Some info -> check_log_invariants info ~merged_logged

--- a/test/test_interleaving_properties.ml
+++ b/test/test_interleaving_properties.ml
@@ -899,9 +899,9 @@ let check_human_messages_preserved ~(prev : Patch_agent.t)
     the affected agent's [pr_body_delivered] and [pr_body_artifact_miss_count]
     are unchanged from before the command. The runner only logs in those
     branches; no state mutation. *)
-let check_sync_outcome_invariants ~prev_agents ~curr_orch cmd =
+let check_sync_outcome_invariants ~patches ~prev_agents ~curr_orch cmd =
   match cmd with
-  | Apply_sync_outcome { patch_idx = _; kind; outcome } ->
+  | Apply_sync_outcome { patch_idx; kind; outcome } -> (
       (* INV-C is enforced by the generator: kind=Pr_body always gets
          Sync_no_op_k. Cross-check here so a regression in the generator
          surfaces as a test failure rather than silently exercising
@@ -913,22 +913,20 @@ let check_sync_outcome_invariants ~prev_agents ~curr_orch cmd =
              failwith
                "INV-C generator contract violated: Apply_sync_outcome with \
                 kind=Pr_body must yield Sync_no_op_k");
-      List.iter (Orchestrator.all_agents curr_orch)
-        ~f:(fun (a : Patch_agent.t) ->
-          match Map.find prev_agents a.Patch_agent.patch_id with
-          | None ->
-              () (* agent appeared this step — not an Apply_sync_outcome *)
-          | Some (prev : Patch_agent.t) -> (
-              match outcome with
-              | Sync_delivered_k ->
-                  (* INV-A: any agent with pr_body_delivered=true after a
-                     Sync_delivered_k command must have miss_count=0. The
-                     targeted agent has both set by the sync; untouched agents
-                     are unchanged, so this also asserts they were already
-                     coherent. Checking the post-state alone (rather than
-                     guarding on a false→true transition) catches the case
-                     where the targeted agent was already delivered. *)
-                  ignore prev;
+      match outcome with
+      | Sync_delivered_k -> (
+          (* INV-A: the targeted agent ends with pr_body_delivered=true
+             AND miss_count=0 after a Sync_delivered_k command. Scoped to
+             the targeted agent so a bystander left in delivered=true with
+             miss_count>0 by an earlier command in the sequence is not
+             miscredited as an INV-A violation. *)
+          let targeted_pid = resolve_pid patches patch_idx in
+          match Map.find prev_agents targeted_pid with
+          | None -> ()
+          | Some _ -> (
+              match Orchestrator.find_agent curr_orch targeted_pid with
+              | None -> ()
+              | Some (a : Patch_agent.t) ->
                   if
                     a.Patch_agent.pr_body_delivered
                     && a.Patch_agent.pr_body_artifact_miss_count <> 0
@@ -938,9 +936,17 @@ let check_sync_outcome_invariants ~prev_agents ~curr_orch cmd =
                          "INV-A sync_delivered_resets_miss_count violated for \
                           %s: pr_body_delivered=true but miss_count = %d"
                          (Patch_id.to_string a.Patch_agent.patch_id)
-                         a.Patch_agent.pr_body_artifact_miss_count)
-              | Sync_no_op_k | Sync_patch_failed_k ->
-                  (* INV-B: no mutation. *)
+                         a.Patch_agent.pr_body_artifact_miss_count)))
+      | Sync_no_op_k | Sync_patch_failed_k ->
+          (* INV-B: no mutation of pr_body fields for any agent. The runner
+             only logs in those branches, so iterating over every agent
+             asserts that the operation is purely local (no cross-agent
+             side effects either). *)
+          List.iter (Orchestrator.all_agents curr_orch)
+            ~f:(fun (a : Patch_agent.t) ->
+              match Map.find prev_agents a.Patch_agent.patch_id with
+              | None -> ()
+              | Some (prev : Patch_agent.t) ->
                   if
                     Bool.( <> ) a.Patch_agent.pr_body_delivered
                       prev.Patch_agent.pr_body_delivered
@@ -1066,7 +1072,7 @@ let run_sequence ?(debug = false) orch patches cmds =
         let delivered_pid = delivered_pid_of_cmd cmd patches in
         check_all_invariants o patches ~prev_agents ~prev_merged ~curr_merged
           ~removed_pids ~delivered_pid;
-        check_sync_outcome_invariants ~prev_agents ~curr_orch:o cmd;
+        check_sync_outcome_invariants ~patches ~prev_agents ~curr_orch:o cmd;
         let merged_logged =
           match log_info with
           | Some info -> check_log_invariants info ~merged_logged

--- a/test/test_interleaving_properties.ml
+++ b/test/test_interleaving_properties.ml
@@ -921,24 +921,22 @@ let check_sync_outcome_invariants ~prev_agents ~curr_orch cmd =
           | Some (prev : Patch_agent.t) -> (
               match outcome with
               | Sync_delivered_k ->
-                  (* INV-A only applies to the targeted agent. We can't
-                     identify "the targeted agent" precisely here without
-                     plumbing the patch_idx, but every agent's pr_body
-                     fields must remain coherent: if the post-state has
-                     pr_body_delivered but prev didn't, the miss count must
-                     be 0 (since the sync resets it). For untouched
-                     agents, both fields are unchanged (Sync_delivered_k
-                     mutates only the targeted pid). *)
+                  (* INV-A: any agent with pr_body_delivered=true after a
+                     Sync_delivered_k command must have miss_count=0. The
+                     targeted agent has both set by the sync; untouched agents
+                     are unchanged, so this also asserts they were already
+                     coherent. Checking the post-state alone (rather than
+                     guarding on a false→true transition) catches the case
+                     where the targeted agent was already delivered. *)
+                  ignore prev;
                   if
                     a.Patch_agent.pr_body_delivered
-                    && (not prev.Patch_agent.pr_body_delivered)
                     && a.Patch_agent.pr_body_artifact_miss_count <> 0
                   then
                     failwith
                       (Printf.sprintf
                          "INV-A sync_delivered_resets_miss_count violated for \
-                          %s: pr_body_delivered flipped true but miss_count = \
-                          %d"
+                          %s: pr_body_delivered=true but miss_count = %d"
                          (Patch_id.to_string a.Patch_agent.patch_id)
                          a.Patch_agent.pr_body_artifact_miss_count)
               | Sync_no_op_k | Sync_patch_failed_k ->

--- a/test/test_interleaving_properties.ml
+++ b/test/test_interleaving_properties.ml
@@ -916,10 +916,10 @@ let check_sync_outcome_invariants ~patches ~prev_agents ~curr_orch cmd =
       match outcome with
       | Sync_delivered_k -> (
           (* INV-A: the targeted agent ends with pr_body_delivered=true
-             AND miss_count=0 after a Sync_delivered_k command. Scoped to
-             the targeted agent so a bystander left in delivered=true with
-             miss_count>0 by an earlier command in the sequence is not
-             miscredited as an INV-A violation. *)
+             AND miss_count=0 after a Sync_delivered_k command. Both halves
+             are asserted unconditionally so a regression where the runner
+             silently fails to set pr_body_delivered (e.g. find_agent
+             returns None) does not pass vacuously via short-circuit. *)
           let targeted_pid = resolve_pid patches patch_idx in
           match Map.find prev_agents targeted_pid with
           | None -> ()
@@ -927,14 +927,17 @@ let check_sync_outcome_invariants ~patches ~prev_agents ~curr_orch cmd =
               match Orchestrator.find_agent curr_orch targeted_pid with
               | None -> ()
               | Some (a : Patch_agent.t) ->
-                  if
-                    a.Patch_agent.pr_body_delivered
-                    && a.Patch_agent.pr_body_artifact_miss_count <> 0
-                  then
+                  if not a.Patch_agent.pr_body_delivered then
                     failwith
                       (Printf.sprintf
-                         "INV-A sync_delivered_resets_miss_count violated for \
-                          %s: pr_body_delivered=true but miss_count = %d"
+                         "INV-A Sync_delivered_k did not set \
+                          pr_body_delivered=true for %s"
+                         (Patch_id.to_string a.Patch_agent.patch_id));
+                  if a.Patch_agent.pr_body_artifact_miss_count <> 0 then
+                    failwith
+                      (Printf.sprintf
+                         "INV-A Sync_delivered_k did not reset miss_count=0 \
+                          for %s: miss_count = %d"
                          (Patch_id.to_string a.Patch_agent.patch_id)
                          a.Patch_agent.pr_body_artifact_miss_count)))
       | Sync_no_op_k | Sync_patch_failed_k ->

--- a/test/test_patch_decision.ml
+++ b/test/test_patch_decision.ml
@@ -956,8 +956,12 @@ let () =
     assert (equal_artifact_sync_outcome outcome Sync_patch_failed);
     Stdlib.print_endline "AS-22 passed";
 
-    (* AS-23: plan=Sync_attempt_pr_body, Some (`Missing | `Empty) → Sync_no_op
-       (defensive — unreachable when planner gates on changed). *)
+    (* AS-23: plan=Sync_attempt_pr_body, Some (`Missing | `Empty) → Sync_no_op.
+       Both arms are reachable: [`Empty] fires when the file goes from
+       non-empty to empty (normalize_artifact and apply_pr_body_artifact's
+       String.trim use independent emptiness checks); [`Missing] fires if the
+       file is deleted between the runner's post-snapshot and the
+       apply_pr_body_artifact call. *)
     List.iter [ `Missing; `Empty ] ~f:(fun pr ->
         let outcome =
           classify_artifact_sync_outcome ~plan:Sync_attempt_pr_body

--- a/test/test_patch_decision.ml
+++ b/test/test_patch_decision.ml
@@ -875,7 +875,12 @@ let () =
        changed. The Pr_body delivery path is owned by
        classify_pr_body_respond. *)
     List.iter
-      [ (None, None); (Some "x", Some "x"); (None, Some "y") ]
+      [
+        (None, None);
+        (Some "x", Some "x");
+        (None, Some "y");
+        (Some "x", Some "y");
+      ]
       ~f:(fun (pre, post) ->
         let plan =
           plan_artifact_sync ~kind:Operation_kind.Pr_body ~session_ok:true ~pre

--- a/test/test_patch_decision.ml
+++ b/test/test_patch_decision.ml
@@ -751,4 +751,253 @@ let () =
     QCheck2.Test.check_exn prop;
     Stdlib.print_endline "PB-9 passed"
   in
+
+  (* ========== Opportunistic artifact-sync property tests ==========
+
+     These cover the three pure functions added for issue #215:
+     [pr_body_artifact_changed], [plan_artifact_sync], and
+     [classify_artifact_sync_outcome]. Each is small enough that we both
+     enumerate the meaningful boundary cases and add property-based tests for
+     contract-level invariants. *)
+  let () =
+    (* AS-1: (None, None) → false. *)
+    assert (not (pr_body_artifact_changed ~pre:None ~post:None));
+    Stdlib.print_endline "AS-1 passed";
+
+    (* AS-2: equal non-empty content → false. *)
+    assert (not (pr_body_artifact_changed ~pre:(Some "x") ~post:(Some "x")));
+    Stdlib.print_endline "AS-2 passed";
+
+    (* AS-3: distinct non-empty content → true. *)
+    assert (pr_body_artifact_changed ~pre:(Some "x") ~post:(Some "y"));
+    Stdlib.print_endline "AS-3 passed";
+
+    (* AS-4: empty/whitespace collapse — empty and whitespace-only contents
+       are treated as None on both sides. Truncating real content to empty
+       (Some "x" → Some "") is intentionally classified as a change; the
+       downstream apply_pr_body_artifact returns [`Empty] and skips the
+       GitHub PATCH, so no spurious call is issued. *)
+    assert (not (pr_body_artifact_changed ~pre:None ~post:(Some "")));
+    assert (not (pr_body_artifact_changed ~pre:(Some "  \n") ~post:None));
+    assert (not (pr_body_artifact_changed ~pre:(Some "") ~post:(Some "  ")));
+    assert (pr_body_artifact_changed ~pre:(Some "x") ~post:(Some ""));
+    Stdlib.print_endline "AS-4 passed";
+
+    (* AS-5: asymmetric add — new non-empty content from None → true. *)
+    assert (pr_body_artifact_changed ~pre:None ~post:(Some "y"));
+    Stdlib.print_endline "AS-5 passed";
+
+    (* AS-P1 (reflexivity): for any [s], changed pre:s post:s = false. *)
+    let gen_artifact =
+      QCheck2.Gen.(
+        oneof
+          [
+            return None;
+            map (fun s -> Some s) (string_size (int_range 0 8));
+            return (Some "");
+            return (Some "   ");
+            return (Some "\n\t ");
+          ])
+    in
+    let prop =
+      QCheck2.Test.make ~name:"AS-P1: reflexivity" gen_artifact (fun s ->
+          try not (pr_body_artifact_changed ~pre:s ~post:s) with _ -> false)
+    in
+    QCheck2.Test.check_exn prop;
+    Stdlib.print_endline "AS-P1 passed";
+
+    (* AS-P2 (whitespace-only content collapses to None): any whitespace-only
+       string is indistinguishable from None for the change predicate. *)
+    let gen_whitespace =
+      QCheck2.Gen.(
+        map
+          (fun n ->
+            String.init n ~f:(fun i ->
+                match Stdlib.( mod ) i 4 with
+                | 0 -> ' '
+                | 1 -> '\t'
+                | 2 -> '\n'
+                | _ -> ' '))
+          (int_range 0 6))
+    in
+    let prop =
+      QCheck2.Test.make ~name:"AS-P2: whitespace-only collapse" gen_whitespace
+        (fun w ->
+          try
+            (not (pr_body_artifact_changed ~pre:None ~post:(Some w)))
+            && not (pr_body_artifact_changed ~pre:(Some w) ~post:None)
+          with _ -> false)
+    in
+    QCheck2.Test.check_exn prop;
+    Stdlib.print_endline "AS-P2 passed";
+
+    (* AS-P3 (symmetry): changed (a, b) = changed (b, a). The predicate is a
+       boolean over equality of normalized contents, so it must be
+       symmetric — guards against any future implementation that
+       distinguishes pre/post direction. *)
+    let prop =
+      QCheck2.Test.make ~name:"AS-P3: symmetry"
+        QCheck2.Gen.(pair gen_artifact gen_artifact)
+        (fun (a, b) ->
+          try
+            Bool.equal
+              (pr_body_artifact_changed ~pre:a ~post:b)
+              (pr_body_artifact_changed ~pre:b ~post:a)
+          with _ -> false)
+    in
+    QCheck2.Test.check_exn prop;
+    Stdlib.print_endline "AS-P3 passed";
+
+    (* Helpers for plan_artifact_sync enumeration. *)
+    let all_kinds : Operation_kind.t list =
+      Operation_kind.
+        [ Rebase; Human; Merge_conflict; Ci; Review_comments; Pr_body ]
+    in
+    let non_pr_body_kinds : Operation_kind.t list =
+      Operation_kind.[ Rebase; Human; Merge_conflict; Ci; Review_comments ]
+    in
+
+    (* AS-10: session_ok=false → Sync_skip for any kind, any pre/post. *)
+    List.iter all_kinds ~f:(fun kind ->
+        List.iter
+          [
+            (None, None);
+            (Some "x", Some "x");
+            (Some "x", Some "y");
+            (None, Some "y");
+          ]
+          ~f:(fun (pre, post) ->
+            let plan = plan_artifact_sync ~kind ~session_ok:false ~pre ~post in
+            assert (equal_artifact_sync_plan plan Sync_skip)));
+    Stdlib.print_endline "AS-10 passed";
+
+    (* AS-11: kind=Pr_body, session_ok=true → Sync_skip regardless of
+       changed. The Pr_body delivery path is owned by
+       classify_pr_body_respond. *)
+    List.iter
+      [ (None, None); (Some "x", Some "x"); (None, Some "y") ]
+      ~f:(fun (pre, post) ->
+        let plan =
+          plan_artifact_sync ~kind:Operation_kind.Pr_body ~session_ok:true ~pre
+            ~post
+        in
+        assert (equal_artifact_sync_plan plan Sync_skip));
+    Stdlib.print_endline "AS-11 passed";
+
+    (* AS-12: non-Pr_body kind, session_ok=true, changed=true →
+       Sync_attempt_pr_body. *)
+    List.iter non_pr_body_kinds ~f:(fun kind ->
+        let plan =
+          plan_artifact_sync ~kind ~session_ok:true ~pre:None
+            ~post:(Some "notes")
+        in
+        assert (equal_artifact_sync_plan plan Sync_attempt_pr_body));
+    Stdlib.print_endline "AS-12 passed";
+
+    (* AS-13: non-Pr_body kind, session_ok=true, changed=false → Sync_skip. *)
+    List.iter non_pr_body_kinds ~f:(fun kind ->
+        List.iter
+          [ (None, None); (Some "x", Some "x"); (Some "  ", Some "") ]
+          ~f:(fun (pre, post) ->
+            let plan = plan_artifact_sync ~kind ~session_ok:true ~pre ~post in
+            assert (equal_artifact_sync_plan plan Sync_skip)));
+    Stdlib.print_endline "AS-13 passed";
+
+    (* AS-P4: plan_artifact_sync returns Sync_attempt_pr_body if and only if
+       session_ok ∧ kind ≠ Pr_body ∧ changed. The contract says no
+       opportunistic PATCH for Pr_body, no PATCH on failed sessions, no
+       PATCH on unchanged content. *)
+    let gen_kind = QCheck2.Gen.oneof_list all_kinds in
+    let prop =
+      QCheck2.Test.make ~name:"AS-P4: plan_artifact_sync contract"
+        QCheck2.Gen.(quad gen_kind bool gen_artifact gen_artifact)
+        (fun (kind, session_ok, pre, post) ->
+          try
+            let plan = plan_artifact_sync ~kind ~session_ok ~pre ~post in
+            let attempt = equal_artifact_sync_plan plan Sync_attempt_pr_body in
+            let expected =
+              session_ok
+              && (not (Operation_kind.equal kind Operation_kind.Pr_body))
+              && pr_body_artifact_changed ~pre ~post
+            in
+            Bool.equal attempt expected
+          with _ -> false)
+    in
+    QCheck2.Test.check_exn prop;
+    Stdlib.print_endline "AS-P4 passed";
+
+    (* Helpers for classify_artifact_sync_outcome enumeration. *)
+    let all_patch_results :
+        [ `Ok | `Missing | `Empty | `Patch_failed ] option list =
+      [ None; Some `Ok; Some `Missing; Some `Empty; Some `Patch_failed ]
+    in
+
+    (* AS-20: plan=Sync_skip → Sync_no_op for every patch_result. *)
+    List.iter all_patch_results ~f:(fun patch_result ->
+        let outcome =
+          classify_artifact_sync_outcome ~plan:Sync_skip ~patch_result
+        in
+        assert (equal_artifact_sync_outcome outcome Sync_no_op));
+    Stdlib.print_endline "AS-20 passed";
+
+    (* AS-21: plan=Sync_attempt_pr_body, patch_result=Some `Ok → Sync_delivered. *)
+    let outcome =
+      classify_artifact_sync_outcome ~plan:Sync_attempt_pr_body
+        ~patch_result:(Some `Ok)
+    in
+    assert (equal_artifact_sync_outcome outcome Sync_delivered);
+    Stdlib.print_endline "AS-21 passed";
+
+    (* AS-22: plan=Sync_attempt_pr_body, Some `Patch_failed → Sync_patch_failed. *)
+    let outcome =
+      classify_artifact_sync_outcome ~plan:Sync_attempt_pr_body
+        ~patch_result:(Some `Patch_failed)
+    in
+    assert (equal_artifact_sync_outcome outcome Sync_patch_failed);
+    Stdlib.print_endline "AS-22 passed";
+
+    (* AS-23: plan=Sync_attempt_pr_body, Some (`Missing | `Empty) → Sync_no_op
+       (defensive — unreachable when planner gates on changed). *)
+    List.iter [ `Missing; `Empty ] ~f:(fun pr ->
+        let outcome =
+          classify_artifact_sync_outcome ~plan:Sync_attempt_pr_body
+            ~patch_result:(Some pr)
+        in
+        assert (equal_artifact_sync_outcome outcome Sync_no_op));
+    Stdlib.print_endline "AS-23 passed";
+
+    (* AS-24: plan=Sync_attempt_pr_body, patch_result=None → Sync_no_op
+       (defensive — caller skipped PATCH despite plan). *)
+    let outcome =
+      classify_artifact_sync_outcome ~plan:Sync_attempt_pr_body
+        ~patch_result:None
+    in
+    assert (equal_artifact_sync_outcome outcome Sync_no_op);
+    Stdlib.print_endline "AS-24 passed";
+
+    (* AS-P5: Sync_delivered is returned only when both plan =
+       Sync_attempt_pr_body AND patch_result = Some `Ok. The contract for
+       state mutation: pr_body_delivered is flipped only when a real PATCH
+       succeeded. *)
+    let gen_plan = QCheck2.Gen.oneof_list [ Sync_skip; Sync_attempt_pr_body ] in
+    let gen_patch_result = QCheck2.Gen.oneof_list all_patch_results in
+    let prop =
+      QCheck2.Test.make ~name:"AS-P5: Sync_delivered ⇔ attempt ∧ Ok"
+        QCheck2.Gen.(pair gen_plan gen_patch_result)
+        (fun (plan, patch_result) ->
+          try
+            let outcome = classify_artifact_sync_outcome ~plan ~patch_result in
+            let delivered =
+              equal_artifact_sync_outcome outcome Sync_delivered
+            in
+            let expected =
+              equal_artifact_sync_plan plan Sync_attempt_pr_body
+              && match patch_result with Some `Ok -> true | _ -> false
+            in
+            Bool.equal delivered expected
+          with _ -> false)
+    in
+    QCheck2.Test.check_exn prop;
+    Stdlib.print_endline "AS-P5 passed"
+  in
   ()


### PR DESCRIPTION
## Summary

- Generalize the post-session pr-body sync so the orchestrator detects artifact changes from any session kind (CI/Review/Human/Merge_conflict/Rebase), not just Pr_body. Pr_body's existing delivery path (unlink → apply → `classify_pr_body_respond` → miss-counter) is preserved unchanged.
- Decompose the sync into three pure decision functions in `lib/patch_decision.ml` (`pr_body_artifact_changed`, `plan_artifact_sync`, `classify_artifact_sync_outcome`) plus a thin effectful handler in `bin/main.ml`. PATCH failures during opportunistic sync are log-only — they do not couple unrelated operation outcomes to PR-body state.
- Fix `test/dune`: multiple `(test ...)` stanzas in one directory were sharing modules, breaking `dune build @check`. Each stanza now declares `(modules <name>)`.

Closes #215.

## Test plan

- [x] `dune build` clean
- [x] `dune build @check` clean (now passes after dune fix)
- [x] `dune runtest` clean
- [x] 14 enumerated cases (AS-1..AS-24) + 5 QCheck2 properties (AS-P1..AS-P5) for the new pure functions
- [x] Interleaving properties (PI-1..PI-AH-5) extended with `Apply_sync_outcome` command and INV-A/B/C invariants — `Sync_delivered_k` ⇒ `pr_body_delivered ∧ miss_count=0`; `Sync_no_op_k`/`Sync_patch_failed_k` ⇒ no state mutation; generator never produces `(Pr_body, Sync_delivered_k|Sync_patch_failed_k)`
- [ ] Manual sanity (deferred): trigger a Human op via `send_human_message`, have the agent write to `Project_store.pr_body_artifact_path`, confirm the PR description updates and the event log shows "pr-body: synced opportunistically from human session"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Opportunistically sync the PR body artifact after any session (CI/Review/Human/Rebase/Merge_conflict), not just `Pr_body`, so PR descriptions stay current. Satisfies #215; `Pr_body` flow is unchanged and opportunistic PATCH failures are log-only.

- **New Features**
  - Detect changes via pre/post snapshots and PATCH only when changed (whitespace-only collapses to None; truncation to empty counts as a change but maps to no‑op via `Empty`). On success set `pr_body_delivered=true` and reset the miss count; otherwise leave state unchanged. Re-derive `session_ok` from the final result before planning.
  - Added pure planner/classifier in `lib/patch_decision` (`pr_body_artifact_changed`, `plan_artifact_sync`, `classify_artifact_sync_outcome`) with a thin handler in `bin/main.ml`; introduced `Orchestrator.reset_pr_body_artifact_miss_count`. Guards: hard-fail if `pr_number` is missing; if the patch has no gameplan entry (e.g., ad‑hoc agent), skip with a log.
  - Tests: 14 enumerated cases + 5 QCheck2 properties, interleaving checks with a new `Apply_sync_outcome` command (INV‑A/B/C). Added a `(Some "x", Some "y")` distinct-content boundary case to AS‑11.

- **Bug Fixes**
  - Fixed `test/dune` module sharing by declaring `(modules <name>)` per test stanza, restoring `dune build @check`.
  - Docs/tests: corrected reachability notes for `Sync_no_op` fallthroughs (`Missing`/`Empty`/`None`) to reflect real paths; no behavior change.

<sup>Written for commit 03338110afc3f72e9c6088ece87d0a12cf2668d8. Summary will update on new commits. <a href="https://cubic.dev/pr/flowglad/onton/pull/221?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opportunistic PR body artifact synchronization that detects content changes and syncs them to GitHub even outside of dedicated PR body sessions.

* **Tests**
  * Expanded test coverage for artifact synchronization, including interleaving scenarios and patch decision logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->