### PR TITLE
Disable npm install scripts via .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true


### PR DESCRIPTION
## Summary
- Add `.npmrc` with `ignore-scripts=true` so npm refuses to run preinstall/install/postinstall hooks from any dependency during `npm install` / `npm ci`.
- Neutralizes the most common npm supply-chain execution path (e.g. Shai-Hulud-style worms) without changing the dependency set.

## Notes
- The current deps (`@aws-sdk/client-s3`, `@aws-sdk/s3-request-presigner`, `@types/node`) are pure JS, so this is safe today.
- Future deps that genuinely need a build step (native bindings, binary downloads) will need to be vetted and built explicitly after install.

## Test plan
- [ ] `npm install` in this worktree completes without executing any lifecycle scripts
- [ ] Existing worktree-create hook in README (`npm install`) still produces a working `node_modules/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable npm lifecycle scripts by adding `.npmrc` with `ignore-scripts=true`, so `npm install`/`npm ci` will not run any preinstall/install/postinstall hooks. This reduces supply-chain risk without changing dependencies.

<sup>Written for commit 82628ef4f6a818c5740ce5e7b52180352c56751c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

