### PR TITLE
Add review-service backend — agent-driven finding resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ _opam/
 .claude
 .vercel
 node_modules/
+.env
+*.pem
+private.pem

--- a/bin/check_repo_config.ml
+++ b/bin/check_repo_config.ml
@@ -1,0 +1,39 @@
+(** One-off: load and pretty-print the per-repo onton config. Useful to verify a
+    [reviewBackends] block parses before kicking off a real session.
+
+    Usage: [onton-check-repo-config <owner> <repo>] *)
+
+let () =
+  match Array.to_list Sys.argv |> List.tl with
+  | [ owner; repo ] -> (
+      let known_backends = [ "claude"; "codex"; "gemini"; "opencode"; "pi" ] in
+      let config_dir =
+        Onton.User_config.config_dir ~github_owner:owner ~github_repo:repo
+      in
+      Printf.printf "config_dir = %s\n" config_dir;
+      match Onton_core.Repo_config.load ~config_dir ~known_backends () with
+      | Error msg ->
+          Printf.printf "PARSE ERROR: %s\n" msg;
+          exit 1
+      | Ok c ->
+          Printf.printf "complexity_routes : %d entries\n"
+            (List.length c.complexity_routes);
+          Printf.printf "review_backends   : %d entries\n"
+            (List.length c.review_backends);
+          List.iter
+            (fun (b : Onton_core.Review_backend.t) ->
+              Printf.printf "  - name=%s\n" b.name;
+              match b.kind with
+              | Onton_core.Review_backend.Review_service { base_url; auth } ->
+                  Printf.printf "    baseUrl=%s\n" base_url;
+                  Printf.printf "    appId=%s\n" auth.app_id;
+                  Printf.printf "    privateKeyPath=%s\n" auth.private_key_path;
+                  if Sys.file_exists auth.private_key_path then
+                    Printf.printf "    (PEM file exists)\n"
+                  else
+                    Printf.printf
+                      "    WARNING: PEM file does not exist on disk\n")
+            c.review_backends)
+  | _ ->
+      prerr_endline "usage: onton-check-repo-config <owner> <repo>";
+      exit 2

--- a/bin/dune
+++ b/bin/dune
@@ -12,6 +12,13 @@
  (ocamlopt_flags (:standard -w -40-42))
  (ocamlc_flags (:standard -w -40-42)))
 
+(executable
+ (name check_repo_config)
+ (public_name onton-check-repo-config)
+ (libraries onton onton_core)
+ (ocamlopt_flags (:standard -w -40-42))
+ (ocamlc_flags (:standard -w -40-42)))
+
 (rule
  (target version.ml)
  (deps (universe))

--- a/bin/dune
+++ b/bin/dune
@@ -5,6 +5,13 @@
  (ocamlopt_flags (:standard -w -40-42))
  (ocamlc_flags (:standard -w -40-42)))
 
+(executable
+ (name probe_findings_api)
+ (public_name onton-probe-findings-api)
+ (libraries onton onton_core eio eio_main unix)
+ (ocamlopt_flags (:standard -w -40-42))
+ (ocamlc_flags (:standard -w -40-42)))
+
 (rule
  (target version.ml)
  (deps (universe))

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1603,12 +1603,19 @@ let poll_review_backends ~net ~clock ~runtime ~patch_id ~findings_registry
                   possible review-service schema drift"
                  b.Review_backend.name response.Review_service.count
                  parsed_count);
-          Base.List.map response.Review_service.findings
-            ~f:(fun (f : Review_service.finding) ->
-              let key =
-                Findings_registry.make_key ~backend_name:b.Review_backend.name
-                  ~owner ~repo ~pr_number ~finding_id:f.Review_service.id
-              in
+          let keyed_findings =
+            Base.List.map response.Review_service.findings
+              ~f:(fun (f : Review_service.finding) ->
+                let key =
+                  Findings_registry.make_key ~backend_name:b.Review_backend.name
+                    ~owner ~repo ~pr_number ~finding_id:f.Review_service.id
+                in
+                (key, f))
+          in
+          Findings_registry.remove_stale_for_scope findings_registry
+            ~backend_name:b.Review_backend.name ~owner ~repo ~pr_number
+            ~keep_keys:(Base.List.map keyed_findings ~f:fst);
+          Base.List.map keyed_findings ~f:(fun (key, f) ->
               Findings_registry.register findings_registry ~key
                 {
                   Findings_registry.backend = b;
@@ -2554,6 +2561,14 @@ let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name ~pr_registry
                                       (Printf.sprintf
                                          "Skipped %s — nothing to deliver"
                                          (Operation_kind.to_label kind));
+                                    if
+                                      Operation_kind.equal kind
+                                        Operation_kind.Findings
+                                    then
+                                      log_event runtime ~patch_id
+                                        "Skipped findings delivery after \
+                                         pre-session refresh returned no \
+                                         findings; no resolution was posted";
                                     `Skip_empty
                                 | Patch_decision.Deliver
                                     {

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -3152,34 +3152,34 @@ let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name ~pr_registry
                                       | _ -> false
                                     in
                                     let result =
-                                      if session_ok then
-                                        match payload with
-                                        | Patch_decision.Pr_body_payload -> (
-                                            let pr =
-                                              Base.Option.value_exn pr_number
-                                            in
-                                            let patch =
-                                              Base.List.find_exn
-                                                gameplan.Gameplan.patches
-                                                ~f:(fun (p : Patch.t) ->
-                                                  Patch_id.equal p.Patch.id
-                                                    patch_id)
-                                            in
-                                            let artifact_outcome =
-                                              apply_pr_body_artifact ~runtime
-                                                ~net ~github ~project_name
-                                                ~patch_id ~pr_number:pr ~patch
-                                                ~gameplan
-                                            in
-                                            match
-                                              Patch_decision
-                                              .classify_pr_body_respond
-                                                ~artifact_outcome ~tool_failures
-                                            with
-                                            | `Pr_body_miss -> `Pr_body_miss
-                                            | `Ok -> result)
-                                        | Patch_decision.Findings_payload
-                                            { findings } ->
+                                      match payload with
+                                      | Patch_decision.Pr_body_payload
+                                        when session_ok -> (
+                                          let pr =
+                                            Base.Option.value_exn pr_number
+                                          in
+                                          let patch =
+                                            Base.List.find_exn
+                                              gameplan.Gameplan.patches
+                                              ~f:(fun (p : Patch.t) ->
+                                                Patch_id.equal p.Patch.id
+                                                  patch_id)
+                                          in
+                                          let artifact_outcome =
+                                            apply_pr_body_artifact ~runtime ~net
+                                              ~github ~project_name ~patch_id
+                                              ~pr_number:pr ~patch ~gameplan
+                                          in
+                                          match
+                                            Patch_decision
+                                            .classify_pr_body_respond
+                                              ~artifact_outcome ~tool_failures
+                                          with
+                                          | `Pr_body_miss -> `Pr_body_miss
+                                          | `Ok -> result)
+                                      | Patch_decision.Findings_payload
+                                          { findings } ->
+                                          if session_ok then (
                                             let artifact_path =
                                               Project_store
                                               .findings_wontfix_artifact_path
@@ -3195,14 +3195,35 @@ let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name ~pr_registry
                                                 (Printf.sprintf "onton:%s"
                                                    (Patch_id.to_string patch_id))
                                               ();
+                                            result)
+                                          else
+                                            let ids =
+                                              Base.List.map findings
+                                                ~f:(fun
+                                                    (f : Review_service.finding)
+                                                  -> f.Review_service.id)
+                                            in
+                                            log_event runtime ~patch_id
+                                              (Printf.sprintf
+                                                 "Session failed before \
+                                                  resolving findings; \
+                                                  forgetting delivered finding \
+                                                  registry entries: %s"
+                                                 (String.concat ", " ids));
+                                            Base.List.iter findings
+                                              ~f:(fun
+                                                  (f : Review_service.finding)
+                                                ->
+                                                Findings_registry.forget
+                                                  findings_registry
+                                                  ~key:f.Review_service.id);
                                             result
-                                        | Patch_decision.Human_payload _
-                                        | Patch_decision.Ci_payload _
-                                        | Patch_decision.Review_payload _
-                                        | Patch_decision.Merge_conflict_payload
-                                          ->
-                                            result
-                                      else result
+                                      | Patch_decision.Human_payload _
+                                      | Patch_decision.Ci_payload _
+                                      | Patch_decision.Review_payload _
+                                      | Patch_decision.Pr_body_payload
+                                      | Patch_decision.Merge_conflict_payload ->
+                                          result
                                     in
                                     (* Opportunistic pr-body sync. If the
                                        agent updated the artifact during a

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1593,12 +1593,21 @@ let poll_review_backends ~net ~clock ~runtime ~patch_id ~findings_registry
                (Review_service_client.show_error err));
           []
       | Ok response ->
-          Base.List.iter response.Review_service.findings
+          Base.List.map response.Review_service.findings
             ~f:(fun (f : Review_service.finding) ->
-              Findings_registry.register findings_registry
-                ~finding_id:f.Review_service.id
-                { Findings_registry.backend = b; owner; repo; pr_number });
-          response.Review_service.findings)
+              let key =
+                Findings_registry.make_key ~backend_name:b.Review_backend.name
+                  ~owner ~repo ~pr_number ~finding_id:f.Review_service.id
+              in
+              Findings_registry.register findings_registry ~key
+                {
+                  Findings_registry.backend = b;
+                  owner;
+                  repo;
+                  pr_number;
+                  finding_id = f.Review_service.id;
+                };
+              { f with Review_service.id = key }))
 
 let poller_fiber ~runtime ~clock ~net ~process_mgr ~github ~config ~project_name
     ~pr_registry ~branch_of ~event_log ~review_backends ~findings_registry =

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -2571,17 +2571,17 @@ let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name ~pr_registry
                                     `Stale
                                 | Patch_decision.Skip_empty ->
                                     log_event runtime ~patch_id
-                                      (Printf.sprintf
-                                         "Skipped %s — nothing to deliver"
-                                         (Operation_kind.to_label kind));
-                                    if
-                                      Operation_kind.equal kind
-                                        Operation_kind.Findings
-                                    then
-                                      log_event runtime ~patch_id
-                                        "Skipped findings delivery after \
-                                         pre-session refresh returned no \
-                                         findings; no resolution was posted";
+                                      (if
+                                         Operation_kind.equal kind
+                                           Operation_kind.Findings
+                                       then
+                                         "Skipped findings — pre-session \
+                                          refresh returned no findings; no \
+                                          resolution posted"
+                                       else
+                                         Printf.sprintf
+                                           "Skipped %s — nothing to deliver"
+                                           (Operation_kind.to_label kind));
                                     `Skip_empty
                                 | Patch_decision.Deliver
                                     {

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1589,7 +1589,7 @@ let poll_review_backends ~net ~clock ~runtime ~patch_id ~findings_registry
       with
       | Error err ->
           log_event runtime ~patch_id
-            (Printf.sprintf "Review backend %s — %s" b.Review_backend.name
+            (Printf.sprintf "Poll error — %s"
                (Review_service_client.show_error err));
           []
       | Ok response ->

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1879,7 +1879,8 @@ let poller_fiber ~runtime ~clock ~net ~process_mgr ~github ~config ~project_name
 (** Runner fiber — executes orchestrator actions by driving backend sessions
     concurrently. *)
 let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name ~pr_registry
-    ~findings_registry ~transcripts ~github ~net ~event_log ?status_msg () =
+    ~findings_registry ~review_backends ~transcripts ~github ~net ~event_log
+    ?status_msg () =
   let main = config.main_branch in
   let process_mgr = Eio.Stdenv.process_mgr env in
   let clock = Eio.Stdenv.clock env in
@@ -2444,9 +2445,16 @@ let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name ~pr_registry
                   in
                   let prefetched_findings =
                     if Operation_kind.equal kind Operation_kind.Findings then
-                      match fresh_pr_state with
-                      | Some pr_state -> pr_state.Pr_state.findings
-                      | None -> []
+                      match pr_number with
+                      | Some pr_num
+                        when not (Base.List.is_empty review_backends) ->
+                          log_event runtime ~patch_id
+                            "Fetching fresh findings from review backends";
+                          poll_review_backends ~net ~clock ~runtime ~patch_id
+                            ~findings_registry ~review_backends
+                            ~owner:config.github_owner ~repo:config.github_repo
+                            ~pr_number:(Pr_number.to_int pr_num)
+                      | Some _ | None -> []
                     else []
                   in
                   (* Ci freshness gate: if we have no PR number, couldn't
@@ -3911,8 +3919,8 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
           ((fun () -> headless_fiber ~runtime ~clock ~stdout)
           :: (fun () ->
             runner_fiber ~runtime ~env ~config ~pick_backend ~project_name
-              ~pr_registry ~findings_registry ~transcripts ~github ~net
-              ~event_log ())
+              ~pr_registry ~findings_registry ~review_backends ~transcripts
+              ~github ~net ~event_log ())
           :: common_fibers)
       else
         let list_selected = ref 0 in
@@ -3964,8 +3972,8 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
                     ~repo:config.github_repo ~resolve_routing)
                 :: (fun () ->
                   runner_fiber ~runtime ~env ~config ~pick_backend ~project_name
-                    ~pr_registry ~findings_registry ~transcripts ~github ~net
-                    ~event_log ~status_msg ())
+                    ~pr_registry ~findings_registry ~review_backends
+                    ~transcripts ~github ~net ~event_log ~status_msg ())
                 :: common_fibers)
             with Quit_tui -> ())
 

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1580,8 +1580,28 @@ type poll_intent =
 
 (** Poller fiber — periodically polls GitHub for PR state changes and
     reconciles. *)
+let poll_review_backends ~net ~clock ~runtime ~patch_id ~findings_registry
+    ~review_backends ~owner ~repo ~pr_number : Review_service.finding list =
+  Base.List.concat_map review_backends ~f:(fun (b : Review_backend.t) ->
+      match
+        Review_service_client.list_findings ~net ~clock ~backend:b ~owner ~repo
+          ~pr_number ()
+      with
+      | Error err ->
+          log_event runtime ~patch_id
+            (Printf.sprintf "Review backend %s — %s" b.Review_backend.name
+               (Review_service_client.show_error err));
+          []
+      | Ok response ->
+          Base.List.iter response.Review_service.findings
+            ~f:(fun (f : Review_service.finding) ->
+              Findings_registry.register findings_registry
+                ~finding_id:f.Review_service.id
+                { Findings_registry.backend = b; owner; repo; pr_number });
+          response.Review_service.findings)
+
 let poller_fiber ~runtime ~clock ~net ~process_mgr ~github ~config ~project_name
-    ~pr_registry ~branch_of ~event_log =
+    ~pr_registry ~branch_of ~event_log ~review_backends ~findings_registry =
   let main = config.main_branch in
   let skip_logged : (Patch_id.t, bool) Hashtbl.t = Hashtbl.create 16 in
   let rec loop () =
@@ -1630,6 +1650,19 @@ let poller_fiber ~runtime ~clock ~net ~process_mgr ~github ~config ~project_name
                          (Pr_number.to_int pr_number)));
                   None
               | Ok pr_state ->
+                  (* Augment the GitHub-derived [pr_state] with findings from
+                     every configured review backend. Failures are logged
+                     but non-fatal — a flaky review service shouldn't stop
+                     the rest of the poll cycle. *)
+                  let findings =
+                    if Base.List.is_empty review_backends then []
+                    else
+                      poll_review_backends ~net ~clock ~runtime ~patch_id
+                        ~findings_registry ~review_backends
+                        ~owner:config.github_owner ~repo:config.github_repo
+                        ~pr_number:(Pr_number.to_int pr_number)
+                  in
+                  let pr_state = { pr_state with Pr_state.findings } in
                   let poll_result = Poller.poll ~was_merged pr_state in
                   (* PR was closed — re-discover the current open PR.
                      This path does its own I/O and separate atomic update;
@@ -1837,7 +1870,7 @@ let poller_fiber ~runtime ~clock ~net ~process_mgr ~github ~config ~project_name
 (** Runner fiber — executes orchestrator actions by driving backend sessions
     concurrently. *)
 let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name ~pr_registry
-    ~transcripts ~github ~net ~event_log ?status_msg () =
+    ~findings_registry ~transcripts ~github ~net ~event_log ?status_msg () =
   let main = config.main_branch in
   let process_mgr = Eio.Stdenv.process_mgr env in
   let clock = Eio.Stdenv.clock env in
@@ -2400,6 +2433,13 @@ let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name ~pr_registry
                       | None -> []
                     else []
                   in
+                  let prefetched_findings =
+                    if Operation_kind.equal kind Operation_kind.Findings then
+                      match fresh_pr_state with
+                      | Some pr_state -> pr_state.Pr_state.findings
+                      | None -> []
+                    else []
+                  in
                   (* Ci freshness gate: if we have no PR number, couldn't
                      fetch, or the fetched state shows no current failures,
                      skip the delivery — don't wake the agent for a failure
@@ -2459,6 +2499,7 @@ let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name ~pr_registry
                                 let delivery =
                                   Patch_decision.respond_delivery ~agent ~kind
                                     ~pre_fire_agent ~prefetched_comments
+                                    ~prefetched_findings
                                     ~main_branch:(Branch.to_string main)
                                 in
                                 let render_base_changed_prefix base_change =
@@ -2780,6 +2821,7 @@ let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name ~pr_registry
                                         ( Patch_decision.Human_payload _
                                         | Patch_decision.Ci_payload _
                                         | Patch_decision.Review_payload _
+                                        | Patch_decision.Findings_payload _
                                         | Patch_decision.Pr_body_payload ) as
                                         payload;
                                       base_change;
@@ -2826,6 +2868,13 @@ let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name ~pr_registry
                                             (pluralize
                                                (Base.List.length comments)
                                                "comment")
+                                      | Patch_decision.Findings_payload
+                                          { findings } ->
+                                          Printf.sprintf "Delivering %s (%s)"
+                                            (Operation_kind.to_label kind)
+                                            (pluralize
+                                               (Base.List.length findings)
+                                               "finding")
                                       | Patch_decision.Human_payload
                                           { messages } ->
                                           Printf.sprintf "Delivering %s (%s)"
@@ -2871,6 +2920,32 @@ let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name ~pr_registry
                                             ?patch:patch_for_layer ~gameplan
                                             ~base_branch:base_branch_for_layer
                                             comments
+                                      | Patch_decision.Findings_payload
+                                          { findings } ->
+                                          let current_head_sha =
+                                            Base.Option.bind fresh_pr_state
+                                              ~f:(fun ps ->
+                                                ps.Pr_state.head_oid)
+                                          in
+                                          let artifact_path =
+                                            Project_store
+                                            .findings_wontfix_artifact_path
+                                              ~project_name ~patch_id
+                                          in
+                                          Project_store.ensure_dir
+                                            (Stdlib.Filename.dirname
+                                               artifact_path);
+                                          (try Unix.unlink artifact_path
+                                           with
+                                           | Unix.Unix_error (Unix.ENOENT, _, _)
+                                           ->
+                                             ());
+                                          Prompt.render_findings_prompt
+                                            ~project_name ?agents_md ?pr_number
+                                            ?current_head_sha
+                                            ?patch:patch_for_layer ~gameplan
+                                            ~base_branch:base_branch_for_layer
+                                            ~artifact_path findings
                                       | Patch_decision.Human_payload
                                           { messages } ->
                                           Prompt.render_human_message_prompt
@@ -2956,6 +3031,7 @@ let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name ~pr_registry
                                                 patch_id ids)
                                     | Patch_decision.Human_payload _
                                     | Patch_decision.Review_payload _
+                                    | Patch_decision.Findings_payload _
                                     | Patch_decision.Pr_body_payload
                                     | Patch_decision.Merge_conflict_payload ->
                                         ());
@@ -3047,6 +3123,24 @@ let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name ~pr_registry
                                             with
                                             | `Pr_body_miss -> `Pr_body_miss
                                             | `Ok -> result)
+                                        | Patch_decision.Findings_payload
+                                            { findings } ->
+                                            let artifact_path =
+                                              Project_store
+                                              .findings_wontfix_artifact_path
+                                                ~project_name ~patch_id
+                                            in
+                                            Findings_resolver
+                                            .resolve_after_session ~net ~clock
+                                              ~log:(fun msg ->
+                                                log_event runtime ~patch_id msg)
+                                              ~findings_registry ~artifact_path
+                                              ~delivered:findings
+                                              ~actor:
+                                                (Printf.sprintf "onton:%s"
+                                                   (Patch_id.to_string patch_id))
+                                              ();
+                                            result
                                         | Patch_decision.Human_payload _
                                         | Patch_decision.Ci_payload _
                                         | Patch_decision.Review_payload _
@@ -3678,7 +3772,7 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
           User_config.config_dir ~github_owner:config.github_owner
             ~github_repo:config.github_repo
         in
-        match Repo_config.load ~config_dir ~known_backends with
+        match Repo_config.load ~config_dir ~known_backends () with
         | Ok t -> t
         | Error msg ->
             Printf.eprintf "Error: %s\n" msg;
@@ -3790,12 +3884,15 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
       let event_log =
         Event_log.create ~path:(Project_store.event_log_path project_name)
       in
+      let review_backends = repo_config.Repo_config.review_backends in
+      let findings_registry = Findings_registry.create () in
       let common_fibers =
         [
           reconciliation_fiber;
           (fun () ->
             poller_fiber ~runtime ~clock ~net ~process_mgr ~github ~config
-              ~project_name ~pr_registry ~branch_of ~event_log);
+              ~project_name ~pr_registry ~branch_of ~event_log ~review_backends
+              ~findings_registry);
           (fun () ->
             persistence_fiber ~runtime ~clock ~project_name ~transcripts);
         ]
@@ -3805,7 +3902,8 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
           ((fun () -> headless_fiber ~runtime ~clock ~stdout)
           :: (fun () ->
             runner_fiber ~runtime ~env ~config ~pick_backend ~project_name
-              ~pr_registry ~transcripts ~github ~net ~event_log ())
+              ~pr_registry ~findings_registry ~transcripts ~github ~net
+              ~event_log ())
           :: common_fibers)
       else
         let list_selected = ref 0 in
@@ -3857,8 +3955,8 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
                     ~repo:config.github_repo ~resolve_routing)
                 :: (fun () ->
                   runner_fiber ~runtime ~env ~config ~pick_backend ~project_name
-                    ~pr_registry ~transcripts ~github ~net ~event_log
-                    ~status_msg ())
+                    ~pr_registry ~findings_registry ~transcripts ~github ~net
+                    ~event_log ~status_msg ())
                 :: common_fibers)
             with Quit_tui -> ())
 

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1593,6 +1593,16 @@ let poll_review_backends ~net ~clock ~runtime ~patch_id ~findings_registry
                (Review_service_client.show_error err));
           []
       | Ok response ->
+          let parsed_count =
+            Base.List.length response.Review_service.findings
+          in
+          if not (Int.equal parsed_count response.Review_service.count) then
+            log_event runtime ~patch_id
+              (Printf.sprintf
+                 "Review backend %s declared %d finding(s) but parsed %d — \
+                  possible review-service schema drift"
+                 b.Review_backend.name response.Review_service.count
+                 parsed_count);
           Base.List.map response.Review_service.findings
             ~f:(fun (f : Review_service.finding) ->
               let key =

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1603,6 +1603,19 @@ let poll_review_backends ~net ~clock ~runtime ~patch_id ~findings_registry
                   possible review-service schema drift"
                  b.Review_backend.name response.Review_service.count
                  parsed_count);
+          Base.List.iter response.Review_service.dropped_findings
+            ~f:(fun (e : Review_service.finding_parse_error) ->
+              let json =
+                if String.length e.Review_service.json <= 500 then
+                  e.Review_service.json
+                else String.sub e.Review_service.json 0 497 ^ "..."
+              in
+              log_event runtime ~patch_id
+                (Printf.sprintf
+                   "Review backend %s dropped finding at index %d while \
+                    parsing: %s; json=%s"
+                   b.Review_backend.name e.Review_service.index
+                   e.Review_service.error json));
           let keyed_findings =
             Base.List.map response.Review_service.findings
               ~f:(fun (f : Review_service.finding) ->

--- a/bin/probe_findings_api.ml
+++ b/bin/probe_findings_api.ml
@@ -48,12 +48,40 @@ let resolve_pem_path () =
              GITHUB_PRIVATE_KEY_PATH (path to PEM file)";
           exit 2
       | Some pem ->
-          let tmp = Filename.temp_file "onton-probe-key" ".pem" in
-          (try Unix.chmod tmp 0o600 with Unix.Unix_error _ -> ());
-          let oc = open_out tmp in
-          Fun.protect
-            ~finally:(fun () -> close_out_noerr oc)
-            (fun () -> output_string oc pem);
+          let rec create_private_tmp attempts =
+            if attempts <= 0 then (
+              prerr_endline "error: could not create private temporary PEM file";
+              exit 2)
+            else
+              let tmp =
+                Filename.concat
+                  (Filename.get_temp_dir_name ())
+                  (Printf.sprintf "onton-probe-key-%d-%08x.pem" (Unix.getpid ())
+                     (Random.bits ()))
+              in
+              match
+                Unix.openfile tmp
+                  [ Unix.O_CREAT; Unix.O_WRONLY; Unix.O_EXCL ]
+                  0o600
+              with
+              | fd -> (tmp, fd)
+              | exception Unix.Unix_error (Unix.EEXIST, _, _) ->
+                  create_private_tmp (attempts - 1)
+              | exception Unix.Unix_error (err, fn, arg) ->
+                  prerr_endline
+                    (Printf.sprintf "error: could not create PEM tempfile: %s"
+                       (Unix.error_message err));
+                  prerr_endline (Printf.sprintf "while running %s %s" fn arg);
+                  exit 2
+          in
+          let tmp, fd = create_private_tmp 100 in
+          let oc = Unix.out_channel_of_descr fd in
+          (try output_string oc pem
+           with exn ->
+             close_out_noerr oc;
+             (try Unix.unlink tmp with Unix.Unix_error _ -> ());
+             raise exn);
+          close_out_noerr oc;
           (* Best-effort cleanup: register at_exit so the tempfile dies with
              the probe. We rely on it for the duration of the probe and
              tolerate the race window where a crash might leak it. *)

--- a/bin/probe_findings_api.ml
+++ b/bin/probe_findings_api.ml
@@ -48,6 +48,7 @@ let resolve_pem_path () =
              GITHUB_PRIVATE_KEY_PATH (path to PEM file)";
           exit 2
       | Some pem ->
+          Random.self_init ();
           let rec create_private_tmp attempts =
             if attempts <= 0 then (
               prerr_endline "error: could not create private temporary PEM file";

--- a/bin/probe_findings_api.ml
+++ b/bin/probe_findings_api.ml
@@ -99,22 +99,27 @@ let backend_of_env () : Onton_core.Review_backend.t =
   let name =
     Option.value (getenv_opt "ONTON_REVIEW_BACKEND_NAME") ~default:"probe"
   in
-  {
-    Onton_core.Review_backend.name;
-    kind =
-      Onton_core.Review_backend.Review_service
-        {
-          base_url =
-            (* Strip trailing slashes so we don't double them when joining. *)
-            (let rec strip s =
-               let n = String.length s in
-               if n > 0 && s.[n - 1] = '/' then strip (String.sub s 0 (n - 1))
-               else s
-             in
-             strip base_url);
-          auth = { app_id; private_key_path };
-        };
-  }
+  let json =
+    `Assoc
+      [
+        ("name", `String name);
+        ("kind", `String "review-service");
+        ("baseUrl", `String base_url);
+        ( "auth",
+          `Assoc
+            [
+              ("appId", `String app_id);
+              ("privateKeyPath", `String private_key_path);
+            ] );
+      ]
+  in
+  match
+    Onton_core.Review_backend.parse ~known_kinds:[ "review-service" ] json
+  with
+  | Ok backend -> backend
+  | Error msg ->
+      prerr_endline (Printf.sprintf "error: invalid review backend: %s" msg);
+      exit 2
 
 let print_outcome (o : Onton_core.Review_service.outcome) =
   let so opt = match opt with Some s -> s | None -> "" in

--- a/bin/probe_findings_api.ml
+++ b/bin/probe_findings_api.ml
@@ -1,0 +1,194 @@
+(** Live-host probe for the review-service findings API.
+
+    Drives [Review_service_client] (and therefore [Jwt]) against a real server.
+    Mirrors [scripts/probe-findings-api.ts] in the review-service repo so the
+    OCaml client can be diffed against the TypeScript reference.
+
+    Environment:
+    - [GITHUB_PRIVATE_KEY] — PEM contents (preferred); OR
+    - [GITHUB_PRIVATE_KEY_PATH] — path to a PEM file (fallback);
+    - [REVIEW_SERVICE_URL] — default [https://review.flowglad.com];
+    - [ONTON_REVIEW_BACKEND_NAME] — default ["probe"].
+
+    Usage:
+    {v
+      onton-probe-findings-api <owner> <repo> <n>
+      onton-probe-findings-api <owner> <repo> <n> --all
+      onton-probe-findings-api <owner> <repo> <n> resolve <id> <kind> [reason]
+    v} *)
+
+let usage () =
+  prerr_endline
+    "usage:\n\
+    \  onton-probe-findings-api <owner> <repo> <pull_number> [--all]\n\
+    \  onton-probe-findings-api <owner> <repo> <pull_number> resolve <id> \
+     <kind> [reason words...]\n\n\
+     env:\n\
+    \  GITHUB_PRIVATE_KEY        PEM contents (preferred)\n\
+    \  GITHUB_PRIVATE_KEY_PATH   path to PEM file (fallback)\n\
+    \  REVIEW_SERVICE_URL        default https://review.flowglad.com\n";
+  exit 2
+
+let getenv_opt key =
+  match Sys.getenv_opt key with
+  | Some s when String.length (String.trim s) > 0 -> Some s
+  | _ -> None
+
+let resolve_pem_path () =
+  (* If the user supplied a path, use it directly. Otherwise materialise the
+     in-env PEM contents to a tempfile so [Jwt.mint] (which reads from disk)
+     can sign with it. *)
+  match getenv_opt "GITHUB_PRIVATE_KEY_PATH" with
+  | Some p -> p
+  | None -> (
+      match getenv_opt "GITHUB_PRIVATE_KEY" with
+      | None ->
+          prerr_endline
+            "error: set either GITHUB_PRIVATE_KEY (PEM contents) or \
+             GITHUB_PRIVATE_KEY_PATH (path to PEM file)";
+          exit 2
+      | Some pem ->
+          let tmp = Filename.temp_file "onton-probe-key" ".pem" in
+          (try Unix.chmod tmp 0o600 with Unix.Unix_error _ -> ());
+          let oc = open_out tmp in
+          Fun.protect
+            ~finally:(fun () -> close_out_noerr oc)
+            (fun () -> output_string oc pem);
+          (* Best-effort cleanup: register at_exit so the tempfile dies with
+             the probe. We rely on it for the duration of the probe and
+             tolerate the race window where a crash might leak it. *)
+          at_exit (fun () -> try Unix.unlink tmp with Unix.Unix_error _ -> ());
+          tmp)
+
+let backend_of_env () : Onton_core.Review_backend.t =
+  let base_url =
+    Option.value
+      (getenv_opt "REVIEW_SERVICE_URL")
+      ~default:"https://review.flowglad.com"
+  in
+  let private_key_path = resolve_pem_path () in
+  let app_id = Option.value (getenv_opt "ONTON_PROBE_ISS") ~default:"cli" in
+  let name =
+    Option.value (getenv_opt "ONTON_REVIEW_BACKEND_NAME") ~default:"probe"
+  in
+  {
+    Onton_core.Review_backend.name;
+    kind =
+      Onton_core.Review_backend.Review_service
+        {
+          base_url =
+            (* Strip trailing slashes so we don't double them when joining. *)
+            (let rec strip s =
+               let n = String.length s in
+               if n > 0 && s.[n - 1] = '/' then strip (String.sub s 0 (n - 1))
+               else s
+             in
+             strip base_url);
+          auth = { app_id; private_key_path };
+        };
+  }
+
+let print_outcome (o : Onton_core.Review_service.outcome) =
+  let so opt = match opt with Some s -> s | None -> "" in
+  Printf.printf "  outcome.kind  : %s\n"
+    (Onton_core.Review_service.outcome_kind_to_string o.kind);
+  if Option.is_some o.detected_at then
+    Printf.printf "  outcome.detect: %s\n" (so o.detected_at);
+  if Option.is_some o.actor then
+    Printf.printf "  outcome.actor : %s\n" (so o.actor);
+  if Option.is_some o.reason then
+    Printf.printf "  outcome.reason: %s\n" (so o.reason)
+
+let print_finding (f : Onton_core.Review_service.finding) =
+  Printf.printf
+    "- id: %s\n  severity: %s\n  anchor: %s:%d-%d (sha=%s)\n  github_id: %s\n"
+    f.id
+    (Onton_core.Review_service.severity_to_string f.severity)
+    f.path f.start_line f.end_line f.posting_sha
+    (match f.github_comment_id with
+    | Some id -> string_of_int id
+    | None -> "null (outage finding)");
+  print_outcome f.outcome
+
+let do_list ~net ~clock ~backend ~owner ~repo ~pr_number ~_all () =
+  ignore _all;
+  (* The client hardcodes status=unresolved; --all needs the [status=all]
+     branch which we don't expose yet — the probe accepts the flag but for
+     now logs a warning when it can't honor it. Wire-side support is a
+     small addition if needed. *)
+  if _all then
+    prerr_endline
+      "warning: --all is accepted but the OCaml client currently always sends \
+       ?status=unresolved (matches the spec default). Use the TS probe for \
+       --all coverage.";
+  match
+    Onton.Review_service_client.list_findings ~net ~clock ~backend ~owner ~repo
+      ~pr_number ()
+  with
+  | Error err ->
+      prerr_endline (Onton.Review_service_client.show_error err);
+      exit 1
+  | Ok response ->
+      Printf.printf "GET findings → %d findings on %s#%d\n\n"
+        (List.length response.findings)
+        response.repo_id response.pull_number;
+      List.iter
+        (fun f ->
+          print_finding f;
+          print_newline ())
+        response.findings
+
+let parse_kind = function
+  | "addressed" -> Some Onton_core.Review_service.Resolve_addressed
+  | "wontfix" -> Some Onton_core.Review_service.Resolve_wontfix
+  | _ -> None
+
+let do_resolve ~net ~clock ~backend ~owner ~repo ~pr_number ~finding_id ~kind
+    ~reason () =
+  match
+    Onton.Review_service_client.mark_resolved ~net ~clock ~backend ~owner ~repo
+      ~pr_number ~finding_id ~kind ~actor:"onton:probe-findings-api" ?reason ()
+  with
+  | Error err ->
+      prerr_endline (Onton.Review_service_client.show_error err);
+      exit 1
+  | Ok response ->
+      Printf.printf "POST resolve → id=%s\n" response.id;
+      print_outcome response.outcome
+
+let () =
+  let args = Array.to_list Sys.argv |> List.tl in
+  match args with
+  | [] | [ "-h" ] | [ "--help" ] -> usage ()
+  | owner :: repo :: n_raw :: rest -> (
+      let pr_number =
+        match int_of_string_opt n_raw with
+        | Some n when n > 0 -> n
+        | _ ->
+            prerr_endline "invalid pull number";
+            exit 2
+      in
+      let backend = backend_of_env () in
+      Eio_main.run @@ fun env ->
+      let net = Eio.Stdenv.net env in
+      let clock = Eio.Stdenv.clock env in
+      match rest with
+      | [] ->
+          do_list ~net ~clock ~backend ~owner ~repo ~pr_number ~_all:false ()
+      | [ "--all" ] ->
+          do_list ~net ~clock ~backend ~owner ~repo ~pr_number ~_all:true ()
+      | "resolve" :: finding_id :: kind_str :: reason_parts -> (
+          match parse_kind kind_str with
+          | None ->
+              prerr_endline "kind must be 'addressed' or 'wontfix'";
+              exit 2
+          | Some kind ->
+              let reason =
+                match reason_parts with
+                | [] -> None
+                | xs -> Some (String.concat " " xs)
+              in
+              do_resolve ~net ~clock ~backend ~owner ~repo ~pr_number
+                ~finding_id ~kind ~reason ())
+      | _ -> usage ())
+  | _ -> usage ()

--- a/lib/dune
+++ b/lib/dune
@@ -1,6 +1,6 @@
 (library
  (name onton)
- (libraries onton_core base unix eio eio_main eio.unix yojson ppx_yojson_conv_lib cohttp-eio tls-eio mirage-crypto-rng.unix ca-certs cmarkit)
+ (libraries onton_core base unix eio eio_main eio.unix yojson ppx_yojson_conv_lib cohttp-eio tls-eio mirage-crypto-rng.unix mirage-crypto-pk x509 base64 ca-certs cmarkit)
  (flags (:standard -open Onton_core))
  (foreign_stubs
   (language c)

--- a/lib/findings_registry.ml
+++ b/lib/findings_registry.ml
@@ -3,6 +3,7 @@ type entry = {
   owner : string;
   repo : string;
   pr_number : int;
+  finding_id : string;
 }
 
 type t = { mutex : Eio.Mutex.t; table : (string, entry) Hashtbl.t }
@@ -13,11 +14,11 @@ let with_lock t f =
   Eio.Mutex.lock t.mutex;
   Fun.protect ~finally:(fun () -> Eio.Mutex.unlock t.mutex) f
 
-let register t ~finding_id entry =
-  with_lock t (fun () -> Hashtbl.replace t.table finding_id entry)
+let make_key ~backend_name ~owner ~repo ~pr_number ~finding_id =
+  Printf.sprintf "%s/%s/%s#%d/%s" backend_name owner repo pr_number finding_id
 
-let find t ~finding_id =
-  with_lock t (fun () -> Hashtbl.find_opt t.table finding_id)
+let register t ~key entry =
+  with_lock t (fun () -> Hashtbl.replace t.table key entry)
 
-let forget t ~finding_id =
-  with_lock t (fun () -> Hashtbl.remove t.table finding_id)
+let find t ~key = with_lock t (fun () -> Hashtbl.find_opt t.table key)
+let forget t ~key = with_lock t (fun () -> Hashtbl.remove t.table key)

--- a/lib/findings_registry.ml
+++ b/lib/findings_registry.ml
@@ -9,10 +9,7 @@ type entry = {
 type t = { mutex : Eio.Mutex.t; table : (string, entry) Hashtbl.t }
 
 let create () = { mutex = Eio.Mutex.create (); table = Hashtbl.create 64 }
-
-let with_lock t f =
-  Eio.Mutex.lock t.mutex;
-  Fun.protect ~finally:(fun () -> Eio.Mutex.unlock t.mutex) f
+let with_lock t f = Eio.Mutex.use_rw ~protect:true t.mutex f
 
 let make_key ~backend_name ~owner ~repo ~pr_number ~finding_id =
   Printf.sprintf "%s/%s/%s#%d/%s" backend_name owner repo pr_number finding_id

--- a/lib/findings_registry.ml
+++ b/lib/findings_registry.ml
@@ -1,0 +1,23 @@
+type entry = {
+  backend : Onton_core.Review_backend.t;
+  owner : string;
+  repo : string;
+  pr_number : int;
+}
+
+type t = { mutex : Eio.Mutex.t; table : (string, entry) Hashtbl.t }
+
+let create () = { mutex = Eio.Mutex.create (); table = Hashtbl.create 64 }
+
+let with_lock t f =
+  Eio.Mutex.lock t.mutex;
+  Fun.protect ~finally:(fun () -> Eio.Mutex.unlock t.mutex) f
+
+let register t ~finding_id entry =
+  with_lock t (fun () -> Hashtbl.replace t.table finding_id entry)
+
+let find t ~finding_id =
+  with_lock t (fun () -> Hashtbl.find_opt t.table finding_id)
+
+let forget t ~finding_id =
+  with_lock t (fun () -> Hashtbl.remove t.table finding_id)

--- a/lib/findings_registry.ml
+++ b/lib/findings_registry.ml
@@ -17,5 +17,22 @@ let make_key ~backend_name ~owner ~repo ~pr_number ~finding_id =
 let register t ~key entry =
   with_lock t (fun () -> Hashtbl.replace t.table key entry)
 
+let remove_stale_for_scope t ~backend_name ~owner ~repo ~pr_number ~keep_keys =
+  with_lock t (fun () ->
+      let stale = ref [] in
+      Hashtbl.iter
+        (fun key (entry : entry) ->
+          let same_scope =
+            String.equal entry.backend.Onton_core.Review_backend.name
+              backend_name
+            && String.equal entry.owner owner
+            && String.equal entry.repo repo
+            && entry.pr_number = pr_number
+          in
+          if same_scope && not (List.exists (String.equal key) keep_keys) then
+            stale := key :: !stale)
+        t.table;
+      List.iter (fun key -> Hashtbl.remove t.table key) !stale)
+
 let find t ~key = with_lock t (fun () -> Hashtbl.find_opt t.table key)
 let forget t ~key = with_lock t (fun () -> Hashtbl.remove t.table key)

--- a/lib/findings_registry.mli
+++ b/lib/findings_registry.mli
@@ -40,6 +40,19 @@ val register : t -> key:string -> entry -> unit
 (** Idempotent: re-registering the same composite key replaces the prior entry.
     The poller calls this on every successful findings fetch. *)
 
+val remove_stale_for_scope :
+  t ->
+  backend_name:string ->
+  owner:string ->
+  repo:string ->
+  pr_number:int ->
+  keep_keys:string list ->
+  unit
+(** Remove entries for the given backend/PR scope whose composite keys are not
+    in [keep_keys]. Called after a successful poll so the registry reflects the
+    backend's current unresolved findings instead of accumulating stale routes.
+*)
+
 val find : t -> key:string -> entry option
 
 val forget : t -> key:string -> unit

--- a/lib/findings_registry.mli
+++ b/lib/findings_registry.mli
@@ -17,19 +17,31 @@ type entry = {
   owner : string;
   repo : string;
   pr_number : int;
+  finding_id : string;
 }
 (** The information needed to address a resolve verb back to the originating
-    backend, on the same PR coordinates Onton observed. *)
+    backend, on the same PR coordinates Onton observed. [finding_id] is the raw
+    backend-local id used in the review-service API path. *)
 
 val create : unit -> t
 
-val register : t -> finding_id:string -> entry -> unit
-(** Idempotent: re-registering the same id replaces the prior entry. The poller
-    calls this on every successful findings fetch; if a finding moves between
-    backends (operator misconfiguration) the latest fetch wins. *)
+val make_key :
+  backend_name:string ->
+  owner:string ->
+  repo:string ->
+  pr_number:int ->
+  finding_id:string ->
+  string
+(** Composite id used in prompts, artifacts, and this registry. The key
+    namespaces backend-local finding ids by backend and PR coordinates so two
+    review backends can emit the same raw [finding_id] without colliding. *)
 
-val find : t -> finding_id:string -> entry option
+val register : t -> key:string -> entry -> unit
+(** Idempotent: re-registering the same composite key replaces the prior entry.
+    The poller calls this on every successful findings fetch. *)
 
-val forget : t -> finding_id:string -> unit
+val find : t -> key:string -> entry option
+
+val forget : t -> key:string -> unit
 (** Drop the entry. Called after a resolve POST so the table doesn't grow
     unbounded across the lifetime of the process. *)

--- a/lib/findings_registry.mli
+++ b/lib/findings_registry.mli
@@ -1,0 +1,35 @@
+(** Runtime side-table mapping a review-service finding id to the backend it
+    came from.
+
+    The pure {!Onton_core.Review_service.finding} record deliberately does not
+    carry backend attribution — adding a runtime concept to a pure type would
+    muddy the layering. The poller registers each finding here as it fetches
+    them; the post-session resolve flow looks up the backend by finding id when
+    it needs to POST a resolve verb.
+
+    Concurrency: protected internally by an [Eio.Mutex.t]. Callers do not need
+    to coordinate across the poller and runner fibers. *)
+
+type t
+
+type entry = {
+  backend : Onton_core.Review_backend.t;
+  owner : string;
+  repo : string;
+  pr_number : int;
+}
+(** The information needed to address a resolve verb back to the originating
+    backend, on the same PR coordinates Onton observed. *)
+
+val create : unit -> t
+
+val register : t -> finding_id:string -> entry -> unit
+(** Idempotent: re-registering the same id replaces the prior entry. The poller
+    calls this on every successful findings fetch; if a finding moves between
+    backends (operator misconfiguration) the latest fetch wins. *)
+
+val find : t -> finding_id:string -> entry option
+
+val forget : t -> finding_id:string -> unit
+(** Drop the entry. Called after a resolve POST so the table doesn't grow
+    unbounded across the lifetime of the process. *)

--- a/lib/findings_resolver.ml
+++ b/lib/findings_resolver.ml
@@ -40,7 +40,23 @@ let resolve_after_session ~net ~clock ~log ~findings_registry ~artifact_path
                  artifact_path msg);
             false)
   in
-  if artifact_ok then
+  if not artifact_ok then (
+    let ids =
+      List.map (fun (f : Onton_core.Review_service.finding) -> f.id) delivered
+    in
+    (match ids with
+    | [] -> ()
+    | _ ->
+        log
+          (Printf.sprintf
+             "Skipped findings resolution for delivered findings; operator \
+              action required for: %s"
+             (String.concat ", " ids)));
+    List.iter
+      (fun (f : Onton_core.Review_service.finding) ->
+        Findings_registry.forget findings_registry ~key:f.id)
+      delivered)
+  else
     List.iter
       (fun (f : Onton_core.Review_service.finding) ->
         match Findings_registry.find findings_registry ~key:f.id with

--- a/lib/findings_resolver.ml
+++ b/lib/findings_resolver.ml
@@ -10,7 +10,6 @@ let read_artifact path =
 
 let resolve_after_session ~net ~clock ~log ~findings_registry ~artifact_path
     ~delivered ?actor () =
-  let _ = net in
   (* Parse the wontfix artifact. Errors are surfaced and then we proceed —
      a malformed artifact should not cause every finding to silently drop;
      the agent's intent for its non-listed findings was clearly "addressed". *)

--- a/lib/findings_resolver.ml
+++ b/lib/findings_resolver.ml
@@ -30,7 +30,7 @@ let resolve_after_session ~net ~clock ~log ~findings_registry ~artifact_path
            artifact_path msg));
   List.iter
     (fun (f : Onton_core.Review_service.finding) ->
-      match Findings_registry.find findings_registry ~finding_id:f.id with
+      match Findings_registry.find findings_registry ~key:f.id with
       | None ->
           log
             (Printf.sprintf
@@ -48,8 +48,9 @@ let resolve_after_session ~net ~clock ~log ~findings_registry ~artifact_path
               ~backend:entry.Findings_registry.backend
               ~owner:entry.Findings_registry.owner
               ~repo:entry.Findings_registry.repo
-              ~pr_number:entry.Findings_registry.pr_number ~finding_id:f.id
-              ~kind ?actor ?reason ()
+              ~pr_number:entry.Findings_registry.pr_number
+              ~finding_id:entry.Findings_registry.finding_id ~kind ?actor
+              ?reason ()
           with
           | Ok response ->
               log
@@ -57,7 +58,7 @@ let resolve_after_session ~net ~clock ~log ~findings_registry ~artifact_path
                    (Onton_core.Review_service.resolve_kind_to_string kind)
                    (Onton_core.Review_service.outcome_kind_to_string
                       response.Onton_core.Review_service.outcome.kind));
-              Findings_registry.forget findings_registry ~finding_id:f.id
+              Findings_registry.forget findings_registry ~key:f.id
           | Error err ->
               log
                 (Printf.sprintf "Failed to resolve finding %s — %s" f.id

--- a/lib/findings_resolver.ml
+++ b/lib/findings_resolver.ml
@@ -1,0 +1,65 @@
+let read_artifact path =
+  if not (Stdlib.Sys.file_exists path) then ""
+  else
+    try
+      let ic = Stdlib.In_channel.open_text path in
+      Fun.protect
+        ~finally:(fun () -> Stdlib.In_channel.close ic)
+        (fun () -> Stdlib.In_channel.input_all ic)
+    with Sys_error _ -> ""
+
+let resolve_after_session ~net ~clock ~log ~findings_registry ~artifact_path
+    ~delivered ?actor () =
+  let _ = net in
+  (* Parse the wontfix artifact. Errors are surfaced and then we proceed —
+     a malformed artifact should not cause every finding to silently drop;
+     the agent's intent for its non-listed findings was clearly "addressed". *)
+  let body = read_artifact artifact_path in
+  let wontfix_index : (string, string) Hashtbl.t = Hashtbl.create 8 in
+  (match Onton_core.Review_service.parse_wontfix_artifact body with
+  | Ok entries ->
+      List.iter
+        (fun (e : Onton_core.Review_service.wontfix_entry) ->
+          Hashtbl.replace wontfix_index e.id e.reason)
+        entries
+  | Error msg ->
+      log
+        (Printf.sprintf
+           "wontfix artifact at %s could not be parsed (%s) — defaulting all \
+            delivered findings to addressed"
+           artifact_path msg));
+  List.iter
+    (fun (f : Onton_core.Review_service.finding) ->
+      match Findings_registry.find findings_registry ~finding_id:f.id with
+      | None ->
+          log
+            (Printf.sprintf
+               "Skipping resolve for finding %s — no backend registered (was \
+                it not seen by the poller this session?)"
+               f.id)
+      | Some entry -> (
+          let kind, reason =
+            match Hashtbl.find_opt wontfix_index f.id with
+            | Some r -> (Onton_core.Review_service.Resolve_wontfix, Some r)
+            | None -> (Onton_core.Review_service.Resolve_addressed, None)
+          in
+          match
+            Review_service_client.mark_resolved ~net ~clock
+              ~backend:entry.Findings_registry.backend
+              ~owner:entry.Findings_registry.owner
+              ~repo:entry.Findings_registry.repo
+              ~pr_number:entry.Findings_registry.pr_number ~finding_id:f.id
+              ~kind ?actor ?reason ()
+          with
+          | Ok response ->
+              log
+                (Printf.sprintf "Resolved finding %s as %s (server: %s)" f.id
+                   (Onton_core.Review_service.resolve_kind_to_string kind)
+                   (Onton_core.Review_service.outcome_kind_to_string
+                      response.Onton_core.Review_service.outcome.kind));
+              Findings_registry.forget findings_registry ~finding_id:f.id
+          | Error err ->
+              log
+                (Printf.sprintf "Failed to resolve finding %s — %s" f.id
+                   (Review_service_client.show_error err))))
+    delivered

--- a/lib/findings_resolver.ml
+++ b/lib/findings_resolver.ml
@@ -91,5 +91,6 @@ let resolve_after_session ~net ~clock ~log ~findings_registry ~artifact_path
             | Error err ->
                 log
                   (Printf.sprintf "Failed to resolve finding %s — %s" f.id
-                     (Review_service_client.show_error err))))
+                     (Review_service_client.show_error err));
+                Findings_registry.forget findings_registry ~key:f.id))
       delivered

--- a/lib/findings_resolver.ml
+++ b/lib/findings_resolver.ml
@@ -1,65 +1,79 @@
 let read_artifact path =
-  if not (Stdlib.Sys.file_exists path) then ""
+  if not (Stdlib.Sys.file_exists path) then Ok ""
   else
     try
       let ic = Stdlib.In_channel.open_text path in
-      Fun.protect
-        ~finally:(fun () -> Stdlib.In_channel.close ic)
-        (fun () -> Stdlib.In_channel.input_all ic)
-    with Sys_error _ -> ""
+      Ok
+        (Fun.protect
+           ~finally:(fun () -> Stdlib.In_channel.close ic)
+           (fun () -> Stdlib.In_channel.input_all ic))
+    with Sys_error msg -> Error msg
 
 let resolve_after_session ~net ~clock ~log ~findings_registry ~artifact_path
     ~delivered ?actor () =
-  (* Parse the wontfix artifact. Errors are surfaced and then we proceed —
-     a malformed artifact should not cause every finding to silently drop;
-     the agent's intent for its non-listed findings was clearly "addressed". *)
-  let body = read_artifact artifact_path in
+  (* Parse the wontfix artifact. Missing means "no wontfix entries"; read or
+     parse failures fail closed so we do not accidentally mark findings as
+     addressed when the agent's artifact cannot be trusted. *)
   let wontfix_index : (string, string) Hashtbl.t = Hashtbl.create 8 in
-  (match Onton_core.Review_service.parse_wontfix_artifact body with
-  | Ok entries ->
-      List.iter
-        (fun (e : Onton_core.Review_service.wontfix_entry) ->
-          Hashtbl.replace wontfix_index e.id e.reason)
-        entries
-  | Error msg ->
-      log
-        (Printf.sprintf
-           "wontfix artifact at %s could not be parsed (%s) — defaulting all \
-            delivered findings to addressed"
-           artifact_path msg));
-  List.iter
-    (fun (f : Onton_core.Review_service.finding) ->
-      match Findings_registry.find findings_registry ~key:f.id with
-      | None ->
-          log
-            (Printf.sprintf
-               "Skipping resolve for finding %s — no backend registered (was \
-                it not seen by the poller this session?)"
-               f.id)
-      | Some entry -> (
-          let kind, reason =
-            match Hashtbl.find_opt wontfix_index f.id with
-            | Some r -> (Onton_core.Review_service.Resolve_wontfix, Some r)
-            | None -> (Onton_core.Review_service.Resolve_addressed, None)
-          in
-          match
-            Review_service_client.mark_resolved ~net ~clock
-              ~backend:entry.Findings_registry.backend
-              ~owner:entry.Findings_registry.owner
-              ~repo:entry.Findings_registry.repo
-              ~pr_number:entry.Findings_registry.pr_number
-              ~finding_id:entry.Findings_registry.finding_id ~kind ?actor
-              ?reason ()
-          with
-          | Ok response ->
-              log
-                (Printf.sprintf "Resolved finding %s as %s (server: %s)" f.id
-                   (Onton_core.Review_service.resolve_kind_to_string kind)
-                   (Onton_core.Review_service.outcome_kind_to_string
-                      response.Onton_core.Review_service.outcome.kind));
-              Findings_registry.forget findings_registry ~key:f.id
-          | Error err ->
-              log
-                (Printf.sprintf "Failed to resolve finding %s — %s" f.id
-                   (Review_service_client.show_error err))))
-    delivered
+  let artifact_ok =
+    match read_artifact artifact_path with
+    | Error msg ->
+        log
+          (Printf.sprintf
+             "wontfix artifact at %s could not be read (%s) — skipping \
+              findings resolution"
+             artifact_path msg);
+        false
+    | Ok body -> (
+        match Onton_core.Review_service.parse_wontfix_artifact body with
+        | Ok entries ->
+            List.iter
+              (fun (e : Onton_core.Review_service.wontfix_entry) ->
+                Hashtbl.replace wontfix_index e.id e.reason)
+              entries;
+            true
+        | Error msg ->
+            log
+              (Printf.sprintf
+                 "wontfix artifact at %s could not be parsed (%s) — skipping \
+                  findings resolution"
+                 artifact_path msg);
+            false)
+  in
+  if artifact_ok then
+    List.iter
+      (fun (f : Onton_core.Review_service.finding) ->
+        match Findings_registry.find findings_registry ~key:f.id with
+        | None ->
+            log
+              (Printf.sprintf
+                 "Skipping resolve for finding %s — no backend registered (was \
+                  it not seen by the poller this session?)"
+                 f.id)
+        | Some entry -> (
+            let kind, reason =
+              match Hashtbl.find_opt wontfix_index f.id with
+              | Some r -> (Onton_core.Review_service.Resolve_wontfix, Some r)
+              | None -> (Onton_core.Review_service.Resolve_addressed, None)
+            in
+            match
+              Review_service_client.mark_resolved ~net ~clock
+                ~backend:entry.Findings_registry.backend
+                ~owner:entry.Findings_registry.owner
+                ~repo:entry.Findings_registry.repo
+                ~pr_number:entry.Findings_registry.pr_number
+                ~finding_id:entry.Findings_registry.finding_id ~kind ?actor
+                ?reason ()
+            with
+            | Ok response ->
+                log
+                  (Printf.sprintf "Resolved finding %s as %s (server: %s)" f.id
+                     (Onton_core.Review_service.resolve_kind_to_string kind)
+                     (Onton_core.Review_service.outcome_kind_to_string
+                        response.Onton_core.Review_service.outcome.kind));
+                Findings_registry.forget findings_registry ~key:f.id
+            | Error err ->
+                log
+                  (Printf.sprintf "Failed to resolve finding %s — %s" f.id
+                     (Review_service_client.show_error err))))
+      delivered

--- a/lib/findings_resolver.mli
+++ b/lib/findings_resolver.mli
@@ -24,4 +24,6 @@ val resolve_after_session :
     know which backend to talk to.
 
     [artifact_path] is the absolute path of [findings_wontfix.json]. If the file
-    does not exist, every delivered finding is treated as [addressed]. *)
+    does not exist, every delivered finding is treated as [addressed]. If the
+    file exists but cannot be read or parsed, resolution is skipped so findings
+    are not silently marked with the wrong outcome. *)

--- a/lib/findings_resolver.mli
+++ b/lib/findings_resolver.mli
@@ -1,0 +1,27 @@
+(** Post-Findings-session resolution: read the agent's wontfix artifact and POST
+    [resolve] verbs back to the originating review backends.
+
+    Default verb is [addressed] — every delivered finding that is not in the
+    wontfix artifact is reported as fixed. Findings listed in the artifact are
+    reported as [wontfix] with the supplied reason.
+
+    Failures are logged but never raise: a flaky review service must not block
+    the rest of the session pipeline. *)
+
+val resolve_after_session :
+  net:_ Eio.Net.t ->
+  clock:_ Eio.Time.clock ->
+  log:(string -> unit) ->
+  findings_registry:Findings_registry.t ->
+  artifact_path:string ->
+  delivered:Onton_core.Review_service.finding list ->
+  ?actor:string ->
+  unit ->
+  unit
+(** Iterate [delivered], dispatching one resolve POST per finding that has a
+    matching entry in [findings_registry]. Findings without a registry entry are
+    logged and skipped — that means the poller never recorded them, so we don't
+    know which backend to talk to.
+
+    [artifact_path] is the absolute path of [findings_wontfix.json]. If the file
+    does not exist, every delivered finding is treated as [addressed]. *)

--- a/lib/findings_resolver.mli
+++ b/lib/findings_resolver.mli
@@ -26,4 +26,5 @@ val resolve_after_session :
     [artifact_path] is the absolute path of [findings_wontfix.json]. If the file
     does not exist, every delivered finding is treated as [addressed]. If the
     file exists but cannot be read or parsed, resolution is skipped so findings
-    are not silently marked with the wrong outcome. *)
+    are not silently marked with the wrong outcome; delivered finding ids are
+    logged for operator action and forgotten from the runtime registry. *)

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -372,6 +372,10 @@ let parse_response_json ~owner json =
                 ci_checks_truncated;
                 comments;
                 unresolved_comment_count;
+                findings = [];
+                (* GitHub does not produce review-service findings; the
+                     poller in [bin/main.ml] augments this list from
+                     configured review-service backends. *)
                 head_branch;
                 head_oid;
                 base_branch;

--- a/lib/jwt.ml
+++ b/lib/jwt.ml
@@ -49,6 +49,10 @@ let json_compact_of_assoc fields =
 let mint ~now ~app_id ~private_key_path ~ttl_seconds :
     (string, error) Stdlib.Result.t =
   let ( let* ) = Result.bind in
+  (* RSA PKCS1 sign uses [Mirage_crypto_rng] for blinding; seed it before
+     signing so callers don't have to remember. Idempotent — calling more
+     than once is a no-op after the first init. *)
+  Mirage_crypto_rng_unix.use_default ();
   let* pem = read_file private_key_path in
   let* priv = decode_pem pem in
   let iat = int_of_float now in

--- a/lib/jwt.ml
+++ b/lib/jwt.ml
@@ -14,10 +14,7 @@ let show_error = function
 
 (** Base64url without padding — RFC 7515 §2. *)
 let base64url_encode s =
-  let b64 =
-    Base64.encode_string ~pad:false ~alphabet:Base64.uri_safe_alphabet s
-  in
-  b64
+  Base64.encode_string ~pad:false ~alphabet:Base64.uri_safe_alphabet s
 
 let read_file path =
   try

--- a/lib/jwt.ml
+++ b/lib/jwt.ml
@@ -37,6 +37,7 @@ let decode_pem pem =
   | Error (`Msg msg) -> Error (Key_decode_error msg)
 
 let clamp ~lo ~hi v = max lo (min hi v)
+let rng_init = lazy (Mirage_crypto_rng_unix.use_default ())
 
 let json_compact_of_assoc fields =
   (* Yojson.Safe.to_string emits compact (no whitespace) by default — exactly
@@ -47,9 +48,8 @@ let mint ~now ~app_id ~private_key_path ~ttl_seconds :
     (string, error) Stdlib.Result.t =
   let ( let* ) = Result.bind in
   (* RSA PKCS1 sign uses [Mirage_crypto_rng] for blinding; seed it before
-     signing so callers don't have to remember. Idempotent — calling more
-     than once is a no-op after the first init. *)
-  Mirage_crypto_rng_unix.use_default ();
+     signing so callers don't have to remember. *)
+  Lazy.force rng_init;
   let* pem = read_file private_key_path in
   let* priv = decode_pem pem in
   let iat = int_of_float now in

--- a/lib/jwt.ml
+++ b/lib/jwt.ml
@@ -1,0 +1,91 @@
+type error =
+  | Key_read_error of string
+  | Key_decode_error of string
+  | Key_not_rsa of string
+  | Sign_error of string
+
+let show_error = function
+  | Key_read_error msg -> Printf.sprintf "JWT: cannot read private key: %s" msg
+  | Key_decode_error msg ->
+      Printf.sprintf "JWT: cannot decode private key PEM: %s" msg
+  | Key_not_rsa kt ->
+      Printf.sprintf "JWT: private key is %s — RS256 requires an RSA key" kt
+  | Sign_error msg -> Printf.sprintf "JWT: sign failed: %s" msg
+
+(** Base64url without padding — RFC 7515 §2. *)
+let base64url_encode s =
+  let b64 =
+    Base64.encode_string ~pad:false ~alphabet:Base64.uri_safe_alphabet s
+  in
+  b64
+
+let read_file path =
+  try
+    let ic = Stdlib.In_channel.open_text path in
+    let body =
+      Fun.protect
+        ~finally:(fun () -> Stdlib.In_channel.close ic)
+        (fun () -> Stdlib.In_channel.input_all ic)
+    in
+    Ok body
+  with Sys_error msg -> Error (Key_read_error msg)
+
+let decode_pem pem =
+  match X509.Private_key.decode_pem pem with
+  | Ok (`RSA priv) -> Ok priv
+  | Ok (`ED25519 _) -> Error (Key_not_rsa "ED25519")
+  | Ok (`P256 _) -> Error (Key_not_rsa "P-256")
+  | Ok (`P384 _) -> Error (Key_not_rsa "P-384")
+  | Ok (`P521 _) -> Error (Key_not_rsa "P-521")
+  | Error (`Msg msg) -> Error (Key_decode_error msg)
+
+let clamp ~lo ~hi v = max lo (min hi v)
+
+let json_compact_of_assoc fields =
+  (* Yojson.Safe.to_string emits compact (no whitespace) by default — exactly
+     what the JWT spec requires for the canonical form before base64url. *)
+  Yojson.Safe.to_string (`Assoc fields)
+
+let mint ~now ~app_id ~private_key_path ~ttl_seconds :
+    (string, error) Stdlib.Result.t =
+  let ( let* ) = Result.bind in
+  let* pem = read_file private_key_path in
+  let* priv = decode_pem pem in
+  let iat = int_of_float now in
+  let ttl = clamp ~lo:60 ~hi:300 ttl_seconds in
+  let exp = iat + ttl in
+  let header =
+    json_compact_of_assoc [ ("alg", `String "RS256"); ("typ", `String "JWT") ]
+  in
+  let claims =
+    json_compact_of_assoc
+      [ ("iss", `String app_id); ("iat", `Int iat); ("exp", `Int exp) ]
+  in
+  let signing_input = base64url_encode header ^ "." ^ base64url_encode claims in
+  match
+    Mirage_crypto_pk.Rsa.PKCS1.sign ~hash:`SHA256 ~key:priv
+      (`Message signing_input)
+  with
+  | exception exn -> Error (Sign_error (Printexc.to_string exn))
+  | signature -> Ok (signing_input ^ "." ^ base64url_encode signature)
+
+(* {2 Inline tests} *)
+
+let%test "clamp clamps low and high" =
+  clamp ~lo:60 ~hi:300 30 = 60
+  && clamp ~lo:60 ~hi:300 600 = 300
+  && clamp ~lo:60 ~hi:300 200 = 200
+
+let%test "base64url_encode strips padding" =
+  not (String.contains (base64url_encode "abc") '=')
+
+let%test "base64url_encode roundtrips uri-safe" =
+  let s = "any binary \x00\x01\xff" in
+  let enc = base64url_encode s in
+  match Base64.decode ~pad:false ~alphabet:Base64.uri_safe_alphabet enc with
+  | Ok back -> String.equal back s
+  | Error _ -> false
+
+let%test "show_error includes path-like context" =
+  let s = show_error (Key_read_error "no such file") in
+  String.length s > 0

--- a/lib/jwt.mli
+++ b/lib/jwt.mli
@@ -30,4 +30,8 @@ val mint :
     [ttl_seconds] is clamped to [[60, 300]] (60s minimum to absorb clock skew at
     the server, 300s maximum per the spec's server-side window). The PEM is read
     from disk on every call — token mints are infrequent and keeping the key
-    off-heap reduces blast radius. *)
+    off-heap reduces blast radius.
+
+    Seeds [Mirage_crypto_rng] via {!Mirage_crypto_rng_unix.use_default} before
+    signing (RSA PKCS1 needs randomness for blinding). The seed is idempotent —
+    repeated calls are a no-op. *)

--- a/lib/jwt.mli
+++ b/lib/jwt.mli
@@ -1,0 +1,33 @@
+(** Minimal RS256 JWT signer for the review-service backend.
+
+    Mints short-lived tokens whose claims match the review-service spec:
+    - [iss]: the GitHub App ID (caller-supplied)
+    - [iat]: issue time (≤ 120s old per server policy)
+    - [exp]: expiry (≤ 300s after [iat] per server policy)
+
+    No verification path here — Onton is purely a token minter. The server holds
+    the verification key and rejects tampered tokens with 401. *)
+
+type error =
+  | Key_read_error of string  (** Failed to read the PEM file from disk. *)
+  | Key_decode_error of string
+      (** PEM contents did not decode as a private key. *)
+  | Key_not_rsa of string
+      (** PEM decoded but the key was not RSA — the spec requires RS256. *)
+  | Sign_error of string  (** [Mirage_crypto_pk] rejected the sign call. *)
+
+val show_error : error -> string
+
+val mint :
+  now:float ->
+  app_id:string ->
+  private_key_path:string ->
+  ttl_seconds:int ->
+  (string, error) Stdlib.Result.t
+(** [mint ~now ~app_id ~private_key_path ~ttl_seconds] builds and signs a JWT
+    suitable for the review-service [Authorization: Bearer …] header.
+
+    [ttl_seconds] is clamped to [[60, 300]] (60s minimum to absorb clock skew at
+    the server, 300s maximum per the spec's server-side window). The PEM is read
+    from disk on every call — token mints are infrequent and keeping the key
+    off-heap reduces blast radius. *)

--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -147,7 +147,7 @@ let apply_poll_result t patch_id
             | Patch_decision.Cap_reached ->
                 log "CI failure cap reached (>=3) — skipping CI enqueue";
                 acc)
-        | Operation_kind.Review_comments ->
+        | Operation_kind.Review_comments | Operation_kind.Findings ->
             if is_new then
               log (Printf.sprintf "Enqueued %s" (Operation_kind.to_label kind));
             Orchestrator.enqueue acc patch_id kind

--- a/lib/project_store.ml
+++ b/lib/project_store.ml
@@ -48,6 +48,15 @@ let artifact_dir ~project_name ~patch_id =
 let pr_body_artifact_path ~project_name ~patch_id =
   Stdlib.Filename.concat (artifact_dir ~project_name ~patch_id) "pr-body.md"
 
+(** Absolute path the agent writes [findings_wontfix.json] to during a Findings
+    session. Lives alongside [pr-body.md] under [artifacts/<patch_id>/]. The
+    supervisor reads it after the session to decide which findings to POST as
+    ["wontfix"]; everything not listed is POSTed as ["addressed"]. *)
+let findings_wontfix_artifact_path ~project_name ~patch_id =
+  Stdlib.Filename.concat
+    (artifact_dir ~project_name ~patch_id)
+    "findings_wontfix.json"
+
 let ensure_dir path =
   let rec mkdir_p dir =
     if not (Stdlib.Sys.file_exists dir) then (

--- a/lib/project_store.mli
+++ b/lib/project_store.mli
@@ -74,6 +74,14 @@ val pr_body_artifact_path :
     project's data directory at [artifacts/<patch_id>/pr-body.md] — outside the
     worktree so it can never be accidentally committed. *)
 
+val findings_wontfix_artifact_path :
+  project_name:string -> patch_id:Types.Patch_id.t -> string
+(** Absolute path of the [findings_wontfix.json] artifact for a Findings
+    session. The agent writes a JSON list of [{id, reason}] for any finding it
+    has decided not to fix; the supervisor consumes it post-session and POSTs
+    the corresponding resolve verbs to the review backend. Findings not listed
+    here default to [addressed]. *)
+
 val project_exists : string -> bool
 (** Whether a project data directory with config exists. *)
 

--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -716,6 +716,74 @@ let render_review_prompt ~(project_name : string) ?agents_md ?pr_number
     ?agents_md ()
   ^ render_turn_layer_review ~project_name ?pr_number ?current_head_sha comments
 
+let render_turn_layer_findings ~(project_name : string) ?pr_number
+    ?current_head_sha ~artifact_path (findings : Review_service.finding list) :
+    string =
+  let _ = project_name in
+  let pr_num_str =
+    match pr_number with
+    | Some n -> Printf.sprintf "#%d" (Pr_number.to_int n)
+    | None -> "for this PR"
+  in
+  let sha_anchor =
+    match current_head_sha with
+    | Some sha ->
+        Printf.sprintf
+          "\n\n\
+           Note: review findings are anchored to specific commit SHAs (the \
+           [posting_sha] field below). The current HEAD is %s. If a finding's \
+           [posting_sha] differs from HEAD, the line numbers may have drifted \
+           — re-locate the issue by content, not by line number, before \
+           editing."
+          sha (* sha intentionally not abbreviated — exact value matters *)
+    | None -> ""
+  in
+  let formatted =
+    match findings with
+    | [] -> "No outstanding findings."
+    | _ ->
+        List.map findings ~f:(fun (f : Review_service.finding) ->
+            let lines =
+              if f.start_line = f.end_line then
+                Printf.sprintf "%s:%d" f.path f.start_line
+              else Printf.sprintf "%s:%d-%d" f.path f.start_line f.end_line
+            in
+            Printf.sprintf
+              "## [%s] finding %s\nanchor: %s\nposting_sha: %s\n\n%s"
+              (Review_service.severity_to_string f.severity)
+              f.id lines f.posting_sha f.body)
+        |> String.concat ~sep:"\n\n---\n\n"
+  in
+  Printf.sprintf
+    "You are reviewing pull request %s. The findings below come from a review \
+     service, not from GitHub review threads — there is no thread to reply to. \
+     To resolve a finding, you must EITHER (a) make code changes that address \
+     it, OR (b) explicitly mark it as wontfix in an artifact file.%s\n\n\
+     %s\n\n\
+     ## Resolving findings\n\
+     - For each finding you fix in code, do nothing extra: it will be reported \
+     back as `addressed` after this session.\n\
+     - For each finding you decide NOT to fix (out of scope, false positive, \
+     intentional, etc.), write an entry to the artifact file at `%s`. The \
+     supervisor reads it after this session and reports those findings as \
+     `wontfix`.\n\
+     - Artifact format: a JSON array of objects with required string field \
+     `id` (the finding's UUID) and required string field `reason`.\n\
+     - If you create or update the artifact, use the Write tool with the \
+     absolute path above (it is outside the worktree on purpose — do not \
+     commit it).\n\n\
+     After addressing the in-scope findings, commit your changes. The \
+     supervisor will push them for you — do not run `git push`."
+    pr_num_str sha_anchor formatted artifact_path
+
+let render_findings_prompt ~(project_name : string) ?agents_md ?pr_number
+    ?current_head_sha ?patch ?gameplan ?base_branch ~artifact_path
+    (findings : Review_service.finding list) : string =
+  layered_prefix ~project_name ?pr_number ?patch ?gameplan ?base_branch
+    ?agents_md ()
+  ^ render_turn_layer_findings ~project_name ?pr_number ?current_head_sha
+      ~artifact_path findings
+
 let render_turn_layer_ci ~(project_name : string) ?pr_number
     (checks : Ci_check.t list) : string =
   match checks with

--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -719,7 +719,6 @@ let render_review_prompt ~(project_name : string) ?agents_md ?pr_number
 let render_turn_layer_findings ~(project_name : string) ?pr_number
     ?current_head_sha ~artifact_path (findings : Review_service.finding list) :
     string =
-  let _ = project_name in
   let pr_num_str =
     match pr_number with
     | Some n -> Printf.sprintf "#%d" (Pr_number.to_int n)
@@ -754,27 +753,46 @@ let render_turn_layer_findings ~(project_name : string) ?pr_number
               f.id lines f.posting_sha f.body)
         |> String.concat ~sep:"\n\n---\n\n"
   in
-  Printf.sprintf
-    "You are reviewing pull request %s. The findings below come from a review \
-     service, not from GitHub review threads — there is no thread to reply to. \
-     To resolve a finding, you must EITHER (a) make code changes that address \
-     it, OR (b) explicitly mark it as wontfix in an artifact file.%s\n\n\
-     %s\n\n\
-     ## Resolving findings\n\
-     - For each finding you fix in code, do nothing extra: it will be reported \
-     back as `addressed` after this session.\n\
-     - For each finding you decide NOT to fix (out of scope, false positive, \
-     intentional, etc.), write an entry to the artifact file at `%s`. The \
-     supervisor reads it after this session and reports those findings as \
-     `wontfix`.\n\
-     - Artifact format: a JSON array of objects with required string field \
-     `id` (the finding's UUID) and required string field `reason`.\n\
-     - If you create or update the artifact, use the Write tool with the \
-     absolute path above (it is outside the worktree on purpose — do not \
-     commit it).\n\n\
-     After addressing the in-scope findings, commit your changes. The \
-     supervisor will push them for you — do not run `git push`."
-    pr_num_str sha_anchor formatted artifact_path
+  let vars =
+    [
+      ("project_name", project_name);
+      ("findings", formatted);
+      ("count", Int.to_string (List.length findings));
+      ( "pr_number",
+        match pr_number with
+        | Some n -> Int.to_string (Pr_number.to_int n)
+        | None -> "" );
+      ("pr_ref", pr_num_str);
+      ("current_head_sha", Option.value current_head_sha ~default:"");
+      ("sha_anchor", sha_anchor);
+      ("artifact_path", artifact_path);
+    ]
+  in
+  render_with_override ~project_name ~name:"turn_findings" ~vars
+    ~default:(fun () ->
+      Printf.sprintf
+        "You are reviewing pull request %s. The findings below come from a \
+         review service, not from GitHub review threads — there is no thread \
+         to reply to. To resolve a finding, you must EITHER (a) make code \
+         changes that address it, OR (b) explicitly mark it as wontfix in an \
+         artifact file.%s\n\n\
+         %s\n\n\
+         ## Resolving findings\n\
+         - For each finding you fix in code, do nothing extra: it will be \
+         reported back as `addressed` after this session.\n\
+         - For each finding you decide NOT to fix (out of scope, false \
+         positive, intentional, etc.), write an entry to the artifact file at \
+         `%s`. The supervisor reads it after this session and reports those \
+         findings as `wontfix`.\n\
+         - Artifact format: a JSON array of objects with required string field \
+         `id` (the composite finding id shown above) and required string field \
+         `reason`.\n\
+         - If you create or update the artifact, use the Write tool with the \
+         absolute path above (it is outside the worktree on purpose — do not \
+         commit it).\n\n\
+         After addressing the in-scope findings, commit your changes. The \
+         supervisor will push them for you — do not run `git push`."
+        pr_num_str sha_anchor formatted artifact_path)
 
 let render_findings_prompt ~(project_name : string) ?agents_md ?pr_number
     ?current_head_sha ?patch ?gameplan ?base_branch ~artifact_path

--- a/lib/prompt.mli
+++ b/lib/prompt.mli
@@ -124,6 +124,24 @@ val render_review_prompt :
   Comment.t list ->
   string
 
+val render_findings_prompt :
+  project_name:string ->
+  ?agents_md:string ->
+  ?pr_number:Pr_number.t ->
+  ?current_head_sha:string ->
+  ?patch:Patch.t ->
+  ?gameplan:Gameplan.t ->
+  ?base_branch:string ->
+  artifact_path:string ->
+  Review_service.finding list ->
+  string
+(** Findings session prompt. Renders each finding with its severity, anchor
+    (path:start_line-end_line), posting SHA, and body. Instructs the agent to
+    address findings via code edits and, for any finding it cannot or should not
+    fix, write a JSON list of [{id, reason}] objects to [artifact_path]
+    ([findings_wontfix.json]). Findings not listed in the artifact are POSTed as
+    [addressed] to the originating review backend after the session. *)
+
 val render_ci_failure_prompt :
   project_name:string ->
   ?agents_md:string ->

--- a/lib/review_service_client.ml
+++ b/lib/review_service_client.ml
@@ -34,6 +34,8 @@ let https_config () =
       | Ok cfg -> Ok cfg
       | Error (`Msg msg) -> Error ("TLS config failed: " ^ msg))
 
+let cached_https_config = lazy (https_config ())
+
 let https_fun tls_config uri flow =
   let host =
     match Uri.host uri with
@@ -72,68 +74,69 @@ let request ~net ~clock ~backend ~meth ~path ?body () : (string, error) Result.t
   | Ok token -> (
       try
         match
-          Eio.Time.with_timeout clock 30.0 (fun () ->
-              Ok
-                (match
-                   Result.map_error
-                     (fun msg -> Transport_error { meth = meth_s; url; msg })
-                     (https_config ())
-                 with
-                | Error _ as e -> e
-                | Ok tls_config ->
-                    let client =
-                      Cohttp_eio.Client.make
-                        ~https:(Some (https_fun tls_config))
-                        net
-                    in
-                    let uri = Uri.of_string url in
-                    let headers =
-                      Http.Header.of_list
-                        [
-                          ("Authorization", "Bearer " ^ token);
-                          ("Content-Type", "application/json");
-                          ("Accept", "application/json");
-                          ("User-Agent", "onton/0.1.0");
-                        ]
-                    in
-                    Eio.Switch.run @@ fun sw ->
-                    let resp, resp_body =
-                      match meth with
-                      | `GET -> Cohttp_eio.Client.get client ~sw ~headers uri
-                      | `POST ->
-                          let body =
-                            Cohttp_eio.Body.of_string
-                              (Option.value body ~default:"{}")
-                          in
-                          Cohttp_eio.Client.post client ~sw ~headers ~body uri
-                    in
-                    let status =
-                      Http.Response.status resp |> Http.Status.to_int
-                    in
-                    let resp_str =
-                      Eio.Buf_read.(
-                        of_flow ~max_size:max_response_size resp_body
-                        |> take_all)
-                    in
-                    if status >= 200 && status < 300 then Ok resp_str
-                    else
-                      let server_error =
-                        Onton_core.Review_service.parse_error_message resp_str
-                      in
-                      Error
-                        (Http_error
-                           {
-                             meth = meth_s;
-                             url;
-                             status;
-                             body = resp_str;
-                             server_error;
-                           })))
+          Result.map_error
+            (fun msg -> Transport_error { meth = meth_s; url; msg })
+            (Lazy.force cached_https_config)
         with
-        | Ok result -> result
-        | Error `Timeout ->
-            Error
-              (Transport_error { meth = meth_s; url; msg = "request timed out" })
+        | Error _ as e -> e
+        | Ok tls_config -> (
+            match
+              Eio.Time.with_timeout clock 30.0 (fun () ->
+                  Ok
+                    (let client =
+                       Cohttp_eio.Client.make
+                         ~https:(Some (https_fun tls_config))
+                         net
+                     in
+                     let uri = Uri.of_string url in
+                     let headers =
+                       Http.Header.of_list
+                         [
+                           ("Authorization", "Bearer " ^ token);
+                           ("Content-Type", "application/json");
+                           ("Accept", "application/json");
+                           ("User-Agent", "onton/0.1.0");
+                         ]
+                     in
+                     Eio.Switch.run @@ fun sw ->
+                     let resp, resp_body =
+                       match meth with
+                       | `GET -> Cohttp_eio.Client.get client ~sw ~headers uri
+                       | `POST ->
+                           let body =
+                             Cohttp_eio.Body.of_string
+                               (Option.value body ~default:"{}")
+                           in
+                           Cohttp_eio.Client.post client ~sw ~headers ~body uri
+                     in
+                     let status =
+                       Http.Response.status resp |> Http.Status.to_int
+                     in
+                     let resp_str =
+                       Eio.Buf_read.(
+                         of_flow ~max_size:max_response_size resp_body
+                         |> take_all)
+                     in
+                     if status >= 200 && status < 300 then Ok resp_str
+                     else
+                       let server_error =
+                         Onton_core.Review_service.parse_error_message resp_str
+                       in
+                       Error
+                         (Http_error
+                            {
+                              meth = meth_s;
+                              url;
+                              status;
+                              body = resp_str;
+                              server_error;
+                            })))
+            with
+            | Ok result -> result
+            | Error `Timeout ->
+                Error
+                  (Transport_error
+                     { meth = meth_s; url; msg = "request timed out" }))
       with
       | Eio.Cancel.Cancelled _ as exn -> raise exn
       | exn ->

--- a/lib/review_service_client.ml
+++ b/lib/review_service_client.ml
@@ -71,7 +71,6 @@ let request ~net ~clock ~backend ~meth ~path ?body () : (string, error) Result.t
   | Error e -> Error e
   | Ok token -> (
       try
-        Mirage_crypto_rng_unix.use_default ();
         match
           Result.map_error
             (fun msg -> Transport_error { meth = meth_s; url; msg })

--- a/lib/review_service_client.ml
+++ b/lib/review_service_client.ml
@@ -72,52 +72,74 @@ let request ~net ~clock ~backend ~meth ~path ?body () : (string, error) Result.t
   | Ok token -> (
       try
         match
-          Result.map_error
-            (fun msg -> Transport_error { meth = meth_s; url; msg })
-            (https_config ())
+          Eio.Time.with_timeout clock 30.0 (fun () ->
+              Ok
+                (match
+                   Result.map_error
+                     (fun msg -> Transport_error { meth = meth_s; url; msg })
+                     (https_config ())
+                 with
+                | Error _ as e -> e
+                | Ok tls_config ->
+                    let client =
+                      Cohttp_eio.Client.make
+                        ~https:(Some (https_fun tls_config))
+                        net
+                    in
+                    let uri = Uri.of_string url in
+                    let headers =
+                      Http.Header.of_list
+                        [
+                          ("Authorization", "Bearer " ^ token);
+                          ("Content-Type", "application/json");
+                          ("Accept", "application/json");
+                          ("User-Agent", "onton/0.1.0");
+                        ]
+                    in
+                    Eio.Switch.run @@ fun sw ->
+                    let resp, resp_body =
+                      match meth with
+                      | `GET -> Cohttp_eio.Client.get client ~sw ~headers uri
+                      | `POST ->
+                          let body =
+                            Cohttp_eio.Body.of_string
+                              (Option.value body ~default:"{}")
+                          in
+                          Cohttp_eio.Client.post client ~sw ~headers ~body uri
+                    in
+                    let status =
+                      Http.Response.status resp |> Http.Status.to_int
+                    in
+                    let resp_str =
+                      Eio.Buf_read.(
+                        of_flow ~max_size:max_response_size resp_body
+                        |> take_all)
+                    in
+                    if status >= 200 && status < 300 then Ok resp_str
+                    else
+                      let server_error =
+                        Onton_core.Review_service.parse_error_message resp_str
+                      in
+                      Error
+                        (Http_error
+                           {
+                             meth = meth_s;
+                             url;
+                             status;
+                             body = resp_str;
+                             server_error;
+                           })))
         with
-        | Error _ as e -> e
-        | Ok tls_config ->
-            let client =
-              Cohttp_eio.Client.make ~https:(Some (https_fun tls_config)) net
-            in
-            let uri = Uri.of_string url in
-            let headers =
-              Http.Header.of_list
-                [
-                  ("Authorization", "Bearer " ^ token);
-                  ("Content-Type", "application/json");
-                  ("Accept", "application/json");
-                  ("User-Agent", "onton/0.1.0");
-                ]
-            in
-            Eio.Switch.run @@ fun sw ->
-            let resp, resp_body =
-              match meth with
-              | `GET -> Cohttp_eio.Client.get client ~sw ~headers uri
-              | `POST ->
-                  let body =
-                    Cohttp_eio.Body.of_string (Option.value body ~default:"{}")
-                  in
-                  Cohttp_eio.Client.post client ~sw ~headers ~body uri
-            in
-            let status = Http.Response.status resp |> Http.Status.to_int in
-            let resp_str =
-              Eio.Buf_read.(
-                of_flow ~max_size:max_response_size resp_body |> take_all)
-            in
-            if status >= 200 && status < 300 then Ok resp_str
-            else
-              let server_error =
-                Onton_core.Review_service.parse_error_message resp_str
-              in
-              Error
-                (Http_error
-                   { meth = meth_s; url; status; body = resp_str; server_error })
-      with exn ->
-        Error
-          (Transport_error { meth = meth_s; url; msg = Printexc.to_string exn })
-      )
+        | Ok result -> result
+        | Error `Timeout ->
+            Error
+              (Transport_error { meth = meth_s; url; msg = "request timed out" })
+      with
+      | Eio.Cancel.Cancelled _ as exn -> raise exn
+      | exn ->
+          Error
+            (Transport_error
+               { meth = meth_s; url; msg = Printexc.to_string exn }))
 
 let url_encode s = Uri.pct_encode ~component:`Path s
 

--- a/lib/review_service_client.ml
+++ b/lib/review_service_client.ml
@@ -1,0 +1,163 @@
+type error =
+  | Auth_error of Jwt.error
+  | Transport_error of { meth : string; url : string; msg : string }
+  | Http_error of {
+      meth : string;
+      url : string;
+      status : int;
+      body : string;
+      server_error : string option;
+    }
+  | Parse_error of string
+
+let show_error = function
+  | Auth_error e -> Jwt.show_error e
+  | Transport_error { meth; url; msg } ->
+      Printf.sprintf "review-service %s %s — transport error: %s" meth url msg
+  | Http_error { meth; url; status; body; server_error } ->
+      let suffix =
+        match server_error with
+        | Some s -> Printf.sprintf " — server says: %s" s
+        | None when String.length body > 0 -> Printf.sprintf " — body: %s" body
+        | None -> ""
+      in
+      Printf.sprintf "review-service %s %s — HTTP %d%s" meth url status suffix
+  | Parse_error msg -> Printf.sprintf "review-service: parse error: %s" msg
+
+let max_response_size = 1_000_000
+
+let https_config () =
+  match Ca_certs.authenticator () with
+  | Error (`Msg msg) -> Error ("TLS CA setup failed: " ^ msg)
+  | Ok authenticator -> (
+      match Tls.Config.client ~authenticator () with
+      | Ok cfg -> Ok cfg
+      | Error (`Msg msg) -> Error ("TLS config failed: " ^ msg))
+
+let https_fun tls_config uri flow =
+  let host =
+    match Uri.host uri with
+    | None -> None
+    | Some h -> (
+        try Some Domain_name.(of_string_exn h |> host_exn) with _ -> None)
+  in
+  (Tls_eio.client_of_flow tls_config ?host flow :> _ Eio.Flow.two_way)
+
+let backend_base_url (b : Onton_core.Review_backend.t) =
+  match b.kind with
+  | Onton_core.Review_backend.Review_service { base_url; _ } -> base_url
+
+let backend_auth (b : Onton_core.Review_backend.t) =
+  match b.kind with
+  | Onton_core.Review_backend.Review_service { auth; _ } -> auth
+
+let mint_token ~clock backend : (string, error) Result.t =
+  let auth = backend_auth backend in
+  let now = Eio.Time.now clock in
+  match
+    Jwt.mint ~now ~app_id:auth.app_id ~private_key_path:auth.private_key_path
+      ~ttl_seconds:120
+  with
+  | Ok t -> Ok t
+  | Error e -> Error (Auth_error e)
+
+let meth_to_string = function `GET -> "GET" | `POST -> "POST"
+
+let request ~net ~clock ~backend ~meth ~path ?body () : (string, error) Result.t
+    =
+  let meth_s = meth_to_string meth in
+  let url = backend_base_url backend ^ path in
+  match mint_token ~clock backend with
+  | Error e -> Error e
+  | Ok token -> (
+      try
+        Mirage_crypto_rng_unix.use_default ();
+        match
+          Result.map_error
+            (fun msg -> Transport_error { meth = meth_s; url; msg })
+            (https_config ())
+        with
+        | Error _ as e -> e
+        | Ok tls_config ->
+            let client =
+              Cohttp_eio.Client.make ~https:(Some (https_fun tls_config)) net
+            in
+            let uri = Uri.of_string url in
+            let headers =
+              Http.Header.of_list
+                [
+                  ("Authorization", "Bearer " ^ token);
+                  ("Content-Type", "application/json");
+                  ("Accept", "application/json");
+                  ("User-Agent", "onton/0.1.0");
+                ]
+            in
+            Eio.Switch.run @@ fun sw ->
+            let resp, resp_body =
+              match meth with
+              | `GET -> Cohttp_eio.Client.get client ~sw ~headers uri
+              | `POST ->
+                  let body =
+                    Cohttp_eio.Body.of_string (Option.value body ~default:"{}")
+                  in
+                  Cohttp_eio.Client.post client ~sw ~headers ~body uri
+            in
+            let status = Http.Response.status resp |> Http.Status.to_int in
+            let resp_str =
+              Eio.Buf_read.(
+                of_flow ~max_size:max_response_size resp_body |> take_all)
+            in
+            if status >= 200 && status < 300 then Ok resp_str
+            else
+              let server_error =
+                Onton_core.Review_service.parse_error_message resp_str
+              in
+              Error
+                (Http_error
+                   { meth = meth_s; url; status; body = resp_str; server_error })
+      with exn ->
+        Error
+          (Transport_error { meth = meth_s; url; msg = Printexc.to_string exn })
+      )
+
+let url_encode s = Uri.pct_encode ~component:`Path s
+
+let findings_path ~owner ~repo ~pr_number =
+  Printf.sprintf "/prs/%s/%s/%d/findings?status=unresolved" (url_encode owner)
+    (url_encode repo) pr_number
+
+let resolve_path ~owner ~repo ~pr_number ~finding_id =
+  Printf.sprintf "/prs/%s/%s/%d/findings/%s/resolve" (url_encode owner)
+    (url_encode repo) pr_number (url_encode finding_id)
+
+let list_findings ~net ~clock ~backend ~owner ~repo ~pr_number () =
+  match
+    request ~net ~clock ~backend ~meth:`GET
+      ~path:(findings_path ~owner ~repo ~pr_number)
+      ()
+  with
+  | Error _ as e -> e
+  | Ok body -> (
+      match Onton_core.Review_service.parse_findings_response_string body with
+      | Ok r -> Ok r
+      | Error msg -> Error (Parse_error msg))
+
+let mark_resolved ~net ~clock ~backend ~owner ~repo ~pr_number ~finding_id ~kind
+    ?actor ?reason () =
+  let req : Onton_core.Review_service.resolve_request =
+    { kind; actor; reason }
+  in
+  let body =
+    Yojson.Safe.to_string
+      (Onton_core.Review_service.resolve_request_to_yojson req)
+  in
+  match
+    request ~net ~clock ~backend ~meth:`POST
+      ~path:(resolve_path ~owner ~repo ~pr_number ~finding_id)
+      ~body ()
+  with
+  | Error _ as e -> e
+  | Ok body -> (
+      match Onton_core.Review_service.parse_resolve_response_string body with
+      | Ok r -> Ok r
+      | Error msg -> Error (Parse_error msg))

--- a/lib/review_service_client.mli
+++ b/lib/review_service_client.mli
@@ -1,0 +1,58 @@
+(** Effectful HTTP client for the review-service backend.
+
+    Pairs with {!Onton_core.Review_service} (pure parsers) and {!Jwt} (token
+    minter). Each call mints a fresh JWT, hits the configured backend over
+    HTTPS, and returns either the parsed response or a structured error. *)
+
+type error =
+  | Auth_error of Jwt.error
+      (** JWT minting failed (key file missing, bad PEM, sign error). *)
+  | Transport_error of { meth : string; url : string; msg : string }
+      (** Network/TLS layer failure. *)
+  | Http_error of {
+      meth : string;
+      url : string;
+      status : int;
+      body : string;
+      server_error : string option;
+    }
+      (** Non-2xx response. [server_error] is the [error] field decoded from the
+          body when the server returned the spec's error envelope. *)
+  | Parse_error of string
+      (** 2xx response but the body did not decode as the expected shape. *)
+
+val show_error : error -> string
+
+val list_findings :
+  net:_ Eio.Net.t ->
+  clock:_ Eio.Time.clock ->
+  backend:Onton_core.Review_backend.t ->
+  owner:string ->
+  repo:string ->
+  pr_number:int ->
+  unit ->
+  (Onton_core.Review_service.findings_response, error) Stdlib.Result.t
+(** [list_findings ~net ~clock ~backend ~owner ~repo ~pr_number ()] performs
+    [GET /prs/:owner/:repo/:pr_number/findings?status=unresolved] against the
+    configured backend. Status filter is fixed to [unresolved] — the poller only
+    cares about findings the agent has not yet acted on. *)
+
+val mark_resolved :
+  net:_ Eio.Net.t ->
+  clock:_ Eio.Time.clock ->
+  backend:Onton_core.Review_backend.t ->
+  owner:string ->
+  repo:string ->
+  pr_number:int ->
+  finding_id:string ->
+  kind:Onton_core.Review_service.resolve_kind ->
+  ?actor:string ->
+  ?reason:string ->
+  unit ->
+  (Onton_core.Review_service.resolve_response, error) Stdlib.Result.t
+(** [mark_resolved … ~kind …] performs
+    [POST /prs/:owner/:repo/:pr_number/findings/:finding_id/resolve] with a body
+    of [{kind, actor?, reason?}]. The server is idempotent — repeated calls on
+    an already-resolved finding return the current outcome rather than failing.
+    The caller should trust [resolve_response.outcome] over the requested
+    [kind]. *)

--- a/lib/session_driver.ml
+++ b/lib/session_driver.ml
@@ -512,9 +512,9 @@ let run ~(kind : Types.Operation_kind.t option) ~runtime ~process_mgr ~clock ~fs
           let no_commits_is_ok =
             match kind with
             | Some Types.Operation_kind.Human -> true
+            | Some Types.Operation_kind.Findings -> true
             | Some Types.Operation_kind.Ci
             | Some Types.Operation_kind.Review_comments
-            | Some Types.Operation_kind.Findings
             | Some Types.Operation_kind.Pr_body
             | Some Types.Operation_kind.Merge_conflict
             | Some Types.Operation_kind.Rebase

--- a/lib/session_driver.ml
+++ b/lib/session_driver.ml
@@ -223,6 +223,7 @@ let run ~(kind : Types.Operation_kind.t option) ~runtime ~process_mgr ~clock ~fs
                         patch_id)
               | Some Types.Operation_kind.Ci
               | Some Types.Operation_kind.Review_comments
+              | Some Types.Operation_kind.Findings
               | Some Types.Operation_kind.Pr_body
               | Some Types.Operation_kind.Merge_conflict
               | Some Types.Operation_kind.Rebase
@@ -513,6 +514,7 @@ let run ~(kind : Types.Operation_kind.t option) ~runtime ~process_mgr ~clock ~fs
             | Some Types.Operation_kind.Human -> true
             | Some Types.Operation_kind.Ci
             | Some Types.Operation_kind.Review_comments
+            | Some Types.Operation_kind.Findings
             | Some Types.Operation_kind.Pr_body
             | Some Types.Operation_kind.Merge_conflict
             | Some Types.Operation_kind.Rebase

--- a/lib/term.ml
+++ b/lib/term.ml
@@ -534,7 +534,8 @@ module Key_io = struct
               if n = 0 then None else Some (Bytes.get buf 0)
             with _ -> None))
 
-  (** Read bracketed paste content until ESC[201~ (paste end). *)
+  (** Read bracketed paste content until the paste-end CSI sequence
+      ([ESC\[201~]). *)
   let read_bracketed_paste () =
     let buf = Buffer.create 256 in
     let rec consume () =

--- a/lib/tui.ml
+++ b/lib/tui.ml
@@ -14,6 +14,7 @@ type display_status = Display_status.t =
   | Approved_running
   | Fixing_ci
   | Addressing_review
+  | Addressing_findings
   | Resolving_conflict
   | Responding_to_human
   | Writing_pr_body
@@ -22,6 +23,7 @@ type display_status = Display_status.t =
   | Updating
   | Ci_queued
   | Review_queued
+  | Findings_queued
   | Awaiting_ci
   | Awaiting_review
   | Blocked_by_dep
@@ -38,6 +40,7 @@ let label = function
   | Approved_running -> "approved-running"
   | Fixing_ci -> "fixing-ci"
   | Addressing_review -> "addressing-review"
+  | Addressing_findings -> "addressing-findings"
   | Resolving_conflict -> "resolving-conflict"
   | Responding_to_human -> "responding-to-human"
   | Writing_pr_body -> "writing-pr-body"
@@ -46,6 +49,7 @@ let label = function
   | Updating -> "updating"
   | Ci_queued -> "ci-queued"
   | Review_queued -> "review-queued"
+  | Findings_queued -> "findings-queued"
   | Awaiting_ci -> "awaiting-ci"
   | Awaiting_review -> "awaiting-review"
   | Blocked_by_dep -> "blocked-by-dep"
@@ -58,6 +62,7 @@ let color = function
   | Approved_running -> Term.Sgr.fg_cyan
   | Fixing_ci -> Term.Sgr.fg_yellow
   | Addressing_review -> Term.Sgr.fg_yellow
+  | Addressing_findings -> Term.Sgr.fg_yellow
   | Resolving_conflict -> Term.Sgr.fg_yellow
   | Responding_to_human -> Term.Sgr.fg_magenta
   | Writing_pr_body -> Term.Sgr.fg_cyan
@@ -66,6 +71,7 @@ let color = function
   | Updating -> Term.Sgr.fg_cyan
   | Ci_queued -> Term.Sgr.fg_yellow
   | Review_queued -> Term.Sgr.fg_yellow
+  | Findings_queued -> Term.Sgr.fg_yellow
   | Awaiting_ci -> Term.Sgr.fg_blue
   | Awaiting_review -> Term.Sgr.fg_blue
   | Blocked_by_dep -> Term.Sgr.fg_blue
@@ -149,12 +155,12 @@ let status_style = function
   | Needs_help -> [ Term.Sgr.fg_red; Term.Sgr.bold ]
   | Approved_idle -> [ Term.Sgr.fg_green ]
   | Approved_running -> [ Term.Sgr.fg_green; Term.Sgr.bold ]
-  | Fixing_ci | Addressing_review | Resolving_conflict | Responding_to_human
-  | Writing_pr_body ->
+  | Fixing_ci | Addressing_review | Addressing_findings | Resolving_conflict
+  | Responding_to_human | Writing_pr_body ->
       [ Term.Sgr.fg_cyan; Term.Sgr.bold ]
   | Rebasing -> [ Term.Sgr.fg_yellow ]
   | Starting | Updating -> [ Term.Sgr.fg_cyan ]
-  | Ci_queued | Review_queued -> [ Term.Sgr.fg_yellow ]
+  | Ci_queued | Review_queued | Findings_queued -> [ Term.Sgr.fg_yellow ]
   | Awaiting_ci -> [ Term.Sgr.fg_blue ]
   | Awaiting_review -> [ Term.Sgr.fg_blue ]
   | Blocked_by_dep -> [ Term.Sgr.fg_blue ]
@@ -165,12 +171,12 @@ let status_indicator = function
   | Needs_help -> "!"
   | Approved_idle -> "✓"
   | Approved_running -> "▶"
-  | Fixing_ci | Addressing_review | Resolving_conflict | Responding_to_human
-  | Writing_pr_body ->
+  | Fixing_ci | Addressing_review | Addressing_findings | Resolving_conflict
+  | Responding_to_human | Writing_pr_body ->
       "▶"
   | Rebasing -> "↻"
   | Starting | Updating -> "▶"
-  | Ci_queued | Review_queued -> "◎"
+  | Ci_queued | Review_queued | Findings_queued -> "◎"
   | Awaiting_ci | Awaiting_review -> "◎"
   | Blocked_by_dep -> "◎"
   | Pending -> "·"
@@ -432,11 +438,13 @@ let render_status_badge ?(queued = false) status =
   styled_status status (Printf.sprintf "%s %s%s" ind lbl suffix)
 
 let is_running_status = function
-  | Fixing_ci | Addressing_review | Resolving_conflict | Responding_to_human
-  | Writing_pr_body | Rebasing | Starting | Updating | Approved_running ->
+  | Fixing_ci | Addressing_review | Addressing_findings | Resolving_conflict
+  | Responding_to_human | Writing_pr_body | Rebasing | Starting | Updating
+  | Approved_running ->
       true
   | Merged | Needs_help | Approved_idle | Ci_queued | Review_queued
-  | Awaiting_ci | Awaiting_review | Blocked_by_dep | Pending ->
+  | Findings_queued | Awaiting_ci | Awaiting_review | Blocked_by_dep | Pending
+    ->
       false
 
 (** {1 Frame rendering} *)
@@ -464,6 +472,7 @@ let render_header ~project_name ~width =
 let short_op_name = function
   | Operation_kind.Ci -> "ci"
   | Operation_kind.Review_comments -> "review"
+  | Operation_kind.Findings -> "findings"
   | Operation_kind.Merge_conflict -> "conflict"
   | Operation_kind.Human -> "human"
   | Operation_kind.Pr_body -> "pr-body"

--- a/lib/tui.mli
+++ b/lib/tui.mli
@@ -13,6 +13,7 @@ type display_status = Display_status.t =
   | Approved_running
   | Fixing_ci
   | Addressing_review
+  | Addressing_findings
   | Resolving_conflict
   | Responding_to_human
   | Writing_pr_body
@@ -21,6 +22,7 @@ type display_status = Display_status.t =
   | Updating
   | Ci_queued
   | Review_queued
+  | Findings_queued
   | Awaiting_ci
   | Awaiting_review
   | Blocked_by_dep

--- a/lib_core/display_status.ml
+++ b/lib_core/display_status.ml
@@ -16,6 +16,7 @@ type t =
   | Approved_running
   | Fixing_ci
   | Addressing_review
+  | Addressing_findings
   | Resolving_conflict
   | Responding_to_human
   | Writing_pr_body
@@ -24,6 +25,7 @@ type t =
   | Updating
   | Ci_queued
   | Review_queued
+  | Findings_queued
   | Awaiting_ci
   | Awaiting_review
   | Blocked_by_dep
@@ -51,6 +53,7 @@ let derive (ctx : State.Patch_ctx.t) ~patch_id
     match current_op with
     | Some Ci -> Fixing_ci
     | Some Review_comments -> Addressing_review
+    | Some Findings -> Addressing_findings
     | Some Merge_conflict -> Resolving_conflict
     | Some Human -> Responding_to_human
     | Some Pr_body -> Writing_pr_body
@@ -62,6 +65,8 @@ let derive (ctx : State.Patch_ctx.t) ~patch_id
     else if State.Patch_ctx.is_queued ctx ~patch_id ~kind:Ci then Ci_queued
     else if State.Patch_ctx.is_queued ctx ~patch_id ~kind:Review_comments then
       Review_queued
+    else if State.Patch_ctx.is_queued ctx ~patch_id ~kind:Findings then
+      Findings_queued
     else if State.Patch_ctx.ci_failure_count ctx ~patch_id > 0 then Awaiting_ci
     else Awaiting_review
   else Pending

--- a/lib_core/patch_decision.ml
+++ b/lib_core/patch_decision.ml
@@ -31,7 +31,7 @@ let disposition (a : Patch_agent.t) : disposition =
         | Operation_kind.Rebase -> Ready_rebase
         | Operation_kind.Human | Operation_kind.Merge_conflict
         | Operation_kind.Ci | Operation_kind.Review_comments
-        | Operation_kind.Pr_body ->
+        | Operation_kind.Findings | Operation_kind.Pr_body ->
             Ready_respond k)
 
 type ci_decision =
@@ -99,6 +99,10 @@ type delivery_payload =
   | Human_payload of { messages : string list }
   | Ci_payload of { failed_checks : Ci_check.t list }
   | Review_payload of { comments : Comment.t list }
+  | Findings_payload of { findings : Review_service.finding list }
+      (** Review-service findings (see {!Review_backend}). The runner
+          materialises these into the agent's prompt and posts resolve verbs
+          back to the originating backend after the session completes. *)
   | Pr_body_payload
   | Merge_conflict_payload
 [@@deriving show, eq, sexp_of, compare]
@@ -124,8 +128,9 @@ let filter_undelivered_ci_failures (agent : Patch_agent.t) : Ci_check.t list =
 
 let respond_delivery ~(agent : Patch_agent.t) ~(kind : Operation_kind.t)
     ~(pre_fire_agent : Patch_agent.t option)
-    ~(prefetched_comments : Comment.t list) ~(main_branch : string) :
-    respond_delivery =
+    ~(prefetched_comments : Comment.t list)
+    ~(prefetched_findings : Review_service.finding list) ~(main_branch : string)
+    : respond_delivery =
   if
     agent.merged
     || Patch_agent.needs_intervention agent
@@ -141,6 +146,7 @@ let respond_delivery ~(agent : Patch_agent.t) ~(kind : Operation_kind.t)
     let is_empty =
       match kind with
       | Operation_kind.Review_comments -> List.is_empty prefetched_comments
+      | Operation_kind.Findings -> List.is_empty prefetched_findings
       | Operation_kind.Human -> List.is_empty source.human_messages
       | Operation_kind.Ci ->
           (* Freshness is the caller's responsibility: it re-polls GitHub
@@ -177,6 +183,8 @@ let respond_delivery ~(agent : Patch_agent.t) ~(kind : Operation_kind.t)
         | Operation_kind.Ci -> Ci_payload { failed_checks = ci_undelivered }
         | Operation_kind.Review_comments ->
             Review_payload { comments = prefetched_comments }
+        | Operation_kind.Findings ->
+            Findings_payload { findings = prefetched_findings }
         | Operation_kind.Pr_body -> Pr_body_payload
         | Operation_kind.Merge_conflict -> Merge_conflict_payload
         | Operation_kind.Rebase ->
@@ -256,7 +264,7 @@ let plan_artifact_sync ~(kind : Operation_kind.t) ~(session_ok : bool)
     | Operation_kind.Pr_body -> Sync_skip
     | Operation_kind.Rebase | Operation_kind.Human
     | Operation_kind.Merge_conflict | Operation_kind.Ci
-    | Operation_kind.Review_comments ->
+    | Operation_kind.Review_comments | Operation_kind.Findings ->
         if pr_body_artifact_changed ~pre ~post then Sync_attempt_pr_body
         else Sync_skip
 

--- a/lib_core/patch_decision.mli
+++ b/lib_core/patch_decision.mli
@@ -80,6 +80,10 @@ type delivery_payload =
   | Human_payload of { messages : string list }
   | Ci_payload of { failed_checks : Ci_check.t list }
   | Review_payload of { comments : Comment.t list }
+  | Findings_payload of { findings : Review_service.finding list }
+      (** Review-service findings — distinct from GitHub review comments.
+          Carries the data needed both for prompting the agent and (after the
+          session) issuing resolve verbs back to the originating backend. *)
   | Pr_body_payload
   | Merge_conflict_payload
 [@@deriving show, eq, sexp_of, compare]
@@ -95,6 +99,7 @@ val respond_delivery :
   kind:Operation_kind.t ->
   pre_fire_agent:Patch_agent.t option ->
   prefetched_comments:Comment.t list ->
+  prefetched_findings:Review_service.finding list ->
   main_branch:string ->
   respond_delivery
 (** Pure pre-session decision for Respond actions. Determines whether the

--- a/lib_core/poller.ml
+++ b/lib_core/poller.ml
@@ -16,12 +16,16 @@ type t = {
 
 let poll ~was_merged (pr : Pr_state.t) =
   let unresolved = not (List.is_empty pr.comments) in
+  let has_findings = not (List.is_empty pr.findings) in
   let queue =
     let acc = [] in
     (* world-has-comment c p and ~resolved c -> queue' p review-comments *)
     let acc =
       if unresolved then Operation_kind.Review_comments :: acc else acc
     in
+    (* world-has-finding f p -> queue' p findings.
+       Mirror of the comment rule, but for review-service backends. *)
+    let acc = if has_findings then Operation_kind.Findings :: acc else acc in
     (* world-has-conflict p -> queue' p merge-conflict *)
     let acc =
       if Pr_state.has_conflict pr then Operation_kind.Merge_conflict :: acc

--- a/lib_core/pr_state.ml
+++ b/lib_core/pr_state.ml
@@ -14,6 +14,12 @@ type t = {
   ci_checks_truncated : bool;
   comments : Types.Comment.t list;
   unresolved_comment_count : int;
+  findings : Review_service.finding list;
+      (** Unresolved findings from review-service backends, merged across all
+          configured sources. Empty when no review backends are configured or
+          all returned empty. Distinct from [comments] (GitHub review threads)
+          because the agent's resolution surface differs — see
+          {!Operation_kind.Findings}. *)
   head_branch : Types.Branch.t option;
   head_oid : string option;
   base_branch : Types.Branch.t option;

--- a/lib_core/pr_state.mli
+++ b/lib_core/pr_state.mli
@@ -20,6 +20,7 @@ type t = {
   ci_checks_truncated : bool;
   comments : Comment.t list;
   unresolved_comment_count : int;
+  findings : Review_service.finding list;
   head_branch : Branch.t option;
   head_oid : string option;
   base_branch : Branch.t option;

--- a/lib_core/priority.ml
+++ b/lib_core/priority.ml
@@ -9,11 +9,13 @@ let priority (k : Ok.t) : int =
   | Ok.Merge_conflict -> 2
   | Ok.Ci -> 3
   | Ok.Review_comments -> 4
-  | Ok.Pr_body -> 5
+  | Ok.Findings -> 5
+  | Ok.Pr_body -> 6
 
 let is_feedback (k : Ok.t) : bool =
   match k with
-  | Ok.Human | Ok.Merge_conflict | Ok.Ci | Ok.Review_comments | Ok.Pr_body ->
+  | Ok.Human | Ok.Merge_conflict | Ok.Ci | Ok.Review_comments | Ok.Findings
+  | Ok.Pr_body ->
       true
   | Ok.Rebase -> false
 

--- a/lib_core/reconciler.ml
+++ b/lib_core/reconciler.ml
@@ -127,7 +127,7 @@ let plan_operations views ~has_merged ~branch_of ~graph ~main =
                     Some (merge_target graph v.id ~has_merged ~branch_of ~main)
               | Operation_kind.Human | Operation_kind.Merge_conflict
               | Operation_kind.Ci | Operation_kind.Review_comments
-              | Operation_kind.Pr_body ->
+              | Operation_kind.Findings | Operation_kind.Pr_body ->
                   None
             in
             if

--- a/lib_core/repo_config.ml
+++ b/lib_core/repo_config.ml
@@ -1,9 +1,13 @@
 open Base
 
 type route = { backend : string; model : string option }
-type t = { complexity_routes : (int * route) list }
 
-let empty = { complexity_routes = [] }
+type t = {
+  complexity_routes : (int * route) list;
+  review_backends : Review_backend.t list;
+}
+
+let empty = { complexity_routes = []; review_backends = [] }
 let config_path ~config_dir = Stdlib.Filename.concat config_dir "config.json"
 
 let parse_route ~known_backends ~complexity (json : Yojson.Safe.t) :
@@ -84,7 +88,11 @@ let parse_routing ~known_backends (json : Yojson.Safe.t) :
         ("routing must be an object mapping complexity -> {backend, model};"
        ^ " got " ^ Yojson.Safe.to_string json)
 
-let parse_string ~known_backends (raw : string) : (t, string) Result.t =
+let default_known_review_kinds = [ "review-service" ]
+
+let parse_string ~known_backends
+    ?(known_review_kinds = default_known_review_kinds) (raw : string) :
+    (t, string) Result.t =
   match
     try Ok (Yojson.Safe.from_string raw)
     with Yojson.Json_error msg -> Error (Printf.sprintf "config.json: %s" msg)
@@ -95,11 +103,15 @@ let parse_string ~known_backends (raw : string) : (t, string) Result.t =
       match json with
       | `Assoc _ ->
           let routing = member "routing" json in
-          Result.map (parse_routing ~known_backends routing) ~f:(fun routes ->
-              { complexity_routes = routes })
+          let review_backends_json = member "reviewBackends" json in
+          Result.bind (parse_routing ~known_backends routing) ~f:(fun routes ->
+              Result.map
+                (Review_backend.parse_array ~known_kinds:known_review_kinds
+                   review_backends_json) ~f:(fun review_backends ->
+                  { complexity_routes = routes; review_backends }))
       | _ -> Error "config.json: top-level value must be an object")
 
-let load ~config_dir ~known_backends =
+let load ~config_dir ~known_backends ?known_review_kinds () =
   let path = config_path ~config_dir in
   if not (Stdlib.Sys.file_exists path) then Ok empty
   else
@@ -110,7 +122,7 @@ let load ~config_dir ~known_backends =
           ~finally:(fun () -> Stdlib.In_channel.close ic)
           ~f:(fun () -> Stdlib.In_channel.input_all ic)
       in
-      parse_string ~known_backends raw
+      parse_string ~known_backends ?known_review_kinds raw
     with Sys_error msg ->
       Error (Printf.sprintf "config.json: cannot read: %s" msg)
 
@@ -225,4 +237,41 @@ let%test "parse_string: duplicate complexity keys rejected" =
   in
   match parse_string ~known_backends:[ "claude"; "codex" ] raw with
   | Error msg -> String.is_substring msg ~substring:"duplicated"
+  | Ok _ -> false
+
+let%test "parse_string: reviewBackends parse alongside routing" =
+  let raw =
+    {|{
+       "routing":{"1":{"backend":"claude"}},
+       "reviewBackends":[
+         {"name":"primary","kind":"review-service","baseUrl":"https://r.example.com","auth":{"appId":"1","privateKeyPath":"/k"}}
+       ]
+     }|}
+  in
+  match parse_string ~known_backends:[ "claude" ] raw with
+  | Ok t ->
+      List.length t.complexity_routes = 1
+      && List.length t.review_backends = 1
+      && String.equal (List.hd_exn t.review_backends).name "primary"
+  | Error _ -> false
+
+let%test "parse_string: reviewBackends absent -> empty list" =
+  let raw = {|{"routing":{"1":{"backend":"claude"}}}|} in
+  match parse_string ~known_backends:[ "claude" ] raw with
+  | Ok t -> List.is_empty t.review_backends
+  | Error _ -> false
+
+let%test "parse_string: reviewBackends-only config" =
+  let raw =
+    {|{"reviewBackends":[{"name":"a","kind":"review-service","baseUrl":"https://x","auth":{"appId":"1","privateKeyPath":"/k"}}]}|}
+  in
+  match parse_string ~known_backends:[ "claude" ] raw with
+  | Ok t ->
+      List.is_empty t.complexity_routes && List.length t.review_backends = 1
+  | Error _ -> false
+
+let%test "parse_string: invalid reviewBackends propagates as Error" =
+  let raw = {|{"reviewBackends":[{"name":"a","kind":"unknown"}]}|} in
+  match parse_string ~known_backends:[ "claude" ] raw with
+  | Error msg -> String.is_substring msg ~substring:"unknown"
   | Ok _ -> false

--- a/lib_core/repo_config.mli
+++ b/lib_core/repo_config.mli
@@ -24,13 +24,20 @@ type t = {
           the set is tiny and the lookup is per-patch — fast enough. Missing
           keys mean "no override", and the caller falls back to its default
           backend / built-in [auto_model] ladder. *)
+  review_backends : Review_backend.t list;
+      (** Additional review sources to poll alongside the forge. Empty (the
+          default) means GitHub review comments are the only source. *)
 }
 
 val empty : t
 (** Returned when [config.json] is absent — the no-op config. *)
 
 val load :
-  config_dir:string -> known_backends:string list -> (t, string) Stdlib.Result.t
+  config_dir:string ->
+  known_backends:string list ->
+  ?known_review_kinds:string list ->
+  unit ->
+  (t, string) Stdlib.Result.t
 (** Read and validate [<config_dir>/config.json]. [config_dir] should be the
     output of [User_config.config_dir ~github_owner ~github_repo] so the routing
     config lives alongside the [on_worktree_create] hook for the same repo.

--- a/lib_core/review_backend.ml
+++ b/lib_core/review_backend.ml
@@ -31,6 +31,12 @@ let parse_review_service_kind json : (kind, string) Result.t =
   let open Yojson.Safe.Util in
   let ( let* ) = Result.( >>= ) in
   let* base_url = string_field "baseUrl" json in
+  let base_url = strip_trailing_slashes base_url in
+  let* () =
+    if String.is_empty base_url then
+      Error "review-service \"baseUrl\" must not be empty"
+    else Ok ()
+  in
   let auth_json = json |> member "auth" in
   let* () =
     match auth_json with
@@ -40,12 +46,7 @@ let parse_review_service_kind json : (kind, string) Result.t =
   in
   let* app_id = string_field "appId" auth_json in
   let* private_key_path = string_field "privateKeyPath" auth_json in
-  Ok
-    (Review_service
-       {
-         base_url = strip_trailing_slashes base_url;
-         auth = { app_id; private_key_path };
-       })
+  Ok (Review_service { base_url; auth = { app_id; private_key_path } })
 
 let parse ~known_kinds json : (t, string) Result.t =
   let ( let* ) = Result.( >>= ) in
@@ -130,6 +131,16 @@ let%test "parse_array: trailing slash stripped" =
       | Review_service { base_url; _ } -> String.equal base_url "https://x")
   | Ok _ -> false
   | Error _ -> false
+
+let%test "parse_array: rejects all-slash baseUrl" =
+  let raw =
+    {|[{"name":"a","kind":"review-service","baseUrl":"///","auth":{"appId":"1","privateKeyPath":"/k"}}]|}
+  in
+  match
+    parse_array ~known_kinds:known_kind_default (Yojson.Safe.from_string raw)
+  with
+  | Error msg -> String.is_substring msg ~substring:"baseUrl"
+  | Ok _ -> false
 
 let%test "parse_array: rejects unknown kind" =
   let raw =

--- a/lib_core/review_backend.ml
+++ b/lib_core/review_backend.ml
@@ -1,0 +1,173 @@
+open Base
+
+type review_service_auth = { app_id : string; private_key_path : string }
+
+type kind =
+  | Review_service of { base_url : string; auth : review_service_auth }
+
+type t = { name : string; kind : kind }
+
+let known_kind_default = [ "review-service" ]
+
+let string_field field json : (string, string) Result.t =
+  let open Yojson.Safe.Util in
+  match json |> member field with
+  | `String s when not (String.is_empty (String.strip s)) -> Ok (String.strip s)
+  | `String _ -> Error (Printf.sprintf "%S must be a non-empty string" field)
+  | `Null -> Error (Printf.sprintf "missing required field %S" field)
+  | _ -> Error (Printf.sprintf "%S must be a string" field)
+
+let strip_trailing_slashes s =
+  let len = String.length s in
+  let rec last i =
+    if i <= 0 then i
+    else if Char.equal (String.get s (i - 1)) '/' then last (i - 1)
+    else i
+  in
+  let l = last len in
+  if l = len then s else String.sub s ~pos:0 ~len:l
+
+let parse_review_service_kind json : (kind, string) Result.t =
+  let open Yojson.Safe.Util in
+  let ( let* ) = Result.( >>= ) in
+  let* base_url = string_field "baseUrl" json in
+  let auth_json = json |> member "auth" in
+  let* () =
+    match auth_json with
+    | `Assoc _ -> Ok ()
+    | `Null -> Error "review-service backend missing required field \"auth\""
+    | _ -> Error "review-service \"auth\" must be an object"
+  in
+  let* app_id = string_field "appId" auth_json in
+  let* private_key_path = string_field "privateKeyPath" auth_json in
+  Ok
+    (Review_service
+       {
+         base_url = strip_trailing_slashes base_url;
+         auth = { app_id; private_key_path };
+       })
+
+let parse ~known_kinds json : (t, string) Result.t =
+  let ( let* ) = Result.( >>= ) in
+  match json with
+  | `Assoc _ ->
+      let* name = string_field "name" json in
+      let* kind_str = string_field "kind" json in
+      let* () =
+        if List.mem known_kinds kind_str ~equal:String.equal then Ok ()
+        else
+          Error
+            (Printf.sprintf
+               "reviewBackends[*].kind = %S is not a known kind (expected one \
+                of: %s)"
+               kind_str
+               (String.concat ~sep:", " known_kinds))
+      in
+      let* kind =
+        match kind_str with
+        | "review-service" -> parse_review_service_kind json
+        | other ->
+            (* Defensive — [known_kinds] is the authoritative gate, but if a
+               new kind is added to the gate without a parser, fail loud
+               instead of silently constructing garbage. *)
+            Error
+              (Printf.sprintf "reviewBackends[*].kind = %S has no parser" other)
+      in
+      Ok { name; kind }
+  | _ -> Error "reviewBackends[*] must be an object"
+
+let parse_array ~known_kinds json : (t list, string) Result.t =
+  match json with
+  | `Null -> Ok []
+  | `List entries ->
+      let rec loop acc seen = function
+        | [] -> Ok (List.rev acc)
+        | entry :: rest -> (
+            match parse ~known_kinds entry with
+            | Error _ as e -> e
+            | Ok t ->
+                if Set.mem seen t.name then
+                  Error
+                    (Printf.sprintf "reviewBackends contains duplicate name %S"
+                       t.name)
+                else loop (t :: acc) (Set.add seen t.name) rest)
+      in
+      loop [] (Set.empty (module String)) entries
+  | _ -> Error "reviewBackends must be an array"
+
+let%test "parse_array: null -> empty" =
+  match parse_array ~known_kinds:known_kind_default `Null with
+  | Ok [] -> true
+  | Ok _ -> false
+  | Error _ -> false
+
+let%test "parse_array: full review-service entry" =
+  let raw =
+    {|[{"name":"primary","kind":"review-service","baseUrl":"https://review.example.com/","auth":{"appId":"123","privateKeyPath":"/etc/onton/key.pem"}}]|}
+  in
+  match
+    parse_array ~known_kinds:known_kind_default (Yojson.Safe.from_string raw)
+  with
+  | Ok [ t ] -> (
+      match t.kind with
+      | Review_service { base_url; auth } ->
+          String.equal t.name "primary"
+          && String.equal base_url "https://review.example.com"
+          && String.equal auth.app_id "123"
+          && String.equal auth.private_key_path "/etc/onton/key.pem")
+  | Ok _ -> false
+  | Error _ -> false
+
+let%test "parse_array: trailing slash stripped" =
+  let raw =
+    {|[{"name":"a","kind":"review-service","baseUrl":"https://x///","auth":{"appId":"1","privateKeyPath":"/k"}}]|}
+  in
+  match
+    parse_array ~known_kinds:known_kind_default (Yojson.Safe.from_string raw)
+  with
+  | Ok [ t ] -> (
+      match t.kind with
+      | Review_service { base_url; _ } -> String.equal base_url "https://x")
+  | Ok _ -> false
+  | Error _ -> false
+
+let%test "parse_array: rejects unknown kind" =
+  let raw =
+    {|[{"name":"x","kind":"sonarqube","baseUrl":"https://y","auth":{"appId":"1","privateKeyPath":"/k"}}]|}
+  in
+  match
+    parse_array ~known_kinds:known_kind_default (Yojson.Safe.from_string raw)
+  with
+  | Error msg -> String.is_substring msg ~substring:"sonarqube"
+  | Ok _ -> false
+
+let%test "parse_array: rejects duplicate names" =
+  let raw =
+    {|[
+       {"name":"a","kind":"review-service","baseUrl":"https://x","auth":{"appId":"1","privateKeyPath":"/k"}},
+       {"name":"a","kind":"review-service","baseUrl":"https://y","auth":{"appId":"2","privateKeyPath":"/l"}}
+     ]|}
+  in
+  match
+    parse_array ~known_kinds:known_kind_default (Yojson.Safe.from_string raw)
+  with
+  | Error msg -> String.is_substring msg ~substring:"duplicate"
+  | Ok _ -> false
+
+let%test "parse_array: missing auth -> Error" =
+  let raw = {|[{"name":"a","kind":"review-service","baseUrl":"https://x"}]|} in
+  match
+    parse_array ~known_kinds:known_kind_default (Yojson.Safe.from_string raw)
+  with
+  | Error msg -> String.is_substring msg ~substring:"auth"
+  | Ok _ -> false
+
+let%test "parse_array: missing privateKeyPath -> Error" =
+  let raw =
+    {|[{"name":"a","kind":"review-service","baseUrl":"https://x","auth":{"appId":"1"}}]|}
+  in
+  match
+    parse_array ~known_kinds:known_kind_default (Yojson.Safe.from_string raw)
+  with
+  | Error msg -> String.is_substring msg ~substring:"privateKeyPath"
+  | Ok _ -> false

--- a/lib_core/review_backend.ml
+++ b/lib_core/review_backend.ml
@@ -56,6 +56,8 @@ let parse_review_service_kind json : (kind, string) Result.t =
       Error "review-service \"baseUrl\" must not be empty"
     else if not (has_authority base_url) then
       Error "review-service \"baseUrl\" must include a host/authority"
+    else if not (String.is_prefix base_url ~prefix:"https://") then
+      Error "review-service \"baseUrl\" must use https"
     else Ok ()
   in
   let auth_json = json |> member "auth" in
@@ -171,6 +173,16 @@ let%test "parse_array: rejects scheme-only baseUrl" =
     parse_array ~known_kinds:known_kind_default (Yojson.Safe.from_string raw)
   with
   | Error msg -> String.is_substring msg ~substring:"host/authority"
+  | Ok _ -> false
+
+let%test "parse_array: rejects non-https baseUrl" =
+  let raw =
+    {|[{"name":"a","kind":"review-service","baseUrl":"http://x","auth":{"appId":"1","privateKeyPath":"/k"}}]|}
+  in
+  match
+    parse_array ~known_kinds:known_kind_default (Yojson.Safe.from_string raw)
+  with
+  | Error msg -> String.is_substring msg ~substring:"https"
   | Ok _ -> false
 
 let%test "parse_array: rejects unknown kind" =

--- a/lib_core/review_backend.ml
+++ b/lib_core/review_backend.ml
@@ -27,6 +27,25 @@ let strip_trailing_slashes s =
   let l = last len in
   if l = len then s else String.sub s ~pos:0 ~len:l
 
+let has_authority base_url =
+  match String.substr_index base_url ~pattern:"://" with
+  | None -> false
+  | Some scheme_sep ->
+      let len = String.length base_url in
+      let start = scheme_sep + 3 in
+      let rec authority_end i =
+        if i >= len then i
+        else
+          match String.get base_url i with
+          | '/' | '?' | '#' -> i
+          | _ -> authority_end (i + 1)
+      in
+      let stop = authority_end start in
+      stop > start
+      && String.exists
+           (String.sub base_url ~pos:start ~len:(stop - start))
+           ~f:(fun c -> not (Char.equal c ':'))
+
 let parse_review_service_kind json : (kind, string) Result.t =
   let open Yojson.Safe.Util in
   let ( let* ) = Result.( >>= ) in
@@ -35,6 +54,8 @@ let parse_review_service_kind json : (kind, string) Result.t =
   let* () =
     if String.is_empty base_url then
       Error "review-service \"baseUrl\" must not be empty"
+    else if not (has_authority base_url) then
+      Error "review-service \"baseUrl\" must include a host/authority"
     else Ok ()
   in
   let auth_json = json |> member "auth" in
@@ -140,6 +161,16 @@ let%test "parse_array: rejects all-slash baseUrl" =
     parse_array ~known_kinds:known_kind_default (Yojson.Safe.from_string raw)
   with
   | Error msg -> String.is_substring msg ~substring:"baseUrl"
+  | Ok _ -> false
+
+let%test "parse_array: rejects scheme-only baseUrl" =
+  let raw =
+    {|[{"name":"a","kind":"review-service","baseUrl":"https://","auth":{"appId":"1","privateKeyPath":"/k"}}]|}
+  in
+  match
+    parse_array ~known_kinds:known_kind_default (Yojson.Safe.from_string raw)
+  with
+  | Error msg -> String.is_substring msg ~substring:"host/authority"
   | Ok _ -> false
 
 let%test "parse_array: rejects unknown kind" =

--- a/lib_core/review_backend.mli
+++ b/lib_core/review_backend.mli
@@ -1,0 +1,45 @@
+(** Configured review-source the poller queries in addition to the forge.
+
+    Each entry corresponds to one server Onton polls for findings. Only the
+    [review-service] kind is implemented today, but the variant is open-ended so
+    other backends (e.g. SonarQube, custom internal review tools) can slot in
+    without changing the consumer-side wiring. *)
+
+type review_service_auth = {
+  app_id : string;
+      (** GitHub App ID. Embedded as the [iss] claim so the server can pick the
+          right verification key when it eventually supports multiple tenants.
+      *)
+  private_key_path : string;
+}
+(** Authentication for the [review-service] backend.
+
+    Onton mints short-lived JWTs (RS256) signed with the configured GitHub App
+    private key, which the review-service verifies with the corresponding public
+    key. The [private_key_path] is read at sign time — keys are not held in
+    memory across polls. *)
+
+type kind =
+  | Review_service of {
+      base_url : string;
+          (** Origin without trailing slash, e.g.
+              ["https://review.example.com"]. *)
+      auth : review_service_auth;
+    }
+
+type t = {
+  name : string;
+      (** Operator-supplied identifier, used in logs and side-tables to
+          attribute findings back to their source. Must be unique within a
+          config. *)
+  kind : kind;
+}
+
+val parse : known_kinds:string list -> Yojson.Safe.t -> (t, string) Result.t
+(** Parse a single backend entry. Validates that the [kind] field is in
+    [known_kinds]. *)
+
+val parse_array :
+  known_kinds:string list -> Yojson.Safe.t -> (t list, string) Result.t
+(** Parse an array of backend entries from JSON. [`Null]/empty array returns
+    [Ok []]. Validates that [name]s are unique. *)

--- a/lib_core/review_service.ml
+++ b/lib_core/review_service.ml
@@ -1,0 +1,450 @@
+open Base
+
+type severity = Must_fix | Should_fix | Note
+[@@deriving show, eq, sexp_of, compare]
+
+type outcome_kind = Outstanding | Discussed | Addressed | Ignored | Resolved
+[@@deriving show, eq, sexp_of, compare]
+
+type last_reply = { author : string; at : string; body : string }
+[@@deriving show, eq, sexp_of, compare]
+
+type outcome = {
+  kind : outcome_kind;
+  detected_at : string option;
+  actor : string option;
+  reason : string option;
+  last_reply : last_reply option;
+}
+[@@deriving show, eq, sexp_of, compare]
+
+type finding = {
+  id : string;
+  github_comment_id : int option;
+  posting_sha : string;
+  path : string;
+  start_line : int;
+  end_line : int;
+  severity : severity;
+  body : string;
+  created_at : string;
+  outcome : outcome;
+}
+[@@deriving show, eq, sexp_of, compare]
+
+type findings_response = {
+  repo_id : string;
+  pull_number : int;
+  count : int;
+  findings : finding list;
+}
+[@@deriving show, eq, sexp_of, compare]
+
+type resolve_kind = Resolve_addressed | Resolve_wontfix
+[@@deriving show, eq, sexp_of, compare]
+
+let severity_of_string = function
+  | "must-fix" -> Some Must_fix
+  | "should-fix" -> Some Should_fix
+  | "note" -> Some Note
+  | _ -> None
+
+let severity_to_string = function
+  | Must_fix -> "must-fix"
+  | Should_fix -> "should-fix"
+  | Note -> "note"
+
+let outcome_kind_of_string = function
+  | "outstanding" -> Some Outstanding
+  | "discussed" -> Some Discussed
+  | "addressed" -> Some Addressed
+  | "ignored" -> Some Ignored
+  | "resolved" -> Some Resolved
+  | _ -> None
+
+let outcome_kind_to_string = function
+  | Outstanding -> "outstanding"
+  | Discussed -> "discussed"
+  | Addressed -> "addressed"
+  | Ignored -> "ignored"
+  | Resolved -> "resolved"
+
+let resolve_kind_of_string = function
+  | "addressed" -> Some Resolve_addressed
+  | "wontfix" -> Some Resolve_wontfix
+  | _ -> None
+
+let resolve_kind_to_string = function
+  | Resolve_addressed -> "addressed"
+  | Resolve_wontfix -> "wontfix"
+
+(** Total: returns [None] for [`Null], non-strings, or empty strings. *)
+let string_opt = function
+  | `Null -> None
+  | `String s when String.is_empty s -> None
+  | `String s -> Some s
+  | _ -> None
+
+let int_opt = function `Null -> None | `Int n -> Some n | _ -> None
+
+let require_string field json =
+  let open Yojson.Safe.Util in
+  match json |> member field with
+  | `String s -> Ok s
+  | `Null -> Error (Printf.sprintf "missing required field %S" field)
+  | _ -> Error (Printf.sprintf "field %S must be a string" field)
+
+let require_int field json =
+  let open Yojson.Safe.Util in
+  match json |> member field with
+  | `Int n -> Ok n
+  | `Null -> Error (Printf.sprintf "missing required field %S" field)
+  | _ -> Error (Printf.sprintf "field %S must be an integer" field)
+
+let parse_last_reply json : last_reply option =
+  let open Yojson.Safe.Util in
+  match json with
+  | `Null -> None
+  | `Assoc _ ->
+      let author = json |> member "author" |> string_opt in
+      let at = json |> member "at" |> string_opt in
+      let body = json |> member "body" |> string_opt in
+      (* All three required for a meaningful reply; any missing means we skip. *)
+      Option.map3 author at body ~f:(fun author at body -> { author; at; body })
+  | _ -> None
+
+let parse_outcome json : (outcome, string) Result.t =
+  let open Yojson.Safe.Util in
+  match json with
+  | `Null -> Error "outcome is null"
+  | `Assoc _ -> (
+      let kind_str =
+        json |> member "kind" |> string_opt |> Option.value ~default:""
+      in
+      match outcome_kind_of_string kind_str with
+      | None ->
+          Error (Printf.sprintf "outcome.kind is not a known kind: %S" kind_str)
+      | Some kind ->
+          let detected_at = json |> member "detectedAt" |> string_opt in
+          let actor = json |> member "actor" |> string_opt in
+          let reason = json |> member "reason" |> string_opt in
+          let last_reply = parse_last_reply (json |> member "lastReply") in
+          Ok { kind; detected_at; actor; reason; last_reply })
+  | _ -> Error "outcome must be an object"
+
+let parse_finding json : (finding, string) Result.t =
+  let open Yojson.Safe.Util in
+  let ( let* ) = Result.( >>= ) in
+  match json with
+  | `Assoc _ ->
+      let* id = require_string "id" json in
+      let github_comment_id = json |> member "githubCommentId" |> int_opt in
+      let* posting_sha = require_string "postingSha" json in
+      let* path = require_string "path" json in
+      let* start_line = require_int "startLine" json in
+      let* end_line = require_int "endLine" json in
+      let severity_str =
+        json |> member "severity" |> string_opt |> Option.value ~default:""
+      in
+      let* severity =
+        match severity_of_string severity_str with
+        | Some s -> Ok s
+        | None -> Error (Printf.sprintf "unknown severity: %S" severity_str)
+      in
+      let* body = require_string "body" json in
+      let* created_at = require_string "createdAt" json in
+      let* outcome = parse_outcome (json |> member "outcome") in
+      Ok
+        {
+          id;
+          github_comment_id;
+          posting_sha;
+          path;
+          start_line;
+          end_line;
+          severity;
+          body;
+          created_at;
+          outcome;
+        }
+  | _ -> Error "finding must be an object"
+
+let parse_findings_response json : (findings_response, string) Result.t =
+  let open Yojson.Safe.Util in
+  let ( let* ) = Result.( >>= ) in
+  match json with
+  | `Assoc _ ->
+      let* repo_id = require_string "repoId" json in
+      let* pull_number = require_int "pullNumber" json in
+      let count = match json |> member "count" with `Int n -> n | _ -> 0 in
+      let raw_findings =
+        match json |> member "findings" with `List xs -> xs | _ -> []
+      in
+      (* Drop entries that fail to parse rather than failing the whole response.
+         A single schema-drift entry shouldn't blank out a PR's findings — the
+         caller can compare [count] against [List.length findings] to detect
+         partial-decode loss. *)
+      let findings =
+        List.filter_map raw_findings ~f:(fun f ->
+            match parse_finding f with Ok f -> Some f | Error _ -> None)
+      in
+      Ok { repo_id; pull_number; count; findings }
+  | _ -> Error "findings response must be an object"
+
+let parse_findings_response_string body =
+  match Yojson.Safe.from_string body with
+  | exception Yojson.Json_error msg -> Error (Printf.sprintf "JSON: %s" msg)
+  | json -> parse_findings_response json
+
+type resolve_response = { id : string; outcome : outcome }
+[@@deriving show, eq, sexp_of, compare]
+
+let parse_resolve_response json : (resolve_response, string) Result.t =
+  let open Yojson.Safe.Util in
+  let ( let* ) = Result.( >>= ) in
+  match json with
+  | `Assoc _ ->
+      let* id = require_string "id" json in
+      let* outcome = parse_outcome (json |> member "outcome") in
+      Ok { id; outcome }
+  | _ -> Error "resolve response must be an object"
+
+let parse_resolve_response_string body =
+  match Yojson.Safe.from_string body with
+  | exception Yojson.Json_error msg -> Error (Printf.sprintf "JSON: %s" msg)
+  | json -> parse_resolve_response json
+
+type resolve_request = {
+  kind : resolve_kind;
+  actor : string option;
+  reason : string option;
+}
+[@@deriving show, eq, sexp_of, compare]
+
+let resolve_request_to_yojson (req : resolve_request) : Yojson.Safe.t =
+  let fields = [ ("kind", `String (resolve_kind_to_string req.kind)) ] in
+  let fields =
+    match req.actor with
+    | Some s -> fields @ [ ("actor", `String s) ]
+    | None -> fields
+  in
+  let fields =
+    match req.reason with
+    | Some s -> fields @ [ ("reason", `String s) ]
+    | None -> fields
+  in
+  `Assoc fields
+
+let parse_error_message body =
+  match Yojson.Safe.from_string body with
+  | exception _ -> None
+  | `Assoc fields -> (
+      match List.Assoc.find fields ~equal:String.equal "error" with
+      | Some (`String s) -> Some s
+      | _ -> None)
+  | _ -> None
+
+type wontfix_entry = { id : string; reason : string }
+[@@deriving show, eq, sexp_of, compare]
+
+let parse_wontfix_artifact body : (wontfix_entry list, string) Result.t =
+  let trimmed = String.strip body in
+  if String.is_empty trimmed then Ok []
+  else
+    match Yojson.Safe.from_string trimmed with
+    | exception Yojson.Json_error msg ->
+        Error (Printf.sprintf "wontfix artifact: %s" msg)
+    | `List entries ->
+        let parsed =
+          List.filter_map entries ~f:(fun entry ->
+              let open Yojson.Safe.Util in
+              match entry with
+              | `Assoc _ ->
+                  let id = entry |> member "id" |> string_opt in
+                  let reason = entry |> member "reason" |> string_opt in
+                  Option.map2 id reason ~f:(fun id reason -> { id; reason })
+              | _ -> None)
+        in
+        Ok parsed
+    | _ -> Error "wontfix artifact must be a JSON array"
+
+(* {2 Inline tests} *)
+
+let%test "severity round trip" =
+  List.for_all [ Must_fix; Should_fix; Note ] ~f:(fun s ->
+      match severity_of_string (severity_to_string s) with
+      | Some s' -> equal_severity s s'
+      | None -> false)
+
+let%test "severity unknown -> None" =
+  Option.is_none (severity_of_string "critical")
+
+let%test "outcome_kind round trip" =
+  List.for_all [ Outstanding; Discussed; Addressed; Ignored; Resolved ]
+    ~f:(fun k ->
+      match outcome_kind_of_string (outcome_kind_to_string k) with
+      | Some k' -> equal_outcome_kind k k'
+      | None -> false)
+
+let%test "resolve_kind round trip" =
+  List.for_all [ Resolve_addressed; Resolve_wontfix ] ~f:(fun k ->
+      match resolve_kind_of_string (resolve_kind_to_string k) with
+      | Some k' -> equal_resolve_kind k k'
+      | None -> false)
+
+let%test "parse_finding: full object" =
+  let raw =
+    {|{"id":"abc","githubCommentId":42,"postingSha":"deadbeef","path":"src/x.ml","startLine":3,"endLine":5,"severity":"must-fix","body":"oops","createdAt":"2026-05-06T00:00:00Z","outcome":{"kind":"outstanding"}}|}
+  in
+  match parse_finding (Yojson.Safe.from_string raw) with
+  | Ok f ->
+      String.equal f.id "abc"
+      && Option.equal Int.equal f.github_comment_id (Some 42)
+      && String.equal f.posting_sha "deadbeef"
+      && String.equal f.path "src/x.ml"
+      && f.start_line = 3 && f.end_line = 5
+      && equal_severity f.severity Must_fix
+      && equal_outcome_kind f.outcome.kind Outstanding
+  | Error _ -> false
+
+let%test "parse_finding: missing required field" =
+  let raw = {|{"id":"abc"}|} in
+  match parse_finding (Yojson.Safe.from_string raw) with
+  | Error _ -> true
+  | Ok _ -> false
+
+let%test "parse_finding: githubCommentId null -> None" =
+  let raw =
+    {|{"id":"abc","githubCommentId":null,"postingSha":"x","path":"a","startLine":1,"endLine":1,"severity":"note","body":"b","createdAt":"t","outcome":{"kind":"outstanding"}}|}
+  in
+  match parse_finding (Yojson.Safe.from_string raw) with
+  | Ok f -> Option.is_none f.github_comment_id
+  | Error _ -> false
+
+let%test "parse_findings_response: drops malformed entries, keeps the rest" =
+  let raw =
+    {|{"repoId":"o/r","pullNumber":7,"count":2,"findings":[
+       {"id":"a","postingSha":"s","path":"f","startLine":1,"endLine":1,"severity":"note","body":"b","createdAt":"t","outcome":{"kind":"outstanding"}},
+       {"id":"bad"}
+     ]}|}
+  in
+  match parse_findings_response (Yojson.Safe.from_string raw) with
+  | Ok r ->
+      String.equal r.repo_id "o/r"
+      && r.pull_number = 7
+      && List.length r.findings = 1
+  | Error _ -> false
+
+let%test "parse_findings_response_string: invalid JSON -> Error" =
+  match parse_findings_response_string "not json" with
+  | Error _ -> true
+  | Ok _ -> false
+
+let%test "parse_findings_response_string: empty findings -> Ok empty" =
+  let raw = {|{"repoId":"o/r","pullNumber":1,"count":0,"findings":[]}|} in
+  match parse_findings_response_string raw with
+  | Ok r -> List.is_empty r.findings && r.count = 0
+  | Error _ -> false
+
+let%test "parse_resolve_response: ok with addressed outcome" =
+  let raw =
+    {|{"id":"abc","outcome":{"kind":"addressed","detectedAt":"t","actor":"onton:agent-7"}}|}
+  in
+  match parse_resolve_response (Yojson.Safe.from_string raw) with
+  | Ok r ->
+      String.equal r.id "abc"
+      && equal_outcome_kind r.outcome.kind Addressed
+      && Option.equal String.equal r.outcome.actor (Some "onton:agent-7")
+  | Error _ -> false
+
+let%test "resolve_request_to_yojson: omits None fields" =
+  let req = { kind = Resolve_addressed; actor = None; reason = None } in
+  let json = resolve_request_to_yojson req in
+  String.equal (Yojson.Safe.to_string json) {|{"kind":"addressed"}|}
+
+let%test "resolve_request_to_yojson: includes Some fields" =
+  let req =
+    { kind = Resolve_wontfix; actor = Some "x"; reason = Some "rationale" }
+  in
+  let json = resolve_request_to_yojson req in
+  String.equal
+    (Yojson.Safe.to_string json)
+    {|{"kind":"wontfix","actor":"x","reason":"rationale"}|}
+
+let%test "parse_error_message: extracts error" =
+  match parse_error_message {|{"error":"unauthorized"}|} with
+  | Some "unauthorized" -> true
+  | _ -> false
+
+let%test "parse_error_message: returns None on non-JSON" =
+  Option.is_none (parse_error_message "<html></html>")
+
+let%test "parse_error_message: returns None on missing error field" =
+  Option.is_none (parse_error_message {|{"ok":true}|})
+
+let%test "parse_outcome: lastReply roundtrip" =
+  let raw =
+    {|{"kind":"discussed","detectedAt":"t","lastReply":{"author":"u","at":"t2","body":"hi"}}|}
+  in
+  match parse_outcome (Yojson.Safe.from_string raw) with
+  | Ok o -> (
+      match o.last_reply with
+      | Some lr ->
+          String.equal lr.author "u" && String.equal lr.body "hi"
+          && String.equal lr.at "t2"
+      | None -> false)
+  | Error _ -> false
+
+let%test "parse_outcome: partial lastReply -> None (skipped)" =
+  let raw = {|{"kind":"discussed","lastReply":{"author":"u"}}|} in
+  match parse_outcome (Yojson.Safe.from_string raw) with
+  | Ok o -> Option.is_none o.last_reply
+  | Error _ -> false
+
+let%test "parse_wontfix_artifact: empty string -> Ok []" =
+  match parse_wontfix_artifact "" with
+  | Ok [] -> true
+  | Ok _ -> false
+  | Error _ -> false
+
+let%test "parse_wontfix_artifact: whitespace-only -> Ok []" =
+  match parse_wontfix_artifact "   \n\t  " with
+  | Ok [] -> true
+  | Ok _ -> false
+  | Error _ -> false
+
+let%test "parse_wontfix_artifact: empty array -> Ok []" =
+  match parse_wontfix_artifact "[]" with
+  | Ok [] -> true
+  | Ok _ -> false
+  | Error _ -> false
+
+let%test "parse_wontfix_artifact: well-formed entries" =
+  let raw =
+    {|[{"id":"a","reason":"out of scope"},{"id":"b","reason":"false positive"}]|}
+  in
+  match parse_wontfix_artifact raw with
+  | Ok [ a; b ] ->
+      String.equal a.id "a"
+      && String.equal a.reason "out of scope"
+      && String.equal b.id "b"
+      && String.equal b.reason "false positive"
+  | Ok _ -> false
+  | Error _ -> false
+
+let%test "parse_wontfix_artifact: malformed entries skipped, valid ones kept" =
+  let raw =
+    {|[{"id":"a","reason":"r"},{"id":"only-id"},{"reason":"only-r"}]|}
+  in
+  match parse_wontfix_artifact raw with
+  | Ok [ e ] -> String.equal e.id "a" && String.equal e.reason "r"
+  | Ok _ -> false
+  | Error _ -> false
+
+let%test "parse_wontfix_artifact: invalid JSON -> Error" =
+  match parse_wontfix_artifact "not json" with Error _ -> true | Ok _ -> false
+
+let%test "parse_wontfix_artifact: object instead of array -> Error" =
+  match parse_wontfix_artifact {|{"id":"a","reason":"r"}|} with
+  | Error _ -> true
+  | Ok _ -> false

--- a/lib_core/review_service.ml
+++ b/lib_core/review_service.ml
@@ -180,9 +180,13 @@ let parse_findings_response json : (findings_response, string) Result.t =
   | `Assoc _ ->
       let* repo_id = require_string "repoId" json in
       let* pull_number = require_int "pullNumber" json in
-      let count = match json |> member "count" with `Int n -> n | _ -> 0 in
       let raw_findings =
         match json |> member "findings" with `List xs -> xs | _ -> []
+      in
+      let count =
+        match json |> member "count" with
+        | `Int n -> n
+        | _ -> List.length raw_findings
       in
       (* Drop entries that fail to parse rather than failing the whole response,
          but keep diagnostics so the effectful caller can log schema drift. *)
@@ -375,6 +379,17 @@ let%test "parse_findings_response_string: empty findings -> Ok empty" =
       List.is_empty r.findings
       && List.is_empty r.dropped_findings
       && r.count = 0
+  | Error _ -> false
+
+let%test "parse_findings_response_string: missing count defaults to raw length"
+    =
+  let raw =
+    {|{"repoId":"o/r","pullNumber":1,"findings":[
+       {"id":"a","postingSha":"s","path":"f","startLine":1,"endLine":1,"severity":"note","body":"b","createdAt":"t","outcome":{"kind":"outstanding"}}
+     ]}|}
+  in
+  match parse_findings_response_string raw with
+  | Ok r -> r.count = 1 && List.length r.findings = 1
   | Error _ -> false
 
 let%test "parse_resolve_response: ok with addressed outcome" =

--- a/lib_core/review_service.ml
+++ b/lib_core/review_service.ml
@@ -248,6 +248,13 @@ type wontfix_entry = { id : string; reason : string }
 [@@deriving show, eq, sexp_of, compare]
 
 let parse_wontfix_artifact body : (wontfix_entry list, string) Result.t =
+  let nonblank_string_opt = function
+    | `String s ->
+        let s = String.strip s in
+        if String.is_empty s then None else Some s
+    | `Null -> None
+    | _ -> None
+  in
   let trimmed = String.strip body in
   if String.is_empty trimmed then Ok []
   else
@@ -260,8 +267,10 @@ let parse_wontfix_artifact body : (wontfix_entry list, string) Result.t =
               let open Yojson.Safe.Util in
               match entry with
               | `Assoc _ ->
-                  let id = entry |> member "id" |> string_opt in
-                  let reason = entry |> member "reason" |> string_opt in
+                  let id = entry |> member "id" |> nonblank_string_opt in
+                  let reason =
+                    entry |> member "reason" |> nonblank_string_opt
+                  in
                   Option.map2 id reason ~f:(fun id reason -> { id; reason })
               | _ -> None)
         in
@@ -421,7 +430,7 @@ let%test "parse_wontfix_artifact: empty array -> Ok []" =
 
 let%test "parse_wontfix_artifact: well-formed entries" =
   let raw =
-    {|[{"id":"a","reason":"out of scope"},{"id":"b","reason":"false positive"}]|}
+    {|[{"id":" a ","reason":" out of scope "},{"id":"b","reason":"false positive"}]|}
   in
   match parse_wontfix_artifact raw with
   | Ok [ a; b ] ->
@@ -434,7 +443,7 @@ let%test "parse_wontfix_artifact: well-formed entries" =
 
 let%test "parse_wontfix_artifact: malformed entries skipped, valid ones kept" =
   let raw =
-    {|[{"id":"a","reason":"r"},{"id":"only-id"},{"reason":"only-r"}]|}
+    {|[{"id":"a","reason":"r"},{"id":"only-id"},{"reason":"only-r"},{"id":"  ","reason":"r"},{"id":"b","reason":"  "}]|}
   in
   match parse_wontfix_artifact raw with
   | Ok [ e ] -> String.equal e.id "a" && String.equal e.reason "r"

--- a/lib_core/review_service.ml
+++ b/lib_core/review_service.ml
@@ -3,7 +3,7 @@ open Base
 type severity = Must_fix | Should_fix | Note
 [@@deriving show, eq, sexp_of, compare]
 
-type outcome_kind = Outstanding | Discussed | Addressed | Ignored | Resolved
+type outcome_kind = Outstanding | Discussed | Addressed | Ignored | Wontfix
 [@@deriving show, eq, sexp_of, compare]
 
 type last_reply = { author : string; at : string; body : string }
@@ -59,7 +59,7 @@ let outcome_kind_of_string = function
   | "discussed" -> Some Discussed
   | "addressed" -> Some Addressed
   | "ignored" -> Some Ignored
-  | "resolved" -> Some Resolved
+  | "wontfix" -> Some Wontfix
   | _ -> None
 
 let outcome_kind_to_string = function
@@ -67,7 +67,7 @@ let outcome_kind_to_string = function
   | Discussed -> "discussed"
   | Addressed -> "addressed"
   | Ignored -> "ignored"
-  | Resolved -> "resolved"
+  | Wontfix -> "wontfix"
 
 let resolve_kind_of_string = function
   | "addressed" -> Some Resolve_addressed
@@ -280,7 +280,7 @@ let%test "severity unknown -> None" =
   Option.is_none (severity_of_string "critical")
 
 let%test "outcome_kind round trip" =
-  List.for_all [ Outstanding; Discussed; Addressed; Ignored; Resolved ]
+  List.for_all [ Outstanding; Discussed; Addressed; Ignored; Wontfix ]
     ~f:(fun k ->
       match outcome_kind_of_string (outcome_kind_to_string k) with
       | Some k' -> equal_outcome_kind k k'

--- a/lib_core/review_service.ml
+++ b/lib_core/review_service.ml
@@ -32,11 +32,15 @@ type finding = {
 }
 [@@deriving show, eq, sexp_of, compare]
 
+type finding_parse_error = { index : int; error : string; json : string }
+[@@deriving show, eq, sexp_of, compare]
+
 type findings_response = {
   repo_id : string;
   pull_number : int;
   count : int;
   findings : finding list;
+  dropped_findings : finding_parse_error list;
 }
 [@@deriving show, eq, sexp_of, compare]
 
@@ -180,15 +184,23 @@ let parse_findings_response json : (findings_response, string) Result.t =
       let raw_findings =
         match json |> member "findings" with `List xs -> xs | _ -> []
       in
-      (* Drop entries that fail to parse rather than failing the whole response.
-         A single schema-drift entry shouldn't blank out a PR's findings — the
-         caller can compare [count] against [List.length findings] to detect
-         partial-decode loss. *)
-      let findings =
-        List.filter_map raw_findings ~f:(fun f ->
-            match parse_finding f with Ok f -> Some f | Error _ -> None)
+      (* Drop entries that fail to parse rather than failing the whole response,
+         but keep diagnostics so the effectful caller can log schema drift. *)
+      let findings, dropped_findings =
+        List.foldi raw_findings ~init:([], []) ~f:(fun index (ok, dropped) f ->
+            match parse_finding f with
+            | Ok finding -> (finding :: ok, dropped)
+            | Error error ->
+                (ok, { index; error; json = Yojson.Safe.to_string f } :: dropped))
       in
-      Ok { repo_id; pull_number; count; findings }
+      Ok
+        {
+          repo_id;
+          pull_number;
+          count;
+          findings = List.rev findings;
+          dropped_findings = List.rev dropped_findings;
+        }
   | _ -> Error "findings response must be an object"
 
 let parse_findings_response_string body =
@@ -338,10 +350,17 @@ let%test "parse_findings_response: drops malformed entries, keeps the rest" =
      ]}|}
   in
   match parse_findings_response (Yojson.Safe.from_string raw) with
-  | Ok r ->
+  | Ok r -> (
       String.equal r.repo_id "o/r"
       && r.pull_number = 7
       && List.length r.findings = 1
+      &&
+      match r.dropped_findings with
+      | [ e ] ->
+          e.index = 1
+          && String.is_substring e.error ~substring:"postingSha"
+          && String.is_substring e.json ~substring:{|"id":"bad"|}
+      | _ -> false)
   | Error _ -> false
 
 let%test "parse_findings_response_string: invalid JSON -> Error" =
@@ -352,7 +371,10 @@ let%test "parse_findings_response_string: invalid JSON -> Error" =
 let%test "parse_findings_response_string: empty findings -> Ok empty" =
   let raw = {|{"repoId":"o/r","pullNumber":1,"count":0,"findings":[]}|} in
   match parse_findings_response_string raw with
-  | Ok r -> List.is_empty r.findings && r.count = 0
+  | Ok r ->
+      List.is_empty r.findings
+      && List.is_empty r.dropped_findings
+      && r.count = 0
   | Error _ -> false
 
 let%test "parse_resolve_response: ok with addressed outcome" =

--- a/lib_core/review_service.mli
+++ b/lib_core/review_service.mli
@@ -62,11 +62,18 @@ type finding = {
     from the current PR head. The agent should use this when interpreting line
     numbers. *)
 
+type finding_parse_error = { index : int; error : string; json : string }
+[@@deriving show, eq, sexp_of, compare]
+(** Diagnostic for an individual finding entry that was dropped while parsing.
+    [index] is zero-based within the response's [findings] array, [error] is the
+    field-level parser error, and [json] is the compact offending entry. *)
+
 type findings_response = {
   repo_id : string;
   pull_number : int;
   count : int;
   findings : finding list;
+  dropped_findings : finding_parse_error list;
 }
 [@@deriving show, eq, sexp_of, compare]
 
@@ -96,8 +103,8 @@ val parse_finding : Yojson.Safe.t -> (finding, string) Result.t
 val parse_findings_response :
   Yojson.Safe.t -> (findings_response, string) Result.t
 (** Parse the body of [GET /prs/:owner/:repo/:n/findings]. Drops unparseable
-    individual entries (logging is not the parser's job; the caller is
-    responsible for noisy diagnostics). *)
+    individual entries into [dropped_findings] so callers can log schema drift
+    without losing the entries that did parse. *)
 
 val parse_findings_response_string :
   string -> (findings_response, string) Result.t

--- a/lib_core/review_service.mli
+++ b/lib_core/review_service.mli
@@ -1,0 +1,146 @@
+(** Pure parsers for the review-service HTTP API.
+
+    The review-service is a separate review backend (alongside GitHub review
+    comments) that owns its own findings store, severity model, and resolution
+    semantics. This module decodes the JSON wire format; the effectful HTTP
+    client lives in [Review_service_client]. *)
+
+(** {2 Wire types} *)
+
+type severity = Must_fix | Should_fix | Note
+[@@deriving show, eq, sexp_of, compare]
+
+(** Severity classification on a finding. Decoded case-sensitively from the spec
+    strings ["must-fix"], ["should-fix"], ["note"]. *)
+
+type outcome_kind =
+  | Outstanding  (** Posted (or persisted-only) and not yet acted on. *)
+  | Discussed  (** A human replied on GitHub. *)
+  | Addressed  (** Code edits removed the anchor lines. *)
+  | Ignored  (** PR was closed without action. *)
+  | Resolved  (** Explicitly resolved via this API (read-only echo). *)
+[@@deriving show, eq, sexp_of, compare]
+
+type last_reply = { author : string; at : string; body : string }
+[@@deriving show, eq, sexp_of, compare]
+
+type outcome = {
+  kind : outcome_kind;
+  detected_at : string option;
+  actor : string option;
+  reason : string option;
+  last_reply : last_reply option;
+}
+[@@deriving show, eq, sexp_of, compare]
+
+type finding = {
+  id : string;
+  github_comment_id : int option;
+  posting_sha : string;
+  path : string;
+  start_line : int;
+  end_line : int;
+  severity : severity;
+  body : string;
+  created_at : string;
+  outcome : outcome;
+}
+[@@deriving show, eq, sexp_of, compare]
+(** A single finding from the review-service.
+
+    [id] is a UUID, stable across re-fetches. [github_comment_id] is [None] when
+    the finding was generated but never posted (e.g. during a GitHub outage);
+    those are still authoritative and will not be retroactively backfilled.
+
+    [posting_sha] is the head SHA the line numbers are anchored to, distinct
+    from the current PR head. The agent should use this when interpreting line
+    numbers. *)
+
+type findings_response = {
+  repo_id : string;
+  pull_number : int;
+  count : int;
+  findings : finding list;
+}
+[@@deriving show, eq, sexp_of, compare]
+
+(** Resolve verb. The spec accepts ["addressed"] (the agent fixed the issue) and
+    ["wontfix"] (the agent or operator decided not to act).
+
+    Constructors are prefixed [Resolve_*] to avoid collision with
+    {!outcome_kind}, which has its own [Addressed] arm. *)
+type resolve_kind = Resolve_addressed | Resolve_wontfix
+[@@deriving show, eq, sexp_of, compare]
+
+(** {2 Parsers}
+
+    Every parser is total over arbitrary JSON: malformed input returns
+    [Error _], never raises. *)
+
+val severity_of_string : string -> severity option
+val severity_to_string : severity -> string
+val outcome_kind_of_string : string -> outcome_kind option
+val outcome_kind_to_string : outcome_kind -> string
+val resolve_kind_of_string : string -> resolve_kind option
+val resolve_kind_to_string : resolve_kind -> string
+
+val parse_finding : Yojson.Safe.t -> (finding, string) Result.t
+(** Parse a single [Finding] object. Skips unknown fields. *)
+
+val parse_findings_response :
+  Yojson.Safe.t -> (findings_response, string) Result.t
+(** Parse the body of [GET /prs/:owner/:repo/:n/findings]. Drops unparseable
+    individual entries (logging is not the parser's job; the caller is
+    responsible for noisy diagnostics). *)
+
+val parse_findings_response_string :
+  string -> (findings_response, string) Result.t
+(** Convenience: [parse_findings_response_string body] runs JSON parsing first.
+*)
+
+type resolve_response = { id : string; outcome : outcome }
+[@@deriving show, eq, sexp_of, compare]
+(** Parsed body of [POST /prs/:owner/:repo/:n/findings/:id/resolve]. The actor
+    is responsible for trusting [outcome] over the verb they sent — the server
+    echoes the actual current state for already-absorbed findings. *)
+
+val parse_resolve_response :
+  Yojson.Safe.t -> (resolve_response, string) Result.t
+
+val parse_resolve_response_string :
+  string -> (resolve_response, string) Result.t
+
+(** {2 Resolve request} *)
+
+type resolve_request = {
+  kind : resolve_kind;
+  actor : string option;
+  reason : string option;
+}
+[@@deriving show, eq, sexp_of, compare]
+
+val resolve_request_to_yojson : resolve_request -> Yojson.Safe.t
+(** Encode a resolve request body. Omits [actor]/[reason] when [None]. *)
+
+(** {2 Error response} *)
+
+val parse_error_message : string -> string option
+(** Try to extract the [error] field from a JSON error body like
+    [{"error":"unauthorized"}]. Returns [None] if the body isn't JSON or has no
+    [error] field — useful for surfacing the server's reason in logs. *)
+
+(** {2 Wontfix artifact} *)
+
+type wontfix_entry = { id : string; reason : string }
+[@@deriving show, eq, sexp_of, compare]
+
+val parse_wontfix_artifact :
+  string -> (wontfix_entry list, string) Stdlib.Result.t
+(** Decode the agent-authored [findings_wontfix.json] artifact: a JSON array of
+    [{id, reason}] objects. Returns [Ok []] on the empty string, an empty array,
+    or a missing file — callers normalize those cases the same way: no findings
+    declared wontfix.
+
+    Total over arbitrary input — invalid JSON or schema returns [Error _] rather
+    than raising. Entries with missing/empty [id] or [reason] are skipped (not
+    an error) so a single malformed row doesn't poison the whole list. *)

--- a/lib_core/review_service.mli
+++ b/lib_core/review_service.mli
@@ -15,10 +15,16 @@ type severity = Must_fix | Should_fix | Note
 
 type outcome_kind =
   | Outstanding  (** Posted (or persisted-only) and not yet acted on. *)
-  | Discussed  (** A human replied on GitHub. *)
-  | Addressed  (** Code edits removed the anchor lines. *)
-  | Ignored  (** PR was closed without action. *)
-  | Resolved  (** Explicitly resolved via this API (read-only echo). *)
+  | Discussed  (** A non-bot human replied on the GitHub thread. *)
+  | Addressed
+      (** Either: code edits removed the anchored region (engine path), or: a
+          caller marked it addressed via the resolve API. Distinguish via
+          [outcome.actor]/[outcome.reason] — those are present only on the API
+          path. *)
+  | Ignored  (** PR was closed without anyone touching the finding. *)
+  | Wontfix
+      (** Caller actively dismissed via the resolve API. Distinct from [Ignored]
+          (PR-close), distinct from [Addressed] (caller fixed it). *)
 [@@deriving show, eq, sexp_of, compare]
 
 type last_reply = { author : string; at : string; body : string }

--- a/lib_core/types.ml
+++ b/lib_core/types.ml
@@ -47,7 +47,14 @@ module Branch = struct
 end
 
 module Operation_kind = struct
-  type t = Rebase | Human | Merge_conflict | Ci | Review_comments | Pr_body
+  type t =
+    | Rebase
+    | Human
+    | Merge_conflict
+    | Ci
+    | Review_comments
+    | Pr_body
+    | Findings
   [@@deriving show, eq, ord, sexp_of, compare, hash, yojson]
 
   (** Migration-aware deserializer: maps removed constructors to their
@@ -66,6 +73,7 @@ module Operation_kind = struct
     | Ci -> "ci"
     | Review_comments -> "review-comments"
     | Pr_body -> "pr-body"
+    | Findings -> "findings"
 end
 
 module Comment_id = struct

--- a/lib_core/types.mli
+++ b/lib_core/types.mli
@@ -45,7 +45,19 @@ module Branch : sig
 end
 
 module Operation_kind : sig
-  type t = Rebase | Human | Merge_conflict | Ci | Review_comments | Pr_body
+  type t =
+    | Rebase
+    | Human
+    | Merge_conflict
+    | Ci
+    | Review_comments
+    | Pr_body
+    | Findings
+        (** Review-service findings — deliveries from a backend in
+            {!Review_backend} that mints its own finding store separate from
+            GitHub review threads. The agent receives one [Findings_payload] per
+            session and POSTs resolve verbs back to the originating backend
+            after the session completes. *)
   [@@deriving show, eq, ord, sexp_of, compare, hash, yojson]
 
   val t_of_yojson_compat : Yojson.Safe.t -> t

--- a/lib_test/test_generators.ml
+++ b/lib_test/test_generators.ml
@@ -26,11 +26,12 @@ let gen_branch =
 let gen_operation_kind =
   QCheck2.Gen.oneof_list
     Operation_kind.
-      [ Rebase; Human; Merge_conflict; Ci; Review_comments; Pr_body ]
+      [ Rebase; Human; Merge_conflict; Ci; Review_comments; Findings; Pr_body ]
 
 let gen_feedback_kind =
   QCheck2.Gen.oneof_list
-    Operation_kind.[ Human; Merge_conflict; Ci; Review_comments; Pr_body ]
+    Operation_kind.
+      [ Human; Merge_conflict; Ci; Review_comments; Findings; Pr_body ]
 
 let gen_operation_kind_queue =
   QCheck2.Gen.(

--- a/lib_test/test_generators.ml
+++ b/lib_test/test_generators.ml
@@ -288,6 +288,7 @@ let gen_pr_state =
           ci_checks_truncated;
           comments;
           unresolved_comment_count;
+          findings = [];
           head_branch;
           head_oid = None;
           base_branch;
@@ -519,6 +520,7 @@ let all_display_statuses : Onton.Tui.display_status list =
     | Approved_running -> Approved_running
     | Fixing_ci -> Fixing_ci
     | Addressing_review -> Addressing_review
+    | Addressing_findings -> Addressing_findings
     | Resolving_conflict -> Resolving_conflict
     | Responding_to_human -> Responding_to_human
     | Writing_pr_body -> Writing_pr_body
@@ -527,6 +529,7 @@ let all_display_statuses : Onton.Tui.display_status list =
     | Updating -> Updating
     | Ci_queued -> Ci_queued
     | Review_queued -> Review_queued
+    | Findings_queued -> Findings_queued
     | Awaiting_ci -> Awaiting_ci
     | Awaiting_review -> Awaiting_review
     | Blocked_by_dep -> Blocked_by_dep
@@ -540,6 +543,7 @@ let all_display_statuses : Onton.Tui.display_status list =
       Approved_running;
       Fixing_ci;
       Addressing_review;
+      Addressing_findings;
       Resolving_conflict;
       Responding_to_human;
       Writing_pr_body;
@@ -548,6 +552,7 @@ let all_display_statuses : Onton.Tui.display_status list =
       Updating;
       Ci_queued;
       Review_queued;
+      Findings_queued;
       Awaiting_ci;
       Awaiting_review;
       Blocked_by_dep;

--- a/test/dune
+++ b/test/dune
@@ -23,6 +23,13 @@
  (ocamlc_flags (:standard -w -40-42)))
 
 (test
+ (name test_review_service_properties)
+ (modules test_review_service_properties)
+ (libraries onton_core qcheck-core qcheck-core.runner yojson)
+ (ocamlopt_flags (:standard -w -40-42))
+ (ocamlc_flags (:standard -w -40-42)))
+
+(test
  (name test_activity_log_properties)
  (modules test_activity_log_properties)
  (libraries onton_core qcheck-core qcheck-core.runner)

--- a/test/test_action_outcome_properties.ml
+++ b/test/test_action_outcome_properties.ml
@@ -154,7 +154,7 @@ let () =
           match
             Patch_decision.respond_delivery ~agent ~kind:Operation_kind.Human
               ~pre_fire_agent:(Some second_pre) ~prefetched_comments:[]
-              ~main_branch:(Branch.to_string main)
+              ~prefetched_findings:[] ~main_branch:(Branch.to_string main)
           with
           | Patch_decision.Deliver { payload; _ } -> (
               match payload with
@@ -164,6 +164,7 @@ let () =
                   && List.mem first_pre.Patch_agent.human_messages first_msg
                        ~equal:String.equal
               | Patch_decision.Ci_payload _ | Patch_decision.Review_payload _
+              | Patch_decision.Findings_payload _
               | Patch_decision.Pr_body_payload
               | Patch_decision.Merge_conflict_payload ->
                   false)

--- a/test/test_backend_routing.ml
+++ b/test/test_backend_routing.ml
@@ -76,7 +76,7 @@ let gen_repo_config : Repo_config.t QCheck2.Gen.t =
   in
   let* routes = list_size (return (List.length keys)) gen_route in
   let complexity_routes = List.zip_exn keys routes in
-  return { Repo_config.complexity_routes }
+  return { Repo_config.complexity_routes; review_backends = [] }
 
 let pp_decision (d : Backend_routing.decision) =
   Printf.sprintf "{ backend = %s; model = %s }" d.backend

--- a/test/test_interleaving_properties.ml
+++ b/test/test_interleaving_properties.ml
@@ -1265,7 +1265,7 @@ let () =
   QCheck2.Test.check_exn prop_pi4;
   Stdlib.print_endline "PI-4 passed"
 
-(** PI-5: Repeated Session_process_error { is_fresh = true } on a no-PR agent
+(** PI-5: Repeated [Session_process_error { is_fresh = true }] on a no-PR agent
     converges to needs_intervention. This tests the same liveness guarantee as
     PI-4 but for the process-error path. *)
 let () =
@@ -2196,10 +2196,10 @@ let respond_outcome_of session_result =
   | Orchestrator.Session_worktree_missing ->
       Orchestrator.Respond_failed
 
-(** Given the current agent state, produce the session_result that a
-    persistent LLM failure would yield.  This models the session_mode →
-    failure chain: Resume → Session_failed{is_fresh=false}, Fresh →
-    Session_failed{is_fresh=true}, Give_up → Session_give_up. *)
+(** Given the current agent state, produce the session_result that a persistent
+    LLM failure would yield. This models the session_mode → failure chain:
+    Resume → [Session_failed { is_fresh = false }], Fresh →
+    [Session_failed { is_fresh = true }], Give_up → [Session_give_up]. *)
 let session_failure_for_state (a : Patch_agent.t) =
   match a.Patch_agent.session_fallback with
   | Patch_agent.Fresh_available -> (
@@ -2467,9 +2467,10 @@ let () =
 
     Resume-path coverage: [mk_bootstrapped] leaves [llm_session_id = None], so
     [session_failure_for_state] here always enters on the Fresh-first arm
-    (Session_failed {is_fresh=true}).  The Resume-first arm (Session_failed
-    {is_fresh=false}) — i.e. the full [Resume fail → Tried_fresh → Fresh fail
-    → Given_up] chain — is covered explicitly by CV-3b. *)
+    ([Session_failed { is_fresh = true }]). The Resume-first arm
+    ([Session_failed { is_fresh = false }]) — i.e. the full
+    [Resume fail → Tried_fresh → Fresh fail → Given_up] chain — is covered
+    explicitly by CV-3b. *)
 let () =
   let prop_cv5 =
     QCheck2.Test.make

--- a/test/test_patch_decision.ml
+++ b/test/test_patch_decision.ml
@@ -239,7 +239,8 @@ let () =
     assert (
       equal_respond_delivery
         (respond_delivery ~agent:a ~kind:Operation_kind.Human
-           ~pre_fire_agent:None ~prefetched_comments:[] ~main_branch)
+           ~pre_fire_agent:None ~prefetched_comments:[] ~prefetched_findings:[]
+           ~main_branch)
         Respond_stale);
 
     (* needs_intervention → Stale *)
@@ -256,7 +257,8 @@ let () =
     assert (
       equal_respond_delivery
         (respond_delivery ~agent:a ~kind:Operation_kind.Human
-           ~pre_fire_agent:None ~prefetched_comments:[] ~main_branch)
+           ~pre_fire_agent:None ~prefetched_comments:[] ~prefetched_findings:[]
+           ~main_branch)
         Respond_stale);
 
     (* not busy → Stale *)
@@ -264,7 +266,8 @@ let () =
     assert (
       equal_respond_delivery
         (respond_delivery ~agent:a ~kind:Operation_kind.Human
-           ~pre_fire_agent:None ~prefetched_comments:[] ~main_branch)
+           ~pre_fire_agent:None ~prefetched_comments:[] ~prefetched_findings:[]
+           ~main_branch)
         Respond_stale);
     Stdlib.print_endline "RD-1 passed"
   in
@@ -280,7 +283,8 @@ let () =
     assert (
       equal_respond_delivery
         (respond_delivery ~agent:a ~kind:Operation_kind.Human
-           ~pre_fire_agent:(Some pre_fire) ~prefetched_comments:[] ~main_branch)
+           ~pre_fire_agent:(Some pre_fire) ~prefetched_comments:[]
+           ~prefetched_findings:[] ~main_branch)
         Skip_empty);
     Stdlib.print_endline "RD-2a passed"
   in
@@ -312,7 +316,8 @@ let () =
     assert (
       equal_respond_delivery
         (respond_delivery ~agent:a ~kind:Operation_kind.Ci
-           ~pre_fire_agent:(Some pre_fire) ~prefetched_comments:[] ~main_branch)
+           ~pre_fire_agent:(Some pre_fire) ~prefetched_comments:[]
+           ~prefetched_findings:[] ~main_branch)
         Skip_empty);
     Stdlib.print_endline "RD-2b passed"
   in
@@ -327,7 +332,8 @@ let () =
     assert (
       equal_respond_delivery
         (respond_delivery ~agent:a ~kind:Operation_kind.Review_comments
-           ~pre_fire_agent:None ~prefetched_comments:[] ~main_branch)
+           ~pre_fire_agent:None ~prefetched_comments:[] ~prefetched_findings:[]
+           ~main_branch)
         Skip_empty);
     Stdlib.print_endline "RD-2c passed"
   in
@@ -341,15 +347,16 @@ let () =
     let a = respond a Operation_kind.Human in
     (match
        respond_delivery ~agent:a ~kind:Operation_kind.Human
-         ~pre_fire_agent:(Some pre_fire) ~prefetched_comments:[] ~main_branch
+         ~pre_fire_agent:(Some pre_fire) ~prefetched_comments:[]
+         ~prefetched_findings:[] ~main_branch
      with
     | Deliver { payload = Human_payload { messages }; _ } ->
         assert (List.equal String.equal messages [ "fix this" ])
     | Deliver
         {
           payload =
-            ( Ci_payload _ | Review_payload _ | Pr_body_payload
-            | Merge_conflict_payload );
+            ( Ci_payload _ | Review_payload _ | Findings_payload _
+            | Pr_body_payload | Merge_conflict_payload );
           _;
         }
     | Skip_empty | Respond_stale ->
@@ -373,7 +380,8 @@ let () =
     assert (not (List.is_empty post_fire.inflight_human_messages));
     (match
        respond_delivery ~agent:post_fire ~kind:Operation_kind.Human
-         ~pre_fire_agent:(Some pre_fire) ~prefetched_comments:[] ~main_branch
+         ~pre_fire_agent:(Some pre_fire) ~prefetched_comments:[]
+         ~prefetched_findings:[] ~main_branch
      with
     | Deliver { payload = Human_payload { messages }; _ } ->
         (* Messages come from pre_fire.human_messages (reversed) *)
@@ -381,8 +389,8 @@ let () =
     | Deliver
         {
           payload =
-            ( Ci_payload _ | Review_payload _ | Pr_body_payload
-            | Merge_conflict_payload );
+            ( Ci_payload _ | Review_payload _ | Findings_payload _
+            | Pr_body_payload | Merge_conflict_payload );
           _;
         }
     | Skip_empty | Respond_stale ->
@@ -405,7 +413,8 @@ let () =
        but base_branch is now "feature" → base changed *)
     (match
        respond_delivery ~agent:a ~kind:Operation_kind.Human
-         ~pre_fire_agent:(Some pre_fire) ~prefetched_comments:[] ~main_branch
+         ~pre_fire_agent:(Some pre_fire) ~prefetched_comments:[]
+         ~prefetched_findings:[] ~main_branch
      with
     | Deliver { base_change = Some bc; _ } ->
         assert (String.equal bc.old_base (Branch.to_string br));
@@ -440,15 +449,16 @@ let () =
         let a = respond a Operation_kind.Ci in
         match
           respond_delivery ~agent:a ~kind:Operation_kind.Ci
-            ~pre_fire_agent:(Some pre_fire) ~prefetched_comments:[] ~main_branch
+            ~pre_fire_agent:(Some pre_fire) ~prefetched_comments:[]
+            ~prefetched_findings:[] ~main_branch
         with
         | Deliver { payload = Ci_payload { failed_checks }; _ } ->
             assert (not (List.is_empty failed_checks))
         | Deliver
             {
               payload =
-                ( Human_payload _ | Review_payload _ | Pr_body_payload
-                | Merge_conflict_payload );
+                ( Human_payload _ | Review_payload _ | Findings_payload _
+                | Pr_body_payload | Merge_conflict_payload );
               _;
             }
         | Skip_empty | Respond_stale ->
@@ -469,7 +479,7 @@ let () =
         let a = respond a kind in
         match
           respond_delivery ~agent:a ~kind ~pre_fire_agent:None
-            ~prefetched_comments:[] ~main_branch
+            ~prefetched_comments:[] ~prefetched_findings:[] ~main_branch
         with
         | Skip_empty ->
             failwith
@@ -502,7 +512,8 @@ let () =
     let a = respond a Operation_kind.Ci in
     (match
        respond_delivery ~agent:a ~kind:Operation_kind.Ci
-         ~pre_fire_agent:(Some pre_fire) ~prefetched_comments:[] ~main_branch
+         ~pre_fire_agent:(Some pre_fire) ~prefetched_comments:[]
+         ~prefetched_findings:[] ~main_branch
      with
     | Skip_empty -> ()
     | Deliver _ | Respond_stale ->
@@ -534,7 +545,8 @@ let () =
     let a = respond a Operation_kind.Ci in
     (match
        respond_delivery ~agent:a ~kind:Operation_kind.Ci
-         ~pre_fire_agent:(Some pre_fire) ~prefetched_comments:[] ~main_branch
+         ~pre_fire_agent:(Some pre_fire) ~prefetched_comments:[]
+         ~prefetched_findings:[] ~main_branch
      with
     | Deliver { payload = Ci_payload { failed_checks }; _ } ->
         let ids =
@@ -545,8 +557,8 @@ let () =
     | Deliver
         {
           payload =
-            ( Human_payload _ | Review_payload _ | Pr_body_payload
-            | Merge_conflict_payload );
+            ( Human_payload _ | Review_payload _ | Findings_payload _
+            | Pr_body_payload | Merge_conflict_payload );
           _;
         }
     | Skip_empty | Respond_stale ->
@@ -579,15 +591,16 @@ let () =
     let a = respond a Operation_kind.Ci in
     (match
        respond_delivery ~agent:a ~kind:Operation_kind.Ci
-         ~pre_fire_agent:(Some pre_fire) ~prefetched_comments:[] ~main_branch
+         ~pre_fire_agent:(Some pre_fire) ~prefetched_comments:[]
+         ~prefetched_findings:[] ~main_branch
      with
     | Deliver { payload = Ci_payload { failed_checks }; _ } ->
         assert (List.length failed_checks = 1)
     | Deliver
         {
           payload =
-            ( Human_payload _ | Review_payload _ | Pr_body_payload
-            | Merge_conflict_payload );
+            ( Human_payload _ | Review_payload _ | Findings_payload _
+            | Pr_body_payload | Merge_conflict_payload );
           _;
         }
     | Skip_empty | Respond_stale ->

--- a/test/test_reconciler_properties.ml
+++ b/test/test_reconciler_properties.ml
@@ -280,7 +280,7 @@ let prop_plan_new_base_only_for_rebase =
             | Types.Operation_kind.Rebase -> Option.is_some new_base
             | Types.Operation_kind.Human | Types.Operation_kind.Merge_conflict
             | Types.Operation_kind.Ci | Types.Operation_kind.Review_comments
-            | Types.Operation_kind.Pr_body ->
+            | Types.Operation_kind.Findings | Types.Operation_kind.Pr_body ->
                 Option.is_none new_base)
         | Reconciler.Mark_merged _ | Reconciler.Enqueue_rebase _ -> true))
 
@@ -299,7 +299,7 @@ let prop_plan_suppresses_rebase_multi_dep =
                 List.length (Graph.open_pr_deps graph patch_id ~has_merged) <= 1
             | Types.Operation_kind.Human | Types.Operation_kind.Merge_conflict
             | Types.Operation_kind.Ci | Types.Operation_kind.Review_comments
-            | Types.Operation_kind.Pr_body ->
+            | Types.Operation_kind.Findings | Types.Operation_kind.Pr_body ->
                 true)
         | Reconciler.Mark_merged _ | Reconciler.Enqueue_rebase _ -> true))
 

--- a/test/test_review_service_properties.ml
+++ b/test/test_review_service_properties.ml
@@ -1,0 +1,276 @@
+open Base
+open Onton_core
+
+(** Property tests for the pure review-service parsers.
+
+    AGENTS.md mandates that pure modules be total — every parser must return a
+    [Result] over arbitrary input rather than raising. The properties below fuzz
+    the four wire-shaped entry points ([parse_findings_response_string],
+    [parse_resolve_response_string], [parse_error_message],
+    [parse_wontfix_artifact]) plus the small enum coders. *)
+
+(* ─────────────────────────────────────────────────────────────────────────
+   Generators
+   ───────────────────────────────────────────────────────────────────────── *)
+
+let gen_yojson : Yojson.Safe.t QCheck2.Gen.t =
+  let open QCheck2.Gen in
+  sized
+  @@ fix (fun self n ->
+      if n <= 0 then
+        oneof
+          [
+            pure `Null;
+            map (fun b -> `Bool b) bool;
+            map (fun i -> `Int i) nat_small;
+            map (fun i -> `Float (Float.of_int i /. 100.)) (int_range 0 10_000);
+            map (fun s -> `String s) string;
+          ]
+      else
+        oneof
+          [
+            self 0;
+            map (fun xs -> `List xs) (list_size (int_range 0 5) (self (n / 2)));
+            map
+              (fun pairs -> `Assoc pairs)
+              (list_size (int_range 0 5)
+                 (pair (string_size (int_range 1 8)) (self (n / 2))));
+          ])
+
+let gen_arbitrary_string =
+  let open QCheck2.Gen in
+  oneof
+    [
+      string;
+      pure "";
+      pure "{}";
+      pure "[]";
+      pure "not json";
+      pure "\x00\x01\xff";
+      map (fun y -> Yojson.Safe.to_string y) gen_yojson;
+      string_size (int_range 0 1024);
+    ]
+
+(* A "shaped-but-not-validated" findings response — the structure is right
+   on the outside but the contents may be garbage. Used to exercise the
+   "drop malformed entries, keep the rest" path in
+   [parse_findings_response]. *)
+let gen_finding_object : Yojson.Safe.t QCheck2.Gen.t =
+  let open QCheck2.Gen in
+  let opt_field name g =
+    let* present = bool in
+    if present then
+      let* v = g in
+      return [ (name, v) ]
+    else return []
+  in
+  let* id = opt_field "id" (map (fun s -> `String s) string) in
+  let* gh =
+    opt_field "githubCommentId"
+      (oneof [ map (fun n -> `Int n) nat_small; pure `Null ])
+  in
+  let* sha = opt_field "postingSha" (map (fun s -> `String s) string) in
+  let* path = opt_field "path" (map (fun s -> `String s) string) in
+  let* startLine = opt_field "startLine" (map (fun n -> `Int n) nat_small) in
+  let* endLine = opt_field "endLine" (map (fun n -> `Int n) nat_small) in
+  let* sev =
+    opt_field "severity"
+      (map
+         (fun s -> `String s)
+         (oneof
+            [
+              pure "must-fix";
+              pure "should-fix";
+              pure "note";
+              pure "garbage";
+              string;
+            ]))
+  in
+  let* body = opt_field "body" (map (fun s -> `String s) string) in
+  let* createdAt = opt_field "createdAt" (map (fun s -> `String s) string) in
+  let* outcome =
+    opt_field "outcome"
+      (oneof
+         [
+           pure (`Assoc [ ("kind", `String "outstanding") ]);
+           pure (`Assoc [ ("kind", `String "discussed") ]);
+           pure (`Assoc [ ("kind", `String "addressed") ]);
+           pure (`Assoc [ ("kind", `String "ignored") ]);
+           pure (`Assoc [ ("kind", `String "resolved") ]);
+           pure (`Assoc [ ("kind", `String "garbage") ]);
+           pure `Null;
+           gen_yojson;
+         ])
+  in
+  return
+    (`Assoc
+       (id @ gh @ sha @ path @ startLine @ endLine @ sev @ body @ createdAt
+      @ outcome))
+
+let gen_findings_response : string QCheck2.Gen.t =
+  let open QCheck2.Gen in
+  let* repo_id = oneof [ string; pure ""; pure "octo/widgets" ] in
+  let* pull_number = nat_small in
+  let* findings = list_size (int_range 0 6) gen_finding_object in
+  return
+    (Yojson.Safe.to_string
+       (`Assoc
+          [
+            ("repoId", `String repo_id);
+            ("pullNumber", `Int pull_number);
+            ("count", `Int (List.length findings));
+            ("findings", `List findings);
+          ]))
+
+let gen_input =
+  let open QCheck2.Gen in
+  oneof [ gen_arbitrary_string; gen_findings_response ]
+
+(* ─────────────────────────────────────────────────────────────────────────
+   Properties
+   ───────────────────────────────────────────────────────────────────────── *)
+
+let totality ~name f =
+  QCheck2.Test.make ~name ~count:1000 gen_input (fun s ->
+      try
+        ignore (f s);
+        true
+      with _ -> false)
+
+let prop_findings_total =
+  totality ~name:"parse_findings_response_string total" (fun s ->
+      Review_service.parse_findings_response_string s)
+
+let prop_resolve_total =
+  totality ~name:"parse_resolve_response_string total" (fun s ->
+      Review_service.parse_resolve_response_string s)
+
+let prop_error_total =
+  totality ~name:"parse_error_message total" (fun s ->
+      Review_service.parse_error_message s)
+
+let prop_wontfix_total =
+  totality ~name:"parse_wontfix_artifact total" (fun s ->
+      Review_service.parse_wontfix_artifact s)
+
+(* All findings the parser keeps must round-trip the severity/outcome enums. *)
+let prop_findings_kept_have_known_enums =
+  QCheck2.Test.make ~name:"parse_findings keeps only known severities/outcomes"
+    ~count:500 gen_findings_response (fun s ->
+      match Review_service.parse_findings_response_string s with
+      | Error _ -> true
+      | Ok r ->
+          List.for_all r.findings ~f:(fun (f : Review_service.finding) ->
+              let sev_ok =
+                Option.is_some
+                  (Review_service.severity_of_string
+                     (Review_service.severity_to_string f.severity))
+              in
+              let kind_ok =
+                Option.is_some
+                  (Review_service.outcome_kind_of_string
+                     (Review_service.outcome_kind_to_string f.outcome.kind))
+              in
+              sev_ok && kind_ok))
+
+(* Severity round-trip is total over the three known strings and rejects
+   everything else. *)
+let prop_severity_round_trip =
+  QCheck2.Test.make ~name:"severity_of_string ∘ to_string = id" ~count:500
+    QCheck2.Gen.string (fun raw ->
+      match Review_service.severity_of_string raw with
+      | None -> true
+      | Some s -> String.equal (Review_service.severity_to_string s) raw
+      (* If of_string accepted [raw], it must round-trip to the canonical
+             form — but the canonical form is the input itself for the three
+             accepted values. *))
+
+let prop_outcome_kind_round_trip =
+  QCheck2.Test.make ~name:"outcome_kind_of_string ∘ to_string = id" ~count:500
+    QCheck2.Gen.string (fun raw ->
+      match Review_service.outcome_kind_of_string raw with
+      | None -> true
+      | Some k -> String.equal (Review_service.outcome_kind_to_string k) raw)
+
+let prop_resolve_kind_round_trip =
+  QCheck2.Test.make ~name:"resolve_kind_of_string ∘ to_string = id" ~count:500
+    QCheck2.Gen.string (fun raw ->
+      match Review_service.resolve_kind_of_string raw with
+      | None -> true
+      | Some k -> String.equal (Review_service.resolve_kind_to_string k) raw)
+
+(* The resolve request encoder must be total and never raise. *)
+let prop_resolve_request_to_yojson_total =
+  let open QCheck2.Gen in
+  let gen =
+    let* kind =
+      oneof
+        [
+          pure Review_service.Resolve_addressed;
+          pure Review_service.Resolve_wontfix;
+        ]
+    in
+    let* actor = oneof [ pure None; map (fun s -> Some s) string ] in
+    let* reason = oneof [ pure None; map (fun s -> Some s) string ] in
+    return
+      ({ Review_service.kind; actor; reason } : Review_service.resolve_request)
+  in
+  QCheck2.Test.make ~name:"resolve_request_to_yojson total" ~count:500 gen
+    (fun req ->
+      try
+        ignore (Review_service.resolve_request_to_yojson req);
+        true
+      with _ -> false)
+
+(* The encoder always emits an Assoc with a "kind" field and at most one each
+   of "actor"/"reason". *)
+let prop_resolve_request_shape =
+  let open QCheck2.Gen in
+  let gen =
+    let* kind =
+      oneof
+        [
+          pure Review_service.Resolve_addressed;
+          pure Review_service.Resolve_wontfix;
+        ]
+    in
+    let* actor = oneof [ pure None; map (fun s -> Some s) string ] in
+    let* reason = oneof [ pure None; map (fun s -> Some s) string ] in
+    return
+      ({ Review_service.kind; actor; reason } : Review_service.resolve_request)
+  in
+  QCheck2.Test.make ~name:"resolve_request_to_yojson shape" ~count:500 gen
+    (fun req ->
+      match Review_service.resolve_request_to_yojson req with
+      | `Assoc fields ->
+          let has_kind =
+            List.exists fields ~f:(fun (k, _) -> String.equal k "kind")
+          in
+          let actor_present =
+            List.exists fields ~f:(fun (k, _) -> String.equal k "actor")
+          in
+          let reason_present =
+            List.exists fields ~f:(fun (k, _) -> String.equal k "reason")
+          in
+          has_kind
+          && Bool.equal actor_present (Option.is_some req.actor)
+          && Bool.equal reason_present (Option.is_some req.reason)
+      | _ -> false)
+
+let () =
+  let suite =
+    [
+      prop_findings_total;
+      prop_resolve_total;
+      prop_error_total;
+      prop_wontfix_total;
+      prop_findings_kept_have_known_enums;
+      prop_severity_round_trip;
+      prop_outcome_kind_round_trip;
+      prop_resolve_kind_round_trip;
+      prop_resolve_request_to_yojson_total;
+      prop_resolve_request_shape;
+    ]
+  in
+  let exit_code = QCheck_base_runner.run_tests ~verbose:true suite in
+  if exit_code <> 0 then Stdlib.exit exit_code

--- a/test/test_state_machine_properties.ml
+++ b/test/test_state_machine_properties.ml
@@ -493,7 +493,7 @@ let make_busy_orch ~patches ~kind ~messages =
                 Orchestrator.send_human_message acc pid msg)
         | Operation_kind.Rebase | Operation_kind.Merge_conflict
         | Operation_kind.Ci | Operation_kind.Review_comments
-        | Operation_kind.Pr_body ->
+        | Operation_kind.Findings | Operation_kind.Pr_body ->
             Orchestrator.enqueue orch pid kind
       in
       let orch =


### PR DESCRIPTION
## Summary

Introduces a new **review backend** abstraction so Onton can poll a review-service alongside GitHub, deliver findings to the agent as a new operation kind, and POST resolve verbs back after the session.

The plan in `~/.claude/plans/i-think-we-ll-need-humble-sunrise.md` describes the *server-side* contract; this PR is the *client-side* implementation: read endpoint (`GET /prs/:owner/:repo/:n/findings`) for polling, write endpoint (`POST .../resolve`) for marking findings `addressed` or `wontfix`.

### Key design points

- **Findings are first-class, not synthetic GitHub comments.** `Operation_kind.Findings` lives alongside `Review_comments` because the agent's resolution surface is different — there's no GitHub thread to reply on.
- **`addressed` vs `wontfix` via artifact.** Mirrors the existing `pr-body.md` pattern: agent writes `findings_wontfix.json` with `[{id, reason}]` for any finding it explicitly dismisses; everything not listed defaults to `addressed`.
- **Multi-backend.** A mutex-guarded `Findings_registry` maps `finding_id → (backend, owner, repo, pr_number)` so resolves go to the originating backend even when several are configured.
- **JWT auth.** RS256 over `mirage-crypto-pk` + `x509`, key read from disk per call, no in-memory caching.

### Layered breakdown

| Layer | New | Purpose |
|---|---|---|
| `lib_core/` (pure) | `review_service`, `review_backend` | Wire-format parsers + config ADT |
| `lib_core/` (pure) | `Operation_kind.Findings`, `Pr_state.findings`, `Findings_payload`, display arms | New variant threaded through the algebra |
| `lib/` | `jwt`, `review_service_client`, `findings_registry`, `findings_resolver` | Effect side: HTTP, auth, side-table, post-session resolve |
| `lib/` | `Prompt.render_findings_prompt` | Agent prompt explaining the artifact mechanism |
| `bin/main.ml` | poller_fiber, runner_fiber threading | Poll merges into `Pr_state.findings`; runner calls resolver after Findings session |

### Property tests caught one real bug

`parse_error_message` raised `Yojson.Safe.Util.Type_error` on non-`Assoc` JSON (e.g. a body of `"true"`). Fixed by pattern-matching shape directly. The 10-property suite covers totality of every entry point, enum round-trips, and encoder shape.

## Test plan
- [x] dune build clean
- [x] dune build @fmt clean
- [x] dune runtest all green (includes new 10-property × 10K-case suite)
- [ ] Manual end-to-end: configure a reviewBackends entry, observe a Findings session resolve correctly
- [ ] Verify outage path: review-service returns 5xx → logged but doesn't abort the poll cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/249"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a review-service backend so Onton can poll external findings, deliver them in a Findings session, and post resolves (“addressed”/“wontfix”) after the session. It re-polls before delivery, safely skips/drops as needed, and hardens RNG init and findings cleanup to prevent stale routes.

- **New Features**
  - Config: `reviewBackends` supports a `review-service` kind (HTTPS only; RS256 JWT with a GitHub App key), with strict validation (HTTPS URL with authority, normalized `baseUrl`, unique backend names).
  - Findings flow: poll merges findings into PR state and queues a Findings session; runner re-polls backends before delivery, skips if empty, renders a findings prompt, then posts resolves using `findings_wontfix.json` (`[{id, reason}]` → `wontfix`, others default to `addressed`). On artifact read/parse failure, findings are dropped and resolves are skipped; a mutex-guarded registry is cleaned on failure to avoid stale routes.
  - Client/auth/resilience: minimal RS256 signer; HTTPS client with response size cap and structured errors; RNG init hardened and seeded in `Jwt.mint`; logs poll errors and dropped findings. UI shows “findings queued” and “addressing findings”.
  - Tooling/deps: adds `onton-probe-findings-api` and `onton-check-repo-config`; new deps `mirage-crypto-pk`, `x509`, `base64`; `.gitignore` ignores `.env` and PEMs.

- **Migration**
  - Optional: add `reviewBackends` to repo `config.json` with `name`, `kind: "review-service"`, `baseUrl`, `auth.appId`, `auth.privateKeyPath` (must pass validation).
  - Ensure the agent can write `artifacts/<patch_id>/findings_wontfix.json`; the supervisor reads it to post wont-fix reasons. Empty `reviewBackends` keeps behavior unchanged.

<sup>Written for commit 18b099df0f0988a7c0f2004020fbc9813836bcf3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Integrates external review findings into PR workflow; deliveries show findings counts and can include findings for human review
  - Findings can be resolved after sessions as "addressed" or "won't fix" with optional reasons

* **Configuration**
  - Repo config supports defining external review backends with authentication

* **User Interface**
  - New statuses for addressing and queued findings; status indicators reflect findings work

* **Tools**
  - New CLI to probe list/resolve findings and to validate repo config
<!-- end of auto-generated comment: release notes by coderabbit.ai -->