### PR TITLE
spawn_env: seed user auth files into per-patch dirs

### DIFF
--- a/lib/codex_backend.ml
+++ b/lib/codex_backend.ml
@@ -52,10 +52,13 @@ let usage_reasoning_tokens usage =
   let open Yojson.Safe.Util in
   (* Support the current nested Responses schema
      ([usage.output_tokens_details.reasoning_tokens]) plus older/alternate
-     flat spellings that have appeared in streamed usage payloads. *)
+     flat spellings that have appeared in streamed usage payloads. The
+     [output_tokens_details] field may be absent (or explicitly null) on some
+     turn.completed payloads — guard against that before recursing. *)
   let from_details =
-    member "output_tokens_details" usage
-    |> member "reasoning_tokens" |> to_int_option
+    match member "output_tokens_details" usage with
+    | `Assoc _ as details -> member "reasoning_tokens" details |> to_int_option
+    | _ -> None
   in
   Option.first_some from_details
     (member "reasoning_tokens" usage |> to_int_option)
@@ -430,6 +433,23 @@ let%test "cost tracker emits Error when cumulative exceeds cap" =
          Types.Stream_event.Final_result
            { text = ""; stop_reason = Types.Stop_reason.End_turn };
        ]
+
+let%test "cost tracker handles usage without output_tokens_details" =
+  (* Some turn.completed payloads omit [output_tokens_details] entirely. The
+     cost path must not raise Yojson Type_error when chaining into a missing
+     nested object. *)
+  let line =
+    {|{"type":"turn.completed","usage":{"input_tokens":1000,"output_tokens":2000}}|}
+  in
+  let events, _ =
+    parse_event_with_cost_tracking ~model:(Some "gpt-5.5")
+      ~budget_cap_nano_usd:None ~cost_state:initial_cost_state line
+  in
+  List.equal Types.Stream_event.equal events
+    [
+      Types.Stream_event.Final_result
+        { text = ""; stop_reason = Types.Stop_reason.End_turn };
+    ]
 
 let%test "parse_event error" =
   let line = {|{"type":"error","message":"rate limited"}|} in

--- a/lib/codex_backend.ml
+++ b/lib/codex_backend.ml
@@ -1,36 +1,12 @@
 open Base
 
-type cost_state = { cumulative_nano_usd : int64 }
+(* Cost-tracking decision logic lives in [Codex_cost]; this file is the
+   effectful handler — JSON-line decoder + process driver — that threads its
+   state through the stream and decides on per-event basis what to emit. *)
 
-let initial_cost_state = { cumulative_nano_usd = 0L }
+type cost_state = Codex_cost.cost_state
 
-type model_pricing = {
-  input_nano_usd_per_1k : int64;
-  output_nano_usd_per_1k : int64;
-}
-
-let model_pricing = function
-  | Some "gpt-5.4-mini" ->
-      Some
-        {
-          input_nano_usd_per_1k = 750_000L;
-          output_nano_usd_per_1k = 4_500_000L;
-        }
-  | Some "gpt-5.4" ->
-      Some
-        {
-          input_nano_usd_per_1k = 2_500_000L;
-          output_nano_usd_per_1k = 15_000_000L;
-        }
-  | Some "gpt-5.5" ->
-      Some
-        {
-          input_nano_usd_per_1k = 5_000_000L;
-          output_nano_usd_per_1k = 30_000_000L;
-        }
-  (* Unknown/None model: cost tracking disabled, cap not enforced.
-     Keep this table in sync with [auto_model]. *)
-  | _ -> None
+let initial_cost_state = Codex_cost.initial_cost_state
 
 let budget_cap_nano_usd_from_env () =
   match
@@ -43,56 +19,6 @@ let budget_cap_nano_usd_from_env () =
       | Some cap when Float.(cap > 0.) ->
           Some (Int64.of_float (Float.round_nearest (cap *. 1_000_000_000.0)))
       | Some _ | None -> None)
-
-let usage_member_int json name =
-  let open Yojson.Safe.Util in
-  member name json |> to_int_option |> Option.value ~default:0 |> Int.max 0
-
-let usage_reasoning_tokens usage =
-  let open Yojson.Safe.Util in
-  (* Support the current nested Responses schema
-     ([usage.output_tokens_details.reasoning_tokens]) plus older/alternate
-     flat spellings that have appeared in streamed usage payloads. The
-     [output_tokens_details] field may be absent (or explicitly null) on some
-     turn.completed payloads — guard against that before recursing. *)
-  let from_details =
-    match member "output_tokens_details" usage with
-    | `Assoc _ as details -> member "reasoning_tokens" details |> to_int_option
-    | _ -> None
-  in
-  Option.first_some from_details
-    (member "reasoning_tokens" usage |> to_int_option)
-  |> Option.first_some (member "reasoning_output_tokens" usage |> to_int_option)
-  |> Option.value ~default:0 |> Int.max 0
-
-let cost_nano_usd_for_tokens tokens nano_usd_per_1k =
-  Int64.(of_int tokens * nano_usd_per_1k / 1000L)
-
-let float_usd_of_nano_usd nano_usd = Int64.to_float nano_usd /. 1_000_000_000.0
-
-let completed_turn_cost_nano_usd ~model json =
-  match model_pricing model with
-  | None -> None
-  | Some pricing ->
-      let open Yojson.Safe.Util in
-      let usage = member "usage" json in
-      let input_tokens = usage_member_int usage "input_tokens" in
-      let output_tokens = usage_member_int usage "output_tokens" in
-      let reasoning_tokens = usage_reasoning_tokens usage in
-      let visible_output_tokens =
-        Int.max 0 (output_tokens - reasoning_tokens)
-      in
-      let input_cost =
-        cost_nano_usd_for_tokens input_tokens pricing.input_nano_usd_per_1k
-      in
-      let visible_output_cost =
-        cost_nano_usd_for_tokens visible_output_tokens
-          pricing.output_nano_usd_per_1k
-      in
-      let reasoning_cost =
-        cost_nano_usd_for_tokens reasoning_tokens pricing.output_nano_usd_per_1k
-      in
-      Some Int64.(input_cost + visible_output_cost + reasoning_cost)
 
 let parse_event_with_cost_tracking ~model ~budget_cap_nano_usd ~cost_state line
     =
@@ -159,35 +85,11 @@ let parse_event_with_cost_tracking ~model ~budget_cap_nano_usd ~cost_state line
           | _ -> ([], cost_state))
       | Some "turn.started" -> ([ Types.Stream_event.Turn_started ], cost_state)
       | Some "turn.completed" ->
-          let added_cost =
-            completed_turn_cost_nano_usd ~model json |> Option.value ~default:0L
+          let { Codex_cost.events; state } =
+            Codex_cost.on_turn_completed ~model ~budget_cap_nano_usd
+              ~state:cost_state json
           in
-          let cost_state =
-            {
-              cumulative_nano_usd =
-                Int64.(cost_state.cumulative_nano_usd + added_cost);
-            }
-          in
-          let events =
-            match budget_cap_nano_usd with
-            | Some cap when Int64.(cost_state.cumulative_nano_usd > cap) ->
-                [
-                  Types.Stream_event.Error
-                    (Printf.sprintf
-                       "Codex budget cap exceeded: cumulative cost $%.4f > cap \
-                        $%.4f"
-                       (float_usd_of_nano_usd cost_state.cumulative_nano_usd)
-                       (float_usd_of_nano_usd cap));
-                  Types.Stream_event.Final_result
-                    { text = ""; stop_reason = Types.Stop_reason.End_turn };
-                ]
-            | _ ->
-                [
-                  Types.Stream_event.Final_result
-                    { text = ""; stop_reason = Types.Stop_reason.End_turn };
-                ]
-          in
-          (events, cost_state)
+          (events, state)
       | Some "error" ->
           let msg =
             member "message" json |> to_string_option

--- a/lib/codex_backend.mli
+++ b/lib/codex_backend.mli
@@ -18,7 +18,9 @@ val auto_model : complexity:int option -> string option
 (** Codex's complexity → model ladder used to resolve [--model auto]. Exposed so
     the TUI can display the concrete model name a patch will run under. *)
 
-type cost_state = { cumulative_nano_usd : int64 }
+type cost_state = Codex_cost.cost_state
+(** Re-export of {!Codex_cost.cost_state}. Cost-tracking decision logic lives in
+    {!Codex_cost}; this module is the effectful handler that drives it. *)
 
 val initial_cost_state : cost_state
 
@@ -28,8 +30,6 @@ val parse_event_with_cost_tracking :
   cost_state:cost_state ->
   string ->
   Types.Stream_event.t list * cost_state
-(** Parse a single NDJSON line while accumulating per-spawn Codex token cost.
-    [turn.completed] usage is priced using the pinned model's current rates;
-    costs and caps are tracked in nano-USD to avoid floating-point drift; when
-    [budget_cap_nano_usd] is crossed, the returned events include
-    [Stream_event.Error]. Exposed for testing. *)
+(** Parse a single NDJSON line, threading [cost_state] through. Delegates the
+    [turn.completed] cost/cap decision to {!Codex_cost.on_turn_completed} — this
+    function is just a thin JSON-line dispatcher. Exposed for testing. *)

--- a/lib/codex_cost.ml
+++ b/lib/codex_cost.ml
@@ -1,0 +1,281 @@
+open Base
+
+(** Pure cost-tracking decision logic. See [codex_cost.mli] for contract. *)
+
+(* ---------- Cost state ---------- *)
+
+type cost_state = { cumulative_nano_usd : int64 }
+[@@deriving show, eq, sexp_of, compare]
+
+let initial_cost_state = { cumulative_nano_usd = 0L }
+
+let advance s delta =
+  let delta = if Int64.(delta < 0L) then 0L else delta in
+  { cumulative_nano_usd = Int64.(s.cumulative_nano_usd + delta) }
+
+(* ---------- Usage decoding ---------- *)
+
+type usage = { input_tokens : int; output_tokens : int; reasoning_tokens : int }
+[@@deriving show, eq, sexp_of, compare]
+
+let zero_usage = { input_tokens = 0; output_tokens = 0; reasoning_tokens = 0 }
+
+let int_member name json =
+  let open Yojson.Safe.Util in
+  match json with `Assoc _ -> member name json |> to_int_option | _ -> None
+
+(* Reasoning tokens are reported under three schemas. In priority order:
+   1. nested [output_tokens_details.reasoning_tokens] (OpenAI Responses API
+      shape, surfaces in older / passthrough payloads),
+   2. flat [reasoning_tokens] (intermediate shape),
+   3. flat [reasoning_output_tokens] (the shape [codex exec --json] actually
+      emits today — see codex-rs/exec/src/exec_events.rs::Usage).
+   Take the first that decodes as an int; fall through to zero. *)
+let reasoning_tokens_of_usage usage =
+  let from_nested =
+    match usage with
+    | `Assoc _ -> (
+        match Yojson.Safe.Util.member "output_tokens_details" usage with
+        | `Assoc _ as details -> int_member "reasoning_tokens" details
+        | _ -> None)
+    | _ -> None
+  in
+  let from_flat = int_member "reasoning_tokens" usage in
+  let from_alt_flat = int_member "reasoning_output_tokens" usage in
+  Option.first_some from_nested from_flat
+  |> (fun acc -> Option.first_some acc from_alt_flat)
+  |> Option.value ~default:0 |> Int.max 0
+
+let usage_of_yojson json =
+  match json with
+  | `Assoc _ ->
+      let count name =
+        int_member name json |> Option.value ~default:0 |> Int.max 0
+      in
+      {
+        input_tokens = count "input_tokens";
+        output_tokens = count "output_tokens";
+        reasoning_tokens = reasoning_tokens_of_usage json;
+      }
+  | _ -> zero_usage
+
+(* ---------- Pricing & cost ---------- *)
+
+type model_pricing = {
+  input_nano_usd_per_1k : int64;
+  output_nano_usd_per_1k : int64;
+}
+[@@deriving show, eq, sexp_of, compare]
+
+let model_pricing = function
+  | Some "gpt-5.4-mini" ->
+      Some
+        {
+          input_nano_usd_per_1k = 750_000L;
+          output_nano_usd_per_1k = 4_500_000L;
+        }
+  | Some "gpt-5.4" ->
+      Some
+        {
+          input_nano_usd_per_1k = 2_500_000L;
+          output_nano_usd_per_1k = 15_000_000L;
+        }
+  | Some "gpt-5.5" ->
+      Some
+        {
+          input_nano_usd_per_1k = 5_000_000L;
+          output_nano_usd_per_1k = 30_000_000L;
+        }
+  | _ -> None
+
+let cost_nano_usd_for_tokens tokens nano_usd_per_1k =
+  let tokens = Int.max 0 tokens in
+  Int64.(of_int tokens * nano_usd_per_1k / 1000L)
+
+let cost_of_usage ~pricing usage =
+  let visible_output_tokens =
+    Int.max 0 (usage.output_tokens - usage.reasoning_tokens)
+  in
+  let input =
+    cost_nano_usd_for_tokens usage.input_tokens pricing.input_nano_usd_per_1k
+  in
+  let visible =
+    cost_nano_usd_for_tokens visible_output_tokens
+      pricing.output_nano_usd_per_1k
+  in
+  let reasoning =
+    cost_nano_usd_for_tokens usage.reasoning_tokens
+      pricing.output_nano_usd_per_1k
+  in
+  Int64.(input + visible + reasoning)
+
+let float_usd_of_nano_usd nano_usd = Int64.to_float nano_usd /. 1_000_000_000.0
+
+(* ---------- Cap decision ---------- *)
+
+type cap_decision =
+  | Within_cap
+  | Exceeded of { cumulative_nano_usd : int64; cap_nano_usd : int64 }
+[@@deriving show, eq, sexp_of, compare]
+
+let check_cap ~budget_cap_nano_usd state =
+  match budget_cap_nano_usd with
+  | None -> Within_cap
+  | Some cap when Int64.(state.cumulative_nano_usd > cap) ->
+      Exceeded
+        { cumulative_nano_usd = state.cumulative_nano_usd; cap_nano_usd = cap }
+  | Some _ -> Within_cap
+
+(* ---------- Turn-completed decision ---------- *)
+
+type turn_decision = { events : Types.Stream_event.t list; state : cost_state }
+[@@deriving show, eq, sexp_of, compare]
+
+let turn_cost_for_payload ~model json =
+  match model_pricing model with
+  | None -> 0L
+  | Some pricing ->
+      let open Yojson.Safe.Util in
+      let usage =
+        match json with `Assoc _ -> member "usage" json | _ -> `Null
+      in
+      cost_of_usage ~pricing (usage_of_yojson usage)
+
+let final_result =
+  Types.Stream_event.Final_result
+    { text = ""; stop_reason = Types.Stop_reason.End_turn }
+
+let on_turn_completed ~model ~budget_cap_nano_usd ~state json =
+  let added = turn_cost_for_payload ~model json in
+  let state = advance state added in
+  let events =
+    match check_cap ~budget_cap_nano_usd state with
+    | Within_cap -> [ final_result ]
+    | Exceeded { cumulative_nano_usd; cap_nano_usd } ->
+        [
+          Types.Stream_event.Error
+            (Printf.sprintf
+               "Codex budget cap exceeded: cumulative cost $%.4f > cap $%.4f"
+               (float_usd_of_nano_usd cumulative_nano_usd)
+               (float_usd_of_nano_usd cap_nano_usd));
+          final_result;
+        ]
+  in
+  { events; state }
+
+(* ---------- Inline shape tests (property tests live in test/) ---------- *)
+
+let%test "advance is monotone non-decreasing" =
+  let s = advance initial_cost_state 100L in
+  let s' = advance s (-500L) in
+  Int64.equal s'.cumulative_nano_usd 100L
+
+let%test "usage_of_yojson zero on null / non-object" =
+  equal_usage (usage_of_yojson `Null) zero_usage
+  && equal_usage (usage_of_yojson (`Int 7)) zero_usage
+  && equal_usage (usage_of_yojson (`List [ `Int 1 ])) zero_usage
+
+let%test "usage_of_yojson zero when usage is empty object" =
+  equal_usage (usage_of_yojson (`Assoc [])) zero_usage
+
+let%test "usage_of_yojson nested reasoning_tokens schema" =
+  let j =
+    `Assoc
+      [
+        ("input_tokens", `Int 1);
+        ("output_tokens", `Int 2);
+        ("output_tokens_details", `Assoc [ ("reasoning_tokens", `Int 3) ]);
+      ]
+  in
+  equal_usage (usage_of_yojson j)
+    { input_tokens = 1; output_tokens = 2; reasoning_tokens = 3 }
+
+let%test "usage_of_yojson flat reasoning_tokens schema" =
+  let j =
+    `Assoc
+      [
+        ("input_tokens", `Int 4);
+        ("output_tokens", `Int 5);
+        ("reasoning_tokens", `Int 6);
+      ]
+  in
+  equal_usage (usage_of_yojson j)
+    { input_tokens = 4; output_tokens = 5; reasoning_tokens = 6 }
+
+let%test "usage_of_yojson alt-flat reasoning_output_tokens schema" =
+  let j =
+    `Assoc
+      [
+        ("input_tokens", `Int 0);
+        ("output_tokens", `Int 0);
+        ("reasoning_output_tokens", `Int 11);
+      ]
+  in
+  equal_usage (usage_of_yojson j)
+    { input_tokens = 0; output_tokens = 0; reasoning_tokens = 11 }
+
+let%test "usage_of_yojson nested missing falls through to flat" =
+  let j =
+    `Assoc
+      [ ("output_tokens_details", `Assoc []); ("reasoning_tokens", `Int 9) ]
+  in
+  Int.equal (usage_of_yojson j).reasoning_tokens 9
+
+let%test "usage_of_yojson nested null falls through to flat" =
+  let j =
+    `Assoc [ ("output_tokens_details", `Null); ("reasoning_tokens", `Int 7) ]
+  in
+  Int.equal (usage_of_yojson j).reasoning_tokens 7
+
+let%test "usage_of_yojson clamps negatives" =
+  let j =
+    `Assoc
+      [
+        ("input_tokens", `Int (-5));
+        ("output_tokens", `Int (-3));
+        ("reasoning_tokens", `Int (-1));
+      ]
+  in
+  equal_usage (usage_of_yojson j) zero_usage
+
+let%test "check_cap None is always Within_cap" =
+  equal_cap_decision
+    (check_cap ~budget_cap_nano_usd:None
+       (advance initial_cost_state 1_000_000L))
+    Within_cap
+
+let%test "check_cap at boundary is Within_cap (closed cap)" =
+  equal_cap_decision
+    (check_cap ~budget_cap_nano_usd:(Some 100L)
+       (advance initial_cost_state 100L))
+    Within_cap
+
+let%test "check_cap above boundary is Exceeded" =
+  match
+    check_cap ~budget_cap_nano_usd:(Some 100L) (advance initial_cost_state 101L)
+  with
+  | Exceeded { cumulative_nano_usd; cap_nano_usd } ->
+      Int64.equal cumulative_nano_usd 101L && Int64.equal cap_nano_usd 100L
+  | Within_cap -> false
+
+let%test "on_turn_completed unknown model leaves state untouched" =
+  let { state; events } =
+    on_turn_completed ~model:None ~budget_cap_nano_usd:None
+      ~state:initial_cost_state
+      (`Assoc
+         [
+           ( "usage",
+             `Assoc [ ("input_tokens", `Int 100); ("output_tokens", `Int 200) ]
+           );
+         ])
+  in
+  Int64.equal state.cumulative_nano_usd 0L
+  && List.equal Types.Stream_event.equal events [ final_result ]
+
+let%test "on_turn_completed survives malformed payload" =
+  let { state; events } =
+    on_turn_completed ~model:(Some "gpt-5.5") ~budget_cap_nano_usd:None
+      ~state:initial_cost_state `Null
+  in
+  Int64.equal state.cumulative_nano_usd 0L
+  && List.equal Types.Stream_event.equal events [ final_result ]

--- a/lib/codex_cost.mli
+++ b/lib/codex_cost.mli
@@ -1,0 +1,113 @@
+(** Pure cost-tracking decision logic for the Codex backend.
+
+    No I/O, no exceptions: every value-returning function in this module is
+    total over its declared input domain — including ill-formed JSON shapes
+    handed to {!usage_of_yojson} and {!on_turn_completed}. The effectful handler
+    ({!Codex_backend.run_streaming}) reads stdout, accumulates {!cost_state}
+    across lines, and emits the events this module decides.
+
+    Organization:
+    - {b State} — abstract [cost_state] threaded through the decision.
+    - {b Usage decoding} — total Yojson decoder for token-usage payloads.
+    - {b Pricing & cost} — model rate table and per-usage cost computation.
+    - {b Cap decision} — pure check against a budget cap.
+    - {b Turn decision} — orchestration of the above into a [turn_decision]. *)
+
+(** {2 Cost state} *)
+
+type cost_state = private { cumulative_nano_usd : int64 }
+[@@deriving show, eq, sexp_of, compare]
+(** Cumulative cost in nano-USD across all priced [turn.completed] events
+    observed so far in a spawn. Private to enforce monotonicity at construction
+    time: the only ways to obtain a value are {!initial_cost_state} (zero) and
+    {!advance} (clamped non-negative). *)
+
+val initial_cost_state : cost_state
+
+val advance : cost_state -> int64 -> cost_state
+(** [advance s delta] adds [max 0 delta] to the cumulative cost. Negative
+    [delta] is treated as zero so the cumulative is always monotone
+    non-decreasing. *)
+
+(** {2 Usage decoding}
+
+    Codex's [turn.completed] payload has a [usage] sub-object whose schema has
+    drifted: token counts may be missing, [output_tokens_details] may be absent
+    or null, and reasoning tokens have been spelled three different ways across
+    versions ([usage.output_tokens_details.reasoning_tokens],
+    [usage.reasoning_tokens], [usage.reasoning_output_tokens]). *)
+
+type usage = { input_tokens : int; output_tokens : int; reasoning_tokens : int }
+[@@deriving show, eq, sexp_of, compare]
+
+val zero_usage : usage
+
+val usage_of_yojson : Yojson.Safe.t -> usage
+(** Total decoder. Returns {!zero_usage} for any non-object input, missing keys,
+    or non-int values. All token counts are clamped to [>= 0].
+
+    For [reasoning_tokens] the decoder tries three schemas in priority order and
+    returns the first that yields an int:
+    + nested: [output_tokens_details.reasoning_tokens]
+    + flat: [reasoning_tokens]
+    + alt: [reasoning_output_tokens] *)
+
+(** {2 Pricing & cost} *)
+
+type model_pricing = {
+  input_nano_usd_per_1k : int64;
+  output_nano_usd_per_1k : int64;
+}
+[@@deriving show, eq, sexp_of, compare]
+
+val model_pricing : string option -> model_pricing option
+(** Pricing table for known Codex model names. [None] for unknown / unset models
+    — callers treat that as "cost tracking disabled". Keep in sync with
+    {!Codex_backend.auto_model}. *)
+
+val cost_nano_usd_for_tokens : int -> int64 -> int64
+(** [cost_nano_usd_for_tokens tokens nano_usd_per_1k] =
+    [max 0 tokens * rate / 1000]. Saturates negative tokens to zero so the
+    result is always non-negative. *)
+
+val cost_of_usage : pricing:model_pricing -> usage -> int64
+(** Total cost (input + visible output + reasoning) at the given pricing.
+    Visible output tokens = [max 0 (output_tokens - reasoning_tokens)] so
+    reasoning tokens are not double-counted when they are reported as a subset
+    of the output stream. *)
+
+val float_usd_of_nano_usd : int64 -> float
+(** Convert nano-USD to USD as a float, for human-facing strings. *)
+
+(** {2 Budget cap decision} *)
+
+type cap_decision =
+  | Within_cap
+  | Exceeded of { cumulative_nano_usd : int64; cap_nano_usd : int64 }
+[@@deriving show, eq, sexp_of, compare]
+
+val check_cap : budget_cap_nano_usd:int64 option -> cost_state -> cap_decision
+(** [check_cap ~budget_cap_nano_usd s] returns [Within_cap] when no cap is set
+    or [s.cumulative_nano_usd <= cap]; otherwise [Exceeded]. The cap-equal case
+    is intentionally [Within_cap] so the cap is a closed upper bound rather than
+    a strict one. *)
+
+(** {2 Turn-completed decision} *)
+
+type turn_decision = { events : Types.Stream_event.t list; state : cost_state }
+[@@deriving show, eq, sexp_of, compare]
+
+val on_turn_completed :
+  model:string option ->
+  budget_cap_nano_usd:int64 option ->
+  state:cost_state ->
+  Yojson.Safe.t ->
+  turn_decision
+(** Pure decision for a [turn.completed] payload. Always emits a [Final_result];
+    additionally prepends an [Error] when the post-advance cumulative cost has
+    crossed [budget_cap_nano_usd]. The returned [state] is the post-advance
+    state regardless of cap status, so cumulative costs keep accruing after a
+    breach (the handler reacts to the [Error] by self-killing the spawn).
+
+    Total over arbitrary [Yojson.Safe.t]: ill-formed payloads are decoded as
+    {!zero_usage} (zero cost), and unknown models leave the state unchanged. *)

--- a/lib/rlimit_stubs.c
+++ b/lib/rlimit_stubs.c
@@ -18,6 +18,7 @@
 #include <sys/resource.h>
 #include <errno.h>
 #include <string.h>
+#include <stdlib.h>
 
 /* Returns (soft, hard) as an OCaml int pair. */
 CAMLprim value caml_onton_getrlimit_nofile(value unit) {
@@ -51,6 +52,15 @@ CAMLprim value caml_onton_setrlimit_nofile_soft(value v_soft) {
   }
   rl.rlim_cur = (rlim_t)Long_val(v_soft);
   if (setrlimit(RLIMIT_NOFILE, &rl) != 0) {
+    caml_failwith(strerror(errno));
+  }
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value caml_onton_unsetenv(value v_name) {
+  CAMLparam1(v_name);
+  const char *name = String_val(v_name);
+  if (unsetenv(name) != 0) {
     caml_failwith(strerror(errno));
   }
   CAMLreturn(Val_unit);

--- a/lib/spawn_env.ml
+++ b/lib/spawn_env.ml
@@ -1,5 +1,7 @@
 open Base
 
+external unsetenv_stub : string -> unit = "caml_onton_unsetenv"
+
 let patch_root ~project_dir ~patch_id =
   Stdlib.Filename.concat project_dir
     (Stdlib.Filename.concat "spawn-envs" (Types.Patch_id.to_string patch_id))
@@ -17,7 +19,12 @@ let seed_link ~src ~dst =
     | _ -> true
     | exception Unix.Unix_error (Unix.ENOENT, _, _) -> false
   in
-  if (not dst_exists) && Stdlib.Sys.file_exists src then
+  let src_exists =
+    match Unix.lstat src with
+    | _ -> true
+    | exception Unix.Unix_error (Unix.ENOENT, _, _) -> false
+  in
+  if (not dst_exists) && src_exists then
     try Unix.symlink src dst with Unix.Unix_error (Unix.EEXIST, _, _) -> ()
 
 let resolve_user_config_dir ~env_var ~home_subpath =
@@ -273,7 +280,9 @@ let%test "resolve_user_config_dir absolutizes relative env and HOME paths" =
   let cwd = Stdlib.Sys.getcwd () in
   let old_home = Stdlib.Sys.getenv_opt "HOME" in
   let restore_home () =
-    match old_home with Some home -> Unix.putenv "HOME" home | None -> ()
+    match old_home with
+    | Some home -> Unix.putenv "HOME" home
+    | None -> unsetenv_stub "HOME"
   in
   Unix.putenv "HOME" "relative-home";
   Stdlib.Fun.protect ~finally:restore_home @@ fun () ->

--- a/lib/spawn_env.ml
+++ b/lib/spawn_env.ml
@@ -22,7 +22,7 @@ let seed_link ~src ~dst =
   let src_exists =
     match Unix.lstat src with
     | _ -> true
-    | exception Unix.Unix_error (Unix.ENOENT, _, _) -> false
+    | exception Unix.Unix_error _ -> false
   in
   if (not dst_exists) && src_exists then
     try Unix.symlink src dst with Unix.Unix_error (Unix.EEXIST, _, _) -> ()

--- a/lib/spawn_env.ml
+++ b/lib/spawn_env.ml
@@ -20,7 +20,9 @@ let seed_link ~src ~dst =
     | exception Unix.Unix_error (Unix.ENOENT, _, _) -> false
   in
   let src_exists =
-    match Unix.lstat src with _ -> true | exception Unix.Unix_error _ -> false
+    match Unix.lstat src with
+    | _ -> true
+    | exception Unix.Unix_error (Unix.ENOENT, _, _) -> false
   in
   if (not dst_exists) && src_exists then
     try Unix.symlink src dst with Unix.Unix_error (Unix.EEXIST, _, _) -> ()

--- a/lib/spawn_env.ml
+++ b/lib/spawn_env.ml
@@ -6,12 +6,65 @@ let patch_root ~project_dir ~patch_id =
 
 let backend_dir ~root ~backend = Stdlib.Filename.concat root backend
 
+(* Idempotently symlink [src] at [dst]. Skip if [dst] already exists in any
+   form (regular file, dir, or existing symlink): the backend CLI may have
+   replaced the symlink with a freshly-written file (e.g. atomic-rename token
+   refresh) and we must not clobber that real state. Skip if [src] is missing:
+   the user may not be logged in to that backend. *)
+let seed_link ~src ~dst =
+  let dst_exists =
+    match Unix.lstat dst with
+    | _ -> true
+    | exception Unix.Unix_error (Unix.ENOENT, _, _) -> false
+  in
+  if (not dst_exists) && Stdlib.Sys.file_exists src then Unix.symlink src dst
+
+let resolve_user_config_dir ~env_var ~home_subpath =
+  match Stdlib.Sys.getenv_opt env_var with
+  | Some dir when not (String.is_empty dir) -> Some dir
+  | _ -> (
+      match Stdlib.Sys.getenv_opt "HOME" with
+      | Some home when not (String.is_empty home) ->
+          Some (Stdlib.Filename.concat home home_subpath)
+      | _ -> None)
+
+(* Seed the per-patch config dirs with symlinks to the user's real auth
+   files. Symlinks (not copies) so token rotations the backend writes
+   in-place propagate back to the user's real config dir, and so the user's
+   plain CLI continues to share a session with the per-patch CLI. *)
+let seed_auth_links_with ~claude_src_dir ~codex_src_dir ~opencode_src_dir
+    ~claude_dir ~codex_dir ~opencode_dir =
+  let seed src_dir dst_dir filename =
+    Option.iter src_dir ~f:(fun src_dir ->
+        seed_link
+          ~src:(Stdlib.Filename.concat src_dir filename)
+          ~dst:(Stdlib.Filename.concat dst_dir filename))
+  in
+  seed claude_src_dir claude_dir ".credentials.json";
+  seed codex_src_dir codex_dir "auth.json";
+  seed opencode_src_dir opencode_dir "opencode.json"
+
+let seed_auth_links ~claude_dir ~codex_dir ~opencode_dir =
+  let claude_src_dir =
+    resolve_user_config_dir ~env_var:"CLAUDE_CONFIG_DIR" ~home_subpath:".claude"
+  in
+  let codex_src_dir =
+    resolve_user_config_dir ~env_var:"CODEX_HOME" ~home_subpath:".codex"
+  in
+  let opencode_src_dir =
+    resolve_user_config_dir ~env_var:"OPENCODE_CONFIG_DIR"
+      ~home_subpath:".config/opencode"
+  in
+  seed_auth_links_with ~claude_src_dir ~codex_src_dir ~opencode_src_dir
+    ~claude_dir ~codex_dir ~opencode_dir
+
 let per_patch_env_in_project_dir ~project_dir ~patch_id =
   let root = patch_root ~project_dir ~patch_id in
   let claude_dir = backend_dir ~root ~backend:"claude" in
   let codex_dir = backend_dir ~root ~backend:"codex" in
   let opencode_dir = backend_dir ~root ~backend:"opencode" in
   List.iter [ claude_dir; codex_dir; opencode_dir ] ~f:Project_store.ensure_dir;
+  seed_auth_links ~claude_dir ~codex_dir ~opencode_dir;
   [
     ("CLAUDE_CONFIG_DIR", claude_dir);
     ("CODEX_HOME", codex_dir);
@@ -41,13 +94,18 @@ let merge_env ~base_env ~overrides =
   |> Array.of_list
 
 let rec remove_tree path =
-  if Stdlib.Sys.file_exists path then
-    if Stdlib.Sys.is_directory path then (
-      Stdlib.Sys.readdir path
-      |> Array.iter ~f:(fun child ->
-          remove_tree (Stdlib.Filename.concat path child));
-      Unix.rmdir path)
-    else Unix.unlink path
+  match Unix.lstat path with
+  | exception Unix.Unix_error (Unix.ENOENT, _, _) -> ()
+  | stat -> (
+      match stat.Unix.st_kind with
+      | Unix.S_DIR ->
+          Stdlib.Sys.readdir path
+          |> Array.iter ~f:(fun child ->
+              remove_tree (Stdlib.Filename.concat path child));
+          Unix.rmdir path
+      | Unix.S_REG | Unix.S_CHR | Unix.S_BLK | Unix.S_LNK | Unix.S_FIFO
+      | Unix.S_SOCK ->
+          Unix.unlink path)
 
 let with_temp_project_dir f =
   let dir = Stdlib.Filename.temp_dir "onton-spawn-env-" "" in
@@ -99,3 +157,108 @@ let%test "merged env contains per-patch overrides" =
   String.is_substring claude_a ~substring:"spawn-envs/patch-1/claude"
   && String.is_substring codex_a ~substring:"spawn-envs/patch-1/codex"
   && not (String.equal claude_a claude_b)
+
+let write_file path contents =
+  let oc = Stdlib.open_out path in
+  Stdlib.output_string oc contents;
+  Stdlib.close_out oc
+
+let read_file path =
+  let ic = Stdlib.open_in path in
+  let len = Stdlib.in_channel_length ic in
+  let buf = Stdlib.Bytes.create len in
+  Stdlib.really_input ic buf 0 len;
+  Stdlib.close_in ic;
+  Stdlib.Bytes.to_string buf
+
+let make_seed_dirs project_dir patch_id_str =
+  let patch_id = Types.Patch_id.of_string patch_id_str in
+  let root = patch_root ~project_dir ~patch_id in
+  let claude_dir = backend_dir ~root ~backend:"claude" in
+  let codex_dir = backend_dir ~root ~backend:"codex" in
+  let opencode_dir = backend_dir ~root ~backend:"opencode" in
+  List.iter [ claude_dir; codex_dir; opencode_dir ] ~f:Project_store.ensure_dir;
+  (claude_dir, codex_dir, opencode_dir)
+
+let%test "seed_auth_links creates symlinks when src auth files exist" =
+  with_temp_project_dir @@ fun project_dir ->
+  with_temp_project_dir @@ fun src_root ->
+  let claude_src = Stdlib.Filename.concat src_root "claude" in
+  let codex_src = Stdlib.Filename.concat src_root "codex" in
+  let opencode_src = Stdlib.Filename.concat src_root "opencode" in
+  List.iter [ claude_src; codex_src; opencode_src ] ~f:Project_store.ensure_dir;
+  write_file (Stdlib.Filename.concat claude_src ".credentials.json") "c-tok";
+  write_file (Stdlib.Filename.concat codex_src "auth.json") "x-tok";
+  write_file (Stdlib.Filename.concat opencode_src "opencode.json") "o-cfg";
+  let claude_dir, codex_dir, opencode_dir =
+    make_seed_dirs project_dir "patch-seed-1"
+  in
+  seed_auth_links_with ~claude_src_dir:(Some claude_src)
+    ~codex_src_dir:(Some codex_src) ~opencode_src_dir:(Some opencode_src)
+    ~claude_dir ~codex_dir ~opencode_dir;
+  let target dst_dir filename =
+    Unix.readlink (Stdlib.Filename.concat dst_dir filename)
+  in
+  String.equal
+    (target claude_dir ".credentials.json")
+    (Stdlib.Filename.concat claude_src ".credentials.json")
+  && String.equal
+       (target codex_dir "auth.json")
+       (Stdlib.Filename.concat codex_src "auth.json")
+  && String.equal
+       (target opencode_dir "opencode.json")
+       (Stdlib.Filename.concat opencode_src "opencode.json")
+
+let%test "seed_auth_links is idempotent" =
+  with_temp_project_dir @@ fun project_dir ->
+  with_temp_project_dir @@ fun src_root ->
+  let codex_src = Stdlib.Filename.concat src_root "codex" in
+  Project_store.ensure_dir codex_src;
+  write_file (Stdlib.Filename.concat codex_src "auth.json") "x-tok";
+  let claude_dir, codex_dir, opencode_dir =
+    make_seed_dirs project_dir "patch-seed-2"
+  in
+  let do_seed () =
+    seed_auth_links_with ~claude_src_dir:None ~codex_src_dir:(Some codex_src)
+      ~opencode_src_dir:None ~claude_dir ~codex_dir ~opencode_dir
+  in
+  do_seed ();
+  do_seed ();
+  String.equal
+    (Unix.readlink (Stdlib.Filename.concat codex_dir "auth.json"))
+    (Stdlib.Filename.concat codex_src "auth.json")
+
+let%test "seed_auth_links skips backends with no src auth file" =
+  with_temp_project_dir @@ fun project_dir ->
+  with_temp_project_dir @@ fun src_root ->
+  let codex_src = Stdlib.Filename.concat src_root "codex" in
+  Project_store.ensure_dir codex_src;
+  let claude_dir, codex_dir, opencode_dir =
+    make_seed_dirs project_dir "patch-seed-3"
+  in
+  seed_auth_links_with ~claude_src_dir:None ~codex_src_dir:(Some codex_src)
+    ~opencode_src_dir:None ~claude_dir ~codex_dir ~opencode_dir;
+  not (Stdlib.Sys.file_exists (Stdlib.Filename.concat codex_dir "auth.json"))
+
+let%test "seed_auth_links preserves an existing dst file (no clobber)" =
+  with_temp_project_dir @@ fun project_dir ->
+  with_temp_project_dir @@ fun src_root ->
+  let codex_src = Stdlib.Filename.concat src_root "codex" in
+  Project_store.ensure_dir codex_src;
+  write_file (Stdlib.Filename.concat codex_src "auth.json") "src-tok";
+  let claude_dir, codex_dir, opencode_dir =
+    make_seed_dirs project_dir "patch-seed-4"
+  in
+  let dst = Stdlib.Filename.concat codex_dir "auth.json" in
+  write_file dst "preexisting-tok";
+  seed_auth_links_with ~claude_src_dir:None ~codex_src_dir:(Some codex_src)
+    ~opencode_src_dir:None ~claude_dir ~codex_dir ~opencode_dir;
+  let stat = Unix.lstat dst in
+  let is_regular =
+    match stat.Unix.st_kind with
+    | Unix.S_REG -> true
+    | Unix.S_DIR | Unix.S_CHR | Unix.S_BLK | Unix.S_LNK | Unix.S_FIFO
+    | Unix.S_SOCK ->
+        false
+  in
+  is_regular && String.equal (read_file dst) "preexisting-tok"

--- a/lib/spawn_env.ml
+++ b/lib/spawn_env.ml
@@ -17,15 +17,21 @@ let seed_link ~src ~dst =
     | _ -> true
     | exception Unix.Unix_error (Unix.ENOENT, _, _) -> false
   in
-  if (not dst_exists) && Stdlib.Sys.file_exists src then Unix.symlink src dst
+  if (not dst_exists) && Stdlib.Sys.file_exists src then
+    try Unix.symlink src dst with Unix.Unix_error (Unix.EEXIST, _, _) -> ()
 
 let resolve_user_config_dir ~env_var ~home_subpath =
+  let absolutize path =
+    if Stdlib.Filename.is_relative path then
+      Stdlib.Filename.concat (Stdlib.Sys.getcwd ()) path
+    else path
+  in
   match Stdlib.Sys.getenv_opt env_var with
-  | Some dir when not (String.is_empty dir) -> Some dir
+  | Some dir when not (String.is_empty dir) -> Some (absolutize dir)
   | _ -> (
       match Stdlib.Sys.getenv_opt "HOME" with
       | Some home when not (String.is_empty home) ->
-          Some (Stdlib.Filename.concat home home_subpath)
+          Some (Stdlib.Filename.concat (absolutize home) home_subpath)
       | _ -> None)
 
 (* Seed the per-patch config dirs with symlinks to the user's real auth
@@ -262,3 +268,26 @@ let%test "seed_auth_links preserves an existing dst file (no clobber)" =
         false
   in
   is_regular && String.equal (read_file dst) "preexisting-tok"
+
+let%test "resolve_user_config_dir absolutizes relative env and HOME paths" =
+  let cwd = Stdlib.Sys.getcwd () in
+  let old_home = Stdlib.Sys.getenv_opt "HOME" in
+  let restore_home () =
+    match old_home with Some home -> Unix.putenv "HOME" home | None -> ()
+  in
+  Unix.putenv "HOME" "relative-home";
+  Stdlib.Fun.protect ~finally:restore_home @@ fun () ->
+  let env_dir =
+    Option.value_exn
+      (resolve_user_config_dir ~env_var:"HOME" ~home_subpath:".unused")
+  in
+  let home_dir =
+    Option.value_exn
+      (resolve_user_config_dir ~env_var:"ONTON_MISSING_CONFIG_DIR"
+         ~home_subpath:".config/onton")
+  in
+  String.equal env_dir (Stdlib.Filename.concat cwd "relative-home")
+  && String.equal home_dir
+       (Stdlib.Filename.concat
+          (Stdlib.Filename.concat cwd "relative-home")
+          ".config/onton")

--- a/lib/spawn_env.ml
+++ b/lib/spawn_env.ml
@@ -20,9 +20,7 @@ let seed_link ~src ~dst =
     | exception Unix.Unix_error (Unix.ENOENT, _, _) -> false
   in
   let src_exists =
-    match Unix.lstat src with
-    | _ -> true
-    | exception Unix.Unix_error _ -> false
+    match Unix.lstat src with _ -> true | exception Unix.Unix_error _ -> false
   in
   if (not dst_exists) && src_exists then
     try Unix.symlink src dst with Unix.Unix_error (Unix.EEXIST, _, _) -> ()

--- a/lib/spawn_env.ml
+++ b/lib/spawn_env.ml
@@ -251,7 +251,13 @@ let%test "seed_auth_links skips backends with no src auth file" =
   in
   seed_auth_links_with ~claude_src_dir:None ~codex_src_dir:(Some codex_src)
     ~opencode_src_dir:None ~claude_dir ~codex_dir ~opencode_dir;
-  not (Stdlib.Sys.file_exists (Stdlib.Filename.concat codex_dir "auth.json"))
+  let auth_dst = Stdlib.Filename.concat codex_dir "auth.json" in
+  let entry_exists =
+    match Unix.lstat auth_dst with
+    | _ -> true
+    | exception Unix.Unix_error (Unix.ENOENT, _, _) -> false
+  in
+  not entry_exists
 
 let%test "seed_auth_links preserves an existing dst file (no clobber)" =
   with_temp_project_dir @@ fun project_dir ->

--- a/lib/spawn_env.mli
+++ b/lib/spawn_env.mli
@@ -2,7 +2,10 @@ val per_patch_env :
   project_name:string -> patch_id:Types.Patch_id.t -> (string * string) list
 (** Per-patch config-dir overrides for headless agent CLIs. Creates the backing
     directories under the project store before returning:
-    [spawn-envs/<patch_id>/{claude,codex,opencode}]. *)
+    [spawn-envs/<patch_id>/{claude,codex,opencode}]. Also seeds each per-patch
+    dir with a symlink to the user's real auth file
+    ([auth.json]/[.credentials.json]/[opencode.json]) so the backend CLI finds
+    its credentials and token rotations propagate back to the user's home. *)
 
 val merge_env :
   base_env:string array -> overrides:(string * string) list -> string array

--- a/test/dune
+++ b/test/dune
@@ -9,6 +9,13 @@
  (libraries onton qcheck-core))
 
 (test
+ (name test_codex_cost_properties)
+ (modules test_codex_cost_properties)
+ (libraries onton qcheck-core qcheck-core.runner yojson)
+ (ocamlopt_flags (:standard -w -40-42))
+ (ocamlc_flags (:standard -w -40-42)))
+
+(test
  (name test_properties)
  (modules test_properties)
  (libraries onton onton_test_support qcheck-core)

--- a/test/test_codex_cost_properties.ml
+++ b/test/test_codex_cost_properties.ml
@@ -1,0 +1,522 @@
+open Base
+open Onton
+
+(** Property + interleaving tests for {!Codex_cost}.
+
+    Expectations are derived from the Codex reference implementation in
+    [codex-rs/exec/src/exec_events.rs::Usage] (the JSONL schema
+    [codex exec --json] actually emits) and
+    [codex-rs/codex-api/src/sse/responses.rs] (the upstream OpenAI Responses-API
+    schema Codex consumes). Codex CLI emits the flat [reasoning_output_tokens]
+    spelling; [Codex_cost] also accepts two legacy/defensive schemas that may
+    appear in older or intermediate payloads. *)
+
+(* ---------- Generators ---------- *)
+
+(* Token counts: small ranges keep cumulative arithmetic well within int64
+   without overflow concerns, while still covering the boundary cases. *)
+let gen_token_count = QCheck2.Gen.int_range 0 1_000_000
+let gen_negative_int = QCheck2.Gen.int_range (-100_000) (-1)
+
+(* Generate a Codex-spec-shaped usage value (the alt-flat schema emitted by
+   [codex exec --json]). [reasoning_output_tokens <= output_tokens] reflects
+   the Responses API contract: reasoning is a subset of output. *)
+let gen_codex_usage_json =
+  let open QCheck2.Gen in
+  let* input = gen_token_count in
+  let* output = gen_token_count in
+  let* cached = gen_token_count in
+  let* reasoning = int_range 0 output in
+  return
+    (`Assoc
+       [
+         ("input_tokens", `Int input);
+         ("cached_input_tokens", `Int cached);
+         ("output_tokens", `Int output);
+         ("reasoning_output_tokens", `Int reasoning);
+       ])
+
+(* Generate the legacy "Responses-API-shaped" usage (nested
+   output_tokens_details.reasoning_tokens) we still accept defensively. *)
+let gen_responses_api_usage_json =
+  let open QCheck2.Gen in
+  let* input = gen_token_count in
+  let* output = gen_token_count in
+  let* reasoning = int_range 0 output in
+  return
+    (`Assoc
+       [
+         ("input_tokens", `Int input);
+         ("output_tokens", `Int output);
+         ( "output_tokens_details",
+           `Assoc [ ("reasoning_tokens", `Int reasoning) ] );
+       ])
+
+(* Recursive arbitrary Yojson generator (depth-bounded) used to prove
+   [usage_of_yojson] is total — never raises regardless of input shape. *)
+let rec gen_arbitrary_json depth =
+  let open QCheck2.Gen in
+  let leaves =
+    [
+      return `Null;
+      map (fun b -> `Bool b) bool;
+      map (fun i -> `Int i) (int_range (-1_000) 1_000);
+      map (fun s -> `String s) (string_small_of printable);
+      return (`Float 1.5);
+    ]
+  in
+  if depth <= 0 then oneof leaves
+  else
+    let smaller = gen_arbitrary_json (depth - 1) in
+    oneof
+      (leaves
+      @ [
+          map (fun xs -> `List xs) (list_size (int_range 0 4) smaller);
+          map
+            (fun pairs -> `Assoc pairs)
+            (list_size (int_range 0 4)
+               (pair (string_small_of printable) smaller));
+        ])
+
+let gen_arbitrary_yojson = gen_arbitrary_json 3
+
+let gen_pricing =
+  let open QCheck2.Gen in
+  let* in_rate = int_range 1 100_000_000 in
+  let* out_rate = int_range 1 100_000_000 in
+  return
+    Codex_cost.
+      {
+        input_nano_usd_per_1k = Int64.of_int in_rate;
+        output_nano_usd_per_1k = Int64.of_int out_rate;
+      }
+
+let gen_model_name =
+  QCheck2.Gen.oneof_list [ Some "gpt-5.4-mini"; Some "gpt-5.4"; Some "gpt-5.5" ]
+
+(* Cap is large enough that some interleavings stay under and others cross. *)
+let gen_cap_nano_usd =
+  let open QCheck2.Gen in
+  oneof
+    [ return None; map (fun n -> Some (Int64.of_int n)) (int_range 1 100_000) ]
+
+(* ---------- Stream_event predicates (exhaustive — guards against drift) ---------- *)
+
+let is_final_result : Types.Stream_event.t -> bool = function
+  | Final_result _ -> true
+  | Turn_started | Text_delta _ | Tool_use _ | Error _ | Session_init _ -> false
+
+let is_error : Types.Stream_event.t -> bool = function
+  | Error _ -> true
+  | Turn_started | Text_delta _ | Tool_use _ | Final_result _ | Session_init _
+    ->
+      false
+
+(* ---------- Properties: pricing math ---------- *)
+
+let prop_cost_zero_tokens =
+  QCheck2.Test.make ~name:"cost_nano_usd_for_tokens 0 r = 0"
+    QCheck2.Gen.(int_range 0 1_000_000_000)
+    (fun rate ->
+      Int64.equal (Codex_cost.cost_nano_usd_for_tokens 0 (Int64.of_int rate)) 0L)
+
+let prop_cost_negative_tokens_clamps =
+  QCheck2.Test.make ~name:"cost_nano_usd_for_tokens negative tokens = 0"
+    QCheck2.Gen.(pair gen_negative_int (int_range 1 1_000_000_000))
+    (fun (tokens, rate) ->
+      Int64.equal
+        (Codex_cost.cost_nano_usd_for_tokens tokens (Int64.of_int rate))
+        0L)
+
+let prop_cost_monotone_in_tokens =
+  QCheck2.Test.make ~name:"cost_nano_usd_for_tokens monotone non-decreasing"
+    QCheck2.Gen.(triple gen_token_count gen_token_count (int_range 0 1_000_000))
+    (fun (a, b, rate) ->
+      let lo, hi = if a <= b then (a, b) else (b, a) in
+      let r = Int64.of_int rate in
+      Int64.(
+        Codex_cost.cost_nano_usd_for_tokens lo r
+        <= Codex_cost.cost_nano_usd_for_tokens hi r))
+
+let prop_cost_of_usage_equals_input_plus_output =
+  QCheck2.Test.make
+    ~name:
+      "cost_of_usage approximates input * r_in + output * r_out (within 1 \
+       nano-USD truncation)"
+    QCheck2.Gen.(pair gen_codex_usage_json gen_pricing)
+    (fun (json, pricing) ->
+      (* Reasoning tokens are priced at the same rate as visible output, so
+         splitting [output_tokens] into [visible + reasoning] should yield
+         the same cost as charging [output_tokens] uniformly. The split
+         truncates twice (visible*r/1000 and reasoning*r/1000) where the
+         unified form truncates once, so the result can under-count by at
+         most 1 nano-USD per turn. *)
+      let usage = Codex_cost.usage_of_yojson json in
+      let actual = Codex_cost.cost_of_usage ~pricing usage in
+      let unified =
+        Int64.(
+          Codex_cost.cost_nano_usd_for_tokens usage.input_tokens
+            pricing.input_nano_usd_per_1k
+          + Codex_cost.cost_nano_usd_for_tokens usage.output_tokens
+              pricing.output_nano_usd_per_1k)
+      in
+      let drift = Int64.(unified - actual) in
+      Int64.(drift >= 0L && drift <= 1L))
+
+let prop_cost_of_usage_non_negative =
+  QCheck2.Test.make ~name:"cost_of_usage >= 0 for any decoded JSON"
+    QCheck2.Gen.(pair gen_arbitrary_yojson gen_pricing)
+    (fun (json, pricing) ->
+      let usage = Codex_cost.usage_of_yojson json in
+      Int64.(Codex_cost.cost_of_usage ~pricing usage >= 0L))
+
+(* ---------- Properties: usage decoding ---------- *)
+
+let prop_usage_of_yojson_total =
+  QCheck2.Test.make ~name:"usage_of_yojson is total — never raises" ~count:500
+    gen_arbitrary_yojson (fun json ->
+      try
+        let _ = Codex_cost.usage_of_yojson json in
+        true
+      with _ -> false)
+
+let prop_usage_of_yojson_non_negative_fields =
+  QCheck2.Test.make
+    ~name:"usage_of_yojson fields are non-negative for any input" ~count:500
+    gen_arbitrary_yojson (fun json ->
+      let u = Codex_cost.usage_of_yojson json in
+      u.input_tokens >= 0 && u.output_tokens >= 0 && u.reasoning_tokens >= 0)
+
+let prop_usage_codex_schema_decodes_alt_flat =
+  QCheck2.Test.make
+    ~name:
+      "Codex CLI schema: reasoning_output_tokens decodes as reasoning_tokens"
+    gen_codex_usage_json (fun json ->
+      let u = Codex_cost.usage_of_yojson json in
+      let open Yojson.Safe.Util in
+      let expected =
+        member "reasoning_output_tokens" json
+        |> to_int_option |> Option.value ~default:0
+      in
+      Int.equal u.reasoning_tokens expected)
+
+let prop_usage_responses_api_schema_decodes_nested =
+  QCheck2.Test.make
+    ~name:
+      "Responses API schema: nested output_tokens_details.reasoning_tokens \
+       decodes (defensive fallback)" gen_responses_api_usage_json (fun json ->
+      let u = Codex_cost.usage_of_yojson json in
+      let open Yojson.Safe.Util in
+      let expected =
+        member "output_tokens_details" json
+        |> member "reasoning_tokens" |> to_int_option |> Option.value ~default:0
+      in
+      Int.equal u.reasoning_tokens expected)
+
+let prop_usage_schema_priority_nested_wins_over_flat =
+  QCheck2.Test.make
+    ~name:"schema priority: nested.reasoning_tokens wins over flat siblings"
+    QCheck2.Gen.(triple (int_range 1 100) (int_range 1 100) (int_range 1 100))
+    (fun (nested, flat, alt_flat) ->
+      let json =
+        `Assoc
+          [
+            ("output_tokens", `Int 1000);
+            ( "output_tokens_details",
+              `Assoc [ ("reasoning_tokens", `Int nested) ] );
+            ("reasoning_tokens", `Int flat);
+            ("reasoning_output_tokens", `Int alt_flat);
+          ]
+      in
+      Int.equal (Codex_cost.usage_of_yojson json).reasoning_tokens nested)
+
+let prop_usage_schema_priority_flat_wins_over_alt =
+  QCheck2.Test.make
+    ~name:
+      "schema priority: flat reasoning_tokens wins over reasoning_output_tokens"
+    QCheck2.Gen.(pair (int_range 1 100) (int_range 1 100))
+    (fun (flat, alt_flat) ->
+      let json =
+        `Assoc
+          [
+            ("output_tokens", `Int 1000);
+            ("reasoning_tokens", `Int flat);
+            ("reasoning_output_tokens", `Int alt_flat);
+          ]
+      in
+      Int.equal (Codex_cost.usage_of_yojson json).reasoning_tokens flat)
+
+(* ---------- Properties: cap decision ---------- *)
+
+let prop_cap_none_always_within =
+  QCheck2.Test.make ~name:"check_cap None is always Within_cap"
+    QCheck2.Gen.(int_range 0 1_000_000_000)
+    (fun delta ->
+      let s =
+        Codex_cost.advance Codex_cost.initial_cost_state (Int64.of_int delta)
+      in
+      Codex_cost.equal_cap_decision
+        (Codex_cost.check_cap ~budget_cap_nano_usd:None s)
+        Codex_cost.Within_cap)
+
+let prop_cap_at_boundary_is_within =
+  QCheck2.Test.make
+    ~name:"check_cap at boundary (cumulative = cap) is Within_cap"
+    QCheck2.Gen.(int_range 1 1_000_000_000)
+    (fun cap ->
+      let s =
+        Codex_cost.advance Codex_cost.initial_cost_state (Int64.of_int cap)
+      in
+      Codex_cost.equal_cap_decision
+        (Codex_cost.check_cap ~budget_cap_nano_usd:(Some (Int64.of_int cap)) s)
+        Codex_cost.Within_cap)
+
+let prop_cap_above_boundary_is_exceeded =
+  QCheck2.Test.make ~name:"check_cap above boundary is Exceeded"
+    QCheck2.Gen.(pair (int_range 1 1_000_000) (int_range 1 1_000_000))
+    (fun (cap, over) ->
+      let s =
+        Codex_cost.advance Codex_cost.initial_cost_state
+          (Int64.of_int (cap + over))
+      in
+      match
+        Codex_cost.check_cap ~budget_cap_nano_usd:(Some (Int64.of_int cap)) s
+      with
+      | Exceeded { cumulative_nano_usd; cap_nano_usd } ->
+          Int64.equal cumulative_nano_usd (Int64.of_int (cap + over))
+          && Int64.equal cap_nano_usd (Int64.of_int cap)
+      | Within_cap -> false)
+
+(* ---------- Properties: advance ---------- *)
+
+let prop_advance_monotone =
+  QCheck2.Test.make ~name:"advance is monotone non-decreasing for any delta"
+    QCheck2.Gen.(pair (int_range 0 1_000_000) (int_range (-100_000) 100_000))
+    (fun (start, delta) ->
+      let s =
+        Codex_cost.advance Codex_cost.initial_cost_state (Int64.of_int start)
+      in
+      let s' = Codex_cost.advance s (Int64.of_int delta) in
+      Int64.(s'.cumulative_nano_usd >= s.cumulative_nano_usd))
+
+let prop_advance_negative_clamps =
+  QCheck2.Test.make ~name:"advance negative delta is a no-op"
+    QCheck2.Gen.(pair (int_range 0 1_000_000) gen_negative_int)
+    (fun (start, delta) ->
+      let s =
+        Codex_cost.advance Codex_cost.initial_cost_state (Int64.of_int start)
+      in
+      let s' = Codex_cost.advance s (Int64.of_int delta) in
+      Int64.equal s'.cumulative_nano_usd s.cumulative_nano_usd)
+
+(* ---------- Properties: on_turn_completed (single step) ---------- *)
+
+let prop_on_turn_emits_exactly_one_final_result =
+  QCheck2.Test.make
+    ~name:"on_turn_completed always emits exactly one Final_result"
+    QCheck2.Gen.(triple gen_codex_usage_json gen_model_name gen_cap_nano_usd)
+    (fun (usage_json, model, cap) ->
+      let json = `Assoc [ ("usage", usage_json) ] in
+      let { Codex_cost.events; _ } =
+        Codex_cost.on_turn_completed ~model ~budget_cap_nano_usd:cap
+          ~state:Codex_cost.initial_cost_state json
+      in
+      Int.equal (List.count events ~f:is_final_result) 1)
+
+let prop_on_turn_state_monotone =
+  QCheck2.Test.make
+    ~name:"on_turn_completed produces monotone non-decreasing state"
+    QCheck2.Gen.(triple gen_codex_usage_json gen_model_name gen_cap_nano_usd)
+    (fun (usage_json, model, cap) ->
+      let json = `Assoc [ ("usage", usage_json) ] in
+      let prior = Codex_cost.advance Codex_cost.initial_cost_state 1_000L in
+      let { Codex_cost.state; _ } =
+        Codex_cost.on_turn_completed ~model ~budget_cap_nano_usd:cap
+          ~state:prior json
+      in
+      Int64.(state.cumulative_nano_usd >= prior.cumulative_nano_usd))
+
+let prop_on_turn_unknown_model_no_cost_change =
+  QCheck2.Test.make
+    ~name:"on_turn_completed with unknown model leaves state unchanged"
+    QCheck2.Gen.(pair gen_codex_usage_json gen_cap_nano_usd)
+    (fun (usage_json, cap) ->
+      let json = `Assoc [ ("usage", usage_json) ] in
+      let prior = Codex_cost.advance Codex_cost.initial_cost_state 42L in
+      let { Codex_cost.state; _ } =
+        Codex_cost.on_turn_completed ~model:None ~budget_cap_nano_usd:cap
+          ~state:prior json
+      in
+      Int64.equal state.cumulative_nano_usd prior.cumulative_nano_usd)
+
+let prop_on_turn_error_iff_exceeded =
+  QCheck2.Test.make
+    ~name:
+      "on_turn_completed emits Error iff post-state cap-decision is Exceeded"
+    QCheck2.Gen.(triple gen_codex_usage_json gen_model_name gen_cap_nano_usd)
+    (fun (usage_json, model, cap) ->
+      let json = `Assoc [ ("usage", usage_json) ] in
+      let { Codex_cost.events; state } =
+        Codex_cost.on_turn_completed ~model ~budget_cap_nano_usd:cap
+          ~state:Codex_cost.initial_cost_state json
+      in
+      let has_error = List.exists events ~f:is_error in
+      let exceeded =
+        match Codex_cost.check_cap ~budget_cap_nano_usd:cap state with
+        | Codex_cost.Exceeded _ -> true
+        | Within_cap -> false
+      in
+      Bool.equal has_error exceeded)
+
+let prop_on_turn_error_precedes_final_result =
+  QCheck2.Test.make
+    ~name:"on_turn_completed: when Error is emitted it precedes Final_result"
+    QCheck2.Gen.(triple gen_codex_usage_json gen_model_name gen_cap_nano_usd)
+    (fun (usage_json, model, cap) ->
+      let json = `Assoc [ ("usage", usage_json) ] in
+      let { Codex_cost.events; _ } =
+        Codex_cost.on_turn_completed ~model ~budget_cap_nano_usd:cap
+          ~state:Codex_cost.initial_cost_state json
+      in
+      match events with
+      | [ ev ] -> is_final_result ev
+      | [ a; b ] -> is_error a && is_final_result b
+      | [] | _ :: _ :: _ :: _ -> false)
+
+(* ---------- Interleaving properties (sequences of turn.completed) ---------- *)
+
+let fold_turns ~model ~cap usages =
+  List.fold usages ~init:(Codex_cost.initial_cost_state, [])
+    ~f:(fun (state, all_events) usage_json ->
+      let json = `Assoc [ ("usage", usage_json) ] in
+      let { Codex_cost.events; state } =
+        Codex_cost.on_turn_completed ~model ~budget_cap_nano_usd:cap ~state json
+      in
+      (state, all_events @ events))
+
+let gen_usage_seq =
+  QCheck2.Gen.(list_size (int_range 0 30) gen_codex_usage_json)
+
+let prop_interleaving_cumulative_monotone =
+  QCheck2.Test.make ~count:200
+    ~name:"interleaving: cumulative state never decreases across a sequence"
+    QCheck2.Gen.(triple gen_usage_seq gen_model_name gen_cap_nano_usd)
+    (fun (usages, model, cap) ->
+      let _, ok =
+        List.fold usages ~init:(Codex_cost.initial_cost_state, true)
+          ~f:(fun (state, ok) usage_json ->
+            let json = `Assoc [ ("usage", usage_json) ] in
+            let { Codex_cost.state = state'; _ } =
+              Codex_cost.on_turn_completed ~model ~budget_cap_nano_usd:cap
+                ~state json
+            in
+            ( state',
+              ok
+              && Int64.(state'.cumulative_nano_usd >= state.cumulative_nano_usd)
+            ))
+      in
+      ok)
+
+let prop_interleaving_cumulative_equals_sum =
+  QCheck2.Test.make ~count:200
+    ~name:"interleaving: cumulative = Σ per-turn cost"
+    QCheck2.Gen.(pair gen_usage_seq gen_model_name)
+    (fun (usages, model) ->
+      let final_state, _ = fold_turns ~model ~cap:None usages in
+      let expected =
+        match Codex_cost.model_pricing model with
+        | None -> 0L
+        | Some pricing ->
+            List.fold usages ~init:0L ~f:(fun acc usage_json ->
+                let usage = Codex_cost.usage_of_yojson usage_json in
+                Int64.(acc + Codex_cost.cost_of_usage ~pricing usage))
+      in
+      Int64.equal final_state.cumulative_nano_usd expected)
+
+let prop_interleaving_final_result_count_equals_turn_count =
+  QCheck2.Test.make ~count:200
+    ~name:"interleaving: # Final_result events = # turns"
+    QCheck2.Gen.(triple gen_usage_seq gen_model_name gen_cap_nano_usd)
+    (fun (usages, model, cap) ->
+      let _, events = fold_turns ~model ~cap usages in
+      Int.equal (List.count events ~f:is_final_result) (List.length usages))
+
+(* Once cumulative crosses the cap, every subsequent turn should also emit
+   Error: the state stays Exceeded forever (cumulative is monotone, cap is
+   constant). *)
+let prop_interleaving_error_is_sticky =
+  QCheck2.Test.make ~count:200
+    ~name:
+      "interleaving: once cap is exceeded, every later turn also emits Error"
+    QCheck2.Gen.(pair gen_usage_seq gen_model_name)
+    (fun (usages, model) ->
+      (* Pick a cap small enough that some sequence will cross it but not so
+         small that the very first turn always crosses (interesting cases
+         have a transition mid-sequence). *)
+      let cap = Some 10_000L in
+      let _, events_per_turn =
+        List.fold usages ~init:(Codex_cost.initial_cost_state, [])
+          ~f:(fun (state, acc) usage_json ->
+            let json = `Assoc [ ("usage", usage_json) ] in
+            let { Codex_cost.events; state } =
+              Codex_cost.on_turn_completed ~model ~budget_cap_nano_usd:cap
+                ~state json
+            in
+            (state, acc @ [ events ]))
+      in
+      let has_error events = List.exists events ~f:is_error in
+      let rec stickiness_ok seen_error = function
+        | [] -> true
+        | turn :: rest ->
+            let now_error = has_error turn in
+            if seen_error && not now_error then false
+            else stickiness_ok (seen_error || now_error) rest
+      in
+      stickiness_ok false events_per_turn)
+
+let prop_interleaving_state_independent_of_order =
+  QCheck2.Test.make ~count:200
+    ~name:
+      "interleaving: cumulative state is invariant under permutation (cost is \
+       commutative)"
+    QCheck2.Gen.(pair gen_usage_seq gen_model_name)
+    (fun (usages, model) ->
+      let s1, _ = fold_turns ~model ~cap:None usages in
+      let s2, _ = fold_turns ~model ~cap:None (List.rev usages) in
+      Int64.equal s1.cumulative_nano_usd s2.cumulative_nano_usd)
+
+(* ---------- Runner ---------- *)
+
+let () =
+  let suite =
+    [
+      prop_cost_zero_tokens;
+      prop_cost_negative_tokens_clamps;
+      prop_cost_monotone_in_tokens;
+      prop_cost_of_usage_equals_input_plus_output;
+      prop_cost_of_usage_non_negative;
+      prop_usage_of_yojson_total;
+      prop_usage_of_yojson_non_negative_fields;
+      prop_usage_codex_schema_decodes_alt_flat;
+      prop_usage_responses_api_schema_decodes_nested;
+      prop_usage_schema_priority_nested_wins_over_flat;
+      prop_usage_schema_priority_flat_wins_over_alt;
+      prop_cap_none_always_within;
+      prop_cap_at_boundary_is_within;
+      prop_cap_above_boundary_is_exceeded;
+      prop_advance_monotone;
+      prop_advance_negative_clamps;
+      prop_on_turn_emits_exactly_one_final_result;
+      prop_on_turn_state_monotone;
+      prop_on_turn_unknown_model_no_cost_change;
+      prop_on_turn_error_iff_exceeded;
+      prop_on_turn_error_precedes_final_result;
+      prop_interleaving_cumulative_monotone;
+      prop_interleaving_cumulative_equals_sum;
+      prop_interleaving_final_result_count_equals_turn_count;
+      prop_interleaving_error_is_sticky;
+      prop_interleaving_state_independent_of_order;
+    ]
+  in
+  let errcode = QCheck_base_runner.run_tests ~verbose:true suite in
+  if errcode <> 0 then Stdlib.exit errcode


### PR DESCRIPTION
## Summary

Fixes a regression introduced today by PR #238 (commit 449f956), which started overriding `CLAUDE_CONFIG_DIR` / `CODEX_HOME` / `OPENCODE_CONFIG_DIR` to per-patch dirs but left those dirs empty. Codex spawned by onton fails to load `auth.json`, sends no bearer to OpenAI, and exits 117 on `401 Unauthorized — Missing bearer or basic authentication in header`. Patch 242 was the first observed casualty (event log `Session_failed {is_fresh = true}`); Claude and OpenCode were latently broken too — they just hadn't been spawned since the merge.

The fix symlinks the user's real auth file into each per-patch dir at creation. Symlinks (not copies) so in-place token rotations the CLI performs (e.g. Codex's ChatGPT-mode JWT refresh) propagate back to `~/.codex/auth.json`, keeping the user's plain CLI session alive across onton runs. The seed is idempotent and skips backends the user hasn't logged into.

Files seeded:
- `~/.codex/auth.json` → `<spawn-envs>/<patch>/codex/auth.json`
- `~/.claude/.credentials.json` → `<spawn-envs>/<patch>/claude/.credentials.json`
- `~/.config/opencode/opencode.json` → `<spawn-envs>/<patch>/opencode/opencode.json`

`.mcp.json` and other behavioral config are intentionally **not** seeded — that's behavioral drift, a separate concern from the auth-blocking regression. Captured in audit notes for follow-up.

Drive-by: `remove_tree` now uses `Unix.lstat` so it correctly handles symlinks (including dangling ones) instead of falling through `Sys.file_exists` and failing `rmdir` with `ENOTEMPTY`. Surfaced by the new tests but a real bug in the test cleanup helper.

## Test plan

- [x] `dune build` clean, `dune runtest` green
- [x] Four new `let%test` cases in `spawn_env.ml`: symlink-created, idempotent, missing-src is OK, existing-dst preserved (CLI atomic-replace case)
- [ ] Live verification: rebuild onton, retrigger merge-conflict op for PR #242, confirm `<spawn-envs>/242/codex/auth.json` is a symlink and Codex no longer 401s
- [ ] Cross-backend: spawn a Claude-backed and an OpenCode-backed patch on a fresh `<spawn-envs>/<id>/`, confirm each finds credentials
- [ ] Token-refresh round-trip: let Codex rotate `auth.json` through onton, then run plain `codex` from a normal shell and confirm no re-login required

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/244"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes per-patch envs by symlinking the user’s auth files into each patch, restoring auth for `codex`/`claude`/`opencode` and preventing 401s. Also extracts Codex cost tracking into a pure `Codex_cost` module with total JSON decoding and cap enforcement to avoid crashes on malformed `turn.completed` payloads.

- **Bug Fixes**
  - Seed per-patch dirs with symlinks to user auth found via `CLAUDE_CONFIG_DIR`/`CODEX_HOME`/`OPENCODE_CONFIG_DIR` (fallback to `HOME`); narrow the probe to those locations, absolutize relative env/HOME paths, ignore invalid or missing sources, add `unsetenv` binding; use symlinks so rotations propagate and never overwrite existing files.
  - Cleanup uses `Unix.lstat` to handle symlinks (including dangling) and avoid `ENOTEMPTY`; cost tracking now tolerates missing or nested usage fields and works when `output_tokens_details` is absent.

- **Refactors**
  - New `Codex_cost` module (state, usage decoding, pricing, cap); `codex_backend` re-exports `cost_state` and delegates `turn.completed` decisions; adds property/interleaving tests for pricing math, schema priority, caps, and cumulative behavior.

<sup>Written for commit facefb2b373e2478f989dbd5080f3186129528a6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-patch environments now seed backend credential files by creating symlinks from the user's config (resolving env vars or HOME paths).

* **Bug Fixes**
  * Safer, idempotent symlink creation and more robust cleanup of files/directories (handles symlinks and missing paths).

* **Tests**
  * Added unit tests covering seeding, idempotency, missing-source skipping and path-resolution behavior.

* **Documentation**
  * Expanded per-patch env docs to describe credential seeding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->