### PR TITLE
Show per-patch backend/model in TUI detail pane

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -669,7 +669,8 @@ let intervention_reasons_of_log (log : Activity_log.t)
 let tui_fiber ~runtime ~clock ~stdout ~list_selected ~detail_scroll
     ~detail_follow ~timeline_scroll ~view_mode ~show_help ~status_msg
     ~transcripts ~sorted_patch_ids ~input_mode ~prompt_line ~patches_start_row
-    ~patches_scroll_offset ~patches_visible_count ~backend_name =
+    ~patches_scroll_offset ~patches_visible_count ~backend_name ~resolve_routing
+    =
   Eio.Flow.copy_string (Tui.enter_tui ()) stdout;
   let first = ref true in
   let prev_output = ref "" in
@@ -699,7 +700,7 @@ let tui_fiber ~runtime ~clock ~stdout ~list_selected ~detail_scroll
     in
     let views =
       Tui.views_of_orchestrator ~orchestrator:orch ~gameplan:gp ~activity
-        ~intervention_reasons ()
+        ~resolve_routing ~intervention_reasons ()
     in
     sorted_patch_ids :=
       Base.List.map views ~f:(fun (pv : Tui.patch_view) -> pv.Tui.patch_id);
@@ -767,7 +768,7 @@ let input_fiber ~runtime ~process_mgr ~net ~github ~list_selected ~detail_scroll
     ~detail_follow ~timeline_scroll ~detail_scrolls ~view_mode ~pr_registry
     ~project_name ~show_help ~status_msg ~sorted_patch_ids ~input_mode
     ~prompt_line ~patches_start_row ~patches_scroll_offset
-    ~patches_visible_count ~owner ~repo =
+    ~patches_visible_count ~owner ~repo ~resolve_routing =
   let buf = Tui_input.Edit_buffer.create () in
   let selected_pid () =
     let pids = !sorted_patch_ids in
@@ -932,7 +933,8 @@ let input_fiber ~runtime ~process_mgr ~net ~github ~list_selected ~detail_scroll
                       Runtime.read runtime (fun snap ->
                           Tui.views_of_orchestrator
                             ~orchestrator:snap.Runtime.orchestrator
-                            ~gameplan:snap.Runtime.gameplan ~activity:[] ())
+                            ~gameplan:snap.Runtime.gameplan ~activity:[]
+                            ~resolve_routing ())
                     in
                     let active =
                       Base.List.filter views ~f:(fun (pv : Tui.patch_view) ->
@@ -3625,6 +3627,19 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
         Backend_registry.get registry ~backend ~model
       in
       let default_backend = pick_backend ~complexity:None in
+      (* Display-side counterpart to [pick_backend]: returns the routing
+         decision with the [auto] sentinel resolved to the concrete model
+         name, so the TUI shows what will actually run. *)
+      let resolve_routing ~complexity : Backend_routing.decision =
+        let dec : Backend_routing.decision =
+          Backend_routing.decide ~repo_config ~default_backend:config.backend
+            ~cli_model:cli_model_opt ~complexity
+        in
+        Backend_routing.resolve_auto dec
+          ~auto_model:
+            (Backend_registry.auto_model ~backend:dec.Backend_routing.backend)
+          ~complexity
+      in
       let net = Eio.Stdenv.net env in
       let stdout = Eio.Stdenv.stdout env in
       (* Capture agent state and worktree list BEFORE launching concurrent
@@ -3757,7 +3772,8 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
                      ~show_help ~status_msg ~transcripts ~sorted_patch_ids
                      ~input_mode ~prompt_line ~patches_start_row
                      ~patches_scroll_offset ~patches_visible_count
-                     ~backend_name:default_backend.Llm_backend.name)
+                     ~backend_name:default_backend.Llm_backend.name
+                     ~resolve_routing)
                 :: (fun () ->
                   input_fiber ~runtime ~process_mgr ~net ~github ~list_selected
                     ~detail_scroll ~detail_follow ~timeline_scroll
@@ -3765,7 +3781,7 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
                     ~show_help ~status_msg ~sorted_patch_ids ~input_mode
                     ~prompt_line ~patches_start_row ~patches_scroll_offset
                     ~patches_visible_count ~owner:config.github_owner
-                    ~repo:config.github_repo)
+                    ~repo:config.github_repo ~resolve_routing)
                 :: (fun () ->
                   runner_fiber ~runtime ~env ~config ~pick_backend ~project_name
                     ~pr_registry ~transcripts ~github ~net ~event_log

--- a/lib/backend_registry.ml
+++ b/lib/backend_registry.ml
@@ -43,6 +43,17 @@ let create ~process_mgr ~clock ~timeout ~setsid_exec =
     cache = Hashtbl.Poly.create ();
   }
 
+let auto_model ~backend ~complexity =
+  match backend with
+  | "claude" -> Claude_runner.auto_model ~complexity
+  | "codex" -> Codex_backend.auto_model ~complexity
+  | "opencode" -> Opencode_backend.auto_model ~complexity
+  | "pi" -> Pi_backend.auto_model ~complexity
+  | "gemini" -> Gemini_backend.auto_model ~complexity
+  | other ->
+      invalid_arg
+        (Printf.sprintf "Backend_registry.auto_model: unknown backend %S" other)
+
 let get t ~backend ~model =
   let key = (backend, model) in
   match Hashtbl.find t.cache key with

--- a/lib/backend_registry.mli
+++ b/lib/backend_registry.mli
@@ -24,3 +24,9 @@ val get : t -> backend:string -> model:string option -> Llm_backend.t
 (** Return the cached [Llm_backend.t] for [(backend, model)], constructing it on
     first request. Raises [Invalid_argument] for unrecognised backend names —
     callers are expected to validate against the known list before asking. *)
+
+val auto_model : backend:string -> complexity:int option -> string option
+(** Look up the named backend's hardcoded complexity → model ladder — the model
+    name it would resolve [--model auto] to for this complexity. Pure; no [t]
+    required, no IO. Raises [Invalid_argument] on unknown backend names,
+    matching {!get}. *)

--- a/lib/backend_routing.ml
+++ b/lib/backend_routing.ml
@@ -19,3 +19,32 @@ let decide ~(repo_config : Repo_config.t) ~default_backend ~cli_model
            ([(backend, model)]). [resolve_auto_model] downstream lowercases
            anyway, so observable behaviour is unchanged. *)
         { backend = default_backend; model = Some "auto" }
+
+let resolve_auto (dec : decision) ~auto_model ~complexity : decision =
+  if is_auto_model dec.model then { dec with model = auto_model ~complexity }
+  else dec
+
+let%test "resolve_auto: replaces 'auto' with auto_model result" =
+  let auto_model ~complexity:_ = Some "resolved" in
+  let dec = { backend = "claude"; model = Some "auto" } in
+  let out = resolve_auto dec ~auto_model ~complexity:(Some 1) in
+  Option.equal String.equal out.model (Some "resolved")
+  && String.equal out.backend "claude"
+
+let%test "resolve_auto: case-insensitive on AUTO" =
+  let auto_model ~complexity:_ = Some "resolved" in
+  let dec = { backend = "codex"; model = Some "AUTO" } in
+  let out = resolve_auto dec ~auto_model ~complexity:None in
+  Option.equal String.equal out.model (Some "resolved")
+
+let%test "resolve_auto: leaves explicit model unchanged" =
+  let auto_model ~complexity:_ = Some "resolved" in
+  let dec = { backend = "claude"; model = Some "sonnet" } in
+  let out = resolve_auto dec ~auto_model ~complexity:(Some 2) in
+  Option.equal String.equal out.model (Some "sonnet")
+
+let%test "resolve_auto: leaves None unchanged" =
+  let auto_model ~complexity:_ = Some "resolved" in
+  let dec = { backend = "claude"; model = None } in
+  let out = resolve_auto dec ~auto_model ~complexity:(Some 2) in
+  Option.is_none out.model

--- a/lib/backend_routing.mli
+++ b/lib/backend_routing.mli
@@ -42,3 +42,13 @@ val is_auto_model : string option -> bool
 (** [is_auto_model m] returns [true] iff [m] is [Some s] where [s]
     case-insensitively equals ["auto"]. Exposed for tests and call sites that
     need to gate other behavior on the same predicate. *)
+
+val resolve_auto :
+  decision ->
+  auto_model:(complexity:int option -> string option) ->
+  complexity:int option ->
+  decision
+(** Inline the [Some "auto"] sentinel: when [decision.model] is auto, replace it
+    with [auto_model ~complexity]; otherwise return [decision] unchanged. Used
+    by display sites (the TUI) that want to show the concrete model name a patch
+    will run under, rather than the sentinel. *)

--- a/lib/codex_backend.mli
+++ b/lib/codex_backend.mli
@@ -13,3 +13,7 @@ val create :
 
 val parse_event : string -> Types.Stream_event.t list
 (** Parse a single NDJSON line from Codex's JSON output. Exposed for testing. *)
+
+val auto_model : complexity:int option -> string option
+(** Codex's complexity → model ladder used to resolve [--model auto]. Exposed so
+    the TUI can display the concrete model name a patch will run under. *)

--- a/lib/gemini_backend.mli
+++ b/lib/gemini_backend.mli
@@ -13,3 +13,7 @@ val create :
 val parse_event : string -> Types.Stream_event.t list
 (** Parse a single NDJSON line from Gemini's stream-json output. Exposed for
     testing. *)
+
+val auto_model : complexity:int option -> string option
+(** Gemini's complexity → model ladder used to resolve [--model auto]. Exposed
+    so the TUI can display the concrete model name a patch will run under. *)

--- a/lib/opencode_backend.mli
+++ b/lib/opencode_backend.mli
@@ -13,3 +13,7 @@ val create :
 val parse_event : string -> Types.Stream_event.t list
 (** Parse a single NDJSON line from OpenCode's JSON output. Exposed for testing.
 *)
+
+val auto_model : complexity:int option -> string option
+(** OpenCode's complexity → model ladder used to resolve [--model auto]. Exposed
+    so the TUI can display the concrete model name a patch will run under. *)

--- a/lib/pi_backend.mli
+++ b/lib/pi_backend.mli
@@ -13,3 +13,7 @@ val create :
 
 val parse_event : string -> Types.Stream_event.t list
 (** Parse a single NDJSON line from Pi's JSON output. Exposed for testing. *)
+
+val auto_model : complexity:int option -> string option
+(** Pi's complexity → model ladder used to resolve [--model auto]. Exposed so
+    the TUI can display the concrete model name a patch will run under. *)

--- a/lib/tui.ml
+++ b/lib/tui.ml
@@ -512,15 +512,22 @@ type patch_view = {
   automerge_enabled : bool;
   automerge_deadline : float option;
   automerge_failure_count : int;
+  complexity : int option;
+  backend : string;
+  model : string option;
 }
 [@@warning "-69"]
 
 let patch_view_of_agent (agent : Patch_agent.t)
     ~(patches_by_id : Patch.t Map.M(Patch_id).t) ~(graph : Graph.t)
     ~(main_branch : Branch.t) ~(agents_by_id : Patch_agent.t Map.M(Patch_id).t)
-    =
+    ~(resolve_routing : complexity:int option -> Backend_routing.decision) =
   let patch_id = agent.patch_id in
   let patch_opt = Map.find patches_by_id patch_id in
+  let complexity = Option.bind patch_opt ~f:(fun p -> p.Patch.complexity) in
+  let { Backend_routing.backend = backend_name; model } =
+    resolve_routing ~complexity
+  in
   let title =
     match patch_opt with
     | Some p -> p.Patch.title
@@ -612,6 +619,9 @@ let patch_view_of_agent (agent : Patch_agent.t)
     automerge_enabled = agent.automerge_enabled;
     automerge_deadline = agent.automerge_deadline;
     automerge_failure_count = agent.automerge_failure_count;
+    complexity;
+    backend = backend_name;
+    model;
   }
 
 (** {1 Render helpers} *)
@@ -854,6 +864,11 @@ let detail_info_rows (pv : patch_view) ~width ~now =
         | None -> "(not set)");
       fit_value "  Worktree:    "
         (match pv.worktree_path with Some p -> p | None -> "(none)");
+      Printf.sprintf "  Complexity:  %s"
+        (match pv.complexity with Some n -> Int.to_string n | None -> "—");
+      fit_value "  Backend:     " pv.backend;
+      fit_value "  Model:       "
+        (match pv.model with Some m -> m | None -> "(backend default)");
       Printf.sprintf "  PR:          %s"
         (match pv.pr_number with
         | Some n -> Printf.sprintf "#%d" (Pr_number.to_int n)
@@ -1255,6 +1270,7 @@ let detail_info_height (pv : patch_view) =
 
 let views_of_orchestrator ~(orchestrator : Orchestrator.t)
     ~(gameplan : Gameplan.t) ~(activity : activity_entry list)
+    ~(resolve_routing : complexity:int option -> Backend_routing.decision)
     ?(intervention_reasons = Map.Poly.empty) () =
   let agents = Orchestrator.all_agents orchestrator in
   let graph = Orchestrator.graph orchestrator in
@@ -1273,7 +1289,7 @@ let views_of_orchestrator ~(orchestrator : Orchestrator.t)
         let main_branch = Orchestrator.main_branch orchestrator in
         let pv =
           patch_view_of_agent agent ~patches_by_id ~graph ~main_branch
-            ~agents_by_id
+            ~agents_by_id ~resolve_routing
         in
         let pid_str = Patch_id.to_string agent.patch_id in
         let filtered =

--- a/lib/tui.mli
+++ b/lib/tui.mli
@@ -100,6 +100,16 @@ type patch_view = {
   automerge_enabled : bool;
   automerge_deadline : float option;
   automerge_failure_count : int;
+  complexity : int option;
+      (** Gameplan-author's complexity tier for this patch (1/2/3), or [None]
+          when the gameplan didn't specify. *)
+  backend : string;
+      (** Backend name (e.g. ["claude"], ["codex"]) routed to for this patch
+          given its complexity, the CLI flags, and the repo config. *)
+  model : string option;
+      (** Concrete model name the patch will run under (auto sentinel already
+          resolved), or [None] when no [--model] flag was supplied and the
+          backend uses its built-in default. *)
 }
 
 (** {2 Frame rendering} *)
@@ -130,6 +140,7 @@ val views_of_orchestrator :
   orchestrator:Orchestrator.t ->
   gameplan:Gameplan.t ->
   activity:activity_entry list ->
+  resolve_routing:(complexity:int option -> Backend_routing.decision) ->
   ?intervention_reasons:(Patch_id.t, string) Map.Poly.t ->
   unit ->
   patch_view list


### PR DESCRIPTION
## Summary

The routing layer added in #233 picks a `(backend, model)` per patch from complexity + repo config + CLI flags, but none of that was visible in the TUI — the summary line only showed the run-wide default. This change surfaces the resolved values on the per-patch detail pane.

- New rows in the detail pane (between **Worktree** and **PR**): `Complexity`, `Backend`, `Model`.
- The `auto` sentinel is inlined to the concrete model name the backend would pick (e.g. `gpt-5.4`, `opus`) so users see what will actually run.
- List view intentionally unchanged — most runs use a single backend, and per-row badges would be clutter.

### How it's wired

- Each backend's hardcoded complexity → model ladder is exposed via `auto_model` in its `.mli`; `Backend_registry.auto_model ~backend ~complexity` dispatches by name.
- A new `Backend_routing.resolve_auto` post-processes a `decision` to inline `Some "auto"`.
- `Tui.patch_view` gains `complexity`, `backend`, `model` fields, populated in `views_of_orchestrator` via an injected `~resolve_routing` callback.
- `bin/main.ml` defines `resolve_routing` next to `pick_backend` and threads it to both `views_of_orchestrator` call sites.

## Test plan

- [x] `dune build` (zero warnings under `-fatal-warnings`)
- [x] `dune runtest` — all existing tests pass; 4 new inline `%test`s in `backend_routing.ml` cover `resolve_auto` (auto / AUTO / explicit / None)
- [x] `dune fmt` clean
- [ ] Manual smoke against a multi-tier gameplan with `--model auto` + a `repo_config` route map; confirm each patch's detail pane shows the routed `(backend, model)` and complexity matches the gameplan

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/234"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the routed backend and model per patch in the TUI detail pane, with `auto` resolved to the concrete model so users see what will actually run. List view stays the same to avoid clutter.

- **New Features**
  - Detail pane adds “Complexity”, “Backend”, and “Model” rows (between Worktree and PR).
  - Resolves `auto` to the backend’s concrete model (e.g., `gpt-5.4`, `opus`); shows backend default when unset.
  - Values reflect complexity + repo config + CLI flags for each patch.

- **Refactors**
  - Exposed per-backend `auto_model` and added `Backend_registry.auto_model` for complexity→model lookup.
  - Added `Backend_routing.resolve_auto` and wired a `resolve_routing` callback through TUI and `bin/main.ml` to populate per-patch fields; included inline tests.

<sup>Written for commit e2ff61985158ce491b3be6dc31aecad0ceb033c4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * TUI now displays routing information including complexity level, selected backend, and concrete model selection for improved visibility into patch execution decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->