### PR TITLE
[codex] mitigate Codex OAuth refresh races

### DIFF
--- a/lib/codex_backend.ml
+++ b/lib/codex_backend.ml
@@ -15,6 +15,19 @@ let parse_event = Codex_event_parser.parse_event
 let build_args = Codex_event_parser.build_args
 let auto_model = Codex_event_parser.auto_model
 
+let is_likely_auth_refresh_failure (result : Llm_backend.result) =
+  let contains haystack needle =
+    String.is_substring haystack ~substring:needle
+  in
+  let haystack = String.lowercase (result.stderr ^ "\n" ^ result.stdout) in
+  (not result.timed_out) && result.exit_code <> 0 && (not result.got_events)
+  && (contains haystack "refresh token"
+     || contains haystack "oauth"
+     || contains haystack "unauthorized"
+     || contains haystack "authentication")
+  && (contains haystack "token" || contains haystack "auth"
+    || contains haystack "login")
+
 let budget_cap_nano_usd_from_env () =
   match
     Sys.getenv "ONTON_BUDGET_CAP_USD"
@@ -34,7 +47,8 @@ let run_streaming ~model ~process_mgr ~clock ~timeout ~setsid_exec ~project_name
   let args = build_args ~model ~cwd_path ~prompt ~resume_session in
   let env =
     Spawn_env.merge_env ~base_env:(Unix.environment ())
-      ~overrides:(Spawn_env.per_patch_env ~project_name ~patch_id)
+      ~overrides:
+        (Spawn_env.per_patch_env_without_codex_home ~project_name ~patch_id)
   in
   let budget_cap_nano_usd = budget_cap_nano_usd_from_env () in
   let cost_state = ref initial_cost_state in
@@ -49,8 +63,15 @@ let run_streaming ~model ~process_mgr ~clock ~timeout ~setsid_exec ~project_name
       cost_state := next_cost_state;
       events
   in
-  Llm_backend.spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~env
-    ~setsid_exec ~args ~process_line ~on_event
+  let run_once () =
+    Llm_backend.spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~env
+      ~setsid_exec ~args ~process_line ~on_event
+  in
+  let result = run_once () in
+  if is_likely_auth_refresh_failure result then (
+    Eio.Time.sleep clock 2.0;
+    run_once ())
+  else result
 
 let create ~model ~process_mgr ~clock ~timeout ~setsid_exec : Llm_backend.t =
   {

--- a/lib/spawn_env.ml
+++ b/lib/spawn_env.ml
@@ -41,10 +41,10 @@ let resolve_user_config_dir ~env_var ~home_subpath =
           Some (Stdlib.Filename.concat (absolutize home) home_subpath)
       | _ -> None)
 
-(* Seed the per-patch config dirs with symlinks to the user's real auth
-   files. Symlinks (not copies) so token rotations the backend writes
-   in-place propagate back to the user's real config dir, and so the user's
-   plain CLI continues to share a session with the per-patch CLI. *)
+(* Seed the per-patch config dirs with symlinks to the user's real auth files.
+   Symlinks (not copies) are better than stale snapshots, but they are still not
+   a refresh-token lock. Codex callers should generally inherit the user's real
+   CODEX_HOME instead of using the per-patch codex dir. *)
 let seed_auth_links_with ~claude_src_dir ~codex_src_dir ~opencode_src_dir
     ~claude_dir ~codex_dir ~opencode_dir =
   let seed src_dir dst_dir filename =
@@ -84,8 +84,17 @@ let per_patch_env_in_project_dir ~project_dir ~patch_id =
     ("OPENCODE_CONFIG_DIR", opencode_dir);
   ]
 
+let per_patch_env_without_codex_home_in_project_dir ~project_dir ~patch_id =
+  per_patch_env_in_project_dir ~project_dir ~patch_id
+  |> List.filter ~f:(fun (key, _) -> not (String.equal key "CODEX_HOME"))
+
 let per_patch_env ~project_name ~patch_id =
   per_patch_env_in_project_dir
+    ~project_dir:(Project_store.project_dir project_name)
+    ~patch_id
+
+let per_patch_env_without_codex_home ~project_name ~patch_id =
+  per_patch_env_without_codex_home_in_project_dir
     ~project_dir:(Project_store.project_dir project_name)
     ~patch_id
 
@@ -170,6 +179,17 @@ let%test "merged env contains per-patch overrides" =
   String.is_substring claude_a ~substring:"spawn-envs/patch-1/claude"
   && String.is_substring codex_a ~substring:"spawn-envs/patch-1/codex"
   && not (String.equal claude_a claude_b)
+
+let%test "codex home override can be omitted" =
+  with_temp_project_dir @@ fun project_dir ->
+  let patch_id = Types.Patch_id.of_string "patch-no-codex-home" in
+  let env =
+    per_patch_env_without_codex_home_in_project_dir ~project_dir ~patch_id
+  in
+  let find key = List.Assoc.find env ~equal:String.equal key in
+  Option.is_some (find "CLAUDE_CONFIG_DIR")
+  && Option.is_some (find "OPENCODE_CONFIG_DIR")
+  && Option.is_none (find "CODEX_HOME")
 
 let write_file path contents =
   let oc = Stdlib.open_out path in

--- a/lib/spawn_env.mli
+++ b/lib/spawn_env.mli
@@ -3,9 +3,13 @@ val per_patch_env :
 (** Per-patch config-dir overrides for headless agent CLIs. Creates the backing
     directories under the project store before returning:
     [spawn-envs/<patch_id>/{claude,codex,opencode}]. Also seeds each per-patch
-    dir with a symlink to the user's real auth file
-    ([auth.json]/[.credentials.json]/[opencode.json]) so the backend CLI finds
-    its credentials and token rotations propagate back to the user's home. *)
+    dir with a symlink to the user's real auth file. *)
+
+val per_patch_env_without_codex_home :
+  project_name:string -> patch_id:Types.Patch_id.t -> (string * string) list
+(** Like {!per_patch_env}, but omits [CODEX_HOME] so Codex sessions use the
+    user's normal Codex home. Codex refresh tokens rotate and are not safe to
+    fan out across independent homes. *)
 
 val merge_env :
   base_env:string array -> overrides:(string * string) list -> string array

--- a/onton.opam
+++ b/onton.opam
@@ -4,11 +4,12 @@ version: "0.6.0"
 synopsis: "OCaml orchestrator for parallel Claude Code agents"
 maintainer: ["flowglad"]
 depends: [
-  "ocaml" {>= "5.4.0"}
-  "dune" {>= "3.21"}
+  "ocaml" {= "5.4.0"}
+  "dune" {>= "3.21" & < "3.22"}
   "base" {>= "v0.17.0"}
   "eio" {>= "1.3"}
   "eio_main" {>= "1.3"}
+  "eio_posix" {>= "1.3"}
   "yojson" {>= "3.0.0"}
   "cohttp-eio" {>= "6.0.0"}
   "tls-eio" {>= "2.0.0"}
@@ -26,7 +27,7 @@ depends: [
   "ppx_inline_test" {with-test & >= "v0.17.0"}
   "ppx_assert" {with-test & >= "v0.17.0"}
   "qcheck-core" {with-test & >= "0.21"}
-  "ocamlformat" {with-dev-setup & = "0.28.1"}
+  "ocamlformat" {= "0.28.1"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]


### PR DESCRIPTION
## Summary

- stop setting a per-patch `CODEX_HOME` for the Codex backend so Codex uses the normal user auth store instead of per-patch auth state
- keep legacy per-patch config behavior available for other backends, with an explicit `per_patch_env_without_codex_home` helper for Codex
- retry a Codex session once after a likely OAuth/auth refresh failure with no parsed stream events
- tighten `onton.opam` so the repo switch owns the expected toolchain: OCaml `5.4.0`, Dune `3.21.x`, explicit `eio_posix`, and `ocamlformat 0.28.1`

## Why

Parallel Codex sessions can race when refresh tokens rotate. Per-patch Codex homes make that worse because each session can hold stale auth state. Sharing the normal Codex home matches interactive Codex behavior more closely and gives Codex's own reload-before-refresh logic a better chance to observe a token rotated by another process.

The local switch was also broken because `_opam/bin` was missing, so shells fell through to Homebrew OCaml/Dune while still seeing `_opam/lib`. The manifest now encodes the repo's intended toolchain more strictly so the local switch is rebuilt consistently.

This is a short-term mitigation until OpenAI auth moves behind the planned patch-agent auth broker.

## Validation

- `opam exec --switch=/Users/zax/onton -- dune fmt`
- `opam exec --switch=/Users/zax/onton -- dune build`
- `opam exec --switch=/Users/zax/onton -- dune runtest`

Local toolchain after repair:

- `ocamlc`: `/Users/zax/onton/_opam/bin/ocamlc`, version `5.4.0`
- `dune`: `/Users/zax/onton/_opam/bin/dune`, version `3.21.1`
- `ocamlformat`: `/Users/zax/onton/_opam/bin/ocamlformat`, version `0.28.1`

I also unlinked Homebrew `ocaml` and `dune` locally so they no longer mask a broken project switch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added automatic retry mechanism to improve reliability when authentication issues occur during streaming operations.

* **Chores**
  * Updated project dependencies: OCaml 5.4.0, Dune 3.21+, OCamlformat 0.28.1, and added eio_posix 1.3+.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->