### PR TITLE
[headless-cache-tuning] Patch 3: Per-patch config dir isolation (CLAUDE_CONFIG_DIR / CODEX_HOME)

### DIFF
--- a/lib/claude_backend.ml
+++ b/lib/claude_backend.ml
@@ -3,8 +3,15 @@ let create ~name ~model ~process_mgr ~clock ~timeout ~setsid_exec :
   {
     name;
     run_streaming =
-      (fun ~cwd ~patch_id ~prompt ~resume_session ~complexity ~on_event ->
+      (fun ~project_name
+        ~cwd
+        ~patch_id
+        ~prompt
+        ~resume_session
+        ~complexity
+        ~on_event
+      ->
         Claude_runner.run_streaming ~model ~process_mgr ~clock ~timeout
-          ~setsid_exec ~cwd ~patch_id ~prompt ~resume_session ~complexity
-          ~on_event);
+          ~setsid_exec ~project_name ~cwd ~patch_id ~prompt ~resume_session
+          ~complexity ~on_event);
   }

--- a/lib/claude_runner.ml
+++ b/lib/claude_runner.ml
@@ -269,17 +269,20 @@ let run ~model ~process_mgr ~cwd ~patch_id ~prompt ~resume_session =
     timed_out = false;
   }
 
-let run_streaming ~model ~process_mgr ~clock ~timeout ~setsid_exec ~cwd
-    ~patch_id ~prompt ~resume_session ~complexity ~on_event =
-  ignore (patch_id : Types.Patch_id.t);
+let run_streaming ~model ~process_mgr ~clock ~timeout ~setsid_exec ~project_name
+    ~cwd ~patch_id ~prompt ~resume_session ~complexity ~on_event =
   let model = Llm_backend.resolve_auto_model ~model ~complexity ~auto_model in
   let args = build_stream_args ~model ~prompt ~resume_session in
+  let env =
+    Spawn_env.merge_env ~base_env:(Unix.environment ())
+      ~overrides:(Spawn_env.per_patch_env ~project_name ~patch_id)
+  in
   let process_line line =
     let trimmed = strip_ansi (String.strip line) in
     if String.is_empty trimmed then [] else parse_stream_events trimmed
   in
-  Llm_backend.spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~setsid_exec
-    ~args ~process_line ~on_event
+  Llm_backend.spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~env
+    ~setsid_exec ~args ~process_line ~on_event
 
 let%test "auto_model: complexity 1 -> haiku" =
   Option.equal String.equal (auto_model ~complexity:(Some 1)) (Some "haiku")

--- a/lib/claude_runner.mli
+++ b/lib/claude_runner.mli
@@ -47,6 +47,7 @@ val run_streaming :
   clock:_ Eio.Time.clock ->
   timeout:float ->
   setsid_exec:string option ->
+  project_name:string ->
   cwd:Eio.Fs.dir_ty Eio.Path.t ->
   patch_id:Types.Patch_id.t ->
   prompt:string ->

--- a/lib/codex_backend.ml
+++ b/lib/codex_backend.ml
@@ -101,26 +101,36 @@ let auto_model ~complexity =
   | Some 3 -> Some "gpt-5.5"
   | Some _ | None -> Some "gpt-5.5"
 
-let run_streaming ~model ~process_mgr ~clock ~timeout ~setsid_exec ~cwd
-    ~patch_id ~prompt ~resume_session ~complexity ~on_event =
-  ignore (patch_id : Types.Patch_id.t);
+let run_streaming ~model ~process_mgr ~clock ~timeout ~setsid_exec ~project_name
+    ~cwd ~patch_id ~prompt ~resume_session ~complexity ~on_event =
   let model = Llm_backend.resolve_auto_model ~model ~complexity ~auto_model in
   let cwd_path = snd cwd in
   let args = build_args ~model ~cwd_path ~prompt ~resume_session in
+  let env =
+    Spawn_env.merge_env ~base_env:(Unix.environment ())
+      ~overrides:(Spawn_env.per_patch_env ~project_name ~patch_id)
+  in
   let process_line line =
     let trimmed = String.strip line in
     if String.is_empty trimmed then [] else parse_event trimmed
   in
-  Llm_backend.spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~setsid_exec
-    ~args ~process_line ~on_event
+  Llm_backend.spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~env
+    ~setsid_exec ~args ~process_line ~on_event
 
 let create ~model ~process_mgr ~clock ~timeout ~setsid_exec : Llm_backend.t =
   {
     name = "Codex";
     run_streaming =
-      (fun ~cwd ~patch_id ~prompt ~resume_session ~complexity ~on_event ->
+      (fun ~project_name
+        ~cwd
+        ~patch_id
+        ~prompt
+        ~resume_session
+        ~complexity
+        ~on_event
+      ->
         run_streaming ~model ~process_mgr ~clock ~timeout ~setsid_exec ~cwd
-          ~patch_id ~prompt ~resume_session ~complexity ~on_event);
+          ~project_name ~patch_id ~prompt ~resume_session ~complexity ~on_event);
   }
 
 let%test "build_args fresh (no resume, no model)" =

--- a/lib/gemini_backend.ml
+++ b/lib/gemini_backend.ml
@@ -86,25 +86,35 @@ let auto_model ~complexity =
   | Some 3 -> Some "gemini-3-pro-preview"
   | Some _ | None -> Some "gemini-3-pro-preview"
 
-let run_streaming ~model ~process_mgr ~clock ~timeout ~setsid_exec ~cwd
-    ~patch_id ~prompt ~resume_session ~complexity ~on_event =
-  ignore (patch_id : Types.Patch_id.t);
+let run_streaming ~model ~process_mgr ~clock ~timeout ~setsid_exec ~project_name
+    ~cwd ~patch_id ~prompt ~resume_session ~complexity ~on_event =
   let model = Llm_backend.resolve_auto_model ~model ~complexity ~auto_model in
   let args = build_args ~model ~prompt ~resume_session in
+  let env =
+    Spawn_env.merge_env ~base_env:(Unix.environment ())
+      ~overrides:(Spawn_env.per_patch_env ~project_name ~patch_id)
+  in
   let process_line line =
     let trimmed = String.strip line in
     if String.is_empty trimmed then [] else parse_event trimmed
   in
-  Llm_backend.spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~setsid_exec
-    ~args ~process_line ~on_event
+  Llm_backend.spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~env
+    ~setsid_exec ~args ~process_line ~on_event
 
 let create ~model ~process_mgr ~clock ~timeout ~setsid_exec : Llm_backend.t =
   {
     name = "Gemini";
     run_streaming =
-      (fun ~cwd ~patch_id ~prompt ~resume_session ~complexity ~on_event ->
+      (fun ~project_name
+        ~cwd
+        ~patch_id
+        ~prompt
+        ~resume_session
+        ~complexity
+        ~on_event
+      ->
         run_streaming ~model ~process_mgr ~clock ~timeout ~setsid_exec ~cwd
-          ~patch_id ~prompt ~resume_session ~complexity ~on_event);
+          ~project_name ~patch_id ~prompt ~resume_session ~complexity ~on_event);
   }
 
 let%test "build_args fresh (no resume, no model)" =

--- a/lib/llm_backend.ml
+++ b/lib/llm_backend.ml
@@ -19,7 +19,7 @@ let kill_group ~pid ~signal =
   try Unix.kill (-pid) signal
   with Unix.Unix_error ((ESRCH | EPERM), _, _) -> ()
 
-let spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~setsid_exec ~args
+let spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~env ~setsid_exec ~args
     ~(process_line : string -> Types.Stream_event.t list) ~on_event =
   let args =
     match setsid_exec with Some path -> path :: args | None -> args
@@ -56,7 +56,7 @@ let spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~setsid_exec ~args
       let stderr_r, stderr_w = Eio.Process.pipe ~sw process_mgr in
       let child =
         Eio.Process.spawn ~sw process_mgr ~cwd ~stdin:stdin_r ~stdout:stdout_w
-          ~stderr:stderr_w args
+          ~stderr:stderr_w ~env args
       in
       let pid = Eio.Process.pid child in
       let have_group = Option.is_some setsid_exec in
@@ -185,6 +185,7 @@ let spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~setsid_exec ~args
 type t = {
   name : string;
   run_streaming :
+    project_name:string ->
     cwd:Eio.Fs.dir_ty Eio.Path.t ->
     patch_id:Types.Patch_id.t ->
     prompt:string ->

--- a/lib/llm_backend.mli
+++ b/lib/llm_backend.mli
@@ -34,6 +34,7 @@ val spawn_and_stream :
   clock:_ Eio.Time.clock ->
   timeout:float ->
   cwd:Eio.Fs.dir_ty Eio.Path.t ->
+  env:string array ->
   setsid_exec:string option ->
   args:string list ->
   process_line:(string -> Types.Stream_event.t list) ->
@@ -55,6 +56,7 @@ val spawn_and_stream :
 type t = {
   name : string;
   run_streaming :
+    project_name:string ->
     cwd:Eio.Fs.dir_ty Eio.Path.t ->
     patch_id:Types.Patch_id.t ->
     prompt:string ->

--- a/lib/opencode_backend.ml
+++ b/lib/opencode_backend.ml
@@ -111,26 +111,36 @@ let auto_model ~complexity =
   | Some 3 -> Some "anthropic/claude-opus-4-7"
   | Some _ | None -> Some "anthropic/claude-opus-4-7"
 
-let run_streaming ~model ~process_mgr ~clock ~timeout ~setsid_exec ~cwd
-    ~patch_id ~prompt ~resume_session ~complexity ~on_event =
-  ignore (patch_id : Types.Patch_id.t);
+let run_streaming ~model ~process_mgr ~clock ~timeout ~setsid_exec ~project_name
+    ~cwd ~patch_id ~prompt ~resume_session ~complexity ~on_event =
   let model = Llm_backend.resolve_auto_model ~model ~complexity ~auto_model in
   let cwd_path = snd cwd in
   let args = build_args ~model ~cwd_path ~prompt ~resume_session in
+  let env =
+    Spawn_env.merge_env ~base_env:(Unix.environment ())
+      ~overrides:(Spawn_env.per_patch_env ~project_name ~patch_id)
+  in
   let process_line line =
     let trimmed = String.strip line in
     if String.is_empty trimmed then [] else parse_event trimmed
   in
-  Llm_backend.spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~setsid_exec
-    ~args ~process_line ~on_event
+  Llm_backend.spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~env
+    ~setsid_exec ~args ~process_line ~on_event
 
 let create ~model ~process_mgr ~clock ~timeout ~setsid_exec : Llm_backend.t =
   {
     name = "OpenCode";
     run_streaming =
-      (fun ~cwd ~patch_id ~prompt ~resume_session ~complexity ~on_event ->
+      (fun ~project_name
+        ~cwd
+        ~patch_id
+        ~prompt
+        ~resume_session
+        ~complexity
+        ~on_event
+      ->
         run_streaming ~model ~process_mgr ~clock ~timeout ~setsid_exec ~cwd
-          ~patch_id ~prompt ~resume_session ~complexity ~on_event);
+          ~project_name ~patch_id ~prompt ~resume_session ~complexity ~on_event);
   }
 
 let%test "build_args without continue (no model)" =

--- a/lib/pi_backend.ml
+++ b/lib/pi_backend.ml
@@ -64,28 +64,39 @@ let auto_model ~complexity =
   ignore complexity;
   None
 
-let run_streaming ~model ~process_mgr ~clock ~timeout ~setsid_exec ~cwd
-    ~patch_id ~prompt ~resume_session ~complexity ~on_event =
+let run_streaming ~model ~process_mgr ~clock ~timeout ~setsid_exec ~project_name
+    ~cwd ~patch_id ~prompt ~resume_session ~complexity ~on_event =
   let model = Llm_backend.resolve_auto_model ~model ~complexity ~auto_model in
   let cwd_path = snd cwd in
   let patch_id_str = Types.Patch_id.to_string patch_id in
   let args =
     build_args ~model ~cwd_path ~patch_id:patch_id_str ~prompt ~resume_session
   in
+  let env =
+    Spawn_env.merge_env ~base_env:(Unix.environment ())
+      ~overrides:(Spawn_env.per_patch_env ~project_name ~patch_id)
+  in
   let process_line line =
     let trimmed = String.strip line in
     if String.is_empty trimmed then [] else parse_event trimmed
   in
-  Llm_backend.spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~setsid_exec
-    ~args ~process_line ~on_event
+  Llm_backend.spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~env
+    ~setsid_exec ~args ~process_line ~on_event
 
 let create ~model ~process_mgr ~clock ~timeout ~setsid_exec : Llm_backend.t =
   {
     name = "Pi";
     run_streaming =
-      (fun ~cwd ~patch_id ~prompt ~resume_session ~complexity ~on_event ->
+      (fun ~project_name
+        ~cwd
+        ~patch_id
+        ~prompt
+        ~resume_session
+        ~complexity
+        ~on_event
+      ->
         run_streaming ~model ~process_mgr ~clock ~timeout ~setsid_exec ~cwd
-          ~patch_id ~prompt ~resume_session ~complexity ~on_event);
+          ~project_name ~patch_id ~prompt ~resume_session ~complexity ~on_event);
   }
 
 let%test "build_args without continue (no model)" =

--- a/lib/session_driver.ml
+++ b/lib/session_driver.ml
@@ -354,8 +354,8 @@ let run ~(kind : Types.Operation_kind.t option) ~runtime ~process_mgr ~clock ~fs
           let result =
             try
               Ok
-                (backend.Llm_backend.run_streaming ~cwd ~patch_id ~prompt
-                   ~resume_session ~complexity ~on_event)
+                (backend.Llm_backend.run_streaming ~project_name ~cwd ~patch_id
+                   ~prompt ~resume_session ~complexity ~on_event)
             with exn -> Error (Stdlib.Printexc.to_string exn)
           in
           let open Run_classification in

--- a/lib/spawn_env.ml
+++ b/lib/spawn_env.ml
@@ -1,0 +1,105 @@
+open Base
+
+let patch_root ~project_dir ~patch_id =
+  Stdlib.Filename.concat project_dir
+    (Stdlib.Filename.concat "spawn-envs" (Types.Patch_id.to_string patch_id))
+
+let backend_dir ~root ~backend = Stdlib.Filename.concat root backend
+
+let per_patch_env_in_project_dir ~project_dir ~patch_id =
+  let root = patch_root ~project_dir ~patch_id in
+  let claude_dir = backend_dir ~root ~backend:"claude" in
+  let codex_dir = backend_dir ~root ~backend:"codex" in
+  let opencode_dir = backend_dir ~root ~backend:"opencode" in
+  List.iter [ claude_dir; codex_dir; opencode_dir ] ~f:Project_store.ensure_dir;
+  [
+    ("CLAUDE_CONFIG_DIR", claude_dir);
+    ("CODEX_HOME", codex_dir);
+    ("OPENCODE_CONFIG_DIR", opencode_dir);
+  ]
+
+let per_patch_env ~project_name ~patch_id =
+  per_patch_env_in_project_dir
+    ~project_dir:(Project_store.project_dir project_name)
+    ~patch_id
+
+let split_env_entry entry =
+  match String.lsplit2 entry ~on:'=' with
+  | Some (key, value) -> (key, value)
+  | None -> (entry, "")
+
+let merge_env ~base_env ~overrides =
+  let merged = Hashtbl.create (module String) in
+  Array.iter base_env ~f:(fun entry ->
+      let key, value = split_env_entry entry in
+      Hashtbl.set merged ~key ~data:value);
+  List.iter overrides ~f:(fun (key, value) ->
+      Hashtbl.set merged ~key ~data:value);
+  Hashtbl.to_alist merged
+  |> List.map ~f:(fun (key, value) -> key ^ "=" ^ value)
+  |> Array.of_list
+
+let rec remove_tree path =
+  if Stdlib.Sys.file_exists path then
+    if Stdlib.Sys.is_directory path then (
+      Stdlib.Sys.readdir path
+      |> Array.iter ~f:(fun child ->
+          remove_tree (Stdlib.Filename.concat path child));
+      Unix.rmdir path)
+    else Unix.unlink path
+
+let with_temp_project_dir f =
+  let base = Stdlib.Filename.get_temp_dir_name () in
+  let dir =
+    Stdlib.Filename.concat base
+      (Printf.sprintf "onton-spawn-env-%06x" (Random.bits ()))
+  in
+  Project_store.ensure_dir dir;
+  Stdlib.Fun.protect ~finally:(fun () -> remove_tree dir) (fun () -> f dir)
+
+let%test "distinct patch_ids yield distinct config dirs" =
+  with_temp_project_dir @@ fun project_dir ->
+  let patch_a = Types.Patch_id.of_string "patch-1" in
+  let patch_b = Types.Patch_id.of_string "patch-2" in
+  let env_a = per_patch_env_in_project_dir ~project_dir ~patch_id:patch_a in
+  let env_b = per_patch_env_in_project_dir ~project_dir ~patch_id:patch_b in
+  let find key env = List.Assoc.find env ~equal:String.equal key in
+  not
+    (String.equal
+       (Option.value_exn (find "CLAUDE_CONFIG_DIR" env_a))
+       (Option.value_exn (find "CLAUDE_CONFIG_DIR" env_b)))
+
+let%test "merged env contains per-patch overrides" =
+  with_temp_project_dir @@ fun project_dir ->
+  let patch_a = Types.Patch_id.of_string "patch-1" in
+  let patch_b = Types.Patch_id.of_string "patch-2" in
+  let base_env =
+    [|
+      "PATH=/usr/bin";
+      "CLAUDE_CONFIG_DIR=/shared/claude";
+      "CODEX_HOME=/shared/codex";
+    |]
+  in
+  let env_a =
+    merge_env ~base_env
+      ~overrides:(per_patch_env_in_project_dir ~project_dir ~patch_id:patch_a)
+  in
+  let env_b =
+    merge_env ~base_env
+      ~overrides:(per_patch_env_in_project_dir ~project_dir ~patch_id:patch_b)
+  in
+  let find key env =
+    Array.find_map env ~f:(fun entry ->
+        match String.lsplit2 entry ~on:'=' with
+        | Some (k, v) when String.equal k key -> Some v
+        | _ -> None)
+  in
+  Option.is_some (find "PATH" env_a)
+  && Option.is_some (find "OPENCODE_CONFIG_DIR" env_a)
+  &&
+  let claude_a = Option.value_exn (find "CLAUDE_CONFIG_DIR" env_a) in
+  let claude_b = Option.value_exn (find "CLAUDE_CONFIG_DIR" env_b) in
+  let codex_a = Option.value_exn (find "CODEX_HOME" env_a) in
+  String.is_substring claude_a ~substring:"spawn-envs/patch-1/claude"
+  && String.is_substring codex_a ~substring:"spawn-envs/patch-1/codex"
+  && not (String.equal claude_a claude_b)

--- a/lib/spawn_env.ml
+++ b/lib/spawn_env.ml
@@ -36,6 +36,7 @@ let merge_env ~base_env ~overrides =
   List.iter overrides ~f:(fun (key, value) ->
       Hashtbl.set merged ~key ~data:value);
   Hashtbl.to_alist merged
+  |> List.sort ~compare:(fun (k1, _) (k2, _) -> String.compare k1 k2)
   |> List.map ~f:(fun (key, value) -> key ^ "=" ^ value)
   |> Array.of_list
 
@@ -49,12 +50,7 @@ let rec remove_tree path =
     else Unix.unlink path
 
 let with_temp_project_dir f =
-  let base = Stdlib.Filename.get_temp_dir_name () in
-  let dir =
-    Stdlib.Filename.concat base
-      (Printf.sprintf "onton-spawn-env-%06x" (Random.bits ()))
-  in
-  Project_store.ensure_dir dir;
+  let dir = Stdlib.Filename.temp_dir "onton-spawn-env-" "" in
   Stdlib.Fun.protect ~finally:(fun () -> remove_tree dir) (fun () -> f dir)
 
 let%test "distinct patch_ids yield distinct config dirs" =

--- a/lib/spawn_env.mli
+++ b/lib/spawn_env.mli
@@ -1,0 +1,10 @@
+val per_patch_env :
+  project_name:string -> patch_id:Types.Patch_id.t -> (string * string) list
+(** Per-patch config-dir overrides for headless agent CLIs. Creates the backing
+    directories under the project store before returning:
+    [spawn-envs/<patch_id>/{claude,codex,opencode}]. *)
+
+val merge_env :
+  base_env:string array -> overrides:(string * string) list -> string array
+(** Merge [overrides] into [base_env], replacing any existing entries with the
+    same variable name. *)

--- a/test/test_backend_smoke.ml
+++ b/test/test_backend_smoke.ml
@@ -14,8 +14,9 @@ let smoke ?setsid_exec ~process_mgr ~clock ~cwd ~ndjson ~process_line () =
   let on_event ev = events := ev :: !events in
   let payload = String.concat ~sep:"\n" ndjson in
   let args = [ "printf"; "%s"; payload ] in
+  let env = Unix.environment () in
   let result =
-    Llm_backend.spawn_and_stream ~process_mgr ~clock ~timeout:60.0 ~cwd
+    Llm_backend.spawn_and_stream ~process_mgr ~clock ~timeout:60.0 ~cwd ~env
       ~setsid_exec ~args ~process_line ~on_event
   in
   (result, List.rev !events)
@@ -105,7 +106,7 @@ let () =
     in
     let result =
       Llm_backend.spawn_and_stream ~process_mgr ~clock ~timeout:60.0 ~cwd
-        ~setsid_exec:None ~args
+        ~env:(Unix.environment ()) ~setsid_exec:None ~args
         ~process_line:(process_line_strip Codex_backend.parse_event)
         ~on_event
     in
@@ -143,7 +144,7 @@ let () =
     let on_event ev = events := ev :: !events in
     let result =
       Llm_backend.spawn_and_stream ~process_mgr ~clock ~timeout:60.0 ~cwd
-        ~setsid_exec:None
+        ~env:(Unix.environment ()) ~setsid_exec:None
         ~args:[ "printf"; "%s"; "not-json\n" ]
         ~process_line:(fun _ -> [])
         ~on_event
@@ -257,7 +258,8 @@ let () =
     let started = Unix.gettimeofday () in
     let result =
       Llm_backend.spawn_and_stream ~process_mgr ~clock ~timeout:30.0 ~cwd
-        ~setsid_exec:None ~args ~process_line:process_line_claude ~on_event
+        ~env:(Unix.environment ()) ~setsid_exec:None ~args
+        ~process_line:process_line_claude ~on_event
     in
     let elapsed = Unix.gettimeofday () -. started in
     if not result.Llm_backend.saw_final_result then (
@@ -281,7 +283,8 @@ let () =
     let started = Unix.gettimeofday () in
     let result =
       Llm_backend.spawn_and_stream ~process_mgr ~clock ~timeout:1.0 ~cwd
-        ~setsid_exec:None ~args ~process_line:process_line_claude ~on_event
+        ~env:(Unix.environment ()) ~setsid_exec:None ~args
+        ~process_line:process_line_claude ~on_event
     in
     let elapsed = Unix.gettimeofday () -. started in
     if not result.Llm_backend.timed_out then (
@@ -334,8 +337,8 @@ exit 0|}
         let args = [ "sh"; "-c"; script ] in
         let result =
           Llm_backend.spawn_and_stream ~process_mgr ~clock ~timeout:30.0 ~cwd
-            ~setsid_exec:(Some shim) ~args ~process_line:process_line_claude
-            ~on_event
+            ~env:(Unix.environment ()) ~setsid_exec:(Some shim) ~args
+            ~process_line:process_line_claude ~on_event
         in
         if not result.Llm_backend.saw_final_result then (
           Stdio.printf "FAIL: grandchild reap: Final_result not seen\n";


### PR DESCRIPTION
## Patch 3: Per-patch config dir isolation (CLAUDE_CONFIG_DIR / CODEX_HOME)

- Create lib/spawn_env.ml with `per_patch_env ~project_name ~patch_id` returning a `(string * string) list` of env-var bindings under `<project_store>/<project_name>/spawn-envs/<patch_id>/{claude,codex,opencode}`.
- mkdir-p the directory tree so the child process doesn't error on first read.
- Add `env:string array` to `Llm_backend.spawn_and_stream` and pass it through to `Eio.Process.spawn ~env`. Build the env by combining the current process env with the per-patch overrides (per-patch wins).
- Plumb `env` through the per-backend run_streaming wrappers in claude/codex/pi/gemini/opencode.
- Add an inline test in spawn_env confirming distinct patch_ids yield distinct paths.
- Add an inline test that two parallel run_streaming calls receive distinct env values (shape only — don't actually spawn).

## Changes
- Create lib/spawn_env.ml with `per_patch_env ~project_name ~patch_id` returning a `(string * string) list` of env-var bindings under `<project_store>/<project_name>/spawn-envs/<patch_id>/{claude,codex,opencode}`.
- mkdir-p the directory tree so the child process doesn't error on first read.
- Add `env:string array` to `Llm_backend.spawn_and_stream` and pass it through to `Eio.Process.spawn ~env`. Build the env by combining the current process env with the per-patch overrides (per-patch wins).
- Plumb `env` through the per-backend run_streaming wrappers in claude/codex/pi/gemini/opencode.
- Add an inline test in spawn_env confirming distinct patch_ids yield distinct paths.
- Add an inline test that two parallel run_streaming calls receive distinct env values (shape only — don't actually spawn).

## Files to Modify
- lib/spawn_env.ml (create): Helper: compute the env vars for a per-patch isolated config dir. Returns [("CLAUDE_CONFIG_DIR", <path>); ("CODEX_HOME", <path>); ("OPENCODE_CONFIG_DIR", <path>)] under the project store. mkdir-p the dirs.
- lib/spawn_env.mli (create): Interface for spawn_env.
- lib/llm_backend.ml (modify): Add `env:string array` parameter to spawn_and_stream and pass it to Eio.Process.spawn. Update the callers' types.
- lib/llm_backend.mli (modify): Update spawn_and_stream signature.
- lib/claude_runner.ml (modify): Compute env via Spawn_env.per_patch_env in run_streaming, merge with the current process env, and pass to spawn_and_stream.
- lib/codex_backend.ml (modify): Same env plumbing as claude_runner.ml.
- lib/pi_backend.ml (modify): Same env plumbing (PI_CODING_AGENT_SESSION_DIR is already per-patch via --session-dir, but adding a per-patch dir for any other ambient state is cheap).
- lib/gemini_backend.ml (modify): Same env plumbing.
- lib/opencode_backend.ml (modify): Same env plumbing.
- lib/dune (modify): Add spawn_env to the modules list.

## Gameplan Specification

```
module HEADLESS_CACHE_TUNING.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> After this gameplan, every onton-spawned coding-agent
> invocation is tuned for prompt-cache reuse and bounded
> token consumption. Static prompt prefixes are reused
> across patches in one gameplan. Isolated per-spawn
> config dirs stabilise spawn environment. Onton-minted
> session UUIDs remove the parsing race and enable resume
> without re-sending the prompt. Turn caps scale with
> complexity. Per-spawn USD budget caps put a hard floor
> under runaway token spend.

Patch.
Gameplan.
Spawn.
Arg.
Prompt.
Text.
SessionId.
Dir.
Backend.

claude => Backend.
codex => Backend.
pi => Backend.

backend s: Spawn => Backend.
spawn-of p: Patch => Spawn.
complexity p: Patch => Nat.

render p: Patch, gp: Gameplan => Prompt.
prefix pr: Prompt => Text.
suffix pr: Prompt => Text.
shared? t: Text, gp: Gameplan => Bool.
specific? t: Text, p: Patch => Bool.

args s: Spawn => Arg.
has-flag? a: Arg, name: String => Bool.

config-dir s: Spawn => Dir.
max-turns s: Spawn => Nat.

session-id p: Patch => SessionId.
persisted-before-spawn? id: SessionId, s: Spawn => Bool.
passed-to-cli? id: SessionId, s: Spawn => Bool.
minted-session-flag-on? => Bool.

budget-cap-set? s: Spawn => Bool.
flag-emitted? s: Spawn => Bool.
cost-tracked? s: Spawn => Bool.
self-terminates-on-overshoot? s: Spawn => Bool.

bare-flag-on? => Bool.
worktree-claude-md p: Patch => Text.
non-empty? t: Text => Bool.
prompt-of s: Spawn => Prompt.
contains? t: Text, sub: String => Bool.
---

> Static prefix is gameplan-shared.
all p: Patch, gp: Gameplan | shared? (prefix (render p gp)) gp.

> Dynamic suffix is patch-specific.
all p: Patch, gp: Gameplan | specific? (suffix (render p gp)) p.

> Claude spawns pass --exclude-dynamic-system-prompt-sections.
all s: Spawn, backend s = claude |
  has-flag? (args s) "--exclude-dynamic-system-prompt-sections".

> Distinct patches have distinct config dirs.
all p1: Patch, p2: Patch, p1 ~= p2 |
  config-dir (spawn-of p1) ~= config-dir (spawn-of p2).

> Turn caps are monotone non-decreasing in complexity.
all p1: Patch, p2: Patch, complexity p1 < complexity p2 |
  max-turns (spawn-of p1) <= max-turns (spawn-of p2).

> Session-ID minting (when enabled) persists before spawn and
> passes to the CLI.
all p: Patch, minted-session-flag-on? |
  persisted-before-spawn? (session-id p) (spawn-of p).

all p: Patch, minted-session-flag-on? |
  passed-to-cli? (session-id p) (spawn-of p).

> When the budget cap is set, Claude spawns emit the flag and
> Codex spawns track cost + self-terminate.
all s: Spawn, backend s = claude, budget-cap-set? s |
  flag-emitted? s.

all s: Spawn, backend s = codex, budget-cap-set? s |
  cost-tracked? s and self-terminates-on-overshoot? s.

> When --bare is enabled, Claude spawns pass --bare and the
> worktree's CLAUDE.md content is reachable from the spawn's
> prompt prefix.
all p: Patch, bare-flag-on?, backend (spawn-of p) = claude |
  has-flag? (args (spawn-of p)) "--bare".

all p: Patch, bare-flag-on?, non-empty? (worktree-claude-md p) |
  contains? (prefix (prompt-of (spawn-of p))) "CLAUDE.md".

```

## Patch Specification

```
module HEADLESS_CACHE_TUNING_PATCH_3.

> Patch 4 isolates each spawn's config directory so parallel
> agents don't race on shared user-level state. Stable config
> dirs are also a precondition for stable cache keys: agents
> that read different ambient settings produce different
> system-prompt content.

Patch.
Spawn.
Dir.

spawn-of p: Patch => Spawn.
config-dir s: Spawn => Dir.
---

> Distinct patches have distinct config dirs.
all p1: Patch, p2: Patch, p1 ~= p2 |
  config-dir (spawn-of p1) ~= config-dir (spawn-of p2).

```


## Implementation Notes

- I threaded `project_name` through `Llm_backend.t.run_streaming` so each backend can derive its per-patch config root locally. That is the only new call-surface change beyond `spawn_and_stream ~env`; without it, the backend wrappers had no access to the project store path.
- `Spawn_env` owns both directory creation and env merging. I kept merge logic in one place so all backends get identical override precedence (`per-patch` wins over inherited process env) instead of reimplementing that in five wrappers.
- The inline env test is intentionally shape-only: it validates that merged `CLAUDE_CONFIG_DIR` / `CODEX_HOME` values differ across patch IDs without spawning subprocesses. Backend smoke tests were updated only to satisfy the new `~env` parameter, not to re-test per-patch isolation.
- I avoided the planned `lib/dune` module-list change. This library stanza does not enumerate modules today; adding `(modules spawn_env)` would have restricted the library to that single module and broken the build. Dune auto-discovers the new module correctly without any stanza change.
- The inline tests use a temporary project dir helper rather than the real `ONTON_DATA_DIR`/home-backed project store path, so they do not leave persistent directories behind on the developer machine or CI runner.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolates each spawn’s config in a per-patch directory and passes it via the process env. This prevents cross-patch state races and stabilizes cache keys.

- New Features
  - Added `lib/spawn_env` with `per_patch_env` and `merge_env`. It creates `<project_store>/<project_name>/spawn-envs/<patch_id>/{claude,codex,opencode}` and returns `CLAUDE_CONFIG_DIR`, `CODEX_HOME`, `OPENCODE_CONFIG_DIR`.
  - `Llm_backend.spawn_and_stream` now accepts `env:string array` and forwards it to `Eio.Process.spawn ~env`. Backends (`claude`, `codex`, `pi`, `gemini`, `opencode`) build a per-patch env from `project_name`/`patch_id` and pass it through.
  - Inline tests cover distinct per-patch paths and env merging.

- Refactors
  - `Llm_backend.t.run_streaming` and `Claude_runner.run_streaming` now take `project_name`; `session_driver`, backend call sites, and smoke tests updated to pass `env`.
  - Stabilized spawn-env test helpers with temp project dirs and cleanup to avoid leftover directories.

<sup>Written for commit 764a9defcc04546c42af923623c523e62b7e39e6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

