### PR TITLE
[headless-cache-tuning] Patch 1: Restructure render_patch_prompt for cacheable static prefix

### DIFF
--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -131,7 +131,7 @@ let render_patch_prompt ~(project_name : string) ?pr_number (patch : Patch.t)
          branch. Your worktree already contains that patch's changes. This is \
          expected — build on top of those changes. Your PR will target `%s`, \
          so the diff should only show YOUR patch's changes, not the \
-         dependency's.\n"
+         dependency's.\n\n"
         base_branch base_branch
   in
   let pr_instructions =

--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -127,8 +127,7 @@ let render_patch_prompt ~(project_name : string) ?pr_number (patch : Patch.t)
     if String.equal base_branch "main" then ""
     else
       Printf.sprintf
-        "\n\
-         **NOTE:** Your branch is based on `%s`, which is a dependency patch's \
+        "**NOTE:** Your branch is based on `%s`, which is a dependency patch's \
          branch. Your worktree already contains that patch's changes. This is \
          expected — build on top of those changes. Your PR will target `%s`, \
          so the diff should only show YOUR patch's changes, not the \
@@ -986,12 +985,12 @@ let%test "patch prompt includes title and deps" =
   && String.is_substring result ~substring:"Patch 1: Core types"
   && String.is_substring result ~substring:"## Patch 5: Prompt renderer"
 
-let prompt_prefix_through_patch_heading prompt =
-  match String.substr_index prompt ~pattern:"## Patch " with
-  | None -> None
-  | Some idx -> Some (String.prefix prompt (idx + String.length "## Patch "))
-
 let%test "patch prompt static prefix is byte-identical across patches" =
+  let prompt_prefix_through_patch_heading prompt =
+    match String.substr_index prompt ~pattern:"## Patch " with
+    | None -> None
+    | Some idx -> Some (String.prefix prompt (idx + String.length "## Patch "))
+  in
   let patch_1 : Patch.t =
     Patch.
       {

--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -241,7 +241,7 @@ Continue implementing until all tests pass.|}
   in
   render_with_override ~project_name ~name:"patch" ~vars ~default:(fun () ->
       substitute_variables
-        {|# [{{project_name}}] Patch {{patch_id}}{{classification_note}}: {{title}}
+        {|# [{{project_name}}]
 
 ## Problem Statement
 {{problem_statement}}
@@ -249,20 +249,23 @@ Continue implementing until all tests pass.|}
 ## Solution Summary
 {{solution_summary}}
 {{final_state_spec_section}}{{explicit_opinions_section}}{{current_state_section}}
+## Patches in Gameplan
+{{patches_list}}
+
+## Patch {{patch_id}}{{classification_note}}: {{title}}
+
 ## Dependencies
 {{dependencies}}
 
 ## Your Task
 
-{{description}}
+{{base_branch_note}}{{description}}
 {{changes_section}}{{files_section}}{{test_stubs_introduced_section}}{{test_stubs_implemented_section}}{{spec_section}}{{acceptance_criteria_section}}
 ## Git Instructions
 - Branch: {{branch}}
 - Base branch: {{base_branch}}
 - PR: {{pr_str}}
-{{base_branch_note}}{{pr_instructions}}
-## Patches in Gameplan
-{{patches_list}}|}
+{{pr_instructions}}|}
         vars)
 
 let render_spec_suffix (patch : Patch.t) (gameplan : Gameplan.t) : string =
@@ -978,11 +981,85 @@ let%test "patch prompt includes title and deps" =
     render_patch_prompt ~project_name:"onton-port" patch gameplan
       ~base_branch:"onton-port/patch-1"
   in
-  String.is_substring result
-    ~substring:"# [onton-port] Patch 5: Prompt renderer"
+  String.is_substring result ~substring:"# [onton-port]\n"
   && String.is_substring result ~substring:"Patches 1"
   && String.is_substring result ~substring:"Patch 1: Core types"
-  && String.is_substring result ~substring:"Patch 5: Prompt renderer"
+  && String.is_substring result ~substring:"## Patch 5: Prompt renderer"
+
+let prompt_prefix_through_patch_heading prompt =
+  match String.substr_index prompt ~pattern:"## Patch " with
+  | None -> None
+  | Some idx -> Some (String.prefix prompt (idx + String.length "## Patch "))
+
+let%test "patch prompt static prefix is byte-identical across patches" =
+  let patch_1 : Patch.t =
+    Patch.
+      {
+        id = Patch_id.of_string "1";
+        title = "Restructure prompt";
+        description = "Make shared content static.";
+        branch = Branch.of_string "headless-cache-tuning/patch-1";
+        dependencies = [];
+        spec = "module P1.";
+        acceptance_criteria = [ "Prefix is stable." ];
+        files = [ "lib/prompt.ml" ];
+        classification = "INFRA";
+        changes = [ "Move shared sections above patch heading." ];
+        test_stubs_introduced = [];
+        test_stubs_implemented =
+          [
+            "Prompt > static prefix is byte-identical across patches in one \
+             gameplan";
+          ];
+        complexity = None;
+      }
+  in
+  let patch_2 : Patch.t =
+    Patch.
+      {
+        id = Patch_id.of_string "2";
+        title = "Add Claude flags";
+        description = "Add spawn args.";
+        branch = Branch.of_string "headless-cache-tuning/patch-2";
+        dependencies = [ Patch_id.of_string "1" ];
+        spec = "module P2.";
+        acceptance_criteria = [ "Claude gets the new flag." ];
+        files = [ "lib/claude_runner.ml" ];
+        classification = "INFRA";
+        changes = [ "Emit exclude-dynamic-system-prompt-sections." ];
+        test_stubs_introduced = [];
+        test_stubs_implemented = [];
+        complexity = None;
+      }
+  in
+  let gameplan : Gameplan.t =
+    Gameplan.
+      {
+        project_name = "onton";
+        problem_statement = "Prompt cache hit rate is low.";
+        solution_summary = "Move shared prompt content into a stable prefix.";
+        final_state_spec = "module HEADLESS_CACHE_TUNING.";
+        current_state_analysis = "Patch-specific text currently appears first.";
+        explicit_opinions = "- Use env vars for flags.";
+        acceptance_criteria = [];
+        open_questions = [];
+        patches = [ patch_1; patch_2 ];
+      }
+  in
+  let prompt_1 =
+    render_patch_prompt ~project_name:"onton" patch_1 gameplan
+      ~base_branch:"main"
+  in
+  let prompt_2 =
+    render_patch_prompt ~project_name:"onton" patch_2 gameplan
+      ~base_branch:"headless-cache-tuning/patch-1"
+  in
+  match
+    ( prompt_prefix_through_patch_heading prompt_1,
+      prompt_prefix_through_patch_heading prompt_2 )
+  with
+  | Some prefix_1, Some prefix_2 -> String.equal prefix_1 prefix_2
+  | _ -> false
 
 let%test "substitute_variables replaces placeholders" =
   let result =

--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -987,9 +987,13 @@ let%test "patch prompt includes title and deps" =
 
 let%test "patch prompt static prefix is byte-identical across patches" =
   let prompt_prefix_through_patch_heading prompt =
-    match String.substr_index prompt ~pattern:"## Patch " with
+    let marker = "## Patch " in
+    let all =
+      String.substr_index_all prompt ~pattern:marker ~may_overlap:false
+    in
+    match List.last all with
     | None -> None
-    | Some idx -> Some (String.prefix prompt (idx + String.length "## Patch "))
+    | Some idx -> Some (String.prefix prompt (idx + String.length marker))
   in
   let patch_1 : Patch.t =
     Patch.
@@ -1035,11 +1039,12 @@ let%test "patch prompt static prefix is byte-identical across patches" =
     Gameplan.
       {
         project_name = "onton";
-        problem_statement = "Prompt cache hit rate is low.";
+        problem_statement = "Prompt cache hit rate is low.\n\n## Patch notes";
         solution_summary = "Move shared prompt content into a stable prefix.";
-        final_state_spec = "module HEADLESS_CACHE_TUNING.";
-        current_state_analysis = "Patch-specific text currently appears first.";
-        explicit_opinions = "- Use env vars for flags.";
+        final_state_spec = "module HEADLESS_CACHE_TUNING.\n\n## Patch state.";
+        current_state_analysis =
+          "Patch-specific text currently appears first.\n\n## Patch drift.";
+        explicit_opinions = "- Use env vars for flags.\n- ## Patch fallback.";
         acceptance_criteria = [];
         open_questions = [];
         patches = [ patch_1; patch_2 ];

--- a/lib/prompt.mli
+++ b/lib/prompt.mli
@@ -15,7 +15,9 @@ val render_patch_prompt :
   string
 (** Renders the patch prompt such that the prefix up to and including the
     [`## Patch `] heading marker is gameplan-stable and intended for
-    prompt-cache reuse across patches in the same orchestrator run. *)
+    prompt-cache reuse across patches in the same orchestrator run when using
+    the built-in default template. Project-level prompt overrides are
+    user-controlled and may not preserve this structure. *)
 
 val render_pr_description :
   project_name:string -> Patch.t -> Gameplan.t -> string

--- a/lib/prompt.mli
+++ b/lib/prompt.mli
@@ -13,6 +13,9 @@ val render_patch_prompt :
   Gameplan.t ->
   base_branch:string ->
   string
+(** Renders the patch prompt such that the prefix up to and including the
+    [`## Patch `] heading marker is gameplan-stable and intended for
+    prompt-cache reuse across patches in the same orchestrator run. *)
 
 val render_pr_description :
   project_name:string -> Patch.t -> Gameplan.t -> string


### PR DESCRIPTION
## Patch 1: Restructure render_patch_prompt for cacheable static prefix

- Reorder the `default` template inside render_patch_prompt: top section is `# [{{project_name}}]` banner, problem statement, solution summary, final_state_spec_section, explicit_opinions_section, current_state_section, patches_list.
- After the static block, emit `## Patch {{patch_id}}{{classification_note}}: {{title}}` as the boundary heading.
- Below the heading: dependencies, base_branch_note, description, changes_section, files_section, test_stubs_introduced_section, test_stubs_implemented_section, spec_section, acceptance_criteria_section, branch/base_branch/PR git instructions, pr_instructions.
- Add an inline test verifying that for two patches in the same gameplan, the substring up to and including `## Patch ` is byte-identical.

## Changes
- Reorder the `default` template inside render_patch_prompt: top section is `# [{{project_name}}]` banner, problem statement, solution summary, final_state_spec_section, explicit_opinions_section, current_state_section, patches_list.
- After the static block, emit `## Patch {{patch_id}}{{classification_note}}: {{title}}` as the boundary heading.
- Below the heading: dependencies, base_branch_note, description, changes_section, files_section, test_stubs_introduced_section, test_stubs_implemented_section, spec_section, acceptance_criteria_section, branch/base_branch/PR git instructions, pr_instructions.
- Add an inline test verifying that for two patches in the same gameplan, the substring up to and including `## Patch ` is byte-identical.

## Files to Modify
- lib/prompt.ml (modify): Move all gameplan-shared content (project_name banner, problem statement, solution summary, final state spec, explicit opinions, current state analysis, patches list) above all patch-specific content (title, classification, dependencies, branch, PR, description, changes, files, test stubs, spec, acceptance criteria, git instructions). Add a `## Patch <id>: <title>` heading as the boundary marker between the static prefix and the dynamic suffix.
- lib/prompt.mli (modify): Document in a comment that the rendered prompt's prefix-up-to-the-Patch-heading is gameplan-stable and intended for prompt-cache reuse.

## Gameplan Specification

```
module HEADLESS_CACHE_TUNING.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> After this gameplan, every onton-spawned coding-agent
> invocation is tuned for prompt-cache reuse and bounded
> token consumption. Static prompt prefixes are reused
> across patches in one gameplan. Isolated per-spawn
> config dirs stabilise spawn environment. Onton-minted
> session UUIDs remove the parsing race and enable resume
> without re-sending the prompt. Turn caps scale with
> complexity. Per-spawn USD budget caps put a hard floor
> under runaway token spend.

Patch.
Gameplan.
Spawn.
Arg.
Prompt.
Text.
SessionId.
Dir.
Backend.

claude => Backend.
codex => Backend.
pi => Backend.

backend s: Spawn => Backend.
spawn-of p: Patch => Spawn.
complexity p: Patch => Nat.

render p: Patch, gp: Gameplan => Prompt.
prefix pr: Prompt => Text.
suffix pr: Prompt => Text.
shared? t: Text, gp: Gameplan => Bool.
specific? t: Text, p: Patch => Bool.

args s: Spawn => Arg.
has-flag? a: Arg, name: String => Bool.

config-dir s: Spawn => Dir.
max-turns s: Spawn => Nat.

session-id p: Patch => SessionId.
persisted-before-spawn? id: SessionId, s: Spawn => Bool.
passed-to-cli? id: SessionId, s: Spawn => Bool.
minted-session-flag-on? => Bool.

budget-cap-set? s: Spawn => Bool.
flag-emitted? s: Spawn => Bool.
cost-tracked? s: Spawn => Bool.
self-terminates-on-overshoot? s: Spawn => Bool.

bare-flag-on? => Bool.
worktree-claude-md p: Patch => Text.
non-empty? t: Text => Bool.
prompt-of s: Spawn => Prompt.
contains? t: Text, sub: String => Bool.
---

> Static prefix is gameplan-shared.
all p: Patch, gp: Gameplan | shared? (prefix (render p gp)) gp.

> Dynamic suffix is patch-specific.
all p: Patch, gp: Gameplan | specific? (suffix (render p gp)) p.

> Claude spawns pass --exclude-dynamic-system-prompt-sections.
all s: Spawn, backend s = claude |
  has-flag? (args s) "--exclude-dynamic-system-prompt-sections".

> Distinct patches have distinct config dirs.
all p1: Patch, p2: Patch, p1 ~= p2 |
  config-dir (spawn-of p1) ~= config-dir (spawn-of p2).

> Turn caps are monotone non-decreasing in complexity.
all p1: Patch, p2: Patch, complexity p1 < complexity p2 |
  max-turns (spawn-of p1) <= max-turns (spawn-of p2).

> Session-ID minting (when enabled) persists before spawn and
> passes to the CLI.
all p: Patch, minted-session-flag-on? |
  persisted-before-spawn? (session-id p) (spawn-of p).

all p: Patch, minted-session-flag-on? |
  passed-to-cli? (session-id p) (spawn-of p).

> When the budget cap is set, Claude spawns emit the flag and
> Codex spawns track cost + self-terminate.
all s: Spawn, backend s = claude, budget-cap-set? s |
  flag-emitted? s.

all s: Spawn, backend s = codex, budget-cap-set? s |
  cost-tracked? s and self-terminates-on-overshoot? s.

> When --bare is enabled, Claude spawns pass --bare and the
> worktree's CLAUDE.md content is reachable from the spawn's
> prompt prefix.
all p: Patch, bare-flag-on?, backend (spawn-of p) = claude |
  has-flag? (args (spawn-of p)) "--bare".

all p: Patch, bare-flag-on?, non-empty? (worktree-claude-md p) |
  contains? (prefix (prompt-of (spawn-of p))) "CLAUDE.md".

```

## Patch Specification

```
module HEADLESS_CACHE_TUNING_PATCH_1.

> Patch 1 reshapes the rendered patch prompt into a
> static-prefix / dynamic-suffix layout. The static prefix
> is shared across every patch in one gameplan; the suffix
> is patch-specific. This enables prompt-cache reuse on the
> server side: the long, identical prefix is cached once and
> reused for every patch in the run.

Patch.
Gameplan.
Prompt.
Text.

render p: Patch, gp: Gameplan => Prompt.
prefix pr: Prompt => Text.
suffix pr: Prompt => Text.
shared? t: Text, gp: Gameplan => Bool.
specific? t: Text, p: Patch => Bool.
---

> Every patch's rendered prefix is gameplan-shared.
all p: Patch, gp: Gameplan | shared? (prefix (render p gp)) gp.

> The dynamic suffix is patch-specific.
all p: Patch, gp: Gameplan | specific? (suffix (render p gp)) p.

```


## Implementation Notes

- The cache boundary test compares the rendered prefix through the literal `## Patch ` marker rather than the full heading, so it stays stable even when patch id, classification, title, or base-branch messaging differ.
- I kept the default-template change localized to `render_patch_prompt`; there is no secondary wrapper or post-processing step, so override templates still behave the same way and the cacheability contract lives in one place.
- `base_branch_note` now renders inside the patch-specific body instead of the Git instructions block. That keeps dependency-branch context out of the shared prefix, which matters for retries and later patches in the same run.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restructured the patch prompt into a shared static prefix and a patch-specific suffix to enable prompt-cache reuse and reduce tokens. Hardened the boundary test to use the last `## Patch ` marker for reliable prefix detection.

- **Refactors**
  - Reordered default template: banner, problem, solution, final state, opinions, current state, patches list in static prefix; `## Patch {{patch_id}}{{classification_note}}: {{title}}` starts the dynamic suffix.
  - Moved `base_branch_note` into the patch-specific task body before the description.
  - Tests: assert prefix up to `## Patch ` is byte-identical across patches; updated the title/deps test; boundary lookup now uses the last marker occurrence.
  - Documented the cache boundary in `lib/prompt.mli`; fixed `base_branch_note` spacing (no leading newline, extra trailing newline).

<sup>Written for commit 0d6758f1d06b6ae2388f5ef5fb4035d8cc081fde. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Reorganized prompt layout for clearer, more consistent patch notes (sections reordered, spacing adjusted, and instruction placement refined).
  * Stabilized the prompt prefix up through the patch heading to enable safe prompt caching and faster repeated operations.
* **Documentation**
  * Added clarifying documentation about the stable prompt prefix and layout expectations.
* **Tests**
  * Updated and added tests to assert the new initial layout and stable prefix behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->