### PR TITLE
[headless-cache-tuning] Patch 2: Add --exclude-dynamic-system-prompt-sections to Claude args

### DIFF
--- a/lib/claude_runner.ml
+++ b/lib/claude_runner.ml
@@ -366,6 +366,10 @@ let%test "build_args with resume session" =
       "--exclude-dynamic-system-prompt-sections";
     ]
 
+let%test "build_args includes --exclude-dynamic-system-prompt-sections" =
+  let args = build_args ~model:None ~prompt:"do stuff" ~resume_session:None in
+  List.mem args "--exclude-dynamic-system-prompt-sections" ~equal:String.equal
+
 let%test "build_stream_args fresh (no resume, with model)" =
   let args =
     build_stream_args ~model:(Some "sonnet") ~prompt:"do stuff"

--- a/lib/claude_runner.ml
+++ b/lib/claude_runner.ml
@@ -59,7 +59,14 @@ let build_args ~model ~prompt ~resume_session =
   let session_args =
     match resume_session with Some id -> [ "--resume"; id ] | None -> []
   in
-  let flags = [ "--dangerously-skip-permissions"; "--max-turns"; "200" ] in
+  let flags =
+    [
+      "--dangerously-skip-permissions";
+      "--max-turns";
+      "200";
+      "--exclude-dynamic-system-prompt-sections";
+    ]
+  in
   base @ model_args model @ prompt_args @ session_args @ flags
 
 let build_stream_args ~model ~prompt ~resume_session =
@@ -70,7 +77,14 @@ let build_stream_args ~model ~prompt ~resume_session =
   let session_args =
     match resume_session with Some id -> [ "--resume"; id ] | None -> []
   in
-  let flags = [ "--dangerously-skip-permissions"; "--max-turns"; "200" ] in
+  let flags =
+    [
+      "--dangerously-skip-permissions";
+      "--max-turns";
+      "200";
+      "--exclude-dynamic-system-prompt-sections";
+    ]
+  in
   base @ model_args model @ prompt_args @ session_args @ flags
 
 (** Find the first '\{' in [s] and return the substring starting there. Defense
@@ -312,6 +326,7 @@ let%test "build_args fresh (no resume, with model)" =
       "--dangerously-skip-permissions";
       "--max-turns";
       "200";
+      "--exclude-dynamic-system-prompt-sections";
     ]
 
 let%test "build_args fresh (no resume, no model)" =
@@ -326,6 +341,7 @@ let%test "build_args fresh (no resume, no model)" =
       "--dangerously-skip-permissions";
       "--max-turns";
       "200";
+      "--exclude-dynamic-system-prompt-sections";
     ]
 
 let%test "build_args with resume session" =
@@ -347,6 +363,7 @@ let%test "build_args with resume session" =
       "--dangerously-skip-permissions";
       "--max-turns";
       "200";
+      "--exclude-dynamic-system-prompt-sections";
     ]
 
 let%test "build_stream_args fresh (no resume, with model)" =
@@ -367,6 +384,7 @@ let%test "build_stream_args fresh (no resume, with model)" =
       "--dangerously-skip-permissions";
       "--max-turns";
       "200";
+      "--exclude-dynamic-system-prompt-sections";
     ]
 
 let%test "build_stream_args fresh (no resume, no model)" =
@@ -384,6 +402,7 @@ let%test "build_stream_args fresh (no resume, no model)" =
       "--dangerously-skip-permissions";
       "--max-turns";
       "200";
+      "--exclude-dynamic-system-prompt-sections";
     ]
 
 let%test "build_stream_args with resume session" =
@@ -406,7 +425,14 @@ let%test "build_stream_args with resume session" =
       "--dangerously-skip-permissions";
       "--max-turns";
       "200";
+      "--exclude-dynamic-system-prompt-sections";
     ]
+
+let%test "build_stream_args includes --exclude-dynamic-system-prompt-sections" =
+  let args =
+    build_stream_args ~model:None ~prompt:"do stuff" ~resume_session:None
+  in
+  List.mem args "--exclude-dynamic-system-prompt-sections" ~equal:String.equal
 
 let%test "strip_ansi removes escape sequences" =
   String.equal (strip_ansi "\027[31mhello\027[0m") "hello"


### PR DESCRIPTION
## Patch 2: Add --exclude-dynamic-system-prompt-sections to Claude args

- In build_args: extend `flags = [ "--dangerously-skip-permissions"; "--max-turns"; "200" ]` to also include `"--exclude-dynamic-system-prompt-sections"`.
- In build_stream_args: same change.
- Update the inline tests `build_args fresh (no resume, with model)`, `build_args fresh (no resume, no model)`, `build_args with resume session`, and the three `build_stream_args ...` tests to expect the new flag at the appropriate position.
- Add an inline test `build_stream_args includes --exclude-dynamic-system-prompt-sections` that asserts the flag appears in the result.

## Changes
- In build_args: extend `flags = [ "--dangerously-skip-permissions"; "--max-turns"; "200" ]` to also include `"--exclude-dynamic-system-prompt-sections"`.
- In build_stream_args: same change.
- Update the inline tests `build_args fresh (no resume, with model)`, `build_args fresh (no resume, no model)`, `build_args with resume session`, and the three `build_stream_args ...` tests to expect the new flag at the appropriate position.
- Add an inline test `build_stream_args includes --exclude-dynamic-system-prompt-sections` that asserts the flag appears in the result.

## Files to Modify
- lib/claude_runner.ml (modify): Append --exclude-dynamic-system-prompt-sections to the flag list in build_args and build_stream_args. Update the inline tests that pin the exact argv ordering.

## Gameplan Specification

```
module HEADLESS_CACHE_TUNING.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> After this gameplan, every onton-spawned coding-agent
> invocation is tuned for prompt-cache reuse and bounded
> token consumption. Static prompt prefixes are reused
> across patches in one gameplan. Isolated per-spawn
> config dirs stabilise spawn environment. Onton-minted
> session UUIDs remove the parsing race and enable resume
> without re-sending the prompt. Turn caps scale with
> complexity. Per-spawn USD budget caps put a hard floor
> under runaway token spend.

Patch.
Gameplan.
Spawn.
Arg.
Prompt.
Text.
SessionId.
Dir.
Backend.

claude => Backend.
codex => Backend.
pi => Backend.

backend s: Spawn => Backend.
spawn-of p: Patch => Spawn.
complexity p: Patch => Nat.

render p: Patch, gp: Gameplan => Prompt.
prefix pr: Prompt => Text.
suffix pr: Prompt => Text.
shared? t: Text, gp: Gameplan => Bool.
specific? t: Text, p: Patch => Bool.

args s: Spawn => Arg.
has-flag? a: Arg, name: String => Bool.

config-dir s: Spawn => Dir.
max-turns s: Spawn => Nat.

session-id p: Patch => SessionId.
persisted-before-spawn? id: SessionId, s: Spawn => Bool.
passed-to-cli? id: SessionId, s: Spawn => Bool.
minted-session-flag-on? => Bool.

budget-cap-set? s: Spawn => Bool.
flag-emitted? s: Spawn => Bool.
cost-tracked? s: Spawn => Bool.
self-terminates-on-overshoot? s: Spawn => Bool.

bare-flag-on? => Bool.
worktree-claude-md p: Patch => Text.
non-empty? t: Text => Bool.
prompt-of s: Spawn => Prompt.
contains? t: Text, sub: String => Bool.
---

> Static prefix is gameplan-shared.
all p: Patch, gp: Gameplan | shared? (prefix (render p gp)) gp.

> Dynamic suffix is patch-specific.
all p: Patch, gp: Gameplan | specific? (suffix (render p gp)) p.

> Claude spawns pass --exclude-dynamic-system-prompt-sections.
all s: Spawn, backend s = claude |
  has-flag? (args s) "--exclude-dynamic-system-prompt-sections".

> Distinct patches have distinct config dirs.
all p1: Patch, p2: Patch, p1 ~= p2 |
  config-dir (spawn-of p1) ~= config-dir (spawn-of p2).

> Turn caps are monotone non-decreasing in complexity.
all p1: Patch, p2: Patch, complexity p1 < complexity p2 |
  max-turns (spawn-of p1) <= max-turns (spawn-of p2).

> Session-ID minting (when enabled) persists before spawn and
> passes to the CLI.
all p: Patch, minted-session-flag-on? |
  persisted-before-spawn? (session-id p) (spawn-of p).

all p: Patch, minted-session-flag-on? |
  passed-to-cli? (session-id p) (spawn-of p).

> When the budget cap is set, Claude spawns emit the flag and
> Codex spawns track cost + self-terminate.
all s: Spawn, backend s = claude, budget-cap-set? s |
  flag-emitted? s.

all s: Spawn, backend s = codex, budget-cap-set? s |
  cost-tracked? s and self-terminates-on-overshoot? s.

> When --bare is enabled, Claude spawns pass --bare and the
> worktree's CLAUDE.md content is reachable from the spawn's
> prompt prefix.
all p: Patch, bare-flag-on?, backend (spawn-of p) = claude |
  has-flag? (args (spawn-of p)) "--bare".

all p: Patch, bare-flag-on?, non-empty? (worktree-claude-md p) |
  contains? (prefix (prompt-of (spawn-of p))) "CLAUDE.md".

```

## Patch Specification

```
module HEADLESS_CACHE_TUNING_PATCH_2.

> Patch 2 adds --exclude-dynamic-system-prompt-sections to
> Claude's argv. Volatile content (cwd, env, git status) is
> kept out of the cacheable system prompt.

Spawn.
Arg.
Backend.

claude => Backend.
backend s: Spawn => Backend.
args s: Spawn => Arg.
has-flag? a: Arg, name: String => Bool.
---

> Every Claude spawn passes the flag.
all s: Spawn, backend s = claude |
  has-flag? (args s) "--exclude-dynamic-system-prompt-sections".

```


## Implementation Notes

- Appended the flag to the shared trailing argv block in both Claude builders so the exact ordering stays stable across the text and stream-json paths.
- Added one explicit membership test for `build_stream_args` in addition to updating the full-argv equality checks, so the new flag is covered both structurally and behaviorally.
- No other runtime behavior changed in this patch; the change is limited to Claude CLI argument construction and its inline tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the `--exclude-dynamic-system-prompt-sections` flag to all Claude runs (text and streaming) to keep volatile system prompt parts out of cache. This improves prompt-cache reuse and stabilizes token usage.

- **New Features**
  - Pass the flag in `build_args` and `build_stream_args`.
  - Update inline tests to expect the flag and add direct presence checks for both text and streaming args.

<sup>Written for commit 3d8fbfdd54f927d486483f68563b3b5f7c44ce21. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--exclude-dynamic-system-prompt-sections` CLI flag for runtime configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->