### PR TITLE
[patch-agent-onton-integration] Patch 1: Add Llm_backend_long_lived interface

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -1,5 +1,6 @@
 (library
  (name onton)
+ (modules :standard)
  (libraries onton_core base unix eio eio_main eio.unix yojson ppx_yojson_conv_lib cohttp-eio tls-eio mirage-crypto-rng.unix mirage-crypto-pk x509 base64 ca-certs cmarkit)
  (flags (:standard -open Onton_core))
  (foreign_stubs

--- a/lib/llm_backend_long_lived.ml
+++ b/lib/llm_backend_long_lived.ml
@@ -1,0 +1,58 @@
+open Base
+
+type handle = unit
+
+type result = {
+  exit_code : int;
+  stdout : string;
+  stderr : string;
+  got_events : bool;
+  saw_final_result : bool;
+  timed_out : bool;
+}
+[@@deriving show, eq, sexp_of, compare]
+
+type t = {
+  name : string;
+  start :
+    process_mgr:[ `Process_mgr | `Platform of [ `Generic ] ] Eio.Resource.t ->
+    clock:[ `Clock of float ] Eio.Resource.t ->
+    timeout:float ->
+    cwd:Eio.Fs.dir_ty Eio.Path.t ->
+    env:string array ->
+    project_name:string ->
+    patch_id:Types.Patch_id.t ->
+    gameplan:string ->
+    patch:string ->
+    resume_session:string option ->
+    complexity:int option ->
+    handle;
+  prompt :
+    handle ->
+    process_mgr:[ `Process_mgr | `Platform of [ `Generic ] ] Eio.Resource.t ->
+    clock:[ `Clock of float ] Eio.Resource.t ->
+    timeout:float ->
+    cwd:Eio.Fs.dir_ty Eio.Path.t ->
+    env:string array ->
+    prompt:string ->
+    on_event:(Types.Stream_event.t -> unit) ->
+    result;
+  abort : handle -> unit;
+  shutdown : handle -> unit;
+}
+
+let not_implemented () = raise (Failure "not implemented; see patch 4")
+
+let placeholder ~name =
+  {
+    name;
+    start =
+      (fun ~process_mgr:_ ~clock:_ ~timeout:_ ~cwd:_ ~env:_ ~project_name:_
+           ~patch_id:_ ~gameplan:_ ~patch:_ ~resume_session:_ ~complexity:_ ->
+        not_implemented ());
+    prompt =
+      (fun _ ~process_mgr:_ ~clock:_ ~timeout:_ ~cwd:_ ~env:_ ~prompt:_
+           ~on_event:_ -> not_implemented ());
+    abort = (fun _ -> not_implemented ());
+    shutdown = (fun _ -> not_implemented ());
+  }

--- a/lib/llm_backend_long_lived.ml
+++ b/lib/llm_backend_long_lived.ml
@@ -47,12 +47,28 @@ let placeholder ~name =
   {
     name;
     start =
-      (fun ~process_mgr:_ ~clock:_ ~timeout:_ ~cwd:_ ~env:_ ~project_name:_
-           ~patch_id:_ ~gameplan:_ ~patch:_ ~resume_session:_ ~complexity:_ ->
-        not_implemented ());
+      (fun ~process_mgr:_
+        ~clock:_
+        ~timeout:_
+        ~cwd:_
+        ~env:_
+        ~project_name:_
+        ~patch_id:_
+        ~gameplan:_
+        ~patch:_
+        ~resume_session:_
+        ~complexity:_
+      -> not_implemented ());
     prompt =
-      (fun _ ~process_mgr:_ ~clock:_ ~timeout:_ ~cwd:_ ~env:_ ~prompt:_
-           ~on_event:_ -> not_implemented ());
+      (fun _
+        ~process_mgr:_
+        ~clock:_
+        ~timeout:_
+        ~cwd:_
+        ~env:_
+        ~prompt:_
+        ~on_event:_
+      -> not_implemented ());
     abort = (fun _ -> not_implemented ());
     shutdown = (fun _ -> not_implemented ());
   }

--- a/lib/llm_backend_long_lived.ml
+++ b/lib/llm_backend_long_lived.ml
@@ -1,22 +1,14 @@
 open Base
 
 type handle = unit
-
-type result = {
-  exit_code : int;
-  stdout : string;
-  stderr : string;
-  got_events : bool;
-  saw_final_result : bool;
-  timed_out : bool;
-}
-[@@deriving show, eq, sexp_of, compare]
+type result = Llm_backend.result [@@deriving show, eq, sexp_of, compare]
 
 type t = {
   name : string;
   start :
-    process_mgr:[ `Process_mgr | `Platform of [ `Generic ] ] Eio.Resource.t ->
-    clock:[ `Clock of float ] Eio.Resource.t ->
+    'tag 'clock.
+    process_mgr:[> 'tag Eio.Process.mgr_ty ] Eio.Resource.t ->
+    clock:'clock Eio.Time.clock ->
     timeout:float ->
     cwd:Eio.Fs.dir_ty Eio.Path.t ->
     env:string array ->
@@ -28,9 +20,10 @@ type t = {
     complexity:int option ->
     handle;
   prompt :
+    'tag 'clock.
     handle ->
-    process_mgr:[ `Process_mgr | `Platform of [ `Generic ] ] Eio.Resource.t ->
-    clock:[ `Clock of float ] Eio.Resource.t ->
+    process_mgr:[> 'tag Eio.Process.mgr_ty ] Eio.Resource.t ->
+    clock:'clock Eio.Time.clock ->
     timeout:float ->
     cwd:Eio.Fs.dir_ty Eio.Path.t ->
     env:string array ->

--- a/lib/llm_backend_long_lived.ml
+++ b/lib/llm_backend_long_lived.ml
@@ -1,7 +1,7 @@
 open Base
 
 type handle = unit
-type result = Llm_backend.result [@@deriving show, eq, sexp_of, compare]
+type result = Llm_backend.result
 
 type t = {
   name : string;

--- a/lib/llm_backend_long_lived.mli
+++ b/lib/llm_backend_long_lived.mli
@@ -9,7 +9,7 @@ open Base
 type handle
 (** Abstract session handle for a live long-lived backend process. *)
 
-type result = Llm_backend.result [@@deriving show, eq, sexp_of, compare]
+type result = Llm_backend.result
 
 type t = {
   name : string;

--- a/lib/llm_backend_long_lived.mli
+++ b/lib/llm_backend_long_lived.mli
@@ -1,0 +1,58 @@
+open Base
+
+(** Generic long-lived LLM backend interface.
+
+    A long-lived backend owns a persistent subprocess across a patch lifetime.
+    The gameplan-stable and patch-stable prompt layers are supplied once at
+    {!start}; each subsequent {!prompt} sends only the turn-dynamic suffix. *)
+
+type handle
+(** Abstract session handle for a live long-lived backend process. *)
+
+type result = {
+  exit_code : int;
+  stdout : string;
+      (** Bounded raw stdout capture retained for diagnostics. *)
+  stderr : string;
+  got_events : bool;
+  saw_final_result : bool;
+  timed_out : bool;
+}
+[@@deriving show, eq, sexp_of, compare]
+
+type t = {
+  name : string;
+  start :
+    process_mgr:[ `Process_mgr | `Platform of [ `Generic ] ] Eio.Resource.t ->
+    clock:[ `Clock of float ] Eio.Resource.t ->
+    timeout:float ->
+    cwd:Eio.Fs.dir_ty Eio.Path.t ->
+    env:string array ->
+    project_name:string ->
+    patch_id:Types.Patch_id.t ->
+    gameplan:string ->
+    patch:string ->
+    resume_session:string option ->
+    complexity:int option ->
+    handle;
+  prompt :
+    handle ->
+    process_mgr:[ `Process_mgr | `Platform of [ `Generic ] ] Eio.Resource.t ->
+    clock:[ `Clock of float ] Eio.Resource.t ->
+    timeout:float ->
+    cwd:Eio.Fs.dir_ty Eio.Path.t ->
+    env:string array ->
+    prompt:string ->
+    on_event:(Types.Stream_event.t -> unit) ->
+    result;
+  abort : handle -> unit;
+  shutdown : handle -> unit;
+}
+(** [complexity] is the gameplan-author's 1/2/3 estimate for this patch. When
+    the user passes [--model auto], a long-lived backend can resolve the actual
+    model at {!start} time from this value. [None] means the gameplan did not
+    specify a complexity. *)
+
+val placeholder : name:string -> t
+(** Placeholder implementation for incremental integration. Every lifecycle
+    function raises [Failure "not implemented; see patch 4"]. *)

--- a/lib/llm_backend_long_lived.mli
+++ b/lib/llm_backend_long_lived.mli
@@ -9,21 +9,14 @@ open Base
 type handle
 (** Abstract session handle for a live long-lived backend process. *)
 
-type result = {
-  exit_code : int;
-  stdout : string;  (** Bounded raw stdout capture retained for diagnostics. *)
-  stderr : string;
-  got_events : bool;
-  saw_final_result : bool;
-  timed_out : bool;
-}
-[@@deriving show, eq, sexp_of, compare]
+type result = Llm_backend.result [@@deriving show, eq, sexp_of, compare]
 
 type t = {
   name : string;
   start :
-    process_mgr:[ `Process_mgr | `Platform of [ `Generic ] ] Eio.Resource.t ->
-    clock:[ `Clock of float ] Eio.Resource.t ->
+    'tag 'clock.
+    process_mgr:[> 'tag Eio.Process.mgr_ty ] Eio.Resource.t ->
+    clock:'clock Eio.Time.clock ->
     timeout:float ->
     cwd:Eio.Fs.dir_ty Eio.Path.t ->
     env:string array ->
@@ -35,9 +28,10 @@ type t = {
     complexity:int option ->
     handle;
   prompt :
+    'tag 'clock.
     handle ->
-    process_mgr:[ `Process_mgr | `Platform of [ `Generic ] ] Eio.Resource.t ->
-    clock:[ `Clock of float ] Eio.Resource.t ->
+    process_mgr:[> 'tag Eio.Process.mgr_ty ] Eio.Resource.t ->
+    clock:'clock Eio.Time.clock ->
     timeout:float ->
     cwd:Eio.Fs.dir_ty Eio.Path.t ->
     env:string array ->

--- a/lib/llm_backend_long_lived.mli
+++ b/lib/llm_backend_long_lived.mli
@@ -11,8 +11,7 @@ type handle
 
 type result = {
   exit_code : int;
-  stdout : string;
-      (** Bounded raw stdout capture retained for diagnostics. *)
+  stdout : string;  (** Bounded raw stdout capture retained for diagnostics. *)
   stderr : string;
   got_events : bool;
   saw_final_result : bool;


### PR DESCRIPTION
## Patch 1: Add Llm_backend_long_lived interface

- Define type `handle` (abstract; concretely an Eio process record + stdio pipes — implementation deferred to patch 4).
- Define type `result = { exit_code : int; stdout : string; stderr : string; got_events : bool; saw_final_result : bool; timed_out : bool }` with `[@@deriving show, eq, sexp_of, compare]` (mirrors `Llm_backend.result` for ergonomic onton-side reuse).
- Define record `type t = { name : string; start : ... -> handle; prompt : handle -> string -> on_event:(Types.Stream_event.t -> unit) -> result; abort : handle -> unit; shutdown : handle -> unit }`. The `start` and `prompt` arrows take the same Eio capabilities (process_mgr, clock, timeout, cwd, env) as the ephemeral `run_streaming` for a familiar feel.
- Constructor `val placeholder : name:string -> t` returns a record whose lifecycle functions raise `Failure "not implemented; see patch 4"`. Used only as a stand-in until patch 4 lands.

## Changes
- Define type `handle` (abstract; concretely an Eio process record + stdio pipes — implementation deferred to patch 4).
- Define type `result = { exit_code : int; stdout : string; stderr : string; got_events : bool; saw_final_result : bool; timed_out : bool }` with `[@@deriving show, eq, sexp_of, compare]` (mirrors `Llm_backend.result` for ergonomic onton-side reuse).
- Define record `type t = { name : string; start : ... -> handle; prompt : handle -> string -> on_event:(Types.Stream_event.t -> unit) -> result; abort : handle -> unit; shutdown : handle -> unit }`. The `start` and `prompt` arrows take the same Eio capabilities (process_mgr, clock, timeout, cwd, env) as the ephemeral `run_streaming` for a familiar feel.
- Constructor `val placeholder : name:string -> t` returns a record whose lifecycle functions raise `Failure "not implemented; see patch 4"`. Used only as a stand-in until patch 4 lands.

## Files to Modify
- lib/llm_backend_long_lived.ml (create): Persistent-process backend types and a constructor signature that raises Not_implemented (real impl in patch 4).
- lib/llm_backend_long_lived.mli (create): Public interface: handle abstract type, lifecycle functions (start/prompt/abort/shutdown), backend record.
- lib/dune (modify): Add llm_backend_long_lived to the modules list.

## Gameplan Specification

```
module PATCH_AGENT_INTEGRATION.

> M4 ships a long-lived backend abstraction (Llm_backend_long_lived)
> distinct from the ephemeral fresh-spawn shape, an implementation
> (Patch_agent_backend) that drives the patch-agent stdio RPC, and
> kind-driven dispatch in Patch_controller. The patch-agent backend
> is registered under Backend_registry like every other backend;
> selection follows the existing --backend and modelRouting
> machinery. Existing ephemeral backends are untouched.

Backend.
BackendKind.
ephemeral => BackendKind.
long-lived => BackendKind.
patch-agent-backend => Backend.

Session.
LifecyclePhase.
start-phase => LifecyclePhase.
prompt-phase => LifecyclePhase.
abort-phase => LifecyclePhase.
shutdown-phase => LifecyclePhase.

RpcEvent.
StreamEvent.
map-event e: RpcEvent => StreamEvent.

kind-of b: Backend => BackendKind.
long-lived-dispatch? b: Backend => Bool.

start-count s: Session => Nat0.
shutdown-count s: Session => Nat0.
prompt-after-shutdown? s: Session => Bool.
---
> Lifecycle: each long-lived Session has exactly one start, at most
> one shutdown, and no prompt or abort after shutdown.
all s: Session | start-count s = 1.
all s: Session | shutdown-count s <= 1.
all s: Session | ~prompt-after-shutdown? s.

> The patch-agent backend has kind long-lived.
kind-of patch-agent-backend = long-lived.

> Long-lived dispatch is used iff the backend has kind long-lived.
all b: Backend | long-lived-dispatch? b <-> kind-of b = long-lived.

```

## Patch Specification

```
module PATCH_AGENT_INTEGRATION_PATCH_1.

> Patch 1 introduces the Llm_backend_long_lived type only.
> No behavioral invariants — the contribution is the type structure itself.

Backend.
Handle.
LifecyclePhase.
start-phase => LifecyclePhase.
prompt-phase => LifecyclePhase.
abort-phase => LifecyclePhase.
shutdown-phase => LifecyclePhase.
---
true.

```


## Implementation Notes

- The only non-obvious part was the Eio capability typing in record fields: wildcard row variables like `_ Eio.Process.mgr` are valid in `val` signatures but not inside a record type in an `.mli`. I represented `start`/`prompt` with concrete generic `Eio.Resource.t` tags instead so the new record type remains expressible without changing existing callers.
- `handle` is abstract in the interface but intentionally a trivial placeholder (`unit`) in the implementation for this patch. That keeps patch 1 type-only and lets patch 4 replace the concrete representation without touching downstream signatures.
- `start` takes the patch-lifetime prompt layers (`gameplan` and `patch`) up front, while `prompt` takes only the turn-dynamic prompt string. That split is not enforced anywhere yet, but it matches the intended long-lived session shape and avoids a patch-4 interface churn.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces `Llm_backend_long_lived`, a long-lived LLM backend interface for persistent patch sessions. Ships a placeholder implementation; no behavior change.

- **New Features**
  - Added `lib/llm_backend_long_lived.{mli,ml}`: abstract `handle`; `result` aliases `Llm_backend.result`; backend `t` with `start`, `prompt` (streams `Types.Stream_event.t`), `abort`, `shutdown`.
  - `start` includes `resume_session` and `complexity:int option` for model selection; uses `Eio.Resource.t` capabilities.
  - Updated `lib/dune` with `(modules :standard)` to include the new module.

- **Refactors**
  - Removed deriving from the `result` alias.

<sup>Written for commit d71c9295b576419477c2ac175af7987851187ec7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for long-lived LLM backends: persistent sessions with interactive prompting, streaming event callbacks, and session control (abort and shutdown). Optional complexity hint used for model resolution at session start.

* **Chores**
  * Build configuration updated to include standard module settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->