### PR TITLE
[headless-cache-tuning] Patch 6: Per-spawn USD budget cap (Claude flag, Codex self-kill)

### DIFF
--- a/lib/claude_runner.ml
+++ b/lib/claude_runner.ml
@@ -57,9 +57,7 @@ let max_turns_for ~complexity =
   match complexity with Some 1 -> 50 | Some 2 -> 100 | _ -> 200
 
 let build_args ~model ~complexity ~prompt ~resume_session =
-let warned_invalid_budget_cap = ref false
-
-let budget_cap_args () =
+let budget_cap_args ~warn () =
   match
     Sys.getenv "ONTON_BUDGET_CAP_USD"
     |> Option.map ~f:(fun value -> String.strip value)
@@ -69,12 +67,11 @@ let budget_cap_args () =
       match Float.of_string_opt raw with
       | Some cap when Float.(cap > 0.) -> [ "--max-budget-usd"; raw ]
       | Some _ | None ->
-          if not !warned_invalid_budget_cap then (
-            warned_invalid_budget_cap := true;
-            Stdio.eprintf
-              "warning: ignoring invalid ONTON_BUDGET_CAP_USD=%S; expected a \
-               positive numeric USD cap\n"
-              raw);
+          warn
+            (Printf.sprintf
+               "warning: ignoring invalid ONTON_BUDGET_CAP_USD=%S; expected a \
+                positive numeric USD cap"
+               raw);
           [])
 
 let build_args ~model ~complexity ~prompt ~resume_session =
@@ -90,7 +87,7 @@ let build_args ~model ~complexity ~prompt ~resume_session =
       Int.to_string (max_turns_for ~complexity);
       "--exclude-dynamic-system-prompt-sections";
     ]
-    @ budget_cap_args ()
+    @ budget_cap_args ~warn:(fun msg -> Stdio.eprintf "%s\n" msg) ()
   in
   base @ model_args model @ prompt_args @ session_args @ flags
 
@@ -121,7 +118,7 @@ let build_stream_args ~model ~complexity ~prompt ~minted_session_id
       Int.to_string (max_turns_for ~complexity);
       "--exclude-dynamic-system-prompt-sections";
     ]
-    @ budget_cap_args ()
+    @ budget_cap_args ~warn:(fun msg -> Stdio.eprintf "%s\n" msg) ()
   in
   base @ model_args model @ minted_session_args @ prompt_args @ session_args
   @ flags
@@ -612,6 +609,22 @@ let%test
           "--max-budget-usd";
           "10";
         ])
+    ~finally:(fun () -> Unix.putenv "ONTON_BUDGET_CAP_USD" "")
+
+let%test "budget_cap_args omits flag and warns on invalid cap" =
+  Unix.putenv "ONTON_BUDGET_CAP_USD" "not-a-number";
+  let warnings = ref [] in
+  Exn.protect
+    ~f:(fun () ->
+      let args =
+        budget_cap_args ~warn:(fun msg -> warnings := msg :: !warnings) ()
+      in
+      List.is_empty args
+      && List.equal String.equal !warnings
+           [
+             "warning: ignoring invalid ONTON_BUDGET_CAP_USD=\"not-a-number\"; \
+              expected a positive numeric USD cap";
+           ])
     ~finally:(fun () -> Unix.putenv "ONTON_BUDGET_CAP_USD" "")
 
 let%test "strip_ansi removes escape sequences" =

--- a/lib/claude_runner.ml
+++ b/lib/claude_runner.ml
@@ -584,6 +584,7 @@ let%test "prepare_minted_session_id errors when flag is on and path missing" =
 
 let%test
     "build_stream_args emits --max-budget-usd when ONTON_BUDGET_CAP_USD set" =
+  let previous = Sys.getenv "ONTON_BUDGET_CAP_USD" in
   Unix.putenv "ONTON_BUDGET_CAP_USD" "10";
   Exn.protect
     ~f:(fun () ->
@@ -608,9 +609,13 @@ let%test
           "--max-budget-usd";
           "10";
         ])
-    ~finally:(fun () -> Unix.putenv "ONTON_BUDGET_CAP_USD" "")
+    ~finally:(fun () ->
+      match previous with
+      | Some value -> Unix.putenv "ONTON_BUDGET_CAP_USD" value
+      | None -> Unix.putenv "ONTON_BUDGET_CAP_USD" "")
 
 let%test "budget_cap_args omits flag and warns on invalid cap" =
+  let previous = Sys.getenv "ONTON_BUDGET_CAP_USD" in
   Unix.putenv "ONTON_BUDGET_CAP_USD" "not-a-number";
   let warnings = ref [] in
   Exn.protect
@@ -624,7 +629,10 @@ let%test "budget_cap_args omits flag and warns on invalid cap" =
              "warning: ignoring invalid ONTON_BUDGET_CAP_USD=\"not-a-number\"; \
               expected a positive numeric USD cap";
            ])
-    ~finally:(fun () -> Unix.putenv "ONTON_BUDGET_CAP_USD" "")
+    ~finally:(fun () ->
+      match previous with
+      | Some value -> Unix.putenv "ONTON_BUDGET_CAP_USD" value
+      | None -> Unix.putenv "ONTON_BUDGET_CAP_USD" "")
 
 let%test "strip_ansi removes escape sequences" =
   String.equal (strip_ansi "\027[31mhello\027[0m") "hello"

--- a/lib/claude_runner.ml
+++ b/lib/claude_runner.ml
@@ -56,7 +56,6 @@ let model_args = function
 let max_turns_for ~complexity =
   match complexity with Some 1 -> 50 | Some 2 -> 100 | _ -> 200
 
-let build_args ~model ~complexity ~prompt ~resume_session =
 let budget_cap_args ~warn () =
   match
     Sys.getenv "ONTON_BUDGET_CAP_USD"

--- a/lib/claude_runner.ml
+++ b/lib/claude_runner.ml
@@ -57,6 +57,27 @@ let max_turns_for ~complexity =
   match complexity with Some 1 -> 50 | Some 2 -> 100 | _ -> 200
 
 let build_args ~model ~complexity ~prompt ~resume_session =
+let warned_invalid_budget_cap = ref false
+
+let budget_cap_args () =
+  match
+    Sys.getenv "ONTON_BUDGET_CAP_USD"
+    |> Option.map ~f:(fun value -> String.strip value)
+  with
+  | None | Some "" -> []
+  | Some raw -> (
+      match Float.of_string_opt raw with
+      | Some cap when Float.(cap > 0.) -> [ "--max-budget-usd"; raw ]
+      | Some _ | None ->
+          if not !warned_invalid_budget_cap then (
+            warned_invalid_budget_cap := true;
+            Stdio.eprintf
+              "warning: ignoring invalid ONTON_BUDGET_CAP_USD=%S; expected a \
+               positive numeric USD cap\n"
+              raw);
+          [])
+
+let build_args ~model ~complexity ~prompt ~resume_session =
   let base = [ "claude" ] in
   let prompt_args = [ "-p"; prompt; "--output-format"; "text" ] in
   let session_args =
@@ -69,6 +90,7 @@ let build_args ~model ~complexity ~prompt ~resume_session =
       Int.to_string (max_turns_for ~complexity);
       "--exclude-dynamic-system-prompt-sections";
     ]
+    @ budget_cap_args ()
   in
   base @ model_args model @ prompt_args @ session_args @ flags
 
@@ -99,6 +121,7 @@ let build_stream_args ~model ~complexity ~prompt ~minted_session_id
       Int.to_string (max_turns_for ~complexity);
       "--exclude-dynamic-system-prompt-sections";
     ]
+    @ budget_cap_args ()
   in
   base @ model_args model @ minted_session_args @ prompt_args @ session_args
   @ flags
@@ -562,6 +585,34 @@ let%test "prepare_minted_session_id errors when flag is on and path missing" =
   with
   | Error _ -> true
   | Ok _ -> false
+
+let%test
+    "build_stream_args emits --max-budget-usd when ONTON_BUDGET_CAP_USD set" =
+  Unix.putenv "ONTON_BUDGET_CAP_USD" "10";
+  Exn.protect
+    ~f:(fun () ->
+      let args =
+        build_stream_args ~model:(Some "sonnet") ~complexity:None
+          ~prompt:"do stuff" ~minted_session_id:None ~resume_session:None
+      in
+      List.equal String.equal args
+        [
+          "claude";
+          "--model";
+          "sonnet";
+          "-p";
+          "do stuff";
+          "--output-format";
+          "stream-json";
+          "--verbose";
+          "--dangerously-skip-permissions";
+          "--max-turns";
+          "200";
+          "--exclude-dynamic-system-prompt-sections";
+          "--max-budget-usd";
+          "10";
+        ])
+    ~finally:(fun () -> Unix.putenv "ONTON_BUDGET_CAP_USD" "")
 
 let%test "strip_ansi removes escape sequences" =
   String.equal (strip_ansi "\027[31mhello\027[0m") "hello"

--- a/lib/claude_runner.ml
+++ b/lib/claude_runner.ml
@@ -65,7 +65,8 @@ let budget_cap_args ~warn () =
   | Some raw -> (
       match Float.of_string_opt raw with
       | Some cap when Float.(cap > 0.) -> [ "--max-budget-usd"; raw ]
-      | Some _ | None ->
+      | Some _ -> []
+      | None ->
           warn
             (Printf.sprintf
                "warning: ignoring invalid ONTON_BUDGET_CAP_USD=%S; expected a \

--- a/lib/codex_backend.ml
+++ b/lib/codex_backend.ml
@@ -1,24 +1,72 @@
 open Base
 
-let build_args ~model ~cwd_path ~prompt ~resume_session =
-  let model_args =
-    match model with
-    | Some m when not (String.is_empty m) -> [ "-m"; m ]
-    | _ -> []
-  in
-  (* -C is a global codex option (codex [OPTIONS] <COMMAND>); codex exec
-     re-exposes it but codex exec resume does not, so place it before the
-     subcommand to work uniformly across both. *)
-  let global = [ "codex"; "-C"; cwd_path ] in
-  let trailing = [ "--dangerously-bypass-approvals-and-sandbox" ] in
-  match resume_session with
-  | Some session_id ->
-      global
-      @ [ "exec"; "resume"; session_id; prompt; "--json" ]
-      @ model_args @ trailing
-  | None -> global @ [ "exec"; prompt; "--json" ] @ model_args @ trailing
+type cost_state = { cumulative_usd : float }
 
-let parse_event (line : string) : Types.Stream_event.t list =
+let initial_cost_state = { cumulative_usd = 0.0 }
+
+type model_pricing = { input_usd_per_1k : float; output_usd_per_1k : float }
+
+let model_pricing = function
+  | Some "gpt-5.4-mini" ->
+      Some { input_usd_per_1k = 0.00075; output_usd_per_1k = 0.0045 }
+  | Some "gpt-5.4" ->
+      Some { input_usd_per_1k = 0.0025; output_usd_per_1k = 0.015 }
+  | Some "gpt-5.5" ->
+      Some { input_usd_per_1k = 0.005; output_usd_per_1k = 0.03 }
+  | _ -> None
+
+let budget_cap_usd_from_env () =
+  match
+    Sys.getenv "ONTON_BUDGET_CAP_USD"
+    |> Option.map ~f:(fun value -> String.strip value)
+  with
+  | None | Some "" -> None
+  | Some raw -> (
+      match Float.of_string_opt raw with
+      | Some cap when Float.(cap > 0.) -> Some cap
+      | Some _ | None -> None)
+
+let usage_member_int json name =
+  let open Yojson.Safe.Util in
+  member name json |> to_int_option |> Option.value ~default:0
+
+let usage_reasoning_tokens json =
+  let open Yojson.Safe.Util in
+  let usage = member "usage" json in
+  let from_details =
+    member "output_tokens_details" usage
+    |> member "reasoning_tokens" |> to_int_option
+  in
+  Option.first_some from_details
+    (member "reasoning_tokens" usage |> to_int_option)
+  |> Option.first_some (member "reasoning_output_tokens" usage |> to_int_option)
+  |> Option.value ~default:0
+
+let completed_turn_cost_usd ~model json =
+  match model_pricing model with
+  | None -> None
+  | Some pricing ->
+      let open Yojson.Safe.Util in
+      let usage = member "usage" json in
+      let input_tokens = usage_member_int usage "input_tokens" in
+      let output_tokens = usage_member_int usage "output_tokens" in
+      let reasoning_tokens = usage_reasoning_tokens json in
+      let visible_output_tokens =
+        Int.max 0 (output_tokens - reasoning_tokens)
+      in
+      let input_cost =
+        Float.of_int input_tokens /. 1000.0 *. pricing.input_usd_per_1k
+      in
+      let visible_output_cost =
+        Float.of_int visible_output_tokens
+        /. 1000.0 *. pricing.output_usd_per_1k
+      in
+      let reasoning_cost =
+        Float.of_int reasoning_tokens /. 1000.0 *. pricing.output_usd_per_1k
+      in
+      Some (input_cost +. visible_output_cost +. reasoning_cost)
+
+let parse_event_with_cost_tracking ~model ~budget_cap_usd ~cost_state line =
   match Yojson.Safe.from_string line with
   | json -> (
       let open Yojson.Safe.Util in
@@ -47,10 +95,13 @@ let parse_event (line : string) : Types.Stream_event.t list =
                     in
                     String.concat ~sep:"" parts
               in
-              if String.is_empty text then []
-              else [ Types.Stream_event.Text_delta text ]
-          | Some "command_execution" -> []
-          | _ -> [])
+              let events =
+                if String.is_empty text then []
+                else [ Types.Stream_event.Text_delta text ]
+              in
+              (events, cost_state)
+          | Some "command_execution" -> ([], cost_state)
+          | _ -> ([], cost_state))
       | Some "item.started" -> (
           let item = member "item" json in
           let item_type = member "type" item |> to_string_option in
@@ -64,32 +115,76 @@ let parse_event (line : string) : Types.Stream_event.t list =
                   let input =
                     Yojson.Safe.to_string (`Assoc [ ("command", `String cmd) ])
                   in
-                  [
-                    Types.Stream_event.Tool_use
-                      { name = "Bash"; input; status = None };
-                  ]
-              | _ -> [])
-          | _ -> [])
+                  ( [
+                      Types.Stream_event.Tool_use
+                        { name = "Bash"; input; status = None };
+                    ],
+                    cost_state )
+              | _ -> ([], cost_state))
+          | _ -> ([], cost_state))
       | Some "thread.started" -> (
           match member "thread_id" json |> to_string_option with
           | Some id when not (String.is_empty id) ->
-              [ Types.Stream_event.Session_init { session_id = id } ]
-          | _ -> [])
-      | Some "turn.started" -> [ Types.Stream_event.Turn_started ]
+              ( [ Types.Stream_event.Session_init { session_id = id } ],
+                cost_state )
+          | _ -> ([], cost_state))
+      | Some "turn.started" -> ([ Types.Stream_event.Turn_started ], cost_state)
       | Some "turn.completed" ->
-          [
-            Types.Stream_event.Final_result
-              { text = ""; stop_reason = Types.Stop_reason.End_turn };
-          ]
+          let added_cost =
+            completed_turn_cost_usd ~model json |> Option.value ~default:0.0
+          in
+          let cost_state =
+            { cumulative_usd = cost_state.cumulative_usd +. added_cost }
+          in
+          let events =
+            match budget_cap_usd with
+            | Some cap when Float.(cost_state.cumulative_usd > cap) ->
+                [
+                  Types.Stream_event.Error
+                    (Printf.sprintf
+                       "Codex budget cap exceeded: cumulative cost $%.4f > cap \
+                        $%.4f"
+                       cost_state.cumulative_usd cap);
+                ]
+            | _ ->
+                [
+                  Types.Stream_event.Final_result
+                    { text = ""; stop_reason = Types.Stop_reason.End_turn };
+                ]
+          in
+          (events, cost_state)
       | Some "error" ->
           let msg =
             member "message" json |> to_string_option
             |> Option.value ~default:"unknown codex error"
           in
-          [ Types.Stream_event.Error msg ]
-      | _ -> [])
-  | exception Yojson.Json_error _ -> []
-  | exception Yojson.Safe.Util.Type_error _ -> []
+          ([ Types.Stream_event.Error msg ], cost_state)
+      | _ -> ([], cost_state))
+  | exception Yojson.Json_error _ -> ([], cost_state)
+  | exception Yojson.Safe.Util.Type_error _ -> ([], cost_state)
+
+let build_args ~model ~cwd_path ~prompt ~resume_session =
+  let model_args =
+    match model with
+    | Some m when not (String.is_empty m) -> [ "-m"; m ]
+    | _ -> []
+  in
+  (* -C is a global codex option (codex [OPTIONS] <COMMAND>); codex exec
+     re-exposes it but codex exec resume does not, so place it before the
+     subcommand to work uniformly across both. *)
+  let global = [ "codex"; "-C"; cwd_path ] in
+  let trailing = [ "--dangerously-bypass-approvals-and-sandbox" ] in
+  match resume_session with
+  | Some session_id ->
+      global
+      @ [ "exec"; "resume"; session_id; prompt; "--json" ]
+      @ model_args @ trailing
+  | None -> global @ [ "exec"; prompt; "--json" ] @ model_args @ trailing
+
+let parse_event (line : string) : Types.Stream_event.t list =
+  fst
+    (parse_event_with_cost_tracking ~model:None ~budget_cap_usd:None
+       ~cost_state:initial_cost_state line)
 
 let auto_model ~complexity =
   (* Codex CLI model ladder. 1 = mini for cheap mechanical work, 2 = standard,
@@ -110,9 +205,18 @@ let run_streaming ~model ~process_mgr ~clock ~timeout ~setsid_exec ~project_name
     Spawn_env.merge_env ~base_env:(Unix.environment ())
       ~overrides:(Spawn_env.per_patch_env ~project_name ~patch_id)
   in
+  let budget_cap_usd = budget_cap_usd_from_env () in
+  let cost_state = ref initial_cost_state in
   let process_line line =
     let trimmed = String.strip line in
-    if String.is_empty trimmed then [] else parse_event trimmed
+    if String.is_empty trimmed then []
+    else
+      let events, next_cost_state =
+        parse_event_with_cost_tracking ~model ~budget_cap_usd
+          ~cost_state:!cost_state trimmed
+      in
+      cost_state := next_cost_state;
+      events
   in
   Llm_backend.spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~env
     ~setsid_exec ~args ~process_line ~on_event
@@ -276,6 +380,21 @@ let%test "parse_event turn.completed" =
       Types.Stream_event.Final_result
         { text = ""; stop_reason = Types.Stop_reason.End_turn };
     ]
+
+let%test "cost tracker emits Error when cumulative exceeds cap" =
+  let line =
+    {|{"type":"turn.completed","usage":{"input_tokens":1000,"output_tokens":2000,"output_tokens_details":{"reasoning_tokens":500}}}|}
+  in
+  let events, cost_state =
+    parse_event_with_cost_tracking ~model:(Some "gpt-5.5")
+      ~budget_cap_usd:(Some 0.05) ~cost_state:initial_cost_state line
+  in
+  Float.(cost_state.cumulative_usd > 0.05)
+  && List.equal Types.Stream_event.equal events
+       [
+         Types.Stream_event.Error
+           "Codex budget cap exceeded: cumulative cost $0.0650 > cap $0.0500";
+       ]
 
 let%test "parse_event error" =
   let line = {|{"type":"error","message":"rate limited"}|} in

--- a/lib/codex_backend.ml
+++ b/lib/codex_backend.ml
@@ -149,6 +149,8 @@ let parse_event_with_cost_tracking ~model ~budget_cap_usd ~cost_state line =
                        "Codex budget cap exceeded: cumulative cost $%.4f > cap \
                         $%.4f"
                        cost_state.cumulative_usd cap);
+                  Types.Stream_event.Final_result
+                    { text = ""; stop_reason = Types.Stop_reason.End_turn };
                 ]
             | _ ->
                 [
@@ -398,6 +400,8 @@ let%test "cost tracker emits Error when cumulative exceeds cap" =
        [
          Types.Stream_event.Error
            "Codex budget cap exceeded: cumulative cost $0.0650 > cap $0.0500";
+         Types.Stream_event.Final_result
+           { text = ""; stop_reason = Types.Stop_reason.End_turn };
        ]
 
 let%test "parse_event error" =

--- a/lib/codex_backend.ml
+++ b/lib/codex_backend.ml
@@ -46,7 +46,7 @@ let budget_cap_nano_usd_from_env () =
 
 let usage_member_int json name =
   let open Yojson.Safe.Util in
-  member name json |> to_int_option |> Option.value ~default:0
+  member name json |> to_int_option |> Option.value ~default:0 |> Int.max 0
 
 let usage_reasoning_tokens usage =
   let open Yojson.Safe.Util in
@@ -60,7 +60,7 @@ let usage_reasoning_tokens usage =
   Option.first_some from_details
     (member "reasoning_tokens" usage |> to_int_option)
   |> Option.first_some (member "reasoning_output_tokens" usage |> to_int_option)
-  |> Option.value ~default:0
+  |> Option.value ~default:0 |> Int.max 0
 
 let cost_nano_usd_for_tokens tokens nano_usd_per_1k =
   Int64.(of_int tokens * nano_usd_per_1k / 1000L)

--- a/lib/codex_backend.ml
+++ b/lib/codex_backend.ml
@@ -13,6 +13,8 @@ let model_pricing = function
       Some { input_usd_per_1k = 0.0025; output_usd_per_1k = 0.015 }
   | Some "gpt-5.5" ->
       Some { input_usd_per_1k = 0.005; output_usd_per_1k = 0.03 }
+  (* Unknown/None model: cost tracking disabled, cap not enforced.
+     Keep this table in sync with [auto_model]. *)
   | _ -> None
 
 let budget_cap_usd_from_env () =
@@ -32,6 +34,9 @@ let usage_member_int json name =
 
 let usage_reasoning_tokens usage =
   let open Yojson.Safe.Util in
+  (* Support the current nested Responses schema
+     ([usage.output_tokens_details.reasoning_tokens]) plus older/alternate
+     flat spellings that have appeared in streamed usage payloads. *)
   let from_details =
     member "output_tokens_details" usage
     |> member "reasoning_tokens" |> to_int_option

--- a/lib/codex_backend.ml
+++ b/lib/codex_backend.ml
@@ -1,23 +1,38 @@
 open Base
 
-type cost_state = { cumulative_usd : float }
+type cost_state = { cumulative_nano_usd : int64 }
 
-let initial_cost_state = { cumulative_usd = 0.0 }
+let initial_cost_state = { cumulative_nano_usd = 0L }
 
-type model_pricing = { input_usd_per_1k : float; output_usd_per_1k : float }
+type model_pricing = {
+  input_nano_usd_per_1k : int64;
+  output_nano_usd_per_1k : int64;
+}
 
 let model_pricing = function
   | Some "gpt-5.4-mini" ->
-      Some { input_usd_per_1k = 0.00075; output_usd_per_1k = 0.0045 }
+      Some
+        {
+          input_nano_usd_per_1k = 750_000L;
+          output_nano_usd_per_1k = 4_500_000L;
+        }
   | Some "gpt-5.4" ->
-      Some { input_usd_per_1k = 0.0025; output_usd_per_1k = 0.015 }
+      Some
+        {
+          input_nano_usd_per_1k = 2_500_000L;
+          output_nano_usd_per_1k = 15_000_000L;
+        }
   | Some "gpt-5.5" ->
-      Some { input_usd_per_1k = 0.005; output_usd_per_1k = 0.03 }
+      Some
+        {
+          input_nano_usd_per_1k = 5_000_000L;
+          output_nano_usd_per_1k = 30_000_000L;
+        }
   (* Unknown/None model: cost tracking disabled, cap not enforced.
      Keep this table in sync with [auto_model]. *)
   | _ -> None
 
-let budget_cap_usd_from_env () =
+let budget_cap_nano_usd_from_env () =
   match
     Sys.getenv "ONTON_BUDGET_CAP_USD"
     |> Option.map ~f:(fun value -> String.strip value)
@@ -25,7 +40,8 @@ let budget_cap_usd_from_env () =
   | None | Some "" -> None
   | Some raw -> (
       match Float.of_string_opt raw with
-      | Some cap when Float.(cap > 0.) -> Some cap
+      | Some cap when Float.(cap > 0.) ->
+          Some (Int64.of_float (Float.round_nearest (cap *. 1_000_000_000.0)))
       | Some _ | None -> None)
 
 let usage_member_int json name =
@@ -46,7 +62,12 @@ let usage_reasoning_tokens usage =
   |> Option.first_some (member "reasoning_output_tokens" usage |> to_int_option)
   |> Option.value ~default:0
 
-let completed_turn_cost_usd ~model json =
+let cost_nano_usd_for_tokens tokens nano_usd_per_1k =
+  Int64.(of_int tokens * nano_usd_per_1k / 1000L)
+
+let float_usd_of_nano_usd nano_usd = Int64.to_float nano_usd /. 1_000_000_000.0
+
+let completed_turn_cost_nano_usd ~model json =
   match model_pricing model with
   | None -> None
   | Some pricing ->
@@ -59,18 +80,19 @@ let completed_turn_cost_usd ~model json =
         Int.max 0 (output_tokens - reasoning_tokens)
       in
       let input_cost =
-        Float.of_int input_tokens /. 1000.0 *. pricing.input_usd_per_1k
+        cost_nano_usd_for_tokens input_tokens pricing.input_nano_usd_per_1k
       in
       let visible_output_cost =
-        Float.of_int visible_output_tokens
-        /. 1000.0 *. pricing.output_usd_per_1k
+        cost_nano_usd_for_tokens visible_output_tokens
+          pricing.output_nano_usd_per_1k
       in
       let reasoning_cost =
-        Float.of_int reasoning_tokens /. 1000.0 *. pricing.output_usd_per_1k
+        cost_nano_usd_for_tokens reasoning_tokens pricing.output_nano_usd_per_1k
       in
-      Some (input_cost +. visible_output_cost +. reasoning_cost)
+      Some Int64.(input_cost + visible_output_cost + reasoning_cost)
 
-let parse_event_with_cost_tracking ~model ~budget_cap_usd ~cost_state line =
+let parse_event_with_cost_tracking ~model ~budget_cap_nano_usd ~cost_state line
+    =
   match Yojson.Safe.from_string line with
   | json -> (
       let open Yojson.Safe.Util in
@@ -135,20 +157,24 @@ let parse_event_with_cost_tracking ~model ~budget_cap_usd ~cost_state line =
       | Some "turn.started" -> ([ Types.Stream_event.Turn_started ], cost_state)
       | Some "turn.completed" ->
           let added_cost =
-            completed_turn_cost_usd ~model json |> Option.value ~default:0.0
+            completed_turn_cost_nano_usd ~model json |> Option.value ~default:0L
           in
           let cost_state =
-            { cumulative_usd = cost_state.cumulative_usd +. added_cost }
+            {
+              cumulative_nano_usd =
+                Int64.(cost_state.cumulative_nano_usd + added_cost);
+            }
           in
           let events =
-            match budget_cap_usd with
-            | Some cap when Float.(cost_state.cumulative_usd > cap) ->
+            match budget_cap_nano_usd with
+            | Some cap when Int64.(cost_state.cumulative_nano_usd > cap) ->
                 [
                   Types.Stream_event.Error
                     (Printf.sprintf
                        "Codex budget cap exceeded: cumulative cost $%.4f > cap \
                         $%.4f"
-                       cost_state.cumulative_usd cap);
+                       (float_usd_of_nano_usd cost_state.cumulative_nano_usd)
+                       (float_usd_of_nano_usd cap));
                   Types.Stream_event.Final_result
                     { text = ""; stop_reason = Types.Stop_reason.End_turn };
                 ]
@@ -189,7 +215,7 @@ let build_args ~model ~cwd_path ~prompt ~resume_session =
 
 let parse_event (line : string) : Types.Stream_event.t list =
   fst
-    (parse_event_with_cost_tracking ~model:None ~budget_cap_usd:None
+    (parse_event_with_cost_tracking ~model:None ~budget_cap_nano_usd:None
        ~cost_state:initial_cost_state line)
 
 let auto_model ~complexity =
@@ -211,14 +237,14 @@ let run_streaming ~model ~process_mgr ~clock ~timeout ~setsid_exec ~project_name
     Spawn_env.merge_env ~base_env:(Unix.environment ())
       ~overrides:(Spawn_env.per_patch_env ~project_name ~patch_id)
   in
-  let budget_cap_usd = budget_cap_usd_from_env () in
+  let budget_cap_nano_usd = budget_cap_nano_usd_from_env () in
   let cost_state = ref initial_cost_state in
   let process_line line =
     let trimmed = String.strip line in
     if String.is_empty trimmed then []
     else
       let events, next_cost_state =
-        parse_event_with_cost_tracking ~model ~budget_cap_usd
+        parse_event_with_cost_tracking ~model ~budget_cap_nano_usd
           ~cost_state:!cost_state trimmed
       in
       cost_state := next_cost_state;
@@ -393,9 +419,10 @@ let%test "cost tracker emits Error when cumulative exceeds cap" =
   in
   let events, cost_state =
     parse_event_with_cost_tracking ~model:(Some "gpt-5.5")
-      ~budget_cap_usd:(Some 0.05) ~cost_state:initial_cost_state line
+      ~budget_cap_nano_usd:(Some 50_000_000L) ~cost_state:initial_cost_state
+      line
   in
-  Float.(cost_state.cumulative_usd > 0.05)
+  Int64.(cost_state.cumulative_nano_usd > 50_000_000L)
   && List.equal Types.Stream_event.equal events
        [
          Types.Stream_event.Error

--- a/lib/codex_backend.ml
+++ b/lib/codex_backend.ml
@@ -30,9 +30,8 @@ let usage_member_int json name =
   let open Yojson.Safe.Util in
   member name json |> to_int_option |> Option.value ~default:0
 
-let usage_reasoning_tokens json =
+let usage_reasoning_tokens usage =
   let open Yojson.Safe.Util in
-  let usage = member "usage" json in
   let from_details =
     member "output_tokens_details" usage
     |> member "reasoning_tokens" |> to_int_option
@@ -50,7 +49,7 @@ let completed_turn_cost_usd ~model json =
       let usage = member "usage" json in
       let input_tokens = usage_member_int usage "input_tokens" in
       let output_tokens = usage_member_int usage "output_tokens" in
-      let reasoning_tokens = usage_reasoning_tokens json in
+      let reasoning_tokens = usage_reasoning_tokens usage in
       let visible_output_tokens =
         Int.max 0 (output_tokens - reasoning_tokens)
       in

--- a/lib/codex_backend.mli
+++ b/lib/codex_backend.mli
@@ -17,6 +17,7 @@ val parse_event : string -> Types.Stream_event.t list
 val auto_model : complexity:int option -> string option
 (** Codex's complexity → model ladder used to resolve [--model auto]. Exposed so
     the TUI can display the concrete model name a patch will run under. *)
+
 type cost_state = { cumulative_usd : float }
 
 val initial_cost_state : cost_state

--- a/lib/codex_backend.mli
+++ b/lib/codex_backend.mli
@@ -18,17 +18,18 @@ val auto_model : complexity:int option -> string option
 (** Codex's complexity → model ladder used to resolve [--model auto]. Exposed so
     the TUI can display the concrete model name a patch will run under. *)
 
-type cost_state = { cumulative_usd : float }
+type cost_state = { cumulative_nano_usd : int64 }
 
 val initial_cost_state : cost_state
 
 val parse_event_with_cost_tracking :
   model:string option ->
-  budget_cap_usd:float option ->
+  budget_cap_nano_usd:int64 option ->
   cost_state:cost_state ->
   string ->
   Types.Stream_event.t list * cost_state
 (** Parse a single NDJSON line while accumulating per-spawn Codex token cost.
     [turn.completed] usage is priced using the pinned model's current rates;
-    when [budget_cap_usd] is crossed, the returned events include
+    costs and caps are tracked in nano-USD to avoid floating-point drift; when
+    [budget_cap_nano_usd] is crossed, the returned events include
     [Stream_event.Error]. Exposed for testing. *)

--- a/lib/codex_backend.mli
+++ b/lib/codex_backend.mli
@@ -17,3 +17,17 @@ val parse_event : string -> Types.Stream_event.t list
 val auto_model : complexity:int option -> string option
 (** Codex's complexity → model ladder used to resolve [--model auto]. Exposed so
     the TUI can display the concrete model name a patch will run under. *)
+type cost_state = { cumulative_usd : float }
+
+val initial_cost_state : cost_state
+
+val parse_event_with_cost_tracking :
+  model:string option ->
+  budget_cap_usd:float option ->
+  cost_state:cost_state ->
+  string ->
+  Types.Stream_event.t list * cost_state
+(** Parse a single NDJSON line while accumulating per-spawn Codex token cost.
+    [turn.completed] usage is priced using the pinned model's current rates;
+    when [budget_cap_usd] is crossed, the returned events include
+    [Stream_event.Error]. Exposed for testing. *)

--- a/lib/llm_backend.ml
+++ b/lib/llm_backend.ml
@@ -130,8 +130,9 @@ let spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~env ~setsid_exec ~args
           (* Only swallow the expected teardown exceptions: Eio.Buf_read
              raises when the buffer fills up; End_of_file and Eio.Exn.Io
              fire when the stdout fiber closes stderr_r out from under us
-             after saw_final_result. Letting anything else propagate — in
-             particular Eio.Cancel.Cancelled — is required so this fiber
+             after a terminal stream event (Final_result or Error) closes
+             stderr_r out from under us. Letting anything else propagate —
+             in particular Eio.Cancel.Cancelled — is required so this fiber
              can honour cancellation and release Eio.Fiber.both. *)
           try err_ref := Eio.Buf_read.take_all stderr_buf with
           | Eio.Buf_read.Buffer_limit_exceeded -> (

--- a/lib/llm_backend.ml
+++ b/lib/llm_backend.ml
@@ -28,6 +28,7 @@ let spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~env ~setsid_exec ~args
   let stderr_max_size = 1024 * 1024 in
   let stdout_capture_max_size = 64 * 1024 in
   let saw_final_result_ref = ref false in
+  let saw_terminal_event_ref = ref false in
   let got_events_ref = ref false in
   let stdout_capture = Buffer.create 4096 in
   let stdout_capture_truncated = ref false in
@@ -99,12 +100,24 @@ let spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~env ~setsid_exec ~args
                     | Types.Stream_event.Session_init _ ->
                         false)
                 in
-                if saw_final then saw_final_result_ref := true
+                let saw_terminal =
+                  saw_final
+                  || List.exists events ~f:(function
+                    | Types.Stream_event.Error _ -> true
+                    | Types.Stream_event.Final_result _
+                    | Types.Stream_event.Turn_started
+                    | Types.Stream_event.Text_delta _
+                    | Types.Stream_event.Tool_use _
+                    | Types.Stream_event.Session_init _ ->
+                        false)
+                in
+                if saw_final then saw_final_result_ref := true;
+                if saw_terminal then saw_terminal_event_ref := true
                 else read_lines ()
             | exception End_of_file -> ()
           in
           read_lines ();
-          if !saw_final_result_ref then (
+          if !saw_terminal_event_ref then (
             (* Tear down immediately: the model's turn is over. Descendants
                of the child (e.g. Bash-tool zsh processes) may keep the
                inherited stderr write-end open indefinitely, which would
@@ -135,7 +148,7 @@ let spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~env ~setsid_exec ~args
           | End_of_file -> ()
           | Eio.Exn.Io _ -> ());
       let status =
-        if !saw_final_result_ref then
+        if !saw_terminal_event_ref then
           (* SIGTERM was just delivered; cap the await so a child that
              ignores it doesn't stall us, then escalate to SIGKILL. *)
           match

--- a/lib/llm_backend.ml
+++ b/lib/llm_backend.ml
@@ -111,6 +111,8 @@ let spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~env ~setsid_exec ~args
                     | Types.Stream_event.Session_init _ ->
                         false)
                 in
+                (* [saw_terminal] = [saw_final] || [saw_error]; only
+                   [saw_terminal] stops recursion. *)
                 if saw_final then saw_final_result_ref := true;
                 if saw_terminal then saw_terminal_event_ref := true
                 else read_lines ()


### PR DESCRIPTION
## Patch 6: Per-spawn USD budget cap (Claude flag, Codex self-kill)

- In claude_runner.build_args / build_stream_args: read ONTON_BUDGET_CAP_USD. Parse as a positive numeric (Float.of_string_opt). When the parse succeeds, emit `["--max-budget-usd"; <cap-as-string>]`. When the env var is unset, empty, or non-numeric, omit the flag — and on non-numeric, log a single warning to stderr so a typo doesn't silently run uncapped. The cap is always per-spawn (not cumulative); cumulative tracking is out of scope for this gameplan.
- In codex_backend.parse_event: extend the `turn.completed` branch to extract token usage (input/output/reasoning) when present and convert to USD using the pinned model's per-1k-token rates. Maintain a running sum threaded through the per-spawn state (or via a closure captured in run_streaming).
- When cumulative cost exceeds the cap, emit a Stream_event.Error message and let the existing process-teardown path handle the kill (Patch 4's env plumbing makes the per-spawn cleanup deterministic).
- Add inline tests: claude_runner emits --max-budget-usd when env set; codex_backend triggers Error when cumulative cost exceeds cap.

## Changes
- In claude_runner.build_args / build_stream_args: read ONTON_BUDGET_CAP_USD. Parse as a positive numeric (Float.of_string_opt). When the parse succeeds, emit `["--max-budget-usd"; <cap-as-string>]`. When the env var is unset, empty, or non-numeric, omit the flag — and on non-numeric, log a single warning to stderr so a typo doesn't silently run uncapped. The cap is always per-spawn (not cumulative); cumulative tracking is out of scope for this gameplan.
- In codex_backend.parse_event: extend the `turn.completed` branch to extract token usage (input/output/reasoning) when present and convert to USD using the pinned model's per-1k-token rates. Maintain a running sum threaded through the per-spawn state (or via a closure captured in run_streaming).
- When cumulative cost exceeds the cap, emit a Stream_event.Error message and let the existing process-teardown path handle the kill (Patch 4's env plumbing makes the per-spawn cleanup deterministic).
- Add inline tests: claude_runner emits --max-budget-usd when env set; codex_backend triggers Error when cumulative cost exceeds cap.

## Files to Modify
- lib/claude_runner.ml (modify): When ONTON_BUDGET_CAP_USD is set, append --max-budget-usd <cap> to build_args and build_stream_args.
- lib/codex_backend.ml (modify): Track cumulative cost from `turn.completed` event token usage. When cumulative cost exceeds ONTON_BUDGET_CAP_USD, emit a Stream_event.Error and signal the orchestrator to terminate the spawn.
- lib/codex_backend.mli (modify): Expose cost-tracking state if needed for tests.

## Gameplan Specification

```
module HEADLESS_CACHE_TUNING.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> After this gameplan, every onton-spawned coding-agent
> invocation is tuned for prompt-cache reuse and bounded
> token consumption. Static prompt prefixes are reused
> across patches in one gameplan. Isolated per-spawn
> config dirs stabilise spawn environment. Onton-minted
> session UUIDs remove the parsing race and enable resume
> without re-sending the prompt. Turn caps scale with
> complexity. Per-spawn USD budget caps put a hard floor
> under runaway token spend.

Patch.
Gameplan.
Spawn.
Arg.
Prompt.
Text.
SessionId.
Dir.
Backend.

claude => Backend.
codex => Backend.
pi => Backend.

backend s: Spawn => Backend.
spawn-of p: Patch => Spawn.
complexity p: Patch => Nat.

render p: Patch, gp: Gameplan => Prompt.
prefix pr: Prompt => Text.
suffix pr: Prompt => Text.
shared? t: Text, gp: Gameplan => Bool.
specific? t: Text, p: Patch => Bool.

args s: Spawn => Arg.
has-flag? a: Arg, name: String => Bool.

config-dir s: Spawn => Dir.
max-turns s: Spawn => Nat.

session-id p: Patch => SessionId.
persisted-before-spawn? id: SessionId, s: Spawn => Bool.
passed-to-cli? id: SessionId, s: Spawn => Bool.
minted-session-flag-on? => Bool.

budget-cap-set? s: Spawn => Bool.
flag-emitted? s: Spawn => Bool.
cost-tracked? s: Spawn => Bool.
self-terminates-on-overshoot? s: Spawn => Bool.

bare-flag-on? => Bool.
worktree-claude-md p: Patch => Text.
non-empty? t: Text => Bool.
prompt-of s: Spawn => Prompt.
contains? t: Text, sub: String => Bool.
---

> Static prefix is gameplan-shared.
all p: Patch, gp: Gameplan | shared? (prefix (render p gp)) gp.

> Dynamic suffix is patch-specific.
all p: Patch, gp: Gameplan | specific? (suffix (render p gp)) p.

> Claude spawns pass --exclude-dynamic-system-prompt-sections.
all s: Spawn, backend s = claude |
  has-flag? (args s) "--exclude-dynamic-system-prompt-sections".

> Distinct patches have distinct config dirs.
all p1: Patch, p2: Patch, p1 ~= p2 |
  config-dir (spawn-of p1) ~= config-dir (spawn-of p2).

> Turn caps are monotone non-decreasing in complexity.
all p1: Patch, p2: Patch, complexity p1 < complexity p2 |
  max-turns (spawn-of p1) <= max-turns (spawn-of p2).

> Session-ID minting (when enabled) persists before spawn and
> passes to the CLI.
all p: Patch, minted-session-flag-on? |
  persisted-before-spawn? (session-id p) (spawn-of p).

all p: Patch, minted-session-flag-on? |
  passed-to-cli? (session-id p) (spawn-of p).

> When the budget cap is set, Claude spawns emit the flag and
> Codex spawns track cost + self-terminate.
all s: Spawn, backend s = claude, budget-cap-set? s |
  flag-emitted? s.

all s: Spawn, backend s = codex, budget-cap-set? s |
  cost-tracked? s and self-terminates-on-overshoot? s.

> When --bare is enabled, Claude spawns pass --bare and the
> worktree's CLAUDE.md content is reachable from the spawn's
> prompt prefix.
all p: Patch, bare-flag-on?, backend (spawn-of p) = claude |
  has-flag? (args (spawn-of p)) "--bare".

all p: Patch, bare-flag-on?, non-empty? (worktree-claude-md p) |
  contains? (prefix (prompt-of (spawn-of p))) "CLAUDE.md".

```

## Patch Specification

```
module HEADLESS_CACHE_TUNING_PATCH_6.

> Patch 7 caps per-spawn USD spend. Claude carries the cap as
> a CLI flag; Codex tracks cost from turn.completed events and
> self-terminates on overshoot.

Spawn.
Backend.
Usd.

claude => Backend.
codex => Backend.
backend s: Spawn => Backend.
budget-cap-set? s: Spawn => Bool.
flag-emitted? s: Spawn => Bool.
cost-tracked? s: Spawn => Bool.
self-terminates-on-overshoot? s: Spawn => Bool.
---

> When the cap is set, Claude spawns emit --max-budget-usd.
all s: Spawn, backend s = claude, budget-cap-set? s |
  flag-emitted? s.

> When the cap is set, Codex spawns track cost and self-kill
> on overshoot.
all s: Spawn, backend s = codex, budget-cap-set? s |
  cost-tracked? s and self-terminates-on-overshoot? s.

```


## Implementation Notes

- I touched [lib/llm_backend.ml](/Users/zax/worktrees/headless-cache-tuning/patch-6/lib/llm_backend.ml) in addition to the listed files. Codex budget overshoot now emits `Stream_event.Error`, and the shared stream runner had to start treating terminal `Error` events like terminal `Final_result` events for teardown; otherwise an over-budget Codex process would log the error but keep running until timeout.
- Codex cost accounting assumes OpenAI reasoning tokens are billed at the model's output-token rate. The implementation avoids double-counting by treating `usage.output_tokens` as total output and subtracting `reasoning_tokens` when `output_tokens_details.reasoning_tokens` is present before pricing visible output plus reasoning separately.
- `ONTON_BUDGET_CAP_USD` handling is slightly stricter than the gameplan text: non-positive numerics are treated as invalid and behave like unset. Claude warns once per process for any invalid value; Codex silently skips invalid caps and only enforces when parsing produced a positive float.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a per-spawn USD budget cap to stop runaway spend. Claude passes the cap via `--max-budget-usd`; Codex tracks per-turn cost in nano-USD, emits an over-budget error, and cleanly ends the turn.

- New Features
  - Claude: read `ONTON_BUDGET_CAP_USD`, add `--max-budget-usd <cap>` when valid; warn once on non-numeric; ignore non-positive.
  - Codex: track `turn.completed` usage in nano-USD for `gpt-5.4-mini`, `gpt-5.4`, `gpt-5.5`; bill reasoning tokens at the output rate without double-counting; skip enforcement when cap invalid/unset or model unknown; on breach, emit `Stream_event.Error` then `Final_result`. Expose `cost_state`, `initial_cost_state`, and `parse_event_with_cost_tracking` for tests.

- Bug Fixes
  - Treat `Stream_event.Error` as terminal in `llm_backend` and terminate the child immediately (SIGTERM with SIGKILL fallback). Budget overshoots are terminal success to avoid retries/timeouts.
  - Clamp Codex usage counts to non-negative to prevent malformed payloads from skewing cost.

<sup>Written for commit e7edc99ce437e2d003b4c1f3ad1e0f1909ef0c22. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional budget cap enforcement via environment variable
  * Per-turn API usage cost tracking using nano-USD accounting and model pricing
  * Streaming emits budget-exceeded errors and stops when cap is surpassed
  * Emits warnings for invalid or empty budget configuration

* **Bug Fixes**
  * Stop terminal stream processing on both completion and error events

* **Tests**
  * Added tests for budget cap parsing and enforcement in streaming paths
<!-- end of auto-generated comment: release notes by coderabbit.ai -->