### PR TITLE
Patch complexity + --model auto routing per backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,21 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Cache opam switch
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+      # Split restore/save on the opam switch cache so a canceled run (the
+      # workflow uses [cancel-in-progress: true]) can't poison the cache with
+      # a half-installed switch. The classic symptom is zarith's [make install]
+      # failing with "Package zarith is already installed - META already
+      # exists": the previous run saved [_opam/lib/zarith/META] on disk before
+      # opam recorded the install in the switch state, then the next run
+      # restores that desync and tries to re-install zarith over its own
+      # leftover files. With [cache/save] gated on [success()], only fully
+      # green runs roll the cache forward.
+      - name: Restore opam switch cache
+        id: opam-cache
+        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4
         with:
           path: _opam
-          key: opam-${{ runner.os }}-ocaml-5.4.0-test-v2-${{ hashFiles('*.opam') }}
+          key: opam-${{ runner.os }}-ocaml-5.4.0-test-v3-${{ hashFiles('*.opam') }}
 
       # `dune-cache: true` below makes setup-ocaml manage the ~/.cache/dune
       # lifecycle internally — adding a second actions/cache step on the same
@@ -92,6 +102,15 @@ jobs:
               name, f, line = m.groups()
               print(f'::error file={f},line={line}::Test failed: {name}')
           "
+
+      # Save only on a fully successful job and only if we didn't already
+      # have a hit (cache-hit means the existing entry is still valid).
+      - name: Save opam switch cache
+        if: success() && steps.opam-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        with:
+          path: _opam
+          key: opam-${{ runner.os }}-ocaml-5.4.0-test-v3-${{ hashFiles('*.opam') }}
 
   format:
     name: Format Check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,25 +24,17 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      # Split restore/save on the opam switch cache so a canceled run (the
-      # workflow uses [cancel-in-progress: true]) can't poison the cache with
-      # a half-installed switch. The classic symptom is zarith's [make install]
-      # failing with "Package zarith is already installed - META already
-      # exists": the previous run saved [_opam/lib/zarith/META] on disk before
-      # opam recorded the install in the switch state, then the next run
-      # restores that desync and tries to re-install zarith over its own
-      # leftover files. With [cache/save] gated on [success()], only fully
-      # green runs roll the cache forward.
-      - name: Restore opam switch cache
-        id: opam-cache
-        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4
-        with:
-          path: _opam
-          key: opam-${{ runner.os }}-ocaml-5.4.0-test-v3-${{ hashFiles('*.opam') }}
-
-      # `dune-cache: true` below makes setup-ocaml manage the ~/.cache/dune
-      # lifecycle internally — adding a second actions/cache step on the same
-      # path would race with it on save and clobber on restore.
+      # We deliberately do NOT cache [_opam/] here. setup-ocaml@v3 caches its
+      # own opam-root state at [~/.opam/] (compiler + repo metadata) keyed
+      # separately from anything we'd cache for [_opam/]. Caching the local
+      # switch alongside means the two can drift: a stale [~/.opam/] without
+      # the switch registered makes opam treat [_opam/] as a fresh switch and
+      # try to reinstall packages whose files still exist on disk — the
+      # classic "zarith ... META already exists" symptom we kept hitting
+      # whenever a cancel-in-progress run saved a half-consistent [_opam/].
+      # [dune-cache: true] handles the much larger speed win (avoiding
+      # recompilation), and the opam.ocaml.org archive mirror keeps the
+      # `opam install` step under ~90s by serving precompiled binaries.
       - uses: ocaml/setup-ocaml@e32b06a3e831ff2fbc6f08cf35be2085e3918014 # v3.6.1
         with:
           ocaml-compiler: '5.4.0'
@@ -102,15 +94,6 @@ jobs:
               name, f, line = m.groups()
               print(f'::error file={f},line={line}::Test failed: {name}')
           "
-
-      # Save only on a fully successful job and only if we didn't already
-      # have a hit (cache-hit means the existing entry is still valid).
-      - name: Save opam switch cache
-        if: success() && steps.opam-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4
-        with:
-          path: _opam
-          key: opam-${{ runner.os }}-ocaml-5.4.0-test-v3-${{ hashFiles('*.opam') }}
 
   format:
     name: Format Check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
         with:
           path: _opam
-          key: opam-${{ runner.os }}-ocaml-5.4.0-test-${{ hashFiles('*.opam') }}
+          key: opam-${{ runner.os }}-ocaml-5.4.0-test-v2-${{ hashFiles('*.opam') }}
 
       # `dune-cache: true` below makes setup-ocaml manage the ~/.cache/dune
       # lifecycle internally — adding a second actions/cache step on the same

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1825,7 +1825,7 @@ let poller_fiber ~runtime ~clock ~net ~process_mgr ~github ~config ~project_name
 
 (** Runner fiber — executes orchestrator actions by driving backend sessions
     concurrently. *)
-let runner_fiber ~runtime ~env ~config ~backend ~project_name ~pr_registry
+let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name ~pr_registry
     ~transcripts ~github ~net ~event_log ?status_msg () =
   let main = config.main_branch in
   let process_mgr = Eio.Stdenv.process_mgr env in
@@ -2056,6 +2056,9 @@ let runner_fiber ~runtime ~env ~config ~backend ~project_name ~pr_registry
                                      REST API (Github.list_prs) after the
                                      backend session finishes *)
                                       let on_pr_detected _pr_number = () in
+                                      let complexity =
+                                        patch_complexity ~gameplan ~patch_id
+                                      in
                                       let r, _tool_failures =
                                         Session_driver.run ~kind:None ~runtime
                                           ~process_mgr ~clock ~fs ~project_name
@@ -2065,11 +2068,9 @@ let runner_fiber ~runtime ~env ~config ~backend ~project_name ~pr_registry
                                           ~repo:config.github_repo
                                           ~on_pr_detected ~transcripts
                                           ~user_config:config.user_config
-                                          ~worktree_mutex ~hook_mutex ~backend
-                                          ~complexity:
-                                            (patch_complexity ~gameplan
-                                               ~patch_id)
-                                          ~event_log
+                                          ~worktree_mutex ~hook_mutex
+                                          ~backend:(pick_backend ~complexity)
+                                          ~complexity ~event_log
                                       in
                                       (r
                                         :> [ `Failed
@@ -2533,6 +2534,9 @@ let runner_fiber ~runtime ~env ~config ~backend ~project_name ~pr_registry
                                         else base_changed_prefix ^ "\n" ^ raw
                                       in
                                       let on_pr_detected _pr_number = () in
+                                      let complexity =
+                                        patch_complexity ~gameplan ~patch_id
+                                      in
                                       let result, _tool_failures =
                                         Session_driver.run
                                           ~kind:
@@ -2544,11 +2548,9 @@ let runner_fiber ~runtime ~env ~config ~backend ~project_name ~pr_registry
                                           ~repo:config.github_repo
                                           ~on_pr_detected ~transcripts
                                           ~user_config:config.user_config
-                                          ~worktree_mutex ~hook_mutex ~backend
-                                          ~complexity:
-                                            (patch_complexity ~gameplan
-                                               ~patch_id)
-                                          ~event_log
+                                          ~worktree_mutex ~hook_mutex
+                                          ~backend:(pick_backend ~complexity)
+                                          ~complexity ~event_log
                                       in
                                       (match result with
                                       | `Ok
@@ -2896,6 +2898,9 @@ let runner_fiber ~runtime ~env ~config ~backend ~project_name ~pr_registry
                                         (Project_store.pr_body_artifact_path
                                            ~project_name ~patch_id)
                                     in
+                                    let complexity =
+                                      patch_complexity ~gameplan ~patch_id
+                                    in
                                     let result, tool_failures =
                                       Session_driver.run ~kind:(Some kind)
                                         ~runtime ~process_mgr ~clock ~fs
@@ -2905,10 +2910,9 @@ let runner_fiber ~runtime ~env ~config ~backend ~project_name ~pr_registry
                                         ~repo:config.github_repo ~on_pr_detected
                                         ~transcripts
                                         ~user_config:config.user_config
-                                        ~worktree_mutex ~hook_mutex ~backend
-                                        ~complexity:
-                                          (patch_complexity ~gameplan ~patch_id)
-                                        ~event_log
+                                        ~worktree_mutex ~hook_mutex
+                                        ~backend:(pick_backend ~complexity)
+                                        ~complexity ~event_log
                                     in
                                     let result =
                                       (result
@@ -3591,36 +3595,36 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
             None
         | None -> None
       in
-      let backend =
-        let model_opt =
-          if Base.String.is_empty config.model then None else Some config.model
-        in
-        match config.backend with
-        | "claude" ->
-            let display_name =
-              match model_opt with
-              | Some m -> Printf.sprintf "Claude (%s)" m
-              | None -> "Claude"
-            in
-            Claude_backend.create ~name:display_name ~model:model_opt
-              ~process_mgr ~clock ~timeout:session_timeout ~setsid_exec
-        | "codex" ->
-            Codex_backend.create ~model:model_opt ~process_mgr ~clock
-              ~timeout:session_timeout ~setsid_exec
-        | "opencode" ->
-            Opencode_backend.create ~model:model_opt ~process_mgr ~clock
-              ~timeout:session_timeout ~setsid_exec
-        | "pi" ->
-            Pi_backend.create ~model:model_opt ~process_mgr ~clock
-              ~timeout:session_timeout ~setsid_exec
-        | "gemini" ->
-            Gemini_backend.create ~model:model_opt ~process_mgr ~clock
-              ~timeout:session_timeout ~setsid_exec
-        | other ->
-            invalid_arg
-              (Printf.sprintf "Unsupported --backend=%S (expected %s)" other
-                 (String.concat ", " known_backends))
+      let cli_model_opt =
+        if Base.String.is_empty config.model then None else Some config.model
       in
+      let repo_config =
+        let config_dir =
+          User_config.config_dir ~github_owner:config.github_owner
+            ~github_repo:config.github_repo
+        in
+        match Repo_config.load ~config_dir ~known_backends with
+        | Ok t -> t
+        | Error msg ->
+            Printf.eprintf "Error: %s\n" msg;
+            Stdlib.exit 1
+      in
+      let registry =
+        Backend_registry.create ~process_mgr ~clock ~timeout:session_timeout
+          ~setsid_exec
+      in
+      (* [pick_backend ~complexity] resolves a per-patch (backend, model)
+         tuple via the pure [Backend_routing.decide] and looks it up in the
+         registry. Calling with [~complexity:None] yields the run's default
+         backend (used for ad-hoc sessions and for the TUI display name). *)
+      let pick_backend ~complexity =
+        let { Backend_routing.backend; model } =
+          Backend_routing.decide ~repo_config ~default_backend:config.backend
+            ~cli_model:cli_model_opt ~complexity
+        in
+        Backend_registry.get registry ~backend ~model
+      in
+      let default_backend = pick_backend ~complexity:None in
       let net = Eio.Stdenv.net env in
       let stdout = Eio.Stdenv.stdout env in
       (* Capture agent state and worktree list BEFORE launching concurrent
@@ -3712,7 +3716,7 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
         Eio.Fiber.all
           ((fun () -> headless_fiber ~runtime ~clock ~stdout)
           :: (fun () ->
-            runner_fiber ~runtime ~env ~config ~backend ~project_name
+            runner_fiber ~runtime ~env ~config ~pick_backend ~project_name
               ~pr_registry ~transcripts ~github ~net ~event_log ())
           :: common_fibers)
       else
@@ -3753,7 +3757,7 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
                      ~show_help ~status_msg ~transcripts ~sorted_patch_ids
                      ~input_mode ~prompt_line ~patches_start_row
                      ~patches_scroll_offset ~patches_visible_count
-                     ~backend_name:backend.Llm_backend.name)
+                     ~backend_name:default_backend.Llm_backend.name)
                 :: (fun () ->
                   input_fiber ~runtime ~process_mgr ~net ~github ~list_selected
                     ~detail_scroll ~detail_follow ~timeline_scroll
@@ -3763,7 +3767,7 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
                     ~patches_visible_count ~owner:config.github_owner
                     ~repo:config.github_repo)
                 :: (fun () ->
-                  runner_fiber ~runtime ~env ~config ~backend ~project_name
+                  runner_fiber ~runtime ~env ~config ~pick_backend ~project_name
                     ~pr_registry ~transcripts ~github ~net ~event_log
                     ~status_msg ())
                 :: common_fibers)
@@ -3825,8 +3829,11 @@ let model_arg =
            [sonnet-4-6] for claude; [gpt-5.5] for codex). The literal value \
            [auto] picks a model per patch from the gameplan's [complexity] \
            field (1/2/3 → cheap/standard/strongest tier of the selected \
-           backend). When omitted, onton does not pass --model to the \
-           underlying CLI, so the backend's own default applies.")
+           backend). The per-backend ladder can be overridden by writing \
+           [~/.config/onton/<owner>/<repo>/config.json] with a [routing] map — \
+           see lib/repo_config.mli for the schema. When omitted, onton does \
+           not pass --model to the underlying CLI, so the backend's own \
+           default applies.")
 
 let repo_arg =
   let open Cmdliner in

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -172,7 +172,7 @@ let validate_resolved_config ~backend ~github_token ~github_owner ~github_repo
     separate table populated when PRs are created and used for polling.
 
     PR numbers are discovered by querying GitHub for open PRs matching the
-    patch's branch name after Claude completes work. *)
+    patch's branch name after the backend session completes. *)
 
 module Pr_registry = struct
   type t = { mutex : Eio.Mutex.t; table : (Patch_id.t, Pr_number.t) Hashtbl.t }
@@ -299,6 +299,14 @@ let build_branch_map (gameplan : Gameplan.t) ~default =
   in
   fun pid -> Base.Option.value (Base.Map.find map pid) ~default
 
+(** Look up the gameplan-author's 1/2/3 complexity for a patch. [None] when the
+    patch is missing or the gameplan didn't specify — backends running under
+    [--model auto] should treat that as the highest tier. *)
+let patch_complexity ~(gameplan : Gameplan.t) ~patch_id =
+  Base.List.find gameplan.Gameplan.patches ~f:(fun (p : Patch.t) ->
+      Patch_id.equal p.Patch.id patch_id)
+  |> Base.Option.bind ~f:(fun (p : Patch.t) -> p.Patch.complexity)
+
 (** {1 Shared helpers} *)
 
 (** Pluralize a count for inline rendering: [pluralize 1 "comment"] →
@@ -309,10 +317,7 @@ let pluralize ?plural n singular =
   Printf.sprintf "%d %s" n (if n = 1 then singular else many)
 
 let log_event runtime ?patch_id msg =
-  Runtime.update_activity_log runtime (fun log ->
-      Activity_log.add_event log
-        (Activity_log.Event.create ~timestamp:(Unix.gettimeofday ()) ?patch_id
-           msg))
+  Runtime_logging.log_event runtime ?patch_id msg
 
 (** Reconcile per-patch automerge deadlines. For each deadline that has elapsed,
     merge the PR on GitHub and mark the patch merged on success. On failure the
@@ -570,180 +575,8 @@ let mark_session_failed event_log runtime patch_id =
           ~reason:Orchestrator.Unexpected_exception ~agent_before:before
           ~agent_after:after)
 
-(** Compute the session mode for the fallback chain.
-
-    The fallback chain is: resume existing session → fresh session → give up.
-    - [Fresh_available] with [llm_session_id = Some id]: use [--resume <id>] to
-      target the specific session.
-    - [Fresh_available] without a stored session_id, or [Tried_fresh]: start
-      fresh (no --resume).
-    - [Given_up]: the agent has exhausted its fallback chain — return
-      [`Give_up]. *)
-let session_mode (agent : Patch_agent.t) :
-    [ `Resume of string | `Fresh | `Give_up ] =
-  match agent.Patch_agent.session_fallback with
-  | Patch_agent.Given_up -> `Give_up
-  | Patch_agent.Tried_fresh -> `Fresh
-  | Patch_agent.Fresh_available -> (
-      match agent.Patch_agent.llm_session_id with
-      | Some id -> `Resume id
-      | None -> `Fresh)
-
-(** Extract a PR number from text containing a GitHub PR URL. Scans for
-    [github.com/owner/repo/pull/N] patterns. *)
-let extract_pr_number_from_text ~owner ~repo text =
-  let needle = Printf.sprintf "github.com/%s/%s/pull/" owner repo in
-  let needle_len = String.length needle in
-  let text_len = String.length text in
-  let rec scan i =
-    if i + needle_len >= text_len then None
-    else if String.sub text i needle_len = needle then
-      (* Extract digits after the needle *)
-      let start = i + needle_len in
-      let rec end_pos j =
-        if j < text_len && text.[j] >= '0' && text.[j] <= '9' then
-          end_pos (j + 1)
-        else j
-      in
-      let stop = end_pos start in
-      if stop > start then
-        try
-          Some
-            (Pr_number.of_int
-               (int_of_string (String.sub text start (stop - start))))
-        with _ -> scan (i + 1)
-      else scan (i + 1)
-    else scan (i + 1)
-  in
-  scan 0
-
-(** Log a stream entry to the activity log. *)
-let log_stream_entry runtime ~patch_id kind =
-  Runtime.update_activity_log runtime (fun log ->
-      Activity_log.add_stream_entry log
-        (Activity_log.Stream_entry.create ~timestamp:(Unix.gettimeofday ())
-           ~patch_id ~kind))
-
-(** Run a Claude process with streaming and handle the result. Returns [`Ok] on
-    successful Claude exit (code 0), otherwise [`Failed]. The [on_pr_detected]
-    callback is invoked if a PR number is found in Claude's text output.
-    Implements the session fallback chain: resume → fresh → give up. On success,
-    stores the session ID and clears fallback state. *)
-
-(** Resolve the worktree path for a patch. Checks the stored path first, then
-    searches git worktrees by branch, then falls back to the default computed
-    path. Persists the result so subsequent calls are instant. *)
-let resolve_worktree_path ~process_mgr ~repo_root ~project_name ~patch_id
-    ~(agent : Patch_agent.t) ?branch () =
-  match agent.Patch_agent.worktree_path with
-  | Some p -> p
-  | None ->
-      let search_branch =
-        match branch with Some b -> b | None -> agent.Patch_agent.branch
-      in
-      let found =
-        Worktree.find_for_branch ~process_mgr ~repo_root search_branch
-      in
-      let path =
-        match found with
-        | Some p -> p
-        | None -> Worktree.worktree_dir ~project_name ~patch_id
-      in
-      path
-
-(** Ensure a worktree exists for the given patch. Resolves the path, discovers
-    existing worktrees for the branch, creates one if needed, and persists the
-    path. Returns [Some path] on success or [None] if the branch is unknown and
-    no worktree can be created yet. *)
-let ensure_worktree ~runtime ~process_mgr ~clock ~fs ~repo_root ~project_name
-    ~patch_id ~(agent : Patch_agent.t) ~(user_config : User_config.t)
-    ~worktree_mutex ~hook_mutex ?branch ?base_ref () =
-  let path =
-    resolve_worktree_path ~process_mgr ~repo_root ~project_name ~patch_id ~agent
-      ?branch ()
-  in
-  if Stdlib.Sys.file_exists path then (
-    Runtime.update_orchestrator runtime (fun orch ->
-        Orchestrator.set_worktree_path orch patch_id path);
-    Some path)
-  else
-    let br =
-      match branch with Some b -> b | None -> agent.Patch_agent.branch
-    in
-    match Worktree.find_for_branch ~process_mgr ~repo_root br with
-    | Some existing ->
-        log_event runtime ~patch_id
-          (Printf.sprintf "Found existing worktree for branch at %s" existing);
-        Runtime.update_orchestrator runtime (fun orch ->
-            Orchestrator.set_worktree_path orch patch_id existing);
-        Some existing
-    | None ->
-        if Worktree.is_checked_out_in_repo_root ~process_mgr ~repo_root br then (
-          let main_root = Worktree.resolve_main_root ~process_mgr ~repo_root in
-          log_event runtime ~patch_id
-            (Printf.sprintf
-               "Cannot create worktree — branch %s is checked out in the main \
-                working tree (%s). Switch the main tree to another branch \
-                (e.g. `git -C %s checkout <default-branch>`) and try again."
-               (Branch.to_string br) main_root main_root);
-          None)
-        else
-          let base =
-            match base_ref with
-            | Some b -> b
-            | None -> (
-                match agent.Patch_agent.base_branch with
-                | Some b -> Branch.to_string b
-                | None -> "HEAD")
-          in
-          log_event runtime ~patch_id
-            (Printf.sprintf "Creating worktree at %s" path);
-          (match
-             Eio.Mutex.use_ro worktree_mutex (fun () ->
-                 ignore
-                   (Worktree.create ~process_mgr ~repo_root ~project_name
-                      ~patch_id ~branch:br ~base_ref:base))
-           with
-          | () -> ()
-          | exception (Eio.Cancel.Cancelled _ as exn) -> raise exn
-          | exception exn ->
-              log_event runtime ~patch_id
-                (Printf.sprintf "Worktree creation failed — %s"
-                   (Printexc.to_string exn)));
-          if Stdlib.Sys.file_exists path then (
-            Runtime.update_orchestrator runtime (fun orch ->
-                Orchestrator.set_worktree_path orch patch_id path);
-            (match user_config.User_config.on_worktree_create with
-            | Some script -> (
-                let env =
-                  [
-                    ("ONTON_WORKTREE_PATH", path);
-                    ("ONTON_PATCH_ID", Patch_id.to_string patch_id);
-                    ("ONTON_BRANCH", Branch.to_string br);
-                  ]
-                in
-                let cwd = Eio.Path.(fs / path) in
-                (* [hook_mutex] serializes hook invocations across patch
-                   fibers — npm/dune/bun aren't parallelism-safe across
-                   shared caches, and per-hook fan-out is the dominant
-                   subprocess multiplier (see issue #209). *)
-                match
-                  Eio.Mutex.use_ro hook_mutex (fun () ->
-                      User_config.run_hook ~process_mgr ~clock ~script ~cwd ~env
-                        ())
-                with
-                | Ok () ->
-                    log_event runtime ~patch_id "Ran on_worktree_create hook"
-                | Error msg ->
-                    log_event runtime ~patch_id
-                      (Printf.sprintf "Hook on_worktree_create failed — %s" msg)
-                )
-            | None -> ());
-            Some path)
-          else (
-            log_event runtime ~patch_id
-              (Printf.sprintf "Worktree still missing at %s" path);
-            None)
+let resolve_worktree_path = Worktree_setup.resolve_worktree_path
+let ensure_worktree = Worktree_setup.ensure_worktree
 
 (** Execute a [Worktree_plan.t] against the live filesystem. The plan is built
     purely (see [Worktree_plan.for_rebase] / [for_merge_conflict]); this
@@ -799,421 +632,6 @@ let execute_worktree_plan ~runtime ~process_mgr ~clock ~fs ~repo_root
             (r, path))
   in
   loop ~path:default_path plan
-
-let truncate s n = if String.length s <= n then s else String.sub s 0 n ^ "..."
-
-let run_claude_and_handle ~(kind : Operation_kind.t option) ~runtime
-    ~process_mgr ~clock ~fs ~project_name ~patch_id ~repo_root ~prompt
-    ~(agent : Patch_agent.t) ~owner ~repo ~on_pr_detected ~transcripts
-    ~user_config ~worktree_mutex ~hook_mutex ~backend ~event_log =
-  match session_mode agent with
-  | `Give_up ->
-      log_event runtime ~patch_id
-        "Session fallback exhausted — continue and fresh both failed, needs \
-         intervention";
-      Runtime.update_orchestrator runtime (fun orch ->
-          Orchestrator.apply_session_result orch patch_id
-            Orchestrator.Session_give_up);
-      (`Failed, [])
-  | (`Resume _ | `Fresh) as mode -> (
-      let resume_session, is_fresh =
-        match mode with `Resume id -> (Some id, false) | `Fresh -> (None, true)
-      in
-      match
-        ensure_worktree ~runtime ~process_mgr ~clock ~fs ~repo_root
-          ~project_name ~patch_id ~agent ~user_config ~worktree_mutex
-          ~hook_mutex ()
-      with
-      | None ->
-          Runtime.update_orchestrator runtime (fun orch ->
-              Orchestrator.apply_session_result orch patch_id
-                Orchestrator.Session_worktree_missing);
-          (`Failed, [])
-      | Some worktree_path ->
-          let cwd = Eio.Path.(fs / worktree_path) in
-          let text_buf =
-            let buf = Buffer.create 4096 in
-            (match Hashtbl.find_opt transcripts patch_id with
-            | Some prev when String.length prev > 0 ->
-                Buffer.add_string buf prev;
-                Buffer.add_char buf '\n'
-            | Some _ | None -> ());
-            (* Write the prompt being delivered so it appears in the transcript *)
-            let now = Unix.gettimeofday () in
-            let tm = Unix.localtime now in
-            Buffer.add_string buf
-              (Printf.sprintf
-                 "\n---\n**[%02d:%02d:%02d] Delivered to %s%s:**\n\n"
-                 tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec
-                 backend.Llm_backend.name
-                 (match resume_session with
-                 | Some id ->
-                     Printf.sprintf " (--resume %s)"
-                       (String.sub id 0 (min 8 (String.length id)))
-                 | None -> ""));
-            Buffer.add_string buf prompt;
-            Buffer.add_string buf
-              (Printf.sprintf "\n\n---\n**%s response:**\n\n"
-                 backend.Llm_backend.name);
-            Hashtbl.replace transcripts patch_id (Buffer.contents buf);
-            buf
-          in
-          let error_buf = Buffer.create 256 in
-          let tool_count = ref 0 in
-          (* Accumulates (tool_name, status) for Tool_use events that report a
-             non-"completed" status (OpenCode surfaces [pending]/[running] or
-             error states; other backends do not populate [status] and so never
-             contribute here). Propagated to the caller so artifact-backed
-             phases like Pr_body can tell "agent chose not to write" apart
-             from "a tool call was announced but never executed". *)
-          let tool_failures = ref [] in
-          let pr_found = ref false in
-          let needle_len =
-            String.length (Printf.sprintf "github.com/%s/%s/pull/" owner repo)
-          in
-          let last_sync = ref (Unix.gettimeofday ()) in
-          let sync_transcript () =
-            Hashtbl.replace transcripts patch_id (Buffer.contents text_buf)
-          in
-          let maybe_sync_transcript () =
-            let now = Unix.gettimeofday () in
-            if now -. !last_sync >= 0.2 then (
-              last_sync := now;
-              sync_transcript ())
-          in
-          let captured_session_id = ref None in
-          let backend_accepted_turn = ref false in
-          let mark_backend_accepted_turn () =
-            if not !backend_accepted_turn then (
-              backend_accepted_turn := true;
-              match kind with
-              | Some Operation_kind.Human ->
-                  Runtime.update_orchestrator runtime (fun orch ->
-                      Orchestrator.mark_inflight_human_messages_delivered orch
-                        patch_id)
-              | Some Operation_kind.Ci
-              | Some Operation_kind.Review_comments
-              | Some Operation_kind.Pr_body
-              | Some Operation_kind.Merge_conflict
-              | Some Operation_kind.Rebase
-              | None ->
-                  ())
-          in
-          let on_event (event : Types.Stream_event.t) =
-            match event with
-            (* Turn_started is the preferred signal; the arms below are
-               fallbacks for backends that do not emit it. *)
-            | Types.Stream_event.Turn_started -> mark_backend_accepted_turn ()
-            | Types.Stream_event.Text_delta text -> (
-                mark_backend_accepted_turn ();
-                let prev_len = Buffer.length text_buf in
-                Buffer.add_string text_buf text;
-                maybe_sync_transcript ();
-                if not !pr_found then
-                  let offset = max 0 (prev_len - needle_len) in
-                  let tail =
-                    Buffer.sub text_buf offset (Buffer.length text_buf - offset)
-                  in
-                  match extract_pr_number_from_text ~owner ~repo tail with
-                  | Some pr_number ->
-                      pr_found := true;
-                      log_stream_entry runtime ~patch_id
-                        (Activity_log.Stream_entry.Text_chunk
-                           (Printf.sprintf "PR #%d detected"
-                              (Pr_number.to_int pr_number)));
-                      on_pr_detected pr_number
-                  | None -> ())
-            | Types.Stream_event.Tool_use { name; input; status } ->
-                mark_backend_accepted_turn ();
-                tool_count := !tool_count + 1;
-                (* OpenCode emits pending → running → completed for a single
-                   tool call. Track only the latest unresolved status per tool
-                   name: clear on completed, replace on any other status.
-                   Otherwise a normal pending → completed lifecycle would leave
-                   a stale (name, "pending") entry that
-                   [classify_pr_body_respond] would misread as a blocked Write. *)
-                (match status with
-                | Some s when String.equal s "completed" ->
-                    tool_failures :=
-                      Base.List.filter !tool_failures ~f:(fun (n, _) ->
-                          not (String.equal n name))
-                | Some s ->
-                    let without =
-                      Base.List.filter !tool_failures ~f:(fun (n, _) ->
-                          not (String.equal n name))
-                    in
-                    tool_failures := (name, s) :: without
-                | None -> ());
-                let summary =
-                  try
-                    let json = Yojson.Safe.from_string input in
-                    let field key =
-                      Yojson.Safe.Util.(member key json |> to_string_option)
-                    in
-                    let s =
-                      match name with
-                      | "Bash" -> field "command"
-                      | "Read" | "Write" -> field "file_path"
-                      | "Edit" -> field "file_path"
-                      | "Glob" -> field "pattern"
-                      | "Grep" -> field "pattern"
-                      | _ -> None
-                    in
-                    match s with Some v -> truncate v 80 | None -> ""
-                  with _ -> ""
-                in
-                let detail =
-                  if summary <> "" then Printf.sprintf " %s" summary else ""
-                in
-                let sep =
-                  let len = Buffer.length text_buf in
-                  if len = 0 then ""
-                  else if
-                    len >= 2
-                    && Char.equal (Buffer.nth text_buf (len - 1)) '\n'
-                    && Char.equal (Buffer.nth text_buf (len - 2)) '\n'
-                  then ""
-                  else if Char.equal (Buffer.nth text_buf (len - 1)) '\n' then
-                    "\n"
-                  else "\n\n"
-                in
-                Buffer.add_string text_buf
-                  (Printf.sprintf "%s[tool: %s]%s\n" sep name detail);
-                sync_transcript ();
-                log_stream_entry runtime ~patch_id
-                  (Activity_log.Stream_entry.Tool_use (name, summary))
-            | Types.Stream_event.Final_result { stop_reason; _ } ->
-                mark_backend_accepted_turn ();
-                sync_transcript ();
-                let reason = Types.Stop_reason.to_display stop_reason in
-                log_stream_entry runtime ~patch_id
-                  (Activity_log.Stream_entry.Finished reason)
-            | Types.Stream_event.Error msg ->
-                if Buffer.length error_buf > 0 then
-                  Buffer.add_char error_buf '\n';
-                Buffer.add_string error_buf msg;
-                log_stream_entry runtime ~patch_id
-                  (Activity_log.Stream_entry.Stream_error msg)
-            | Types.Stream_event.Session_init { session_id } ->
-                captured_session_id := Some session_id
-          in
-          let result =
-            try
-              Ok
-                (backend.Llm_backend.run_streaming ~cwd ~patch_id ~prompt
-                   ~resume_session ~on_event)
-            with exn -> Error (Printexc.to_string exn)
-          in
-          let open Run_classification in
-          let outcome =
-            Result.map
-              (fun (r : Llm_backend.result) ->
-                {
-                  exit_code = r.Llm_backend.exit_code;
-                  got_events = r.Llm_backend.got_events;
-                  saw_final_result = r.Llm_backend.saw_final_result;
-                  stderr = r.Llm_backend.stderr;
-                  stream_errors = String.trim (Buffer.contents error_buf);
-                  timed_out = r.Llm_backend.timed_out;
-                })
-              result
-          in
-          (* classify routes Error outcomes to Process_error, so the
-             empty-events arms below only ever see Ok. *)
-          let log_empty_resume ~tail =
-            match result with
-            | Error _ -> ()
-            | Ok r ->
-                let render label s =
-                  let s = String.trim s in
-                  if String.equal s "" then label ^ "=empty"
-                  else
-                    Printf.sprintf "%s=%d chars: %s" label (String.length s)
-                      (truncate s 500)
-                in
-                log_event runtime ~patch_id
-                  (Printf.sprintf
-                     "Resume exited %d (%s) with no parsed stream events%s — \
-                      %s %s"
-                     r.Llm_backend.exit_code backend.Llm_backend.name tail
-                     (render "stdout" r.Llm_backend.stdout)
-                     (render "stderr" r.Llm_backend.stderr))
-          in
-          let session_result, user_result =
-            match
-              classify ~is_resume:(Option.is_some resume_session) outcome
-            with
-            | Process_error msg ->
-                log_event runtime ~patch_id
-                  (Printf.sprintf "Process error from %s — %s"
-                     backend.Llm_backend.name msg);
-                (Orchestrator.Session_process_error { is_fresh }, `Failed)
-            | No_session_to_resume ->
-                log_empty_resume ~tail:" — no session to resume, retrying fresh";
-                (Orchestrator.Session_no_resume, `Failed)
-            | Timed_out ->
-                log_event runtime ~patch_id
-                  (Printf.sprintf "Session timed out (%s) — marking failed"
-                     backend.Llm_backend.name);
-                (Orchestrator.Session_failed { is_fresh }, `Failed)
-            | Success { stream_errors } ->
-                (match (resume_session, result) with
-                | Some _, Ok r when not r.Llm_backend.got_events ->
-                    log_empty_resume ~tail:""
-                | Some _, (Ok _ | Error _) | None, _ -> ());
-                if String.length stream_errors > 0 then
-                  log_event runtime ~patch_id
-                    (Printf.sprintf
-                       "Session exited 0 (%s) with stream errors — %s"
-                       backend.Llm_backend.name
-                       (truncate stream_errors 500));
-                let text_len = Buffer.length text_buf in
-                let tools = !tool_count in
-                if tools = 0 && text_len < 200 then
-                  log_event runtime ~patch_id
-                    (Printf.sprintf
-                       "Session exited 0 (%s) with no tool use and %s of text \
-                        — %s"
-                       backend.Llm_backend.name
-                       (pluralize text_len "char")
-                       (truncate (String.trim (Buffer.contents text_buf)) 200));
-                (Orchestrator.Session_ok, `Ok)
-            | Session_failed { exit_code; detail } ->
-                log_event runtime ~patch_id
-                  (Printf.sprintf "Session failed (%s) — exit %d: %s"
-                     backend.Llm_backend.name exit_code detail);
-                (Orchestrator.Session_failed { is_fresh }, `Failed)
-          in
-          (* Observability: if any tool_use events reported a non-"completed"
-             status (OpenCode's sandbox/rejection/pending states), summarize
-             them so the disconnect is visible in the activity log even when
-             the session otherwise looks healthy. *)
-          (match !tool_failures with
-          | [] -> ()
-          | failures ->
-              let rendered =
-                List.rev failures
-                |> List.map (fun (n, s) -> Printf.sprintf "%s[%s]" n s)
-                |> String.concat ", "
-              in
-              log_event runtime ~patch_id
-                (Printf.sprintf
-                   "Session ended with %d non-completed tool call(s) (%s): %s"
-                   (List.length failures) backend.Llm_backend.name rendered));
-          (* Supervisor-owned push: agent commits locally; we push every
-             local commit to the remote at session end. force_push_with_lease
-             is idempotent (Push_up_to_date when nothing new), and lease-safe
-             against concurrent remote updates. Runs regardless of the LLM's
-             session result so commits made before a partial failure still
-             reach the remote. *)
-          let branch = agent.Patch_agent.branch in
-          let base =
-            match agent.Patch_agent.base_branch with
-            | Some b -> b
-            | None ->
-                (* Invariant: a running session always has a base_branch set
-                   by start/respond/rebase. Fall back to main just in case. *)
-                Runtime.read runtime (fun snap ->
-                    Orchestrator.main_branch snap.Runtime.orchestrator)
-          in
-          let push_outcome =
-            Worktree.force_push_with_lease ~process_mgr ~path:worktree_path
-              ~branch ~base
-          in
-          (match push_outcome with
-          | Worktree.Push_ok ->
-              log_event runtime ~patch_id "runner: pushed after session"
-          | Worktree.Push_up_to_date ->
-              log_event runtime ~patch_id
-                "runner: push up-to-date after session (no new commits)"
-          | Worktree.Push_no_commits ->
-              log_event runtime ~patch_id
-                "runner: session ended with no commits on branch — push \
-                 skipped, PR creation deferred"
-          | Worktree.Push_rejected ->
-              log_event runtime ~patch_id
-                "runner: push rejected after session (lease)"
-          | Worktree.Push_error msg ->
-              log_event runtime ~patch_id
-                (Printf.sprintf "runner: push error after session: %s" msg));
-          (* Combine LLM session outcome with push outcome into a single
-             session_result via the pure decision in
-             [Orchestrator.combine_session_and_push]. user_result mirrors:
-             same Ok/Failed disposition unless the combination promoted us
-             to Session_push_failed (which is always Failed).
-
-             Special case: when the agent is responding to a human message,
-             the human may have asked a question or made a request that
-             requires no code changes. Absence of new commits is therefore
-             not a failure — override Session_no_commits to Session_ok so
-             the no_commits_push_count counter does not march toward
-             needs_intervention and the operation completes cleanly. *)
-          let no_commits_is_ok =
-            match kind with
-            | Some Operation_kind.Human -> true
-            | Some Operation_kind.Ci
-            | Some Operation_kind.Review_comments
-            | Some Operation_kind.Pr_body
-            | Some Operation_kind.Merge_conflict
-            | Some Operation_kind.Rebase
-            | None ->
-                false
-          in
-          let final_session_result =
-            let combined =
-              Orchestrator.combine_session_and_push ~session:session_result
-                ~push:push_outcome
-            in
-            match combined with
-            | Orchestrator.Session_no_commits when no_commits_is_ok ->
-                Orchestrator.Session_ok
-            | Orchestrator.Session_ok | Orchestrator.Session_no_commits
-            | Orchestrator.Session_process_error _
-            | Orchestrator.Session_no_resume | Orchestrator.Session_failed _
-            | Orchestrator.Session_give_up
-            | Orchestrator.Session_worktree_missing
-            | Orchestrator.Session_push_failed ->
-                combined
-          in
-          let final_user_result =
-            match final_session_result with
-            | Orchestrator.Session_ok -> user_result
-            | Orchestrator.Session_push_failed | Orchestrator.Session_no_commits
-              ->
-                (* LLM session ran fine but commits didn't ship (push failed
-                   or the agent made no commits) — signal retry so the
-                   Respond path uses Respond_retry_push (clean complete) and
-                   the reconciler re-enqueues the operation naturally. After
-                   2 consecutive no-commit sessions, needs_intervention fires
-                   and the scheduler stops re-enqueueing. *)
-                `Retry_push
-            | Orchestrator.Session_process_error _
-            | Orchestrator.Session_no_resume | Orchestrator.Session_failed _
-            | Orchestrator.Session_give_up
-            | Orchestrator.Session_worktree_missing ->
-                `Failed
-          in
-          let agent_before, agent_after =
-            Runtime.update_orchestrator_returning runtime (fun orch ->
-                let agent_before = Orchestrator.agent orch patch_id in
-                let orch =
-                  Orchestrator.apply_session_result orch patch_id
-                    final_session_result
-                in
-                (* Store the captured session_id for future --resume calls *)
-                let orch =
-                  match !captured_session_id with
-                  | Some _ ->
-                      Orchestrator.set_llm_session_id orch patch_id
-                        !captured_session_id
-                  | None -> orch
-                in
-                let agent_after = Orchestrator.agent orch patch_id in
-                (orch, (agent_before, agent_after)))
-          in
-          Event_log.log_complete event_log ~patch_id
-            ~result:final_session_result ~agent_before ~agent_after;
-          (final_user_result, List.rev !tool_failures))
 
 (** {1 Fibers} *)
 
@@ -2405,7 +1823,7 @@ let poller_fiber ~runtime ~clock ~net ~process_mgr ~github ~config ~project_name
   in
   loop ()
 
-(** Runner fiber — executes orchestrator actions by spawning Claude processes
+(** Runner fiber — executes orchestrator actions by driving backend sessions
     concurrently. *)
 let runner_fiber ~runtime ~env ~config ~backend ~project_name ~pr_registry
     ~transcripts ~github ~net ~event_log ?status_msg () =
@@ -2419,7 +1837,7 @@ let runner_fiber ~runtime ~env ~config ~backend ~project_name ~pr_registry
     | None -> ()
   in
   let semaphore = Eio.Semaphore.make config.max_concurrency in
-  let with_claude_slot f =
+  let with_session_slot f =
     Eio.Semaphore.acquire semaphore;
     Fun.protect ~finally:(fun () -> Eio.Semaphore.release semaphore) f
   in
@@ -2587,7 +2005,7 @@ let runner_fiber ~runtime ~env ~config ~backend ~project_name ~pr_registry
                     (fun () ->
                       with_busy_guard ~patch_id (fun () ->
                           let result =
-                            with_claude_slot (fun () ->
+                            with_session_slot (fun () ->
                                 let agent =
                                   Runtime.read runtime (fun snap ->
                                       Orchestrator.agent
@@ -2635,22 +2053,29 @@ let runner_fiber ~runtime ~env ~config ~backend ~project_name ~pr_registry
                                       in
                                       (* PR detection from stream text is a hint
                                      only — always confirmed via the GitHub
-                                     REST API (Github.list_prs) after Claude
-                                     finishes *)
+                                     REST API (Github.list_prs) after the
+                                     backend session finishes *)
                                       let on_pr_detected _pr_number = () in
                                       let r, _tool_failures =
-                                        run_claude_and_handle ~kind:None
-                                          ~runtime ~process_mgr ~clock ~fs
-                                          ~project_name ~patch_id
-                                          ~repo_root:config.repo_root ~prompt
-                                          ~agent ~owner:config.github_owner
+                                        Session_driver.run ~kind:None ~runtime
+                                          ~process_mgr ~clock ~fs ~project_name
+                                          ~patch_id ~repo_root:config.repo_root
+                                          ~prompt ~agent
+                                          ~owner:config.github_owner
                                           ~repo:config.github_repo
                                           ~on_pr_detected ~transcripts
                                           ~user_config:config.user_config
                                           ~worktree_mutex ~hook_mutex ~backend
+                                          ~complexity:
+                                            (patch_complexity ~gameplan
+                                               ~patch_id)
                                           ~event_log
                                       in
-                                      r))
+                                      (r
+                                        :> [ `Failed
+                                           | `Ok
+                                           | `Retry_push
+                                           | `Stale ])))
                           in
                           let start_outcome =
                             match result with
@@ -2801,7 +2226,7 @@ let runner_fiber ~runtime ~env ~config ~backend ~project_name ~pr_registry
               Some
                 (fun () ->
                   with_busy_guard ~patch_id (fun () ->
-                      (* Rebase is orchestrator-executed (no Claude slot), so
+                      (* Rebase is orchestrator-executed (no session slot), so
                          work begins immediately under the busy guard. *)
                       Runtime.update_orchestrator runtime (fun orch ->
                           Orchestrator.mark_running orch patch_id);
@@ -2910,7 +2335,7 @@ let runner_fiber ~runtime ~env ~config ~backend ~project_name ~pr_registry
               Some
                 (fun () ->
                   (* For Review_comments and Ci, fetch fresh state from
-                     GitHub before acquiring a Claude slot to avoid blocking
+                     GitHub before acquiring a session slot to avoid blocking
                      concurrency on GitHub API I/O. The Ci fetch is the
                      freshness gate against delivering a failure that's
                      already been superseded by a newer run. *)
@@ -2980,13 +2405,13 @@ let runner_fiber ~runtime ~env ~config ~backend ~project_name ~pr_registry
                         match ci_skip_reason with
                         | Some reason ->
                             (* Fast path: skip decision already made. Don't
-                               consume a Claude slot for a no-op — that
+                               consume a session slot for a no-op — that
                                slot can go to another agent. *)
                             log_event runtime ~patch_id
                               (Printf.sprintf "Skipped ci delivery — %s" reason);
                             `Skip_empty
                         | None ->
-                            with_claude_slot (fun () ->
+                            with_session_slot (fun () ->
                                 Runtime.update_orchestrator runtime (fun orch ->
                                     Orchestrator.mark_running orch patch_id);
                                 (* Write fresh ci_checks under the busy guard
@@ -3109,7 +2534,7 @@ let runner_fiber ~runtime ~env ~config ~backend ~project_name ~pr_registry
                                       in
                                       let on_pr_detected _pr_number = () in
                                       let result, _tool_failures =
-                                        run_claude_and_handle
+                                        Session_driver.run
                                           ~kind:
                                             (Some Operation_kind.Merge_conflict)
                                           ~runtime ~process_mgr ~clock ~fs
@@ -3120,6 +2545,9 @@ let runner_fiber ~runtime ~env ~config ~backend ~project_name ~pr_registry
                                           ~on_pr_detected ~transcripts
                                           ~user_config:config.user_config
                                           ~worktree_mutex ~hook_mutex ~backend
+                                          ~complexity:
+                                            (patch_complexity ~gameplan
+                                               ~patch_id)
                                           ~event_log
                                       in
                                       (match result with
@@ -3133,7 +2561,13 @@ let runner_fiber ~runtime ~env ~config ~backend ~project_name ~pr_registry
                                               .set_notified_base_branch orch
                                                 patch_id (Branch.of_string base))
                                       | _ -> ());
-                                      result
+                                      (result
+                                        :> [ `Failed
+                                           | `Ok
+                                           | `Pr_body_miss
+                                           | `Retry_push
+                                           | `Skip_empty
+                                           | `Stale ])
                                     in
                                     let ancestor_ids =
                                       Runtime.read runtime (fun snap ->
@@ -3452,7 +2886,7 @@ let runner_fiber ~runtime ~env ~config ~backend ~project_name ~pr_registry
                                         ());
                                     (* Snapshot the pr-body artifact before
                                        the session so the post-session sync
-                                       step (after run_claude_and_handle) can
+                                       step (after Session_driver.run) can
                                        detect content changes from any kind
                                        of session, not only Pr_body. For
                                        Pr_body the artifact was just unlinked
@@ -3463,7 +2897,7 @@ let runner_fiber ~runtime ~env ~config ~backend ~project_name ~pr_registry
                                            ~project_name ~patch_id)
                                     in
                                     let result, tool_failures =
-                                      run_claude_and_handle ~kind:(Some kind)
+                                      Session_driver.run ~kind:(Some kind)
                                         ~runtime ~process_mgr ~clock ~fs
                                         ~project_name ~patch_id
                                         ~repo_root:config.repo_root ~prompt
@@ -3472,7 +2906,16 @@ let runner_fiber ~runtime ~env ~config ~backend ~project_name ~pr_registry
                                         ~transcripts
                                         ~user_config:config.user_config
                                         ~worktree_mutex ~hook_mutex ~backend
+                                        ~complexity:
+                                          (patch_complexity ~gameplan ~patch_id)
                                         ~event_log
+                                    in
+                                    let result =
+                                      (result
+                                        :> [ `Failed
+                                           | `Ok
+                                           | `Pr_body_miss
+                                           | `Retry_push ])
                                     in
                                     (match result with
                                     | `Ok when Base.Option.is_some base_change
@@ -3640,7 +3083,13 @@ let runner_fiber ~runtime ~env ~config ~backend ~project_name ~pr_registry
                                           "pr-body: opportunistic sync PATCH \
                                            failed; leaving state — next \
                                            Pr_body cycle will retry");
-                                    result)
+                                    (result
+                                      :> [ `Failed
+                                         | `Ok
+                                         | `Pr_body_miss
+                                         | `Retry_push
+                                         | `Skip_empty
+                                         | `Stale ]))
                       in
                       let respond_outcome =
                         match result with
@@ -3718,7 +3167,7 @@ let runner_fiber ~runtime ~env ~config ~backend ~project_name ~pr_registry
     in
     (* Spawn action fibers without waiting for completion. Each fiber is
        guarded by with_busy_guard (ensures complete on exit) and
-       with_claude_slot (semaphore backpressure). The runner loop continues
+       with_session_slot (semaphore backpressure). The runner loop continues
        immediately to pick up newly-queued actions from the poller. *)
     Base.List.iter action_fibers ~f:(fun f ->
         Eio.Fiber.fork_daemon ~sw (fun () ->
@@ -4038,7 +3487,7 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
       Stdlib.exit 1
   | Ok () ->
       (* Preflight: ensure RLIMIT_NOFILE is high enough for [max_concurrency]
-         long-lived Claude subprocesses (each holding 3 pipes = 6 FDs),
+         long-lived backend subprocesses (each holding 3 pipes = 6 FDs),
          parallel git subprocesses, HTTPS connections, the activity log,
          snapshot files, and the project lock. Budget 256 FDs/slot plus 512
          headroom. Auto-raise the soft limit to the hard cap silently; fail
@@ -4373,9 +3822,11 @@ let model_arg =
     & info [ "model" ] ~docv:"MODEL"
         ~doc:
           "Model name to pass to the selected backend (e.g. [sonnet], [opus], \
-           [sonnet-4-6] for claude; [gpt-5-mini] for codex). When omitted, \
-           onton does not pass --model to the underlying CLI, so the backend's \
-           own default applies.")
+           [sonnet-4-6] for claude; [gpt-5.5] for codex). The literal value \
+           [auto] picks a model per patch from the gameplan's [complexity] \
+           field (1/2/3 → cheap/standard/strongest tier of the selected \
+           backend). When omitted, onton does not pass --model to the \
+           underlying CLI, so the backend's own default applies.")
 
 let repo_arg =
   let open Cmdliner in
@@ -4405,7 +3856,7 @@ let max_concurrency_arg =
   Arg.(
     value & opt int 5
     & info [ "max-concurrency" ] ~docv:"N"
-        ~doc:"Maximum number of concurrent Claude processes (default: 5)."
+        ~doc:"Maximum number of concurrent backend sessions (default: 5)."
         ~env:(Cmd.Env.info "ONTON_MAX_CONCURRENCY"))
 
 let headless_arg =
@@ -4472,7 +3923,7 @@ let main_cmd =
   let info =
     Cmd.info "onton" ~version:Version.s
       ~doc:
-        "Orchestrate parallel patch development with Claude.\n\n\
+        "Orchestrate parallel patch development with an LLM coding agent.\n\n\
          Usage:\n\
         \  onton [PROJECT] --gameplan GAMEPLAN [OPTIONS]   Start a new project\n\
         \  onton PROJECT [OPTIONS]                         Resume a saved \

--- a/lib/backend_registry.ml
+++ b/lib/backend_registry.ml
@@ -1,0 +1,44 @@
+open Base
+
+type t = {
+  factory : backend:string -> model:string option -> Llm_backend.t;
+  cache : (string * string option, Llm_backend.t) Hashtbl.t;
+}
+
+let display_name_of_claude_model = function
+  | Some m -> Printf.sprintf "Claude (%s)" m
+  | None -> "Claude"
+
+let make_factory ~process_mgr ~clock ~timeout ~setsid_exec :
+    backend:string -> model:string option -> Llm_backend.t =
+ fun ~backend ~model ->
+  match backend with
+  | "claude" ->
+      Claude_backend.create
+        ~name:(display_name_of_claude_model model)
+        ~model ~process_mgr ~clock ~timeout ~setsid_exec
+  | "codex" ->
+      Codex_backend.create ~model ~process_mgr ~clock ~timeout ~setsid_exec
+  | "opencode" ->
+      Opencode_backend.create ~model ~process_mgr ~clock ~timeout ~setsid_exec
+  | "pi" -> Pi_backend.create ~model ~process_mgr ~clock ~timeout ~setsid_exec
+  | "gemini" ->
+      Gemini_backend.create ~model ~process_mgr ~clock ~timeout ~setsid_exec
+  | other ->
+      invalid_arg
+        (Printf.sprintf "Backend_registry.get: unknown backend %S" other)
+
+let create ~process_mgr ~clock ~timeout ~setsid_exec =
+  {
+    factory = make_factory ~process_mgr ~clock ~timeout ~setsid_exec;
+    cache = Hashtbl.Poly.create ();
+  }
+
+let get t ~backend ~model =
+  let key = (backend, model) in
+  match Hashtbl.find t.cache key with
+  | Some b -> b
+  | None ->
+      let b = t.factory ~backend ~model in
+      Hashtbl.add_exn t.cache ~key ~data:b;
+      b

--- a/lib/backend_registry.ml
+++ b/lib/backend_registry.ml
@@ -6,6 +6,15 @@ type t = {
 }
 
 let display_name_of_claude_model = function
+  | Some m when Backend_routing.is_auto_model (Some m) ->
+      (* Under [--model auto] the registry caches one backend per
+         [(backend, "auto")] key and [run_streaming] resolves the actual
+         Claude alias from [complexity] at call time, so any single label
+         here would be wrong for at least some patches. Drop the
+         parenthetical: showing "Claude" matches the no-flag default and
+         avoids the literal "Claude (auto)" string treating the sentinel
+         as if it were a Claude model name. *)
+      "Claude"
   | Some m -> Printf.sprintf "Claude (%s)" m
   | None -> "Claude"
 

--- a/lib/backend_registry.ml
+++ b/lib/backend_registry.ml
@@ -40,5 +40,11 @@ let get t ~backend ~model =
   | Some b -> b
   | None ->
       let b = t.factory ~backend ~model in
-      Hashtbl.add_exn t.cache ~key ~data:b;
+      (* [set] (not [add_exn]): the runner forks one daemon fiber per patch
+         action, so two fibers may both miss [find] and race to insert the
+         same key. Constructing a duplicate backend is harmless — they hold
+         the same {process_mgr, clock, timeout, setsid_exec} closure — so
+         losing the race just means one of the two backend records is
+         garbage. [add_exn] would raise [Duplicate] on the loser. *)
+      Hashtbl.set t.cache ~key ~data:b;
       b

--- a/lib/backend_registry.mli
+++ b/lib/backend_registry.mli
@@ -1,0 +1,26 @@
+(** Lazy cache of [Llm_backend.t] instances keyed by [(backend_name, model)].
+
+    A run can route different patches to different backends (see
+    [Repo_config.modelRouting]), so we may need several distinct [Llm_backend.t]
+    values during a single session — one per unique [(backend, model)] tuple
+    referenced by either the CLI flags or the routing map. Constructing them
+    eagerly would be wasteful when the routing only uses one or two; the
+    registry builds each on first lookup and caches it for the rest of the run.
+*)
+
+type t
+
+val create :
+  process_mgr:_ Eio.Process.mgr ->
+  clock:_ Eio.Time.clock ->
+  timeout:float ->
+  setsid_exec:string option ->
+  t
+(** Build an empty registry that knows how to construct any of the supported
+    backends. The Eio capabilities and per-session [timeout] are baked into the
+    closure so callers don't re-thread them on every [get]. *)
+
+val get : t -> backend:string -> model:string option -> Llm_backend.t
+(** Return the cached [Llm_backend.t] for [(backend, model)], constructing it on
+    first request. Raises [Invalid_argument] for unrecognised backend names —
+    callers are expected to validate against the known list before asking. *)

--- a/lib/backend_routing.ml
+++ b/lib/backend_routing.ml
@@ -13,4 +13,9 @@ let decide ~(repo_config : Repo_config.t) ~default_backend ~cli_model
   else
     match Repo_config.route_for_complexity repo_config ~complexity with
     | Some { Repo_config.backend; model } -> { backend; model }
-    | None -> { backend = default_backend; model = cli_model }
+    | None ->
+        (* Canonicalise the auto sentinel to lowercase so e.g. [--model AUTO]
+           and [--model auto] hit the same [Backend_registry] cache key
+           ([(backend, model)]). [resolve_auto_model] downstream lowercases
+           anyway, so observable behaviour is unchanged. *)
+        { backend = default_backend; model = Some "auto" }

--- a/lib/backend_routing.ml
+++ b/lib/backend_routing.ml
@@ -1,0 +1,16 @@
+open Base
+
+type decision = { backend : string; model : string option }
+
+let is_auto_model = function
+  | Some s -> String.equal (String.lowercase s) "auto"
+  | None -> false
+
+let decide ~(repo_config : Repo_config.t) ~default_backend ~cli_model
+    ~complexity : decision =
+  if not (is_auto_model cli_model) then
+    { backend = default_backend; model = cli_model }
+  else
+    match Repo_config.route_for_complexity repo_config ~complexity with
+    | Some { Repo_config.backend; model } -> { backend; model }
+    | None -> { backend = default_backend; model = cli_model }

--- a/lib/backend_routing.mli
+++ b/lib/backend_routing.mli
@@ -1,0 +1,44 @@
+(** Pure decision: which [(backend, model)] tuple should drive a given patch's
+    session?
+
+    Combines four inputs into one tuple, with no IO, no Eio capabilities, and no
+    global state — so the decision is fully testable as a property function. The
+    effectful counterpart that turns this decision into an [Llm_backend.t] is
+    {!Backend_registry}. *)
+
+type decision = {
+  backend : string;
+  model : string option;
+      (** [Some "auto"] (case-insensitive) signals the per-backend hardcoded
+          complexity → model ladder; [Some other] is an explicit model name;
+          [None] drops [--model] from the CLI invocation entirely. *)
+}
+
+val decide :
+  repo_config:Repo_config.t ->
+  default_backend:string ->
+  cli_model:string option ->
+  complexity:int option ->
+  decision
+(** Precedence rules:
+
+    + If [cli_model] is not the literal ["auto"] (case-insensitive), the CLI
+      wins for the whole run: result is
+      [{ backend = default_backend; model = cli_model }]. The repo config is
+      ignored. This preserves the "explicit override" escape hatch.
+    + If [cli_model] is ["auto"] (case-insensitive) AND [Repo_config] has a
+      route for this complexity: the route wins —
+      [{ backend = route.backend; model = route.model }]. This is the only case
+      where the routing map takes effect.
+    + Otherwise ([cli_model] is ["auto"] but no route applies — typically
+      because [complexity = None], or the route map has no entry for this
+      complexity): result is [{ backend = default_backend; model = cli_model }].
+      The downstream backend will see [Some "auto"] and apply its own hardcoded
+      ladder via [Llm_backend.resolve_auto_model].
+
+    The function never raises and is total over all inputs. *)
+
+val is_auto_model : string option -> bool
+(** [is_auto_model m] returns [true] iff [m] is [Some s] where [s]
+    case-insensitively equals ["auto"]. Exposed for tests and call sites that
+    need to gate other behavior on the same predicate. *)

--- a/lib/claude_backend.ml
+++ b/lib/claude_backend.ml
@@ -3,7 +3,8 @@ let create ~name ~model ~process_mgr ~clock ~timeout ~setsid_exec :
   {
     name;
     run_streaming =
-      (fun ~cwd ~patch_id ~prompt ~resume_session ~on_event ->
+      (fun ~cwd ~patch_id ~prompt ~resume_session ~complexity ~on_event ->
         Claude_runner.run_streaming ~model ~process_mgr ~clock ~timeout
-          ~setsid_exec ~cwd ~patch_id ~prompt ~resume_session ~on_event);
+          ~setsid_exec ~cwd ~patch_id ~prompt ~resume_session ~complexity
+          ~on_event);
   }

--- a/lib/claude_runner.ml
+++ b/lib/claude_runner.ml
@@ -39,6 +39,16 @@ let ansi_re =
 (** Strip ANSI escape sequences and stray control characters. *)
 let strip_ansi s = Re.replace_string ansi_re ~by:"" s
 
+let auto_model ~complexity =
+  (* Use Claude Code's stable aliases (resolved by the CLI to the latest
+     pinned version per provider). 1 = haiku, 2 = sonnet, 3 = opus.
+     [None] complexity falls through to opus — be conservative. *)
+  match complexity with
+  | Some 1 -> Some "haiku"
+  | Some 2 -> Some "sonnet"
+  | Some 3 -> Some "opus"
+  | Some _ | None -> Some "opus"
+
 let model_args = function
   | Some m when not (String.is_empty m) -> [ "--model"; m ]
   | _ -> []
@@ -260,8 +270,9 @@ let run ~model ~process_mgr ~cwd ~patch_id ~prompt ~resume_session =
   }
 
 let run_streaming ~model ~process_mgr ~clock ~timeout ~setsid_exec ~cwd
-    ~patch_id ~prompt ~resume_session ~on_event =
+    ~patch_id ~prompt ~resume_session ~complexity ~on_event =
   ignore (patch_id : Types.Patch_id.t);
+  let model = Llm_backend.resolve_auto_model ~model ~complexity ~auto_model in
   let args = build_stream_args ~model ~prompt ~resume_session in
   let process_line line =
     let trimmed = strip_ansi (String.strip line) in
@@ -269,6 +280,21 @@ let run_streaming ~model ~process_mgr ~clock ~timeout ~setsid_exec ~cwd
   in
   Llm_backend.spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~setsid_exec
     ~args ~process_line ~on_event
+
+let%test "auto_model: complexity 1 -> haiku" =
+  Option.equal String.equal (auto_model ~complexity:(Some 1)) (Some "haiku")
+
+let%test "auto_model: complexity 2 -> sonnet" =
+  Option.equal String.equal (auto_model ~complexity:(Some 2)) (Some "sonnet")
+
+let%test "auto_model: complexity 3 -> opus" =
+  Option.equal String.equal (auto_model ~complexity:(Some 3)) (Some "opus")
+
+let%test "auto_model: None -> opus (conservative)" =
+  Option.equal String.equal (auto_model ~complexity:None) (Some "opus")
+
+let%test "auto_model: out-of-range -> opus (conservative)" =
+  Option.equal String.equal (auto_model ~complexity:(Some 7)) (Some "opus")
 
 let%test "build_args fresh (no resume, with model)" =
   let args =

--- a/lib/claude_runner.mli
+++ b/lib/claude_runner.mli
@@ -35,6 +35,11 @@ val run :
     inside a switch they will release on a timer). The streaming counterpart
     {!run_streaming} carries [~clock] and [~timeout] for this purpose. *)
 
+val auto_model : complexity:int option -> string option
+(** Map a 1/2/3 complexity to a Claude model alias. [None] complexity (and any
+    out-of-range value) is treated as the strongest tier — be conservative.
+    Returns [Some "haiku-4-5"] / [Some "sonnet-4-5"] / [Some "opus-4-5"]. *)
+
 val run_streaming :
   model:string option ->
   process_mgr:_ Eio.Process.mgr ->
@@ -45,6 +50,7 @@ val run_streaming :
   patch_id:Types.Patch_id.t ->
   prompt:string ->
   resume_session:string option ->
+  complexity:int option ->
   on_event:(Types.Stream_event.t -> unit) ->
   Llm_backend.result
 (** Like {!run} but uses [--output-format stream-json]. Each NDJSON line is

--- a/lib/claude_runner.mli
+++ b/lib/claude_runner.mli
@@ -38,7 +38,8 @@ val run :
 val auto_model : complexity:int option -> string option
 (** Map a 1/2/3 complexity to a Claude model alias. [None] complexity (and any
     out-of-range value) is treated as the strongest tier — be conservative.
-    Returns [Some "haiku-4-5"] / [Some "sonnet-4-5"] / [Some "opus-4-5"]. *)
+    Returns [Some "haiku"] / [Some "sonnet"] / [Some "opus"] — Claude Code's
+    stable aliases. *)
 
 val run_streaming :
   model:string option ->

--- a/lib/codex_backend.ml
+++ b/lib/codex_backend.ml
@@ -91,9 +91,20 @@ let parse_event (line : string) : Types.Stream_event.t list =
   | exception Yojson.Json_error _ -> []
   | exception Yojson.Safe.Util.Type_error _ -> []
 
+let auto_model ~complexity =
+  (* Codex CLI model ladder. 1 = mini for cheap mechanical work, 2 = standard,
+     3 = the strongest available frontier model. [None] complexity falls
+     through to the strongest tier — be conservative. *)
+  match complexity with
+  | Some 1 -> Some "gpt-5.4-mini"
+  | Some 2 -> Some "gpt-5.4"
+  | Some 3 -> Some "gpt-5.5"
+  | Some _ | None -> Some "gpt-5.5"
+
 let run_streaming ~model ~process_mgr ~clock ~timeout ~setsid_exec ~cwd
-    ~patch_id ~prompt ~resume_session ~on_event =
+    ~patch_id ~prompt ~resume_session ~complexity ~on_event =
   ignore (patch_id : Types.Patch_id.t);
+  let model = Llm_backend.resolve_auto_model ~model ~complexity ~auto_model in
   let cwd_path = snd cwd in
   let args = build_args ~model ~cwd_path ~prompt ~resume_session in
   let process_line line =
@@ -107,9 +118,9 @@ let create ~model ~process_mgr ~clock ~timeout ~setsid_exec : Llm_backend.t =
   {
     name = "Codex";
     run_streaming =
-      (fun ~cwd ~patch_id ~prompt ~resume_session ~on_event ->
+      (fun ~cwd ~patch_id ~prompt ~resume_session ~complexity ~on_event ->
         run_streaming ~model ~process_mgr ~clock ~timeout ~setsid_exec ~cwd
-          ~patch_id ~prompt ~resume_session ~on_event);
+          ~patch_id ~prompt ~resume_session ~complexity ~on_event);
   }
 
 let%test "build_args fresh (no resume, no model)" =

--- a/lib/gameplan_parser.ml
+++ b/lib/gameplan_parser.ml
@@ -256,6 +256,11 @@ let parse_json_string input =
                 | `String s -> s
                 | _ -> ""
               in
+              let complexity =
+                match p |> member "complexity" with
+                | `Int n when n >= 1 && n <= 3 -> Some n
+                | _ -> None
+              in
               let test_stubs_introduced =
                 json_string_list p "testStubsIntroduced"
               in
@@ -295,6 +300,7 @@ let parse_json_string input =
                 changes;
                 test_stubs_introduced;
                 test_stubs_implemented;
+                complexity;
               })
         in
         match open_questions with
@@ -405,6 +411,7 @@ let%test_module "Gameplan_parser" =
               changes = [];
               test_stubs_introduced = [];
               test_stubs_implemented = [];
+              complexity = None;
             };
         ]
       in
@@ -430,6 +437,7 @@ let%test_module "Gameplan_parser" =
             changes = [];
             test_stubs_introduced = [];
             test_stubs_implemented = [];
+            complexity = None;
           }
       in
       let dep_graph = Map.of_alist_exn (module Types.Patch_id) [ (pid, []) ] in

--- a/lib/gemini_backend.ml
+++ b/lib/gemini_backend.ml
@@ -76,9 +76,20 @@ let parse_event (line : string) : Types.Stream_event.t list =
   | exception Yojson.Json_error _ -> []
   | exception Yojson.Safe.Util.Type_error _ -> []
 
+let auto_model ~complexity =
+  (* Gemini CLI model ladder. 1 = the cheapest current Flash, 2 = the latest
+     Flash preview, 3 = the latest Pro preview. [None] complexity falls
+     through to Pro — be conservative. *)
+  match complexity with
+  | Some 1 -> Some "gemini-2.5-flash"
+  | Some 2 -> Some "gemini-3-flash-preview"
+  | Some 3 -> Some "gemini-3-pro-preview"
+  | Some _ | None -> Some "gemini-3-pro-preview"
+
 let run_streaming ~model ~process_mgr ~clock ~timeout ~setsid_exec ~cwd
-    ~patch_id ~prompt ~resume_session ~on_event =
+    ~patch_id ~prompt ~resume_session ~complexity ~on_event =
   ignore (patch_id : Types.Patch_id.t);
+  let model = Llm_backend.resolve_auto_model ~model ~complexity ~auto_model in
   let args = build_args ~model ~prompt ~resume_session in
   let process_line line =
     let trimmed = String.strip line in
@@ -91,9 +102,9 @@ let create ~model ~process_mgr ~clock ~timeout ~setsid_exec : Llm_backend.t =
   {
     name = "Gemini";
     run_streaming =
-      (fun ~cwd ~patch_id ~prompt ~resume_session ~on_event ->
+      (fun ~cwd ~patch_id ~prompt ~resume_session ~complexity ~on_event ->
         run_streaming ~model ~process_mgr ~clock ~timeout ~setsid_exec ~cwd
-          ~patch_id ~prompt ~resume_session ~on_event);
+          ~patch_id ~prompt ~resume_session ~complexity ~on_event);
   }
 
 let%test "build_args fresh (no resume, no model)" =

--- a/lib/llm_backend.ml
+++ b/lib/llm_backend.ml
@@ -189,6 +189,60 @@ type t = {
     patch_id:Types.Patch_id.t ->
     prompt:string ->
     resume_session:string option ->
+    complexity:int option ->
     on_event:(Types.Stream_event.t -> unit) ->
     result;
 }
+
+(** Resolve a model selector for a single backend invocation.
+
+    [Some "auto"] (case-insensitive) routes through the per-backend [auto_model]
+    mapping. [None] / empty / any other string passes through unchanged. This
+    keeps "auto" as a documented sentinel string rather than introducing a new
+    type, so it round-trips cleanly through Project_store and the CLI without
+    any migration.
+
+    [auto_model] is the backend's complexity → model name function. It may
+    return [None] when complexity is missing AND the backend has no sensible
+    fallback — in that case we drop [--model] and let the CLI's own default
+    apply. *)
+let resolve_auto_model ~model ~complexity ~auto_model : string option =
+  let is_auto = function
+    | Some s -> Base.String.equal (Base.String.lowercase s) "auto"
+    | None -> false
+  in
+  if is_auto model then auto_model ~complexity else model
+
+let%test "resolve_auto_model passes None through" =
+  let auto_model ~complexity:_ = Some "fallback" in
+  Option.equal Base.String.equal
+    (resolve_auto_model ~model:None ~complexity:None ~auto_model)
+    None
+
+let%test "resolve_auto_model passes explicit model through unchanged" =
+  let auto_model ~complexity:_ = Some "fallback" in
+  Option.equal Base.String.equal
+    (resolve_auto_model ~model:(Some "sonnet") ~complexity:(Some 1) ~auto_model)
+    (Some "sonnet")
+
+let%test "resolve_auto_model: 'auto' routes through auto_model" =
+  let auto_model ~complexity =
+    match complexity with Some 1 -> Some "fast" | _ -> Some "strong"
+  in
+  Option.equal Base.String.equal
+    (resolve_auto_model ~model:(Some "auto") ~complexity:(Some 1) ~auto_model)
+    (Some "fast")
+
+let%test "resolve_auto_model: 'AUTO' is also recognised (case-insensitive)" =
+  let auto_model ~complexity:_ = Some "picked" in
+  Option.equal Base.String.equal
+    (resolve_auto_model ~model:(Some "AUTO") ~complexity:(Some 2) ~auto_model)
+    (Some "picked")
+
+let%test "resolve_auto_model: 'auto' with no complexity hits fallback tier" =
+  let auto_model ~complexity =
+    match complexity with None -> Some "strong" | _ -> Some "wrong"
+  in
+  Option.equal Base.String.equal
+    (resolve_auto_model ~model:(Some "auto") ~complexity:None ~auto_model)
+    (Some "strong")

--- a/lib/llm_backend.mli
+++ b/lib/llm_backend.mli
@@ -19,6 +19,16 @@ type result = {
 }
 [@@deriving show, eq, sexp_of, compare]
 
+val resolve_auto_model :
+  model:string option ->
+  complexity:int option ->
+  auto_model:(complexity:int option -> string option) ->
+  string option
+(** Resolve the [--model] sentinel ["auto"] (case-insensitive) into a concrete
+    model name using [auto_model] (each backend supplies its own complexity →
+    model mapping). All other model values, including [None] and the empty
+    string, pass through unchanged so the backend's own default still wins. *)
+
 val spawn_and_stream :
   process_mgr:_ Eio.Process.mgr ->
   clock:_ Eio.Time.clock ->
@@ -49,6 +59,12 @@ type t = {
     patch_id:Types.Patch_id.t ->
     prompt:string ->
     resume_session:string option ->
+    complexity:int option ->
     on_event:(Types.Stream_event.t -> unit) ->
     result;
 }
+(** [complexity] is the gameplan-author's 1/2/3 estimate for this patch. When
+    the user passes [--model auto], each backend uses [complexity] to pick a
+    backend-specific model: harder patches get stronger models. [None] means the
+    gameplan didn't specify (legacy gameplans, ad-hoc operations) — the backend
+    should treat that as the highest tier. *)

--- a/lib/opencode_backend.ml
+++ b/lib/opencode_backend.ml
@@ -100,9 +100,21 @@ let parse_event (line : string) : Types.Stream_event.t list =
   | exception Yojson.Json_error _ -> []
   | exception Yojson.Safe.Util.Type_error _ -> []
 
+let auto_model ~complexity =
+  (* OpenCode uses provider/model_id format. Default the auto ladder to
+     Anthropic since it's the most common provider for coding work. Users
+     wanting a different provider can pass --model <provider>/<model>
+     explicitly. [None] complexity falls through to Opus — be conservative. *)
+  match complexity with
+  | Some 1 -> Some "anthropic/claude-haiku-4-5"
+  | Some 2 -> Some "anthropic/claude-sonnet-4-6"
+  | Some 3 -> Some "anthropic/claude-opus-4-7"
+  | Some _ | None -> Some "anthropic/claude-opus-4-7"
+
 let run_streaming ~model ~process_mgr ~clock ~timeout ~setsid_exec ~cwd
-    ~patch_id ~prompt ~resume_session ~on_event =
+    ~patch_id ~prompt ~resume_session ~complexity ~on_event =
   ignore (patch_id : Types.Patch_id.t);
+  let model = Llm_backend.resolve_auto_model ~model ~complexity ~auto_model in
   let cwd_path = snd cwd in
   let args = build_args ~model ~cwd_path ~prompt ~resume_session in
   let process_line line =
@@ -116,9 +128,9 @@ let create ~model ~process_mgr ~clock ~timeout ~setsid_exec : Llm_backend.t =
   {
     name = "OpenCode";
     run_streaming =
-      (fun ~cwd ~patch_id ~prompt ~resume_session ~on_event ->
+      (fun ~cwd ~patch_id ~prompt ~resume_session ~complexity ~on_event ->
         run_streaming ~model ~process_mgr ~clock ~timeout ~setsid_exec ~cwd
-          ~patch_id ~prompt ~resume_session ~on_event);
+          ~patch_id ~prompt ~resume_session ~complexity ~on_event);
   }
 
 let%test "build_args without continue (no model)" =

--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -644,6 +644,7 @@ let make_orchestrator ~patch_id ~main_branch =
       classification = "";
       test_stubs_introduced = [];
       test_stubs_implemented = [];
+      complexity = None;
     }
   in
   (patch, Orchestrator.create ~patches:[ patch ] ~main_branch)

--- a/lib/pi_backend.ml
+++ b/lib/pi_backend.ml
@@ -55,8 +55,18 @@ let parse_event (line : string) : Types.Stream_event.t list =
   | exception Yojson.Json_error _ -> []
   | exception Yojson.Safe.Util.Type_error _ -> []
 
+let auto_model ~complexity =
+  (* Pi accepts user-configured model identifiers (e.g. local Ollama tags or
+     OpenRouter routes), so there is no canonical 1/2/3 ladder we can pick
+     blindly. Returning [None] drops [--model] and lets the user's pi config
+     pick its own default. Users wanting tiered routing should pass
+     [--model <id>] explicitly instead of [--model auto]. *)
+  ignore complexity;
+  None
+
 let run_streaming ~model ~process_mgr ~clock ~timeout ~setsid_exec ~cwd
-    ~patch_id ~prompt ~resume_session ~on_event =
+    ~patch_id ~prompt ~resume_session ~complexity ~on_event =
+  let model = Llm_backend.resolve_auto_model ~model ~complexity ~auto_model in
   let cwd_path = snd cwd in
   let patch_id_str = Types.Patch_id.to_string patch_id in
   let args =
@@ -73,9 +83,9 @@ let create ~model ~process_mgr ~clock ~timeout ~setsid_exec : Llm_backend.t =
   {
     name = "Pi";
     run_streaming =
-      (fun ~cwd ~patch_id ~prompt ~resume_session ~on_event ->
+      (fun ~cwd ~patch_id ~prompt ~resume_session ~complexity ~on_event ->
         run_streaming ~model ~process_mgr ~clock ~timeout ~setsid_exec ~cwd
-          ~patch_id ~prompt ~resume_session ~on_event);
+          ~patch_id ~prompt ~resume_session ~complexity ~on_event);
   }
 
 let%test "build_args without continue (no model)" =

--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -292,6 +292,7 @@ let%test "render_spec_suffix: both empty" =
       classification = "";
       test_stubs_introduced = [];
       test_stubs_implemented = [];
+      complexity = None;
     }
   in
   let gameplan =
@@ -324,6 +325,7 @@ let%test "render_spec_suffix: gameplan spec only" =
       classification = "";
       test_stubs_introduced = [];
       test_stubs_implemented = [];
+      complexity = None;
     }
   in
   let gameplan =
@@ -359,6 +361,7 @@ let%test "render_spec_suffix: patch spec only" =
       classification = "";
       test_stubs_introduced = [];
       test_stubs_implemented = [];
+      complexity = None;
     }
   in
   let gameplan =
@@ -394,6 +397,7 @@ let%test "render_spec_suffix: both present" =
       classification = "";
       test_stubs_introduced = [];
       test_stubs_implemented = [];
+      complexity = None;
     }
   in
   let gameplan =
@@ -935,6 +939,7 @@ let%test "patch prompt includes title and deps" =
         changes = [];
         test_stubs_introduced = [];
         test_stubs_implemented = [];
+        complexity = None;
       }
   in
   let gameplan : Gameplan.t =
@@ -963,6 +968,7 @@ let%test "patch prompt includes title and deps" =
               changes = [];
               test_stubs_introduced = [];
               test_stubs_implemented = [];
+              complexity = None;
             };
             patch;
           ];

--- a/lib/repo_config.ml
+++ b/lib/repo_config.ml
@@ -11,8 +11,14 @@ let parse_route ~known_backends ~complexity (json : Yojson.Safe.t) :
   let open Yojson.Safe.Util in
   match json with
   | `Assoc _ ->
-      let backend =
-        try Some (member "backend" json |> to_string) with _ -> None
+      let backend_result =
+        match member "backend" json with
+        | `Null -> Ok None
+        | `String s when String.is_empty (String.strip s) -> Ok None
+        | `String s -> Ok (Some (String.strip s))
+        | _ ->
+            Error
+              (Printf.sprintf "routing.%d.backend must be a string" complexity)
       in
       let model_result =
         match member "model" json with
@@ -24,22 +30,23 @@ let parse_route ~known_backends ~complexity (json : Yojson.Safe.t) :
               (Printf.sprintf "routing.%d.model must be a string when present"
                  complexity)
       in
-      Result.bind model_result ~f:(fun model ->
-          match backend with
-          | None ->
-              Error
-                (Printf.sprintf
-                   "routing.%d: missing required string field \"backend\""
-                   complexity)
-          | Some name
-            when not (List.mem known_backends name ~equal:String.equal) ->
-              Error
-                (Printf.sprintf
-                   "routing.%d.backend = %S is not a known backend (expected \
-                    one of: %s)"
-                   complexity name
-                   (String.concat ~sep:", " known_backends))
-          | Some name -> Ok { backend = name; model })
+      Result.bind backend_result ~f:(fun backend ->
+          Result.bind model_result ~f:(fun model ->
+              match backend with
+              | None ->
+                  Error
+                    (Printf.sprintf
+                       "routing.%d: missing required string field \"backend\""
+                       complexity)
+              | Some name
+                when not (List.mem known_backends name ~equal:String.equal) ->
+                  Error
+                    (Printf.sprintf
+                       "routing.%d.backend = %S is not a known backend \
+                        (expected one of: %s)"
+                       complexity name
+                       (String.concat ~sep:", " known_backends))
+              | Some name -> Ok { backend = name; model }))
   | _ ->
       Error
         (Printf.sprintf "routing.%d must be an object {backend, model}"
@@ -188,6 +195,14 @@ let%test "route_for_complexity: None complexity -> None route" =
   match parse_string ~known_backends:[ "claude" ] raw with
   | Ok t -> Option.is_none (route_for_complexity t ~complexity:None)
   | Error _ -> false
+
+let%test
+    "parse_string: non-string backend rejected with type error (not 'missing')"
+    =
+  let raw = {|{"routing":{"1":{"backend":123}}}|} in
+  match parse_string ~known_backends:[ "claude" ] raw with
+  | Error msg -> String.is_substring msg ~substring:"backend must be a string"
+  | Ok _ -> false
 
 let%test "parse_string: non-string model rejected" =
   let raw = {|{"routing":{"1":{"backend":"claude","model":123}}}|} in

--- a/lib/repo_config.ml
+++ b/lib/repo_config.ml
@@ -1,0 +1,178 @@
+open Base
+
+type route = { backend : string; model : string option }
+type t = { complexity_routes : (int * route) list }
+
+let empty = { complexity_routes = [] }
+let config_path ~config_dir = Stdlib.Filename.concat config_dir "config.json"
+
+let parse_route ~known_backends ~complexity (json : Yojson.Safe.t) :
+    (route, string) Result.t =
+  let open Yojson.Safe.Util in
+  match json with
+  | `Assoc _ -> (
+      let backend =
+        try Some (member "backend" json |> to_string) with _ -> None
+      in
+      let model =
+        match member "model" json with
+        | `Null -> None
+        | `String s when String.is_empty (String.strip s) -> None
+        | `String s -> Some s
+        | _ -> None
+      in
+      match backend with
+      | None ->
+          Error
+            (Printf.sprintf
+               "routing.%d: missing required string field \"backend\""
+               complexity)
+      | Some name when not (List.mem known_backends name ~equal:String.equal) ->
+          Error
+            (Printf.sprintf
+               "routing.%d.backend = %S is not a known backend (expected one \
+                of: %s)"
+               complexity name
+               (String.concat ~sep:", " known_backends))
+      | Some name -> Ok { backend = name; model })
+  | _ ->
+      Error
+        (Printf.sprintf "routing.%d must be an object {backend, model}"
+           complexity)
+
+let parse_routing ~known_backends (json : Yojson.Safe.t) :
+    ((int * route) list, string) Result.t =
+  match json with
+  | `Null -> Ok []
+  | `Assoc fields ->
+      List.fold_result fields ~init:[] ~f:(fun acc (key, value) ->
+          match Stdlib.int_of_string_opt key with
+          | None ->
+              Error
+                (Printf.sprintf
+                   "routing key %S is not an integer (expected 1, 2, or 3)" key)
+          | Some k when k < 1 || k > 3 ->
+              Error
+                (Printf.sprintf
+                   "routing.%d is out of range (complexity must be 1, 2, or 3)"
+                   k)
+          | Some k ->
+              Result.map (parse_route ~known_backends ~complexity:k value)
+                ~f:(fun route -> (k, route) :: acc))
+      |> Result.map ~f:List.rev
+  | _ ->
+      Error
+        ("routing must be an object mapping complexity -> {backend, model};"
+       ^ " got " ^ Yojson.Safe.to_string json)
+
+let parse_string ~known_backends (raw : string) : (t, string) Result.t =
+  match
+    try Ok (Yojson.Safe.from_string raw)
+    with Yojson.Json_error msg -> Error (Printf.sprintf "config.json: %s" msg)
+  with
+  | Error _ as e -> e
+  | Ok json -> (
+      let open Yojson.Safe.Util in
+      match json with
+      | `Assoc _ ->
+          let routing = member "routing" json in
+          Result.map (parse_routing ~known_backends routing) ~f:(fun routes ->
+              { complexity_routes = routes })
+      | _ -> Error "config.json: top-level value must be an object")
+
+let load ~config_dir ~known_backends =
+  let path = config_path ~config_dir in
+  if not (Stdlib.Sys.file_exists path) then Ok empty
+  else
+    try
+      let ic = Stdlib.In_channel.open_text path in
+      let raw =
+        Exn.protect
+          ~finally:(fun () -> Stdlib.In_channel.close ic)
+          ~f:(fun () -> Stdlib.In_channel.input_all ic)
+      in
+      parse_string ~known_backends raw
+    with Sys_error msg ->
+      Error (Printf.sprintf "config.json: cannot read: %s" msg)
+
+let route_for_complexity (t : t) ~complexity =
+  match complexity with
+  | None -> None
+  | Some k -> List.Assoc.find t.complexity_routes k ~equal:Int.equal
+
+let%test "empty config has no routes" =
+  Option.is_none (route_for_complexity empty ~complexity:(Some 1))
+
+let%test "parse_string: missing routing -> empty" =
+  match parse_string ~known_backends:[ "claude" ] "{}" with
+  | Ok t -> List.is_empty t.complexity_routes
+  | Error _ -> false
+
+let%test "parse_string: unknown top-level keys are ignored (forward compat)" =
+  let raw = {|{"futureKey":{"foo":"bar"}}|} in
+  match parse_string ~known_backends:[ "claude" ] raw with
+  | Ok t -> List.is_empty t.complexity_routes
+  | Error _ -> false
+
+let%test "parse_string: full routing parses" =
+  let raw =
+    {|{"routing":{"1":{"backend":"claude","model":"haiku"},"3":{"backend":"codex","model":"gpt-5.5"}}}|}
+  in
+  match parse_string ~known_backends:[ "claude"; "codex"; "gemini" ] raw with
+  | Ok t -> (
+      let r1 = route_for_complexity t ~complexity:(Some 1) in
+      let r3 = route_for_complexity t ~complexity:(Some 3) in
+      let r2 = route_for_complexity t ~complexity:(Some 2) in
+      Option.is_none r2
+      && (match r1 with
+        | Some { backend = "claude"; model = Some "haiku" } -> true
+        | _ -> false)
+      &&
+      match r3 with
+      | Some { backend = "codex"; model = Some "gpt-5.5" } -> true
+      | _ -> false)
+  | Error _ -> false
+
+let%test "parse_string: model omitted -> None" =
+  let raw = {|{"routing":{"2":{"backend":"claude"}}}|} in
+  match parse_string ~known_backends:[ "claude" ] raw with
+  | Ok t -> (
+      match route_for_complexity t ~complexity:(Some 2) with
+      | Some { backend = "claude"; model = None } -> true
+      | _ -> false)
+  | Error _ -> false
+
+let%test "parse_string: unknown backend rejected" =
+  let raw = {|{"routing":{"1":{"backend":"made-up"}}}|} in
+  match parse_string ~known_backends:[ "claude" ] raw with
+  | Error msg -> String.is_substring msg ~substring:"made-up"
+  | Ok _ -> false
+
+let%test "parse_string: out-of-range complexity rejected" =
+  let raw = {|{"routing":{"4":{"backend":"claude"}}}|} in
+  match parse_string ~known_backends:[ "claude" ] raw with
+  | Error msg -> String.is_substring msg ~substring:"out of range"
+  | Ok _ -> false
+
+let%test "parse_string: non-int key rejected" =
+  let raw = {|{"routing":{"high":{"backend":"claude"}}}|} in
+  match parse_string ~known_backends:[ "claude" ] raw with
+  | Error msg -> String.is_substring msg ~substring:"high"
+  | Ok _ -> false
+
+let%test "parse_string: missing backend rejected" =
+  let raw = {|{"routing":{"1":{"model":"haiku"}}}|} in
+  match parse_string ~known_backends:[ "claude" ] raw with
+  | Error msg -> String.is_substring msg ~substring:"backend"
+  | Ok _ -> false
+
+let%test "parse_string: malformed json -> Error" =
+  match parse_string ~known_backends:[ "claude" ] "{not json}" with
+  | Error _ -> true
+  | Ok _ -> false
+
+let%test "route_for_complexity: None complexity -> None route" =
+  let raw = {|{"routing":{"1":{"backend":"claude"}}}|} in
+  match parse_string ~known_backends:[ "claude" ] raw with
+  | Ok t -> Option.is_none (route_for_complexity t ~complexity:None)
+  | Error _ -> false

--- a/lib/repo_config.ml
+++ b/lib/repo_config.ml
@@ -10,31 +10,36 @@ let parse_route ~known_backends ~complexity (json : Yojson.Safe.t) :
     (route, string) Result.t =
   let open Yojson.Safe.Util in
   match json with
-  | `Assoc _ -> (
+  | `Assoc _ ->
       let backend =
         try Some (member "backend" json |> to_string) with _ -> None
       in
-      let model =
+      let model_result =
         match member "model" json with
-        | `Null -> None
-        | `String s when String.is_empty (String.strip s) -> None
-        | `String s -> Some s
-        | _ -> None
+        | `Null -> Ok None
+        | `String s when String.is_empty (String.strip s) -> Ok None
+        | `String s -> Ok (Some (String.strip s))
+        | _ ->
+            Error
+              (Printf.sprintf "routing.%d.model must be a string when present"
+                 complexity)
       in
-      match backend with
-      | None ->
-          Error
-            (Printf.sprintf
-               "routing.%d: missing required string field \"backend\""
-               complexity)
-      | Some name when not (List.mem known_backends name ~equal:String.equal) ->
-          Error
-            (Printf.sprintf
-               "routing.%d.backend = %S is not a known backend (expected one \
-                of: %s)"
-               complexity name
-               (String.concat ~sep:", " known_backends))
-      | Some name -> Ok { backend = name; model })
+      Result.bind model_result ~f:(fun model ->
+          match backend with
+          | None ->
+              Error
+                (Printf.sprintf
+                   "routing.%d: missing required string field \"backend\""
+                   complexity)
+          | Some name
+            when not (List.mem known_backends name ~equal:String.equal) ->
+              Error
+                (Printf.sprintf
+                   "routing.%d.backend = %S is not a known backend (expected \
+                    one of: %s)"
+                   complexity name
+                   (String.concat ~sep:", " known_backends))
+          | Some name -> Ok { backend = name; model })
   | _ ->
       Error
         (Printf.sprintf "routing.%d must be an object {backend, model}"
@@ -57,8 +62,15 @@ let parse_routing ~known_backends (json : Yojson.Safe.t) :
                    "routing.%d is out of range (complexity must be 1, 2, or 3)"
                    k)
           | Some k ->
-              Result.map (parse_route ~known_backends ~complexity:k value)
-                ~f:(fun route -> (k, route) :: acc))
+              if List.Assoc.mem acc k ~equal:Int.equal then
+                Error
+                  (Printf.sprintf
+                     "routing.%d is duplicated; each complexity may be \
+                      configured at most once"
+                     k)
+              else
+                Result.map (parse_route ~known_backends ~complexity:k value)
+                  ~f:(fun route -> (k, route) :: acc))
       |> Result.map ~f:List.rev
   | _ ->
       Error
@@ -176,3 +188,26 @@ let%test "route_for_complexity: None complexity -> None route" =
   match parse_string ~known_backends:[ "claude" ] raw with
   | Ok t -> Option.is_none (route_for_complexity t ~complexity:None)
   | Error _ -> false
+
+let%test "parse_string: non-string model rejected" =
+  let raw = {|{"routing":{"1":{"backend":"claude","model":123}}}|} in
+  match parse_string ~known_backends:[ "claude" ] raw with
+  | Error msg -> String.is_substring msg ~substring:"model must be a string"
+  | Ok _ -> false
+
+let%test "parse_string: model whitespace is trimmed" =
+  let raw = {|{"routing":{"1":{"backend":"claude","model":"  haiku\t"}}}|} in
+  match parse_string ~known_backends:[ "claude" ] raw with
+  | Ok t -> (
+      match route_for_complexity t ~complexity:(Some 1) with
+      | Some { backend = "claude"; model = Some "haiku" } -> true
+      | _ -> false)
+  | Error _ -> false
+
+let%test "parse_string: duplicate complexity keys rejected" =
+  let raw =
+    {|{"routing":{"1":{"backend":"claude"},"1":{"backend":"codex"}}}|}
+  in
+  match parse_string ~known_backends:[ "claude"; "codex" ] raw with
+  | Error msg -> String.is_substring msg ~substring:"duplicated"
+  | Ok _ -> false

--- a/lib/repo_config.mli
+++ b/lib/repo_config.mli
@@ -1,0 +1,61 @@
+(** Per-repo configuration loaded from
+    [~/.config/onton/<owner>/<repo>/config.json] (the same directory layout the
+    [User_config] hook lives in — see [User_config.config_dir]).
+
+    Currently only carries the [routing] map — a per-patch override that binds
+    each complexity tier (1/2/3) to a [(backend, model)] tuple. The map only
+    takes effect when [onton --model auto] is in use; explicit [--model <name>]
+    still wins for the whole run.
+
+    Unknown top-level keys are ignored so the file can grow with new sections
+    (e.g. timeouts, hook overrides) without breaking older binaries. *)
+
+type route = {
+  backend : string;
+      (** Backend name. Must be in the caller's [known_backends]. *)
+  model : string option;
+      (** Model passed to that backend. [None] leaves [--model] off and lets the
+          backend's own default apply. *)
+}
+
+type t = {
+  complexity_routes : (int * route) list;
+      (** Sparse map indexed by complexity (1/2/3). Stored as an alist because
+          the set is tiny and the lookup is per-patch — fast enough. Missing
+          keys mean "no override", and the caller falls back to its default
+          backend / built-in [auto_model] ladder. *)
+}
+
+val empty : t
+(** Returned when [config.json] is absent — the no-op config. *)
+
+val load :
+  config_dir:string -> known_backends:string list -> (t, string) Stdlib.Result.t
+(** Read and validate [<config_dir>/config.json]. [config_dir] should be the
+    output of [User_config.config_dir ~github_owner ~github_repo] so the routing
+    config lives alongside the [on_worktree_create] hook for the same repo.
+    Returns:
+    - [Ok empty] if the file does not exist (a non-error — the config is
+      optional);
+    - [Ok t] if the file parses cleanly and every backend name is in
+      [known_backends];
+    - [Error msg] on JSON parse failure, schema violations, unknown backend
+      names, or out-of-range complexity keys.
+
+    The schema is:
+    {[
+      {
+        "routing": {
+          "1": { "backend": "claude", "model": "haiku" },
+          "2": { "backend": "codex",  "model": "gpt-5.4" },
+          "3": { "backend": "claude", "model": "opus" }
+        }
+      }
+    ]}
+    [model] is optional. Top-level extra keys are ignored so the file can grow
+    without breaking older binaries. *)
+
+val route_for_complexity : t -> complexity:int option -> route option
+(** Look up the override for a given patch complexity. [None] when the patch has
+    no complexity, or no rule matches — the caller should fall back to its
+    default backend. *)

--- a/lib/runtime_logging.ml
+++ b/lib/runtime_logging.ml
@@ -1,0 +1,11 @@
+let log_event runtime ?patch_id msg =
+  Runtime.update_activity_log runtime (fun log ->
+      Activity_log.add_event log
+        (Activity_log.Event.create ~timestamp:(Unix.gettimeofday ()) ?patch_id
+           msg))
+
+let log_stream_entry runtime ~patch_id kind =
+  Runtime.update_activity_log runtime (fun log ->
+      Activity_log.add_stream_entry log
+        (Activity_log.Stream_entry.create ~timestamp:(Unix.gettimeofday ())
+           ~patch_id ~kind))

--- a/lib/runtime_logging.mli
+++ b/lib/runtime_logging.mli
@@ -1,0 +1,16 @@
+(** Tiny convenience wrappers around [Runtime.update_activity_log] for the two
+    most common log-line shapes. Both stamp [Unix.gettimeofday ()] internally so
+    callers don't need to thread a clock just to drop a line into the activity
+    log. *)
+
+val log_event : Runtime.t -> ?patch_id:Types.Patch_id.t -> string -> unit
+(** Append a free-form event message. [patch_id] is optional because some events
+    (startup, reconciliation) aren't scoped to a single patch. *)
+
+val log_stream_entry :
+  Runtime.t ->
+  patch_id:Types.Patch_id.t ->
+  Activity_log.Stream_entry.kind ->
+  unit
+(** Append a structured stream entry (Tool_use / Text_chunk / Stream_error /
+    Finished) — these are always patch-scoped. *)

--- a/lib/session_driver.ml
+++ b/lib/session_driver.ml
@@ -22,7 +22,12 @@ let extract_pr_number_from_text ?(at_end_of_stream = false) ~owner ~repo text =
   let needle_len = String.length needle in
   let text_len = String.length text in
   let rec scan i =
-    if i + needle_len >= text_len then None
+    (* [>] not [>=]: at [i = text_len - needle_len] the needle still fits
+       exactly. Using [>=] would skip that final position; the digit-run
+       check below correctly returns [None] when the needle ends at
+       [text_len] (no digits possible), so [>] gives the same answer
+       without the off-by-one. *)
+    if i + needle_len > text_len then None
     else if String.equal (String.sub text ~pos:i ~len:needle_len) needle then
       let start = i + needle_len in
       let rec end_pos j =
@@ -84,6 +89,14 @@ let%test_module "extract_pr_number_from_text" =
       Option.is_none
         (extract_pr_number_from_text ~owner:"foo" ~repo:"bar"
            "github.com/other/repo/pull/12345 ")
+
+    let%test "needle ending exactly at text_len -> None (no digits)" =
+      (* The scan-termination guard uses [>] not [>=] so this position is
+         attempted, but the digit-run check correctly returns None since
+         there's no room for a digit after the needle. *)
+      Option.is_none
+        (extract_pr_number_from_text ~at_end_of_stream:true ~owner:"foo"
+           ~repo:"bar" "github.com/foo/bar/pull/")
 
     let%test
         "left-to-right: with two URLs, the first wins (callers must window the \

--- a/lib/session_driver.ml
+++ b/lib/session_driver.ml
@@ -84,6 +84,16 @@ let%test_module "extract_pr_number_from_text" =
       Option.is_none
         (extract_pr_number_from_text ~owner:"foo" ~repo:"bar"
            "github.com/other/repo/pull/12345 ")
+
+    let%test
+        "left-to-right: with two URLs, the first wins (callers must window the \
+         tail to favor the latest)" =
+      Option.equal Types.Pr_number.equal
+        (extract_pr_number_from_text ~at_end_of_stream:true ~owner:"foo"
+           ~repo:"bar"
+           "early stub github.com/foo/bar/pull/12 ... later real \
+            github.com/foo/bar/pull/1234")
+        (pr 12)
   end)
 
 let run ~(kind : Types.Operation_kind.t option) ~runtime ~process_mgr ~clock ~fs
@@ -287,13 +297,26 @@ let run ~(kind : Types.Operation_kind.t option) ~runtime ~process_mgr ~clock ~fs
             | Types.Stream_event.Final_result { stop_reason; _ } ->
                 mark_backend_accepted_turn ();
                 sync_transcript ();
-                (* Final pass over the full buffer with end-of-stream
-                   semantics — catches PR URLs whose digit run terminated
-                   exactly at the buffer end (no trailing newline / next
-                   chunk to provide a non-digit terminator). *)
-                if not !pr_found then
-                  try_extract_pr ~at_end_of_stream:true
-                    (Buffer.contents text_buf);
+                (* Final pass with end-of-stream semantics — catches PR URLs
+                   whose digit run terminates exactly at the buffer end (no
+                   trailing newline / next chunk to provide a non-digit
+                   terminator).
+
+                   Restricted to the same [pr_url_lookback] tail window the
+                   per-chunk path uses: scanning the full buffer would
+                   left-to-right match an earlier stub fragment (e.g. an
+                   abandoned [.../pull/12] from a mid-stream digit-boundary
+                   that the per-chunk path correctly returned [None] for),
+                   reporting the wrong PR if the real URL appears later in
+                   the same buffer. The per-chunk path already saw any URL
+                   that had a non-digit terminator during streaming, so the
+                   final pass only needs to cover what the tail window does. *)
+                (if not !pr_found then
+                   let full = Buffer.contents text_buf in
+                   let len = String.length full in
+                   let offset = max 0 (len - pr_url_lookback) in
+                   let tail = String.sub full ~pos:offset ~len:(len - offset) in
+                   try_extract_pr ~at_end_of_stream:true tail);
                 let reason = Types.Stop_reason.to_display stop_reason in
                 log_stream_entry runtime ~patch_id
                   (Activity_log.Stream_entry.Finished reason)

--- a/lib/session_driver.ml
+++ b/lib/session_driver.ml
@@ -17,7 +17,7 @@ let session_mode (agent : Patch_agent.t) :
       | Some id -> `Resume id
       | None -> `Fresh)
 
-let extract_pr_number_from_text ~owner ~repo text =
+let extract_pr_number_from_text ?(at_end_of_stream = false) ~owner ~repo text =
   let needle = Printf.sprintf "github.com/%s/%s/pull/" owner repo in
   let needle_len = String.length needle in
   let text_len = String.length text in
@@ -31,7 +31,12 @@ let extract_pr_number_from_text ~owner ~repo text =
         else j
       in
       let stop = end_pos start in
-      if stop > start then
+      (* Mid-stream: a digit run that reaches the end of [text] may continue in
+         the next chunk, so committing now would truncate the PR number (e.g.
+         emit #12 when the full URL ends in #1234). Require a non-digit
+         terminator unless the caller asserts no more text is coming. *)
+      let has_terminator = stop < text_len || at_end_of_stream in
+      if stop > start && has_terminator then
         try
           Some
             (Types.Pr_number.of_int
@@ -42,6 +47,44 @@ let extract_pr_number_from_text ~owner ~repo text =
     else scan (i + 1)
   in
   scan 0
+
+let%test_module "extract_pr_number_from_text" =
+  (module struct
+    let pr n = Some (Types.Pr_number.of_int n)
+
+    let%test "complete url with terminator -> commits" =
+      Option.equal Types.Pr_number.equal
+        (extract_pr_number_from_text ~owner:"foo" ~repo:"bar"
+           "see github.com/foo/bar/pull/1234 for details")
+        (pr 1234)
+
+    let%test "digit run at end-of-buffer -> waits (None)" =
+      Option.is_none
+        (extract_pr_number_from_text ~owner:"foo" ~repo:"bar"
+           "see github.com/foo/bar/pull/12")
+
+    let%test "digit run at end-of-buffer with ~at_end_of_stream -> commits" =
+      Option.equal Types.Pr_number.equal
+        (extract_pr_number_from_text ~at_end_of_stream:true ~owner:"foo"
+           ~repo:"bar" "see github.com/foo/bar/pull/12")
+        (pr 12)
+
+    let%test "trailing newline counts as terminator" =
+      Option.equal Types.Pr_number.equal
+        (extract_pr_number_from_text ~owner:"foo" ~repo:"bar"
+           "github.com/foo/bar/pull/42\nmore text")
+        (pr 42)
+
+    let%test "no url -> None" =
+      Option.is_none
+        (extract_pr_number_from_text ~owner:"foo" ~repo:"bar"
+           "no relevant text here")
+
+    let%test "url for different owner/repo -> None" =
+      Option.is_none
+        (extract_pr_number_from_text ~owner:"foo" ~repo:"bar"
+           "github.com/other/repo/pull/12345 ")
+  end)
 
 let run ~(kind : Types.Operation_kind.t option) ~runtime ~process_mgr ~clock ~fs
     ~project_name ~patch_id ~repo_root ~prompt ~(agent : Patch_agent.t) ~owner
@@ -114,6 +157,26 @@ let run ~(kind : Types.Operation_kind.t option) ~runtime ~process_mgr ~clock ~fs
           let needle_len =
             String.length (Printf.sprintf "github.com/%s/%s/pull/" owner repo)
           in
+          (* Lookback window for the per-chunk tail scan. We need to re-scan
+             far enough back to include both the URL prefix and the digit run
+             that may have started in a previous chunk; 32 digits covers any
+             realistic PR number even if split across many tiny chunks. *)
+          let pr_url_lookback = needle_len + 32 in
+          let try_extract_pr ?(at_end_of_stream = false) text =
+            if !pr_found then ()
+            else
+              match
+                extract_pr_number_from_text ~at_end_of_stream ~owner ~repo text
+              with
+              | Some pr_number ->
+                  pr_found := true;
+                  log_stream_entry runtime ~patch_id
+                    (Activity_log.Stream_entry.Text_chunk
+                       (Printf.sprintf "PR #%d detected"
+                          (Types.Pr_number.to_int pr_number)));
+                  on_pr_detected pr_number
+              | None -> ()
+          in
           let last_sync = ref (Unix.gettimeofday ()) in
           let sync_transcript () =
             Stdlib.Hashtbl.replace transcripts patch_id
@@ -148,26 +211,18 @@ let run ~(kind : Types.Operation_kind.t option) ~runtime ~process_mgr ~clock ~fs
             (* Turn_started is the preferred signal; the arms below are
                fallbacks for backends that do not emit it. *)
             | Types.Stream_event.Turn_started -> mark_backend_accepted_turn ()
-            | Types.Stream_event.Text_delta text -> (
+            | Types.Stream_event.Text_delta text ->
                 mark_backend_accepted_turn ();
                 let prev_len = Buffer.length text_buf in
                 Buffer.add_string text_buf text;
                 maybe_sync_transcript ();
                 if not !pr_found then
-                  let offset = max 0 (prev_len - needle_len) in
+                  let offset = max 0 (prev_len - pr_url_lookback) in
                   let tail =
                     Buffer.To_string.sub text_buf ~pos:offset
                       ~len:(Buffer.length text_buf - offset)
                   in
-                  match extract_pr_number_from_text ~owner ~repo tail with
-                  | Some pr_number ->
-                      pr_found := true;
-                      log_stream_entry runtime ~patch_id
-                        (Activity_log.Stream_entry.Text_chunk
-                           (Printf.sprintf "PR #%d detected"
-                              (Types.Pr_number.to_int pr_number)));
-                      on_pr_detected pr_number
-                  | None -> ())
+                  try_extract_pr tail
             | Types.Stream_event.Tool_use { name; input; status } ->
                 mark_backend_accepted_turn ();
                 tool_count := !tool_count + 1;
@@ -232,6 +287,13 @@ let run ~(kind : Types.Operation_kind.t option) ~runtime ~process_mgr ~clock ~fs
             | Types.Stream_event.Final_result { stop_reason; _ } ->
                 mark_backend_accepted_turn ();
                 sync_transcript ();
+                (* Final pass over the full buffer with end-of-stream
+                   semantics — catches PR URLs whose digit run terminated
+                   exactly at the buffer end (no trailing newline / next
+                   chunk to provide a non-digit terminator). *)
+                if not !pr_found then
+                  try_extract_pr ~at_end_of_stream:true
+                    (Buffer.contents text_buf);
                 let reason = Types.Stop_reason.to_display stop_reason in
                 log_stream_entry runtime ~patch_id
                   (Activity_log.Stream_entry.Finished reason)
@@ -443,17 +505,22 @@ let run ~(kind : Types.Operation_kind.t option) ~runtime ~process_mgr ~clock ~fs
           let agent_before, agent_after =
             Runtime.update_orchestrator_returning runtime (fun orch ->
                 let agent_before = Orchestrator.agent orch patch_id in
-                let orch =
-                  Orchestrator.apply_session_result orch patch_id
-                    final_session_result
-                in
-                (* Store the captured session_id for future --resume calls *)
+                (* Store the captured session_id BEFORE applying the session
+                   result. [apply_session_result] clears [llm_session_id] on
+                   start-path fresh failure (via [on_session_failure]) and on
+                   [Session_no_resume] / [Session_give_up]; doing the set
+                   afterwards would overwrite that reset and break the
+                   clean-retry path. *)
                 let orch =
                   match !captured_session_id with
                   | Some _ ->
                       Orchestrator.set_llm_session_id orch patch_id
                         !captured_session_id
                   | None -> orch
+                in
+                let orch =
+                  Orchestrator.apply_session_result orch patch_id
+                    final_session_result
                 in
                 let agent_after = Orchestrator.agent orch patch_id in
                 (orch, (agent_before, agent_after)))

--- a/lib/session_driver.ml
+++ b/lib/session_driver.ml
@@ -227,6 +227,15 @@ let run ~(kind : Types.Operation_kind.t option) ~runtime ~process_mgr ~clock ~fs
                 Buffer.add_string text_buf text;
                 maybe_sync_transcript ();
                 if not !pr_found then
+                  (* Anchor the tail window to [prev_len], NOT [new_len].
+                     We want the window to always cover the ENTIRE new chunk
+                     plus up to [pr_url_lookback] bytes back into the prior
+                     content (to catch a URL/digit run that spanned the
+                     chunk boundary). LLM stream chunks are routinely longer
+                     than [pr_url_lookback] (~62 bytes), so anchoring to
+                     [new_len] would shrink the window to the last
+                     [pr_url_lookback] bytes and miss URLs in the early part
+                     of long chunks. *)
                   let offset = max 0 (prev_len - pr_url_lookback) in
                   let tail =
                     Buffer.To_string.sub text_buf ~pos:offset

--- a/lib/session_driver.ml
+++ b/lib/session_driver.ml
@@ -1,0 +1,463 @@
+open Base
+
+let truncate s n =
+  if String.length s <= n then s else String.sub s ~pos:0 ~len:n ^ "..."
+
+let pluralize ?plural n singular =
+  let many = match plural with Some p -> p | None -> singular ^ "s" in
+  Printf.sprintf "%d %s" n (if n = 1 then singular else many)
+
+let session_mode (agent : Patch_agent.t) :
+    [ `Resume of string | `Fresh | `Give_up ] =
+  match agent.Patch_agent.session_fallback with
+  | Patch_agent.Given_up -> `Give_up
+  | Patch_agent.Tried_fresh -> `Fresh
+  | Patch_agent.Fresh_available -> (
+      match agent.Patch_agent.llm_session_id with
+      | Some id -> `Resume id
+      | None -> `Fresh)
+
+let extract_pr_number_from_text ~owner ~repo text =
+  let needle = Printf.sprintf "github.com/%s/%s/pull/" owner repo in
+  let needle_len = String.length needle in
+  let text_len = String.length text in
+  let rec scan i =
+    if i + needle_len >= text_len then None
+    else if String.equal (String.sub text ~pos:i ~len:needle_len) needle then
+      let start = i + needle_len in
+      let rec end_pos j =
+        if j < text_len && Char.( >= ) text.[j] '0' && Char.( <= ) text.[j] '9'
+        then end_pos (j + 1)
+        else j
+      in
+      let stop = end_pos start in
+      if stop > start then
+        try
+          Some
+            (Types.Pr_number.of_int
+               (Stdlib.int_of_string
+                  (String.sub text ~pos:start ~len:(stop - start))))
+        with _ -> scan (i + 1)
+      else scan (i + 1)
+    else scan (i + 1)
+  in
+  scan 0
+
+let run ~(kind : Types.Operation_kind.t option) ~runtime ~process_mgr ~clock ~fs
+    ~project_name ~patch_id ~repo_root ~prompt ~(agent : Patch_agent.t) ~owner
+    ~repo ~on_pr_detected ~transcripts ~user_config ~worktree_mutex ~hook_mutex
+    ~backend ~complexity ~event_log =
+  let log_event = Runtime_logging.log_event in
+  let log_stream_entry = Runtime_logging.log_stream_entry in
+  match session_mode agent with
+  | `Give_up ->
+      log_event runtime ~patch_id
+        "Session fallback exhausted — continue and fresh both failed, needs \
+         intervention";
+      Runtime.update_orchestrator runtime (fun orch ->
+          Orchestrator.apply_session_result orch patch_id
+            Orchestrator.Session_give_up);
+      (`Failed, [])
+  | (`Resume _ | `Fresh) as mode -> (
+      let resume_session, is_fresh =
+        match mode with `Resume id -> (Some id, false) | `Fresh -> (None, true)
+      in
+      match
+        Worktree_setup.ensure_worktree ~runtime ~process_mgr ~clock ~fs
+          ~repo_root ~project_name ~patch_id ~agent ~user_config ~worktree_mutex
+          ~hook_mutex ()
+      with
+      | None ->
+          Runtime.update_orchestrator runtime (fun orch ->
+              Orchestrator.apply_session_result orch patch_id
+                Orchestrator.Session_worktree_missing);
+          (`Failed, [])
+      | Some worktree_path ->
+          let cwd = Eio.Path.(fs / worktree_path) in
+          let text_buf =
+            let buf = Buffer.create 4096 in
+            (match Stdlib.Hashtbl.find_opt transcripts patch_id with
+            | Some prev when String.length prev > 0 ->
+                Buffer.add_string buf prev;
+                Buffer.add_char buf '\n'
+            | Some _ | None -> ());
+            (* Write the prompt being delivered so it appears in the transcript *)
+            let now = Unix.gettimeofday () in
+            let tm = Unix.localtime now in
+            Buffer.add_string buf
+              (Printf.sprintf
+                 "\n---\n**[%02d:%02d:%02d] Delivered to %s%s:**\n\n"
+                 tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec
+                 backend.Llm_backend.name
+                 (match resume_session with
+                 | Some id ->
+                     Printf.sprintf " (--resume %s)"
+                       (String.sub id ~pos:0 ~len:(min 8 (String.length id)))
+                 | None -> ""));
+            Buffer.add_string buf prompt;
+            Buffer.add_string buf
+              (Printf.sprintf "\n\n---\n**%s response:**\n\n"
+                 backend.Llm_backend.name);
+            Stdlib.Hashtbl.replace transcripts patch_id (Buffer.contents buf);
+            buf
+          in
+          let error_buf = Buffer.create 256 in
+          let tool_count = ref 0 in
+          (* Accumulates (tool_name, status) for Tool_use events that report a
+             non-"completed" status (OpenCode surfaces [pending]/[running] or
+             error states; other backends do not populate [status] and so never
+             contribute here). Propagated to the caller so artifact-backed
+             phases like Pr_body can tell "agent chose not to write" apart
+             from "a tool call was announced but never executed". *)
+          let tool_failures = ref [] in
+          let pr_found = ref false in
+          let needle_len =
+            String.length (Printf.sprintf "github.com/%s/%s/pull/" owner repo)
+          in
+          let last_sync = ref (Unix.gettimeofday ()) in
+          let sync_transcript () =
+            Stdlib.Hashtbl.replace transcripts patch_id
+              (Buffer.contents text_buf)
+          in
+          let maybe_sync_transcript () =
+            let now = Unix.gettimeofday () in
+            if Float.( >= ) (now -. !last_sync) 0.2 then (
+              last_sync := now;
+              sync_transcript ())
+          in
+          let captured_session_id = ref None in
+          let backend_accepted_turn = ref false in
+          let mark_backend_accepted_turn () =
+            if not !backend_accepted_turn then (
+              backend_accepted_turn := true;
+              match kind with
+              | Some Types.Operation_kind.Human ->
+                  Runtime.update_orchestrator runtime (fun orch ->
+                      Orchestrator.mark_inflight_human_messages_delivered orch
+                        patch_id)
+              | Some Types.Operation_kind.Ci
+              | Some Types.Operation_kind.Review_comments
+              | Some Types.Operation_kind.Pr_body
+              | Some Types.Operation_kind.Merge_conflict
+              | Some Types.Operation_kind.Rebase
+              | None ->
+                  ())
+          in
+          let on_event (event : Types.Stream_event.t) =
+            match event with
+            (* Turn_started is the preferred signal; the arms below are
+               fallbacks for backends that do not emit it. *)
+            | Types.Stream_event.Turn_started -> mark_backend_accepted_turn ()
+            | Types.Stream_event.Text_delta text -> (
+                mark_backend_accepted_turn ();
+                let prev_len = Buffer.length text_buf in
+                Buffer.add_string text_buf text;
+                maybe_sync_transcript ();
+                if not !pr_found then
+                  let offset = max 0 (prev_len - needle_len) in
+                  let tail =
+                    Buffer.To_string.sub text_buf ~pos:offset
+                      ~len:(Buffer.length text_buf - offset)
+                  in
+                  match extract_pr_number_from_text ~owner ~repo tail with
+                  | Some pr_number ->
+                      pr_found := true;
+                      log_stream_entry runtime ~patch_id
+                        (Activity_log.Stream_entry.Text_chunk
+                           (Printf.sprintf "PR #%d detected"
+                              (Types.Pr_number.to_int pr_number)));
+                      on_pr_detected pr_number
+                  | None -> ())
+            | Types.Stream_event.Tool_use { name; input; status } ->
+                mark_backend_accepted_turn ();
+                tool_count := !tool_count + 1;
+                (* OpenCode emits pending → running → completed for a single
+                   tool call. Track only the latest unresolved status per tool
+                   name: clear on completed, replace on any other status.
+                   Otherwise a normal pending → completed lifecycle would leave
+                   a stale (name, "pending") entry that
+                   [classify_pr_body_respond] would misread as a blocked Write. *)
+                (match status with
+                | Some s when String.equal s "completed" ->
+                    tool_failures :=
+                      List.filter !tool_failures ~f:(fun (n, _) ->
+                          not (String.equal n name))
+                | Some s ->
+                    let without =
+                      List.filter !tool_failures ~f:(fun (n, _) ->
+                          not (String.equal n name))
+                    in
+                    tool_failures := (name, s) :: without
+                | None -> ());
+                let summary =
+                  try
+                    let json = Yojson.Safe.from_string input in
+                    let field key =
+                      Yojson.Safe.Util.(member key json |> to_string_option)
+                    in
+                    let s =
+                      match name with
+                      | "Bash" -> field "command"
+                      | "Read" | "Write" -> field "file_path"
+                      | "Edit" -> field "file_path"
+                      | "Glob" -> field "pattern"
+                      | "Grep" -> field "pattern"
+                      | _ -> None
+                    in
+                    match s with Some v -> truncate v 80 | None -> ""
+                  with _ -> ""
+                in
+                let detail =
+                  if not (String.is_empty summary) then
+                    Printf.sprintf " %s" summary
+                  else ""
+                in
+                let sep =
+                  let len = Buffer.length text_buf in
+                  if len = 0 then ""
+                  else if
+                    len >= 2
+                    && Char.equal (Buffer.nth text_buf (len - 1)) '\n'
+                    && Char.equal (Buffer.nth text_buf (len - 2)) '\n'
+                  then ""
+                  else if Char.equal (Buffer.nth text_buf (len - 1)) '\n' then
+                    "\n"
+                  else "\n\n"
+                in
+                Buffer.add_string text_buf
+                  (Printf.sprintf "%s[tool: %s]%s\n" sep name detail);
+                sync_transcript ();
+                log_stream_entry runtime ~patch_id
+                  (Activity_log.Stream_entry.Tool_use (name, summary))
+            | Types.Stream_event.Final_result { stop_reason; _ } ->
+                mark_backend_accepted_turn ();
+                sync_transcript ();
+                let reason = Types.Stop_reason.to_display stop_reason in
+                log_stream_entry runtime ~patch_id
+                  (Activity_log.Stream_entry.Finished reason)
+            | Types.Stream_event.Error msg ->
+                if Buffer.length error_buf > 0 then
+                  Buffer.add_char error_buf '\n';
+                Buffer.add_string error_buf msg;
+                log_stream_entry runtime ~patch_id
+                  (Activity_log.Stream_entry.Stream_error msg)
+            | Types.Stream_event.Session_init { session_id } ->
+                captured_session_id := Some session_id
+          in
+          let result =
+            try
+              Ok
+                (backend.Llm_backend.run_streaming ~cwd ~patch_id ~prompt
+                   ~resume_session ~complexity ~on_event)
+            with exn -> Error (Stdlib.Printexc.to_string exn)
+          in
+          let open Run_classification in
+          let outcome =
+            Result.map
+              ~f:(fun (r : Llm_backend.result) ->
+                {
+                  exit_code = r.Llm_backend.exit_code;
+                  got_events = r.Llm_backend.got_events;
+                  saw_final_result = r.Llm_backend.saw_final_result;
+                  stderr = r.Llm_backend.stderr;
+                  stream_errors = String.strip (Buffer.contents error_buf);
+                  timed_out = r.Llm_backend.timed_out;
+                })
+              result
+          in
+          (* classify routes Error outcomes to Process_error, so the
+             empty-events arms below only ever see Ok. *)
+          let log_empty_resume ~tail =
+            match result with
+            | Error _ -> ()
+            | Ok r ->
+                let render label s =
+                  let s = String.strip s in
+                  if String.is_empty s then label ^ "=empty"
+                  else
+                    Printf.sprintf "%s=%d chars: %s" label (String.length s)
+                      (truncate s 500)
+                in
+                log_event runtime ~patch_id
+                  (Printf.sprintf
+                     "Resume exited %d (%s) with no parsed stream events%s — \
+                      %s %s"
+                     r.Llm_backend.exit_code backend.Llm_backend.name tail
+                     (render "stdout" r.Llm_backend.stdout)
+                     (render "stderr" r.Llm_backend.stderr))
+          in
+          let session_result, user_result =
+            match
+              classify ~is_resume:(Option.is_some resume_session) outcome
+            with
+            | Process_error msg ->
+                log_event runtime ~patch_id
+                  (Printf.sprintf "Process error from %s — %s"
+                     backend.Llm_backend.name msg);
+                (Orchestrator.Session_process_error { is_fresh }, `Failed)
+            | No_session_to_resume ->
+                log_empty_resume ~tail:" — no session to resume, retrying fresh";
+                (Orchestrator.Session_no_resume, `Failed)
+            | Timed_out ->
+                log_event runtime ~patch_id
+                  (Printf.sprintf "Session timed out (%s) — marking failed"
+                     backend.Llm_backend.name);
+                (Orchestrator.Session_failed { is_fresh }, `Failed)
+            | Success { stream_errors } ->
+                (match (resume_session, result) with
+                | Some _, Ok r when not r.Llm_backend.got_events ->
+                    log_empty_resume ~tail:""
+                | Some _, (Ok _ | Error _) | None, _ -> ());
+                if String.length stream_errors > 0 then
+                  log_event runtime ~patch_id
+                    (Printf.sprintf
+                       "Session exited 0 (%s) with stream errors — %s"
+                       backend.Llm_backend.name
+                       (truncate stream_errors 500));
+                let text_len = Buffer.length text_buf in
+                let tools = !tool_count in
+                if tools = 0 && text_len < 200 then
+                  log_event runtime ~patch_id
+                    (Printf.sprintf
+                       "Session exited 0 (%s) with no tool use and %s of text \
+                        — %s"
+                       backend.Llm_backend.name
+                       (pluralize text_len "char")
+                       (truncate (String.strip (Buffer.contents text_buf)) 200));
+                (Orchestrator.Session_ok, `Ok)
+            | Session_failed { exit_code; detail } ->
+                log_event runtime ~patch_id
+                  (Printf.sprintf "Session failed (%s) — exit %d: %s"
+                     backend.Llm_backend.name exit_code detail);
+                (Orchestrator.Session_failed { is_fresh }, `Failed)
+          in
+          (* Observability: if any tool_use events reported a non-"completed"
+             status (OpenCode's sandbox/rejection/pending states), summarize
+             them so the disconnect is visible in the activity log even when
+             the session otherwise looks healthy. *)
+          (match !tool_failures with
+          | [] -> ()
+          | failures ->
+              let rendered =
+                List.rev failures
+                |> List.map ~f:(fun (n, s) -> Printf.sprintf "%s[%s]" n s)
+                |> String.concat ~sep:", "
+              in
+              log_event runtime ~patch_id
+                (Printf.sprintf
+                   "Session ended with %d non-completed tool call(s) (%s): %s"
+                   (List.length failures) backend.Llm_backend.name rendered));
+          (* Supervisor-owned push: agent commits locally; we push every
+             local commit to the remote at session end. force_push_with_lease
+             is idempotent (Push_up_to_date when nothing new), and lease-safe
+             against concurrent remote updates. Runs regardless of the LLM's
+             session result so commits made before a partial failure still
+             reach the remote. *)
+          let branch = agent.Patch_agent.branch in
+          let base =
+            match agent.Patch_agent.base_branch with
+            | Some b -> b
+            | None ->
+                (* Invariant: a running session always has a base_branch set
+                   by start/respond/rebase. Fall back to main just in case. *)
+                Runtime.read runtime (fun snap ->
+                    Orchestrator.main_branch snap.Runtime.orchestrator)
+          in
+          let push_outcome =
+            Worktree.force_push_with_lease ~process_mgr ~path:worktree_path
+              ~branch ~base
+          in
+          (match push_outcome with
+          | Worktree.Push_ok ->
+              log_event runtime ~patch_id "runner: pushed after session"
+          | Worktree.Push_up_to_date ->
+              log_event runtime ~patch_id
+                "runner: push up-to-date after session (no new commits)"
+          | Worktree.Push_no_commits ->
+              log_event runtime ~patch_id
+                "runner: session ended with no commits on branch — push \
+                 skipped, PR creation deferred"
+          | Worktree.Push_rejected ->
+              log_event runtime ~patch_id
+                "runner: push rejected after session (lease)"
+          | Worktree.Push_error msg ->
+              log_event runtime ~patch_id
+                (Printf.sprintf "runner: push error after session: %s" msg));
+          (* Combine LLM session outcome with push outcome into a single
+             session_result via the pure decision in
+             [Orchestrator.combine_session_and_push]. user_result mirrors:
+             same Ok/Failed disposition unless the combination promoted us
+             to Session_push_failed (which is always Failed).
+
+             Special case: when the agent is responding to a human message,
+             the human may have asked a question or made a request that
+             requires no code changes. Absence of new commits is therefore
+             not a failure — override Session_no_commits to Session_ok so
+             the no_commits_push_count counter does not march toward
+             needs_intervention and the operation completes cleanly. *)
+          let no_commits_is_ok =
+            match kind with
+            | Some Types.Operation_kind.Human -> true
+            | Some Types.Operation_kind.Ci
+            | Some Types.Operation_kind.Review_comments
+            | Some Types.Operation_kind.Pr_body
+            | Some Types.Operation_kind.Merge_conflict
+            | Some Types.Operation_kind.Rebase
+            | None ->
+                false
+          in
+          let final_session_result =
+            let combined =
+              Orchestrator.combine_session_and_push ~session:session_result
+                ~push:push_outcome
+            in
+            match combined with
+            | Orchestrator.Session_no_commits when no_commits_is_ok ->
+                Orchestrator.Session_ok
+            | Orchestrator.Session_ok | Orchestrator.Session_no_commits
+            | Orchestrator.Session_process_error _
+            | Orchestrator.Session_no_resume | Orchestrator.Session_failed _
+            | Orchestrator.Session_give_up
+            | Orchestrator.Session_worktree_missing
+            | Orchestrator.Session_push_failed ->
+                combined
+          in
+          let final_user_result =
+            match final_session_result with
+            | Orchestrator.Session_ok -> user_result
+            | Orchestrator.Session_push_failed | Orchestrator.Session_no_commits
+              ->
+                (* LLM session ran fine but commits didn't ship (push failed
+                   or the agent made no commits) — signal retry so the
+                   Respond path uses Respond_retry_push (clean complete) and
+                   the reconciler re-enqueues the operation naturally. After
+                   2 consecutive no-commit sessions, needs_intervention fires
+                   and the scheduler stops re-enqueueing. *)
+                `Retry_push
+            | Orchestrator.Session_process_error _
+            | Orchestrator.Session_no_resume | Orchestrator.Session_failed _
+            | Orchestrator.Session_give_up
+            | Orchestrator.Session_worktree_missing ->
+                `Failed
+          in
+          let agent_before, agent_after =
+            Runtime.update_orchestrator_returning runtime (fun orch ->
+                let agent_before = Orchestrator.agent orch patch_id in
+                let orch =
+                  Orchestrator.apply_session_result orch patch_id
+                    final_session_result
+                in
+                (* Store the captured session_id for future --resume calls *)
+                let orch =
+                  match !captured_session_id with
+                  | Some _ ->
+                      Orchestrator.set_llm_session_id orch patch_id
+                        !captured_session_id
+                  | None -> orch
+                in
+                let agent_after = Orchestrator.agent orch patch_id in
+                (orch, (agent_before, agent_after)))
+          in
+          Event_log.log_complete event_log ~patch_id
+            ~result:final_session_result ~agent_before ~agent_after;
+          (final_user_result, List.rev !tool_failures))

--- a/lib/session_driver.mli
+++ b/lib/session_driver.mli
@@ -44,7 +44,17 @@ val session_mode : Patch_agent.t -> [ `Resume of string | `Fresh | `Give_up ]
     invocation should resume an existing session, start fresh, or give up. *)
 
 val extract_pr_number_from_text :
-  owner:string -> repo:string -> string -> Types.Pr_number.t option
+  ?at_end_of_stream:bool ->
+  owner:string ->
+  repo:string ->
+  string ->
+  Types.Pr_number.t option
 (** Scan [text] for a [github.com/<owner>/<repo>/pull/N] URL and return the
     first [N] found. Used to sniff PR creation from the agent's stdout stream.
-*)
+
+    A digit run terminating at the end of [text] is treated as
+    potentially-incomplete by default, so this function will return [None] for
+    [".../pull/12"] when the next stream chunk could turn it into
+    [.../pull/1234]. Pass [~at_end_of_stream:true] when calling on a complete
+    buffer (e.g. on [Final_result]) to treat end-of-buffer as a valid
+    terminator. *)

--- a/lib/session_driver.mli
+++ b/lib/session_driver.mli
@@ -1,0 +1,50 @@
+(** Drive one backend session for one patch.
+
+    [run] is the layer above [Llm_backend.run_streaming]: it owns the session
+    lifecycle (resume vs fresh, fallback chain), worktree provisioning,
+    transcript buffer accumulation, PR-number sniffing from streamed text,
+    activity-log streaming, post-session push, and result classification.
+
+    The function is large because it ties together all of those concerns —
+    splitting it would scatter the supervisor's view of one session across
+    several modules. The backend below is already abstracted; this is the single
+    place where "run a session for this patch" lives. *)
+
+val run :
+  kind:Types.Operation_kind.t option ->
+  runtime:Runtime.t ->
+  process_mgr:_ Eio.Process.mgr ->
+  clock:_ Eio.Time.clock ->
+  fs:Eio.Fs.dir_ty Eio.Path.t ->
+  project_name:string ->
+  patch_id:Types.Patch_id.t ->
+  repo_root:string ->
+  prompt:string ->
+  agent:Patch_agent.t ->
+  owner:string ->
+  repo:string ->
+  on_pr_detected:(Types.Pr_number.t -> unit) ->
+  transcripts:(Types.Patch_id.t, string) Stdlib.Hashtbl.t ->
+  user_config:User_config.t ->
+  worktree_mutex:Eio.Mutex.t ->
+  hook_mutex:Eio.Mutex.t ->
+  backend:Llm_backend.t ->
+  complexity:int option ->
+  event_log:Event_log.t ->
+  [ `Ok | `Failed | `Retry_push ] * (string * string) list
+(** Returns the supervisor disposition and the list of [(tool_name, status)]
+    pairs for any tool calls that did not reach a [completed] state (used by the
+    Pr_body classifier to disambiguate "agent chose not to write" from "Write
+    was blocked"). Callers may also produce a [`Stale] variant from pre-flight
+    checks before invoking this function — the polymorphic-variant union widens
+    at the call site. *)
+
+val session_mode : Patch_agent.t -> [ `Resume of string | `Fresh | `Give_up ]
+(** Inspect the agent's session-fallback state to decide whether the next
+    invocation should resume an existing session, start fresh, or give up. *)
+
+val extract_pr_number_from_text :
+  owner:string -> repo:string -> string -> Types.Pr_number.t option
+(** Scan [text] for a [github.com/<owner>/<repo>/pull/N] URL and return the
+    first [N] found. Used to sniff PR creation from the agent's stdout stream.
+*)

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -135,6 +135,7 @@ module Patch = struct
     changes : string list; [@yojson.default []]
     test_stubs_introduced : string list; [@yojson.default []]
     test_stubs_implemented : string list; [@yojson.default []]
+    complexity : int option; [@yojson.default None]
   }
   [@@deriving show, eq, sexp_of, compare, yojson]
 end

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -103,6 +103,11 @@ module Patch : sig
     changes : string list; [@yojson.default []]
     test_stubs_introduced : string list; [@yojson.default []]
     test_stubs_implemented : string list; [@yojson.default []]
+    complexity : int option; [@yojson.default None]
+        (** Conservative 1/2/3 estimate from the gameplan author. Used by
+            [--model auto] to pick a stronger model for harder patches. [None]
+            for legacy gameplans missing the field; orchestrators should treat
+            that as the highest available tier (be conservative). *)
   }
   [@@deriving show, eq, sexp_of, compare, yojson]
 end

--- a/lib/worktree_setup.ml
+++ b/lib/worktree_setup.ml
@@ -1,0 +1,111 @@
+open Base
+
+let resolve_worktree_path ~process_mgr ~repo_root ~project_name ~patch_id
+    ~(agent : Patch_agent.t) ?branch () =
+  match agent.Patch_agent.worktree_path with
+  | Some p -> p
+  | None ->
+      let search_branch =
+        match branch with Some b -> b | None -> agent.Patch_agent.branch
+      in
+      let found =
+        Worktree.find_for_branch ~process_mgr ~repo_root search_branch
+      in
+      let path =
+        match found with
+        | Some p -> p
+        | None -> Worktree.worktree_dir ~project_name ~patch_id
+      in
+      path
+
+let ensure_worktree ~runtime ~process_mgr ~clock ~fs ~repo_root ~project_name
+    ~patch_id ~(agent : Patch_agent.t) ~(user_config : User_config.t)
+    ~worktree_mutex ~hook_mutex ?branch ?base_ref () =
+  let log_event = Runtime_logging.log_event in
+  let path =
+    resolve_worktree_path ~process_mgr ~repo_root ~project_name ~patch_id ~agent
+      ?branch ()
+  in
+  if Stdlib.Sys.file_exists path then (
+    Runtime.update_orchestrator runtime (fun orch ->
+        Orchestrator.set_worktree_path orch patch_id path);
+    Some path)
+  else
+    let br =
+      match branch with Some b -> b | None -> agent.Patch_agent.branch
+    in
+    match Worktree.find_for_branch ~process_mgr ~repo_root br with
+    | Some existing ->
+        log_event runtime ~patch_id
+          (Printf.sprintf "Found existing worktree for branch at %s" existing);
+        Runtime.update_orchestrator runtime (fun orch ->
+            Orchestrator.set_worktree_path orch patch_id existing);
+        Some existing
+    | None ->
+        if Worktree.is_checked_out_in_repo_root ~process_mgr ~repo_root br then (
+          let main_root = Worktree.resolve_main_root ~process_mgr ~repo_root in
+          log_event runtime ~patch_id
+            (Printf.sprintf
+               "Cannot create worktree — branch %s is checked out in the main \
+                working tree (%s). Switch the main tree to another branch \
+                (e.g. `git -C %s checkout <default-branch>`) and try again."
+               (Types.Branch.to_string br)
+               main_root main_root);
+          None)
+        else
+          let base =
+            match base_ref with
+            | Some b -> b
+            | None -> (
+                match agent.Patch_agent.base_branch with
+                | Some b -> Types.Branch.to_string b
+                | None -> "HEAD")
+          in
+          log_event runtime ~patch_id
+            (Printf.sprintf "Creating worktree at %s" path);
+          (match
+             Eio.Mutex.use_ro worktree_mutex (fun () ->
+                 ignore
+                   (Worktree.create ~process_mgr ~repo_root ~project_name
+                      ~patch_id ~branch:br ~base_ref:base))
+           with
+          | () -> ()
+          | exception (Eio.Cancel.Cancelled _ as exn) -> raise exn
+          | exception exn ->
+              log_event runtime ~patch_id
+                (Printf.sprintf "Worktree creation failed — %s"
+                   (Stdlib.Printexc.to_string exn)));
+          if Stdlib.Sys.file_exists path then (
+            Runtime.update_orchestrator runtime (fun orch ->
+                Orchestrator.set_worktree_path orch patch_id path);
+            (match user_config.User_config.on_worktree_create with
+            | Some script -> (
+                let env =
+                  [
+                    ("ONTON_WORKTREE_PATH", path);
+                    ("ONTON_PATCH_ID", Types.Patch_id.to_string patch_id);
+                    ("ONTON_BRANCH", Types.Branch.to_string br);
+                  ]
+                in
+                let cwd = Eio.Path.(fs / path) in
+                (* [hook_mutex] serializes hook invocations across patch
+                   fibers — npm/dune/bun aren't parallelism-safe across
+                   shared caches, and per-hook fan-out is the dominant
+                   subprocess multiplier (see issue #209). *)
+                match
+                  Eio.Mutex.use_ro hook_mutex (fun () ->
+                      User_config.run_hook ~process_mgr ~clock ~script ~cwd ~env
+                        ())
+                with
+                | Ok () ->
+                    log_event runtime ~patch_id "Ran on_worktree_create hook"
+                | Error msg ->
+                    log_event runtime ~patch_id
+                      (Printf.sprintf "Hook on_worktree_create failed — %s" msg)
+                )
+            | None -> ());
+            Some path)
+          else (
+            log_event runtime ~patch_id
+              (Printf.sprintf "Worktree still missing at %s" path);
+            None)

--- a/lib/worktree_setup.ml
+++ b/lib/worktree_setup.ml
@@ -2,9 +2,13 @@ open Base
 
 let resolve_worktree_path ~process_mgr ~repo_root ~project_name ~patch_id
     ~(agent : Patch_agent.t) ?branch () =
-  match agent.Patch_agent.worktree_path with
-  | Some p -> p
-  | None ->
+  (* When the caller passes [?branch], they're asking for that branch's
+     worktree specifically — the agent's stored [worktree_path] may be from
+     a previous branch and would be stale. Only short-circuit on the stored
+     path when no [branch] is supplied. *)
+  match (branch, agent.Patch_agent.worktree_path) with
+  | None, Some p -> p
+  | _ ->
       let search_branch =
         match branch with Some b -> b | None -> agent.Patch_agent.branch
       in
@@ -63,19 +67,22 @@ let ensure_worktree ~runtime ~process_mgr ~clock ~fs ~repo_root ~project_name
           in
           log_event runtime ~patch_id
             (Printf.sprintf "Creating worktree at %s" path);
-          (match
-             Eio.Mutex.use_ro worktree_mutex (fun () ->
-                 ignore
-                   (Worktree.create ~process_mgr ~repo_root ~project_name
-                      ~patch_id ~branch:br ~base_ref:base))
-           with
-          | () -> ()
-          | exception (Eio.Cancel.Cancelled _ as exn) -> raise exn
-          | exception exn ->
-              log_event runtime ~patch_id
-                (Printf.sprintf "Worktree creation failed — %s"
-                   (Stdlib.Printexc.to_string exn)));
-          if Stdlib.Sys.file_exists path then (
+          let created =
+            match
+              Eio.Mutex.use_ro worktree_mutex (fun () ->
+                  ignore
+                    (Worktree.create ~process_mgr ~repo_root ~project_name
+                       ~patch_id ~branch:br ~base_ref:base))
+            with
+            | () -> true
+            | exception (Eio.Cancel.Cancelled _ as exn) -> raise exn
+            | exception exn ->
+                log_event runtime ~patch_id
+                  (Printf.sprintf "Worktree creation failed — %s"
+                     (Stdlib.Printexc.to_string exn));
+                false
+          in
+          if created && Stdlib.Sys.file_exists path then (
             Runtime.update_orchestrator runtime (fun orch ->
                 Orchestrator.set_worktree_path orch patch_id path);
             (match user_config.User_config.on_worktree_create with

--- a/lib/worktree_setup.ml
+++ b/lib/worktree_setup.ml
@@ -45,7 +45,7 @@ let ensure_worktree ~runtime ~process_mgr ~clock ~fs ~repo_root ~project_name
         Runtime.update_orchestrator runtime (fun orch ->
             Orchestrator.set_worktree_path orch patch_id existing);
         Some existing
-    | None ->
+    | None -> (
         if Worktree.is_checked_out_in_repo_root ~process_mgr ~repo_root br then (
           let main_root = Worktree.resolve_main_root ~process_mgr ~repo_root in
           log_event runtime ~patch_id
@@ -82,37 +82,57 @@ let ensure_worktree ~runtime ~process_mgr ~clock ~fs ~repo_root ~project_name
                      (Stdlib.Printexc.to_string exn));
                 false
           in
-          if created && Stdlib.Sys.file_exists path then (
-            Runtime.update_orchestrator runtime (fun orch ->
-                Orchestrator.set_worktree_path orch patch_id path);
-            (match user_config.User_config.on_worktree_create with
-            | Some script -> (
-                let env =
-                  [
-                    ("ONTON_WORKTREE_PATH", path);
-                    ("ONTON_PATCH_ID", Types.Patch_id.to_string patch_id);
-                    ("ONTON_BRANCH", Types.Branch.to_string br);
-                  ]
-                in
-                let cwd = Eio.Path.(fs / path) in
-                (* [hook_mutex] serializes hook invocations across patch
-                   fibers — npm/dune/bun aren't parallelism-safe across
-                   shared caches, and per-hook fan-out is the dominant
-                   subprocess multiplier (see issue #209). *)
-                match
-                  Eio.Mutex.use_ro hook_mutex (fun () ->
-                      User_config.run_hook ~process_mgr ~clock ~script ~cwd ~env
-                        ())
-                with
-                | Ok () ->
-                    log_event runtime ~patch_id "Ran on_worktree_create hook"
-                | Error msg ->
-                    log_event runtime ~patch_id
-                      (Printf.sprintf "Hook on_worktree_create failed — %s" msg)
-                )
-            | None -> ());
-            Some path)
-          else (
-            log_event runtime ~patch_id
-              (Printf.sprintf "Worktree still missing at %s" path);
-            None)
+          match (created, Stdlib.Sys.file_exists path) with
+          | true, true ->
+              Runtime.update_orchestrator runtime (fun orch ->
+                  Orchestrator.set_worktree_path orch patch_id path);
+              (match user_config.User_config.on_worktree_create with
+              | Some script -> (
+                  let env =
+                    [
+                      ("ONTON_WORKTREE_PATH", path);
+                      ("ONTON_PATCH_ID", Types.Patch_id.to_string patch_id);
+                      ("ONTON_BRANCH", Types.Branch.to_string br);
+                    ]
+                  in
+                  let cwd = Eio.Path.(fs / path) in
+                  (* [hook_mutex] serializes hook invocations across patch
+                     fibers — npm/dune/bun aren't parallelism-safe across
+                     shared caches, and per-hook fan-out is the dominant
+                     subprocess multiplier (see issue #209). *)
+                  match
+                    Eio.Mutex.use_ro hook_mutex (fun () ->
+                        User_config.run_hook ~process_mgr ~clock ~script ~cwd
+                          ~env ())
+                  with
+                  | Ok () ->
+                      log_event runtime ~patch_id "Ran on_worktree_create hook"
+                  | Error msg ->
+                      log_event runtime ~patch_id
+                        (Printf.sprintf "Hook on_worktree_create failed — %s"
+                           msg))
+              | None -> ());
+              Some path
+          | true, false ->
+              log_event runtime ~patch_id
+                (Printf.sprintf "Worktree still missing at %s" path);
+              None
+          | false, _ -> (
+              (* [Worktree.create] raised. A concurrent fiber may have already
+                 added a real worktree for [br] before our attempt collided.
+                 [find_for_branch] queries [git worktree list], which only
+                 reports atomically-registered worktrees — so a hit here is a
+                 genuine adoptable path, not a partially-created stub. The
+                 [on_worktree_create] hook is intentionally skipped on this
+                 branch: the winning creator is already responsible for it,
+                 mirroring the existing "Found existing worktree for branch"
+                 path above. *)
+              match Worktree.find_for_branch ~process_mgr ~repo_root br with
+              | Some existing ->
+                  log_event runtime ~patch_id
+                    (Printf.sprintf
+                       "Adopting concurrently-created worktree at %s" existing);
+                  Runtime.update_orchestrator runtime (fun orch ->
+                      Orchestrator.set_worktree_path orch patch_id existing);
+                  Some existing
+              | None -> None))

--- a/lib/worktree_setup.mli
+++ b/lib/worktree_setup.mli
@@ -1,0 +1,42 @@
+(** Worktree provisioning for a patch.
+
+    The runner and the worktree-plan executor both need to materialise a
+    worktree on disk before they can do anything else with a patch. This module
+    owns that logic so both callers go through the same code path — same
+    persistence, same hook invocation, same logging. *)
+
+val resolve_worktree_path :
+  process_mgr:_ Eio.Process.mgr ->
+  repo_root:string ->
+  project_name:string ->
+  patch_id:Types.Patch_id.t ->
+  agent:Patch_agent.t ->
+  ?branch:Types.Branch.t ->
+  unit ->
+  string
+(** Resolve the worktree path for a patch. Checks the stored path first, then
+    searches git worktrees by branch, then falls back to the canonical
+    [Worktree.worktree_dir] path. Pure-ish — no side effects on disk; the
+    persisted path on the agent record is consulted but not written. *)
+
+val ensure_worktree :
+  runtime:Runtime.t ->
+  process_mgr:_ Eio.Process.mgr ->
+  clock:_ Eio.Time.clock ->
+  fs:Eio.Fs.dir_ty Eio.Path.t ->
+  repo_root:string ->
+  project_name:string ->
+  patch_id:Types.Patch_id.t ->
+  agent:Patch_agent.t ->
+  user_config:User_config.t ->
+  worktree_mutex:Eio.Mutex.t ->
+  hook_mutex:Eio.Mutex.t ->
+  ?branch:Types.Branch.t ->
+  ?base_ref:string ->
+  unit ->
+  string option
+(** Ensure a worktree exists for the patch. Returns [Some path] on success or
+    [None] when the branch's worktree cannot be created (e.g. it's checked out
+    in the main tree). On creation, runs the user's [on_worktree_create] hook
+    serialised through [hook_mutex] and persists the path on the agent record.
+    All log lines go through [Runtime_logging.log_event]. *)

--- a/lib_test/test_generators.ml
+++ b/lib_test/test_generators.ml
@@ -87,6 +87,7 @@ let gen_patch =
             changes = [];
             test_stubs_introduced = [];
             test_stubs_implemented = [];
+            complexity = None;
           })
       gen_patch_id gen_title gen_branch gen_deps)
 
@@ -158,6 +159,7 @@ let gen_patch_list_linear =
                 changes = [];
                 test_stubs_introduced = [];
                 test_stubs_implemented = [];
+                complexity = None;
               }))
       (int_range 1 8))
 
@@ -205,6 +207,7 @@ let gen_patch_dag =
               changes = [];
               test_stubs_introduced = [];
               test_stubs_implemented = [];
+              complexity = None;
             }
         in
         gen_patches (i + 1) (patch :: acc)
@@ -224,6 +227,7 @@ let gen_patch_dag =
           changes = [];
           test_stubs_introduced = [];
           test_stubs_implemented = [];
+          complexity = None;
         }
     in
     gen_patches 1 [ root ])
@@ -676,6 +680,7 @@ let mk_linear_patches n =
           changes = [];
           test_stubs_introduced = [];
           test_stubs_implemented = [];
+          complexity = None;
         })
 
 let make_test_gameplan patches =

--- a/skills/write-gameplan/SKILL.md
+++ b/skills/write-gameplan/SKILL.md
@@ -66,7 +66,7 @@ All of these fields are **required** and must be present in every gameplan:
 
 ### Required Patch Fields
 
-Each patch object must have: `number`, `classification` (INFRA\|GATED\|BEHAVIOR), `title`, `files` (array of `{ path, action, description }`), `changes` (string array), `testStubsIntroduced` (string array or null), `testStubsImplemented` (string array or null), `spec` (string).
+Each patch object must have: `number`, `classification` (INFRA\|GATED\|BEHAVIOR), `complexity` (1\|2\|3), `title`, `files` (array of `{ path, action, description }`), `changes` (string array), `testStubsIntroduced` (string array or null), `testStubsImplemented` (string array or null), `spec` (string).
 
 The inline `spec` and `finalStateSpec` string fields in the JSON are the **sole source of truth** for formal specifications. Do not maintain separate spec files alongside the gameplan. For verification, extract the strings and validate them with the spec language's toolchain (see [Specification Language](#specification-language) below). Do not persist the extracted files.
 
@@ -102,6 +102,29 @@ Each patch includes a `classification` field:
 - `BEHAVIOR` — Changes observable behavior. Requires careful review. Should be as small as possible.
 
 **Goal**: Maximize `INFRA` and `GATED` patches. Minimize `BEHAVIOR` patches.
+
+## Patch Complexity
+
+Each patch includes a `complexity` field — an integer in `1`/`2`/`3` estimating how hard the patch is to implement correctly. This is used by orchestrators (e.g. onton's `--model auto`) to route harder patches to stronger models.
+
+- `1` — **Mechanical / shallow / well-precedented.** A rename, a single-call-site signature change, adding a field that already has an obvious default, copy-pasting a pattern that already exists nearby. Could be done by reading only the patch description and a few surrounding lines.
+- `2` — **Moderate.** Requires reading the surrounding code to understand context, designing a small abstraction, writing non-trivial tests, or coordinating two or three files. The shape of the solution is clear once you've read the relevant code, but a careless implementation would miss something.
+- `3` — **Deep.** Requires reasoning about subtle invariants, concurrency, distributed state, novel algorithms, performance trade-offs, security boundaries, or unfamiliar third-party APIs whose contracts must be researched. Implementations that "look right" can still be wrong.
+
+### Be conservative
+
+**When in doubt, choose the higher value.** Under-estimating complexity costs more than over-estimating it: a too-weak model on a complex patch silently produces broken code, while a too-strong model on a simple patch only costs extra tokens. The bias is intentional.
+
+### Read the code, then research, then decide
+
+Do not assign complexity from the patch title alone. Before scoring:
+
+1. **Read the relevant files** named in `files` and any code the patch touches transitively. If the patch modifies a function with many callers, scan the callers.
+2. **If the patch involves a third-party API or unfamiliar library**, fetch the relevant docs (e.g. `WebFetch` against the library's reference) so you know whether the integration is mechanical or has gotchas.
+3. **If the patch touches an area the codebase has historical bugs in** (concurrency primitives, migrations, auth, billing, anything safety-critical), bias up.
+4. **Score based on the worst case among the changes the patch introduces**, not the median. A patch that mostly renames things but also adds one tricky lock should be scored on the lock.
+
+If after reading you cannot tell whether something is `2` or `3`, it is `3`. If you cannot tell whether something is `1` or `2`, it is `2`.
 
 ## Mergability Strategy
 

--- a/skills/write-gameplan/references/example.json
+++ b/skills/write-gameplan/references/example.json
@@ -76,6 +76,7 @@
     {
       "number": 1,
       "classification": "INFRA",
+      "complexity": 1,
       "title": "Add Patch_decision types and module skeleton",
       "files": [
         {
@@ -106,6 +107,7 @@
     {
       "number": 2,
       "classification": "INFRA",
+      "complexity": 1,
       "title": "Add QCheck2 test stubs for decision properties",
       "files": [
         {
@@ -135,6 +137,7 @@
     {
       "number": 3,
       "classification": "INFRA",
+      "complexity": 2,
       "title": "Implement decision functions and enable tests",
       "files": [
         {
@@ -164,6 +167,7 @@
     {
       "number": 4,
       "classification": "BEHAVIOR",
+      "complexity": 2,
       "title": "Wire Patch_decision into main.ml runner_fiber",
       "files": [
         {

--- a/skills/write-gameplan/references/gameplan-schema.json
+++ b/skills/write-gameplan/references/gameplan-schema.json
@@ -210,13 +210,16 @@
     },
     "patch": {
       "type": "object",
-      "required": ["number", "classification", "title", "files", "changes", "spec"],
+      "required": ["number", "classification", "complexity", "title", "files", "changes", "spec"],
       "properties": {
         "number": {
           "$ref": "#/$defs/patchId"
         },
         "classification": {
           "$ref": "#/$defs/patchClassification"
+        },
+        "complexity": {
+          "$ref": "#/$defs/patchComplexity"
         },
         "title": {
           "type": "string",
@@ -255,6 +258,11 @@
     "patchClassification": {
       "type": "string",
       "enum": ["INFRA", "GATED", "BEHAVIOR"]
+    },
+    "patchComplexity": {
+      "type": "integer",
+      "enum": [1, 2, 3],
+      "description": "Conservative estimate of how hard this patch is to implement correctly. 1 = mechanical / shallow / well-precedented; 2 = moderate — requires reading the surrounding code, designing a small abstraction, or writing non-trivial tests; 3 = deep — requires reasoning about subtle invariants, concurrency, distributed state, novel algorithms, or unfamiliar third-party APIs. When in doubt, choose the higher value. Used by orchestrators (e.g. onton --model auto) to pick a model strong enough for the task."
     },
     "patchFile": {
       "type": "object",

--- a/test/dune
+++ b/test/dune
@@ -97,6 +97,13 @@
  (ocamlc_flags (:standard -w -40-42)))
 
 (test
+ (name test_backend_routing)
+ (modules test_backend_routing)
+ (libraries onton qcheck-core qcheck-core.runner)
+ (ocamlopt_flags (:standard -w -40-42))
+ (ocamlc_flags (:standard -w -40-42)))
+
+(test
  (name test_run_classification)
  (modules test_run_classification)
  (libraries onton onton_test_support qcheck-core qcheck-core.runner)

--- a/test/test_backend_routing.ml
+++ b/test/test_backend_routing.ml
@@ -148,8 +148,10 @@ let () =
               Backend_routing.decide ~repo_config ~default_backend
                 ~cli_model:(Some auto) ~complexity
             in
+            (* The fallback canonicalises to lowercase "auto" regardless of
+               how the user typed [--model], so registry deduplication works. *)
             String.equal d.backend default_backend
-            && Option.equal String.equal d.model (Some auto))
+            && Option.equal String.equal d.model (Some "auto"))
   in
 
   let prop_auto_none_complexity_falls_back =
@@ -163,7 +165,7 @@ let () =
             ~cli_model:(Some auto) ~complexity:None
         in
         String.equal d.backend default_backend
-        && Option.equal String.equal d.model (Some auto))
+        && Option.equal String.equal d.model (Some "auto"))
   in
 
   let prop_auto_case_insensitive =
@@ -180,10 +182,11 @@ let () =
         match decisions with
         | [] -> true
         | first :: rest -> (
-            (* The model field for "auto" fallback preserves the user's exact
-               case (to avoid surprising downstream tooling), so equality is
-               taken on the backend only when the route doesn't match — but
-               when the route matches, all variants must agree fully. *)
+            (* All variants must agree on BOTH backend and model. The fallback
+               arm canonicalises model to [Some "auto"] (lowercase), so the
+               backend-only check that used to live here would have allowed
+               case-divergent model fields to slip through and fragment the
+               [Backend_registry] cache. *)
             let route =
               Repo_config.route_for_complexity repo_config ~complexity
             in
@@ -194,7 +197,8 @@ let () =
                     && Option.equal String.equal d.model r.model)
             | None ->
                 List.for_all rest ~f:(fun d ->
-                    String.equal d.backend first.backend)))
+                    String.equal d.backend first.backend
+                    && Option.equal String.equal d.model first.model)))
   in
 
   let prop_total =

--- a/test/test_backend_routing.ml
+++ b/test/test_backend_routing.ml
@@ -1,0 +1,245 @@
+open Base
+open Onton
+
+(** QCheck2 property-based tests for [Backend_routing.decide].
+
+    The function is fully pure: ([Repo_config.t], default_backend, cli_model,
+    complexity) -> [decision]. The properties below exhaust the four branches of
+    the precedence rules and the case-insensitive [auto] detection. *)
+
+let known_backends = [ "claude"; "codex"; "opencode"; "pi"; "gemini" ]
+let gen_backend_name = QCheck2.Gen.oneof_list known_backends
+
+(* Mix in some plausible non-auto model strings, [None] (no flag), and
+   pathological strings. We exclude any string equal to "auto" (in any case
+   variant) so the property applies cleanly. *)
+let gen_non_auto_cli_model : string option QCheck2.Gen.t =
+  let open QCheck2.Gen in
+  oneof
+    [
+      return None;
+      map
+        (fun s -> Some s)
+        (oneof_list
+           [
+             "sonnet";
+             "opus";
+             "haiku";
+             "gpt-5.5";
+             "gpt-5.4-mini";
+             "gemini-3-pro-preview";
+             "anthropic/claude-opus-4-7";
+             "";
+           ]);
+    ]
+
+let gen_auto_variant : string QCheck2.Gen.t =
+  QCheck2.Gen.oneof_list [ "auto"; "AUTO"; "Auto"; "aUTo"; "auTO" ]
+
+let gen_complexity : int option QCheck2.Gen.t =
+  let open QCheck2.Gen in
+  oneof
+    [
+      return None;
+      map (fun k -> Some k) (oneof_list [ 1; 2; 3 ]);
+      (* Out-of-range values shouldn't crash — surface them too. *)
+      map (fun k -> Some k) (oneof_list [ 0; 4; 5; -1; 99 ]);
+    ]
+
+let gen_route_model : string option QCheck2.Gen.t =
+  let open QCheck2.Gen in
+  oneof
+    [
+      return None;
+      map
+        (fun s -> Some s)
+        (oneof_list
+           [
+             "haiku"; "sonnet"; "opus"; "gpt-5.5"; "gpt-5.4"; "gemini-2.5-flash";
+           ]);
+    ]
+
+let gen_route : Repo_config.route QCheck2.Gen.t =
+  let open QCheck2.Gen in
+  let* backend = gen_backend_name in
+  let* model = gen_route_model in
+  return { Repo_config.backend; model }
+
+(* Generate a repo config with a random subset of complexity tiers populated.
+   The empty config (no routes) is one possible value. *)
+let gen_repo_config : Repo_config.t QCheck2.Gen.t =
+  let open QCheck2.Gen in
+  let* keys =
+    let* size = int_range 0 3 in
+    let* sub = list_size (return size) (oneof_list [ 1; 2; 3 ]) in
+    return (List.dedup_and_sort sub ~compare:Int.compare)
+  in
+  let* routes = list_size (return (List.length keys)) gen_route in
+  let complexity_routes = List.zip_exn keys routes in
+  return { Repo_config.complexity_routes }
+
+let pp_decision (d : Backend_routing.decision) =
+  Printf.sprintf "{ backend = %s; model = %s }" d.backend
+    (match d.model with Some s -> Printf.sprintf "Some %S" s | None -> "None")
+
+let () =
+  let open QCheck2 in
+  let prop_explicit_model_passes_through =
+    Test.make
+      ~name:
+        "decide: non-auto cli_model passes through unchanged on default backend"
+      ~count:500
+      (Gen.tup4 gen_repo_config gen_backend_name gen_non_auto_cli_model
+         gen_complexity)
+      (fun (repo_config, default_backend, cli_model, complexity) ->
+        let d =
+          Backend_routing.decide ~repo_config ~default_backend ~cli_model
+            ~complexity
+        in
+        String.equal d.backend default_backend
+        && Option.equal String.equal d.model cli_model)
+  in
+
+  let prop_explicit_ignores_repo_config =
+    Test.make ~name:"decide: non-auto cli_model is unaffected by repo_config"
+      ~count:500
+      (Gen.tup4 gen_repo_config gen_backend_name gen_non_auto_cli_model
+         gen_complexity)
+      (fun (repo_config, default_backend, cli_model, complexity) ->
+        let with_cfg =
+          Backend_routing.decide ~repo_config ~default_backend ~cli_model
+            ~complexity
+        in
+        let without_cfg =
+          Backend_routing.decide ~repo_config:Repo_config.empty ~default_backend
+            ~cli_model ~complexity
+        in
+        String.equal with_cfg.backend without_cfg.backend
+        && Option.equal String.equal with_cfg.model without_cfg.model)
+  in
+
+  let prop_auto_with_route_uses_route =
+    Test.make ~name:"decide: auto + matching route -> route's (backend, model)"
+      ~count:500
+      (Gen.tup4 gen_repo_config gen_backend_name gen_auto_variant gen_complexity)
+      (fun (repo_config, default_backend, auto, complexity) ->
+        match Repo_config.route_for_complexity repo_config ~complexity with
+        | None -> true (* not in scope for this property *)
+        | Some route ->
+            let d =
+              Backend_routing.decide ~repo_config ~default_backend
+                ~cli_model:(Some auto) ~complexity
+            in
+            String.equal d.backend route.backend
+            && Option.equal String.equal d.model route.model)
+  in
+
+  let prop_auto_without_route_falls_back =
+    Test.make
+      ~name:
+        "decide: auto + no matching route -> { default_backend; Some \"auto\" }"
+      ~count:500
+      (Gen.tup4 gen_repo_config gen_backend_name gen_auto_variant gen_complexity)
+      (fun (repo_config, default_backend, auto, complexity) ->
+        match Repo_config.route_for_complexity repo_config ~complexity with
+        | Some _ -> true (* not in scope for this property *)
+        | None ->
+            let d =
+              Backend_routing.decide ~repo_config ~default_backend
+                ~cli_model:(Some auto) ~complexity
+            in
+            String.equal d.backend default_backend
+            && Option.equal String.equal d.model (Some auto))
+  in
+
+  let prop_auto_none_complexity_falls_back =
+    Test.make
+      ~name:
+        "decide: auto + complexity=None -> { default_backend; Some \"auto\" }"
+      ~count:200 (Gen.tup3 gen_repo_config gen_backend_name gen_auto_variant)
+      (fun (repo_config, default_backend, auto) ->
+        let d =
+          Backend_routing.decide ~repo_config ~default_backend
+            ~cli_model:(Some auto) ~complexity:None
+        in
+        String.equal d.backend default_backend
+        && Option.equal String.equal d.model (Some auto))
+  in
+
+  let prop_auto_case_insensitive =
+    Test.make
+      ~name:"decide: auto detection is case-insensitive (all variants agree)"
+      ~count:300 (Gen.tup3 gen_repo_config gen_backend_name gen_complexity)
+      (fun (repo_config, default_backend, complexity) ->
+        let variants = [ "auto"; "AUTO"; "Auto"; "aUTo"; "auTO" ] in
+        let decisions =
+          List.map variants ~f:(fun v ->
+              Backend_routing.decide ~repo_config ~default_backend
+                ~cli_model:(Some v) ~complexity)
+        in
+        match decisions with
+        | [] -> true
+        | first :: rest -> (
+            (* The model field for "auto" fallback preserves the user's exact
+               case (to avoid surprising downstream tooling), so equality is
+               taken on the backend only when the route doesn't match — but
+               when the route matches, all variants must agree fully. *)
+            let route =
+              Repo_config.route_for_complexity repo_config ~complexity
+            in
+            match route with
+            | Some r ->
+                List.for_all decisions ~f:(fun d ->
+                    String.equal d.backend r.backend
+                    && Option.equal String.equal d.model r.model)
+            | None ->
+                List.for_all rest ~f:(fun d ->
+                    String.equal d.backend first.backend)))
+  in
+
+  let prop_total =
+    Test.make
+      ~name:"decide: total — never raises and yields a non-empty backend"
+      ~count:1000
+      (Gen.tup4 gen_repo_config gen_backend_name
+         (Gen.oneof [ Gen.return None; Gen.map (fun s -> Some s) Gen.string ])
+         gen_complexity)
+      (fun (repo_config, default_backend, cli_model, complexity) ->
+        try
+          let d =
+            Backend_routing.decide ~repo_config ~default_backend ~cli_model
+              ~complexity
+          in
+          not (String.is_empty d.backend)
+        with _ -> false)
+  in
+
+  let prop_is_auto_model_case_insensitive =
+    Test.make ~name:"is_auto_model: case-insensitive on 'auto'" ~count:200
+      Gen.string (fun s ->
+        let detected = Backend_routing.is_auto_model (Some s) in
+        let expected = String.equal (String.lowercase s) "auto" in
+        Bool.equal detected expected)
+  in
+
+  let prop_is_auto_model_none =
+    Test.make ~name:"is_auto_model: None -> false" ~count:1 (Gen.return ())
+      (fun () -> not (Backend_routing.is_auto_model None))
+  in
+
+  let suite =
+    [
+      prop_explicit_model_passes_through;
+      prop_explicit_ignores_repo_config;
+      prop_auto_with_route_uses_route;
+      prop_auto_without_route_falls_back;
+      prop_auto_none_complexity_falls_back;
+      prop_auto_case_insensitive;
+      prop_total;
+      prop_is_auto_model_case_insensitive;
+      prop_is_auto_model_none;
+    ]
+  in
+  let errcode = QCheck_base_runner.run_tests ~verbose:true suite in
+  if errcode <> 0 then Stdlib.exit errcode;
+  ignore pp_decision

--- a/test/test_interleaving_properties.ml
+++ b/test/test_interleaving_properties.ml
@@ -1959,6 +1959,7 @@ let () =
             changes = [];
             test_stubs_introduced = [];
             test_stubs_implemented = [];
+            complexity = None;
           }
         in
         let b : Patch.t =

--- a/test/test_onton.ml
+++ b/test/test_onton.ml
@@ -15,6 +15,7 @@ let () =
           changes = [];
           test_stubs_introduced = [];
           test_stubs_implemented = [];
+          complexity = None;
         };
     ]
   in

--- a/test/test_patch_controller.ml
+++ b/test/test_patch_controller.ml
@@ -19,6 +19,7 @@ let make_patch pid branch =
       changes = [];
       test_stubs_introduced = [];
       test_stubs_implemented = [];
+      complexity = None;
     }
 
 let make_gameplan patch =

--- a/test/test_patch_controller_state_machine.ml
+++ b/test/test_patch_controller_state_machine.ml
@@ -19,6 +19,7 @@ let make_patch pid branch =
       changes = [];
       test_stubs_introduced = [];
       test_stubs_implemented = [];
+      complexity = None;
     }
 
 let make_gameplan patch =

--- a/test/test_persistence_properties.ml
+++ b/test/test_persistence_properties.ml
@@ -32,6 +32,7 @@ let gameplan_for_agent (agent : Onton.Patch_agent.t) =
             changes = [];
             test_stubs_introduced = [];
             test_stubs_implemented = [];
+            complexity = None;
           };
         ];
       current_state_analysis = "";

--- a/test/test_poll_log_properties.ml
+++ b/test/test_poll_log_properties.ml
@@ -28,6 +28,7 @@ let make_patch pid branch =
       changes = [];
       test_stubs_introduced = [];
       test_stubs_implemented = [];
+      complexity = None;
     }
 
 let make_orch patch agent =

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -153,6 +153,7 @@ let () =
          changes = [];
          test_stubs_introduced = [];
          test_stubs_implemented = [];
+         complexity = None;
        }
    in
    let a = Types.Patch_id.of_string "A" in
@@ -392,6 +393,7 @@ let () =
           changes = [];
           test_stubs_introduced = [];
           test_stubs_implemented = [];
+          complexity = None;
         };
     ]
   in
@@ -451,6 +453,7 @@ let () =
         changes = [];
         test_stubs_introduced = [];
         test_stubs_implemented = [];
+        complexity = None;
       }
   in
 
@@ -561,6 +564,7 @@ let () =
           changes = [];
           test_stubs_introduced = [];
           test_stubs_implemented = [];
+          complexity = None;
         };
       Types.Patch.
         {
@@ -576,6 +580,7 @@ let () =
           changes = [];
           test_stubs_introduced = [];
           test_stubs_implemented = [];
+          complexity = None;
         };
     ]
   in
@@ -623,6 +628,7 @@ let () =
             changes = [];
             test_stubs_introduced = [];
             test_stubs_implemented = [];
+            complexity = None;
           };
       ]
     in
@@ -650,6 +656,7 @@ let () =
                 changes = [];
                 test_stubs_introduced = [];
                 test_stubs_implemented = [];
+                complexity = None;
               };
           ]
         in
@@ -755,6 +762,7 @@ let () =
             changes = [];
             test_stubs_introduced = [];
             test_stubs_implemented = [];
+            complexity = None;
           };
       ]
     in
@@ -819,6 +827,7 @@ let () =
                   changes = [];
                   test_stubs_introduced = [];
                   test_stubs_implemented = [];
+                  complexity = None;
                 };
             ]
           in
@@ -894,6 +903,7 @@ let () =
             changes = [];
             test_stubs_introduced = [];
             test_stubs_implemented = [];
+            complexity = None;
           };
       ]
     in

--- a/test/test_reconciler_properties.ml
+++ b/test/test_reconciler_properties.ml
@@ -549,6 +549,7 @@ let prop_reconcile_e2e_catches_drift =
           changes = [];
           test_stubs_introduced = [];
           test_stubs_implemented = [];
+          complexity = None;
         }
       in
       let graph = Graph.of_patches [ patch ] in
@@ -588,6 +589,7 @@ let prop_reconcile_dedup_rebase =
           changes = [];
           test_stubs_introduced = [];
           test_stubs_implemented = [];
+          complexity = None;
         }
       in
       let graph = Graph.of_patches [ patch ] in


### PR DESCRIPTION
## Summary

- **Gameplan complexity**: `/write-gameplan` now requires every patch to carry a `complexity` integer (1/2/3) estimating how hard the patch is to implement correctly. The skill instructs the author to be **conservative** — when in doubt, score higher — and to read the relevant code (and external docs for unfamiliar APIs) before scoring rather than going off the title alone.
- **`--model auto`**: when this flag is passed, each backend resolves the literal `auto` to a backend-specific model based on the patch's complexity. Conservative fallback: missing/out-of-range complexity routes to the strongest tier. Per-backend ladders use current model names (mid-2026):
  - **claude** — `haiku` / `sonnet` / `opus` (stable aliases)
  - **codex** — `gpt-5.4-mini` / `gpt-5.4` / `gpt-5.5`
  - **gemini** — `gemini-2.5-flash` / `gemini-3-flash-preview` / `gemini-3-pro-preview`
  - **opencode** — `anthropic/claude-haiku-4-5` / `anthropic/claude-sonnet-4-6` / `anthropic/claude-opus-4-7`
  - **pi** — no canonical ladder; `auto` falls back to pi's CLI default
- **Refactor**: extracts the 412-line `run_claude_and_handle` (and its helpers `ensure_worktree`, `log_event`, `log_stream_entry`, `extract_pr_number_from_text`, `session_mode`) out of `bin/main.ml` into three new lib modules: `Session_driver`, `Worktree_setup`, `Runtime_logging`. `main.ml` shrinks 4338 → 3934 lines.
- **Naming**: renames `run_claude_and_handle` → `Session_driver.run`, `with_claude_slot` → `with_session_slot`, and rewords comments/CLI docs that referred to "Claude" generically. Remaining `claude` references are all about the Claude backend specifically (dispatch case, display name, `--model` example).

The `model` value flows as `string option` end-to-end, so the literal `"auto"` round-trips cleanly through `Project_store` (resume) and the CLI without a migration.

## Test plan

- [x] `dune build` clean (with strict warnings)
- [x] `dune runtest` — all inline + property tests pass
- [x] `dune fmt` clean
- [x] New unit tests for `Llm_backend.resolve_auto_model` and `Claude_runner.auto_model` cover the conservative fallback and case-insensitive `auto` recognition
- [ ] Smoke-test `--model auto` against a real gameplan with complexity=1/2/3 patches across at least the claude and codex backends
- [ ] Verify `--model auto` round-trips through `onton PROJECT` resume after a fresh `onton --gameplan ... --model auto` start

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per‑patch complexity and `--model auto` routing that picks a backend/model per patch, with optional per‑repo overrides. Also extracts session/worktree/logging into `Session_driver`, `Worktree_setup`, and `Runtime_logging`, and adds a cached backend registry to slim down `main.ml` and reuse backends.

- **New Features**
  - Gameplan patches include `complexity` (1/2/3). Be conservative when scoring.
  - `--model auto` resolves per backend per patch:
    - claude: 1→haiku, 2→sonnet, 3→opus; codex: 1→gpt-5.4-mini, 2→gpt-5.4, 3→gpt-5.5; gemini: 1→gemini-2.5-flash, 2→gemini-3-flash-preview, 3→gemini-3-pro-preview; opencode: 1→anthropic/claude-haiku-4-5, 2→anthropic/claude-sonnet-4-6, 3→anthropic/claude-opus-4-7; pi: uses CLI default.
  - Per‑repo routing: `~/.config/onton/<owner>/<repo>/config.json` can override the ladder with `routing.{1,2,3} = { "backend": "<name>", "model": "<id>|null" }`. Only applies with `--model auto`; explicit `--model <name>` wins.

- **Bug Fixes**
  - Repo routing validation: reject non‑string `backend`/`model`, trim whitespace, and error on duplicate `routing` keys.
  - PR URL sniffing: treat digit runs at buffer end as incomplete mid‑stream; window the final pass to the same tail; widen lookback; fix an off‑by‑one scan guard; add inline docs on window anchoring.
  - Session lifecycle: capture `llm_session_id` before applying results to avoid clobbering clean‑retry state.
  - Worktrees: avoid stale stored paths when `?branch` is provided; persist path/run hooks only on successful create; if a create races and another fiber wins, adopt the registered worktree and skip the create hook.
  - Backend registry: use `Hashtbl.set` to avoid duplicate insert races; show `Claude` (no “(auto)”) when `--model auto`; canonicalize fallback `"auto"` to lowercase for stable `(backend, model)` cache keys.
  - CI: drop the manual `_opam` cache from Build & Test and rely on `setup-ocaml@v3` caching `~/.opam` to avoid desynced switch errors.

<sup>Written for commit 41fa3979a3a96cfdca03159772b707e9cd6ef73d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-patch complexity (1/2/3) influences model/backend selection and session routing.
  * Per-repo routing config to override backend/model by complexity.
  * Session orchestration now streams activity, detects PRs from outputs, and classifies push outcomes (including skip/stale cases).

* **Improvements**
  * Auto-model selection extended across backends and reused via a backend registry.
  * CLI/TUI wording changed from “Claude” to “LLM coding agent”.
  * Improved activity logging and more robust worktree provisioning.

* **Documentation**
  * Gameplan docs/schema updated to require and describe patch complexity.

* **Tests**
  * New routing tests and many fixtures updated for complexity handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->