### PR TITLE
Show current backend in the overview summary line

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -130,6 +130,16 @@ let normalize_backend backend =
 let known_backends =
   [ "claude-sonnet"; "claude-opus"; "codex"; "opencode"; "pi"; "gemini" ]
 
+let backend_display_name backend =
+  match normalize_backend backend with
+  | "claude-sonnet" -> "Claude Sonnet"
+  | "claude-opus" -> "Claude Opus"
+  | "codex" -> "Codex"
+  | "opencode" -> "OpenCode"
+  | "pi" -> "Pi"
+  | "gemini" -> "Gemini"
+  | other -> other
+
 let validate_resolved_config ~backend ~github_token ~github_owner ~github_repo
     ~main_branch ~poll_interval ~max_concurrency =
   let backend = normalize_backend backend in
@@ -1239,7 +1249,7 @@ let intervention_reasons_of_log (log : Activity_log.t)
 let tui_fiber ~runtime ~clock ~stdout ~list_selected ~detail_scroll
     ~detail_follow ~timeline_scroll ~view_mode ~show_help ~status_msg
     ~transcripts ~sorted_patch_ids ~input_mode ~prompt_line ~patches_start_row
-    ~patches_scroll_offset ~patches_visible_count =
+    ~patches_scroll_offset ~patches_visible_count ~backend_name =
   Eio.Flow.copy_string (Tui.enter_tui ()) stdout;
   let first = ref true in
   let prev_output = ref "" in
@@ -1294,7 +1304,7 @@ let tui_fiber ~runtime ~clock ~stdout ~list_selected ~detail_scroll
     let frame =
       Tui.render_frame ~width ~height ~selected:!list_selected ~scroll_offset
         ~view_mode:!view_mode ~activity ~project_name:gp.Gameplan.project_name
-        ~show_help:!show_help
+        ~backend_name ~show_help:!show_help
         ~show_manage:
           (Tui_input.equal_input_mode !input_mode Tui_input.Manage_patch)
         ~now:(Unix.gettimeofday ()) ~transcript ?status_msg:!status_msg
@@ -4292,7 +4302,8 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
                      ~detail_scroll ~detail_follow ~timeline_scroll ~view_mode
                      ~show_help ~status_msg ~transcripts ~sorted_patch_ids
                      ~input_mode ~prompt_line ~patches_start_row
-                     ~patches_scroll_offset ~patches_visible_count)
+                     ~patches_scroll_offset ~patches_visible_count
+                     ~backend_name:(backend_display_name config.backend))
                 :: (fun () ->
                   input_fiber ~runtime ~process_mgr ~net ~github ~list_selected
                     ~detail_scroll ~detail_follow ~timeline_scroll

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -130,16 +130,6 @@ let normalize_backend backend =
 let known_backends =
   [ "claude-sonnet"; "claude-opus"; "codex"; "opencode"; "pi"; "gemini" ]
 
-let backend_display_name backend =
-  match normalize_backend backend with
-  | "claude-sonnet" -> "Claude Sonnet"
-  | "claude-opus" -> "Claude Opus"
-  | "codex" -> "Codex"
-  | "opencode" -> "OpenCode"
-  | "pi" -> "Pi"
-  | "gemini" -> "Gemini"
-  | other -> other
-
 let validate_resolved_config ~backend ~github_token ~github_owner ~github_repo
     ~main_branch ~poll_interval ~max_concurrency =
   let backend = normalize_backend backend in
@@ -2405,69 +2395,12 @@ let poller_fiber ~runtime ~clock ~net ~process_mgr ~github ~config ~project_name
 
 (** Runner fiber — executes orchestrator actions by spawning Claude processes
     concurrently. *)
-let runner_fiber ~runtime ~env ~config ~project_name ~pr_registry ~transcripts
-    ~github ~net ~event_log ?status_msg () =
+let runner_fiber ~runtime ~env ~config ~backend ~project_name ~pr_registry
+    ~transcripts ~github ~net ~event_log ?status_msg () =
   let main = config.main_branch in
   let process_mgr = Eio.Stdenv.process_mgr env in
   let clock = Eio.Stdenv.clock env in
   let fs = Eio.Stdenv.fs env in
-  let session_timeout =
-    1800.0
-    (* 30 minutes *)
-  in
-  (* Locate the [onton-setsid-exec] shim so subprocesses can run in their
-     own process group; without it, tool-call grandchildren reparent to
-     PID 1 on exit and leak. We probe [$ONTON_SETSID_EXEC] first (for
-     tests that want direct spawn to compare behavior), then fall back
-     to a sibling of our own executable. A missing shim is not fatal —
-     we log and run without group isolation (Phase A early-exit still
-     ends the stall; only grandchild reaping is lost). *)
-  let setsid_exec =
-    let candidate =
-      match Sys.getenv_opt "ONTON_SETSID_EXEC" with
-      | Some "" -> None
-      | Some p -> Some p
-      | None ->
-          Some
-            (Filename.concat
-               (Filename.dirname Sys.executable_name)
-               "onton-setsid-exec")
-    in
-    match candidate with
-    | Some p when Sys.file_exists p -> Some p
-    | Some p ->
-        Eio.traceln
-          "onton-setsid-exec not found at %s; grandchildren will reparent to \
-           PID 1 on teardown"
-          p;
-        None
-    | None -> None
-  in
-  let backend =
-    match normalize_backend config.backend with
-    | "claude-sonnet" ->
-        Claude_backend.create ~name:"Claude Sonnet" ~model:"sonnet" ~process_mgr
-          ~clock ~timeout:session_timeout ~setsid_exec
-    | "claude-opus" ->
-        Claude_backend.create ~name:"Claude Opus" ~model:"opus" ~process_mgr
-          ~clock ~timeout:session_timeout ~setsid_exec
-    | "codex" ->
-        Codex_backend.create ~process_mgr ~clock ~timeout:session_timeout
-          ~setsid_exec
-    | "opencode" ->
-        Opencode_backend.create ~process_mgr ~clock ~timeout:session_timeout
-          ~setsid_exec
-    | "pi" ->
-        Pi_backend.create ~process_mgr ~clock ~timeout:session_timeout
-          ~setsid_exec
-    | "gemini" ->
-        Gemini_backend.create ~process_mgr ~clock ~timeout:session_timeout
-          ~setsid_exec
-    | other ->
-        invalid_arg
-          (Printf.sprintf "Unsupported --backend=%S (expected %s)" other
-             (String.concat ", " known_backends))
-  in
   let set_status ~level ~text ?expires_at () =
     match status_msg with
     | Some r -> r := Some { Tui.level; text; expires_at }
@@ -4171,6 +4104,53 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
       let branch_of = build_branch_map gameplan ~default:config.main_branch in
       let process_mgr = Eio.Stdenv.process_mgr env in
       let clock = Eio.Stdenv.clock env in
+      let session_timeout = 1800.0 in
+      let setsid_exec =
+        let candidate =
+          match Sys.getenv_opt "ONTON_SETSID_EXEC" with
+          | Some "" -> None
+          | Some p -> Some p
+          | None ->
+              Some
+                (Filename.concat
+                   (Filename.dirname Sys.executable_name)
+                   "onton-setsid-exec")
+        in
+        match candidate with
+        | Some p when Sys.file_exists p -> Some p
+        | Some p ->
+            Eio.traceln
+              "onton-setsid-exec not found at %s; grandchildren will reparent \
+               to PID 1 on teardown"
+              p;
+            None
+        | None -> None
+      in
+      let backend =
+        match normalize_backend config.backend with
+        | "claude-sonnet" ->
+            Claude_backend.create ~name:"Claude Sonnet" ~model:"sonnet"
+              ~process_mgr ~clock ~timeout:session_timeout ~setsid_exec
+        | "claude-opus" ->
+            Claude_backend.create ~name:"Claude Opus" ~model:"opus" ~process_mgr
+              ~clock ~timeout:session_timeout ~setsid_exec
+        | "codex" ->
+            Codex_backend.create ~process_mgr ~clock ~timeout:session_timeout
+              ~setsid_exec
+        | "opencode" ->
+            Opencode_backend.create ~process_mgr ~clock ~timeout:session_timeout
+              ~setsid_exec
+        | "pi" ->
+            Pi_backend.create ~process_mgr ~clock ~timeout:session_timeout
+              ~setsid_exec
+        | "gemini" ->
+            Gemini_backend.create ~process_mgr ~clock ~timeout:session_timeout
+              ~setsid_exec
+        | other ->
+            invalid_arg
+              (Printf.sprintf "Unsupported --backend=%S (expected %s)" other
+                 (String.concat ", " known_backends))
+      in
       let net = Eio.Stdenv.net env in
       let stdout = Eio.Stdenv.stdout env in
       (* Capture agent state and worktree list BEFORE launching concurrent
@@ -4262,8 +4242,8 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
         Eio.Fiber.all
           ((fun () -> headless_fiber ~runtime ~clock ~stdout)
           :: (fun () ->
-            runner_fiber ~runtime ~env ~config ~project_name ~pr_registry
-              ~transcripts ~github ~net ~event_log ())
+            runner_fiber ~runtime ~env ~config ~backend ~project_name
+              ~pr_registry ~transcripts ~github ~net ~event_log ())
           :: common_fibers)
       else
         let list_selected = ref 0 in
@@ -4303,7 +4283,7 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
                      ~show_help ~status_msg ~transcripts ~sorted_patch_ids
                      ~input_mode ~prompt_line ~patches_start_row
                      ~patches_scroll_offset ~patches_visible_count
-                     ~backend_name:(backend_display_name config.backend))
+                     ~backend_name:backend.Llm_backend.name)
                 :: (fun () ->
                   input_fiber ~runtime ~process_mgr ~net ~github ~list_selected
                     ~detail_scroll ~detail_follow ~timeline_scroll
@@ -4313,8 +4293,9 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
                     ~patches_visible_count ~owner:config.github_owner
                     ~repo:config.github_repo)
                 :: (fun () ->
-                  runner_fiber ~runtime ~env ~config ~project_name ~pr_registry
-                    ~transcripts ~github ~net ~event_log ~status_msg ())
+                  runner_fiber ~runtime ~env ~config ~backend ~project_name
+                    ~pr_registry ~transcripts ~github ~net ~event_log
+                    ~status_msg ())
                 :: common_fibers)
             with Quit_tui -> ())
 

--- a/lib/tui.ml
+++ b/lib/tui.ml
@@ -775,7 +775,7 @@ let render_patches ~width ~selected ~max_visible ~now (views : patch_view list)
       offset,
       vis_count )
 
-let render_summary (views : patch_view list) =
+let render_summary ~backend_name (views : patch_view list) =
   let count status =
     List.count views ~f:(fun v -> equal_display_status v.status status)
   in
@@ -790,6 +790,7 @@ let render_summary (views : patch_view list) =
   let needs_help = count Needs_help in
   let parts =
     [
+      backend_name;
       Printf.sprintf "%d/%d merged" merged total;
       (if running > 0 then Printf.sprintf "%d running" running else "");
       (if queued > 0 then Printf.sprintf "%d queued" queued else "");
@@ -1305,8 +1306,9 @@ let views_of_orchestrator ~(orchestrator : Orchestrator.t)
       Int.compare idx_a idx_b)
 
 let render_frame ~width ~height ~selected ~scroll_offset ~view_mode
-    ~(activity : activity_entry list) ~project_name ~show_help ~show_manage ~now
-    ?(transcript = "") ?status_msg ?prompt_line (views : patch_view list) =
+    ~(activity : activity_entry list) ~project_name ~backend_name ~show_help
+    ~show_manage ~now ?(transcript = "") ?status_msg ?prompt_line
+    (views : patch_view list) =
   let no_patches =
     {
       lines = [];
@@ -1336,7 +1338,7 @@ let render_frame ~width ~height ~selected ~scroll_offset ~view_mode
     { no_patches with lines = overlay; detail_scroll_offset = scroll_offset }
   else
     let header = render_header ~project_name ~width in
-    let summary = [ render_summary views ] in
+    let summary = [ render_summary ~backend_name views ] in
     let footer = render_footer ~width ~view_mode ?prompt_line () in
     let status_line =
       let rendered = render_status_msg ~width status_msg in

--- a/lib/tui.mli
+++ b/lib/tui.mli
@@ -149,6 +149,7 @@ val render_frame :
   view_mode:view_mode ->
   activity:activity_entry list ->
   project_name:string ->
+  backend_name:string ->
   show_help:bool ->
   show_manage:bool ->
   now:float ->


### PR DESCRIPTION
## Summary
- Prepends the active backend's display name (e.g. \`Claude Opus\`, \`Codex\`) to the existing summary row, so the line now reads like \`Claude Opus │ 0/13 merged │ 3 running\`.
- Adds a \`backend_display_name\` helper in \`bin/main.ml\` that maps the \`--backend\` flag value to the same human-readable string each backend's \`Llm_backend.t\` already exposes.
- Threads \`~backend_name\` through \`Tui.render_frame\` / \`render_summary\` and the TUI fiber call site.

## Test plan
- [ ] \`dune build\` is clean.
- [ ] \`dune runtest\` passes (no expect-test changes here).
- [ ] Launch the TUI against any project and confirm the summary line shows the backend name first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the active backend’s display name at the start of the TUI overview summary line so it’s clear which model is running. Uses the backend record’s `Llm_backend.name` instead of a separate mapping.

- **Refactors**
  - Construct backend in `run_with_config`; pass `backend` to `runner_fiber` and `backend_name` to `tui_fiber`.
  - Remove `backend_display_name` helper; rely on `backend.Llm_backend.name`.
  - Update TUI API: `render_frame`/`render_summary` accept `backend_name` and prepend it in the counts row.

<sup>Written for commit fdd5088ac3c516308084e00a98c30d836a374319. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

