### PR TITLE
[headless-cache-tuning] Patch 4: Scale --max-turns with patch complexity

### DIFF
--- a/lib/claude_runner.ml
+++ b/lib/claude_runner.ml
@@ -53,7 +53,10 @@ let model_args = function
   | Some m when not (String.is_empty m) -> [ "--model"; m ]
   | _ -> []
 
-let build_args ~model ~prompt ~resume_session =
+let max_turns_for ~complexity =
+  match complexity with Some 1 -> 50 | Some 2 -> 100 | _ -> 200
+
+let build_args ~model ~complexity ~prompt ~resume_session =
   let base = [ "claude" ] in
   let prompt_args = [ "-p"; prompt; "--output-format"; "text" ] in
   let session_args =
@@ -63,13 +66,13 @@ let build_args ~model ~prompt ~resume_session =
     [
       "--dangerously-skip-permissions";
       "--max-turns";
-      "200";
+      Int.to_string (max_turns_for ~complexity);
       "--exclude-dynamic-system-prompt-sections";
     ]
   in
   base @ model_args model @ prompt_args @ session_args @ flags
 
-let build_stream_args ~model ~prompt ~resume_session =
+let build_stream_args ~model ~complexity ~prompt ~resume_session =
   let base = [ "claude" ] in
   let prompt_args =
     [ "-p"; prompt; "--output-format"; "stream-json"; "--verbose" ]
@@ -81,7 +84,7 @@ let build_stream_args ~model ~prompt ~resume_session =
     [
       "--dangerously-skip-permissions";
       "--max-turns";
-      "200";
+      Int.to_string (max_turns_for ~complexity);
       "--exclude-dynamic-system-prompt-sections";
     ]
   in
@@ -227,9 +230,9 @@ let parse_stream_events (line : string) : Types.Stream_event.t list =
 let parse_stream_event (line : string) : Types.Stream_event.t option =
   match parse_stream_events line with [] -> None | e :: _ -> Some e
 
-let run ~model ~process_mgr ~cwd ~patch_id ~prompt ~resume_session =
+let run ~model ~process_mgr ~cwd ~patch_id ~prompt ~resume_session ~complexity =
   ignore (patch_id : Types.Patch_id.t);
-  let args = build_args ~model ~prompt ~resume_session in
+  let args = build_args ~model ~complexity ~prompt ~resume_session in
   let stdout_content, stderr_content, exit_code =
     Eio.Switch.run @@ fun sw ->
     let stdin_r, stdin_w = Eio.Process.pipe ~sw process_mgr in
@@ -286,7 +289,7 @@ let run ~model ~process_mgr ~cwd ~patch_id ~prompt ~resume_session =
 let run_streaming ~model ~process_mgr ~clock ~timeout ~setsid_exec ~project_name
     ~cwd ~patch_id ~prompt ~resume_session ~complexity ~on_event =
   let model = Llm_backend.resolve_auto_model ~model ~complexity ~auto_model in
-  let args = build_stream_args ~model ~prompt ~resume_session in
+  let args = build_stream_args ~model ~complexity ~prompt ~resume_session in
   let env =
     Spawn_env.merge_env ~base_env:(Unix.environment ())
       ~overrides:(Spawn_env.per_patch_env ~project_name ~patch_id)
@@ -313,9 +316,23 @@ let%test "auto_model: None -> opus (conservative)" =
 let%test "auto_model: out-of-range -> opus (conservative)" =
   Option.equal String.equal (auto_model ~complexity:(Some 7)) (Some "opus")
 
+let%test "max_turns_for: complexity 1 -> 50" =
+  Int.equal (max_turns_for ~complexity:(Some 1)) 50
+
+let%test "max_turns_for: complexity 2 -> 100" =
+  Int.equal (max_turns_for ~complexity:(Some 2)) 100
+
+let%test "max_turns_for: complexity 3 -> 200" =
+  Int.equal (max_turns_for ~complexity:(Some 3)) 200
+
+let%test "max_turns_for: None -> 200" =
+  Int.equal (max_turns_for ~complexity:None) 200
+
 let%test "build_args fresh (no resume, with model)" =
+  let complexity = Some 2 in
   let args =
-    build_args ~model:(Some "sonnet") ~prompt:"do stuff" ~resume_session:None
+    build_args ~model:(Some "sonnet") ~complexity ~prompt:"do stuff"
+      ~resume_session:None
   in
   List.equal String.equal args
     [
@@ -328,12 +345,15 @@ let%test "build_args fresh (no resume, with model)" =
       "text";
       "--dangerously-skip-permissions";
       "--max-turns";
-      "200";
+      "100";
       "--exclude-dynamic-system-prompt-sections";
     ]
 
 let%test "build_args fresh (no resume, no model)" =
-  let args = build_args ~model:None ~prompt:"do stuff" ~resume_session:None in
+  let complexity = Some 1 in
+  let args =
+    build_args ~model:None ~complexity ~prompt:"do stuff" ~resume_session:None
+  in
   List.equal String.equal args
     [
       "claude";
@@ -343,13 +363,14 @@ let%test "build_args fresh (no resume, no model)" =
       "text";
       "--dangerously-skip-permissions";
       "--max-turns";
-      "200";
+      "50";
       "--exclude-dynamic-system-prompt-sections";
     ]
 
 let%test "build_args with resume session" =
+  let complexity = Some 3 in
   let args =
-    build_args ~model:(Some "opus") ~prompt:"do stuff"
+    build_args ~model:(Some "opus") ~complexity ~prompt:"do stuff"
       ~resume_session:(Some "abc-123")
   in
   List.equal String.equal args
@@ -370,12 +391,16 @@ let%test "build_args with resume session" =
     ]
 
 let%test "build_args includes --exclude-dynamic-system-prompt-sections" =
-  let args = build_args ~model:None ~prompt:"do stuff" ~resume_session:None in
+  let args =
+    build_args ~model:None ~complexity:None ~prompt:"do stuff"
+      ~resume_session:None
+  in
   List.mem args "--exclude-dynamic-system-prompt-sections" ~equal:String.equal
 
 let%test "build_stream_args fresh (no resume, with model)" =
+  let complexity = Some 2 in
   let args =
-    build_stream_args ~model:(Some "sonnet") ~prompt:"do stuff"
+    build_stream_args ~model:(Some "sonnet") ~complexity ~prompt:"do stuff"
       ~resume_session:None
   in
   List.equal String.equal args
@@ -390,13 +415,15 @@ let%test "build_stream_args fresh (no resume, with model)" =
       "--verbose";
       "--dangerously-skip-permissions";
       "--max-turns";
-      "200";
+      "100";
       "--exclude-dynamic-system-prompt-sections";
     ]
 
 let%test "build_stream_args fresh (no resume, no model)" =
+  let complexity = None in
   let args =
-    build_stream_args ~model:None ~prompt:"do stuff" ~resume_session:None
+    build_stream_args ~model:None ~complexity ~prompt:"do stuff"
+      ~resume_session:None
   in
   List.equal String.equal args
     [
@@ -413,8 +440,9 @@ let%test "build_stream_args fresh (no resume, no model)" =
     ]
 
 let%test "build_stream_args with resume session" =
+  let complexity = Some 1 in
   let args =
-    build_stream_args ~model:(Some "opus") ~prompt:"do stuff"
+    build_stream_args ~model:(Some "opus") ~complexity ~prompt:"do stuff"
       ~resume_session:(Some "abc-123")
   in
   List.equal String.equal args
@@ -431,13 +459,14 @@ let%test "build_stream_args with resume session" =
       "abc-123";
       "--dangerously-skip-permissions";
       "--max-turns";
-      "200";
+      "50";
       "--exclude-dynamic-system-prompt-sections";
     ]
 
 let%test "build_stream_args includes --exclude-dynamic-system-prompt-sections" =
   let args =
-    build_stream_args ~model:None ~prompt:"do stuff" ~resume_session:None
+    build_stream_args ~model:None ~complexity:None ~prompt:"do stuff"
+      ~resume_session:None
   in
   List.mem args "--exclude-dynamic-system-prompt-sections" ~equal:String.equal
 

--- a/lib/claude_runner.mli
+++ b/lib/claude_runner.mli
@@ -21,6 +21,7 @@ val run :
   patch_id:Types.Patch_id.t ->
   prompt:string ->
   resume_session:string option ->
+  complexity:int option ->
   Llm_backend.result
 (** Spawn a Claude CLI process for [patch_id] in directory [cwd].
 
@@ -74,6 +75,7 @@ val strip_ansi : string -> string
 
 val build_args :
   model:string option ->
+  complexity:int option ->
   prompt:string ->
   resume_session:string option ->
   string list
@@ -81,6 +83,7 @@ val build_args :
 
 val build_stream_args :
   model:string option ->
+  complexity:int option ->
   prompt:string ->
   resume_session:string option ->
   string list


### PR DESCRIPTION
## Patch 4: Scale --max-turns with patch complexity

- Add `let max_turns_for ~complexity = match complexity with Some 1 -> 50 | Some 2 -> 100 | _ -> 200` (Some 3 and None fall through to 200).
- Thread `complexity` into build_args / build_stream_args so they can compute the cap. (build_stream_args already receives complexity via run_streaming's resolve_auto_model call — extend the build_*_args signature similarly.)
- Update existing inline tests that assert exact argv to use the new variable cap.
- Add inline tests for max_turns_for: 1 -> 50, 2 -> 100, 3 -> 200, None -> 200.

## Changes
- Add `let max_turns_for ~complexity = match complexity with Some 1 -> 50 | Some 2 -> 100 | _ -> 200` (Some 3 and None fall through to 200).
- Thread `complexity` into build_args / build_stream_args so they can compute the cap. (build_stream_args already receives complexity via run_streaming's resolve_auto_model call — extend the build_*_args signature similarly.)
- Update existing inline tests that assert exact argv to use the new variable cap.
- Add inline tests for max_turns_for: 1 -> 50, 2 -> 100, 3 -> 200, None -> 200.

## Files to Modify
- lib/claude_runner.ml (modify): Add `max_turns_for ~complexity` returning 50/100/200 for complexity 1/2/3 (None falls to 200). Replace the hard-coded 200 in build_args and build_stream_args.

## Gameplan Specification

```
module HEADLESS_CACHE_TUNING.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> After this gameplan, every onton-spawned coding-agent
> invocation is tuned for prompt-cache reuse and bounded
> token consumption. Static prompt prefixes are reused
> across patches in one gameplan. Isolated per-spawn
> config dirs stabilise spawn environment. Onton-minted
> session UUIDs remove the parsing race and enable resume
> without re-sending the prompt. Turn caps scale with
> complexity. Per-spawn USD budget caps put a hard floor
> under runaway token spend.

Patch.
Gameplan.
Spawn.
Arg.
Prompt.
Text.
SessionId.
Dir.
Backend.

claude => Backend.
codex => Backend.
pi => Backend.

backend s: Spawn => Backend.
spawn-of p: Patch => Spawn.
complexity p: Patch => Nat.

render p: Patch, gp: Gameplan => Prompt.
prefix pr: Prompt => Text.
suffix pr: Prompt => Text.
shared? t: Text, gp: Gameplan => Bool.
specific? t: Text, p: Patch => Bool.

args s: Spawn => Arg.
has-flag? a: Arg, name: String => Bool.

config-dir s: Spawn => Dir.
max-turns s: Spawn => Nat.

session-id p: Patch => SessionId.
persisted-before-spawn? id: SessionId, s: Spawn => Bool.
passed-to-cli? id: SessionId, s: Spawn => Bool.
minted-session-flag-on? => Bool.

budget-cap-set? s: Spawn => Bool.
flag-emitted? s: Spawn => Bool.
cost-tracked? s: Spawn => Bool.
self-terminates-on-overshoot? s: Spawn => Bool.

bare-flag-on? => Bool.
worktree-claude-md p: Patch => Text.
non-empty? t: Text => Bool.
prompt-of s: Spawn => Prompt.
contains? t: Text, sub: String => Bool.
---

> Static prefix is gameplan-shared.
all p: Patch, gp: Gameplan | shared? (prefix (render p gp)) gp.

> Dynamic suffix is patch-specific.
all p: Patch, gp: Gameplan | specific? (suffix (render p gp)) p.

> Claude spawns pass --exclude-dynamic-system-prompt-sections.
all s: Spawn, backend s = claude |
  has-flag? (args s) "--exclude-dynamic-system-prompt-sections".

> Distinct patches have distinct config dirs.
all p1: Patch, p2: Patch, p1 ~= p2 |
  config-dir (spawn-of p1) ~= config-dir (spawn-of p2).

> Turn caps are monotone non-decreasing in complexity.
all p1: Patch, p2: Patch, complexity p1 < complexity p2 |
  max-turns (spawn-of p1) <= max-turns (spawn-of p2).

> Session-ID minting (when enabled) persists before spawn and
> passes to the CLI.
all p: Patch, minted-session-flag-on? |
  persisted-before-spawn? (session-id p) (spawn-of p).

all p: Patch, minted-session-flag-on? |
  passed-to-cli? (session-id p) (spawn-of p).

> When the budget cap is set, Claude spawns emit the flag and
> Codex spawns track cost + self-terminate.
all s: Spawn, backend s = claude, budget-cap-set? s |
  flag-emitted? s.

all s: Spawn, backend s = codex, budget-cap-set? s |
  cost-tracked? s and self-terminates-on-overshoot? s.

> When --bare is enabled, Claude spawns pass --bare and the
> worktree's CLAUDE.md content is reachable from the spawn's
> prompt prefix.
all p: Patch, bare-flag-on?, backend (spawn-of p) = claude |
  has-flag? (args (spawn-of p)) "--bare".

all p: Patch, bare-flag-on?, non-empty? (worktree-claude-md p) |
  contains? (prefix (prompt-of (spawn-of p))) "CLAUDE.md".

```

## Patch Specification

```
module HEADLESS_CACHE_TUNING_PATCH_4.

> Patch 5 scales --max-turns with patch complexity so simple
> patches can't burn the full 200-turn budget.

Patch.
Spawn.

complexity p: Patch => Nat.
spawn-of p: Patch => Spawn.
max-turns s: Spawn => Nat.
---

> Turn cap is monotone non-decreasing in complexity.
all p1: Patch, p2: Patch, complexity p1 < complexity p2 |
  max-turns (spawn-of p1) <= max-turns (spawn-of p2).

```


## Implementation Notes

- The new cap is computed at the Claude runner boundary and threaded through both `run` and `run_streaming` so the helper stays the single source of truth for argv generation.
- I kept the ladder intentionally coarse: complexity 3 and unknown/absent complexity both stay on 200, matching the patch’s stated policy and preserving existing fallback behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional complexity parameter to dynamically adjust AI processing capacity based on task difficulty (lower complexity enables faster execution, higher complexity enables deeper analysis)

* **Tests**
  * Expanded test coverage for new complexity-based functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->