### PR TITLE
[patch-agent-onton-integration] Patch 5: Integration-test stub against fixture patch

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -19,6 +19,12 @@
  (name test_patch_agent_event_mapper)
  (modules test_patch_agent_event_mapper)
  (libraries onton onton_core qcheck-core qcheck-core.runner)
+
+(test
+ (name test_patch_agent_backend_integration)
+ (modules test_patch_agent_backend_integration)
+ (libraries onton onton_core onton_test_support qcheck-core qcheck-core.runner
+   eio eio_main eio.unix unix)
  (ocamlopt_flags (:standard -w -40-42))
  (ocamlc_flags (:standard -w -40-42)))
 

--- a/test/dune
+++ b/test/dune
@@ -19,6 +19,8 @@
  (name test_patch_agent_event_mapper)
  (modules test_patch_agent_event_mapper)
  (libraries onton onton_core qcheck-core qcheck-core.runner)
+ (ocamlopt_flags (:standard -w -40-42))
+ (ocamlc_flags (:standard -w -40-42)))
 
 (test
  (name test_patch_agent_backend_integration)

--- a/test/fixtures/patch_agent_integration/gameplan.md
+++ b/test/fixtures/patch_agent_integration/gameplan.md
@@ -1,0 +1,5 @@
+# Patch-agent integration smoke
+
+Run a single long-lived backend session.
+Use the fixture patch prompt from the same directory.
+Stop after replying to one prompt.

--- a/test/fixtures/patch_agent_integration/patch.md
+++ b/test/fixtures/patch_agent_integration/patch.md
@@ -1,0 +1,5 @@
+# Fixture patch
+
+Touch only the temporary fixture worktree created by the test.
+Do not rely on network or repository-specific state.
+Reply briefly, then stop.

--- a/test/test_patch_agent_backend_integration.ml
+++ b/test/test_patch_agent_backend_integration.ml
@@ -3,12 +3,11 @@ open Base
 let pending_test =
   QCheck2.Test.make
     ~name:"Patch_agent_backend_integration > one-turn smoke against real binary"
-    ~count:1
-    QCheck2.Gen.unit (fun () ->
+    ~count:1 QCheck2.Gen.unit (fun () ->
       (* PENDING: implemented in patch 6 *)
       Stdlib.prerr_endline
-        "SKIP: pending integration smoke for patch-agent backend \
-         (implemented in patch 6)";
+        "SKIP: pending integration smoke for patch-agent backend (implemented \
+         in patch 6)";
       true)
 
 let () =

--- a/test/test_patch_agent_backend_integration.ml
+++ b/test/test_patch_agent_backend_integration.ml
@@ -1,0 +1,16 @@
+open Base
+
+let pending_test =
+  QCheck2.Test.make
+    ~name:"Patch_agent_backend_integration > one-turn smoke against real binary"
+    ~count:1
+    QCheck2.Gen.unit (fun () ->
+      (* PENDING: implemented in patch 6 *)
+      Stdlib.prerr_endline
+        "SKIP: pending integration smoke for patch-agent backend \
+         (implemented in patch 6)";
+      true)
+
+let () =
+  let exit_code = QCheck_base_runner.run_tests ~verbose:true [ pending_test ] in
+  if exit_code <> 0 then Stdlib.exit exit_code


### PR DESCRIPTION
## Patch 5: Integration-test stub against fixture patch

- Add `[@tags "pending"]` skip marker on the test (or the project's QCheck2-equivalent skip mechanism). Test body is implemented in patch 6.
- Test outline: setup a temp git worktree; locate the patch-agent binary from `$PATH` (skip with a clear message if not found, similar to the existing OAuth-credentials-skip pattern); call `Patch_agent_backend.create` to get a `Llm_backend_long_lived.t`; call `start` with the fixtures and Anthropic Sonnet 4.6 (or the project's smoke model); call `prompt` with `"Reply with exactly OK and stop."`; assert the event stream contains Session_init -> Turn_started -> at least one Text_delta -> Final_result; call `shutdown`; assert process exits cleanly with no zombie children.
- Pending comment: `(* PENDING: implemented in patch 6 *)`

## Changes
- Add `[@tags "pending"]` skip marker on the test (or the project's QCheck2-equivalent skip mechanism). Test body is implemented in patch 6.
- Test outline: setup a temp git worktree; locate the patch-agent binary from `$PATH` (skip with a clear message if not found, similar to the existing OAuth-credentials-skip pattern); call `Patch_agent_backend.create` to get a `Llm_backend_long_lived.t`; call `start` with the fixtures and Anthropic Sonnet 4.6 (or the project's smoke model); call `prompt` with `"Reply with exactly OK and stop."`; assert the event stream contains Session_init -> Turn_started -> at least one Text_delta -> Final_result; call `shutdown`; assert process exits cleanly with no zombie children.
- Pending comment: `(* PENDING: implemented in patch 6 *)`

## Files to Modify
- test/test_patch_agent_backend_integration.ml (create): Skip-marked test that spawns the real patch-agent binary against a minimal fixture and asserts the long-lived lifecycle event sequence. Implementation lands in patch 6.
- test/fixtures/patch_agent_integration/gameplan.md (create): Minimal gameplan-prompt fixture (3-5 lines).
- test/fixtures/patch_agent_integration/patch.md (create): Minimal patch-prompt fixture (3-5 lines).
- test/dune (modify): Add test_patch_agent_backend_integration to test executables.

## Gameplan Specification

```
module PATCH_AGENT_INTEGRATION.

> M4 ships a long-lived backend abstraction (Llm_backend_long_lived)
> distinct from the ephemeral fresh-spawn shape, an implementation
> (Patch_agent_backend) that drives the patch-agent stdio RPC, and
> kind-driven dispatch in Patch_controller. The patch-agent backend
> is registered under Backend_registry like every other backend;
> selection follows the existing --backend and modelRouting
> machinery. Existing ephemeral backends are untouched.

Backend.
BackendKind.
ephemeral => BackendKind.
long-lived => BackendKind.
patch-agent-backend => Backend.

Session.
LifecyclePhase.
start-phase => LifecyclePhase.
prompt-phase => LifecyclePhase.
abort-phase => LifecyclePhase.
shutdown-phase => LifecyclePhase.

RpcEvent.
StreamEvent.
map-event e: RpcEvent => StreamEvent.

kind-of b: Backend => BackendKind.
long-lived-dispatch? b: Backend => Bool.

start-count s: Session => Nat0.
shutdown-count s: Session => Nat0.
prompt-after-shutdown? s: Session => Bool.
---
> Lifecycle: each long-lived Session has exactly one start, at most
> one shutdown, and no prompt or abort after shutdown.
all s: Session | start-count s = 1.
all s: Session | shutdown-count s <= 1.
all s: Session | ~prompt-after-shutdown? s.

> The patch-agent backend has kind long-lived.
kind-of patch-agent-backend = long-lived.

> Long-lived dispatch is used iff the backend has kind long-lived.
all b: Backend | long-lived-dispatch? b <-> kind-of b = long-lived.

```

## Patch Specification

```
module PATCH_AGENT_INTEGRATION_PATCH_5.

> Patch 5 introduces an integration-test stub. No new invariants —
> redeclare Patch 4's session lifecycle types so this module is
> self-contained.

Session.
LifecyclePhase.
start-phase => LifecyclePhase.
prompt-phase => LifecyclePhase.
abort-phase => LifecyclePhase.
shutdown-phase => LifecyclePhase.
---
true.

```


## Implementation Notes

- The repo does not appear to use `[@tags "pending"]` on these standalone test executables, so the stub uses the allowed QCheck2-equivalent pending mechanism instead: a single-count QCheck test that always passes and emits one clear `SKIP:` line. I set `~count:1` specifically to avoid log spam during `dune runtest`.
- The fixture prompt files were added now so patch 6 can implement the real smoke path without reshaping the test harness or test data layout.
- No behavioral code changed in this patch; it is limited to test wiring, placeholder fixture data, and the explicit `(* PENDING: implemented in patch 6 *)` marker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added patch-agent long-lived backend enabling persistent LLM subprocess sessions with streaming I/O, process lifecycle management, timeout enforcement, and graceful shutdown capabilities.

* **Tests**
  * Added integration test infrastructure and fixtures for patch-agent backend validation.

* **Refactor**
  * Simplified long-lived backend API with consolidated configuration and explicit result handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->