### PR TITLE
worktree: detect deleted worktree + reconstruct cleanly

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -2307,6 +2307,12 @@ let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name ~pr_registry
                             | Worktree.Push_rejected ->
                                 log_event runtime ~patch_id
                                   "Force-push rejected — lease violated"
+                            | Worktree.Push_worktree_missing ->
+                                log_event runtime ~patch_id
+                                  (Printf.sprintf
+                                     "Worktree disappeared (%s) — rebase will \
+                                      reconstruct on retry"
+                                     wt_path)
                             | Worktree.Push_error msg ->
                                 log_event runtime ~patch_id
                                   (Printf.sprintf "Force-push failed — %s" msg));
@@ -2714,6 +2720,14 @@ let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name ~pr_registry
                                                 log_event runtime ~patch_id
                                                   "Conflict force-push \
                                                    rejected — lease violated"
+                                            | Worktree.Push_worktree_missing ->
+                                                log_event runtime ~patch_id
+                                                  (Printf.sprintf
+                                                     "Worktree disappeared \
+                                                      (%s) — conflict \
+                                                      resolution will \
+                                                      reconstruct on retry"
+                                                     wt_path)
                                             | Worktree.Push_error msg ->
                                                 log_event runtime ~patch_id
                                                   (Printf.sprintf

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -493,9 +493,14 @@ let apply_rebase_push_result t patch_id
       let t = set_has_conflict t patch_id in
       let t = enqueue t patch_id Operation_kind.Merge_conflict in
       (t, Rebase_push_failed)
-  | Some Worktree.Push_no_commits | Some (Worktree.Push_error _) ->
+  | Some Worktree.Push_no_commits
+  | Some (Worktree.Push_error _)
+  | Some Worktree.Push_worktree_missing ->
       (* Push_no_commits after rebase means every commit squashed away — treat
-         as an infrastructure error and retry the rebase. *)
+         as an infrastructure error and retry the rebase. Push_worktree_missing
+         lands here because the next Rebase invocation re-runs through
+         [ensure_worktree], which reconstructs the missing worktree before
+         retrying. *)
       let t = enqueue t patch_id Operation_kind.Rebase in
       (t, Rebase_push_error)
 
@@ -557,7 +562,7 @@ let apply_conflict_push_result t patch_id decision
       ( None
       | Some
           ( Worktree.Push_rejected | Worktree.Push_no_commits
-          | Worktree.Push_error _ ) ) ) ->
+          | Worktree.Push_error _ | Worktree.Push_worktree_missing ) ) ) ->
       let t = set_has_conflict t patch_id in
       let t = enqueue t patch_id Operation_kind.Merge_conflict in
       (t, Conflict_retry_push)
@@ -566,7 +571,7 @@ let apply_conflict_push_result t patch_id decision
       | Some
           ( Worktree.Push_ok | Worktree.Push_up_to_date
           | Worktree.Push_no_commits | Worktree.Push_rejected
-          | Worktree.Push_error _ ) ) ) ->
+          | Worktree.Push_error _ | Worktree.Push_worktree_missing ) ) ) ->
       (t, Conflict_needs_agent)
   | Conflict_failed, _ -> (t, Conflict_give_up)
 
@@ -693,16 +698,30 @@ let apply_session_result t patch_id result =
 
 let combine_session_and_push ~(session : session_result)
     ~(push : Worktree.push_result) : session_result =
-  match session with
-  | Session_ok -> (
-      match push with
-      | Worktree.Push_ok | Worktree.Push_up_to_date -> Session_ok
-      | Worktree.Push_no_commits -> Session_no_commits
-      | Worktree.Push_rejected | Worktree.Push_error _ -> Session_push_failed)
-  | Session_process_error _ | Session_no_resume | Session_failed _
-  | Session_give_up | Session_worktree_missing | Session_push_failed
-  | Session_no_commits ->
-      session
+  (* Push_worktree_missing dominates every prior session outcome: even if the
+     LLM session reported [Session_ok], the worktree (and thus the local
+     commits) are gone, so the only safe action is to clear inflight state
+     and let the next session rebuild the worktree from scratch via
+     [ensure_worktree]. The [Session_push_failed] retry-push path would loop
+     forever because the deleted directory cannot be repaired by retrying. *)
+  match push with
+  | Worktree.Push_worktree_missing -> Session_worktree_missing
+  | Worktree.Push_ok | Worktree.Push_up_to_date | Worktree.Push_no_commits
+  | Worktree.Push_rejected | Worktree.Push_error _ -> (
+      match session with
+      | Session_ok -> (
+          match push with
+          | Worktree.Push_ok | Worktree.Push_up_to_date -> Session_ok
+          | Worktree.Push_no_commits -> Session_no_commits
+          | Worktree.Push_rejected | Worktree.Push_error _ ->
+              Session_push_failed
+          | Worktree.Push_worktree_missing ->
+              Session_worktree_missing
+              (* unreachable — outer match catches this *))
+      | Session_process_error _ | Session_no_resume | Session_failed _
+      | Session_give_up | Session_worktree_missing | Session_push_failed
+      | Session_no_commits ->
+          session)
 
 type start_outcome = Start_ok | Start_failed | Start_stale
 [@@deriving show, eq, sexp_of]

--- a/lib/session_driver.ml
+++ b/lib/session_driver.ml
@@ -487,6 +487,12 @@ let run ~(kind : Types.Operation_kind.t option) ~runtime ~process_mgr ~clock ~fs
           | Worktree.Push_rejected ->
               log_event runtime ~patch_id
                 "runner: push rejected after session (lease)"
+          | Worktree.Push_worktree_missing ->
+              log_event runtime ~patch_id
+                (Printf.sprintf
+                   "runner: worktree disappeared mid-session (%s) — local \
+                    commits are lost; will reconstruct on next attempt"
+                   worktree_path)
           | Worktree.Push_error msg ->
               log_event runtime ~patch_id
                 (Printf.sprintf "runner: push error after session: %s" msg));

--- a/lib/worktree.ml
+++ b/lib/worktree.ml
@@ -651,6 +651,14 @@ type push_result =
   | Push_up_to_date
   | Push_no_commits
   | Push_rejected
+  | Push_worktree_missing
+      (** The worktree directory was deleted out from under us between session
+          start and push. Distinguished from [Push_error] so the caller can
+          route to the [Session_worktree_missing] cleanup path (which clears
+          inflight state for a clean retry that will rebuild the worktree via
+          [Worktree_setup.ensure_worktree]) rather than the
+          [Session_push_failed] retry-push path (which assumes the worktree is
+          intact and the commits exist locally). *)
   | Push_error of string
 [@@deriving show, eq, sexp_of, compare]
 
@@ -714,25 +722,33 @@ let commits_ahead_of_base ~process_mgr ~path ~base =
   parse_commit_count ~code ~stdout
 
 let force_push_with_lease ~process_mgr ~path ~branch ~base =
-  let count = commits_ahead_of_base ~process_mgr ~path ~base in
-  match push_gate_from_count count with
-  | Skip_no_commits -> Push_no_commits
-  | Proceed ->
-      let branch_str = Types.Branch.to_string branch in
-      let code, stdout, stderr =
-        run_git_exit_code ~process_mgr
-          [
-            "git";
-            "-C";
-            path;
-            "push";
-            "--porcelain";
-            "--force-with-lease";
-            "origin";
-            branch_str;
-          ]
-      in
-      classify_push_result ~code ~stdout ~stderr
+  (* If the worktree directory is gone (deleted out from under us mid-session),
+     short-circuit before spawning git so the caller can route to the
+     worktree-missing cleanup path. Without this, every git invocation below
+     fails with "fatal: cannot change to '<path>': No such file or directory"
+     and surfaces as a generic [Push_error] that triggers retry-push instead
+     of reconstruction. *)
+  if not (Stdlib.Sys.file_exists path) then Push_worktree_missing
+  else
+    let count = commits_ahead_of_base ~process_mgr ~path ~base in
+    match push_gate_from_count count with
+    | Skip_no_commits -> Push_no_commits
+    | Proceed ->
+        let branch_str = Types.Branch.to_string branch in
+        let code, stdout, stderr =
+          run_git_exit_code ~process_mgr
+            [
+              "git";
+              "-C";
+              path;
+              "push";
+              "--porcelain";
+              "--force-with-lease";
+              "origin";
+              branch_str;
+            ]
+        in
+        classify_push_result ~code ~stdout ~stderr
 
 let rebase_in_progress ~process_mgr ~path =
   let code, stdout, _ =
@@ -842,6 +858,18 @@ let find_for_branch ~process_mgr ~repo_root branch =
   let pairs = try list_with_branches ~process_mgr ~repo_root with _ -> [] in
   List.find_map pairs ~f:(fun (path, b) ->
       if Types.Branch.equal b branch then Some path else None)
+
+(** Drop git's worktree-registry entries for directories that no longer exist on
+    disk. Useful before [find_for_branch] / [create] when a previous worktree
+    directory was deleted out-of-band ([rm -rf] or a leftover failed checkout):
+    without this, [git worktree list] still reports the stale entry and
+    [git worktree add] refuses to recreate the same path. *)
+let prune_admin ~process_mgr ~repo_root =
+  let _ =
+    run_git_exit_code ~process_mgr
+      [ "git"; "-C"; repo_root; "worktree"; "prune" ]
+  in
+  ()
 
 let exists t = Stdlib.Sys.file_exists t.path
 let path t = t.path

--- a/lib/worktree.mli
+++ b/lib/worktree.mli
@@ -216,6 +216,13 @@ type push_result =
   | Push_up_to_date
   | Push_no_commits
   | Push_rejected
+  | Push_worktree_missing
+      (** Returned when the worktree directory was deleted between session start
+          and push — typically a manual [rm -rf] or a leftover failed checkout.
+          The caller should route this to a clean state-reset (e.g.
+          [Session_worktree_missing]) rather than retry-push, since the local
+          commits the LLM produced are gone with the directory and retry-push
+          would just keep failing the same way. *)
   | Push_error of string
 [@@deriving show, eq, sexp_of, compare]
 
@@ -260,7 +267,16 @@ val find_for_branch :
   Types.Branch.t ->
   string option
 (** Search existing git worktrees for one checked out at [branch]. Returns
-    [None] if no matching worktree is found or if listing fails. *)
+    [None] if no matching worktree is found or if listing fails. The result
+    reflects what [git worktree list] reports, which can include stale entries
+    whose directories were deleted on disk; callers that need disk truth should
+    additionally check [Sys.file_exists] or call {!prune_admin} first. *)
+
+val prune_admin : process_mgr:_ Eio.Process.mgr -> repo_root:string -> unit
+(** Run [git worktree prune] in [repo_root] to drop registry entries whose
+    directories were deleted on disk. Idempotent; silent on failure. Callers use
+    this to bring git's worktree bookkeeping in sync with disk state before
+    {!find_for_branch} or {!create}. *)
 
 val normalize_path : string -> string
 (** Resolve a relative path to absolute using the current working directory. *)

--- a/lib/worktree_setup.ml
+++ b/lib/worktree_setup.ml
@@ -38,7 +38,29 @@ let ensure_worktree ~runtime ~process_mgr ~clock ~fs ~repo_root ~project_name
     let br =
       match branch with Some b -> b | None -> agent.Patch_agent.branch
     in
-    match Worktree.find_for_branch ~process_mgr ~repo_root br with
+    (* The previous worktree directory is gone — prune git's registry first so
+       a stale entry (deleted dir but still listed by [git worktree list])
+       does not steer [find_for_branch] back to the same dead path and
+       prevent [Worktree.create] from re-registering it. *)
+    Worktree.prune_admin ~process_mgr ~repo_root;
+    let found = Worktree.find_for_branch ~process_mgr ~repo_root br in
+    (* Treat a hit whose directory is gone as a miss — defends against races
+       (another process re-registering between our prune and our list) or
+       git versions that leave half-pruned state. We log the discard so the
+       user can see why we are recreating despite git's bookkeeping. *)
+    let live_existing =
+      match found with
+      | Some p when Stdlib.Sys.file_exists p -> Some p
+      | Some stale ->
+          log_event runtime ~patch_id
+            (Printf.sprintf
+               "Ignoring stale worktree registration (git lists %s but \
+                directory is gone) — will recreate"
+               stale);
+          None
+      | None -> None
+    in
+    match live_existing with
     | Some existing ->
         log_event runtime ~patch_id
           (Printf.sprintf "Found existing worktree for branch at %s" existing);

--- a/test/dune
+++ b/test/dune
@@ -97,6 +97,13 @@
  (ocamlc_flags (:standard -w -40-42)))
 
 (test
+ (name test_worktree_missing_recovery)
+ (modules test_worktree_missing_recovery)
+ (libraries onton eio eio_main eio.unix unix)
+ (ocamlopt_flags (:standard -w -40-42))
+ (ocamlc_flags (:standard -w -40-42)))
+
+(test
  (name test_backend_routing)
  (modules test_backend_routing)
  (libraries onton qcheck-core qcheck-core.runner)

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -1021,9 +1021,15 @@ let () =
         Gen.map (fun s -> Worktree.Push_error s) Gen.string_small;
       ]
   in
+  let gen_any_session : Orchestrator.session_result Gen.t =
+    Gen.oneof [ Gen.return Orchestrator.Session_ok; gen_non_ok_session ]
+  in
   let prop_cp5_failure_dominates =
-    Test.make ~name:"CP-5: pre-existing failure dominates any push outcome"
-      ~count:300 (Gen.pair gen_non_ok_session gen_push) (fun (session, push) ->
+    Test.make
+      ~name:
+        "CP-5: pre-existing failure dominates any push outcome \
+         (Push_worktree_missing excluded — handled by CP-7)" ~count:300
+      (Gen.pair gen_non_ok_session gen_push) (fun (session, push) ->
         Orchestrator.equal_session_result
           (Orchestrator.combine_session_and_push ~session ~push)
           session)
@@ -1035,6 +1041,23 @@ let () =
           (Orchestrator.combine_session_and_push ~session:Session_ok
              ~push:Worktree.Push_no_commits)
           Session_no_commits)
+  in
+  (* Push_worktree_missing means the worktree directory was deleted between
+     session start and push; the local commits are gone. Whatever the session
+     reported, the only correct next step is to clear inflight state and let
+     the next session rebuild the worktree via [ensure_worktree] — that
+     mapping is [Session_worktree_missing], which goes through the
+     pre-session-failure path rather than the retry-push path that assumes
+     the directory still exists. *)
+  let prop_cp7_worktree_missing_dominates =
+    Test.make ~count:300
+      ~name:
+        "CP-7: any session + Push_worktree_missing = Session_worktree_missing"
+      gen_any_session (fun session ->
+        Orchestrator.equal_session_result
+          (Orchestrator.combine_session_and_push ~session
+             ~push:Worktree.Push_worktree_missing)
+          Session_worktree_missing)
   in
   (* Session_no_commits property tests (PNC-N) mirror PSF-N: clear fallback,
      increment counter, reset on Session_ok, trigger needs_intervention at
@@ -1261,7 +1284,7 @@ let () =
         match Worktree.classify_push_result ~code ~stdout:"" ~stderr with
         | Worktree.Push_error _ -> true
         | Worktree.Push_ok | Worktree.Push_up_to_date | Worktree.Push_no_commits
-        | Worktree.Push_rejected ->
+        | Worktree.Push_rejected | Worktree.Push_worktree_missing ->
             false)
   in
   let prop_classify_never_returns_no_commits =
@@ -1273,7 +1296,7 @@ let () =
       (Gen.triple (Gen.int_range 0 255) Gen.string_small Gen.string_small)
       (fun (code, stdout, stderr) ->
         match Worktree.classify_push_result ~code ~stdout ~stderr with
-        | Worktree.Push_no_commits -> false
+        | Worktree.Push_no_commits | Worktree.Push_worktree_missing -> false
         | Worktree.Push_ok | Worktree.Push_up_to_date | Worktree.Push_rejected
         | Worktree.Push_error _ ->
             true)
@@ -1290,6 +1313,7 @@ let () =
       prop_cp4_ok_error;
       prop_cp5_failure_dominates;
       prop_cp6_ok_no_commits;
+      prop_cp7_worktree_missing_dominates;
       prop_pnc1_clears_session_fallback;
       prop_pnc2_increments_counter;
       prop_pnc3_intervention_threshold;

--- a/test/test_worktree_missing_recovery.ml
+++ b/test/test_worktree_missing_recovery.ml
@@ -1,0 +1,125 @@
+open Base
+open Onton
+
+(** End-to-end recovery pipeline for "worktree deleted between session start and
+    post-session push". Drives:
+
+    1. {!Worktree.force_push_with_lease} against a path that does not exist —
+    must return [Push_worktree_missing] without spawning git. 2.
+    {!Orchestrator.combine_session_and_push} with [Session_ok] folded against
+    [Push_worktree_missing] — must collapse to [Session_worktree_missing] (not
+    the misleading [Session_push_failed]). 3.
+    {!Orchestrator.apply_session_result} given the combined outcome — must take
+    the pre-session-failure cleanup branch so the next scheduling tick can
+    rebuild the worktree from scratch via [Worktree_setup.ensure_worktree]. *)
+
+let assert_eq label want got =
+  if not (String.equal want got) then
+    failwith (Printf.sprintf "%s: expected %S got %S" label want got)
+
+let assert_true label cond =
+  if not cond then failwith (Printf.sprintf "%s: assertion failed" label)
+
+let nonexistent_path () =
+  Stdlib.Filename.concat
+    (Stdlib.Filename.get_temp_dir_name ())
+    (Printf.sprintf "onton-worktree-missing-%d-%d" (Unix.getpid ())
+       (Random.bits ()))
+
+let () =
+  Eio_main.run @@ fun env ->
+  let process_mgr = Eio.Stdenv.process_mgr env in
+
+  (* (1) Precheck path: missing directory -> Push_worktree_missing without
+     spawning git. We use a path that has never existed, so any subsequent
+     git invocation would fail with exit 128. *)
+  let path = nonexistent_path () in
+  assert_true "precondition: path does not exist"
+    (not (Stdlib.Sys.file_exists path));
+  let push_outcome =
+    Worktree.force_push_with_lease ~process_mgr ~path
+      ~branch:(Types.Branch.of_string "feat")
+      ~base:(Types.Branch.of_string "main")
+  in
+  if
+    not (Worktree.equal_push_result push_outcome Worktree.Push_worktree_missing)
+  then
+    failwith
+      (Printf.sprintf
+         "force_push_with_lease on nonexistent path returned %s, expected \
+          Push_worktree_missing"
+         (Worktree.show_push_result push_outcome));
+  Stdlib.print_endline
+    "test1: force_push_with_lease on missing path -> Push_worktree_missing";
+
+  (* (2) Combine: Session_ok + Push_worktree_missing -> Session_worktree_missing.
+     Even though the LLM session itself ran cleanly, the local commits are
+     gone with the directory, so the combined outcome must route through
+     the pre-session-failure path. *)
+  let combined =
+    Orchestrator.combine_session_and_push ~session:Orchestrator.Session_ok
+      ~push:Worktree.Push_worktree_missing
+  in
+  if
+    not
+      (Orchestrator.equal_session_result combined
+         Orchestrator.Session_worktree_missing)
+  then
+    failwith
+      (Printf.sprintf "combine returned %s, expected Session_worktree_missing"
+         (Orchestrator.show_session_result combined));
+  Stdlib.print_endline
+    "test2: combine Session_ok + Push_worktree_missing -> \
+     Session_worktree_missing";
+
+  (* (3) apply_session_result Session_worktree_missing -> agent.busy=false +
+     start_attempts_without_pr incremented (the [on_pre_session_failure]
+     bookkeeping that backs needs_intervention). The next scheduling tick
+     will see the agent idle and re-enqueue work; the next session will
+     reconstruct the worktree via [ensure_worktree]. *)
+  let main = Types.Branch.of_string "main" in
+  let pid = Types.Patch_id.of_string "wm-pid" in
+  let patches =
+    [
+      Types.Patch.
+        {
+          id = pid;
+          title = "P";
+          description = "";
+          branch = Types.Branch.of_string "wm";
+          dependencies = [];
+          spec = "";
+          acceptance_criteria = [];
+          files = [];
+          classification = "";
+          changes = [];
+          test_stubs_introduced = [];
+          test_stubs_implemented = [];
+          complexity = None;
+        };
+    ]
+  in
+  let orch = Orchestrator.create ~patches ~main_branch:main in
+  (* Drive the agent to busy without a PR (start path). *)
+  let orch = Orchestrator.fire orch (Orchestrator.Start (pid, main)) in
+  let agent_before = Orchestrator.agent orch pid in
+  assert_true "agent_before busy" agent_before.Patch_agent.busy;
+  let attempts_before = agent_before.Patch_agent.start_attempts_without_pr in
+  let orch =
+    Orchestrator.apply_session_result orch pid
+      Orchestrator.Session_worktree_missing
+  in
+  let agent_after = Orchestrator.agent orch pid in
+  assert_true "agent_after not busy" (not agent_after.Patch_agent.busy);
+  let attempts_after = agent_after.Patch_agent.start_attempts_without_pr in
+  if not (Int.equal attempts_after (attempts_before + 1)) then
+    failwith
+      (Printf.sprintf
+         "start_attempts_without_pr should increment by 1: before=%d after=%d"
+         attempts_before attempts_after);
+  Stdlib.print_endline
+    "test3: apply_session_result Session_worktree_missing -> agent idle, \
+     start_attempts incremented (next tick will rebuild)";
+
+  assert_eq "all tests passed marker" "ok" "ok";
+  Stdlib.print_endline "All worktree-missing recovery tests passed."


### PR DESCRIPTION
## Summary

Fixes the loop reported during the chat-semantic-search session:

```
2: Process error from Codex — Eio.Io Fs Not_found (No such file or directory, "openat", "/Users/zax/worktrees/chat-semantic-search/patch-2")
2: Found existing worktree for branch at /Users/zax/worktrees/chat-semantic-search/patch-2
2: Found existing worktree for branch at /Users/zax/worktrees/chat-semantic-search/patch-2
2: runner: push error after session: push failed (exit 128): fatal: cannot change to '...': No such file or directory
```

When a worktree directory is deleted between session start and post-session push (manual rm -rf, leftover failed checkout), recovery looped because:
1. Push failed with a generic "push error" instead of a directory-missing signal.
2. \`git worktree list\` still reported the dead path, so \`ensure_worktree\` kept "finding" the stale registration.
3. The next session spawn then failed with \`Eio Not_found / openat\` instead of recreating.

## Fix

Three changes that compose into reconstruct-and-retry:

1. **\`Worktree.force_push_with_lease\`** — \`Sys.file_exists path\` precheck. Missing dir returns the new \`Push_worktree_missing\` variant instead of letting every \`git -C\` invocation fail with exit 128.
2. **\`Orchestrator.combine_session_and_push\`** — \`Push_worktree_missing\` dominates every prior session outcome and folds to \`Session_worktree_missing\`. The retry-push path (\`Session_push_failed\`) assumes the dir still exists and would loop; the worktree-missing path goes through \`on_pre_session_failure + complete_failed\`, clearing inflight state so the next scheduling tick rebuilds via \`ensure_worktree\`.
3. **\`Worktree_setup.ensure_worktree\`** — runs \`git worktree prune\` before \`find_for_branch\` when the on-disk path is gone, and defensively filters \`find_for_branch\`'s result by \`Sys.file_exists\` (logs and discards a stale hit). Either way, the create branch is reached and a fresh worktree is registered.

## Test plan

- [x] \`test/test_worktree_missing_recovery.ml\` — end-to-end: precheck → combine → apply_session_result, all the way to \`agent.busy = false\` + \`start_attempts_without_pr\` incremented (next tick rebuilds).
- [x] \`test/test_properties.ml\` CP-7 — property: any session combined with \`Push_worktree_missing\` folds to \`Session_worktree_missing\`.
- [x] Full \`dune runtest\` (existing rebase, conflict, classify_push, combine_session_and_push, smoke suite) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/245"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detect and recover when a git worktree directory is deleted mid-session. This prevents push/retry loops by clearing state and reconstructing the worktree automatically.

- **Bug Fixes**
  - `Worktree.force_push_with_lease`: prechecks `Sys.file_exists path`; returns `Push_worktree_missing` to avoid generic exit 128 failures.
  - `Orchestrator.combine_session_and_push`: treats `Push_worktree_missing` as `Session_worktree_missing`, skipping retry-push loops and triggering a clean rebuild.
  - `Worktree_setup.ensure_worktree`: runs `git worktree prune` and ignores stale entries whose directories are gone; recreates the worktree.
  - Adds `Worktree.prune_admin` helper; updates logs to note “worktree disappeared” cases.
  - Tests: adds `test_worktree_missing_recovery.ml` (end-to-end) and CP-7 property; updates property tests and `dune`.

- **Migration**
  - If you pattern-match on `Worktree.push_result`, handle the new `Push_worktree_missing` constructor. No other changes required.

<sup>Written for commit 5cd908dfeb0874d288208be0c361979bebb5756d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

