### PR TITLE
Fix codex --resume by placing -C globally

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1018,6 +1018,27 @@ let run_claude_and_handle ~(kind : Operation_kind.t option) ~runtime
                 })
               result
           in
+          (* classify routes Error outcomes to Process_error, so the
+             empty-events arms below only ever see Ok. *)
+          let log_empty_resume ~tail =
+            match result with
+            | Error _ -> ()
+            | Ok r ->
+                let render label s =
+                  let s = String.trim s in
+                  if String.equal s "" then label ^ "=empty"
+                  else
+                    Printf.sprintf "%s=%d chars: %s" label (String.length s)
+                      (truncate s 500)
+                in
+                log_event runtime ~patch_id
+                  (Printf.sprintf
+                     "Resume exited %d (%s) with no parsed stream events%s — \
+                      %s %s"
+                     r.Llm_backend.exit_code backend.Llm_backend.name tail
+                     (render "stdout" r.Llm_backend.stdout)
+                     (render "stderr" r.Llm_backend.stderr))
+          in
           let session_result, user_result =
             match
               classify ~is_resume:(Option.is_some resume_session) outcome
@@ -1028,9 +1049,7 @@ let run_claude_and_handle ~(kind : Operation_kind.t option) ~runtime
                      backend.Llm_backend.name msg);
                 (Orchestrator.Session_process_error { is_fresh }, `Failed)
             | No_session_to_resume ->
-                log_event runtime ~patch_id
-                  "Resume produced no events — no session to resume, retrying \
-                   fresh";
+                log_empty_resume ~tail:" — no session to resume, retrying fresh";
                 (Orchestrator.Session_no_resume, `Failed)
             | Timed_out ->
                 log_event runtime ~patch_id
@@ -1040,21 +1059,7 @@ let run_claude_and_handle ~(kind : Operation_kind.t option) ~runtime
             | Success { stream_errors } ->
                 (match (resume_session, result) with
                 | Some _, Ok r when not r.Llm_backend.got_events ->
-                    let stdout = String.trim r.Llm_backend.stdout in
-                    let stderr = String.trim r.Llm_backend.stderr in
-                    log_event runtime ~patch_id
-                      (Printf.sprintf
-                         "Resume exited 0 (%s) with no parsed stream events — \
-                          stdout=%s stderr=%s"
-                         backend.Llm_backend.name
-                         (if String.equal stdout "" then "empty"
-                          else
-                            Printf.sprintf "%d chars: %s" (String.length stdout)
-                              (truncate stdout 500))
-                         (if String.equal stderr "" then "empty"
-                          else
-                            Printf.sprintf "%d chars: %s" (String.length stderr)
-                              (truncate stderr 500)))
+                    log_empty_resume ~tail:""
                 | Some _, (Ok _ | Error _) | None, _ -> ());
                 if String.length stream_errors > 0 then
                   log_event runtime ~patch_id

--- a/lib/codex_backend.ml
+++ b/lib/codex_backend.ml
@@ -6,15 +6,17 @@ let build_args ~model ~cwd_path ~prompt ~resume_session =
     | Some m when not (String.is_empty m) -> [ "-m"; m ]
     | _ -> []
   in
+  (* -C is a global codex option (codex [OPTIONS] <COMMAND>); codex exec
+     re-exposes it but codex exec resume does not, so place it before the
+     subcommand to work uniformly across both. *)
+  let global = [ "codex"; "-C"; cwd_path ] in
+  let trailing = [ "--dangerously-bypass-approvals-and-sandbox" ] in
   match resume_session with
   | Some session_id ->
-      [ "codex"; "exec"; "resume"; session_id; prompt; "--json" ]
-      @ model_args
-      @ [ "--dangerously-bypass-approvals-and-sandbox"; "-C"; cwd_path ]
-  | None ->
-      [ "codex"; "exec"; prompt; "--json" ]
-      @ model_args
-      @ [ "--dangerously-bypass-approvals-and-sandbox"; "-C"; cwd_path ]
+      global
+      @ [ "exec"; "resume"; session_id; prompt; "--json" ]
+      @ model_args @ trailing
+  | None -> global @ [ "exec"; prompt; "--json" ] @ model_args @ trailing
 
 let parse_event (line : string) : Types.Stream_event.t list =
   match Yojson.Safe.from_string line with
@@ -118,12 +120,12 @@ let%test "build_args fresh (no resume, no model)" =
   List.equal String.equal args
     [
       "codex";
+      "-C";
+      "/tmp/work";
       "exec";
       "do stuff";
       "--json";
       "--dangerously-bypass-approvals-and-sandbox";
-      "-C";
-      "/tmp/work";
     ]
 
 let%test "build_args fresh with model" =
@@ -134,14 +136,14 @@ let%test "build_args fresh with model" =
   List.equal String.equal args
     [
       "codex";
+      "-C";
+      "/tmp/work";
       "exec";
       "do stuff";
       "--json";
       "-m";
       "gpt-5-mini";
       "--dangerously-bypass-approvals-and-sandbox";
-      "-C";
-      "/tmp/work";
     ]
 
 let%test "build_args with resume session passes prompt and bypass flag" =
@@ -152,14 +154,14 @@ let%test "build_args with resume session passes prompt and bypass flag" =
   List.equal String.equal args
     [
       "codex";
+      "-C";
+      "/tmp/work";
       "exec";
       "resume";
       "sess-1";
       "do stuff";
       "--json";
       "--dangerously-bypass-approvals-and-sandbox";
-      "-C";
-      "/tmp/work";
     ]
 
 let%test "build_args with resume session and model" =
@@ -170,6 +172,8 @@ let%test "build_args with resume session and model" =
   List.equal String.equal args
     [
       "codex";
+      "-C";
+      "/tmp/work";
       "exec";
       "resume";
       "sess-1";
@@ -178,8 +182,6 @@ let%test "build_args with resume session and model" =
       "-m";
       "gpt-5-mini";
       "--dangerously-bypass-approvals-and-sandbox";
-      "-C";
-      "/tmp/work";
     ]
 
 let%test "parse_event thread.started emits Session_init" =


### PR DESCRIPTION
## Summary

- **Bug:** every `codex --resume` invocation was failing instantly. `lib/codex_backend.ml` placed `-C <cwd>` after the subcommand. `codex exec` re-exposes `-C` as a subcommand option, but `codex exec resume` does not — it bails with `error: unexpected argument '-C' found`. The non-zero exit + no events landed in `Session_no_resume`, and the orchestrator quietly fell back to a fresh session every time, defeating session reuse for codex.
- **Fix:** move `-C <cwd>` to its global codex position (`codex -C <cwd> <subcommand>`), which both `exec` and `exec resume` accept. Updates the four `build_args` tests.
- **Diagnostics:** the `No_session_to_resume` arm in `bin/main.ml` previously logged only a generic "Resume produced no events — retrying fresh" — no stderr capture. Now it emits the same `Resume exited <code> (<backend>) with no parsed stream events ... stdout=... stderr=...` line that the Success-with-no-events arm already produces (cff58d3), via a shared `log_empty_resume` helper. This is the diagnostic line that surfaced the actual codex stderr (`unexpected argument '-C' found`) and unblocked this fix.

## Test plan

- [x] `dune build` clean
- [x] `dune runtest` passes (all backend smoke tests + `build_args` cases for fresh / fresh+model / resume / resume+model)
- [x] Locally reinstalled and reproduced: `codex exec resume <id> ...` previously exited 2 with the `-C` error; with this change the resume call is accepted.
- [ ] After merge, restart the running `onton --backend codex` daemon and confirm subsequent codex sessions actually reuse the session id instead of falling back fresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes failing `codex --resume` by moving `-C <cwd>` to a global position so both `exec` and `exec resume` accept it. Adds clearer logging when resume exits with no events to surface stderr and avoid silent fallbacks.

- **Bug Fixes**
  - Build args now place `-C` before the subcommand: `codex -C <cwd> exec ...` for fresh and resume, preventing “unexpected argument '-C' found”.
  - Share `log_empty_resume` in `bin/main.ml` to log stdout/stderr when resume yields no events (both exit 0 and non-zero), making rejection reasons visible.
  - Update four `build_args` tests to reflect the new arg order.

<sup>Written for commit aa1e15b4903624399d4087f7b165c0d218e8c9a1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved logging organization for backend events to ensure consistent message formatting.
  * Optimized command-line argument construction and ordering.

* **Tests**
  * Updated test cases to reflect argument reordering changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->