### PR TITLE
[headless-cache-tuning] Patch 5: Mint Claude session UUIDs in onton, persist before spawn

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -3558,6 +3558,8 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
             Printf.eprintf "Starting new project %S.\n%!" project_name;
             Runtime.create ~gameplan ~main_branch:config.main_branch ()
       in
+      Unix.putenv "ONTON_SNAPSHOT_PATH"
+        (Project_store.snapshot_path project_name);
       let github =
         Github.create ~token:config.github_token ~owner:config.github_owner
           ~repo:config.github_repo

--- a/lib/claude_runner.ml
+++ b/lib/claude_runner.ml
@@ -74,6 +74,12 @@ let build_args ~model ~complexity ~prompt ~resume_session =
 
 let build_stream_args ~model ~complexity ~prompt ~minted_session_id
     ~resume_session =
+  (match (minted_session_id, resume_session) with
+  | Some _, Some _ ->
+      invalid_arg
+        "Claude_runner.build_stream_args: minted_session_id and resume_session \
+         are mutually exclusive"
+  | _ -> ());
   let base = [ "claude" ] in
   let prompt_args =
     [ "-p"; prompt; "--output-format"; "stream-json"; "--verbose" ]
@@ -534,6 +540,14 @@ let%test "build_stream_args emits --session-id when minted_session_id is Some" =
       "200";
       "--exclude-dynamic-system-prompt-sections";
     ]
+
+let%test "build_stream_args rejects session-id plus resume together" =
+  match
+    build_stream_args ~model:None ~complexity:None ~prompt:"do stuff"
+      ~minted_session_id:(Some "minted") ~resume_session:(Some "resume")
+  with
+  | _ -> false
+  | exception Invalid_argument _ -> true
 
 let%test "prepare_minted_session_id errors when flag is on and path missing" =
   let patch_id = Types.Patch_id.of_string "5" in

--- a/lib/claude_runner.ml
+++ b/lib/claude_runner.ml
@@ -97,11 +97,11 @@ let build_stream_args ~model ~complexity ~prompt ~minted_session_id
   base @ model_args model @ minted_session_args @ prompt_args @ session_args
   @ flags
 
-let prepare_minted_session_id ~patch_id ~resume_session =
-  match (resume_session, Stdlib.Sys.getenv_opt "ONTON_MINTED_SESSION_IDS") with
+let prepare_minted_session_id_with_env ~getenv_opt ~patch_id ~resume_session =
+  match (resume_session, getenv_opt "ONTON_MINTED_SESSION_IDS") with
   | Some _, _ | _, None | _, Some "" -> Ok None
   | None, Some "1" -> (
-      match Stdlib.Sys.getenv_opt "ONTON_SNAPSHOT_PATH" with
+      match getenv_opt "ONTON_SNAPSHOT_PATH" with
       | Some snapshot_path
         when not (String.is_empty (String.strip snapshot_path)) ->
           let session_id = Session_id.mint () in
@@ -112,6 +112,9 @@ let prepare_minted_session_id ~patch_id ~resume_session =
           Error
             "ONTON_MINTED_SESSION_IDS=1 requires ONTON_SNAPSHOT_PATH to be set")
   | None, Some _ -> Ok None
+
+let prepare_minted_session_id =
+  prepare_minted_session_id_with_env ~getenv_opt:Stdlib.Sys.getenv_opt
 
 (** Find the first '\{' in [s] and return the substring starting there. Defense
     against any leading garbage in a stream-json line. *)
@@ -534,23 +537,17 @@ let%test "build_stream_args emits --session-id when minted_session_id is Some" =
 
 let%test "prepare_minted_session_id errors when flag is on and path missing" =
   let patch_id = Types.Patch_id.of_string "5" in
-  let restore name value =
-    match value with
-    | Some v -> Unix.putenv name v
-    | None -> Unix.putenv name ""
+  let getenv_opt = function
+    | "ONTON_MINTED_SESSION_IDS" -> Some "1"
+    | "ONTON_SNAPSHOT_PATH" -> None
+    | _ -> None
   in
-  let old_flag = Stdlib.Sys.getenv_opt "ONTON_MINTED_SESSION_IDS" in
-  let old_path = Stdlib.Sys.getenv_opt "ONTON_SNAPSHOT_PATH" in
-  Stdlib.Fun.protect
-    ~finally:(fun () ->
-      restore "ONTON_MINTED_SESSION_IDS" old_flag;
-      restore "ONTON_SNAPSHOT_PATH" old_path)
-    (fun () ->
-      Unix.putenv "ONTON_MINTED_SESSION_IDS" "1";
-      Unix.putenv "ONTON_SNAPSHOT_PATH" "";
-      match prepare_minted_session_id ~patch_id ~resume_session:None with
-      | Error _ -> true
-      | Ok _ -> false)
+  match
+    prepare_minted_session_id_with_env ~getenv_opt ~patch_id
+      ~resume_session:None
+  with
+  | Error _ -> true
+  | Ok _ -> false
 
 let%test "strip_ansi removes escape sequences" =
   String.equal (strip_ansi "\027[31mhello\027[0m") "hello"

--- a/lib/claude_runner.ml
+++ b/lib/claude_runner.ml
@@ -72,10 +72,17 @@ let build_args ~model ~complexity ~prompt ~resume_session =
   in
   base @ model_args model @ prompt_args @ session_args @ flags
 
-let build_stream_args ~model ~complexity ~prompt ~resume_session =
+let build_stream_args ~model ~prompt ~minted_session_id ~resume_session =
+let build_stream_args ~model ~complexity ~prompt ~minted_session_id
+    ~resume_session =
   let base = [ "claude" ] in
   let prompt_args =
     [ "-p"; prompt; "--output-format"; "stream-json"; "--verbose" ]
+  in
+  let minted_session_args =
+    match minted_session_id with
+    | Some id -> [ "--session-id"; id ]
+    | None -> []
   in
   let session_args =
     match resume_session with Some id -> [ "--resume"; id ] | None -> []
@@ -88,7 +95,8 @@ let build_stream_args ~model ~complexity ~prompt ~resume_session =
       "--exclude-dynamic-system-prompt-sections";
     ]
   in
-  base @ model_args model @ prompt_args @ session_args @ flags
+  base @ model_args model @ minted_session_args @ prompt_args @ session_args
+  @ flags
 
 (** Find the first '\{' in [s] and return the substring starting there. Defense
     against any leading garbage in a stream-json line. *)
@@ -289,7 +297,25 @@ let run ~model ~process_mgr ~cwd ~patch_id ~prompt ~resume_session ~complexity =
 let run_streaming ~model ~process_mgr ~clock ~timeout ~setsid_exec ~project_name
     ~cwd ~patch_id ~prompt ~resume_session ~complexity ~on_event =
   let model = Llm_backend.resolve_auto_model ~model ~complexity ~auto_model in
-  let args = build_stream_args ~model ~complexity ~prompt ~resume_session in
+  let minted_session_id =
+    match
+      (resume_session, Stdlib.Sys.getenv_opt "ONTON_MINTED_SESSION_IDS")
+    with
+    | None, Some "1" ->
+        let session_id = Session_id.mint () in
+        (match Stdlib.Sys.getenv_opt "ONTON_SNAPSHOT_PATH" with
+        | Some snapshot_path ->
+            ignore
+              (Persistence.record_session_id ~snapshot_path ~patch_id
+                 ~session_id)
+        | None -> ());
+        Some session_id
+    | _ -> None
+  in
+  let args =
+    build_stream_args ~model ~complexity ~prompt ~minted_session_id
+      ~resume_session
+  in
   let env =
     Spawn_env.merge_env ~base_env:(Unix.environment ())
       ~overrides:(Spawn_env.per_patch_env ~project_name ~patch_id)
@@ -401,7 +427,7 @@ let%test "build_stream_args fresh (no resume, with model)" =
   let complexity = Some 2 in
   let args =
     build_stream_args ~model:(Some "sonnet") ~complexity ~prompt:"do stuff"
-      ~resume_session:None
+      ~minted_session_id:None ~resume_session:None
   in
   List.equal String.equal args
     [
@@ -423,7 +449,7 @@ let%test "build_stream_args fresh (no resume, no model)" =
   let complexity = None in
   let args =
     build_stream_args ~model:None ~complexity ~prompt:"do stuff"
-      ~resume_session:None
+      ~minted_session_id:None ~resume_session:None
   in
   List.equal String.equal args
     [
@@ -443,7 +469,7 @@ let%test "build_stream_args with resume session" =
   let complexity = Some 1 in
   let args =
     build_stream_args ~model:(Some "opus") ~complexity ~prompt:"do stuff"
-      ~resume_session:(Some "abc-123")
+      ~minted_session_id:None ~resume_session:(Some "abc-123")
   in
   List.equal String.equal args
     [
@@ -466,9 +492,34 @@ let%test "build_stream_args with resume session" =
 let%test "build_stream_args includes --exclude-dynamic-system-prompt-sections" =
   let args =
     build_stream_args ~model:None ~complexity:None ~prompt:"do stuff"
-      ~resume_session:None
+      ~minted_session_id:None ~resume_session:None
   in
   List.mem args "--exclude-dynamic-system-prompt-sections" ~equal:String.equal
+
+let%test "build_stream_args emits --session-id when minted_session_id is Some" =
+  let complexity = None in
+  let args =
+    build_stream_args ~model:(Some "sonnet") ~complexity ~prompt:"do stuff"
+      ~minted_session_id:(Some "123e4567-e89b-42d3-a456-426614174000")
+      ~resume_session:None
+  in
+  List.equal String.equal args
+    [
+      "claude";
+      "--model";
+      "sonnet";
+      "--session-id";
+      "123e4567-e89b-42d3-a456-426614174000";
+      "-p";
+      "do stuff";
+      "--output-format";
+      "stream-json";
+      "--verbose";
+      "--dangerously-skip-permissions";
+      "--max-turns";
+      "200";
+      "--exclude-dynamic-system-prompt-sections";
+    ]
 
 let%test "strip_ansi removes escape sequences" =
   String.equal (strip_ansi "\027[31mhello\027[0m") "hello"

--- a/lib/claude_runner.ml
+++ b/lib/claude_runner.ml
@@ -72,7 +72,6 @@ let build_args ~model ~complexity ~prompt ~resume_session =
   in
   base @ model_args model @ prompt_args @ session_args @ flags
 
-let build_stream_args ~model ~prompt ~minted_session_id ~resume_session =
 let build_stream_args ~model ~complexity ~prompt ~minted_session_id
     ~resume_session =
   let base = [ "claude" ] in
@@ -97,6 +96,22 @@ let build_stream_args ~model ~complexity ~prompt ~minted_session_id
   in
   base @ model_args model @ minted_session_args @ prompt_args @ session_args
   @ flags
+
+let prepare_minted_session_id ~patch_id ~resume_session =
+  match (resume_session, Stdlib.Sys.getenv_opt "ONTON_MINTED_SESSION_IDS") with
+  | Some _, _ | _, None | _, Some "" -> Ok None
+  | None, Some "1" -> (
+      match Stdlib.Sys.getenv_opt "ONTON_SNAPSHOT_PATH" with
+      | Some snapshot_path
+        when not (String.is_empty (String.strip snapshot_path)) ->
+          let session_id = Session_id.mint () in
+          Result.map
+            (Persistence.record_session_id ~snapshot_path ~patch_id ~session_id)
+            ~f:(fun () -> Some session_id)
+      | _ ->
+          Error
+            "ONTON_MINTED_SESSION_IDS=1 requires ONTON_SNAPSHOT_PATH to be set")
+  | None, Some _ -> Ok None
 
 (** Find the first '\{' in [s] and return the substring starting there. Defense
     against any leading garbage in a stream-json line. *)
@@ -297,35 +312,31 @@ let run ~model ~process_mgr ~cwd ~patch_id ~prompt ~resume_session ~complexity =
 let run_streaming ~model ~process_mgr ~clock ~timeout ~setsid_exec ~project_name
     ~cwd ~patch_id ~prompt ~resume_session ~complexity ~on_event =
   let model = Llm_backend.resolve_auto_model ~model ~complexity ~auto_model in
-  let minted_session_id =
-    match
-      (resume_session, Stdlib.Sys.getenv_opt "ONTON_MINTED_SESSION_IDS")
-    with
-    | None, Some "1" ->
-        let session_id = Session_id.mint () in
-        (match Stdlib.Sys.getenv_opt "ONTON_SNAPSHOT_PATH" with
-        | Some snapshot_path ->
-            ignore
-              (Persistence.record_session_id ~snapshot_path ~patch_id
-                 ~session_id)
-        | None -> ());
-        Some session_id
-    | _ -> None
-  in
-  let args =
-    build_stream_args ~model ~complexity ~prompt ~minted_session_id
-      ~resume_session
-  in
   let env =
     Spawn_env.merge_env ~base_env:(Unix.environment ())
       ~overrides:(Spawn_env.per_patch_env ~project_name ~patch_id)
   in
-  let process_line line =
-    let trimmed = strip_ansi (String.strip line) in
-    if String.is_empty trimmed then [] else parse_stream_events trimmed
-  in
-  Llm_backend.spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~env
-    ~setsid_exec ~args ~process_line ~on_event
+  match prepare_minted_session_id ~patch_id ~resume_session with
+  | Error msg ->
+      {
+        Llm_backend.exit_code = 1;
+        stdout = "";
+        stderr = msg;
+        got_events = false;
+        saw_final_result = false;
+        timed_out = false;
+      }
+  | Ok minted_session_id ->
+      let args =
+        build_stream_args ~model ~complexity ~prompt ~minted_session_id
+          ~resume_session
+      in
+      let process_line line =
+        let trimmed = strip_ansi (String.strip line) in
+        if String.is_empty trimmed then [] else parse_stream_events trimmed
+      in
+      Llm_backend.spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~env
+        ~setsid_exec ~args ~process_line ~on_event
 
 let%test "auto_model: complexity 1 -> haiku" =
   Option.equal String.equal (auto_model ~complexity:(Some 1)) (Some "haiku")
@@ -520,6 +531,26 @@ let%test "build_stream_args emits --session-id when minted_session_id is Some" =
       "200";
       "--exclude-dynamic-system-prompt-sections";
     ]
+
+let%test "prepare_minted_session_id errors when flag is on and path missing" =
+  let patch_id = Types.Patch_id.of_string "5" in
+  let restore name value =
+    match value with
+    | Some v -> Unix.putenv name v
+    | None -> Unix.putenv name ""
+  in
+  let old_flag = Stdlib.Sys.getenv_opt "ONTON_MINTED_SESSION_IDS" in
+  let old_path = Stdlib.Sys.getenv_opt "ONTON_SNAPSHOT_PATH" in
+  Stdlib.Fun.protect
+    ~finally:(fun () ->
+      restore "ONTON_MINTED_SESSION_IDS" old_flag;
+      restore "ONTON_SNAPSHOT_PATH" old_path)
+    (fun () ->
+      Unix.putenv "ONTON_MINTED_SESSION_IDS" "1";
+      Unix.putenv "ONTON_SNAPSHOT_PATH" "";
+      match prepare_minted_session_id ~patch_id ~resume_session:None with
+      | Error _ -> true
+      | Ok _ -> false)
 
 let%test "strip_ansi removes escape sequences" =
   String.equal (strip_ansi "\027[31mhello\027[0m") "hello"

--- a/lib/claude_runner.mli
+++ b/lib/claude_runner.mli
@@ -89,4 +89,5 @@ val build_stream_args :
   resume_session:string option ->
   string list
 (** Build the CLI argument list for stream-json output mode. Exposed for
-    testing. *)
+    testing. [minted_session_id] and [resume_session] are mutually exclusive:
+    fresh spawns pass the former, resumes pass the latter. *)

--- a/lib/claude_runner.mli
+++ b/lib/claude_runner.mli
@@ -85,6 +85,7 @@ val build_stream_args :
   model:string option ->
   complexity:int option ->
   prompt:string ->
+  minted_session_id:string option ->
   resume_session:string option ->
   string list
 (** Build the CLI argument list for stream-json output mode. Exposed for

--- a/lib/persistence.ml
+++ b/lib/persistence.ml
@@ -3,6 +3,79 @@ open Types
 
 (* ---------- helpers ---------- *)
 
+let write_file_atomically ~path ~content =
+  let dir = Stdlib.Filename.dirname path in
+  let base = Stdlib.Filename.basename path in
+  let tmp_path = Stdlib.Filename.temp_file ~temp_dir:dir (base ^ ".") ".tmp" in
+  try
+    let oc = Stdlib.open_out_bin tmp_path in
+    Stdlib.Fun.protect
+      ~finally:(fun () -> Stdlib.close_out oc)
+      (fun () ->
+        Stdlib.output_string oc content;
+        Stdlib.flush oc);
+    Stdlib.Sys.rename tmp_path path;
+    Ok ()
+  with exn ->
+    (try Stdlib.Sys.remove tmp_path with _ -> ());
+    Error (Stdlib.Printexc.to_string exn)
+
+let remove_if_exists path =
+  if Stdlib.Sys.file_exists path then Stdlib.Sys.remove path
+
+let session_id_dir ~snapshot_path =
+  Stdlib.Filename.concat
+    (Stdlib.Filename.dirname snapshot_path)
+    "llm-session-ids"
+
+let session_id_path ~snapshot_path ~patch_id =
+  Stdlib.Filename.concat
+    (session_id_dir ~snapshot_path)
+    (Patch_id.to_string patch_id ^ ".txt")
+
+let sync_session_id_sidecars ~snapshot_path (snap : Runtime.snapshot) =
+  let dir = session_id_dir ~snapshot_path in
+  Project_store.ensure_dir dir;
+  Orchestrator.all_agents snap.Runtime.orchestrator
+  |> List.iter ~f:(fun (agent : Patch_agent.t) ->
+      let path =
+        session_id_path ~snapshot_path ~patch_id:agent.Patch_agent.patch_id
+      in
+      match agent.Patch_agent.llm_session_id with
+      | Some session_id ->
+          ignore (write_file_atomically ~path ~content:session_id)
+      | None ->
+          (* A fresh Claude session may have minted and persisted its ID
+                before the in-memory orchestrator has observed the first
+                stream event. While that session is still marked busy, preserve
+                any existing sidecar rather than deleting the crash-recovery
+                resume key. *)
+          if not agent.Patch_agent.busy then remove_if_exists path)
+
+let overlay_session_id_sidecars ~snapshot_path (snap : Runtime.snapshot) =
+  let orchestrator =
+    List.fold (Orchestrator.all_agents snap.Runtime.orchestrator)
+      ~init:snap.Runtime.orchestrator ~f:(fun orch (agent : Patch_agent.t) ->
+        let path =
+          session_id_path ~snapshot_path ~patch_id:agent.Patch_agent.patch_id
+        in
+        if Stdlib.Sys.file_exists path then
+          try
+            let ic = Stdlib.open_in path in
+            let session_id =
+              Stdlib.Fun.protect
+                ~finally:(fun () -> Stdlib.close_in_noerr ic)
+                (fun () -> Stdlib.In_channel.input_all ic |> String.strip)
+            in
+            if String.is_empty session_id then orch
+            else
+              Orchestrator.set_llm_session_id orch agent.Patch_agent.patch_id
+                (Some session_id)
+          with _ -> orch
+        else orch)
+  in
+  { snap with Runtime.orchestrator }
+
 let string_member key json = Yojson.Safe.Util.(member key json |> to_string)
 
 let string_member_opt key json =
@@ -584,23 +657,13 @@ let snapshot_of_yojson json =
 (* ---------- File I/O ---------- *)
 
 let save ~path (snap : Runtime.snapshot) =
-  let dir = Stdlib.Filename.dirname path in
-  let base = Stdlib.Filename.basename path in
-  let tmp_path = Stdlib.Filename.temp_file ~temp_dir:dir (base ^ ".") ".tmp" in
   try
     let json = snapshot_to_yojson snap in
     let content = Yojson.Safe.pretty_to_string json in
-    let oc = Stdlib.open_out_bin tmp_path in
-    Stdlib.Fun.protect
-      ~finally:(fun () -> Stdlib.close_out oc)
-      (fun () ->
-        Stdlib.output_string oc content;
-        Stdlib.flush oc);
-    Stdlib.Sys.rename tmp_path path;
+    Result.ok_or_failwith (write_file_atomically ~path ~content);
+    sync_session_id_sidecars ~snapshot_path:path snap;
     Ok ()
-  with exn ->
-    (try Stdlib.Sys.remove tmp_path with _ -> ());
-    Error (Stdlib.Printexc.to_string exn)
+  with exn -> Error (Stdlib.Printexc.to_string exn)
 
 let load ~path =
   try
@@ -611,6 +674,16 @@ let load ~path =
         (fun () -> Stdlib.In_channel.input_all ic)
     in
     let json = Yojson.Safe.from_string content in
-    let result = snapshot_of_yojson json in
+    let result =
+      Result.map (snapshot_of_yojson json)
+        ~f:(overlay_session_id_sidecars ~snapshot_path:path)
+    in
     result
   with exn -> Error (Stdlib.Printexc.to_string exn)
+
+let record_session_id ~snapshot_path ~patch_id ~session_id =
+  let dir = session_id_dir ~snapshot_path in
+  Project_store.ensure_dir dir;
+  write_file_atomically
+    ~path:(session_id_path ~snapshot_path ~patch_id)
+    ~content:session_id

--- a/lib/persistence.ml
+++ b/lib/persistence.ml
@@ -34,23 +34,27 @@ let session_id_path ~snapshot_path ~patch_id =
     (Patch_id.to_string patch_id ^ ".txt")
 
 let sync_session_id_sidecars ~snapshot_path (snap : Runtime.snapshot) =
-  let dir = session_id_dir ~snapshot_path in
-  Project_store.ensure_dir dir;
-  Orchestrator.all_agents snap.Runtime.orchestrator
-  |> List.iter ~f:(fun (agent : Patch_agent.t) ->
-      let path =
-        session_id_path ~snapshot_path ~patch_id:agent.Patch_agent.patch_id
-      in
-      match agent.Patch_agent.llm_session_id with
-      | Some session_id ->
-          ignore (write_file_atomically ~path ~content:session_id)
-      | None ->
-          (* A fresh Claude session may have minted and persisted its ID
-                before the in-memory orchestrator has observed the first
-                stream event. While that session is still marked busy, preserve
-                any existing sidecar rather than deleting the crash-recovery
-                resume key. *)
-          if not agent.Patch_agent.busy then remove_if_exists path)
+  let ( let* ) r f = Result.bind r ~f in
+  try
+    let dir = session_id_dir ~snapshot_path in
+    Project_store.ensure_dir dir;
+    List.fold (Orchestrator.all_agents snap.Runtime.orchestrator) ~init:(Ok ())
+      ~f:(fun acc (agent : Patch_agent.t) ->
+        let* () = acc in
+        let path =
+          session_id_path ~snapshot_path ~patch_id:agent.Patch_agent.patch_id
+        in
+        match agent.Patch_agent.llm_session_id with
+        | Some session_id -> write_file_atomically ~path ~content:session_id
+        | None ->
+            (* A fresh Claude session may have minted and persisted its ID
+               before the in-memory orchestrator has observed the first
+               stream event. While that session is still marked busy, preserve
+               any existing sidecar rather than deleting the crash-recovery
+               resume key. *)
+            if not agent.Patch_agent.busy then remove_if_exists path;
+            Ok ())
+  with exn -> Error (Stdlib.Printexc.to_string exn)
 
 let overlay_session_id_sidecars ~snapshot_path (snap : Runtime.snapshot) =
   let orchestrator =
@@ -59,7 +63,11 @@ let overlay_session_id_sidecars ~snapshot_path (snap : Runtime.snapshot) =
         let path =
           session_id_path ~snapshot_path ~patch_id:agent.Patch_agent.patch_id
         in
-        if Stdlib.Sys.file_exists path then
+        if
+          agent.Patch_agent.busy
+          && Option.is_none agent.Patch_agent.llm_session_id
+          && Stdlib.Sys.file_exists path
+        then
           try
             let ic = Stdlib.open_in path in
             let session_id =
@@ -660,9 +668,8 @@ let save ~path (snap : Runtime.snapshot) =
   try
     let json = snapshot_to_yojson snap in
     let content = Yojson.Safe.pretty_to_string json in
-    Result.ok_or_failwith (write_file_atomically ~path ~content);
-    sync_session_id_sidecars ~snapshot_path:path snap;
-    Ok ()
+    Result.bind (write_file_atomically ~path ~content) ~f:(fun () ->
+        sync_session_id_sidecars ~snapshot_path:path snap)
   with exn -> Error (Stdlib.Printexc.to_string exn)
 
 let load ~path =
@@ -687,3 +694,125 @@ let record_session_id ~snapshot_path ~patch_id ~session_id =
   write_file_atomically
     ~path:(session_id_path ~snapshot_path ~patch_id)
     ~content:session_id
+
+let%test_module "session_id_sidecars" =
+  (module struct
+    let patch_id = Patch_id.of_string "5"
+    let main_branch = Branch.of_string "main"
+
+    let patch =
+      Patch.
+        {
+          id = patch_id;
+          title = "Patch 5";
+          description = "";
+          branch = Branch.of_string "patch-5";
+          dependencies = [];
+          spec = "";
+          acceptance_criteria = [];
+          files = [];
+          classification = "";
+          changes = [];
+          test_stubs_introduced = [];
+          test_stubs_implemented = [];
+          complexity = None;
+        }
+
+    let gameplan =
+      Gameplan.
+        {
+          project_name = "sidecar-test";
+          problem_statement = "";
+          solution_summary = "";
+          final_state_spec = "";
+          patches = [ patch ];
+          current_state_analysis = "";
+          explicit_opinions = "";
+          acceptance_criteria = [];
+          open_questions = [];
+        }
+
+    let snapshot ?(busy = false) ?llm_session_id () =
+      let agent =
+        Patch_agent.restore ~patch_id ~branch:patch.branch ~pr_number:None
+          ~has_session:false ~busy ~merged:false ~queue:[] ~satisfies:false
+          ~changed:false ~has_conflict:false ~base_branch:None
+          ~notified_base_branch:None ~ci_failure_count:0
+          ~session_fallback:Patch_agent.Fresh_available ~human_messages:[]
+          ~inflight_human_messages:[] ~ci_checks:[] ~merge_ready:false
+          ~is_draft:false ~pr_body_delivered:true ~pr_body_artifact_miss_count:0
+          ~start_attempts_without_pr:0 ~conflict_noop_count:0
+          ~no_commits_push_count:0 ~branch_rebased_onto:None
+          ~checks_passing:false ~current_op:None
+          ~current_op_state:Patch_agent.Queued ~current_message_id:None
+          ~generation:0 ~worktree_path:None ~branch_blocked:false
+          ~llm_session_id ~automerge_enabled:false ~automerge_deadline:None
+          ~automerge_inflight:false ~automerge_failure_count:0
+          ~delivered_ci_run_ids:[]
+      in
+      let orch =
+        Orchestrator.restore
+          ~graph:(Graph.of_patches [ patch ])
+          ~agents:(Map.singleton (module Patch_id) patch_id agent)
+          ~outbox:(Map.empty (module Message_id))
+          ~main_branch
+      in
+      {
+        Runtime.orchestrator = orch;
+        activity_log = Activity_log.empty;
+        gameplan;
+        transcripts = Hashtbl.create (module Patch_id);
+      }
+
+    let with_temp_snapshot_path f =
+      let dir = Stdlib.Filename.temp_file "onton-persistence" ".tmpdir" in
+      Stdlib.Sys.remove dir;
+      Stdlib.Sys.mkdir dir 0o755;
+      Stdlib.Fun.protect
+        ~finally:(fun () ->
+          try
+            Stdlib.Sys.command
+              (Printf.sprintf "rm -rf %s" (Stdlib.Filename.quote dir))
+            |> ignore
+          with _ -> ())
+        (fun () -> f (Stdlib.Filename.concat dir "snapshot.json"))
+
+    let%test "load overlays sidecar for crashed busy session missing id" =
+      with_temp_snapshot_path @@ fun snapshot_path ->
+      Result.is_ok (save ~path:snapshot_path (snapshot ~busy:true ()))
+      && Result.is_ok
+           (record_session_id ~snapshot_path ~patch_id ~session_id:"minted")
+      &&
+      match load ~path:snapshot_path with
+      | Ok loaded -> (
+          match
+            Orchestrator.find_agent loaded.Runtime.orchestrator patch_id
+          with
+          | Some agent ->
+              Option.equal String.equal agent.Patch_agent.llm_session_id
+                (Some "minted")
+          | None -> false)
+      | Error _ -> false
+
+    let%test "load ignores stale sidecar for idle session without id" =
+      with_temp_snapshot_path @@ fun snapshot_path ->
+      Result.is_ok (save ~path:snapshot_path (snapshot ()))
+      && Result.is_ok
+           (record_session_id ~snapshot_path ~patch_id ~session_id:"stale")
+      &&
+      match load ~path:snapshot_path with
+      | Ok loaded -> (
+          match
+            Orchestrator.find_agent loaded.Runtime.orchestrator patch_id
+          with
+          | Some agent -> Option.is_none agent.Patch_agent.llm_session_id
+          | None -> false)
+      | Error _ -> false
+
+    let%test "save surfaces sidecar write failures" =
+      with_temp_snapshot_path @@ fun snapshot_path ->
+      let blocking_path = session_id_dir ~snapshot_path in
+      ignore (write_file_atomically ~path:blocking_path ~content:"not a dir");
+      Result.is_error
+        (save ~path:snapshot_path (snapshot ~llm_session_id:"id" ()))
+  end)

--- a/lib/persistence.ml
+++ b/lib/persistence.ml
@@ -689,11 +689,13 @@ let load ~path =
   with exn -> Error (Stdlib.Printexc.to_string exn)
 
 let record_session_id ~snapshot_path ~patch_id ~session_id =
-  let dir = session_id_dir ~snapshot_path in
-  Project_store.ensure_dir dir;
-  write_file_atomically
-    ~path:(session_id_path ~snapshot_path ~patch_id)
-    ~content:session_id
+  try
+    let dir = session_id_dir ~snapshot_path in
+    Project_store.ensure_dir dir;
+    write_file_atomically
+      ~path:(session_id_path ~snapshot_path ~patch_id)
+      ~content:session_id
+  with exn -> Error (Stdlib.Printexc.to_string exn)
 
 let%test_module "session_id_sidecars" =
   (module struct

--- a/lib/persistence.mli
+++ b/lib/persistence.mli
@@ -13,6 +13,14 @@ val load : path:string -> (Runtime.snapshot, string) result
     orchestrator graph directly from the saved JSON. Returns [Error msg] if the
     file is missing, malformed, or incompatible. *)
 
+val record_session_id :
+  snapshot_path:string ->
+  patch_id:Types.Patch_id.t ->
+  session_id:string ->
+  (unit, string) result
+(** Persist a patch's backend session ID synchronously before spawn so crash
+    recovery can resume even if the first stream event never arrives. *)
+
 val snapshot_to_yojson : Runtime.snapshot -> Yojson.Safe.t
 (** Convert a snapshot to its JSON representation. *)
 

--- a/lib/session_id.ml
+++ b/lib/session_id.ml
@@ -39,8 +39,7 @@ let mint () =
   in
   let buf = Buffer.create 36 in
   Array.iteri normalized ~f:(fun i byte ->
-      if List.mem [ 4; 6; 8; 10 ] i ~equal:Int.equal then
-        Buffer.add_char buf '-';
+      (match i with 4 | 6 | 8 | 10 -> Buffer.add_char buf '-' | _ -> ());
       append_hex_byte buf byte);
   Buffer.contents buf
 

--- a/lib/session_id.ml
+++ b/lib/session_id.ml
@@ -1,0 +1,57 @@
+open Base
+
+let rng_ready =
+  lazy
+    (Mirage_crypto_rng_unix.use_default ();
+     ())
+
+let hex = "0123456789abcdef"
+
+let append_hex_byte buf byte =
+  Buffer.add_char buf hex.[byte lsr 4];
+  Buffer.add_char buf hex.[byte land 0x0f]
+
+let mint () =
+  Lazy.force rng_ready;
+  let bytes = Mirage_crypto_rng.generate 16 in
+  let byte i = Char.to_int bytes.[i] in
+  let b6 = byte 6 land 0x0f lor 0x40 in
+  let b8 = byte 8 land 0x3f lor 0x80 in
+  let normalized =
+    [|
+      byte 0;
+      byte 1;
+      byte 2;
+      byte 3;
+      byte 4;
+      byte 5;
+      b6;
+      byte 7;
+      b8;
+      byte 9;
+      byte 10;
+      byte 11;
+      byte 12;
+      byte 13;
+      byte 14;
+      byte 15;
+    |]
+  in
+  let buf = Buffer.create 36 in
+  Array.iteri normalized ~f:(fun i byte ->
+      if List.mem [ 4; 6; 8; 10 ] i ~equal:Int.equal then
+        Buffer.add_char buf '-';
+      append_hex_byte buf byte);
+  Buffer.contents buf
+
+let%test "mint produces UUID-v4-shaped strings" =
+  let id = mint () in
+  String.length id = 36
+  && Char.equal id.[8] '-'
+  && Char.equal id.[13] '-'
+  && Char.equal id.[18] '-'
+  && Char.equal id.[23] '-'
+  && Char.equal id.[14] '4'
+  && match id.[19] with '8' | '9' | 'a' | 'b' -> true | _ -> false
+
+let%test "distinct mints differ" = not (String.equal (mint ()) (mint ()))

--- a/lib/session_id.mli
+++ b/lib/session_id.mli
@@ -1,0 +1,2 @@
+val mint : unit -> string
+(** Mint a UUID v4 string suitable for caller-provided Claude session IDs. *)


### PR DESCRIPTION
## Patch 5: Mint Claude session UUIDs in onton, persist before spawn

- Create lib/session_id.ml with `mint : unit -> string` returning a UUID v4 (e.g. `Printf.sprintf "%08lx-%04x-4%03x-%c%03x-%012Lx" ...` from random bytes).
- Add `minted_session_id:string option` to claude_runner.build_stream_args. When `Some uuid`, prepend `["--session-id"; uuid]` after `--model`.
- Read `ONTON_MINTED_SESSION_IDS` in run_streaming. When set to "1", call Session_id.mint, persist immediately via persistence.record_session_id, and pass to build_stream_args.
- Update persistence to write the session-id file synchronously before returning control to the spawn caller.
- Add inline tests for session_id.mint (length 36, hyphen positions, version-4 nibble).
- Add inline tests for build_stream_args with minted_session_id.

## Changes
- Create lib/session_id.ml with `mint : unit -> string` returning a UUID v4 (e.g. `Printf.sprintf "%08lx-%04x-4%03x-%c%03x-%012Lx" ...` from random bytes).
- Add `minted_session_id:string option` to claude_runner.build_stream_args. When `Some uuid`, prepend `["--session-id"; uuid]` after `--model`.
- Read `ONTON_MINTED_SESSION_IDS` in run_streaming. When set to "1", call Session_id.mint, persist immediately via persistence.record_session_id, and pass to build_stream_args.
- Update persistence to write the session-id file synchronously before returning control to the spawn caller.
- Add inline tests for session_id.mint (length 36, hyphen positions, version-4 nibble).
- Add inline tests for build_stream_args with minted_session_id.

## Files to Modify
- lib/session_id.ml (create): Mint UUID v4 strings. Use a cryptographically-strong source (Mirage_crypto_rng or /dev/urandom — pick whichever is already a transitive dep) so the IDs collide-resistant across parallel orchestrators.
- lib/session_id.mli (create): Interface for session_id.
- lib/dune (modify): Add session_id to the modules list.
- lib/claude_runner.ml (modify): Accept an optional minted_session_id in build_stream_args. When Some uuid, emit --session-id <uuid> on the initial spawn. --resume continues to use the existing path (the minted ID becomes the resume key).
- lib/persistence.ml (modify): Persist the minted session ID for a patch BEFORE the spawn returns. On crash recovery, the stored ID becomes the resume key.
- lib/persistence.mli (modify): Expose the persist-before-spawn API.

## Gameplan Specification

```
module HEADLESS_CACHE_TUNING.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> After this gameplan, every onton-spawned coding-agent
> invocation is tuned for prompt-cache reuse and bounded
> token consumption. Static prompt prefixes are reused
> across patches in one gameplan. Isolated per-spawn
> config dirs stabilise spawn environment. Onton-minted
> session UUIDs remove the parsing race and enable resume
> without re-sending the prompt. Turn caps scale with
> complexity. Per-spawn USD budget caps put a hard floor
> under runaway token spend.

Patch.
Gameplan.
Spawn.
Arg.
Prompt.
Text.
SessionId.
Dir.
Backend.

claude => Backend.
codex => Backend.
pi => Backend.

backend s: Spawn => Backend.
spawn-of p: Patch => Spawn.
complexity p: Patch => Nat.

render p: Patch, gp: Gameplan => Prompt.
prefix pr: Prompt => Text.
suffix pr: Prompt => Text.
shared? t: Text, gp: Gameplan => Bool.
specific? t: Text, p: Patch => Bool.

args s: Spawn => Arg.
has-flag? a: Arg, name: String => Bool.

config-dir s: Spawn => Dir.
max-turns s: Spawn => Nat.

session-id p: Patch => SessionId.
persisted-before-spawn? id: SessionId, s: Spawn => Bool.
passed-to-cli? id: SessionId, s: Spawn => Bool.
minted-session-flag-on? => Bool.

budget-cap-set? s: Spawn => Bool.
flag-emitted? s: Spawn => Bool.
cost-tracked? s: Spawn => Bool.
self-terminates-on-overshoot? s: Spawn => Bool.

bare-flag-on? => Bool.
worktree-claude-md p: Patch => Text.
non-empty? t: Text => Bool.
prompt-of s: Spawn => Prompt.
contains? t: Text, sub: String => Bool.
---

> Static prefix is gameplan-shared.
all p: Patch, gp: Gameplan | shared? (prefix (render p gp)) gp.

> Dynamic suffix is patch-specific.
all p: Patch, gp: Gameplan | specific? (suffix (render p gp)) p.

> Claude spawns pass --exclude-dynamic-system-prompt-sections.
all s: Spawn, backend s = claude |
  has-flag? (args s) "--exclude-dynamic-system-prompt-sections".

> Distinct patches have distinct config dirs.
all p1: Patch, p2: Patch, p1 ~= p2 |
  config-dir (spawn-of p1) ~= config-dir (spawn-of p2).

> Turn caps are monotone non-decreasing in complexity.
all p1: Patch, p2: Patch, complexity p1 < complexity p2 |
  max-turns (spawn-of p1) <= max-turns (spawn-of p2).

> Session-ID minting (when enabled) persists before spawn and
> passes to the CLI.
all p: Patch, minted-session-flag-on? |
  persisted-before-spawn? (session-id p) (spawn-of p).

all p: Patch, minted-session-flag-on? |
  passed-to-cli? (session-id p) (spawn-of p).

> When the budget cap is set, Claude spawns emit the flag and
> Codex spawns track cost + self-terminate.
all s: Spawn, backend s = claude, budget-cap-set? s |
  flag-emitted? s.

all s: Spawn, backend s = codex, budget-cap-set? s |
  cost-tracked? s and self-terminates-on-overshoot? s.

> When --bare is enabled, Claude spawns pass --bare and the
> worktree's CLAUDE.md content is reachable from the spawn's
> prompt prefix.
all p: Patch, bare-flag-on?, backend (spawn-of p) = claude |
  has-flag? (args (spawn-of p)) "--bare".

all p: Patch, bare-flag-on?, non-empty? (worktree-claude-md p) |
  contains? (prefix (prompt-of (spawn-of p))) "CLAUDE.md".

```

## Patch Specification

```
module HEADLESS_CACHE_TUNING_PATCH_5.

> Patch 6 inverts session-ID ownership for Claude. Onton mints
> the UUID, persists it before spawn, and passes it via
> --session-id. Resume after a crash reads the persisted ID
> and re-attaches without parsing stream output.

Patch.
Spawn.
SessionId.

spawn-of p: Patch => Spawn.
session-id p: Patch => SessionId.
persisted-before-spawn? id: SessionId, s: Spawn => Bool.
passed-to-cli? id: SessionId, s: Spawn => Bool.
flag-on? => Bool.
---

> When the feature flag is on, minted IDs are persisted before
> the spawn and passed to the CLI.
all p: Patch, flag-on? |
  persisted-before-spawn? (session-id p) (spawn-of p).

all p: Patch, flag-on? |
  passed-to-cli? (session-id p) (spawn-of p).

```


## Implementation Notes

- Pre-spawn persistence is implemented as a per-patch sidecar under the project data dir, not by mutating the main snapshot in-place. That avoids a race where the first Claude stream event has not arrived yet but we still need a durable resume key for crash recovery.
- `Persistence.save` and `Persistence.load` now sync and overlay those sidecars. The save path deliberately preserves an existing sidecar while an agent is still `busy` with `llm_session_id = None`, because that is the short window where a minted ID has been written before the in-memory orchestrator has observed it from the stream.
- Claude minting only happens for fresh spawns when `ONTON_MINTED_SESSION_IDS=1`; resume still uses the existing `--resume` path unchanged. The minted UUID becomes the resume key for later retries/recovery.
- I added a small internal plumbing env var, `ONTON_SNAPSHOT_PATH`, so the Claude runner can persist before spawn without widening the backend interface just for this patch.
- The gameplan listed `lib/dune`, but no `dune` edit was needed here because this library stanza is using Dune’s default module discovery; adding `lib/session_id.ml` was sufficient.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mint UUID v4 Claude session IDs in Onton, persist them before spawn, and pass via `--session-id` for reliable resume and better prompt-cache reuse. Adds atomic sidecar persistence with overlay-on-load, strict env checks, env-pure tests, and fast-fail errors when misconfigured.

- New Features
  - Added `Session_id.mint` (UUID v4 via `Mirage_crypto_rng`) with shape/distinctness tests; nibble-hex formatter sets correct version/variant bits.
  - `claude_runner.build_stream_args` accepts `minted_session_id` and emits `--session-id <uuid>` after `--model`; rejects using it with `--resume` (mutually exclusive, tested).
  - `run_streaming` now uses `prepare_minted_session_id`: when `ONTON_MINTED_SESSION_IDS=1` and not resuming, mint and persist via `Persistence.record_session_id`; if `ONTON_SNAPSHOT_PATH` is missing, exit early with a clear error; then pass to CLI.
  - Persistence: atomic sidecar writes; `save` syncs sidecars and surfaces write failures; `load` overlays sidecars for busy agents missing IDs and ignores stale ones; preserves an existing sidecar while an agent is busy.
  - `bin/main` sets `ONTON_SNAPSHOT_PATH` so persistence knows where to write sidecars.
  - Introduced `prepare_minted_session_id_with_env` to enable env-pure tests for the minted-session path (including missing-path and exclusivity error cases).

<sup>Written for commit 73881757fb7388eaba05c9b41203e37bd3bddc69. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

