### PR TITLE
Decompose --backend into --backend + --model

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,10 +439,9 @@ onton --backend opencode --model anthropic/claude-sonnet-4-5
 ```
 
 Both flags are persisted in project config and reused on resume unless
-overridden. The legacy `--backend claude-opus` / `--backend claude-sonnet`
-forms are still accepted and split into the equivalent `--backend claude
---model {opus,sonnet}` pair. Stored configs from older onton versions are
-migrated automatically on load.
+overridden. Stored configs written by older onton versions (where `backend`
+was `claude-opus` or `claude-sonnet`) are migrated to the decomposed shape
+automatically on load.
 
 ### Supported models
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ of these must be installed and configured before onton can run.
 |------|---------|---------|
 | `git` | Worktree CRUD, branch detection, rebase | `brew install git` (or system package manager) |
 | `gh` (GitHub CLI) | Token resolution, PR discovery (`gh pr list`), and the main vehicle agents use to interact with GitHub (`gh pr create`, `gh pr edit`, `gh pr view`, `gh api`, `gh api graphql`) | `brew install gh`, then `gh auth login` |
-| Coding-agent CLI | Drives the actual patches. One of: `claude` ([Claude Code](https://docs.anthropic.com/en/docs/claude-code); selected as `claude-opus` or `claude-sonnet` via `--backend`), `codex` ([OpenAI Codex CLI](https://github.com/openai/codex)), `opencode`, `pi`, `gemini`. Selected via `--backend` (default `claude-opus`) and must be on `PATH` | See each tool's docs |
+| Coding-agent CLI | Drives the actual patches. One of: `claude` ([Claude Code](https://docs.anthropic.com/en/docs/claude-code)), `codex` ([OpenAI Codex CLI](https://github.com/openai/codex)), `opencode` ([OpenCode](https://opencode.ai)), `pi`, `gemini` ([Gemini CLI](https://github.com/google-gemini/gemini-cli)). Selected via `--backend` (default `claude`) and `--model` (see [Backend & model](#backend--model) below). Must be on `PATH` | See each tool's docs |
 
 Onton is built and tested on macOS (ARM64 and x86_64). Linux should work but is
 not part of the release pipeline.
@@ -220,6 +220,8 @@ onton --repo ../my-repo [OPTIONS]        # Ad-hoc mode (no gameplan)
 | `--gameplan` | — | Path to the gameplan markdown file |
 | `--repo` | `.` | Path to the git repository. GitHub owner/repo are inferred from `git remote` |
 | `--token` | `$GITHUB_TOKEN` or `gh auth token` | GitHub API token |
+| `--backend` | `claude` | LLM backend: `claude`, `codex`, `opencode`, `pi`, `gemini`. See [Backend & model](#backend--model) |
+| `--model` | backend default (`opus` for `claude`) | Model name passed to the backend CLI |
 | `--main-branch` | (auto-detected) | Main branch name (inferred from remote HEAD if omitted) |
 | `--poll-interval` | `30.0` | GitHub polling interval in seconds |
 | `--max-concurrency` | `5` / `$ONTON_MAX_CONCURRENCY` | Maximum concurrent Claude processes |
@@ -419,21 +421,44 @@ GitHub Actions runs on every push and PR:
 - **Property tests** — QCheck2 with 10,000 iterations
 - **Format check** — `ocamlformat` via `ocaml/setup-ocaml/lint-fmt`
 
-## CLI
+## Backend & model
 
-Backend selection uses `--backend`:
+Two flags control which agent runs the patches:
 
-- `onton --backend claude-opus`
-- `onton --backend claude-sonnet`
-- `onton --backend codex`
-- `onton --backend opencode`
-- `onton --backend pi`
-- `onton --backend gemini`
+- `--backend BACKEND` — one of `claude`, `codex`, `opencode`, `pi`, `gemini`.
+  Default: `claude`.
+- `--model MODEL` — model name passed through to the backend's CLI. When
+  omitted, the backend picks its own default (for `claude`, that's `opus`).
 
-If omitted for a new project, `claude-opus` is the default. Existing stored
-`claude` configs are migrated to `claude-opus`. The selected backend is
-persisted in project config and reused on resume unless you pass `--backend`
-again to override it.
+```sh
+onton --backend claude --model sonnet-4-6
+onton --backend claude --model opus
+onton --backend codex --model gpt-5-codex
+onton --backend gemini --model gemini-2.5-pro
+onton --backend opencode --model anthropic/claude-sonnet-4-5
+```
+
+Both flags are persisted in project config and reused on resume unless
+overridden. The legacy `--backend claude-opus` / `--backend claude-sonnet`
+forms are still accepted and split into the equivalent `--backend claude
+--model {opus,sonnet}` pair. Stored configs from older onton versions are
+migrated automatically on load.
+
+### Supported models
+
+Onton passes `--model` through to the backend CLI verbatim, so any model the
+underlying CLI accepts will work. Use unpinned aliases (e.g. `sonnet`,
+`opus`) when you want "current best in tier"; pin a specific version when you
+need reproducibility. The names below are accurate as of February 2026 —
+**check each provider's docs for the current list**:
+
+| Backend | Common model names | Source of truth |
+|---------|-------------------|-----------------|
+| `claude` | `opus`, `sonnet`, `haiku` (unpinned aliases); `claude-opus-4-7`, `claude-sonnet-4-6`, `claude-haiku-4-5` (pinned) | [Anthropic models](https://docs.anthropic.com/en/docs/about-claude/models) |
+| `codex` | `gpt-5-codex`, `gpt-5`, `gpt-5-mini` | [OpenAI models](https://platform.openai.com/docs/models), [Codex CLI README](https://github.com/openai/codex) |
+| `gemini` | `gemini-2.5-pro`, `gemini-2.5-flash` | [Gemini API models](https://ai.google.dev/gemini-api/docs/models) |
+| `opencode` | Provider-prefixed, e.g. `anthropic/claude-sonnet-4-5`, `openai/gpt-5` | [OpenCode docs](https://opencode.ai/docs) |
+| `pi` | Run `pi --help` for the current list | Pi CLI |
 
 Pushing a `v*` tag builds a macOS ARM64 binary, creates a GitHub release, and
 updates the Homebrew formula.

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ onton --repo ../my-repo [OPTIONS]        # Ad-hoc mode (no gameplan)
 | `--repo` | `.` | Path to the git repository. GitHub owner/repo are inferred from `git remote` |
 | `--token` | `$GITHUB_TOKEN` or `gh auth token` | GitHub API token |
 | `--backend` | `claude` | LLM backend: `claude`, `codex`, `opencode`, `pi`, `gemini`. See [Backend & model](#backend--model) |
-| `--model` | backend default (`opus` for `claude`) | Model name passed to the backend CLI |
+| `--model` | (backend CLI's own default) | Model name passed to the backend CLI |
 | `--main-branch` | (auto-detected) | Main branch name (inferred from remote HEAD if omitted) |
 | `--poll-interval` | `30.0` | GitHub polling interval in seconds |
 | `--max-concurrency` | `5` / `$ONTON_MAX_CONCURRENCY` | Maximum concurrent Claude processes |
@@ -428,7 +428,8 @@ Two flags control which agent runs the patches:
 - `--backend BACKEND` — one of `claude`, `codex`, `opencode`, `pi`, `gemini`.
   Default: `claude`.
 - `--model MODEL` — model name passed through to the backend's CLI. When
-  omitted, the backend picks its own default (for `claude`, that's `opus`).
+  omitted, onton does not pass `--model` to the underlying CLI, so each
+  provider's own default applies.
 
 ```sh
 onton --backend claude --model sonnet-4-6

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -127,35 +127,17 @@ let default_backend = "claude"
 let default_claude_model = "opus"
 let known_backends = [ "claude"; "codex"; "opencode"; "pi"; "gemini" ]
 
-(** Decompose legacy combined backend strings (["claude-opus"],
-    ["claude-sonnet"]) into [(backend, model)]. Returns [None] for current,
-    already-decomposed forms. *)
-let split_legacy_backend = function
-  | "claude-sonnet" -> Some ("claude", "sonnet")
-  | "claude-opus" -> Some ("claude", "opus")
-  | _ -> None
-
 (** Resolve a CLI [--backend]/[--model] pair (or stored equivalents) into the
-    canonical [(backend, model)] tuple used internally.
-
-    - Empty [backend] falls back to [default_backend].
-    - Legacy combined names like ["claude-opus"] are split. An explicit [model]
-      still overrides the embedded one — so
-      [--backend claude-sonnet --model opus] yields [("claude", "opus")].
-    - For ["claude"] with no model, fills in [default_claude_model] so
-      historical behaviour ([--backend claude] ≡ opus) is preserved. *)
+    canonical [(backend, model)] tuple used internally. Empty [backend] falls
+    back to [default_backend]; an empty [model] paired with ["claude"] is filled
+    in with [default_claude_model] so [--backend claude] alone keeps its
+    historical meaning of "opus". *)
 let resolve_backend_model ~backend ~model =
   let backend =
     if Base.String.is_empty (Base.String.strip backend) then default_backend
     else Base.String.strip backend
   in
   let model = Base.String.strip model in
-  let backend, model =
-    match split_legacy_backend backend with
-    | Some (b, default_m) ->
-        (b, if Base.String.is_empty model then default_m else model)
-    | None -> (backend, model)
-  in
   let model =
     if String.equal backend "claude" && Base.String.is_empty model then
       default_claude_model
@@ -4384,10 +4366,7 @@ let backend_arg =
   Arg.(
     value & opt string ""
     & info [ "backend" ] ~docv:"BACKEND"
-        ~doc:
-          "LLM backend to use: claude, codex, opencode, pi, or gemini. The \
-           legacy values [claude-sonnet] and [claude-opus] are accepted and \
-           split into [--backend claude --model sonnet|opus].")
+        ~doc:"LLM backend to use: claude, codex, opencode, pi, or gemini.")
 
 let model_arg =
   let open Cmdliner in

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -6,6 +6,7 @@ open Onton.Types
 type config = {
   project : string option;
   backend : string;
+  model : string;
   github_token : string;
   github_owner : string;
   github_repo : string;
@@ -122,17 +123,48 @@ let infer_default_branch ~repo_root =
           | Some _ -> "master"
           | None -> "main"))
 
-let default_backend = "claude-opus"
+let default_backend = "claude"
+let default_claude_model = "opus"
+let known_backends = [ "claude"; "codex"; "opencode"; "pi"; "gemini" ]
 
-let normalize_backend backend =
-  match backend with "claude" -> default_backend | other -> other
+(** Decompose legacy combined backend strings (["claude-opus"],
+    ["claude-sonnet"]) into [(backend, model)]. Returns [None] for current,
+    already-decomposed forms. *)
+let split_legacy_backend = function
+  | "claude-sonnet" -> Some ("claude", "sonnet")
+  | "claude-opus" -> Some ("claude", "opus")
+  | _ -> None
 
-let known_backends =
-  [ "claude-sonnet"; "claude-opus"; "codex"; "opencode"; "pi"; "gemini" ]
+(** Resolve a CLI [--backend]/[--model] pair (or stored equivalents) into the
+    canonical [(backend, model)] tuple used internally.
+
+    - Empty [backend] falls back to [default_backend].
+    - Legacy combined names like ["claude-opus"] are split. An explicit [model]
+      still overrides the embedded one — so
+      [--backend claude-sonnet --model opus] yields [("claude", "opus")].
+    - For ["claude"] with no model, fills in [default_claude_model] so
+      historical behaviour ([--backend claude] ≡ opus) is preserved. *)
+let resolve_backend_model ~backend ~model =
+  let backend =
+    if Base.String.is_empty (Base.String.strip backend) then default_backend
+    else Base.String.strip backend
+  in
+  let model = Base.String.strip model in
+  let backend, model =
+    match split_legacy_backend backend with
+    | Some (b, default_m) ->
+        (b, if Base.String.is_empty model then default_m else model)
+    | None -> (backend, model)
+  in
+  let model =
+    if String.equal backend "claude" && Base.String.is_empty model then
+      default_claude_model
+    else model
+  in
+  (backend, model)
 
 let validate_resolved_config ~backend ~github_token ~github_owner ~github_repo
     ~main_branch ~poll_interval ~max_concurrency =
-  let backend = normalize_backend backend in
   let errors =
     Base.List.filter_map
       [
@@ -3815,8 +3847,9 @@ let with_snapshot_load ~project_name config gameplan =
       project name.
     - [PROJECT] only: load stored config + gameplan. CLI flags override stored
       values. *)
-let resolve_config ~project ~gameplan_path ~github_token ~backend ~main_branch
-    ~poll_interval ~(repo_root : string option) ~max_concurrency ~headless =
+let resolve_config ~project ~gameplan_path ~github_token ~backend ~model
+    ~main_branch ~poll_interval ~(repo_root : string option) ~max_concurrency
+    ~headless =
   let repo_root_for_fresh =
     Repo_root.normalize (Base.Option.value repo_root ~default:".")
   in
@@ -3849,19 +3882,17 @@ let resolve_config ~project ~gameplan_path ~github_token ~backend ~main_branch
             open_questions = [];
           }
       in
-      let backend =
-        if Base.String.is_empty backend then default_backend
-        else backend |> normalize_backend
-      in
+      let backend, model = resolve_backend_model ~backend ~model in
       let main_branch = resolve_branch ~repo_root main_branch in
       Project_store.save_config ~project_name ~github_token:token
-        ~github_owner:owner ~github_repo:repo ~backend
+        ~github_owner:owner ~github_repo:repo ~backend ~model
         ~main_branch:(Branch.to_string main_branch)
         ~poll_interval ~repo_root ~max_concurrency;
       let config =
         {
           project = Some project_name;
           backend;
+          model;
           github_token = token;
           github_owner = owner;
           github_repo = repo;
@@ -3888,13 +3919,10 @@ let resolve_config ~project ~gameplan_path ~github_token ~backend ~main_branch
           let token, owner, repo =
             resolve_github_credentials ~github_token ~repo_root
           in
-          let backend =
-            if Base.String.is_empty backend then default_backend
-            else backend |> normalize_backend
-          in
+          let backend, model = resolve_backend_model ~backend ~model in
           let main_branch = resolve_branch ~repo_root main_branch in
           Project_store.save_config ~project_name ~github_token:token
-            ~github_owner:owner ~github_repo:repo ~backend
+            ~github_owner:owner ~github_repo:repo ~backend ~model
             ~main_branch:(Branch.to_string main_branch)
             ~poll_interval ~repo_root ~max_concurrency;
           Project_store.save_gameplan_source ~project_name ~source_path:gp_path;
@@ -3902,6 +3930,7 @@ let resolve_config ~project ~gameplan_path ~github_token ~backend ~main_branch
             {
               project = Some project_name;
               backend;
+              model;
               github_token = token;
               github_owner = owner;
               github_repo = repo;
@@ -3944,9 +3973,15 @@ let resolve_config ~project ~gameplan_path ~github_token ~backend ~main_branch
                     let c = Base.String.strip cli in
                     if Base.String.is_empty c then stored_val else c
                   in
-                  let backend =
+                  let resolved_backend_str =
                     merge_cli_stored backend stored.Project_store.backend
-                    |> normalize_backend
+                  in
+                  let resolved_model_str =
+                    merge_cli_stored model stored.Project_store.model
+                  in
+                  let backend, model =
+                    resolve_backend_model ~backend:resolved_backend_str
+                      ~model:resolved_model_str
                   in
                   let token_from_stored =
                     merge_cli_stored github_token
@@ -3985,13 +4020,14 @@ let resolve_config ~project ~gameplan_path ~github_token ~backend ~main_branch
                      CLI overrides picks up the current values. *)
                   Project_store.save_config ~project_name:proj
                     ~github_token:token ~github_owner:owner ~github_repo:repo
-                    ~backend ~main_branch:(Branch.to_string branch)
+                    ~backend ~model ~main_branch:(Branch.to_string branch)
                     ~poll_interval:stored.Project_store.poll_interval ~repo_root
                     ~max_concurrency:stored.Project_store.max_concurrency;
                   let config =
                     {
                       project = Some proj;
                       backend;
+                      model;
                       github_token = token;
                       github_owner = owner;
                       github_repo = repo;
@@ -4127,25 +4163,30 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
         | None -> None
       in
       let backend =
-        match normalize_backend config.backend with
-        | "claude-sonnet" ->
-            Claude_backend.create ~name:"Claude Sonnet" ~model:"sonnet"
+        let model_opt =
+          if Base.String.is_empty config.model then None else Some config.model
+        in
+        match config.backend with
+        | "claude" ->
+            let claude_model =
+              if Base.String.is_empty config.model then default_claude_model
+              else config.model
+            in
+            let display_name = Printf.sprintf "Claude (%s)" claude_model in
+            Claude_backend.create ~name:display_name ~model:claude_model
               ~process_mgr ~clock ~timeout:session_timeout ~setsid_exec
-        | "claude-opus" ->
-            Claude_backend.create ~name:"Claude Opus" ~model:"opus" ~process_mgr
-              ~clock ~timeout:session_timeout ~setsid_exec
         | "codex" ->
-            Codex_backend.create ~process_mgr ~clock ~timeout:session_timeout
-              ~setsid_exec
+            Codex_backend.create ~model:model_opt ~process_mgr ~clock
+              ~timeout:session_timeout ~setsid_exec
         | "opencode" ->
-            Opencode_backend.create ~process_mgr ~clock ~timeout:session_timeout
-              ~setsid_exec
+            Opencode_backend.create ~model:model_opt ~process_mgr ~clock
+              ~timeout:session_timeout ~setsid_exec
         | "pi" ->
-            Pi_backend.create ~process_mgr ~clock ~timeout:session_timeout
-              ~setsid_exec
+            Pi_backend.create ~model:model_opt ~process_mgr ~clock
+              ~timeout:session_timeout ~setsid_exec
         | "gemini" ->
-            Gemini_backend.create ~process_mgr ~clock ~timeout:session_timeout
-              ~setsid_exec
+            Gemini_backend.create ~model:model_opt ~process_mgr ~clock
+              ~timeout:session_timeout ~setsid_exec
         | other ->
             invalid_arg
               (Printf.sprintf "Unsupported --backend=%S (expected %s)" other
@@ -4299,12 +4340,12 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
                 :: common_fibers)
             with Quit_tui -> ())
 
-let run ~project ~gameplan_path ~github_token ~backend
+let run ~project ~gameplan_path ~github_token ~backend ~model
     ~(main_branch : Branch.t option) ~poll_interval ~(repo_root : string option)
     ~max_concurrency ~headless ~no_lock =
   match
-    resolve_config ~project ~gameplan_path ~github_token ~backend ~main_branch
-      ~poll_interval ~repo_root ~max_concurrency ~headless
+    resolve_config ~project ~gameplan_path ~github_token ~backend ~model
+      ~main_branch ~poll_interval ~repo_root ~max_concurrency ~headless
   with
   | Error errs ->
       Base.List.iter errs ~f:(fun e -> Printf.eprintf "Error: %s\n" e);
@@ -4344,8 +4385,20 @@ let backend_arg =
     value & opt string ""
     & info [ "backend" ] ~docv:"BACKEND"
         ~doc:
-          "LLM backend to use: claude-sonnet, claude-opus, codex, opencode, \
-           pi, or gemini.")
+          "LLM backend to use: claude, codex, opencode, pi, or gemini. The \
+           legacy values [claude-sonnet] and [claude-opus] are accepted and \
+           split into [--backend claude --model sonnet|opus].")
+
+let model_arg =
+  let open Cmdliner in
+  Arg.(
+    value & opt string ""
+    & info [ "model" ] ~docv:"MODEL"
+        ~doc:
+          "Model name to pass to the selected backend (e.g. [sonnet], [opus], \
+           [sonnet-4-6] for claude; [gpt-5-mini] for codex). When omitted, the \
+           backend's own default is used (except for claude, which defaults to \
+           opus).")
 
 let repo_arg =
   let open Cmdliner in
@@ -4405,7 +4458,7 @@ let no_lock_arg =
 
 let main_cmd =
   let open Cmdliner in
-  let run_cmd project gameplan_path github_token backend main_branch
+  let run_cmd project gameplan_path github_token backend model main_branch
       poll_interval repo_root max_concurrency headless upload_debug no_lock =
     if upload_debug then (
       match project with
@@ -4430,13 +4483,13 @@ let main_cmd =
       in
       run ~project ~gameplan_path ~github_token
         ~backend:(Base.String.strip backend)
-        ~main_branch ~poll_interval ~repo_root ~max_concurrency ~headless
-        ~no_lock
+        ~model:(Base.String.strip model) ~main_branch ~poll_interval ~repo_root
+        ~max_concurrency ~headless ~no_lock
   in
   let term =
     Term.(
       const run_cmd $ project_arg $ gameplan_path_arg $ github_token_arg
-      $ backend_arg $ main_branch_arg $ poll_interval_arg $ repo_arg
+      $ backend_arg $ model_arg $ main_branch_arg $ poll_interval_arg $ repo_arg
       $ max_concurrency_arg $ headless_arg $ upload_debug_arg $ no_lock_arg)
   in
   let info =

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -124,26 +124,19 @@ let infer_default_branch ~repo_root =
           | None -> "main"))
 
 let default_backend = "claude"
-let default_claude_model = "opus"
 let known_backends = [ "claude"; "codex"; "opencode"; "pi"; "gemini" ]
 
 (** Resolve a CLI [--backend]/[--model] pair (or stored equivalents) into the
     canonical [(backend, model)] tuple used internally. Empty [backend] falls
-    back to [default_backend]; an empty [model] paired with ["claude"] is filled
-    in with [default_claude_model] so [--backend claude] alone keeps its
-    historical meaning of "opus". *)
+    back to [default_backend]. An empty [model] is preserved — the backend
+    dispatch then omits [--model] from the underlying CLI call so each
+    provider's own default applies. *)
 let resolve_backend_model ~backend ~model =
   let backend =
     if Base.String.is_empty (Base.String.strip backend) then default_backend
     else Base.String.strip backend
   in
-  let model = Base.String.strip model in
-  let model =
-    if String.equal backend "claude" && Base.String.is_empty model then
-      default_claude_model
-    else model
-  in
-  (backend, model)
+  (backend, Base.String.strip model)
 
 let validate_resolved_config ~backend ~github_token ~github_owner ~github_repo
     ~main_branch ~poll_interval ~max_concurrency =
@@ -4150,12 +4143,12 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
         in
         match config.backend with
         | "claude" ->
-            let claude_model =
-              if Base.String.is_empty config.model then default_claude_model
-              else config.model
+            let display_name =
+              match model_opt with
+              | Some m -> Printf.sprintf "Claude (%s)" m
+              | None -> "Claude"
             in
-            let display_name = Printf.sprintf "Claude (%s)" claude_model in
-            Claude_backend.create ~name:display_name ~model:claude_model
+            Claude_backend.create ~name:display_name ~model:model_opt
               ~process_mgr ~clock ~timeout:session_timeout ~setsid_exec
         | "codex" ->
             Codex_backend.create ~model:model_opt ~process_mgr ~clock
@@ -4375,9 +4368,9 @@ let model_arg =
     & info [ "model" ] ~docv:"MODEL"
         ~doc:
           "Model name to pass to the selected backend (e.g. [sonnet], [opus], \
-           [sonnet-4-6] for claude; [gpt-5-mini] for codex). When omitted, the \
-           backend's own default is used (except for claude, which defaults to \
-           opus).")
+           [sonnet-4-6] for claude; [gpt-5-mini] for codex). When omitted, \
+           onton does not pass --model to the underlying CLI, so the backend's \
+           own default applies.")
 
 let repo_arg =
   let open Cmdliner in

--- a/lib/claude_backend.mli
+++ b/lib/claude_backend.mli
@@ -1,13 +1,14 @@
 val create :
   name:string ->
-  model:string ->
+  model:string option ->
   process_mgr:_ Eio.Process.mgr ->
   clock:_ Eio.Time.clock ->
   timeout:float ->
   setsid_exec:string option ->
   Llm_backend.t
-(** Create an LLM backend that uses the Claude CLI. [timeout] is the maximum
-    session duration in seconds before the process is killed. [setsid_exec],
-    when [Some path], routes the subprocess through the [onton-setsid-exec] shim
-    so it leads its own process group and the whole tree can be reaped on
-    teardown. *)
+(** Create an LLM backend that uses the Claude CLI. [model], when provided, is
+    passed via [--model]; [None] (or empty) lets the Claude CLI pick its own
+    default. [timeout] is the maximum session duration in seconds before the
+    process is killed. [setsid_exec], when [Some path], routes the subprocess
+    through the [onton-setsid-exec] shim so it leads its own process group and
+    the whole tree can be reaped on teardown. *)

--- a/lib/claude_runner.ml
+++ b/lib/claude_runner.ml
@@ -39,34 +39,29 @@ let ansi_re =
 (** Strip ANSI escape sequences and stray control characters. *)
 let strip_ansi s = Re.replace_string ansi_re ~by:"" s
 
+let model_args = function
+  | Some m when not (String.is_empty m) -> [ "--model"; m ]
+  | _ -> []
+
 let build_args ~model ~prompt ~resume_session =
-  let base =
-    [ "claude"; "--model"; model; "-p"; prompt; "--output-format"; "text" ]
-  in
+  let base = [ "claude" ] in
+  let prompt_args = [ "-p"; prompt; "--output-format"; "text" ] in
   let session_args =
     match resume_session with Some id -> [ "--resume"; id ] | None -> []
   in
   let flags = [ "--dangerously-skip-permissions"; "--max-turns"; "200" ] in
-  base @ session_args @ flags
+  base @ model_args model @ prompt_args @ session_args @ flags
 
 let build_stream_args ~model ~prompt ~resume_session =
-  let base =
-    [
-      "claude";
-      "--model";
-      model;
-      "-p";
-      prompt;
-      "--output-format";
-      "stream-json";
-      "--verbose";
-    ]
+  let base = [ "claude" ] in
+  let prompt_args =
+    [ "-p"; prompt; "--output-format"; "stream-json"; "--verbose" ]
   in
   let session_args =
     match resume_session with Some id -> [ "--resume"; id ] | None -> []
   in
   let flags = [ "--dangerously-skip-permissions"; "--max-turns"; "200" ] in
-  base @ session_args @ flags
+  base @ model_args model @ prompt_args @ session_args @ flags
 
 (** Find the first '\{' in [s] and return the substring starting there. Defense
     against any leading garbage in a stream-json line. *)
@@ -275,9 +270,9 @@ let run_streaming ~model ~process_mgr ~clock ~timeout ~setsid_exec ~cwd
   Llm_backend.spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~setsid_exec
     ~args ~process_line ~on_event
 
-let%test "build_args fresh (no resume)" =
+let%test "build_args fresh (no resume, with model)" =
   let args =
-    build_args ~model:"sonnet" ~prompt:"do stuff" ~resume_session:None
+    build_args ~model:(Some "sonnet") ~prompt:"do stuff" ~resume_session:None
   in
   List.equal String.equal args
     [
@@ -293,9 +288,24 @@ let%test "build_args fresh (no resume)" =
       "200";
     ]
 
+let%test "build_args fresh (no resume, no model)" =
+  let args = build_args ~model:None ~prompt:"do stuff" ~resume_session:None in
+  List.equal String.equal args
+    [
+      "claude";
+      "-p";
+      "do stuff";
+      "--output-format";
+      "text";
+      "--dangerously-skip-permissions";
+      "--max-turns";
+      "200";
+    ]
+
 let%test "build_args with resume session" =
   let args =
-    build_args ~model:"opus" ~prompt:"do stuff" ~resume_session:(Some "abc-123")
+    build_args ~model:(Some "opus") ~prompt:"do stuff"
+      ~resume_session:(Some "abc-123")
   in
   List.equal String.equal args
     [
@@ -313,9 +323,10 @@ let%test "build_args with resume session" =
       "200";
     ]
 
-let%test "build_stream_args fresh (no resume)" =
+let%test "build_stream_args fresh (no resume, with model)" =
   let args =
-    build_stream_args ~model:"sonnet" ~prompt:"do stuff" ~resume_session:None
+    build_stream_args ~model:(Some "sonnet") ~prompt:"do stuff"
+      ~resume_session:None
   in
   List.equal String.equal args
     [
@@ -332,9 +343,26 @@ let%test "build_stream_args fresh (no resume)" =
       "200";
     ]
 
+let%test "build_stream_args fresh (no resume, no model)" =
+  let args =
+    build_stream_args ~model:None ~prompt:"do stuff" ~resume_session:None
+  in
+  List.equal String.equal args
+    [
+      "claude";
+      "-p";
+      "do stuff";
+      "--output-format";
+      "stream-json";
+      "--verbose";
+      "--dangerously-skip-permissions";
+      "--max-turns";
+      "200";
+    ]
+
 let%test "build_stream_args with resume session" =
   let args =
-    build_stream_args ~model:"opus" ~prompt:"do stuff"
+    build_stream_args ~model:(Some "opus") ~prompt:"do stuff"
       ~resume_session:(Some "abc-123")
   in
   List.equal String.equal args

--- a/lib/claude_runner.mli
+++ b/lib/claude_runner.mli
@@ -15,7 +15,7 @@ open Base
     busy patches don't get new work. *)
 
 val run :
-  model:string ->
+  model:string option ->
   process_mgr:_ Eio.Process.mgr ->
   cwd:Eio.Fs.dir_ty Eio.Path.t ->
   patch_id:Types.Patch_id.t ->
@@ -36,7 +36,7 @@ val run :
     {!run_streaming} carries [~clock] and [~timeout] for this purpose. *)
 
 val run_streaming :
-  model:string ->
+  model:string option ->
   process_mgr:_ Eio.Process.mgr ->
   clock:_ Eio.Time.clock ->
   timeout:float ->
@@ -65,10 +65,16 @@ val strip_ansi : string -> string
     Exposed for testing. *)
 
 val build_args :
-  model:string -> prompt:string -> resume_session:string option -> string list
+  model:string option ->
+  prompt:string ->
+  resume_session:string option ->
+  string list
 (** Build the CLI argument list for the Claude process. Exposed for testing. *)
 
 val build_stream_args :
-  model:string -> prompt:string -> resume_session:string option -> string list
+  model:string option ->
+  prompt:string ->
+  resume_session:string option ->
+  string list
 (** Build the CLI argument list for stream-json output mode. Exposed for
     testing. *)

--- a/lib/codex_backend.ml
+++ b/lib/codex_backend.ml
@@ -1,29 +1,20 @@
 open Base
 
-let build_args ~cwd_path ~prompt ~resume_session =
+let build_args ~model ~cwd_path ~prompt ~resume_session =
+  let model_args =
+    match model with
+    | Some m when not (String.is_empty m) -> [ "-m"; m ]
+    | _ -> []
+  in
   match resume_session with
   | Some session_id ->
-      [
-        "codex";
-        "exec";
-        "resume";
-        session_id;
-        prompt;
-        "--json";
-        "--dangerously-bypass-approvals-and-sandbox";
-        "-C";
-        cwd_path;
-      ]
+      [ "codex"; "exec"; "resume"; session_id; prompt; "--json" ]
+      @ model_args
+      @ [ "--dangerously-bypass-approvals-and-sandbox"; "-C"; cwd_path ]
   | None ->
-      [
-        "codex";
-        "exec";
-        prompt;
-        "--json";
-        "--dangerously-bypass-approvals-and-sandbox";
-        "-C";
-        cwd_path;
-      ]
+      [ "codex"; "exec"; prompt; "--json" ]
+      @ model_args
+      @ [ "--dangerously-bypass-approvals-and-sandbox"; "-C"; cwd_path ]
 
 let parse_event (line : string) : Types.Stream_event.t list =
   match Yojson.Safe.from_string line with
@@ -98,11 +89,11 @@ let parse_event (line : string) : Types.Stream_event.t list =
   | exception Yojson.Json_error _ -> []
   | exception Yojson.Safe.Util.Type_error _ -> []
 
-let run_streaming ~process_mgr ~clock ~timeout ~setsid_exec ~cwd ~patch_id
-    ~prompt ~resume_session ~on_event =
+let run_streaming ~model ~process_mgr ~clock ~timeout ~setsid_exec ~cwd
+    ~patch_id ~prompt ~resume_session ~on_event =
   ignore (patch_id : Types.Patch_id.t);
   let cwd_path = snd cwd in
-  let args = build_args ~cwd_path ~prompt ~resume_session in
+  let args = build_args ~model ~cwd_path ~prompt ~resume_session in
   let process_line line =
     let trimmed = String.strip line in
     if String.is_empty trimmed then [] else parse_event trimmed
@@ -110,18 +101,19 @@ let run_streaming ~process_mgr ~clock ~timeout ~setsid_exec ~cwd ~patch_id
   Llm_backend.spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~setsid_exec
     ~args ~process_line ~on_event
 
-let create ~process_mgr ~clock ~timeout ~setsid_exec : Llm_backend.t =
+let create ~model ~process_mgr ~clock ~timeout ~setsid_exec : Llm_backend.t =
   {
     name = "Codex";
     run_streaming =
       (fun ~cwd ~patch_id ~prompt ~resume_session ~on_event ->
-        run_streaming ~process_mgr ~clock ~timeout ~setsid_exec ~cwd ~patch_id
-          ~prompt ~resume_session ~on_event);
+        run_streaming ~model ~process_mgr ~clock ~timeout ~setsid_exec ~cwd
+          ~patch_id ~prompt ~resume_session ~on_event);
   }
 
-let%test "build_args fresh (no resume)" =
+let%test "build_args fresh (no resume, no model)" =
   let args =
-    build_args ~cwd_path:"/tmp/work" ~prompt:"do stuff" ~resume_session:None
+    build_args ~model:None ~cwd_path:"/tmp/work" ~prompt:"do stuff"
+      ~resume_session:None
   in
   List.equal String.equal args
     [
@@ -134,9 +126,27 @@ let%test "build_args fresh (no resume)" =
       "/tmp/work";
     ]
 
+let%test "build_args fresh with model" =
+  let args =
+    build_args ~model:(Some "gpt-5-mini") ~cwd_path:"/tmp/work"
+      ~prompt:"do stuff" ~resume_session:None
+  in
+  List.equal String.equal args
+    [
+      "codex";
+      "exec";
+      "do stuff";
+      "--json";
+      "-m";
+      "gpt-5-mini";
+      "--dangerously-bypass-approvals-and-sandbox";
+      "-C";
+      "/tmp/work";
+    ]
+
 let%test "build_args with resume session passes prompt and bypass flag" =
   let args =
-    build_args ~cwd_path:"/tmp/work" ~prompt:"do stuff"
+    build_args ~model:None ~cwd_path:"/tmp/work" ~prompt:"do stuff"
       ~resume_session:(Some "sess-1")
   in
   List.equal String.equal args
@@ -147,6 +157,26 @@ let%test "build_args with resume session passes prompt and bypass flag" =
       "sess-1";
       "do stuff";
       "--json";
+      "--dangerously-bypass-approvals-and-sandbox";
+      "-C";
+      "/tmp/work";
+    ]
+
+let%test "build_args with resume session and model" =
+  let args =
+    build_args ~model:(Some "gpt-5-mini") ~cwd_path:"/tmp/work"
+      ~prompt:"do stuff" ~resume_session:(Some "sess-1")
+  in
+  List.equal String.equal args
+    [
+      "codex";
+      "exec";
+      "resume";
+      "sess-1";
+      "do stuff";
+      "--json";
+      "-m";
+      "gpt-5-mini";
       "--dangerously-bypass-approvals-and-sandbox";
       "-C";
       "/tmp/work";

--- a/lib/codex_backend.mli
+++ b/lib/codex_backend.mli
@@ -1,12 +1,15 @@
 val create :
+  model:string option ->
   process_mgr:_ Eio.Process.mgr ->
   clock:_ Eio.Time.clock ->
   timeout:float ->
   setsid_exec:string option ->
   Llm_backend.t
-(** Create an LLM backend that uses the Codex CLI. [timeout] is the maximum
-    session duration in seconds before the process is killed. See
-    {!Claude_backend.create} for [setsid_exec] semantics. *)
+(** Create an LLM backend that uses the Codex CLI. [model], when provided, is
+    passed to [codex exec] via the [-m] flag; [None] (or empty) lets the Codex
+    CLI pick its own default. [timeout] is the maximum session duration in
+    seconds before the process is killed. See {!Claude_backend.create} for
+    [setsid_exec] semantics. *)
 
 val parse_event : string -> Types.Stream_event.t list
 (** Parse a single NDJSON line from Codex's JSON output. Exposed for testing. *)

--- a/lib/gemini_backend.ml
+++ b/lib/gemini_backend.ml
@@ -1,15 +1,20 @@
 open Base
 
-let build_args ~prompt ~resume_session =
+let build_args ~model ~prompt ~resume_session =
   let base =
     [ "gemini"; "-p"; prompt; "--output-format"; "stream-json"; "--yolo" ]
+  in
+  let model_args =
+    match model with
+    | Some m when not (String.is_empty m) -> [ "-m"; m ]
+    | _ -> []
   in
   let resume_args =
     match resume_session with
     | Some session_id -> [ "-r"; session_id ]
     | None -> []
   in
-  base @ resume_args
+  base @ model_args @ resume_args
 
 let parse_event (line : string) : Types.Stream_event.t list =
   match Yojson.Safe.from_string line with
@@ -71,10 +76,10 @@ let parse_event (line : string) : Types.Stream_event.t list =
   | exception Yojson.Json_error _ -> []
   | exception Yojson.Safe.Util.Type_error _ -> []
 
-let run_streaming ~process_mgr ~clock ~timeout ~setsid_exec ~cwd ~patch_id
-    ~prompt ~resume_session ~on_event =
+let run_streaming ~model ~process_mgr ~clock ~timeout ~setsid_exec ~cwd
+    ~patch_id ~prompt ~resume_session ~on_event =
   ignore (patch_id : Types.Patch_id.t);
-  let args = build_args ~prompt ~resume_session in
+  let args = build_args ~model ~prompt ~resume_session in
   let process_line line =
     let trimmed = String.strip line in
     if String.is_empty trimmed then [] else parse_event trimmed
@@ -82,22 +87,41 @@ let run_streaming ~process_mgr ~clock ~timeout ~setsid_exec ~cwd ~patch_id
   Llm_backend.spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~setsid_exec
     ~args ~process_line ~on_event
 
-let create ~process_mgr ~clock ~timeout ~setsid_exec : Llm_backend.t =
+let create ~model ~process_mgr ~clock ~timeout ~setsid_exec : Llm_backend.t =
   {
     name = "Gemini";
     run_streaming =
       (fun ~cwd ~patch_id ~prompt ~resume_session ~on_event ->
-        run_streaming ~process_mgr ~clock ~timeout ~setsid_exec ~cwd ~patch_id
-          ~prompt ~resume_session ~on_event);
+        run_streaming ~model ~process_mgr ~clock ~timeout ~setsid_exec ~cwd
+          ~patch_id ~prompt ~resume_session ~on_event);
   }
 
-let%test "build_args fresh (no resume)" =
-  let args = build_args ~prompt:"do stuff" ~resume_session:None in
+let%test "build_args fresh (no resume, no model)" =
+  let args = build_args ~model:None ~prompt:"do stuff" ~resume_session:None in
   List.equal String.equal args
     [ "gemini"; "-p"; "do stuff"; "--output-format"; "stream-json"; "--yolo" ]
 
+let%test "build_args with model" =
+  let args =
+    build_args ~model:(Some "gemini-2.5-pro") ~prompt:"do stuff"
+      ~resume_session:None
+  in
+  List.equal String.equal args
+    [
+      "gemini";
+      "-p";
+      "do stuff";
+      "--output-format";
+      "stream-json";
+      "--yolo";
+      "-m";
+      "gemini-2.5-pro";
+    ]
+
 let%test "build_args with resume session" =
-  let args = build_args ~prompt:"do stuff" ~resume_session:(Some "latest") in
+  let args =
+    build_args ~model:None ~prompt:"do stuff" ~resume_session:(Some "latest")
+  in
   List.equal String.equal args
     [
       "gemini";

--- a/lib/gemini_backend.ml
+++ b/lib/gemini_backend.ml
@@ -134,6 +134,25 @@ let%test "build_args with resume session" =
       "latest";
     ]
 
+let%test "build_args with model and resume session" =
+  let args =
+    build_args ~model:(Some "gemini-2.5-pro") ~prompt:"do stuff"
+      ~resume_session:(Some "latest")
+  in
+  List.equal String.equal args
+    [
+      "gemini";
+      "-p";
+      "do stuff";
+      "--output-format";
+      "stream-json";
+      "--yolo";
+      "-m";
+      "gemini-2.5-pro";
+      "-r";
+      "latest";
+    ]
+
 let%test "parse_event init" =
   let line =
     {|{"type":"init","timestamp":"2026-04-13T14:16:47.453Z","session_id":"abc-123","model":"gemini-3-flash-preview"}|}

--- a/lib/gemini_backend.mli
+++ b/lib/gemini_backend.mli
@@ -1,12 +1,14 @@
 val create :
+  model:string option ->
   process_mgr:_ Eio.Process.mgr ->
   clock:_ Eio.Time.clock ->
   timeout:float ->
   setsid_exec:string option ->
   Llm_backend.t
-(** Create an LLM backend that uses the Gemini CLI. [timeout] is the maximum
-    session duration in seconds before the process is killed. See
-    {!Claude_backend.create} for [setsid_exec] semantics. *)
+(** Create an LLM backend that uses the Gemini CLI. [model], when provided, is
+    passed via [-m]; [None] (or empty) lets the Gemini CLI pick its own default.
+    [timeout] is the maximum session duration in seconds before the process is
+    killed. See {!Claude_backend.create} for [setsid_exec] semantics. *)
 
 val parse_event : string -> Types.Stream_event.t list
 (** Parse a single NDJSON line from Gemini's stream-json output. Exposed for

--- a/lib/opencode_backend.ml
+++ b/lib/opencode_backend.ml
@@ -1,13 +1,18 @@
 open Base
 
-let build_args ~cwd_path ~prompt ~resume_session =
+let build_args ~model ~cwd_path ~prompt ~resume_session =
   let base = [ "opencode"; "run"; "--format"; "json"; "--dir"; cwd_path ] in
+  let model_args =
+    match model with
+    | Some m when not (String.is_empty m) -> [ "-m"; m ]
+    | _ -> []
+  in
   let resume_args =
     match resume_session with
     | Some session_id -> [ "--session"; session_id ]
     | None -> []
   in
-  base @ resume_args @ [ prompt ]
+  base @ model_args @ resume_args @ [ prompt ]
 
 (* OpenCode emits lowercase tool names and camelCase input keys, while the
    downstream summary extractor in [bin/main.ml] expects the PascalCase names
@@ -95,11 +100,11 @@ let parse_event (line : string) : Types.Stream_event.t list =
   | exception Yojson.Json_error _ -> []
   | exception Yojson.Safe.Util.Type_error _ -> []
 
-let run_streaming ~process_mgr ~clock ~timeout ~setsid_exec ~cwd ~patch_id
-    ~prompt ~resume_session ~on_event =
+let run_streaming ~model ~process_mgr ~clock ~timeout ~setsid_exec ~cwd
+    ~patch_id ~prompt ~resume_session ~on_event =
   ignore (patch_id : Types.Patch_id.t);
   let cwd_path = snd cwd in
-  let args = build_args ~cwd_path ~prompt ~resume_session in
+  let args = build_args ~model ~cwd_path ~prompt ~resume_session in
   let process_line line =
     let trimmed = String.strip line in
     if String.is_empty trimmed then [] else parse_event trimmed
@@ -107,25 +112,44 @@ let run_streaming ~process_mgr ~clock ~timeout ~setsid_exec ~cwd ~patch_id
   Llm_backend.spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~setsid_exec
     ~args ~process_line ~on_event
 
-let create ~process_mgr ~clock ~timeout ~setsid_exec : Llm_backend.t =
+let create ~model ~process_mgr ~clock ~timeout ~setsid_exec : Llm_backend.t =
   {
     name = "OpenCode";
     run_streaming =
       (fun ~cwd ~patch_id ~prompt ~resume_session ~on_event ->
-        run_streaming ~process_mgr ~clock ~timeout ~setsid_exec ~cwd ~patch_id
-          ~prompt ~resume_session ~on_event);
+        run_streaming ~model ~process_mgr ~clock ~timeout ~setsid_exec ~cwd
+          ~patch_id ~prompt ~resume_session ~on_event);
   }
 
-let%test "build_args without continue" =
+let%test "build_args without continue (no model)" =
   let args =
-    build_args ~cwd_path:"/tmp/work" ~prompt:"do stuff" ~resume_session:None
+    build_args ~model:None ~cwd_path:"/tmp/work" ~prompt:"do stuff"
+      ~resume_session:None
   in
   List.equal String.equal args
     [ "opencode"; "run"; "--format"; "json"; "--dir"; "/tmp/work"; "do stuff" ]
 
+let%test "build_args without continue (with model)" =
+  let args =
+    build_args ~model:(Some "anthropic/claude-sonnet-4-5") ~cwd_path:"/tmp/work"
+      ~prompt:"do stuff" ~resume_session:None
+  in
+  List.equal String.equal args
+    [
+      "opencode";
+      "run";
+      "--format";
+      "json";
+      "--dir";
+      "/tmp/work";
+      "-m";
+      "anthropic/claude-sonnet-4-5";
+      "do stuff";
+    ]
+
 let%test "build_args with continue" =
   let args =
-    build_args ~cwd_path:"/tmp/work" ~prompt:"do stuff"
+    build_args ~model:None ~cwd_path:"/tmp/work" ~prompt:"do stuff"
       ~resume_session:(Some "x")
   in
   List.equal String.equal args

--- a/lib/opencode_backend.mli
+++ b/lib/opencode_backend.mli
@@ -1,12 +1,14 @@
 val create :
+  model:string option ->
   process_mgr:_ Eio.Process.mgr ->
   clock:_ Eio.Time.clock ->
   timeout:float ->
   setsid_exec:string option ->
   Llm_backend.t
-(** Create an LLM backend that uses the OpenCode CLI. [timeout] is the maximum
-    session duration in seconds before the process is killed. See
-    {!Claude_backend.create} for [setsid_exec] semantics. *)
+(** Create an LLM backend that uses the OpenCode CLI. [model], when provided, is
+    passed via [-m]; [None] (or empty) lets OpenCode pick its own default.
+    [timeout] is the maximum session duration in seconds before the process is
+    killed. See {!Claude_backend.create} for [setsid_exec] semantics. *)
 
 val parse_event : string -> Types.Stream_event.t list
 (** Parse a single NDJSON line from OpenCode's JSON output. Exposed for testing.

--- a/lib/pi_backend.ml
+++ b/lib/pi_backend.ml
@@ -1,15 +1,20 @@
 open Base
 
-let build_args ~cwd_path ~patch_id ~prompt ~resume_session =
+let build_args ~model ~cwd_path ~patch_id ~prompt ~resume_session =
   let session_dir = cwd_path ^ "/.pi-sessions/" ^ patch_id in
   let base = [ "pi"; "-p"; prompt; "--mode"; "json" ] in
+  let model_args =
+    match model with
+    | Some m when not (String.is_empty m) -> [ "--model"; m ]
+    | _ -> []
+  in
   let resume_args =
     match resume_session with
     | Some session_id -> [ "--resume"; session_id ]
     | None -> []
   in
   let session_args = [ "--session-dir"; session_dir ] in
-  base @ resume_args @ session_args
+  base @ model_args @ resume_args @ session_args
 
 let parse_event (line : string) : Types.Stream_event.t list =
   match Yojson.Safe.from_string line with
@@ -50,12 +55,12 @@ let parse_event (line : string) : Types.Stream_event.t list =
   | exception Yojson.Json_error _ -> []
   | exception Yojson.Safe.Util.Type_error _ -> []
 
-let run_streaming ~process_mgr ~clock ~timeout ~setsid_exec ~cwd ~patch_id
-    ~prompt ~resume_session ~on_event =
+let run_streaming ~model ~process_mgr ~clock ~timeout ~setsid_exec ~cwd
+    ~patch_id ~prompt ~resume_session ~on_event =
   let cwd_path = snd cwd in
   let patch_id_str = Types.Patch_id.to_string patch_id in
   let args =
-    build_args ~cwd_path ~patch_id:patch_id_str ~prompt ~resume_session
+    build_args ~model ~cwd_path ~patch_id:patch_id_str ~prompt ~resume_session
   in
   let process_line line =
     let trimmed = String.strip line in
@@ -64,19 +69,19 @@ let run_streaming ~process_mgr ~clock ~timeout ~setsid_exec ~cwd ~patch_id
   Llm_backend.spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~setsid_exec
     ~args ~process_line ~on_event
 
-let create ~process_mgr ~clock ~timeout ~setsid_exec : Llm_backend.t =
+let create ~model ~process_mgr ~clock ~timeout ~setsid_exec : Llm_backend.t =
   {
     name = "Pi";
     run_streaming =
       (fun ~cwd ~patch_id ~prompt ~resume_session ~on_event ->
-        run_streaming ~process_mgr ~clock ~timeout ~setsid_exec ~cwd ~patch_id
-          ~prompt ~resume_session ~on_event);
+        run_streaming ~model ~process_mgr ~clock ~timeout ~setsid_exec ~cwd
+          ~patch_id ~prompt ~resume_session ~on_event);
   }
 
-let%test "build_args without continue" =
+let%test "build_args without continue (no model)" =
   let args =
-    build_args ~cwd_path:"/tmp/work" ~patch_id:"patch-1" ~prompt:"do stuff"
-      ~resume_session:None
+    build_args ~model:None ~cwd_path:"/tmp/work" ~patch_id:"patch-1"
+      ~prompt:"do stuff" ~resume_session:None
   in
   List.equal String.equal args
     [
@@ -89,10 +94,28 @@ let%test "build_args without continue" =
       "/tmp/work/.pi-sessions/patch-1";
     ]
 
+let%test "build_args with model" =
+  let args =
+    build_args ~model:(Some "pi-3") ~cwd_path:"/tmp/work" ~patch_id:"patch-1"
+      ~prompt:"do stuff" ~resume_session:None
+  in
+  List.equal String.equal args
+    [
+      "pi";
+      "-p";
+      "do stuff";
+      "--mode";
+      "json";
+      "--model";
+      "pi-3";
+      "--session-dir";
+      "/tmp/work/.pi-sessions/patch-1";
+    ]
+
 let%test "build_args with continue" =
   let args =
-    build_args ~cwd_path:"/tmp/work" ~patch_id:"patch-1" ~prompt:"do stuff"
-      ~resume_session:(Some "x")
+    build_args ~model:None ~cwd_path:"/tmp/work" ~patch_id:"patch-1"
+      ~prompt:"do stuff" ~resume_session:(Some "x")
   in
   List.equal String.equal args
     [

--- a/lib/pi_backend.mli
+++ b/lib/pi_backend.mli
@@ -1,12 +1,15 @@
 val create :
+  model:string option ->
   process_mgr:_ Eio.Process.mgr ->
   clock:_ Eio.Time.clock ->
   timeout:float ->
   setsid_exec:string option ->
   Llm_backend.t
-(** Create an LLM backend that uses the Pi CLI. [timeout] is the maximum session
-    duration in seconds before the process is killed. See
-    {!Claude_backend.create} for [setsid_exec] semantics. *)
+(** Create an LLM backend that uses the Pi CLI. [model], when provided, is
+    passed via [--model]; [None] (or empty) lets the Pi CLI pick its own
+    default. [timeout] is the maximum session duration in seconds before the
+    process is killed. See {!Claude_backend.create} for [setsid_exec] semantics.
+*)
 
 val parse_event : string -> Types.Stream_event.t list
 (** Parse a single NDJSON line from Pi's JSON output. Exposed for testing. *)

--- a/lib/project_store.ml
+++ b/lib/project_store.ml
@@ -96,11 +96,12 @@ let save_config ~project_name ~github_token ~github_owner ~github_repo ~backend
       Stdlib.output_string oc (Yojson.Safe.pretty_to_string json);
       Stdlib.flush oc)
 
-(* Migrate legacy ["claude-sonnet"]/["claude-opus"] backend strings (and the
-   bare ["claude"] alias) into the decomposed [backend] + [model] form. The
-   [model] field was added after [backend] and is missing from older configs.
-   Splitting here means the rest of the codebase only deals with the new
-   shape. *)
+(* Migrate legacy combined backend strings (["claude-sonnet"], ["claude-opus"])
+   into the decomposed [backend] + [model] form, and ensure the [model] field
+   is always present (it was added after [backend] and is missing from older
+   configs). Only the legacy combined names inject a model; bare ["claude"]
+   stays bare and lets the runtime omit [--model] so the Claude CLI applies
+   its own default. *)
 let migrate_backend_model fields =
   let assoc = List.Assoc.find fields ~equal:String.equal in
   let stored_backend =
@@ -113,10 +114,7 @@ let migrate_backend_model fields =
     match (stored_backend, stored_model) with
     | "claude-sonnet", "" -> ("claude", "sonnet")
     | "claude-opus", "" -> ("claude", "opus")
-    | "claude-sonnet", m | "claude-opus", m -> ("claude", m)
-    | "claude", "" -> ("claude", "opus")
-    | "", _ ->
-        ("claude", if String.is_empty stored_model then "opus" else stored_model)
+    | ("claude-sonnet" | "claude-opus"), m -> ("claude", m)
     | b, m -> (b, m)
   in
   let without =

--- a/lib/project_store.ml
+++ b/lib/project_store.ml
@@ -114,6 +114,8 @@ let migrate_backend_model fields =
     match (stored_backend, stored_model) with
     | "claude-sonnet", "" -> ("claude", "sonnet")
     | "claude-opus", "" -> ("claude", "opus")
+    (* Legacy combined name with an explicitly stored model: keep the stored
+       model rather than overriding it from the legacy backend suffix. *)
     | ("claude-sonnet" | "claude-opus"), m -> ("claude", m)
     | b, m -> (b, m)
   in

--- a/lib/project_store.ml
+++ b/lib/project_store.ml
@@ -62,6 +62,7 @@ type stored_config = {
   github_owner : string;
   github_repo : string;
   backend : string;
+  model : string;
   main_branch : string;
   poll_interval : float;
   repo_root : string;
@@ -70,7 +71,7 @@ type stored_config = {
 [@@deriving yojson]
 
 let save_config ~project_name ~github_token ~github_owner ~github_repo ~backend
-    ~main_branch ~poll_interval ~repo_root ~max_concurrency =
+    ~model ~main_branch ~poll_interval ~repo_root ~max_concurrency =
   let dir = project_dir project_name in
   ensure_dir dir;
   let config =
@@ -80,6 +81,7 @@ let save_config ~project_name ~github_token ~github_owner ~github_repo ~backend
       github_owner;
       github_repo;
       backend;
+      model;
       main_branch;
       poll_interval;
       repo_root;
@@ -94,6 +96,35 @@ let save_config ~project_name ~github_token ~github_owner ~github_repo ~backend
       Stdlib.output_string oc (Yojson.Safe.pretty_to_string json);
       Stdlib.flush oc)
 
+(* Migrate legacy ["claude-sonnet"]/["claude-opus"] backend strings (and the
+   bare ["claude"] alias) into the decomposed [backend] + [model] form. The
+   [model] field was added after [backend] and is missing from older configs.
+   Splitting here means the rest of the codebase only deals with the new
+   shape. *)
+let migrate_backend_model fields =
+  let assoc = List.Assoc.find fields ~equal:String.equal in
+  let stored_backend =
+    match assoc "backend" with Some (`String s) -> s | _ -> ""
+  in
+  let stored_model =
+    match assoc "model" with Some (`String s) -> s | _ -> ""
+  in
+  let backend, model =
+    match (stored_backend, stored_model) with
+    | "claude-sonnet", "" -> ("claude", "sonnet")
+    | "claude-opus", "" -> ("claude", "opus")
+    | "claude-sonnet", m | "claude-opus", m -> ("claude", m)
+    | "claude", "" -> ("claude", "opus")
+    | "", _ ->
+        ("claude", if String.is_empty stored_model then "opus" else stored_model)
+    | b, m -> (b, m)
+  in
+  let without =
+    List.filter fields ~f:(fun (k, _) ->
+        not (String.equal k "backend" || String.equal k "model"))
+  in
+  ("backend", `String backend) :: ("model", `String model) :: without
+
 let load_config ~project_name =
   let path = config_path project_name in
   try
@@ -106,17 +137,7 @@ let load_config ~project_name =
     let json = Yojson.Safe.from_string content in
     match json with
     | `Assoc fields ->
-        let fields =
-          let fields =
-            if List.Assoc.mem fields "backend" ~equal:String.equal then fields
-            else ("backend", `String "claude-opus") :: fields
-          in
-          List.map fields ~f:(fun (key, value) ->
-              match (key, value) with
-              | "backend", `String "claude" -> (key, `String "claude-opus")
-              | _ -> (key, value))
-        in
-        Ok (stored_config_of_yojson (`Assoc fields))
+        Ok (stored_config_of_yojson (`Assoc (migrate_backend_model fields)))
     | _ -> Ok (stored_config_of_yojson json)
   with exn -> Error (Stdlib.Printexc.to_string exn)
 

--- a/lib/project_store.mli
+++ b/lib/project_store.mli
@@ -28,6 +28,7 @@ type stored_config = {
   github_owner : string;
   github_repo : string;
   backend : string;
+  model : string;
   main_branch : string;
   poll_interval : float;
   repo_root : string;
@@ -41,6 +42,7 @@ val save_config :
   github_owner:string ->
   github_repo:string ->
   backend:string ->
+  model:string ->
   main_branch:string ->
   poll_interval:float ->
   repo_root:string ->


### PR DESCRIPTION
## Summary

- `--backend` now selects only the backend (`claude`, `codex`, `opencode`, `pi`, `gemini`); model is a separate `--model` flag, passed through to each backend's CLI.
- Legacy `--backend claude-opus` / `--backend claude-sonnet` are still accepted and silently split into the equivalent decomposed pair, including for stored project configs migrated on load.
- README documents the new flags, common model names per backend, and links to each provider's authoritative model list.

## Examples

\`\`\`sh
onton --backend claude --model sonnet-4-6
onton --backend codex --model gpt-5-codex
onton --backend gemini --model gemini-2.5-pro
onton --backend opencode --model anthropic/claude-sonnet-4-5
\`\`\`

When `--model` is omitted, each backend uses its own default. For `claude` we keep `opus` as the historical default so existing setups don't change behavior.

## Implementation notes

- `Project_store.stored_config` gains a `model : string` field.
- `load_config` migrates legacy configs (no `model` field, or `backend: "claude-opus"`/`"claude-sonnet"`) into the new shape.
- All four non-claude backend `create` functions now take `~model:string option` and forward it to their CLIs (`-m` for codex/opencode/gemini, `--model` for pi).

## Test plan

- [x] `dune build` clean
- [x] `dune runtest` — all inline tests for the four updated `build_args` functions plus existing backend smoke tests
- [x] `dune fmt` clean
- [x] `--help` shows new `--backend` / `--model` flags with updated docs
- [ ] Manual: launch a project with `--backend claude --model sonnet-4-6`, kill it, resume by name (no flags) → confirm stored config replays the same backend+model
- [ ] Manual: load a project saved by an older onton (config has `"backend": "claude-opus"` and no `model` field) → confirm it migrates and runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/230"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split backend selection into `--backend` and `--model` so model choice works across all backends. Default backend is `claude`; when `--model` is omitted, onton won’t pass a model so each provider CLI uses its own default.

- **New Features**
  - `--backend` accepts only: `claude`, `codex`, `opencode`, `pi`, `gemini`.
  - New `--model` flag is passed through to each CLI when provided (`claude --model`, `codex -m`, `opencode -m`, `gemini -m`, `pi --model`).
  - Defaults: backend `claude`; no onton-specific model default (provider CLI decides if `--model` is omitted).
  - Backend and model are saved in project config and reused on resume.
  - README adds a “Backend & model” section, examples, and a supported models table with links to each provider.

- **Migration**
  - Combined CLI values like `--backend claude-opus` / `claude-sonnet` are no longer accepted on the command line.
  - Stored configs without `model` (or with `backend: "claude-opus"/"claude-sonnet"`) are migrated on load to `backend: "claude"` with the corresponding `model`; bare `"claude"` remains without a model so the CLI default applies.

<sup>Written for commit 727be7d7f27ac85707fd203a91550bb142f4d330. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added independent --backend and --model CLI flags
  * Default backend now set to "claude"
  * Automatic migration of older backend configurations to the new backend+model format

* **Documentation**
  * README updated with a "Backend & model" section, usage flags table, example invocations, and a February 2026 supported-models table
<!-- end of auto-generated comment: release notes by coderabbit.ai -->