### PR TITLE
Stop tests from corrupting parent .git under leaked GIT_DIR

### DIFF
--- a/lib/git_env.ml
+++ b/lib/git_env.ml
@@ -1,0 +1,18 @@
+open Base
+
+let stripped_prefixes =
+  [
+    "GIT_DIR=";
+    "GIT_WORK_TREE=";
+    "GIT_INDEX_FILE=";
+    "GIT_COMMON_DIR=";
+    "GIT_OBJECT_DIRECTORY=";
+  ]
+
+let clean_env () =
+  Unix.environment () |> Array.to_list
+  |> List.filter ~f:(fun s ->
+      not
+        (List.exists stripped_prefixes ~f:(fun p ->
+             String.is_prefix s ~prefix:p)))
+  |> Array.of_list

--- a/lib/git_env.ml
+++ b/lib/git_env.ml
@@ -1,18 +1,6 @@
 open Base
 
-let stripped_prefixes =
-  [
-    "GIT_DIR=";
-    "GIT_WORK_TREE=";
-    "GIT_INDEX_FILE=";
-    "GIT_COMMON_DIR=";
-    "GIT_OBJECT_DIRECTORY=";
-  ]
-
 let clean_env () =
   Unix.environment () |> Array.to_list
-  |> List.filter ~f:(fun s ->
-      not
-        (List.exists stripped_prefixes ~f:(fun p ->
-             String.is_prefix s ~prefix:p)))
+  |> List.filter ~f:(fun s -> not (String.is_prefix s ~prefix:"GIT_"))
   |> Array.of_list

--- a/lib/git_env.mli
+++ b/lib/git_env.mli
@@ -1,8 +1,8 @@
 (** A scrubbed [Unix.environment ()] for spawning [git] subprocesses.
 
-    Any inherited [GIT_*] variable can override the [-C path] flag, redirect
-    git at a different repository, or change object/index storage. The most
-    common source of leaked vars is git's own pre-commit / post-checkout hook
+    Any inherited [GIT_*] variable can override the [-C path] flag, redirect git
+    at a different repository, or change object/index storage. The most common
+    source of leaked vars is git's own pre-commit / post-checkout hook
     environment, but they can also leak through [gh], IDE integrations, or
     shells started inside a repo.
 
@@ -13,5 +13,5 @@ val clean_env : unit -> string array
 (** [Unix.environment ()] with all [GIT_*] variables removed.
 
     onton only spawns git for repository queries, not for authoring commits, so
-    stripping [GIT_AUTHOR_*] / [GIT_COMMITTER_*] along with the rest is
-    harmless and keeps the isolation boundary simple. *)
+    stripping [GIT_AUTHOR_*] / [GIT_COMMITTER_*] along with the rest is harmless
+    and keeps the isolation boundary simple. *)

--- a/lib/git_env.mli
+++ b/lib/git_env.mli
@@ -1,0 +1,17 @@
+(** A scrubbed [Unix.environment ()] for spawning [git] subprocesses.
+
+    Any inherited [GIT_DIR] / [GIT_WORK_TREE] / [GIT_INDEX_FILE] /
+    [GIT_COMMON_DIR] / [GIT_OBJECT_DIRECTORY] would override the [-C path] flag
+    and the cwd we just set, redirecting git at a different repository than the
+    caller intended. The most common source of leaked vars is git's own
+    pre-commit / post-checkout hook environment, but they can also leak through
+    [gh], IDE integrations, or shells started under one of the above.
+
+    Always pass [clean_env ()] (or its result) as the env array when spawning
+    git from this codebase. *)
+
+val clean_env : unit -> string array
+(** [Unix.environment ()] minus the env vars that redirect git's repository
+    target. [GIT_AUTHOR_*] / [GIT_COMMITTER_*] are intentionally preserved —
+    they only affect new commits, they don't poison config or override the
+    target repo. *)

--- a/lib/git_env.mli
+++ b/lib/git_env.mli
@@ -1,17 +1,17 @@
 (** A scrubbed [Unix.environment ()] for spawning [git] subprocesses.
 
-    Any inherited [GIT_DIR] / [GIT_WORK_TREE] / [GIT_INDEX_FILE] /
-    [GIT_COMMON_DIR] / [GIT_OBJECT_DIRECTORY] would override the [-C path] flag
-    and the cwd we just set, redirecting git at a different repository than the
-    caller intended. The most common source of leaked vars is git's own
-    pre-commit / post-checkout hook environment, but they can also leak through
-    [gh], IDE integrations, or shells started under one of the above.
+    Any inherited [GIT_*] variable can override the [-C path] flag, redirect
+    git at a different repository, or change object/index storage. The most
+    common source of leaked vars is git's own pre-commit / post-checkout hook
+    environment, but they can also leak through [gh], IDE integrations, or
+    shells started inside a repo.
 
     Always pass [clean_env ()] (or its result) as the env array when spawning
     git from this codebase. *)
 
 val clean_env : unit -> string array
-(** [Unix.environment ()] minus the env vars that redirect git's repository
-    target. [GIT_AUTHOR_*] / [GIT_COMMITTER_*] are intentionally preserved —
-    they only affect new commits, they don't poison config or override the
-    target repo. *)
+(** [Unix.environment ()] with all [GIT_*] variables removed.
+
+    onton only spawns git for repository queries, not for authoring commits, so
+    stripping [GIT_AUTHOR_*] / [GIT_COMMITTER_*] along with the rest is
+    harmless and keeps the isolation boundary simple. *)

--- a/lib/repo_root.ml
+++ b/lib/repo_root.ml
@@ -5,7 +5,7 @@ open Base
     working tree. Returns [None] if [path] is not inside a git repository or the
     command fails for any reason. *)
 let resolve_main_working_tree path =
-  let env = Unix.environment () in
+  let env = Git_env.clean_env () in
   let argv =
     [|
       "git";

--- a/lib/worktree.ml
+++ b/lib/worktree.ml
@@ -38,14 +38,7 @@ let rec has_cancellation = function
       List.exists exns ~f:(fun (exn, _bt) -> has_cancellation exn)
   | _ -> false
 
-let clean_git_env =
-  Stdlib.Lazy.from_fun (fun () ->
-      Unix.environment () |> Array.to_list
-      |> List.filter ~f:(fun s ->
-          (not (String.is_prefix s ~prefix:"GIT_DIR="))
-          && (not (String.is_prefix s ~prefix:"GIT_WORK_TREE="))
-          && not (String.is_prefix s ~prefix:"GIT_INDEX_FILE="))
-      |> Array.of_list)
+let clean_git_env = Stdlib.Lazy.from_fun Git_env.clean_env
 
 let ref_exists ~process_mgr ~repo_root ref_path =
   let buf = Buffer.create 16 in

--- a/lib_test/dune
+++ b/lib_test/dune
@@ -1,5 +1,5 @@
 (library
  (name onton_test_support)
- (libraries onton qcheck-core)
+ (libraries onton qcheck-core unix)
  (preprocess (pps ppx_deriving.show ppx_deriving.eq ppx_deriving.ord
                   ppx_sexp_conv ppx_compare ppx_hash)))

--- a/lib_test/git_env.ml
+++ b/lib_test/git_env.ml
@@ -34,7 +34,12 @@ let run_git ~cwd args =
               Unix.create_process_env "git" argv env devnull devnull stderr_w)
         in
         let stderr_buf = read_all stderr_r in
-        let _, status = Unix.waitpid [] pid in
+        let rec waitpid () =
+          match Unix.waitpid [] pid with
+          | result -> result
+          | exception Unix.Unix_error (Unix.EINTR, _, _) -> waitpid ()
+        in
+        let _, status = waitpid () in
         (stderr_buf, status))
   in
   match status with

--- a/lib_test/git_env.ml
+++ b/lib_test/git_env.ml
@@ -21,20 +21,22 @@ let run_git ~cwd args =
   let env = clean_env () in
   let stderr_r, stderr_w = Unix.pipe ~cloexec:true () in
   let devnull = Unix.openfile "/dev/null" [ Unix.O_RDWR ] 0 in
-  let pid =
-    Stdlib.Fun.protect
-      ~finally:(fun () ->
-        (try Unix.close stderr_w with _ -> ());
-        try Unix.close devnull with _ -> ())
-      (fun () ->
-        Unix.create_process_env "git" argv env devnull devnull stderr_w)
-  in
-  let stderr_buf =
+  let stderr_buf, status =
     Stdlib.Fun.protect
       ~finally:(fun () -> try Unix.close stderr_r with _ -> ())
-      (fun () -> read_all stderr_r)
+      (fun () ->
+        let pid =
+          Stdlib.Fun.protect
+            ~finally:(fun () ->
+              (try Unix.close stderr_w with _ -> ());
+              try Unix.close devnull with _ -> ())
+            (fun () ->
+              Unix.create_process_env "git" argv env devnull devnull stderr_w)
+        in
+        let stderr_buf = read_all stderr_r in
+        let _, status = Unix.waitpid [] pid in
+        (stderr_buf, status))
   in
-  let _, status = Unix.waitpid [] pid in
   match status with
   | Unix.WEXITED 0 -> ()
   | Unix.WEXITED n ->

--- a/lib_test/git_env.ml
+++ b/lib_test/git_env.ml
@@ -20,7 +20,14 @@ let run_git ~cwd args =
   let argv = Array.of_list ("git" :: "-C" :: cwd :: args) in
   let env = clean_env () in
   let stderr_r, stderr_w = Unix.pipe ~cloexec:true () in
-  let devnull = Unix.openfile "/dev/null" [ Unix.O_RDWR ] 0 in
+  let devnull =
+    match Unix.openfile "/dev/null" [ Unix.O_RDWR ] 0 with
+    | fd -> fd
+    | exception exn ->
+        (try Unix.close stderr_r with _ -> ());
+        (try Unix.close stderr_w with _ -> ());
+        raise exn
+  in
   let stderr_buf, status =
     Stdlib.Fun.protect
       ~finally:(fun () -> try Unix.close stderr_r with _ -> ())

--- a/lib_test/git_env.ml
+++ b/lib_test/git_env.ml
@@ -1,0 +1,71 @@
+open Base
+
+let clean_env = Onton.Git_env.clean_env
+
+let read_all fd =
+  let buf = Buffer.create 256 in
+  let bytes = Bytes.create 4096 in
+  let rec loop () =
+    match Unix.read fd bytes 0 (Bytes.length bytes) with
+    | 0 -> ()
+    | n ->
+        Buffer.add_subbytes buf bytes ~pos:0 ~len:n;
+        loop ()
+    | exception Unix.Unix_error (Unix.EINTR, _, _) -> loop ()
+  in
+  loop ();
+  Buffer.contents buf
+
+let run_git ~cwd args =
+  let argv = Array.of_list ("git" :: "-C" :: cwd :: args) in
+  let env = clean_env () in
+  let stderr_r, stderr_w = Unix.pipe ~cloexec:true () in
+  let devnull = Unix.openfile "/dev/null" [ Unix.O_RDWR ] 0 in
+  let pid =
+    Stdlib.Fun.protect
+      ~finally:(fun () ->
+        (try Unix.close stderr_w with _ -> ());
+        try Unix.close devnull with _ -> ())
+      (fun () ->
+        Unix.create_process_env "git" argv env devnull devnull stderr_w)
+  in
+  let stderr_buf =
+    Stdlib.Fun.protect
+      ~finally:(fun () -> try Unix.close stderr_r with _ -> ())
+      (fun () -> read_all stderr_r)
+  in
+  let _, status = Unix.waitpid [] pid in
+  match status with
+  | Unix.WEXITED 0 -> ()
+  | Unix.WEXITED n ->
+      Stdlib.failwith
+        (Printf.sprintf "git %s in %s: exit %d\nstderr: %s"
+           (String.concat ~sep:" " args)
+           cwd n (String.strip stderr_buf))
+  | Unix.WSIGNALED n ->
+      Stdlib.failwith
+        (Printf.sprintf "git %s in %s: signaled %d\nstderr: %s"
+           (String.concat ~sep:" " args)
+           cwd n (String.strip stderr_buf))
+  | Unix.WSTOPPED n ->
+      Stdlib.failwith
+        (Printf.sprintf "git %s in %s: stopped %d\nstderr: %s"
+           (String.concat ~sep:" " args)
+           cwd n (String.strip stderr_buf))
+
+let init_repo dir =
+  run_git ~cwd:dir [ "init"; "-q"; "-b"; "main" ];
+  run_git ~cwd:dir [ "config"; "user.email"; "test@example.com" ];
+  run_git ~cwd:dir [ "config"; "user.name"; "test" ]
+
+let rm_rf dir =
+  let cmd = Printf.sprintf "rm -rf %s" (Stdlib.Filename.quote dir) in
+  ignore (Stdlib.Sys.command cmd : int)
+
+let with_temp_repo f =
+  let dir = Stdlib.Filename.temp_dir "onton-test-repo-" "" in
+  Stdlib.Fun.protect
+    ~finally:(fun () -> rm_rf dir)
+    (fun () ->
+      init_repo dir;
+      f dir)

--- a/lib_test/git_env.mli
+++ b/lib_test/git_env.mli
@@ -9,15 +9,17 @@
     spawning your own process. *)
 
 val clean_env : unit -> string array
-(** A copy of [Unix.environment ()] with the env vars that redirect git's
-    repository target stripped: [GIT_DIR], [GIT_WORK_TREE], [GIT_INDEX_FILE],
-    [GIT_COMMON_DIR], [GIT_OBJECT_DIRECTORY].
+(** A copy of [Unix.environment ()] with all [GIT_*] variables removed.
 
-    Vars like [GIT_AUTHOR_*] and [GIT_COMMITTER_*] are intentionally preserved —
-    they only override identity for new commits, they don't poison the parent's
-    config. If you want full hermeticity from the user's [~/.gitconfig] (e.g.
-    [commit.gpgsign], [init.defaultBranch]) append [GIT_CONFIG_GLOBAL=/dev/null]
-    / [GIT_CONFIG_SYSTEM=/dev/null] yourself. *)
+    This covers repository-redirecting vars ([GIT_DIR], [GIT_WORK_TREE],
+    [GIT_INDEX_FILE], [GIT_COMMON_DIR], [GIT_OBJECT_DIRECTORY]) as well as
+    identity vars ([GIT_AUTHOR_*], [GIT_COMMITTER_*]) and any others.  onton
+    spawns git only for repo queries, so stripping everything with the [GIT_]
+    prefix is safe and keeps the boundary simple.
+
+    If you need full hermeticity from [~/.gitconfig] (e.g. [commit.gpgsign],
+    [init.defaultBranch]) append [GIT_CONFIG_GLOBAL=/dev/null] /
+    [GIT_CONFIG_SYSTEM=/dev/null] yourself. *)
 
 val run_git : cwd:string -> string list -> unit
 (** Spawn [git <args>] in [cwd] with {!clean_env}. Waits for exit. Raises

--- a/lib_test/git_env.mli
+++ b/lib_test/git_env.mli
@@ -1,0 +1,39 @@
+(** Test helpers for spawning [git] without inheriting a poisoned environment.
+
+    When [dune runtest] runs inside this project's pre-commit hook, git sets
+    [GIT_DIR] / [GIT_INDEX_FILE] / etc. on the hook process. Tests that shell
+    out to [git init] without scrubbing the env will reinitialize the parent
+    [.git] (since [git init] honors [GIT_DIR] over [cwd]) and silently set
+    [core.bare = true] in the real config. Always run [git] in tests through the
+    helpers below, or pass the result of {!clean_env} as the env array when
+    spawning your own process. *)
+
+val clean_env : unit -> string array
+(** A copy of [Unix.environment ()] with the env vars that redirect git's
+    repository target stripped: [GIT_DIR], [GIT_WORK_TREE], [GIT_INDEX_FILE],
+    [GIT_COMMON_DIR], [GIT_OBJECT_DIRECTORY].
+
+    Vars like [GIT_AUTHOR_*] and [GIT_COMMITTER_*] are intentionally preserved —
+    they only override identity for new commits, they don't poison the parent's
+    config. If you want full hermeticity from the user's [~/.gitconfig] (e.g.
+    [commit.gpgsign], [init.defaultBranch]) append [GIT_CONFIG_GLOBAL=/dev/null]
+    / [GIT_CONFIG_SYSTEM=/dev/null] yourself. *)
+
+val run_git : cwd:string -> string list -> unit
+(** Spawn [git <args>] in [cwd] with {!clean_env}. Waits for exit. Raises
+    [Failure] with the command, cwd, exit code, and captured stderr on non-zero
+    exit (or signal). Stdout is discarded — for tests that need it, use
+    [Unix.create_process_env] directly with {!clean_env}. *)
+
+val init_repo : string -> unit
+(** Initialize a fresh git repo at [dir] with a deterministic identity: runs
+    [git init -q -b main], then sets local [user.email] and [user.name]. Does
+    {b not} create an initial commit — callers that need a HEAD (e.g. before
+    [git worktree add]) should follow up with their own [commit --allow-empty],
+    and callers that build a precise commit graph (rebase tests) get a clean
+    slate. [dir] must already exist. *)
+
+val with_temp_repo : (string -> 'a) -> 'a
+(** [with_temp_repo f] creates a fresh temp directory, runs {!init_repo} on it,
+    calls [f dir], and best-effort [rm -rf]s the directory afterward (even if
+    [f] raises). Returns [f]'s result. *)

--- a/lib_test/git_env.mli
+++ b/lib_test/git_env.mli
@@ -13,7 +13,7 @@ val clean_env : unit -> string array
 
     This covers repository-redirecting vars ([GIT_DIR], [GIT_WORK_TREE],
     [GIT_INDEX_FILE], [GIT_COMMON_DIR], [GIT_OBJECT_DIRECTORY]) as well as
-    identity vars ([GIT_AUTHOR_*], [GIT_COMMITTER_*]) and any others.  onton
+    identity vars ([GIT_AUTHOR_*], [GIT_COMMITTER_*]) and any others. onton
     spawns git only for repo queries, so stripping everything with the [GIT_]
     prefix is safe and keeps the boundary simple.
 

--- a/test/dune
+++ b/test/dune
@@ -91,7 +91,8 @@
 (test
  (name test_rebase_onto)
  (modules test_rebase_onto)
- (libraries onton qcheck-core qcheck-core.runner eio eio_main eio.unix)
+ (libraries onton onton_test_support qcheck-core qcheck-core.runner eio
+   eio_main eio.unix)
  (ocamlopt_flags (:standard -w -40-42))
  (ocamlc_flags (:standard -w -40-42)))
 
@@ -172,7 +173,7 @@
 (test
  (name test_repo_root)
  (modules test_repo_root)
- (libraries onton unix))
+ (libraries onton onton_test_support unix))
 
 (test
  (name test_project_lock)

--- a/test/test_rebase_onto.ml
+++ b/test/test_rebase_onto.ml
@@ -1,5 +1,6 @@
 open Base
 open Onton
+module Git_env = Onton_test_support.Git_env
 
 (* ───────────────────────────────────────────────────────────────────────
    Pure tests for [Worktree.oldest_non_ancestor_commit] with no ancestors
@@ -678,21 +679,15 @@ let () =
    then calls rebase_onto and checks the result.
    ─────────────────────────────────────────────────────────────────────── *)
 
-(** Strip GIT_DIR etc. so tests are not affected when run inside a git hook. *)
-let clean_git_env () =
-  Unix.environment () |> Array.to_list
-  |> List.filter ~f:(fun s ->
-      (not (String.is_prefix s ~prefix:"GIT_DIR="))
-      && (not (String.is_prefix s ~prefix:"GIT_WORK_TREE="))
-      && not (String.is_prefix s ~prefix:"GIT_INDEX_FILE="))
-  |> Array.of_list
-
-(** Run a git command in [dir], fail on non-zero exit. *)
+(** Run a git command in [dir], fail on non-zero exit. Captures stdout (used by
+    [commit_file] to read back the new commit's SHA). The env is scrubbed via
+    {!Git_env.clean_env} so tests are unaffected when run inside a git hook
+    (which would otherwise leak [GIT_DIR] / [GIT_WORK_TREE]). *)
 let git ~process_mgr ~dir args =
   Eio.Switch.run @@ fun sw ->
   let stdout_buf = Buffer.create 64 in
   let stderr_buf = Buffer.create 64 in
-  let env = clean_git_env () in
+  let env = Git_env.clean_env () in
   let child =
     Eio.Process.spawn ~sw process_mgr ~env
       ~stdout:(Eio.Flow.buffer_sink stdout_buf)
@@ -710,12 +705,11 @@ let git ~process_mgr ~dir args =
   | `Signaled s -> failwith (Printf.sprintf "git signaled %d" s));
   String.strip (Buffer.contents stdout_buf)
 
-(** Create a fresh git repo in a temp dir with an initial commit on main. *)
-let init_repo ~process_mgr =
+(** Create a fresh git repo in a temp dir. No initial commit — callers add their
+    own commits via [commit_file] to build a precise graph. *)
+let init_repo () =
   let dir = Stdlib.Filename.temp_dir "onton_rebase_test_" "" in
-  git ~process_mgr ~dir [ "init"; "-b"; "main" ] |> ignore;
-  git ~process_mgr ~dir [ "config"; "user.email"; "test@test.com" ] |> ignore;
-  git ~process_mgr ~dir [ "config"; "user.name"; "Test" ] |> ignore;
+  Git_env.init_repo dir;
   dir
 
 (** Write a file, add, commit. Returns the commit SHA. *)
@@ -771,7 +765,7 @@ let () =
   (* main: A -- B
      feat:    \-- C
      After rebase onto main: A -- B -- C *)
-  (let dir = init_repo ~process_mgr in
+  (let dir = init_repo () in
    commit_file ~process_mgr ~dir ~filename:"a.txt" ~content:"a" ~msg:"A"
    |> ignore;
    commit_file ~process_mgr ~dir ~filename:"b.txt" ~content:"b" ~msg:"B"
@@ -803,7 +797,7 @@ let () =
 
      rebase_onto feat onto main should produce:
      main: A -- S -- F1'            (only F1 replayed, not D1/D2) *)
-  (let dir = init_repo ~process_mgr in
+  (let dir = init_repo () in
    commit_file ~process_mgr ~dir ~filename:"a.txt" ~content:"a" ~msg:"A"
    |> ignore;
    (* Create dep branch with 2 commits *)
@@ -840,7 +834,7 @@ let () =
      feat: A -- D1 -- D2 -- D3 -- F1 -- F2 -- F3
      After squash-merge of dep and rebase:
      main: A -- S -- F1' -- F2' -- F3' *)
-  (let dir = init_repo ~process_mgr in
+  (let dir = init_repo () in
    commit_file ~process_mgr ~dir ~filename:"a.txt" ~content:"a" ~msg:"A"
    |> ignore;
    git ~process_mgr ~dir [ "checkout"; "-b"; "dep" ] |> ignore;
@@ -875,7 +869,7 @@ let () =
    Stdlib.Sys.command (Printf.sprintf "rm -rf %s" dir) |> ignore);
 
   (* ── Test 4: already up-to-date → Noop ──────────────────────────── *)
-  (let dir = init_repo ~process_mgr in
+  (let dir = init_repo () in
    commit_file ~process_mgr ~dir ~filename:"a.txt" ~content:"a" ~msg:"A"
    |> ignore;
    git ~process_mgr ~dir [ "checkout"; "-b"; "feat" ] |> ignore;
@@ -891,7 +885,7 @@ let () =
 
   (* ── Test 5: conflict during rebase → Conflict, working dir clean ─ *)
   (* Both main and feat modify the same file differently after dep merge *)
-  (let dir = init_repo ~process_mgr in
+  (let dir = init_repo () in
    commit_file ~process_mgr ~dir ~filename:"shared.txt" ~content:"base" ~msg:"A"
    |> ignore;
    git ~process_mgr ~dir [ "checkout"; "-b"; "dep" ] |> ignore;
@@ -930,7 +924,7 @@ let () =
      dep1 squash-merged into main. feat rebases onto dep2 (not main).
      dep2 still has D1 in its history so this tests rebasing onto a
      non-main target that shares commits. *)
-  (let dir = init_repo ~process_mgr in
+  (let dir = init_repo () in
    commit_file ~process_mgr ~dir ~filename:"a.txt" ~content:"a" ~msg:"A"
    |> ignore;
    git ~process_mgr ~dir [ "checkout"; "-b"; "dep1" ] |> ignore;
@@ -955,7 +949,7 @@ let () =
   (* Verifies --onto still works when dep is merge-committed (the dep
      commits ARE in main's history, so cherry-pick filtering should
      identify only feat's own commits). *)
-  (let dir = init_repo ~process_mgr in
+  (let dir = init_repo () in
    commit_file ~process_mgr ~dir ~filename:"a.txt" ~content:"a" ~msg:"A"
    |> ignore;
    git ~process_mgr ~dir [ "checkout"; "-b"; "dep" ] |> ignore;
@@ -992,7 +986,7 @@ let () =
   (* Edge case: feat branch = dep branch exactly. After dep squash-merge,
      rebasing feat onto main should ideally be a noop or produce an empty
      branch (all commits are duplicates). *)
-  (let dir = init_repo ~process_mgr in
+  (let dir = init_repo () in
    commit_file ~process_mgr ~dir ~filename:"a.txt" ~content:"a" ~msg:"A"
    |> ignore;
    git ~process_mgr ~dir [ "checkout"; "-b"; "dep" ] |> ignore;
@@ -1020,7 +1014,7 @@ let () =
   (* dep:  creates file X with "v1"
      feat: modifies X to "v2", adds own file
      After dep squash-merge, rebase should apply feat's changes cleanly *)
-  (let dir = init_repo ~process_mgr in
+  (let dir = init_repo () in
    commit_file ~process_mgr ~dir ~filename:"a.txt" ~content:"a" ~msg:"A"
    |> ignore;
    git ~process_mgr ~dir [ "checkout"; "-b"; "dep" ] |> ignore;
@@ -1057,7 +1051,7 @@ let () =
      patch-id. Without the ancestor_ids fallback, the old dep commit
      would be replayed onto main; with ancestor_ids=["1"] find_old_base
      picks a newer old_base and only our own commit survives. *)
-  (let dir = init_repo ~process_mgr in
+  (let dir = init_repo () in
    commit_file ~process_mgr ~dir ~filename:"a.txt" ~content:"a" ~msg:"A"
    |> ignore;
    git ~process_mgr ~dir [ "checkout"; "-b"; "dep" ] |> ignore;

--- a/test/test_repo_root.ml
+++ b/test/test_repo_root.ml
@@ -3,55 +3,24 @@
     working tree, never to a worktree path. *)
 
 open Onton
+module Git_env = Onton_test_support.Git_env
 
 let ( // ) = Filename.concat
 
-(** Create a unique temp directory. *)
-let mktempdir prefix =
-  let base = Filename.get_temp_dir_name () in
-  let rec loop n =
-    let dir = base // Printf.sprintf "%s-%d-%d" prefix (Unix.getpid ()) n in
-    try
-      Unix.mkdir dir 0o755;
-      dir
-    with Unix.Unix_error (Unix.EEXIST, _, _) -> loop (n + 1)
-  in
-  loop 0
-
-(** Remove [dir] recursively. Best-effort; swallows errors. *)
-let rm_rf dir =
-  let cmd = Printf.sprintf "rm -rf %s" (Filename.quote dir) in
-  ignore (Sys.command cmd)
-
-(** Run a command from [cwd] and assert it succeeded. *)
-let sh_at cwd cmd =
-  let full =
-    Printf.sprintf "cd %s && %s >/dev/null 2>&1" (Filename.quote cwd) cmd
-  in
-  match Sys.command full with
-  | 0 -> ()
-  | n -> failwith (Printf.sprintf "command failed (%d): %s" n cmd)
-
-(** Initialize a git repo at [dir] with a single commit. *)
-let init_repo dir =
-  sh_at dir "git init -q -b main";
-  sh_at dir "git config user.email test@example.com";
-  sh_at dir "git config user.name test";
-  sh_at dir "git commit -q --allow-empty -m init"
-
 let with_main_and_worktree f =
-  let main = mktempdir "onton-repo-root-main" in
-  let wt_parent = mktempdir "onton-repo-root-wt" in
-  let wt = wt_parent // "patch-1" in
-  Fun.protect
-    ~finally:(fun () ->
-      rm_rf main;
-      rm_rf wt_parent)
-    (fun () ->
-      init_repo main;
-      sh_at main
-        (Printf.sprintf "git worktree add -b feat %s" (Filename.quote wt));
-      f ~main ~wt)
+  Git_env.with_temp_repo (fun main ->
+      Git_env.run_git ~cwd:main
+        [ "commit"; "-q"; "--allow-empty"; "-m"; "init" ];
+      let wt_parent = Filename.temp_dir "onton-repo-root-wt-" "" in
+      let wt = wt_parent // "patch-1" in
+      Fun.protect
+        ~finally:(fun () ->
+          ignore
+            (Sys.command
+               (Printf.sprintf "rm -rf %s" (Filename.quote wt_parent))))
+        (fun () ->
+          Git_env.run_git ~cwd:main [ "worktree"; "add"; "-b"; "feat"; wt ];
+          f ~main ~wt))
 
 let with_chdir dir f =
   let saved = Sys.getcwd () in
@@ -106,9 +75,10 @@ let test_trailing_slash_stripped () =
 let test_non_repo_passthrough () =
   (* Outside any git repo: return absolute-but-unresolved, so downstream
      error paths surface the non-repo case rather than masking it. *)
-  let tmp = mktempdir "onton-repo-root-nonrepo" in
+  let tmp = Filename.temp_dir "onton-repo-root-nonrepo-" "" in
   Fun.protect
-    ~finally:(fun () -> rm_rf tmp)
+    ~finally:(fun () ->
+      ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote tmp))))
     (fun () ->
       let got = Repo_root.normalize tmp in
       (* No git repo here, so the resolved path equals the input. *)


### PR DESCRIPTION
## Summary

When \`dune runtest\` runs inside this project's pre-commit hook, git sets \`GIT_DIR=…/.git\` (and friends) on the hook process. \`test/test_repo_root.ml\`'s \`git init\` via \`Sys.command\` inherited those vars and — because \`git init\` honors \`GIT_DIR\` over cwd — reinitialized the parent \`.git\` as a bare repo, silently writing \`core.bare = true\` to the real config every commit.

This PR does a clean cutover so future git-touching tests can't reintroduce the leak:

- **New \`lib/git_env.ml\`** — promotes the \`clean_env\` filter that was previously inlined inside \`lib/worktree.ml\` into a single shared production module. \`lib/worktree.ml\` and \`lib/repo_root.ml\` both call into it; \`lib/repo_root.ml\` was the missing production callsite that left the test-side fix incomplete (its \`git rev-parse --git-common-dir\` was passing through \`Unix.environment ()\` directly).
- **New \`lib_test/git_env.ml\`** — \`Onton_test_support.Git_env\` with \`clean_env\` (delegating to the production module), \`run_git\`, \`init_repo\`, and \`with_temp_repo\`. \`run_git\` uses \`Unix.create_process_env\` (no shell, no quoting bugs, captured stderr in error messages).
- **\`test/test_repo_root.ml\` and \`test/test_rebase_onto.ml\`** — both adopt the helper. \`test_rebase_onto.ml\` keeps its bespoke Eio process wrapper for stdout capture but pulls \`clean_env\` from the shared module. \`init_repo\` no longer creates a phantom empty \`init\` commit (the rebase tests build a precise commit graph and an extra root commit shifted ancestor counts).

A sweep confirms \`test_repo_root.ml\` and \`test_rebase_onto.ml\` were the only tests that shelled out to git. \`test_project_lock.ml\`'s \`Sys.command\` is just \`rm -rf\` cleanup.

## Test plan

\`\`\`
git config --get core.bare                                         # baseline empty
GIT_DIR=\$ONTON/.git GIT_INDEX_FILE=\$ONTON/.git/index dune runtest  # exits 0
git config --get core.bare                                         # still empty
\`\`\`

- [x] \`dune build\` clean
- [x] \`dune runtest\` clean from a fresh shell
- [x] \`dune runtest\` clean with \`GIT_DIR\` / \`GIT_INDEX_FILE\` leaked into the env
- [x] \`core.bare\` stays unset after committing (the original repro path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/229"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops tests from corrupting the parent `.git` when `GIT_*` leaks and makes all git spawns safe by default. Also hardens the git test helper against FD leaks and `EINTR`.

- **Bug Fixes**
  - Added `Onton.Git_env.clean_env` to strip all `GIT_*` vars; used in `lib/repo_root.ml` and `lib/worktree.ml` (docs updated to match).
  - Introduced `Onton_test_support.Git_env` with `clean_env`, `run_git`, `init_repo`, `with_temp_repo`; updated `test_repo_root.ml` and `test_rebase_onto.ml` to use it.
  - `run_git`: closes FDs if `Unix.create_process_env` or opening `/dev/null` fails, and retries `waitpid` on `EINTR`.
  - Removed the extra empty init commit from test repo setup to keep commit graphs precise.
  - Running `dune runtest` under leaked `GIT_*` vars no longer sets `core.bare` or touches the parent repo.

<sup>Written for commit e2f9220273cec6d1d5dd80961d10a66864c7bbe7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

