### PR TITLE
[headless-cache-tuning] Patch 7: --bare + CLAUDE.md injection 

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -2057,15 +2057,9 @@ let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name ~pr_registry
                                       `Failed
                                   | Some _wt_path ->
                                       let claude_md =
-                                        match
-                                          Stdlib.Sys.getenv_opt
-                                            "ONTON_BARE_CLAUDE"
-                                        with
-                                        | Some "1" ->
-                                            read_optional_file
-                                              (Stdlib.Filename.concat _wt_path
-                                                 "CLAUDE.md")
-                                        | _ -> None
+                                        read_optional_file
+                                          (Stdlib.Filename.concat _wt_path
+                                             "CLAUDE.md")
                                       in
                                       let prompt =
                                         Prompt.render_patch_prompt ~project_name

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -502,6 +502,16 @@ let read_artifact_file path =
     else None
   with _ -> None
 
+let read_optional_file path =
+  try
+    if Stdlib.Sys.file_exists path then
+      let ic = Stdlib.In_channel.open_text path in
+      Stdlib.Fun.protect
+        ~finally:(fun () -> Stdlib.In_channel.close ic)
+        (fun () -> Some (Stdlib.In_channel.input_all ic))
+    else None
+  with _ -> None
+
 (** Apply the agent-authored notes artifact to the PR. Composes the final body
     as: gameplan description + specs + Implementation Notes (from artifact).
     Returns a tag describing the outcome so the caller can correlate with
@@ -2046,8 +2056,20 @@ let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name ~pr_registry
                                             .Session_worktree_missing);
                                       `Failed
                                   | Some _wt_path ->
+                                      let claude_md =
+                                        match
+                                          Stdlib.Sys.getenv_opt
+                                            "ONTON_BARE_CLAUDE"
+                                        with
+                                        | Some "1" ->
+                                            read_optional_file
+                                              (Stdlib.Filename.concat _wt_path
+                                                 "CLAUDE.md")
+                                        | _ -> None
+                                      in
                                       let prompt =
                                         Prompt.render_patch_prompt ~project_name
+                                          ?claude_md
                                           ?pr_number:agent.Patch_agent.pr_number
                                           patch gameplan
                                           ~base_branch:

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -486,22 +486,6 @@ let reconcile_and_execute_automerge ~runtime ~net ~github =
                      (Printexc.to_string exn))))
     decisions
 
-(** Read an artifact file. Returns [Some contents] if the file exists and is
-    readable, [None] otherwise. *)
-let read_artifact_file path =
-  try
-    if Stdlib.Sys.file_exists path then
-      let ic = Stdlib.open_in path in
-      Stdlib.Fun.protect
-        ~finally:(fun () -> Stdlib.close_in_noerr ic)
-        (fun () ->
-          let len = Stdlib.in_channel_length ic in
-          let s = Bytes.create len in
-          Stdlib.really_input ic s 0 len;
-          Some (Bytes.to_string s))
-    else None
-  with _ -> None
-
 let read_optional_file path =
   try
     if Stdlib.Sys.file_exists path then
@@ -511,6 +495,10 @@ let read_optional_file path =
         (fun () -> Some (Stdlib.In_channel.input_all ic))
     else None
   with _ -> None
+
+(** Read an artifact file. Returns [Some contents] if the file exists and is
+    readable, [None] otherwise. *)
+let read_artifact_file = read_optional_file
 
 (** Apply the agent-authored notes artifact to the PR. Composes the final body
     as: gameplan description + specs + Implementation Notes (from artifact).
@@ -2056,7 +2044,7 @@ let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name ~pr_registry
                                             .Session_worktree_missing);
                                       `Failed
                                   | Some _wt_path ->
-                                      let agents_md =
+                                      let claude_md =
                                         match
                                           Stdlib.Sys.getenv_opt
                                             "ONTON_BARE_CLAUDE"
@@ -2064,12 +2052,12 @@ let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name ~pr_registry
                                         | Some "1" ->
                                             read_optional_file
                                               (Stdlib.Filename.concat _wt_path
-                                                 "AGENTS.md")
+                                                 "CLAUDE.md")
                                         | _ -> None
                                       in
                                       let prompt =
                                         Prompt.render_patch_prompt ~project_name
-                                          ?agents_md
+                                          ?claude_md
                                           ?pr_number:agent.Patch_agent.pr_number
                                           patch gameplan
                                           ~base_branch:

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -2057,9 +2057,15 @@ let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name ~pr_registry
                                       `Failed
                                   | Some _wt_path ->
                                       let agents_md =
-                                        read_optional_file
-                                          (Stdlib.Filename.concat _wt_path
-                                             "AGENTS.md")
+                                        match
+                                          Stdlib.Sys.getenv_opt
+                                            "ONTON_BARE_CLAUDE"
+                                        with
+                                        | Some "1" ->
+                                            read_optional_file
+                                              (Stdlib.Filename.concat _wt_path
+                                                 "AGENTS.md")
+                                        | _ -> None
                                       in
                                       let prompt =
                                         Prompt.render_patch_prompt ~project_name

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -2056,14 +2056,14 @@ let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name ~pr_registry
                                             .Session_worktree_missing);
                                       `Failed
                                   | Some _wt_path ->
-                                      let claude_md =
+                                      let agents_md =
                                         read_optional_file
                                           (Stdlib.Filename.concat _wt_path
-                                             "CLAUDE.md")
+                                             "AGENTS.md")
                                       in
                                       let prompt =
                                         Prompt.render_patch_prompt ~project_name
-                                          ?claude_md
+                                          ?agents_md
                                           ?pr_number:agent.Patch_agent.pr_number
                                           patch gameplan
                                           ~base_branch:

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -2045,15 +2045,9 @@ let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name ~pr_registry
                                       `Failed
                                   | Some _wt_path ->
                                       let claude_md =
-                                        match
-                                          Stdlib.Sys.getenv_opt
-                                            "ONTON_BARE_CLAUDE"
-                                        with
-                                        | Some "1" ->
-                                            read_optional_file
-                                              (Stdlib.Filename.concat _wt_path
-                                                 "CLAUDE.md")
-                                        | _ -> None
+                                        read_optional_file
+                                          (Stdlib.Filename.concat _wt_path
+                                             "CLAUDE.md")
                                       in
                                       let prompt =
                                         Prompt.render_patch_prompt ~project_name

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -2044,14 +2044,14 @@ let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name ~pr_registry
                                             .Session_worktree_missing);
                                       `Failed
                                   | Some _wt_path ->
-                                      let claude_md =
+                                      let agents_md =
                                         read_optional_file
                                           (Stdlib.Filename.concat _wt_path
-                                             "CLAUDE.md")
+                                             "AGENTS.md")
                                       in
                                       let prompt =
                                         Prompt.render_patch_prompt ~project_name
-                                          ?claude_md
+                                          ?agents_md
                                           ?pr_number:agent.Patch_agent.pr_number
                                           patch gameplan
                                           ~base_branch:

--- a/lib/claude_runner.ml
+++ b/lib/claude_runner.ml
@@ -422,7 +422,6 @@ let%test "build_args fresh (no resume, with model)" =
       "--max-turns";
       "100";
       "--exclude-dynamic-system-prompt-sections";
-      "--bare";
     ]
 
 let%test "build_args fresh (no resume, no model)" =
@@ -442,7 +441,6 @@ let%test "build_args fresh (no resume, no model)" =
       "--max-turns";
       "50";
       "--exclude-dynamic-system-prompt-sections";
-      "--bare";
     ]
 
 let%test "build_args with resume session" =
@@ -466,7 +464,6 @@ let%test "build_args with resume session" =
       "--max-turns";
       "200";
       "--exclude-dynamic-system-prompt-sections";
-      "--bare";
     ]
 
 let%test "build_args includes --exclude-dynamic-system-prompt-sections" =
@@ -496,7 +493,6 @@ let%test "build_stream_args fresh (no resume, with model)" =
       "--max-turns";
       "100";
       "--exclude-dynamic-system-prompt-sections";
-      "--bare";
     ]
 
 let%test "build_stream_args fresh (no resume, no model)" =
@@ -517,7 +513,6 @@ let%test "build_stream_args fresh (no resume, no model)" =
       "--max-turns";
       "200";
       "--exclude-dynamic-system-prompt-sections";
-      "--bare";
     ]
 
 let%test "build_stream_args with resume session" =
@@ -543,7 +538,6 @@ let%test "build_stream_args with resume session" =
       "--max-turns";
       "50";
       "--exclude-dynamic-system-prompt-sections";
-      "--bare";
     ]
 
 let%test "build_stream_args includes --exclude-dynamic-system-prompt-sections" =

--- a/lib/claude_runner.ml
+++ b/lib/claude_runner.ml
@@ -147,19 +147,6 @@ let prepare_minted_session_id_with_env ~getenv_opt ~patch_id ~resume_session =
 let prepare_minted_session_id =
   prepare_minted_session_id_with_env ~getenv_opt:Stdlib.Sys.getenv_opt
 
-let with_onton_bare_claude value f =
-  let original = Stdlib.Sys.getenv_opt "ONTON_BARE_CLAUDE" in
-  let restore () =
-    match original with
-    | Some v -> Unix.putenv "ONTON_BARE_CLAUDE" v
-    | None -> Unix.putenv "ONTON_BARE_CLAUDE" ""
-  in
-  Stdlib.Fun.protect ~finally:restore (fun () ->
-      (match value with
-      | Some v -> Unix.putenv "ONTON_BARE_CLAUDE" v
-      | None -> Unix.putenv "ONTON_BARE_CLAUDE" "");
-      f ())
-
 (** Find the first '\{' in [s] and return the substring starting there. Defense
     against any leading garbage in a stream-json line. *)
 let find_json_start s =
@@ -435,6 +422,7 @@ let%test "build_args fresh (no resume, with model)" =
       "--max-turns";
       "100";
       "--exclude-dynamic-system-prompt-sections";
+      "--bare";
     ]
 
 let%test "build_args fresh (no resume, no model)" =
@@ -454,6 +442,7 @@ let%test "build_args fresh (no resume, no model)" =
       "--max-turns";
       "50";
       "--exclude-dynamic-system-prompt-sections";
+      "--bare";
     ]
 
 let%test "build_args with resume session" =
@@ -477,6 +466,7 @@ let%test "build_args with resume session" =
       "--max-turns";
       "200";
       "--exclude-dynamic-system-prompt-sections";
+      "--bare";
     ]
 
 let%test "build_args includes --exclude-dynamic-system-prompt-sections" =
@@ -506,6 +496,7 @@ let%test "build_stream_args fresh (no resume, with model)" =
       "--max-turns";
       "100";
       "--exclude-dynamic-system-prompt-sections";
+      "--bare";
     ]
 
 let%test "build_stream_args fresh (no resume, no model)" =
@@ -526,6 +517,7 @@ let%test "build_stream_args fresh (no resume, no model)" =
       "--max-turns";
       "200";
       "--exclude-dynamic-system-prompt-sections";
+      "--bare";
     ]
 
 let%test "build_stream_args with resume session" =
@@ -551,6 +543,7 @@ let%test "build_stream_args with resume session" =
       "--max-turns";
       "50";
       "--exclude-dynamic-system-prompt-sections";
+      "--bare";
     ]
 
 let%test "build_stream_args includes --exclude-dynamic-system-prompt-sections" =

--- a/lib/claude_runner.ml
+++ b/lib/claude_runner.ml
@@ -405,9 +405,9 @@ let%test "max_turns_for: None -> 200" =
 let%test "build_args fresh (no resume, with model)" =
   let complexity = Some 2 in
   let args =
-    build_args ~getenv_opt:(fun _ -> None) ~model:(Some "sonnet") ~complexity
-      ~prompt:"do stuff"
-      ~resume_session:None
+    build_args
+      ~getenv_opt:(fun _ -> None)
+      ~model:(Some "sonnet") ~complexity ~prompt:"do stuff" ~resume_session:None
   in
   List.equal String.equal args
     [
@@ -427,8 +427,9 @@ let%test "build_args fresh (no resume, with model)" =
 let%test "build_args fresh (no resume, no model)" =
   let complexity = Some 1 in
   let args =
-    build_args ~getenv_opt:(fun _ -> None) ~model:None ~complexity
-      ~prompt:"do stuff" ~resume_session:None
+    build_args
+      ~getenv_opt:(fun _ -> None)
+      ~model:None ~complexity ~prompt:"do stuff" ~resume_session:None
   in
   List.equal String.equal args
     [
@@ -446,8 +447,10 @@ let%test "build_args fresh (no resume, no model)" =
 let%test "build_args with resume session" =
   let complexity = Some 3 in
   let args =
-    build_args ~getenv_opt:(fun _ -> None) ~model:(Some "opus") ~complexity
-      ~prompt:"do stuff" ~resume_session:(Some "abc-123")
+    build_args
+      ~getenv_opt:(fun _ -> None)
+      ~model:(Some "opus") ~complexity ~prompt:"do stuff"
+      ~resume_session:(Some "abc-123")
   in
   List.equal String.equal args
     [
@@ -468,16 +471,19 @@ let%test "build_args with resume session" =
 
 let%test "build_args includes --exclude-dynamic-system-prompt-sections" =
   let args =
-    build_args ~getenv_opt:(fun _ -> None) ~model:None ~complexity:None
-      ~prompt:"do stuff" ~resume_session:None
+    build_args
+      ~getenv_opt:(fun _ -> None)
+      ~model:None ~complexity:None ~prompt:"do stuff" ~resume_session:None
   in
   List.mem args "--exclude-dynamic-system-prompt-sections" ~equal:String.equal
 
 let%test "build_stream_args fresh (no resume, with model)" =
   let complexity = Some 2 in
   let args =
-    build_stream_args ~getenv_opt:(fun _ -> None) ~model:(Some "sonnet")
-      ~complexity ~prompt:"do stuff" ~minted_session_id:None ~resume_session:None
+    build_stream_args
+      ~getenv_opt:(fun _ -> None)
+      ~model:(Some "sonnet") ~complexity ~prompt:"do stuff"
+      ~minted_session_id:None ~resume_session:None
   in
   List.equal String.equal args
     [
@@ -498,8 +504,10 @@ let%test "build_stream_args fresh (no resume, with model)" =
 let%test "build_stream_args fresh (no resume, no model)" =
   let complexity = None in
   let args =
-    build_stream_args ~getenv_opt:(fun _ -> None) ~model:None ~complexity
-      ~prompt:"do stuff" ~minted_session_id:None ~resume_session:None
+    build_stream_args
+      ~getenv_opt:(fun _ -> None)
+      ~model:None ~complexity ~prompt:"do stuff" ~minted_session_id:None
+      ~resume_session:None
   in
   List.equal String.equal args
     [
@@ -518,9 +526,10 @@ let%test "build_stream_args fresh (no resume, no model)" =
 let%test "build_stream_args with resume session" =
   let complexity = Some 1 in
   let args =
-    build_stream_args ~getenv_opt:(fun _ -> None) ~model:(Some "opus")
-      ~complexity ~prompt:"do stuff" ~minted_session_id:None
-      ~resume_session:(Some "abc-123")
+    build_stream_args
+      ~getenv_opt:(fun _ -> None)
+      ~model:(Some "opus") ~complexity ~prompt:"do stuff"
+      ~minted_session_id:None ~resume_session:(Some "abc-123")
   in
   List.equal String.equal args
     [
@@ -542,16 +551,19 @@ let%test "build_stream_args with resume session" =
 
 let%test "build_stream_args includes --exclude-dynamic-system-prompt-sections" =
   let args =
-    build_stream_args ~getenv_opt:(fun _ -> None) ~model:None ~complexity:None
-      ~prompt:"do stuff" ~minted_session_id:None ~resume_session:None
+    build_stream_args
+      ~getenv_opt:(fun _ -> None)
+      ~model:None ~complexity:None ~prompt:"do stuff" ~minted_session_id:None
+      ~resume_session:None
   in
   List.mem args "--exclude-dynamic-system-prompt-sections" ~equal:String.equal
 
 let%test "build_stream_args emits --session-id when minted_session_id is Some" =
   let complexity = None in
   let args =
-    build_stream_args ~getenv_opt:(fun _ -> None) ~model:(Some "sonnet")
-      ~complexity ~prompt:"do stuff"
+    build_stream_args
+      ~getenv_opt:(fun _ -> None)
+      ~model:(Some "sonnet") ~complexity ~prompt:"do stuff"
       ~minted_session_id:(Some "123e4567-e89b-42d3-a456-426614174000")
       ~resume_session:None
   in
@@ -575,9 +587,10 @@ let%test "build_stream_args emits --session-id when minted_session_id is Some" =
 
 let%test "build_stream_args rejects session-id plus resume together" =
   match
-    build_stream_args ~getenv_opt:(fun _ -> None) ~model:None ~complexity:None
-      ~prompt:"do stuff" ~minted_session_id:(Some "minted")
-      ~resume_session:(Some "resume")
+    build_stream_args
+      ~getenv_opt:(fun _ -> None)
+      ~model:None ~complexity:None ~prompt:"do stuff"
+      ~minted_session_id:(Some "minted") ~resume_session:(Some "resume")
   with
   | _ -> false
   | exception Invalid_argument _ -> true
@@ -603,9 +616,10 @@ let%test
   Exn.protect
     ~f:(fun () ->
       let args =
-        build_stream_args ~getenv_opt:(fun _ -> None) ~model:(Some "sonnet")
-          ~complexity:None ~prompt:"do stuff" ~minted_session_id:None
-          ~resume_session:None
+        build_stream_args
+          ~getenv_opt:(fun _ -> None)
+          ~model:(Some "sonnet") ~complexity:None ~prompt:"do stuff"
+          ~minted_session_id:None ~resume_session:None
       in
       List.equal String.equal args
         [

--- a/lib/claude_runner.ml
+++ b/lib/claude_runner.ml
@@ -74,7 +74,10 @@ let budget_cap_args ~warn () =
                raw);
           [])
 
-let build_args ~model ~complexity ~prompt ~resume_session =
+let bare_args ~getenv_opt =
+  match getenv_opt "ONTON_BARE_CLAUDE" with Some "1" -> [ "--bare" ] | _ -> []
+
+let build_args ~getenv_opt ~model ~complexity ~prompt ~resume_session =
   let base = [ "claude" ] in
   let prompt_args = [ "-p"; prompt; "--output-format"; "text" ] in
   let session_args =
@@ -88,10 +91,11 @@ let build_args ~model ~complexity ~prompt ~resume_session =
       "--exclude-dynamic-system-prompt-sections";
     ]
     @ budget_cap_args ~warn:(fun msg -> Stdio.eprintf "%s\n" msg) ()
+    @ bare_args ~getenv_opt
   in
   base @ model_args model @ prompt_args @ session_args @ flags
 
-let build_stream_args ~model ~complexity ~prompt ~minted_session_id
+let build_stream_args ~getenv_opt ~model ~complexity ~prompt ~minted_session_id
     ~resume_session =
   (match (minted_session_id, resume_session) with
   | Some _, Some _ ->
@@ -119,6 +123,7 @@ let build_stream_args ~model ~complexity ~prompt ~minted_session_id
       "--exclude-dynamic-system-prompt-sections";
     ]
     @ budget_cap_args ~warn:(fun msg -> Stdio.eprintf "%s\n" msg) ()
+    @ bare_args ~getenv_opt
   in
   base @ model_args model @ minted_session_args @ prompt_args @ session_args
   @ flags
@@ -141,6 +146,19 @@ let prepare_minted_session_id_with_env ~getenv_opt ~patch_id ~resume_session =
 
 let prepare_minted_session_id =
   prepare_minted_session_id_with_env ~getenv_opt:Stdlib.Sys.getenv_opt
+
+let with_onton_bare_claude value f =
+  let original = Stdlib.Sys.getenv_opt "ONTON_BARE_CLAUDE" in
+  let restore () =
+    match original with
+    | Some v -> Unix.putenv "ONTON_BARE_CLAUDE" v
+    | None -> Unix.putenv "ONTON_BARE_CLAUDE" ""
+  in
+  Stdlib.Fun.protect ~finally:restore (fun () ->
+      (match value with
+      | Some v -> Unix.putenv "ONTON_BARE_CLAUDE" v
+      | None -> Unix.putenv "ONTON_BARE_CLAUDE" "");
+      f ())
 
 (** Find the first '\{' in [s] and return the substring starting there. Defense
     against any leading garbage in a stream-json line. *)
@@ -284,7 +302,10 @@ let parse_stream_event (line : string) : Types.Stream_event.t option =
 
 let run ~model ~process_mgr ~cwd ~patch_id ~prompt ~resume_session ~complexity =
   ignore (patch_id : Types.Patch_id.t);
-  let args = build_args ~model ~complexity ~prompt ~resume_session in
+  let args =
+    build_args ~getenv_opt:Stdlib.Sys.getenv_opt ~model ~complexity ~prompt
+      ~resume_session
+  in
   let stdout_content, stderr_content, exit_code =
     Eio.Switch.run @@ fun sw ->
     let stdin_r, stdin_w = Eio.Process.pipe ~sw process_mgr in
@@ -357,8 +378,8 @@ let run_streaming ~model ~process_mgr ~clock ~timeout ~setsid_exec ~project_name
       }
   | Ok minted_session_id ->
       let args =
-        build_stream_args ~model ~complexity ~prompt ~minted_session_id
-          ~resume_session
+        build_stream_args ~getenv_opt:Stdlib.Sys.getenv_opt ~model ~complexity
+          ~prompt ~minted_session_id ~resume_session
       in
       let process_line line =
         let trimmed = strip_ansi (String.strip line) in
@@ -397,7 +418,8 @@ let%test "max_turns_for: None -> 200" =
 let%test "build_args fresh (no resume, with model)" =
   let complexity = Some 2 in
   let args =
-    build_args ~model:(Some "sonnet") ~complexity ~prompt:"do stuff"
+    build_args ~getenv_opt:(fun _ -> None) ~model:(Some "sonnet") ~complexity
+      ~prompt:"do stuff"
       ~resume_session:None
   in
   List.equal String.equal args
@@ -418,7 +440,8 @@ let%test "build_args fresh (no resume, with model)" =
 let%test "build_args fresh (no resume, no model)" =
   let complexity = Some 1 in
   let args =
-    build_args ~model:None ~complexity ~prompt:"do stuff" ~resume_session:None
+    build_args ~getenv_opt:(fun _ -> None) ~model:None ~complexity
+      ~prompt:"do stuff" ~resume_session:None
   in
   List.equal String.equal args
     [
@@ -436,8 +459,8 @@ let%test "build_args fresh (no resume, no model)" =
 let%test "build_args with resume session" =
   let complexity = Some 3 in
   let args =
-    build_args ~model:(Some "opus") ~complexity ~prompt:"do stuff"
-      ~resume_session:(Some "abc-123")
+    build_args ~getenv_opt:(fun _ -> None) ~model:(Some "opus") ~complexity
+      ~prompt:"do stuff" ~resume_session:(Some "abc-123")
   in
   List.equal String.equal args
     [
@@ -458,16 +481,16 @@ let%test "build_args with resume session" =
 
 let%test "build_args includes --exclude-dynamic-system-prompt-sections" =
   let args =
-    build_args ~model:None ~complexity:None ~prompt:"do stuff"
-      ~resume_session:None
+    build_args ~getenv_opt:(fun _ -> None) ~model:None ~complexity:None
+      ~prompt:"do stuff" ~resume_session:None
   in
   List.mem args "--exclude-dynamic-system-prompt-sections" ~equal:String.equal
 
 let%test "build_stream_args fresh (no resume, with model)" =
   let complexity = Some 2 in
   let args =
-    build_stream_args ~model:(Some "sonnet") ~complexity ~prompt:"do stuff"
-      ~minted_session_id:None ~resume_session:None
+    build_stream_args ~getenv_opt:(fun _ -> None) ~model:(Some "sonnet")
+      ~complexity ~prompt:"do stuff" ~minted_session_id:None ~resume_session:None
   in
   List.equal String.equal args
     [
@@ -488,8 +511,8 @@ let%test "build_stream_args fresh (no resume, with model)" =
 let%test "build_stream_args fresh (no resume, no model)" =
   let complexity = None in
   let args =
-    build_stream_args ~model:None ~complexity ~prompt:"do stuff"
-      ~minted_session_id:None ~resume_session:None
+    build_stream_args ~getenv_opt:(fun _ -> None) ~model:None ~complexity
+      ~prompt:"do stuff" ~minted_session_id:None ~resume_session:None
   in
   List.equal String.equal args
     [
@@ -508,8 +531,9 @@ let%test "build_stream_args fresh (no resume, no model)" =
 let%test "build_stream_args with resume session" =
   let complexity = Some 1 in
   let args =
-    build_stream_args ~model:(Some "opus") ~complexity ~prompt:"do stuff"
-      ~minted_session_id:None ~resume_session:(Some "abc-123")
+    build_stream_args ~getenv_opt:(fun _ -> None) ~model:(Some "opus")
+      ~complexity ~prompt:"do stuff" ~minted_session_id:None
+      ~resume_session:(Some "abc-123")
   in
   List.equal String.equal args
     [
@@ -531,15 +555,16 @@ let%test "build_stream_args with resume session" =
 
 let%test "build_stream_args includes --exclude-dynamic-system-prompt-sections" =
   let args =
-    build_stream_args ~model:None ~complexity:None ~prompt:"do stuff"
-      ~minted_session_id:None ~resume_session:None
+    build_stream_args ~getenv_opt:(fun _ -> None) ~model:None ~complexity:None
+      ~prompt:"do stuff" ~minted_session_id:None ~resume_session:None
   in
   List.mem args "--exclude-dynamic-system-prompt-sections" ~equal:String.equal
 
 let%test "build_stream_args emits --session-id when minted_session_id is Some" =
   let complexity = None in
   let args =
-    build_stream_args ~model:(Some "sonnet") ~complexity ~prompt:"do stuff"
+    build_stream_args ~getenv_opt:(fun _ -> None) ~model:(Some "sonnet")
+      ~complexity ~prompt:"do stuff"
       ~minted_session_id:(Some "123e4567-e89b-42d3-a456-426614174000")
       ~resume_session:None
   in
@@ -563,8 +588,9 @@ let%test "build_stream_args emits --session-id when minted_session_id is Some" =
 
 let%test "build_stream_args rejects session-id plus resume together" =
   match
-    build_stream_args ~model:None ~complexity:None ~prompt:"do stuff"
-      ~minted_session_id:(Some "minted") ~resume_session:(Some "resume")
+    build_stream_args ~getenv_opt:(fun _ -> None) ~model:None ~complexity:None
+      ~prompt:"do stuff" ~minted_session_id:(Some "minted")
+      ~resume_session:(Some "resume")
   with
   | _ -> false
   | exception Invalid_argument _ -> true
@@ -590,8 +616,9 @@ let%test
   Exn.protect
     ~f:(fun () ->
       let args =
-        build_stream_args ~model:(Some "sonnet") ~complexity:None
-          ~prompt:"do stuff" ~minted_session_id:None ~resume_session:None
+        build_stream_args ~getenv_opt:(fun _ -> None) ~model:(Some "sonnet")
+          ~complexity:None ~prompt:"do stuff" ~minted_session_id:None
+          ~resume_session:None
       in
       List.equal String.equal args
         [
@@ -614,6 +641,40 @@ let%test
       match previous with
       | Some value -> Unix.putenv "ONTON_BUDGET_CAP_USD" value
       | None -> Unix.putenv "ONTON_BUDGET_CAP_USD" "")
+
+let%test "build_stream_args includes --bare when ONTON_BARE_CLAUDE=1" =
+  List.mem
+    (build_stream_args
+       ~getenv_opt:(fun name ->
+         if String.equal name "ONTON_BARE_CLAUDE" then Some "1" else None)
+       ~model:None ~complexity:None ~prompt:"do stuff" ~minted_session_id:None
+       ~resume_session:None)
+    "--bare" ~equal:String.equal
+
+let%test "build_stream_args omits --bare when ONTON_BARE_CLAUDE is unset" =
+  not
+    (List.mem
+       (build_stream_args
+          ~getenv_opt:(fun _ -> None)
+          ~model:None ~complexity:None ~prompt:"do stuff"
+          ~minted_session_id:None ~resume_session:None)
+       "--bare" ~equal:String.equal)
+
+let%test "build_args includes --bare when ONTON_BARE_CLAUDE=1" =
+  List.mem
+    (build_args
+       ~getenv_opt:(fun name ->
+         if String.equal name "ONTON_BARE_CLAUDE" then Some "1" else None)
+       ~model:None ~complexity:None ~prompt:"do stuff" ~resume_session:None)
+    "--bare" ~equal:String.equal
+
+let%test "build_args omits --bare when ONTON_BARE_CLAUDE is unset" =
+  not
+    (List.mem
+       (build_args
+          ~getenv_opt:(fun _ -> None)
+          ~model:None ~complexity:None ~prompt:"do stuff" ~resume_session:None)
+       "--bare" ~equal:String.equal)
 
 let%test "budget_cap_args omits flag and warns on invalid cap" =
   let previous = Sys.getenv "ONTON_BUDGET_CAP_USD" in

--- a/lib/claude_runner.ml
+++ b/lib/claude_runner.ml
@@ -74,10 +74,10 @@ let budget_cap_args ~warn () =
                raw);
           [])
 
-let bare_args ~getenv_opt =
-  match getenv_opt "ONTON_BARE_CLAUDE" with Some "1" -> [ "--bare" ] | _ -> []
+let bare_args = [ "--bare" ]
 
 let build_args ~getenv_opt ~model ~complexity ~prompt ~resume_session =
+  ignore getenv_opt;
   let base = [ "claude" ] in
   let prompt_args = [ "-p"; prompt; "--output-format"; "text" ] in
   let session_args =
@@ -91,12 +91,13 @@ let build_args ~getenv_opt ~model ~complexity ~prompt ~resume_session =
       "--exclude-dynamic-system-prompt-sections";
     ]
     @ budget_cap_args ~warn:(fun msg -> Stdio.eprintf "%s\n" msg) ()
-    @ bare_args ~getenv_opt
+    @ bare_args
   in
   base @ model_args model @ prompt_args @ session_args @ flags
 
 let build_stream_args ~getenv_opt ~model ~complexity ~prompt ~minted_session_id
     ~resume_session =
+  ignore getenv_opt;
   (match (minted_session_id, resume_session) with
   | Some _, Some _ ->
       invalid_arg
@@ -123,7 +124,7 @@ let build_stream_args ~getenv_opt ~model ~complexity ~prompt ~minted_session_id
       "--exclude-dynamic-system-prompt-sections";
     ]
     @ budget_cap_args ~warn:(fun msg -> Stdio.eprintf "%s\n" msg) ()
-    @ bare_args ~getenv_opt
+    @ bare_args
   in
   base @ model_args model @ minted_session_args @ prompt_args @ session_args
   @ flags
@@ -422,6 +423,7 @@ let%test "build_args fresh (no resume, with model)" =
       "--max-turns";
       "100";
       "--exclude-dynamic-system-prompt-sections";
+      "--bare";
     ]
 
 let%test "build_args fresh (no resume, no model)" =
@@ -442,6 +444,7 @@ let%test "build_args fresh (no resume, no model)" =
       "--max-turns";
       "50";
       "--exclude-dynamic-system-prompt-sections";
+      "--bare";
     ]
 
 let%test "build_args with resume session" =
@@ -467,6 +470,7 @@ let%test "build_args with resume session" =
       "--max-turns";
       "200";
       "--exclude-dynamic-system-prompt-sections";
+      "--bare";
     ]
 
 let%test "build_args includes --exclude-dynamic-system-prompt-sections" =
@@ -499,6 +503,7 @@ let%test "build_stream_args fresh (no resume, with model)" =
       "--max-turns";
       "100";
       "--exclude-dynamic-system-prompt-sections";
+      "--bare";
     ]
 
 let%test "build_stream_args fresh (no resume, no model)" =
@@ -521,6 +526,7 @@ let%test "build_stream_args fresh (no resume, no model)" =
       "--max-turns";
       "200";
       "--exclude-dynamic-system-prompt-sections";
+      "--bare";
     ]
 
 let%test "build_stream_args with resume session" =
@@ -547,6 +553,7 @@ let%test "build_stream_args with resume session" =
       "--max-turns";
       "50";
       "--exclude-dynamic-system-prompt-sections";
+      "--bare";
     ]
 
 let%test "build_stream_args includes --exclude-dynamic-system-prompt-sections" =
@@ -583,6 +590,7 @@ let%test "build_stream_args emits --session-id when minted_session_id is Some" =
       "--max-turns";
       "200";
       "--exclude-dynamic-system-prompt-sections";
+      "--bare";
     ]
 
 let%test "build_stream_args rejects session-id plus resume together" =
@@ -637,45 +645,27 @@ let%test
           "--exclude-dynamic-system-prompt-sections";
           "--max-budget-usd";
           "10";
+          "--bare";
         ])
     ~finally:(fun () ->
       match previous with
       | Some value -> Unix.putenv "ONTON_BUDGET_CAP_USD" value
       | None -> Unix.putenv "ONTON_BUDGET_CAP_USD" "")
 
-let%test "build_stream_args includes --bare when ONTON_BARE_CLAUDE=1" =
+let%test "build_stream_args includes --bare" =
   List.mem
     (build_stream_args
-       ~getenv_opt:(fun name ->
-         if String.equal name "ONTON_BARE_CLAUDE" then Some "1" else None)
+       ~getenv_opt:(fun _ -> None)
        ~model:None ~complexity:None ~prompt:"do stuff" ~minted_session_id:None
        ~resume_session:None)
     "--bare" ~equal:String.equal
 
-let%test "build_stream_args omits --bare when ONTON_BARE_CLAUDE is unset" =
-  not
-    (List.mem
-       (build_stream_args
-          ~getenv_opt:(fun _ -> None)
-          ~model:None ~complexity:None ~prompt:"do stuff"
-          ~minted_session_id:None ~resume_session:None)
-       "--bare" ~equal:String.equal)
-
-let%test "build_args includes --bare when ONTON_BARE_CLAUDE=1" =
+let%test "build_args includes --bare" =
   List.mem
     (build_args
-       ~getenv_opt:(fun name ->
-         if String.equal name "ONTON_BARE_CLAUDE" then Some "1" else None)
+       ~getenv_opt:(fun _ -> None)
        ~model:None ~complexity:None ~prompt:"do stuff" ~resume_session:None)
     "--bare" ~equal:String.equal
-
-let%test "build_args omits --bare when ONTON_BARE_CLAUDE is unset" =
-  not
-    (List.mem
-       (build_args
-          ~getenv_opt:(fun _ -> None)
-          ~model:None ~complexity:None ~prompt:"do stuff" ~resume_session:None)
-       "--bare" ~equal:String.equal)
 
 let%test "budget_cap_args omits flag and warns on invalid cap" =
   let previous = Sys.getenv "ONTON_BUDGET_CAP_USD" in

--- a/lib/claude_runner.mli
+++ b/lib/claude_runner.mli
@@ -74,6 +74,7 @@ val strip_ansi : string -> string
     Exposed for testing. *)
 
 val build_args :
+  getenv_opt:(string -> string option) ->
   model:string option ->
   complexity:int option ->
   prompt:string ->
@@ -82,6 +83,7 @@ val build_args :
 (** Build the CLI argument list for the Claude process. Exposed for testing. *)
 
 val build_stream_args :
+  getenv_opt:(string -> string option) ->
   model:string option ->
   complexity:int option ->
   prompt:string ->

--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -95,12 +95,12 @@ let optional_list_section ~header items =
   | [] -> ""
   | _ -> optional_section ~header (format_list items)
 
-let agents_md_section = function
+let claude_md_section = function
   | Some content when not (String.is_empty (String.strip content)) ->
-      "\n## Project Conventions (AGENTS.md)\n\n" ^ content ^ "\n"
+      "## Project Conventions (CLAUDE.md)\n\n" ^ content ^ "\n\n"
   | Some _ | None -> ""
 
-let render_patch_prompt ~(project_name : string) ?agents_md ?pr_number
+let render_patch_prompt ~(project_name : string) ?claude_md ?pr_number
     (patch : Patch.t) (gameplan : Gameplan.t) ~(base_branch : string) =
   let patch_id = Patch_id.to_string patch.Patch.id in
   let deps =
@@ -177,7 +177,7 @@ Continue implementing until all tests pass.|}
       ("spec", patch.Patch.spec);
       ("acceptance_criteria", format_list patch.Patch.acceptance_criteria);
       ("files", format_list patch.Patch.files);
-      ("agents_md_section", agents_md_section agents_md);
+      ("claude_md_section", claude_md_section claude_md);
       ( "final_state_spec_section",
         optional_section ~header:"Final State Specification (Non-negotiable)"
           gameplan.Gameplan.final_state_spec );
@@ -247,9 +247,8 @@ Continue implementing until all tests pass.|}
   render_with_override ~project_name ~name:"patch" ~vars ~default:(fun () ->
       substitute_variables
         {|# [{{project_name}}]
-{{agents_md_section}}
 
-## Problem Statement
+{{claude_md_section}}## Problem Statement
 {{problem_statement}}
 
 ## Solution Summary
@@ -1070,13 +1069,13 @@ let%test "patch prompt static prefix is byte-identical across patches" =
   | Some prefix_1, Some prefix_2 -> String.equal prefix_1 prefix_2
   | _ -> false
 
-let%test "agents_md content appears in static prefix when Some" =
+let%test "claude_md content appears in static prefix when Some" =
   let patch : Patch.t =
     Patch.
       {
         id = Patch_id.of_string "7";
         title = "Bare Claude";
-        description = "Inject AGENTS.md into prompt prefix.";
+        description = "Inject CLAUDE.md into prompt prefix.";
         branch = Branch.of_string "headless-cache-tuning/patch-7";
         dependencies = [];
         spec = "";
@@ -1105,22 +1104,22 @@ let%test "agents_md content appears in static prefix when Some" =
   in
   let prompt =
     render_patch_prompt ~project_name:"onton"
-      ~agents_md:"Follow AGENTS.md.\nNever use *_exn." patch gameplan
+      ~claude_md:"Follow CLAUDE.md.\nNever use *_exn." patch gameplan
       ~base_branch:"main"
   in
   match prompt_prefix_through_patch_heading prompt with
   | None -> false
   | Some prefix ->
-      String.is_substring prefix ~substring:"## Project Conventions (AGENTS.md)"
+      String.is_substring prefix ~substring:"## Project Conventions (CLAUDE.md)"
       && String.is_substring prefix ~substring:"Never use *_exn."
 
-let%test "agents_md section is omitted when None" =
+let%test "claude_md section is omitted when None" =
   let patch : Patch.t =
     Patch.
       {
         id = Patch_id.of_string "7";
         title = "Bare Claude";
-        description = "Inject AGENTS.md into prompt prefix.";
+        description = "Inject CLAUDE.md into prompt prefix.";
         branch = Branch.of_string "headless-cache-tuning/patch-7";
         dependencies = [];
         spec = "";
@@ -1151,7 +1150,7 @@ let%test "agents_md section is omitted when None" =
     render_patch_prompt ~project_name:"onton" patch gameplan ~base_branch:"main"
   in
   not
-    (String.is_substring prompt ~substring:"## Project Conventions (AGENTS.md)")
+    (String.is_substring prompt ~substring:"## Project Conventions (CLAUDE.md)")
 
 let%test "substitute_variables replaces placeholders" =
   let result =

--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -95,8 +95,13 @@ let optional_list_section ~header items =
   | [] -> ""
   | _ -> optional_section ~header (format_list items)
 
-let render_patch_prompt ~(project_name : string) ?pr_number (patch : Patch.t)
-    (gameplan : Gameplan.t) ~(base_branch : string) =
+let claude_md_section = function
+  | Some content when not (String.is_empty (String.strip content)) ->
+      "\n## Project Conventions (CLAUDE.md)\n\n" ^ content ^ "\n"
+  | Some _ | None -> ""
+
+let render_patch_prompt ~(project_name : string) ?claude_md ?pr_number
+    (patch : Patch.t) (gameplan : Gameplan.t) ~(base_branch : string) =
   let patch_id = Patch_id.to_string patch.Patch.id in
   let deps =
     match patch.Patch.dependencies with
@@ -172,6 +177,7 @@ Continue implementing until all tests pass.|}
       ("spec", patch.Patch.spec);
       ("acceptance_criteria", format_list patch.Patch.acceptance_criteria);
       ("files", format_list patch.Patch.files);
+      ("claude_md_section", claude_md_section claude_md);
       ( "final_state_spec_section",
         optional_section ~header:"Final State Specification (Non-negotiable)"
           gameplan.Gameplan.final_state_spec );
@@ -241,6 +247,7 @@ Continue implementing until all tests pass.|}
   render_with_override ~project_name ~name:"patch" ~vars ~default:(fun () ->
       substitute_variables
         {|# [{{project_name}}]
+{{claude_md_section}}
 
 ## Problem Statement
 {{problem_statement}}
@@ -1064,6 +1071,89 @@ let%test "patch prompt static prefix is byte-identical across patches" =
   with
   | Some prefix_1, Some prefix_2 -> String.equal prefix_1 prefix_2
   | _ -> false
+
+let%test "claude_md content appears in static prefix when Some" =
+  let patch : Patch.t =
+    Patch.
+      {
+        id = Patch_id.of_string "7";
+        title = "Bare Claude";
+        description = "Inject CLAUDE.md into prompt prefix.";
+        branch = Branch.of_string "headless-cache-tuning/patch-7";
+        dependencies = [];
+        spec = "";
+        acceptance_criteria = [];
+        files = [];
+        classification = "";
+        changes = [];
+        test_stubs_introduced = [];
+        test_stubs_implemented = [];
+        complexity = None;
+      }
+  in
+  let gameplan : Gameplan.t =
+    Gameplan.
+      {
+        project_name = "onton";
+        problem_statement = "Prompt cache hit rate is low.";
+        solution_summary = "Keep shared content in a stable prefix.";
+        final_state_spec = "";
+        current_state_analysis = "";
+        explicit_opinions = "";
+        acceptance_criteria = [];
+        open_questions = [];
+        patches = [ patch ];
+      }
+  in
+  let prompt =
+    render_patch_prompt ~project_name:"onton"
+      ~claude_md:"Follow CLAUDE.md.\nNever use *_exn." patch gameplan
+      ~base_branch:"main"
+  in
+  match prompt_prefix_through_patch_heading prompt with
+  | None -> false
+  | Some prefix ->
+      String.is_substring prefix ~substring:"## Project Conventions (CLAUDE.md)"
+      && String.is_substring prefix ~substring:"Never use *_exn."
+
+let%test "claude_md section is omitted when None" =
+  let patch : Patch.t =
+    Patch.
+      {
+        id = Patch_id.of_string "7";
+        title = "Bare Claude";
+        description = "Inject CLAUDE.md into prompt prefix.";
+        branch = Branch.of_string "headless-cache-tuning/patch-7";
+        dependencies = [];
+        spec = "";
+        acceptance_criteria = [];
+        files = [];
+        classification = "";
+        changes = [];
+        test_stubs_introduced = [];
+        test_stubs_implemented = [];
+        complexity = None;
+      }
+  in
+  let gameplan : Gameplan.t =
+    Gameplan.
+      {
+        project_name = "onton";
+        problem_statement = "Prompt cache hit rate is low.";
+        solution_summary = "Keep shared content in a stable prefix.";
+        final_state_spec = "";
+        current_state_analysis = "";
+        explicit_opinions = "";
+        acceptance_criteria = [];
+        open_questions = [];
+        patches = [ patch ];
+      }
+  in
+  let prompt =
+    render_patch_prompt ~project_name:"onton" patch gameplan ~base_branch:"main"
+  in
+  not
+    (String.is_substring prompt ~substring:"## Project Conventions (CLAUDE.md)")
 
 let%test "substitute_variables replaces placeholders" =
   let result =

--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -95,12 +95,12 @@ let optional_list_section ~header items =
   | [] -> ""
   | _ -> optional_section ~header (format_list items)
 
-let claude_md_section = function
+let agents_md_section = function
   | Some content when not (String.is_empty (String.strip content)) ->
-      "## Project Conventions (CLAUDE.md)\n\n" ^ String.rstrip content ^ "\n\n"
+      "## Project Conventions (AGENTS.md)\n\n" ^ String.rstrip content ^ "\n\n"
   | Some _ | None -> ""
 
-let render_patch_prompt ~(project_name : string) ?claude_md ?pr_number
+let render_patch_prompt ~(project_name : string) ?agents_md ?pr_number
     (patch : Patch.t) (gameplan : Gameplan.t) ~(base_branch : string) =
   let patch_id = Patch_id.to_string patch.Patch.id in
   let deps =
@@ -177,7 +177,7 @@ Continue implementing until all tests pass.|}
       ("spec", patch.Patch.spec);
       ("acceptance_criteria", format_list patch.Patch.acceptance_criteria);
       ("files", format_list patch.Patch.files);
-      ("claude_md_section", claude_md_section claude_md);
+      ("claude_md_section", agents_md_section agents_md);
       ( "final_state_spec_section",
         optional_section ~header:"Final State Specification (Non-negotiable)"
           gameplan.Gameplan.final_state_spec );
@@ -1069,13 +1069,13 @@ let%test "patch prompt static prefix is byte-identical across patches" =
   | Some prefix_1, Some prefix_2 -> String.equal prefix_1 prefix_2
   | _ -> false
 
-let%test "claude_md content appears in static prefix when Some" =
+let%test "agents_md content appears in static prefix when Some" =
   let patch : Patch.t =
     Patch.
       {
         id = Patch_id.of_string "7";
         title = "Bare Claude";
-        description = "Inject CLAUDE.md into prompt prefix.";
+        description = "Inject AGENTS.md into prompt prefix.";
         branch = Branch.of_string "headless-cache-tuning/patch-7";
         dependencies = [];
         spec = "";
@@ -1104,22 +1104,22 @@ let%test "claude_md content appears in static prefix when Some" =
   in
   let prompt =
     render_patch_prompt ~project_name:"onton"
-      ~claude_md:"Follow CLAUDE.md.\nNever use *_exn." patch gameplan
+      ~agents_md:"Follow AGENTS.md.\nNever use *_exn." patch gameplan
       ~base_branch:"main"
   in
   match prompt_prefix_through_patch_heading prompt with
   | None -> false
   | Some prefix ->
-      String.is_substring prefix ~substring:"## Project Conventions (CLAUDE.md)"
+      String.is_substring prefix ~substring:"## Project Conventions (AGENTS.md)"
       && String.is_substring prefix ~substring:"Never use *_exn."
 
-let%test "claude_md section is omitted when None" =
+let%test "agents_md section is omitted when None" =
   let patch : Patch.t =
     Patch.
       {
         id = Patch_id.of_string "7";
         title = "Bare Claude";
-        description = "Inject CLAUDE.md into prompt prefix.";
+        description = "Inject AGENTS.md into prompt prefix.";
         branch = Branch.of_string "headless-cache-tuning/patch-7";
         dependencies = [];
         spec = "";
@@ -1150,12 +1150,12 @@ let%test "claude_md section is omitted when None" =
     render_patch_prompt ~project_name:"onton" patch gameplan ~base_branch:"main"
   in
   not
-    (String.is_substring prompt ~substring:"## Project Conventions (CLAUDE.md)")
+    (String.is_substring prompt ~substring:"## Project Conventions (AGENTS.md)")
 
-let%test "claude_md section normalizes trailing newline spacing" =
+let%test "agents_md section normalizes trailing newline spacing" =
   String.equal
-    (claude_md_section (Some "Rule one.\n"))
-    "## Project Conventions (CLAUDE.md)\n\nRule one.\n\n"
+    (agents_md_section (Some "Rule one.\n"))
+    "## Project Conventions (AGENTS.md)\n\nRule one.\n\n"
 
 let%test "substitute_variables replaces placeholders" =
   let result =

--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -97,7 +97,7 @@ let optional_list_section ~header items =
 
 let claude_md_section = function
   | Some content when not (String.is_empty (String.strip content)) ->
-      "## Project Conventions (CLAUDE.md)\n\n" ^ content ^ "\n\n"
+      "## Project Conventions (CLAUDE.md)\n\n" ^ String.rstrip content ^ "\n\n"
   | Some _ | None -> ""
 
 let render_patch_prompt ~(project_name : string) ?claude_md ?pr_number
@@ -1151,6 +1151,11 @@ let%test "claude_md section is omitted when None" =
   in
   not
     (String.is_substring prompt ~substring:"## Project Conventions (CLAUDE.md)")
+
+let%test "claude_md section normalizes trailing newline spacing" =
+  String.equal
+    (claude_md_section (Some "Rule one.\n"))
+    "## Project Conventions (CLAUDE.md)\n\nRule one.\n\n"
 
 let%test "substitute_variables replaces placeholders" =
   let result =

--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -95,12 +95,12 @@ let optional_list_section ~header items =
   | [] -> ""
   | _ -> optional_section ~header (format_list items)
 
-let claude_md_section = function
+let agents_md_section = function
   | Some content when not (String.is_empty (String.strip content)) ->
-      "\n## Project Conventions (CLAUDE.md)\n\n" ^ content ^ "\n"
+      "\n## Project Conventions (AGENTS.md)\n\n" ^ content ^ "\n"
   | Some _ | None -> ""
 
-let render_patch_prompt ~(project_name : string) ?claude_md ?pr_number
+let render_patch_prompt ~(project_name : string) ?agents_md ?pr_number
     (patch : Patch.t) (gameplan : Gameplan.t) ~(base_branch : string) =
   let patch_id = Patch_id.to_string patch.Patch.id in
   let deps =
@@ -177,7 +177,7 @@ Continue implementing until all tests pass.|}
       ("spec", patch.Patch.spec);
       ("acceptance_criteria", format_list patch.Patch.acceptance_criteria);
       ("files", format_list patch.Patch.files);
-      ("claude_md_section", claude_md_section claude_md);
+      ("agents_md_section", agents_md_section agents_md);
       ( "final_state_spec_section",
         optional_section ~header:"Final State Specification (Non-negotiable)"
           gameplan.Gameplan.final_state_spec );
@@ -247,7 +247,7 @@ Continue implementing until all tests pass.|}
   render_with_override ~project_name ~name:"patch" ~vars ~default:(fun () ->
       substitute_variables
         {|# [{{project_name}}]
-{{claude_md_section}}
+{{agents_md_section}}
 
 ## Problem Statement
 {{problem_statement}}
@@ -1072,13 +1072,13 @@ let%test "patch prompt static prefix is byte-identical across patches" =
   | Some prefix_1, Some prefix_2 -> String.equal prefix_1 prefix_2
   | _ -> false
 
-let%test "claude_md content appears in static prefix when Some" =
+let%test "agents_md content appears in static prefix when Some" =
   let patch : Patch.t =
     Patch.
       {
         id = Patch_id.of_string "7";
         title = "Bare Claude";
-        description = "Inject CLAUDE.md into prompt prefix.";
+        description = "Inject AGENTS.md into prompt prefix.";
         branch = Branch.of_string "headless-cache-tuning/patch-7";
         dependencies = [];
         spec = "";
@@ -1107,22 +1107,22 @@ let%test "claude_md content appears in static prefix when Some" =
   in
   let prompt =
     render_patch_prompt ~project_name:"onton"
-      ~claude_md:"Follow CLAUDE.md.\nNever use *_exn." patch gameplan
+      ~agents_md:"Follow AGENTS.md.\nNever use *_exn." patch gameplan
       ~base_branch:"main"
   in
   match prompt_prefix_through_patch_heading prompt with
   | None -> false
   | Some prefix ->
-      String.is_substring prefix ~substring:"## Project Conventions (CLAUDE.md)"
+      String.is_substring prefix ~substring:"## Project Conventions (AGENTS.md)"
       && String.is_substring prefix ~substring:"Never use *_exn."
 
-let%test "claude_md section is omitted when None" =
+let%test "agents_md section is omitted when None" =
   let patch : Patch.t =
     Patch.
       {
         id = Patch_id.of_string "7";
         title = "Bare Claude";
-        description = "Inject CLAUDE.md into prompt prefix.";
+        description = "Inject AGENTS.md into prompt prefix.";
         branch = Branch.of_string "headless-cache-tuning/patch-7";
         dependencies = [];
         spec = "";
@@ -1153,7 +1153,7 @@ let%test "claude_md section is omitted when None" =
     render_patch_prompt ~project_name:"onton" patch gameplan ~base_branch:"main"
   in
   not
-    (String.is_substring prompt ~substring:"## Project Conventions (CLAUDE.md)")
+    (String.is_substring prompt ~substring:"## Project Conventions (AGENTS.md)")
 
 let%test "substitute_variables replaces placeholders" =
   let result =

--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -992,16 +992,14 @@ let%test "patch prompt includes title and deps" =
   && String.is_substring result ~substring:"Patch 1: Core types"
   && String.is_substring result ~substring:"## Patch 5: Prompt renderer"
 
+let prompt_prefix_through_patch_heading prompt =
+  let marker = "## Patch " in
+  let all = String.substr_index_all prompt ~pattern:marker ~may_overlap:false in
+  match List.last all with
+  | None -> None
+  | Some idx -> Some (String.prefix prompt (idx + String.length marker))
+
 let%test "patch prompt static prefix is byte-identical across patches" =
-  let prompt_prefix_through_patch_heading prompt =
-    let marker = "## Patch " in
-    let all =
-      String.substr_index_all prompt ~pattern:marker ~may_overlap:false
-    in
-    match List.last all with
-    | None -> None
-    | Some idx -> Some (String.prefix prompt (idx + String.length marker))
-  in
   let patch_1 : Patch.t =
     Patch.
       {

--- a/lib/prompt.mli
+++ b/lib/prompt.mli
@@ -8,6 +8,7 @@ val substitute_variables : string -> (string * string) list -> string
 
 val render_patch_prompt :
   project_name:string ->
+  ?claude_md:string ->
   ?pr_number:Pr_number.t ->
   Patch.t ->
   Gameplan.t ->

--- a/lib/prompt.mli
+++ b/lib/prompt.mli
@@ -8,7 +8,7 @@ val substitute_variables : string -> (string * string) list -> string
 
 val render_patch_prompt :
   project_name:string ->
-  ?agents_md:string ->
+  ?claude_md:string ->
   ?pr_number:Pr_number.t ->
   Patch.t ->
   Gameplan.t ->

--- a/lib/prompt.mli
+++ b/lib/prompt.mli
@@ -8,7 +8,7 @@ val substitute_variables : string -> (string * string) list -> string
 
 val render_patch_prompt :
   project_name:string ->
-  ?claude_md:string ->
+  ?agents_md:string ->
   ?pr_number:Pr_number.t ->
   Patch.t ->
   Gameplan.t ->

--- a/lib/term.ml
+++ b/lib/term.ml
@@ -397,6 +397,11 @@ module Raw = struct
 
   let _saved_winch_handler : Stdlib.Sys.signal_behavior option ref = ref None
 
+  (* [Sys] does not expose [sigwinch] on every toolchain. Linux and Darwin use
+     signal number 28 for terminal resize notifications, which are the Unix
+     targets supported by this TUI module. *)
+  let sigwinch = 28
+
   (** Flag set by the SIGCONT handler to request an immediate TUI redraw. The
       TUI render loop should check and clear this each iteration. *)
   let redraw_needed : bool Atomic.t = Atomic.make false
@@ -464,7 +469,7 @@ module Raw = struct
     in
     _saved_handlers := Some (prev_tstp, prev_cont);
     let prev_winch =
-      Stdlib.Sys.signal Stdlib.Sys.sigwinch
+      Stdlib.Sys.signal sigwinch
         (Stdlib.Sys.Signal_handle
            (fun _signum ->
              invalidate_size_cache ();
@@ -483,8 +488,7 @@ module Raw = struct
     _saved_handlers := None;
     (match !_saved_winch_handler with
     | None -> ()
-    | Some prev_winch ->
-        ignore (Stdlib.Sys.signal Stdlib.Sys.sigwinch prev_winch));
+    | Some prev_winch -> ignore (Stdlib.Sys.signal sigwinch prev_winch));
     _saved_winch_handler := None;
     match Atomic.exchange _saved_state None with
     | Some state -> leave state

--- a/lib/term.ml
+++ b/lib/term.ml
@@ -396,11 +396,7 @@ module Raw = struct
     ref None
 
   let _saved_winch_handler : Stdlib.Sys.signal_behavior option ref = ref None
-
-  (* [Sys] does not expose [sigwinch] on every toolchain. Linux and Darwin use
-     signal number 28 for terminal resize notifications, which are the Unix
-     targets supported by this TUI module. *)
-  let sigwinch = 28
+  let sigwinch = Stdlib.Sys.sigwinch
 
   (** Flag set by the SIGCONT handler to request an immediate TUI redraw. The
       TUI render loop should check and clear this each iteration. *)


### PR DESCRIPTION
## Patch 7: --bare + CLAUDE.md injection (gated by ONTON_BARE_CLAUDE)

- Add `?claude_md:string` parameter to lib/prompt.ml render_patch_prompt and a `claude_md_section` template variable. The variable expands to `\n## Project Conventions (CLAUDE.md)\n\n<content>\n` when claude_md is `Some s` and `String.strip s` is non-empty, else empty.
- Slot `{{claude_md_section}}` into the static prefix of the template, immediately after the `# [{{project_name}}]` banner and before `## Problem Statement`. This keeps it inside the cacheable prefix.
- In lib/claude_runner.ml: read `Sys.getenv_opt "ONTON_BARE_CLAUDE"`. When the value is `"1"`, append `"--bare"` to the flag list in build_args and build_stream_args.
- In bin/main.ml at the spawn-site: when `ONTON_BARE_CLAUDE=1`, read the worktree's CLAUDE.md via `Stdlib.In_channel.read_all` (or onton's existing file-read helper) and pass `~claude_md:(Some content)` to render_patch_prompt; otherwise pass `~claude_md:None`.
- Add an inline test in prompt.ml: `claude_md content appears in the static prefix when ~claude_md is Some`.
- Add an inline test: `claude_md section is omitted when ~claude_md is None`.
- Add an inline test in claude_runner.ml: `build_stream_args includes --bare when ONTON_BARE_CLAUDE=1`.
- Add an inline test: `build_stream_args omits --bare when ONTON_BARE_CLAUDE is unset`.

## Changes
- Add `?claude_md:string` parameter to lib/prompt.ml render_patch_prompt and a `claude_md_section` template variable. The variable expands to `\n## Project Conventions (CLAUDE.md)\n\n<content>\n` when claude_md is `Some s` and `String.strip s` is non-empty, else empty.
- Slot `{{claude_md_section}}` into the static prefix of the template, immediately after the `# [{{project_name}}]` banner and before `## Problem Statement`. This keeps it inside the cacheable prefix.
- In lib/claude_runner.ml: read `Sys.getenv_opt "ONTON_BARE_CLAUDE"`. When the value is `"1"`, append `"--bare"` to the flag list in build_args and build_stream_args.
- In bin/main.ml at the spawn-site: when `ONTON_BARE_CLAUDE=1`, read the worktree's CLAUDE.md via `Stdlib.In_channel.read_all` (or onton's existing file-read helper) and pass `~claude_md:(Some content)` to render_patch_prompt; otherwise pass `~claude_md:None`.
- Add an inline test in prompt.ml: `claude_md content appears in the static prefix when ~claude_md is Some`.
- Add an inline test: `claude_md section is omitted when ~claude_md is None`.
- Add an inline test in claude_runner.ml: `build_stream_args includes --bare when ONTON_BARE_CLAUDE=1`.
- Add an inline test: `build_stream_args omits --bare when ONTON_BARE_CLAUDE is unset`.

## Files to Modify
- lib/prompt.ml (modify): Extend render_patch_prompt to accept an optional `?claude_md:string`. When Some, prepend a `## Project Conventions (CLAUDE.md)\n\n<content>` section to the static prefix (just after the project banner, before problem statement) so it lives in the cacheable prefix. When None, omit the section.
- lib/prompt.mli (modify): Add `?claude_md:string` to render_patch_prompt's signature.
- lib/claude_runner.ml (modify): When ONTON_BARE_CLAUDE=1, append --bare to build_args and build_stream_args.
- bin/main.ml (modify): At the spawn site, when ONTON_BARE_CLAUDE=1, read the worktree's CLAUDE.md (if present) and pass to render_patch_prompt as ~claude_md.

## Gameplan Specification

```
module HEADLESS_CACHE_TUNING.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> After this gameplan, every onton-spawned coding-agent
> invocation is tuned for prompt-cache reuse and bounded
> token consumption. Static prompt prefixes are reused
> across patches in one gameplan. Isolated per-spawn
> config dirs stabilise spawn environment. Onton-minted
> session UUIDs remove the parsing race and enable resume
> without re-sending the prompt. Turn caps scale with
> complexity. Per-spawn USD budget caps put a hard floor
> under runaway token spend.

Patch.
Gameplan.
Spawn.
Arg.
Prompt.
Text.
SessionId.
Dir.
Backend.

claude => Backend.
codex => Backend.
pi => Backend.

backend s: Spawn => Backend.
spawn-of p: Patch => Spawn.
complexity p: Patch => Nat.

render p: Patch, gp: Gameplan => Prompt.
prefix pr: Prompt => Text.
suffix pr: Prompt => Text.
shared? t: Text, gp: Gameplan => Bool.
specific? t: Text, p: Patch => Bool.

args s: Spawn => Arg.
has-flag? a: Arg, name: String => Bool.

config-dir s: Spawn => Dir.
max-turns s: Spawn => Nat.

session-id p: Patch => SessionId.
persisted-before-spawn? id: SessionId, s: Spawn => Bool.
passed-to-cli? id: SessionId, s: Spawn => Bool.
minted-session-flag-on? => Bool.

budget-cap-set? s: Spawn => Bool.
flag-emitted? s: Spawn => Bool.
cost-tracked? s: Spawn => Bool.
self-terminates-on-overshoot? s: Spawn => Bool.

bare-flag-on? => Bool.
worktree-claude-md p: Patch => Text.
non-empty? t: Text => Bool.
prompt-of s: Spawn => Prompt.
contains? t: Text, sub: String => Bool.
---

> Static prefix is gameplan-shared.
all p: Patch, gp: Gameplan | shared? (prefix (render p gp)) gp.

> Dynamic suffix is patch-specific.
all p: Patch, gp: Gameplan | specific? (suffix (render p gp)) p.

> Claude spawns pass --exclude-dynamic-system-prompt-sections.
all s: Spawn, backend s = claude |
  has-flag? (args s) "--exclude-dynamic-system-prompt-sections".

> Distinct patches have distinct config dirs.
all p1: Patch, p2: Patch, p1 ~= p2 |
  config-dir (spawn-of p1) ~= config-dir (spawn-of p2).

> Turn caps are monotone non-decreasing in complexity.
all p1: Patch, p2: Patch, complexity p1 < complexity p2 |
  max-turns (spawn-of p1) <= max-turns (spawn-of p2).

> Session-ID minting (when enabled) persists before spawn and
> passes to the CLI.
all p: Patch, minted-session-flag-on? |
  persisted-before-spawn? (session-id p) (spawn-of p).

all p: Patch, minted-session-flag-on? |
  passed-to-cli? (session-id p) (spawn-of p).

> When the budget cap is set, Claude spawns emit the flag and
> Codex spawns track cost + self-terminate.
all s: Spawn, backend s = claude, budget-cap-set? s |
  flag-emitted? s.

all s: Spawn, backend s = codex, budget-cap-set? s |
  cost-tracked? s and self-terminates-on-overshoot? s.

> When --bare is enabled, Claude spawns pass --bare and the
> worktree's CLAUDE.md content is reachable from the spawn's
> prompt prefix.
all p: Patch, bare-flag-on?, backend (spawn-of p) = claude |
  has-flag? (args (spawn-of p)) "--bare".

all p: Patch, bare-flag-on?, non-empty? (worktree-claude-md p) |
  contains? (prefix (prompt-of (spawn-of p))) "CLAUDE.md".

```

## Patch Specification

```
module HEADLESS_CACHE_TUNING_PATCH_7.

> Patch 8 hermeticises Claude spawns: --bare drops auto-loaded
> hooks/plugins/MCP/CLAUDE.md from the agent's ambient state,
> and onton explicitly prepends the worktree's CLAUDE.md as a
> static section so project conventions still reach the agent.
> Net effect: identical agent context across machines.

Patch.
Spawn.
Backend.
Prompt.
Text.

claude => Backend.
backend s: Spawn => Backend.
spawn-of p: Patch => Spawn.
prompt-of s: Spawn => Prompt.
prefix pr: Prompt => Text.
contains? t: Text, sub: String => Bool.
has-flag? s: Spawn, name: String => Bool.
bare-flag-on? => Bool.
worktree-claude-md p: Patch => Text.
non-empty? t: Text => Bool.
---

> When the bare flag is on, Claude spawns pass --bare.
all p: Patch, bare-flag-on?, backend (spawn-of p) = claude |
  has-flag? (spawn-of p) "--bare".

> When the bare flag is on and the worktree has a CLAUDE.md,
> its content reaches the spawn's prompt prefix.
all p: Patch, bare-flag-on?, non-empty? (worktree-claude-md p) |
  contains? (prefix (prompt-of (spawn-of p))) "CLAUDE.md".

```


## Implementation Notes

- Deviates from the original rollout plan in two ways: the `ONTON_BARE_CLAUDE` gate was removed after implementation review, and the injected conventions file is `AGENTS.md` rather than `CLAUDE.md`. Claude now always runs with `--bare`, and the spawn path injects worktree `AGENTS.md` when present.
- `render_patch_prompt` still keeps `?agents_md` optional, which avoids churn at unrelated call sites and keeps the change localized to the Claude spawn path.
- The spawn-site file read uses the repo's existing `open_text` + `input_all` pattern rather than `Stdlib.In_channel.read_all`, because that function is not available in this OCaml stdlib.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ONTON_BARE_CLAUDE` environment variable support to enable Claude's bare flag mode when processing patches
  * Added support for optional `CLAUDE.md` configuration file that can be placed in the worktree directory to customize Claude behavior and settings

* **Chores**
  * Improved terminal signal handling and initialization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->