### PR TITLE
Preserve inflight human messages on abnormal fiber exit

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -533,12 +533,29 @@ let apply_pr_body_artifact ~runtime ~net ~github ~project_name ~patch_id
           `Patch_failed)
 
 (** Terminal failure — forces [Given_up] so [complete] raises intervention. Used
-    for non-retryable errors (patch not found, PR discovery failed). *)
-let mark_session_failed runtime patch_id =
+    for non-retryable errors (patch not found, PR discovery failed).
+
+    Routes through the pure [Orchestrator.apply_force_complete] decision so any
+    inflight human messages are restored to the inbox rather than silently
+    dropped, and emits a [log_force_complete] audit event so a dispatched
+    [Respond] action always has a matching close in the JSONL log. *)
+let mark_session_failed event_log runtime patch_id =
+  let snapshot = ref None in
   Runtime.update_orchestrator runtime (fun orch ->
-      let orch = Orchestrator.set_session_failed orch patch_id in
-      let orch = Orchestrator.set_tried_fresh orch patch_id in
-      Orchestrator.complete orch patch_id)
+      match Orchestrator.find_agent orch patch_id with
+      | None -> orch
+      | Some before ->
+          let orch' =
+            Orchestrator.apply_force_complete orch patch_id
+              Orchestrator.Unexpected_exception
+          in
+          let after = Orchestrator.agent orch' patch_id in
+          snapshot := Some (before, after);
+          orch');
+  Base.Option.iter !snapshot ~f:(fun (before, after) ->
+      Event_log.log_force_complete event_log ~patch_id
+        ~reason:Orchestrator.Unexpected_exception ~agent_before:before
+        ~agent_after:after)
 
 (** Compute the session mode for the fallback chain.
 
@@ -2443,30 +2460,51 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
      #209 blew through the system FD table. *)
   let hook_mutex = Eio.Mutex.create () in
   let with_busy_guard ~patch_id f =
+    let cancelled = ref false in
     Fun.protect
       ~finally:(fun () ->
-        (* Check-and-complete must be atomic to avoid racing with another
-           fiber that completes the same patch between read and update. *)
-        let was_busy =
-          Runtime.update_orchestrator_returning runtime (fun orch ->
-              match Orchestrator.find_agent orch patch_id with
-              | None -> (orch, false)
-              | Some agent ->
-                  if agent.Patch_agent.busy then
-                    (Orchestrator.complete orch patch_id, true)
-                  else (orch, false))
+        let reason =
+          if !cancelled then Orchestrator.Cancelled
+          else Orchestrator.Unexpected_exception
         in
-        if was_busy then
-          log_event runtime ~patch_id
-            "Forced complete — runner fiber exited with busy=true")
+        (* Check-and-complete must be atomic to avoid racing with another
+           fiber that completes the same patch between read and update.
+           Routes through the pure [apply_force_complete] decision so any
+           inflight human messages are restored to the inbox rather than
+           silently dropped — a regression that previously cost a delivered
+           Brand.refined instruction in the id-brands run. *)
+        let snapshot = ref None in
+        Runtime.update_orchestrator runtime (fun orch ->
+            match Orchestrator.find_agent orch patch_id with
+            | None -> orch
+            | Some before ->
+                if before.Patch_agent.busy then (
+                  let orch' =
+                    Orchestrator.apply_force_complete orch patch_id reason
+                  in
+                  let after = Orchestrator.agent orch' patch_id in
+                  snapshot := Some (before, after);
+                  orch')
+                else orch);
+        Base.Option.iter !snapshot ~f:(fun (before, after) ->
+            Event_log.log_force_complete event_log ~patch_id ~reason
+              ~agent_before:before ~agent_after:after;
+            log_event runtime ~patch_id
+              (Printf.sprintf
+                 "Forced complete (%s) — runner fiber exited with busy=true"
+                 (Orchestrator.show_force_complete_reason reason))))
       (fun () ->
         try f () with
-        | Eio.Cancel.Cancelled _ as exn -> raise exn
+        | Eio.Cancel.Cancelled _ as exn ->
+            cancelled := true;
+            raise exn
         | exn ->
             log_event runtime ~patch_id
               (Printf.sprintf "Unexpected action exception — %s"
-                 (Printexc.to_string exn));
-            mark_session_failed runtime patch_id)
+                 (Printexc.to_string exn))
+        (* Do not call [mark_session_failed] here — the [finally] block
+           routes through [apply_force_complete ~reason:Unexpected_exception]
+           which subsumes its effect. *))
   in
   let rec loop sw =
     let gameplan = Runtime.read runtime (fun snap -> snap.Runtime.gameplan) in
@@ -2556,7 +2594,7 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
               | None ->
                   log_event runtime ~patch_id
                     "Skipping start — patch not found in gameplan";
-                  mark_session_failed runtime patch_id;
+                  mark_session_failed event_log runtime patch_id;
                   None
               | Some patch ->
                   Some

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -553,9 +553,15 @@ let mark_session_failed event_log runtime patch_id =
           snapshot := Some (before, after);
           orch');
   Base.Option.iter !snapshot ~f:(fun (before, after) ->
-      Event_log.log_force_complete event_log ~patch_id
-        ~reason:Orchestrator.Unexpected_exception ~agent_before:before
-        ~agent_after:after)
+      (* Only emit a force-complete audit event if the agent was actually
+         busy. The "patch not found in gameplan" call site at the Start
+         dispatch fires this before [with_busy_guard] runs, so no Respond
+         was ever dispatched — logging a force-complete close in that case
+         would falsely claim a Respond/close pair. *)
+      if before.Patch_agent.busy then
+        Event_log.log_force_complete event_log ~patch_id
+          ~reason:Orchestrator.Unexpected_exception ~agent_before:before
+          ~agent_after:after)
 
 (** Compute the session mode for the fallback chain.
 

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -2461,11 +2461,22 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
   let hook_mutex = Eio.Mutex.create () in
   let with_busy_guard ~patch_id f =
     let cancelled = ref false in
+    let exception_raised = ref false in
     Fun.protect
       ~finally:(fun () ->
+        (* Three exit modes:
+           - cancelled: f raised [Eio.Cancel.Cancelled]; clean teardown.
+           - exception_raised: f raised any other exception; session
+             fallback must advance.
+           - neither: f returned normally (already called [complete]
+             itself, so the busy=false guard below skips the rest). The
+             reason value is unused in that case, but [Cancelled] is the
+             safe default — it leaves [session_fallback] untouched if a
+             future code path in [f] ever exits normally with [busy=true]. *)
         let reason =
           if !cancelled then Orchestrator.Cancelled
-          else Orchestrator.Unexpected_exception
+          else if !exception_raised then Orchestrator.Unexpected_exception
+          else Orchestrator.Cancelled
         in
         (* Check-and-complete must be atomic to avoid racing with another
            fiber that completes the same patch between read and update.
@@ -2499,6 +2510,7 @@ let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
             cancelled := true;
             raise exn
         | exn ->
+            exception_raised := true;
             log_event runtime ~patch_id
               (Printf.sprintf "Unexpected action exception — %s"
                  (Printexc.to_string exn))

--- a/lib/event_log.ml
+++ b/lib/event_log.ml
@@ -80,6 +80,18 @@ let log_complete t ~patch_id ~result ~agent_before ~agent_after =
          ("agent_after", agent_json agent_after);
        ])
 
+let log_force_complete t ~patch_id ~reason ~agent_before ~agent_after =
+  write_entry t
+    (`Assoc
+       [
+         ("ts", `String (timestamp ()));
+         ("kind", `String "force_complete");
+         ("patch_id", patch_id_json patch_id);
+         ("reason", `String (Orchestrator.show_force_complete_reason reason));
+         ("agent_before", agent_json agent_before);
+         ("agent_after", agent_json agent_after);
+       ])
+
 let log_conflict_rebase t ~patch_id ~result ~decision ~agent_before ~agent_after
     =
   write_entry t

--- a/lib/event_log.mli
+++ b/lib/event_log.mli
@@ -37,6 +37,19 @@ val log_complete :
   unit
 (** Log a session completion with before/after state. *)
 
+val log_force_complete :
+  t ->
+  patch_id:Patch_id.t ->
+  reason:Orchestrator.force_complete_reason ->
+  agent_before:Patch_agent.t ->
+  agent_after:Patch_agent.t ->
+  unit
+(** Log a forced completion triggered by an abnormally-exiting runner fiber
+    (cancellation or unexpected exception). Distinct from [log_complete]: the
+    LLM session itself produced no [session_result]. Emitted by both the
+    [with_busy_guard] finally and [mark_session_failed] so every dispatched
+    [Orchestrator.Respond] action has a matching close in the event log. *)
+
 val log_conflict_rebase :
   t ->
   patch_id:Patch_id.t ->

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -616,7 +616,7 @@ type force_complete_reason = Cancelled | Unexpected_exception
 let apply_force_complete t patch_id reason =
   match find_agent t patch_id with
   | None -> t
-  | Some a ->
+  | Some _ ->
       let t =
         match reason with
         | Cancelled -> t
@@ -624,6 +624,12 @@ let apply_force_complete t patch_id reason =
             let t = set_session_failed t patch_id in
             set_tried_fresh t patch_id
       in
+      (* Re-read the agent post-transition so the busy/inflight routing
+         decision reflects any state mutated by the [reason] branch. Today
+         [set_session_failed]/[set_tried_fresh] don't touch [busy] or
+         [inflight_human_messages], but reading the stale snapshot would
+         silently break if a future helper ever cleared inflight. *)
+      let a = agent t patch_id in
       if not a.Patch_agent.busy then t
       else if List.is_empty a.Patch_agent.inflight_human_messages then
         complete t patch_id

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -600,6 +600,35 @@ let complete_failed t patch_id =
   in
   if has_messages then enqueue t patch_id Operation_kind.Human else t
 
+type force_complete_reason = Cancelled | Unexpected_exception
+[@@deriving show, eq, sexp_of]
+
+(** Pure applicator for runner fibers that exited abnormally while the agent was
+    [busy]. Single source of truth for the two effectful sites in [bin/main.ml]
+    that previously called [complete] directly and silently dropped
+    [inflight_human_messages]:
+    - [with_busy_guard]'s [Fun.protect] finally
+    - [mark_session_failed]
+
+    The reason that a fiber bailed is carried as data so the same pure function
+    can serve both cancellation (clean teardown) and unexpected exception
+    (poisoned session) paths. *)
+let apply_force_complete t patch_id reason =
+  match find_agent t patch_id with
+  | None -> t
+  | Some a ->
+      let t =
+        match reason with
+        | Cancelled -> t
+        | Unexpected_exception ->
+            let t = set_session_failed t patch_id in
+            set_tried_fresh t patch_id
+      in
+      if not a.Patch_agent.busy then t
+      else if List.is_empty a.Patch_agent.inflight_human_messages then
+        complete t patch_id
+      else complete_failed t patch_id
+
 let apply_session_result t patch_id result =
   match result with
   | Session_ok ->

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -236,6 +236,29 @@ val apply_respond_outcome :
     increment_pr_body_artifact_miss_count (does NOT set_pr_body_delivered — the
     reconciler re-enqueues Pr_body naturally). *)
 
+type force_complete_reason = Cancelled | Unexpected_exception
+[@@deriving show, eq, sexp_of]
+
+val apply_force_complete : t -> Patch_id.t -> force_complete_reason -> t
+(** Pure applicator for runner fibers that exited abnormally while the agent was
+    [busy]. The single source of truth for the [bin/main.ml] [with_busy_guard]
+    finally and [mark_session_failed] sites that previously called [complete]
+    directly — and so silently dropped [inflight_human_messages].
+
+    Semantics:
+    - Unknown patch: identity.
+    - [Unexpected_exception]: always advances [session_fallback] via
+      [set_session_failed] then [set_tried_fresh] (preserving the prior
+      [mark_session_failed] semantics, which pushed [Fresh_available] all the
+      way to [Given_up]). This still runs even when the agent is not busy.
+    - [Cancelled]: leaves [session_fallback] alone — a clean cancel should not
+      poison the fallback chain.
+    - If [busy] AND [inflight_human_messages <> []]: routes through
+      [complete_failed], which restores inflight back to [human_messages] and
+      re-enqueues [Operation_kind.Human].
+    - If [busy] AND inflight is empty: routes through plain [complete].
+    - If not [busy]: skip the complete step. *)
+
 (** Side effects emitted by rebase result application. The runner is responsible
     for executing these (e.g. force-pushing the branch to the remote). Modeled
     as data so property tests can assert on effect presence. *)

--- a/test/test_interleaving_properties.ml
+++ b/test/test_interleaving_properties.ml
@@ -81,6 +81,8 @@ type push_result_kind =
    [gen_sync_outcome_command] below. *)
 type sync_outcome_kind = Sync_no_op_k | Sync_delivered_k | Sync_patch_failed_k
 
+type force_reason_kind = Cancelled_k | Unexpected_k
+
 type command =
   | Apply_poll of { patch_idx : int; poll_kind : poll_kind }
   | Reconcile
@@ -104,6 +106,11 @@ type command =
       kind : Operation_kind.t;
       outcome : sync_outcome_kind;
     }
+  | Force_complete of { patch_idx : int; reason : force_reason_kind }
+      (** Models a runner fiber exiting abnormally while the agent is busy:
+          either a clean cancellation ([Cancelled_k]) or an unhandled exception
+          ([Unexpected_k]). Routes through [Orchestrator.apply_force_complete]
+          so I-14 (human messages never lost) covers this transition. *)
 
 let show_poll_kind = function
   | Poll_normal -> "Normal"
@@ -170,6 +177,13 @@ let show_command = function
       Printf.sprintf "Apply_sync_outcome(%d, %s, %s)" patch_idx
         (Operation_kind.to_label kind)
         (show_sync_outcome_kind outcome)
+  | Force_complete { patch_idx; reason } ->
+      let r =
+        match reason with
+        | Cancelled_k -> "Cancelled"
+        | Unexpected_k -> "Unexpected"
+      in
+      Printf.sprintf "Force_complete(%d, %s)" patch_idx r
 
 (* -- Ad-hoc patch helpers -- *)
 
@@ -255,6 +269,12 @@ let gen_sync_outcome_command ~gen_idx =
     let* outcome = gen_outcome_for kind in
     return (Apply_sync_outcome { patch_idx; kind; outcome }))
 
+let gen_force_reason_kind = QCheck2.Gen.oneof_list [ Cancelled_k; Unexpected_k ]
+
+let to_force_complete_reason = function
+  | Cancelled_k -> Orchestrator.Cancelled
+  | Unexpected_k -> Orchestrator.Unexpected_exception
+
 let gen_command ~n =
   let total = n + max_adhoc in
   QCheck2.Gen.(
@@ -286,6 +306,9 @@ let gen_command ~n =
         map (fun i -> Remove_adhoc i) (int_range 0 (max_adhoc - 1));
         map (fun i -> Discover_pr i) gen_idx;
         gen_sync_outcome_command ~gen_idx;
+        map2
+          (fun i r -> Force_complete { patch_idx = i; reason = r })
+          gen_idx gen_force_reason_kind;
       ])
 
 let gen_command_seq ~n ~len =
@@ -322,6 +345,9 @@ let gen_atomic_command ~n =
         map (fun i -> Remove_adhoc i) (int_range 0 (max_adhoc - 1));
         map (fun i -> Discover_pr i) gen_idx;
         gen_sync_outcome_command ~gen_idx;
+        map2
+          (fun i r -> Force_complete { patch_idx = i; reason = r })
+          gen_idx gen_force_reason_kind;
       ])
 
 let gen_atomic_command_seq ~n ~len =
@@ -569,6 +595,10 @@ let rec apply_command orch patches cmd =
           | Sync_delivered_k ->
               let orch = Orchestrator.set_pr_body_delivered orch pid true in
               Orchestrator.reset_pr_body_artifact_miss_count orch pid))
+  | Force_complete { patch_idx; reason } ->
+      let pid = resolve_pid patches patch_idx in
+      Orchestrator.apply_force_complete orch pid
+        (to_force_complete_reason reason)
 
 type poll_log_info = {
   agent_before : Patch_agent.t;
@@ -620,7 +650,7 @@ let rec apply_command_with_logs orch patches cmd =
   | Reconcile | Runner_tick | Complete _ | Apply_session_result _
   | Apply_rebase_result _ | Send_human_message _ | Reset_intervention _
   | Apply_conflict_rebase_result _ | Apply_rebase_push_result _ | Add_adhoc _
-  | Remove_adhoc _ | Discover_pr _ | Apply_sync_outcome _ ->
+  | Remove_adhoc _ | Discover_pr _ | Apply_sync_outcome _ | Force_complete _ ->
       (apply_command orch patches cmd, None)
 
 (* ========== Log invariant checks ========== *)
@@ -969,7 +999,8 @@ let check_sync_outcome_invariants ~patches ~prev_agents ~curr_orch cmd =
   | Apply_poll _ | Reconcile | Runner_tick | Complete _ | Apply_session_result _
   | Apply_rebase_result _ | Send_human_message _ | Reset_intervention _
   | Atomic_poll_reconcile _ | Apply_conflict_rebase_result _
-  | Apply_rebase_push_result _ | Add_adhoc _ | Remove_adhoc _ | Discover_pr _ ->
+  | Apply_rebase_push_result _ | Add_adhoc _ | Remove_adhoc _ | Discover_pr _
+  | Force_complete _ ->
       ()
 
 (* ========== Combined check ========== *)
@@ -1022,7 +1053,7 @@ let delivered_pid_of_cmd cmd patches =
   | Apply_rebase_result _ | Send_human_message _ | Reset_intervention _
   | Atomic_poll_reconcile _ | Apply_conflict_rebase_result _
   | Apply_rebase_push_result _ | Add_adhoc _ | Remove_adhoc _ | Discover_pr _
-  | Apply_sync_outcome _ ->
+  | Apply_sync_outcome _ | Force_complete _ ->
       None
 
 let removed_pids_of_cmd cmd prev_removed =
@@ -1032,7 +1063,7 @@ let removed_pids_of_cmd cmd prev_removed =
   | Apply_session_result _ | Apply_rebase_result _ | Send_human_message _
   | Reset_intervention _ | Atomic_poll_reconcile _
   | Apply_conflict_rebase_result _ | Apply_rebase_push_result _ | Discover_pr _
-  | Apply_sync_outcome _ ->
+  | Apply_sync_outcome _ | Force_complete _ ->
       prev_removed
 
 let run_sequence ?(debug = false) orch patches cmds =
@@ -1057,7 +1088,8 @@ let run_sequence ?(debug = false) orch patches cmds =
           | Apply_session_result _ | Apply_rebase_result _
           | Send_human_message _ | Reset_intervention _
           | Atomic_poll_reconcile _ | Apply_conflict_rebase_result _
-          | Apply_rebase_push_result _ | Discover_pr _ | Apply_sync_outcome _ ->
+          | Apply_rebase_push_result _ | Discover_pr _ | Apply_sync_outcome _
+          | Force_complete _ ->
               merged_logged
         in
         let curr_merged = merged_set_of o in

--- a/test/test_interleaving_properties.ml
+++ b/test/test_interleaving_properties.ml
@@ -80,7 +80,6 @@ type push_result_kind =
    planner). The interleaving generator preserves that contract — see
    [gen_sync_outcome_command] below. *)
 type sync_outcome_kind = Sync_no_op_k | Sync_delivered_k | Sync_patch_failed_k
-
 type force_reason_kind = Cancelled_k | Unexpected_k
 
 type command =

--- a/test/test_state_machine_properties.ml
+++ b/test/test_state_machine_properties.ml
@@ -461,45 +461,48 @@ let gen_force_complete_reason =
   QCheck2.Gen.oneof_list Orchestrator.[ Cancelled; Unexpected_exception ]
 
 (** Build an orchestrator + patch_id where the agent is busy with the given
-    operation kind, optionally carrying inflight human messages (when
-    [kind = Human] AND messages were enqueued before fire). Mirrors the live
-    [accept_message → fire(Respond k)] code path so the inflight slot is
-    populated by the same [Patch_agent.respond] used in production. *)
+    operation kind, optionally carrying inflight human messages (only when
+    [kind = Human]; messages are ignored for other kinds since they would
+    enqueue Human, contaminating the queue with a higher-priority operation and
+    breaking [Patch_agent.respond]'s "k == highest_priority" precondition).
+    Mirrors the live [accept_message → fire(Respond k)] code path so the
+    inflight slot is populated by the same [Patch_agent.respond] used in
+    production.
+
+    The setup deliberately skips [tick_all] reconciliation: those passes enqueue
+    arbitrary higher-priority operations (e.g. Rebase) that would similarly fail
+    the highest-priority precondition. We construct the minimal idle-with-PR
+    state by hand and enqueue only the kind under test, so [fire] always
+    satisfies its preconditions and the property runs on every input rather than
+    vacuously passing on setup failures. *)
 let make_busy_orch ~patches ~kind ~messages =
   match patches with
   | [] -> None
-  | first :: _ -> (
+  | first :: _ ->
       let pid = first.Patch.id in
       let orch = Orchestrator.create ~patches ~main_branch:main in
-      let rec tick_all o n =
-        if n = 0 then o
-        else
-          let o, _effects, _actions =
-            Patch_controller.tick o ~project_name:"test-project"
-              ~gameplan:(make_gameplan patches)
-          in
-          tick_all o (n - 1)
-      in
-      let orch = tick_all orch (List.length patches + 1) in
       let orch = Orchestrator.set_pr_number orch pid (Pr_number.of_int 1) in
       let orch = Orchestrator.set_pr_body_delivered orch pid true in
-      let orch = Orchestrator.complete orch pid in
-      let orch =
-        List.fold messages ~init:orch ~f:(fun acc msg ->
-            Orchestrator.send_human_message acc pid msg)
-      in
       let orch =
         match kind with
         | Operation_kind.Human ->
-            (* [send_human_message] above already enqueues Human. *)
-            orch
+            (* [send_human_message] both appends to [human_messages] and
+               enqueues [Human], so no separate [enqueue] is needed. *)
+            List.fold messages ~init:orch ~f:(fun acc msg ->
+                Orchestrator.send_human_message acc pid msg)
         | Operation_kind.Rebase | Operation_kind.Merge_conflict
         | Operation_kind.Ci | Operation_kind.Review_comments
         | Operation_kind.Pr_body ->
             Orchestrator.enqueue orch pid kind
       in
-      try Some (Orchestrator.fire orch (Orchestrator.Respond (pid, kind)), pid)
-      with Invalid_argument _ -> None)
+      let orch =
+        if
+          Operation_kind.equal kind Operation_kind.Human
+          && List.is_empty messages
+        then Orchestrator.enqueue orch pid Operation_kind.Human
+        else orch
+      in
+      Some (Orchestrator.fire orch (Orchestrator.Respond (pid, kind)), pid)
 
 let count_messages (a : Patch_agent.t) =
   List.length a.human_messages + List.length a.inflight_human_messages

--- a/test/test_state_machine_properties.ml
+++ b/test/test_state_machine_properties.ml
@@ -639,18 +639,21 @@ let () =
 (** P13: applying force_complete twice in a row is the same as applying it once.
     After the first call the agent is idle and (for [Unexpected_exception])
     [session_fallback] has already advanced, so a second call must be the
-    identity. *)
+    identity. Exercises both the [complete] path (inflight empty) and the
+    [complete_failed] path (inflight non-empty) so a non-idempotence in either
+    branch fails the property. *)
 let () =
   let prop =
     QCheck2.Test.make ~name:"P13: force_complete on idle agent is identity"
       ~count:300
       QCheck2.Gen.(
-        triple Onton_test_support.Test_generators.gen_patch_list_unique
+        quad Onton_test_support.Test_generators.gen_patch_list_unique
           Onton_test_support.Test_generators.gen_feedback_kind
-          gen_force_complete_reason)
-      (fun (patches, kind, reason) ->
+          gen_force_complete_reason
+          (oneof_list [ []; [ "msg" ] ]))
+      (fun (patches, kind, reason, messages) ->
         safe (fun () ->
-            match make_busy_orch ~patches ~kind ~messages:[ "msg" ] with
+            match make_busy_orch ~patches ~kind ~messages with
             | None -> true
             | Some (orch, pid) ->
                 let orch1 = Orchestrator.apply_force_complete orch pid reason in

--- a/test/test_state_machine_properties.ml
+++ b/test/test_state_machine_properties.ml
@@ -446,4 +446,255 @@ let () =
   QCheck2.Test.check_exn prop_p8;
   Stdlib.print_endline "P8 passed"
 
+(* ========== Force-complete properties (P9–P14) ==========
+
+   Cover [Orchestrator.apply_force_complete], the pure decision invoked when
+   a runner fiber exits abnormally (cancellation or unhandled exception)
+   while [busy]. The decision must:
+   - never silently drop [inflight_human_messages] (regression: a delivered
+     human instruction was lost in the id-brands run on 2026-04-29)
+   - re-enqueue [Operation_kind.Human] iff the inflight slot was non-empty
+   - clear [busy], [current_op], [current_message_id], and the inflight slot
+   - advance [session_fallback] iff [reason = Unexpected_exception] *)
+
+let gen_force_complete_reason =
+  QCheck2.Gen.oneof_list Orchestrator.[ Cancelled; Unexpected_exception ]
+
+(** Build an orchestrator + patch_id where the agent is busy with the given
+    operation kind, optionally carrying inflight human messages (when
+    [kind = Human] AND messages were enqueued before fire). Mirrors the live
+    [accept_message → fire(Respond k)] code path so the inflight slot is
+    populated by the same [Patch_agent.respond] used in production. *)
+let make_busy_orch ~patches ~kind ~messages =
+  match patches with
+  | [] -> None
+  | first :: _ -> (
+      let pid = first.Patch.id in
+      let orch = Orchestrator.create ~patches ~main_branch:main in
+      let rec tick_all o n =
+        if n = 0 then o
+        else
+          let o, _effects, _actions =
+            Patch_controller.tick o ~project_name:"test-project"
+              ~gameplan:(make_gameplan patches)
+          in
+          tick_all o (n - 1)
+      in
+      let orch = tick_all orch (List.length patches + 1) in
+      let orch = Orchestrator.set_pr_number orch pid (Pr_number.of_int 1) in
+      let orch = Orchestrator.set_pr_body_delivered orch pid true in
+      let orch = Orchestrator.complete orch pid in
+      let orch =
+        List.fold messages ~init:orch ~f:(fun acc msg ->
+            Orchestrator.send_human_message acc pid msg)
+      in
+      let orch =
+        match kind with
+        | Operation_kind.Human ->
+            (* [send_human_message] above already enqueues Human. *)
+            orch
+        | Operation_kind.Rebase | Operation_kind.Merge_conflict
+        | Operation_kind.Ci | Operation_kind.Review_comments
+        | Operation_kind.Pr_body ->
+            Orchestrator.enqueue orch pid kind
+      in
+      try Some (Orchestrator.fire orch (Orchestrator.Respond (pid, kind)), pid)
+      with Invalid_argument _ -> None)
+
+let count_messages (a : Patch_agent.t) =
+  List.length a.human_messages + List.length a.inflight_human_messages
+
+(** P9: message preservation — for any busy agent and any reason, the total of
+    [human_messages + inflight_human_messages] never decreases. Strengthens the
+    existing I-14 (Human messages never lost) at the unit level. *)
+let () =
+  let prop =
+    QCheck2.Test.make ~name:"P9: force_complete preserves human messages"
+      ~count:500
+      QCheck2.Gen.(
+        triple Onton_test_support.Test_generators.gen_patch_list_unique
+          Onton_test_support.Test_generators.gen_feedback_kind
+          (let* msgs =
+             list_size (int_range 0 4)
+               (string_size ~gen:printable (int_range 1 40))
+           in
+           pair (return msgs) gen_force_complete_reason))
+      (fun (patches, kind, (messages, reason)) ->
+        safe (fun () ->
+            (* Inflight is only populated when fire(Human) consumes
+               [human_messages]. For non-Human kinds the messages remain in
+               [human_messages] and the property is trivial; we still exercise
+               the path to confirm no field is mishandled. *)
+            match make_busy_orch ~patches ~kind ~messages with
+            | None -> true
+            | Some (orch, pid) ->
+                let before = Orchestrator.agent orch pid in
+                let orch' = Orchestrator.apply_force_complete orch pid reason in
+                let after = Orchestrator.agent orch' pid in
+                count_messages after >= count_messages before))
+  in
+  QCheck2.Test.check_exn prop;
+  Stdlib.print_endline "P9 passed"
+
+(** P10: post-state idle — when the agent was busy before, it is no longer busy
+    after, [current_op] and [current_message_id] are cleared, and the inflight
+    slot is empty (its contents have been moved to [human_messages] when
+    non-empty). *)
+let () =
+  let prop =
+    QCheck2.Test.make ~name:"P10: force_complete clears busy state" ~count:300
+      QCheck2.Gen.(
+        triple Onton_test_support.Test_generators.gen_patch_list_unique
+          Onton_test_support.Test_generators.gen_feedback_kind
+          gen_force_complete_reason)
+      (fun (patches, kind, reason) ->
+        safe (fun () ->
+            match make_busy_orch ~patches ~kind ~messages:[ "msg" ] with
+            | None -> true
+            | Some (orch, pid) ->
+                let orch' = Orchestrator.apply_force_complete orch pid reason in
+                let after = Orchestrator.agent orch' pid in
+                (not after.busy)
+                && Option.is_none after.current_op
+                && Option.is_none after.current_message_id
+                && List.is_empty after.inflight_human_messages))
+  in
+  QCheck2.Test.check_exn prop;
+  Stdlib.print_endline "P10 passed"
+
+(** P11: Human re-enqueue iff inflight was non-empty. After force-complete,
+    [Operation_kind.Human] is in the queue iff there was at least one inflight
+    message at fire time. *)
+let () =
+  let prop =
+    QCheck2.Test.make ~name:"P11: force_complete re-enqueues Human iff inflight"
+      ~count:500
+      QCheck2.Gen.(
+        triple Onton_test_support.Test_generators.gen_patch_list_unique
+          (let* msgs =
+             list_size (int_range 0 3)
+               (string_size ~gen:printable (int_range 1 40))
+           in
+           return msgs)
+          gen_force_complete_reason)
+      (fun (patches, messages, reason) ->
+        safe (fun () ->
+            (* Use Human as the kind so messages move into [inflight] on fire. *)
+            match
+              make_busy_orch ~patches ~kind:Operation_kind.Human ~messages
+            with
+            | None -> true
+            | Some (orch, pid) ->
+                let before = Orchestrator.agent orch pid in
+                let orch' = Orchestrator.apply_force_complete orch pid reason in
+                let after = Orchestrator.agent orch' pid in
+                let had_inflight =
+                  not (List.is_empty before.inflight_human_messages)
+                in
+                let human_in_queue =
+                  List.mem after.queue Operation_kind.Human
+                    ~equal:Operation_kind.equal
+                in
+                Bool.equal had_inflight human_in_queue))
+  in
+  QCheck2.Test.check_exn prop;
+  Stdlib.print_endline "P11 passed"
+
+(** P12: session_fallback advances iff reason is Unexpected_exception. The
+    [Cancelled] path leaves [session_fallback] unchanged; clean shutdown must
+    not poison the fallback chain. [Unexpected_exception] runs both
+    [set_session_failed] and [set_tried_fresh], pushing the agent two steps
+    along the chain (Fresh_available → Tried_fresh → Given_up). *)
+let () =
+  let prop =
+    QCheck2.Test.make ~name:"P12: session_fallback advances iff Unexpected"
+      ~count:300
+      QCheck2.Gen.(
+        triple Onton_test_support.Test_generators.gen_patch_list_unique
+          Onton_test_support.Test_generators.gen_feedback_kind
+          gen_force_complete_reason)
+      (fun (patches, kind, reason) ->
+        safe (fun () ->
+            match make_busy_orch ~patches ~kind ~messages:[] with
+            | None -> true
+            | Some (orch, pid) -> (
+                let before = Orchestrator.agent orch pid in
+                let orch' = Orchestrator.apply_force_complete orch pid reason in
+                let after = Orchestrator.agent orch' pid in
+                match reason with
+                | Orchestrator.Cancelled ->
+                    Patch_agent.equal_session_fallback before.session_fallback
+                      after.session_fallback
+                | Orchestrator.Unexpected_exception ->
+                    let expected =
+                      Patch_agent.set_tried_fresh
+                        (Patch_agent.set_session_failed before)
+                    in
+                    Patch_agent.equal_session_fallback expected.session_fallback
+                      after.session_fallback)))
+  in
+  QCheck2.Test.check_exn prop;
+  Stdlib.print_endline "P12 passed"
+
+(** P13: applying force_complete twice in a row is the same as applying it once.
+    After the first call the agent is idle and (for [Unexpected_exception])
+    [session_fallback] has already advanced, so a second call must be the
+    identity. *)
+let () =
+  let prop =
+    QCheck2.Test.make ~name:"P13: force_complete on idle agent is identity"
+      ~count:300
+      QCheck2.Gen.(
+        triple Onton_test_support.Test_generators.gen_patch_list_unique
+          Onton_test_support.Test_generators.gen_feedback_kind
+          gen_force_complete_reason)
+      (fun (patches, kind, reason) ->
+        safe (fun () ->
+            match make_busy_orch ~patches ~kind ~messages:[ "msg" ] with
+            | None -> true
+            | Some (orch, pid) ->
+                let orch1 = Orchestrator.apply_force_complete orch pid reason in
+                let after1 = Orchestrator.agent orch1 pid in
+                if after1.busy then false
+                else
+                  let orch2 =
+                    Orchestrator.apply_force_complete orch1 pid reason
+                  in
+                  let after2 = Orchestrator.agent orch2 pid in
+                  Patch_agent.equal after1 after2))
+  in
+  QCheck2.Test.check_exn prop;
+  Stdlib.print_endline "P13 passed"
+
+(** P14: unknown patch is identity. [apply_force_complete] on a [patch_id] not
+    present in the orchestrator must not raise and must leave the state
+    untouched. *)
+let () =
+  let prop =
+    QCheck2.Test.make ~name:"P14: force_complete on unknown patch is identity"
+      ~count:200
+      QCheck2.Gen.(
+        triple Onton_test_support.Test_generators.gen_patch_list_unique
+          Onton_test_support.Test_generators.gen_patch_id
+          gen_force_complete_reason)
+      (fun (patches, missing_pid, reason) ->
+        safe (fun () ->
+            (* Skip when the random pid happens to clash with one of the
+               generated patches. *)
+            if
+              List.exists patches ~f:(fun (p : Patch.t) ->
+                  Patch_id.equal p.Patch.id missing_pid)
+            then true
+            else
+              let orch = Orchestrator.create ~patches ~main_branch:main in
+              let orch' =
+                Orchestrator.apply_force_complete orch missing_pid reason
+              in
+              List.equal Patch_agent.equal
+                (Orchestrator.all_agents orch)
+                (Orchestrator.all_agents orch')))
+  in
+  QCheck2.Test.check_exn prop;
+  Stdlib.print_endline "P14 passed"
+
 let () = Stdlib.print_endline "all state machine properties passed"


### PR DESCRIPTION
## Summary

- When a runner fiber exited abnormally while busy (Eio cancellation or unhandled exception), `with_busy_guard`'s finally and `mark_session_failed` both called `Orchestrator.complete` directly. `Patch_agent.complete` clears `inflight_human_messages` without restoring them, so a delivered Human message could be silently dropped — observed live in the `id-brands` run on 2026-04-29 where a `Brand.refined` instruction to patch 2 was lost.
- Introduce a single pure decision `Orchestrator.apply_force_complete` (`force_complete_reason = Cancelled | Unexpected_exception`) that both effectful sites delegate to. It routes through `complete_failed` when inflight is non-empty (restoring messages and re-enqueuing `Human`) and through `complete` otherwise; for `Unexpected_exception` it also advances `session_fallback`, preserving the prior `mark_session_failed` semantics.
- New `Event_log.log_force_complete` writes a `kind: "force_complete"` JSONL record with the reason, so every dispatched `Respond` action now has a matching close in the audit trail.

## Property coverage

- Six pure properties (P9–P14) in `test/test_state_machine_properties.ml`: message preservation, busy clearance, Human re-enqueue iff inflight, `session_fallback` advance iff `Unexpected_exception`, idempotence on idle agents, identity on unknown patches.
- New `Force_complete { patch_idx; reason }` command in `test/test_interleaving_properties.ml`, plumbed through `gen_command`, `gen_atomic_command`, `apply_command`, and the exhaustive matches. Existing invariant **I-14 (human messages never lost)** now witnesses this transition across all interleavings.
- Both suites were verified to falsify when the fix is reverted to the buggy `complete`-only behaviour.

## Test plan

- [x] `dune build` clean under warnings-as-errors
- [x] `dune runtest` passes (P1–P14, PI-1..PI-17, plus all existing suites)
- [x] Confirmed `dune exec test/test_state_machine_properties.exe` fails P9 when `apply_force_complete` is reverted to always-`complete`
- [x] Confirmed `dune exec test/test_interleaving_properties.exe` reports `I-14 human_messages_preserved violated` under the same revert
- [ ] Watch the next `id-brands`-style run for a `kind: "force_complete"` event in `events.jsonl` after a cancelled human delivery

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves in-flight Human messages when a runner fiber exits while busy by routing abnormal exits through a single force-complete decision and logging a matching audit event with before/after state. Also guards event emission so we only log closes for actually-dispatched Responds.

- **Bug Fixes**
  - Added Orchestrator.apply_force_complete (Cancelled | Unexpected_exception) and used it in with_busy_guard finally and mark_session_failed. If busy with inflight, restore messages and re-enqueue Human; otherwise complete. On Unexpected_exception, advance session_fallback. Always clear busy/current_op/current_message_id and re-read the agent after the transition.
  - Added Event_log.log_force_complete. with_busy_guard always emits before/after; mark_session_failed emits only when the agent was busy to avoid a close when no Respond was dispatched. Ensures every dispatched Respond has a matching audit event.
  - with_busy_guard now distinguishes Cancelled vs unexpected exceptions; reason is computed in finally. Normal return defaults to Cancelled. Removed the redundant mark_session_failed call in the handler.
  - Tests: added P9–P14 and a Force_complete interleaving command. Fixed property setup to avoid vacuous passes and ensure both inflight and empty branches are exercised.

<sup>Written for commit 20e46cceca39bfd5effb95d597d7eb651b6b830e. Summary will update on new commits. <a href="https://cubic.dev/pr/flowglad/onton/pull/222?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

