### PR TITLE
Open the patch-management modal from the overview

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1392,8 +1392,14 @@ let input_fiber ~runtime ~process_mgr ~net ~github ~list_selected ~detail_scroll
           | Term.Key.Escape -> input_mode := Tui_input.Normal
           | Term.Key.Char 'm' -> (
               input_mode := Tui_input.Normal;
-              match !view_mode with
-              | Tui.Detail_view patch_id ->
+              let target_patch_id =
+                match !view_mode with
+                | Tui.Detail_view patch_id -> Some patch_id
+                | Tui.List_view -> selected_pid ()
+                | Tui.Timeline_view -> None
+              in
+              match target_patch_id with
+              | Some patch_id ->
                   let busy, has_pr =
                     Runtime.read runtime (fun snap ->
                         let agent =
@@ -1411,11 +1417,17 @@ let input_fiber ~runtime ~process_mgr ~net ~github ~list_selected ~detail_scroll
                     Runtime.update_orchestrator runtime (fun orch ->
                         Orchestrator.mark_merged orch patch_id);
                     log_event runtime ~patch_id "Force-marked as merged")
-              | Tui.List_view | Tui.Timeline_view -> ())
+              | None -> ())
           | Term.Key.Char 'a' -> (
-              match !view_mode with
-              | Tui.Detail_view patch_id -> (
-                  input_mode := Tui_input.Normal;
+              input_mode := Tui_input.Normal;
+              let target_patch_id =
+                match !view_mode with
+                | Tui.Detail_view patch_id -> Some patch_id
+                | Tui.List_view -> selected_pid ()
+                | Tui.Timeline_view -> None
+              in
+              match target_patch_id with
+              | Some patch_id -> (
                   let enabled_after =
                     Runtime.update_orchestrator_returning runtime (fun orch ->
                         match Orchestrator.find_agent orch patch_id with
@@ -1432,7 +1444,7 @@ let input_fiber ~runtime ~process_mgr ~net ~github ~list_selected ~detail_scroll
                   | Some false ->
                       log_event runtime ~patch_id "Automerge disabled"
                   | None -> ())
-              | Tui.List_view | Tui.Timeline_view -> ())
+              | None -> ())
           | Term.Key.Char _ | Term.Key.Enter | Term.Key.Tab | Term.Key.Paste _
           | Term.Key.Backspace | Term.Key.Up | Term.Key.Down | Term.Key.Left
           | Term.Key.Right | Term.Key.Home | Term.Key.End | Term.Key.Page_up
@@ -1893,7 +1905,8 @@ let input_fiber ~runtime ~process_mgr ~net ~github ~list_selected ~detail_scroll
           | Term.Key.Char 'm'
             when match !view_mode with
                  | Tui.Detail_view _ -> true
-                 | Tui.List_view | Tui.Timeline_view -> false ->
+                 | Tui.List_view -> Option.is_some (selected_pid ())
+                 | Tui.Timeline_view -> false ->
               input_mode := Tui_input.Manage_patch;
               loop ()
           | Term.Key.Char _ | Term.Key.Enter | Term.Key.Tab | Term.Key.Backspace

--- a/lib/tui.ml
+++ b/lib/tui.ml
@@ -1123,7 +1123,7 @@ let render_footer ~width ~view_mode ?prompt_line () =
         | List_view ->
             Term.styled [ Term.Sgr.dim ]
               " q:quit  ↑/↓:navigate  enter:detail  +:add PR  w:worktree  \
-               -:remove  o:open browser  h:help"
+               -:remove  m:manage  o:open browser  h:help"
         | Detail_view _ ->
             Term.styled [ Term.Sgr.dim ]
               " q:quit  esc/backspace:back  enter:message  m:manage  o:open \
@@ -1158,6 +1158,7 @@ let render_help_overlay ~width ~height =
           "+         Add PR (enter number)";
           "w         Register worktree (enter path)";
           "-/x       Remove selected patch";
+          "m         Manage patch";
           "o         Open PR in browser";
           "t         Toggle timeline";
           "q         Quit";
@@ -1326,7 +1327,10 @@ let render_frame ~width ~height ~selected ~scroll_offset ~view_mode
       | Detail_view patch_id ->
           List.find views ~f:(fun pv -> Patch_id.equal pv.patch_id patch_id)
           |> Option.value_map ~default:false ~f:(fun pv -> pv.automerge_enabled)
-      | List_view | Timeline_view -> false
+      | List_view ->
+          List.nth views selected
+          |> Option.value_map ~default:false ~f:(fun pv -> pv.automerge_enabled)
+      | Timeline_view -> false
     in
     let overlay = render_manage_overlay ~width ~height ~automerge_enabled in
     { no_patches with lines = overlay; detail_scroll_offset = scroll_offset }


### PR DESCRIPTION
## Summary
- Pressing `m` on a selected overview row now opens the Manage Patch modal (force-mark merged, toggle automerge), mirroring the existing detail-view shortcut.
- The modal's `m`/`a` actions resolve their target patch from `view_mode` + `selected_pid ()`, the same pattern already used by the `o` (open in browser) shortcut.
- `render_frame`'s manage overlay now reads `automerge_enabled` from the selected row when invoked from list view, and the footer/help overlay advertise the new shortcut.

## Test plan
- [ ] `dune build` and `dune runtest` clean (verified locally).
- [ ] In the TUI, select a row in the overview, press `m`, confirm the Manage Patch modal opens with the correct automerge state for that row.
- [ ] Press `a` from the overview-invoked modal and confirm automerge toggles on the selected patch.
- [ ] Press `m` (force-mark) from the overview-invoked modal and confirm it applies to the selected patch (when busy/no-PR, log shows the same guards as detail view).
- [ ] From detail view, `m` still opens the modal and behaves as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/226"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pressing `m` on a selected overview row now opens the Manage Patch modal, so you can force‑mark merged or toggle automerge without opening the detail view. The modal targets the selected patch in list view, shows the correct automerge state, supports `a` from the overview, and the footer/help advertise `m`.

<sup>Written for commit 92a29a05c881c8c01edbfbcd3ea0b5fba62ef13a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

