### PR TITLE
[patch-agent-onton-integration] Patch 6: Register patch-agent backend; branch dispatch on lifecycle kind

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1912,7 +1912,7 @@ let poller_fiber ~runtime ~clock ~net ~process_mgr ~github ~config ~project_name
     concurrently. *)
 let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name ~pr_registry
     ~findings_registry ~review_backends ~transcripts ~github ~net ~event_log
-    ~session_timeout ?status_msg () =
+    ?status_msg () =
   let main = config.main_branch in
   let process_mgr = Eio.Stdenv.process_mgr env in
   let clock = Eio.Stdenv.clock env in
@@ -1992,7 +1992,6 @@ let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name ~pr_registry
                     Session_driver.create_long_lived_session ~backend
                       ~provider:patch_agent_provider ~model:patch_agent_model
                       ~effort:patch_agent_effort ~gameplan_prompt ~patch_prompt
-                      ~timeout:session_timeout
                   in
                   Stdlib.Hashtbl.replace long_lived_sessions patch_id session;
                   session
@@ -4100,7 +4099,7 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
           :: (fun () ->
             runner_fiber ~runtime ~env ~config ~pick_backend ~project_name
               ~pr_registry ~findings_registry ~review_backends ~transcripts
-              ~github ~net ~event_log ~session_timeout ())
+              ~github ~net ~event_log ())
           :: common_fibers)
       else
         let list_selected = ref 0 in
@@ -4153,8 +4152,7 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
                 :: (fun () ->
                   runner_fiber ~runtime ~env ~config ~pick_backend ~project_name
                     ~pr_registry ~findings_registry ~review_backends
-                    ~transcripts ~github ~net ~event_log ~session_timeout
-                    ~status_msg ())
+                    ~transcripts ~github ~net ~event_log ~status_msg ())
                 :: common_fibers)
             with Quit_tui -> ())
 

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1962,40 +1962,46 @@ let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name ~pr_registry
           ~owner:config.github_owner ~repo:config.github_repo ~on_pr_detected
           ~transcripts ~user_config:config.user_config ~worktree_mutex
           ~hook_mutex ~backend ~complexity ~event_log
-    | Backend_registry.Long_lived backend, decision ->
-        let patch_agent_model =
+    | Backend_registry.Long_lived backend, decision -> (
+        let patch_agent_model_result =
           match
             Backend_registry.resolve_model
               ~backend:decision.Backend_routing.backend
               ~model:decision.Backend_routing.model ~complexity
           with
           | Some m when not (Base.String.is_empty (Base.String.strip m)) ->
-              Base.String.strip m
+              Ok (Base.String.strip m)
           | Some _ | None ->
-              invalid_arg
-                "patch-agent backend requires a concrete model after routing"
+              Error
+                "patch-agent backend requires a concrete non-empty model after \
+                 routing"
         in
-        let session =
-          match Stdlib.Hashtbl.find_opt long_lived_sessions patch_id with
-          | Some session ->
-              Session_driver.update_long_lived_session_prompts session
-                ~gameplan_prompt ~patch_prompt;
-              session
-          | None ->
-              let session =
-                Session_driver.create_long_lived_session ~backend
-                  ~provider:patch_agent_provider ~model:patch_agent_model
-                  ~effort:patch_agent_effort ~gameplan_prompt ~patch_prompt
-                  ~timeout:session_timeout
-              in
-              Stdlib.Hashtbl.replace long_lived_sessions patch_id session;
-              session
-        in
-        Session_driver.run_long_lived ~sw ~kind ~runtime ~process_mgr ~clock ~fs
-          ~project_name ~patch_id ~repo_root:config.repo_root ~prompt ~agent
-          ~owner:config.github_owner ~repo:config.github_repo ~on_pr_detected
-          ~transcripts ~user_config:config.user_config ~worktree_mutex
-          ~hook_mutex ~session ~complexity ~event_log
+        match patch_agent_model_result with
+        | Error message ->
+            log_event runtime ~patch_id message;
+            (`Failed, [])
+        | Ok patch_agent_model ->
+            let session =
+              match Stdlib.Hashtbl.find_opt long_lived_sessions patch_id with
+              | Some session ->
+                  Session_driver.update_long_lived_session_prompts session
+                    ~gameplan_prompt ~patch_prompt;
+                  session
+              | None ->
+                  let session =
+                    Session_driver.create_long_lived_session ~backend
+                      ~provider:patch_agent_provider ~model:patch_agent_model
+                      ~effort:patch_agent_effort ~gameplan_prompt ~patch_prompt
+                      ~timeout:session_timeout
+                  in
+                  Stdlib.Hashtbl.replace long_lived_sessions patch_id session;
+                  session
+            in
+            Session_driver.run_long_lived ~sw ~kind ~runtime ~process_mgr ~clock
+              ~fs ~project_name ~patch_id ~repo_root:config.repo_root ~prompt
+              ~agent ~owner:config.github_owner ~repo:config.github_repo
+              ~on_pr_detected ~transcripts ~user_config:config.user_config
+              ~worktree_mutex ~hook_mutex ~session ~complexity ~event_log)
   in
   let shutdown_finished_long_lived_sessions ~sw () =
     let finished =

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -2015,7 +2015,8 @@ let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name ~pr_registry
                   Orchestrator.find_agent snap.Runtime.orchestrator patch_id
                 with
                 | None -> (patch_id, session) :: acc
-                | Some agent when agent.Patch_agent.merged ->
+                | Some agent
+                  when agent.Patch_agent.merged && not agent.Patch_agent.busy ->
                     (patch_id, session) :: acc
                 | Some _ -> acc)
             long_lived_sessions [])

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1973,7 +1973,10 @@ let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name ~pr_registry
         in
         let session =
           match Stdlib.Hashtbl.find_opt long_lived_sessions patch_id with
-          | Some session -> session
+          | Some session ->
+              Session_driver.update_long_lived_session_prompts session
+                ~gameplan_prompt ~patch_prompt;
+              session
           | None ->
               let session =
                 Session_driver.create_long_lived_session ~backend
@@ -1990,26 +1993,36 @@ let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name ~pr_registry
           ~transcripts ~user_config:config.user_config ~worktree_mutex
           ~hook_mutex ~session ~complexity ~event_log
   in
-  let shutdown_finished_long_lived_sessions () =
+  let shutdown_finished_long_lived_sessions ~sw () =
     let finished =
       Runtime.read runtime (fun snap ->
           Stdlib.Hashtbl.fold
             (fun patch_id session acc ->
-              match
-                Orchestrator.find_agent snap.Runtime.orchestrator patch_id
-              with
-              | None -> (patch_id, session) :: acc
-              | Some agent
-                when agent.Patch_agent.merged
-                     || (not agent.Patch_agent.busy)
-                        && Patch_agent.needs_intervention agent ->
-                  (patch_id, session) :: acc
-              | Some _ -> acc)
+              if Session_driver.long_lived_session_failed session then
+                (patch_id, session) :: acc
+              else
+                match
+                  Orchestrator.find_agent snap.Runtime.orchestrator patch_id
+                with
+                | None -> (patch_id, session) :: acc
+                | Some agent
+                  when agent.Patch_agent.merged
+                       || (not agent.Patch_agent.busy)
+                          && Patch_agent.needs_intervention agent ->
+                    (patch_id, session) :: acc
+                | Some _ -> acc)
             long_lived_sessions [])
     in
     Base.List.iter finished ~f:(fun (patch_id, session) ->
-        Session_driver.shutdown_long_lived_session session;
-        Stdlib.Hashtbl.remove long_lived_sessions patch_id)
+        Stdlib.Hashtbl.remove long_lived_sessions patch_id;
+        Eio.Fiber.fork_daemon ~sw (fun () ->
+            (try Session_driver.shutdown_long_lived_session session with
+            | Eio.Cancel.Cancelled _ -> ()
+            | exn ->
+                log_event runtime ~patch_id
+                  (Printf.sprintf "long-lived backend shutdown error — %s"
+                     (Printexc.to_string exn)));
+            `Stop_daemon))
   in
   let with_busy_guard ~patch_id f =
     let cancelled = ref false in
@@ -2071,7 +2084,7 @@ let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name ~pr_registry
            which subsumes its effect. *))
   in
   let rec loop sw =
-    shutdown_finished_long_lived_sessions ();
+    shutdown_finished_long_lived_sessions ~sw ();
     let gameplan = Runtime.read runtime (fun snap -> snap.Runtime.gameplan) in
     let lifecycle_effects, messages, pre_fire_agents =
       Runtime.update_orchestrator_returning runtime (fun orch ->
@@ -3513,7 +3526,7 @@ let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name ~pr_registry
         Eio.Fiber.fork_daemon ~sw (fun () ->
             f ();
             `Stop_daemon));
-    shutdown_finished_long_lived_sessions ();
+    shutdown_finished_long_lived_sessions ~sw ();
     Eio.Time.sleep clock 1.0;
     loop sw
   in

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1964,12 +1964,16 @@ let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name ~pr_registry
           ~hook_mutex ~backend ~complexity ~event_log
     | Backend_registry.Long_lived backend, decision ->
         let patch_agent_model =
-          match decision.Backend_routing.model with
-          | Some m
-            when (not (Base.String.is_empty (Base.String.strip m)))
-                 && not (Backend_routing.is_auto_model (Some m)) ->
+          match
+            Backend_registry.resolve_model
+              ~backend:decision.Backend_routing.backend
+              ~model:decision.Backend_routing.model ~complexity
+          with
+          | Some m when not (Base.String.is_empty (Base.String.strip m)) ->
               Base.String.strip m
-          | Some _ | None -> "claude-sonnet-4-5"
+          | Some _ | None ->
+              invalid_arg
+                "patch-agent backend requires a concrete model after routing"
         in
         let session =
           match Stdlib.Hashtbl.find_opt long_lived_sessions patch_id with
@@ -3986,10 +3990,12 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
           Backend_routing.decide ~repo_config ~default_backend:config.backend
             ~cli_model:cli_model_opt ~complexity
         in
-        Backend_routing.resolve_auto dec
-          ~auto_model:
-            (Backend_registry.auto_model ~backend:dec.Backend_routing.backend)
-          ~complexity
+        {
+          dec with
+          model =
+            Backend_registry.resolve_model ~backend:dec.Backend_routing.backend
+              ~model:dec.Backend_routing.model ~complexity;
+        }
       in
       let net = Eio.Stdenv.net env in
       let stdout = Eio.Stdenv.stdout env in

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -2005,10 +2005,7 @@ let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name ~pr_registry
                   Orchestrator.find_agent snap.Runtime.orchestrator patch_id
                 with
                 | None -> (patch_id, session) :: acc
-                | Some agent
-                  when agent.Patch_agent.merged
-                       || (not agent.Patch_agent.busy)
-                          && Patch_agent.needs_intervention agent ->
+                | Some agent when agent.Patch_agent.merged ->
                     (patch_id, session) :: acc
                 | Some _ -> acc)
             long_lived_sessions [])
@@ -3526,7 +3523,6 @@ let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name ~pr_registry
         Eio.Fiber.fork_daemon ~sw (fun () ->
             f ();
             `Stop_daemon));
-    shutdown_finished_long_lived_sessions ~sw ();
     Eio.Time.sleep clock 1.0;
     loop sw
   in

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -4180,7 +4180,9 @@ let backend_arg =
   Arg.(
     value & opt string ""
     & info [ "backend" ] ~docv:"BACKEND"
-        ~doc:"LLM backend to use: claude, codex, opencode, pi, or gemini.")
+        ~doc:
+          "LLM backend to use: claude, codex, opencode, pi, gemini, or \
+           patch-agent.")
 
 let model_arg =
   let open Cmdliner in

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -125,7 +125,9 @@ let infer_default_branch ~repo_root =
           | None -> "main"))
 
 let default_backend = "claude"
-let known_backends = [ "claude"; "codex"; "opencode"; "pi"; "gemini" ]
+
+let known_backends =
+  [ "claude"; "codex"; "opencode"; "pi"; "gemini"; "patch-agent" ]
 
 (** Resolve a CLI [--backend]/[--model] pair (or stored equivalents) into the
     canonical [(backend, model)] tuple used internally. Empty [backend] falls
@@ -1910,7 +1912,7 @@ let poller_fiber ~runtime ~clock ~net ~process_mgr ~github ~config ~project_name
     concurrently. *)
 let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name ~pr_registry
     ~findings_registry ~review_backends ~transcripts ~github ~net ~event_log
-    ?status_msg () =
+    ~session_timeout ?status_msg () =
   let main = config.main_branch in
   let process_mgr = Eio.Stdenv.process_mgr env in
   let clock = Eio.Stdenv.clock env in
@@ -1935,6 +1937,80 @@ let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name ~pr_registry
      of short-lived children. Running 10 hooks in parallel is how issue
      #209 blew through the system FD table. *)
   let hook_mutex = Eio.Mutex.create () in
+  let long_lived_sessions :
+      (Patch_id.t, Session_driver.long_lived_session) Stdlib.Hashtbl.t =
+    Stdlib.Hashtbl.create 16
+  in
+  let patch_agent_provider =
+    match Stdlib.Sys.getenv_opt "PATCH_AGENT_PROVIDER" with
+    | Some s when not (Base.String.is_empty (Base.String.strip s)) ->
+        Base.String.strip s
+    | Some _ | None -> "anthropic"
+  in
+  let patch_agent_effort =
+    match Stdlib.Sys.getenv_opt "PATCH_AGENT_EFFORT" with
+    | Some s when not (Base.String.is_empty (Base.String.strip s)) ->
+        Base.String.strip s
+    | Some _ | None -> "medium"
+  in
+  let run_llm_session ~sw ~gameplan_prompt ~patch_prompt ~kind ~patch_id ~prompt
+      ~agent ~on_pr_detected ~complexity =
+    match pick_backend ~complexity with
+    | Backend_registry.Ephemeral backend, _decision ->
+        Session_driver.run ~kind ~runtime ~process_mgr ~clock ~fs ~project_name
+          ~patch_id ~repo_root:config.repo_root ~prompt ~agent
+          ~owner:config.github_owner ~repo:config.github_repo ~on_pr_detected
+          ~transcripts ~user_config:config.user_config ~worktree_mutex
+          ~hook_mutex ~backend ~complexity ~event_log
+    | Backend_registry.Long_lived backend, decision ->
+        let patch_agent_model =
+          match decision.Backend_routing.model with
+          | Some m
+            when (not (Base.String.is_empty (Base.String.strip m)))
+                 && not (Backend_routing.is_auto_model (Some m)) ->
+              Base.String.strip m
+          | Some _ | None -> "claude-sonnet-4-5"
+        in
+        let session =
+          match Stdlib.Hashtbl.find_opt long_lived_sessions patch_id with
+          | Some session -> session
+          | None ->
+              let session =
+                Session_driver.create_long_lived_session ~backend
+                  ~provider:patch_agent_provider ~model:patch_agent_model
+                  ~effort:patch_agent_effort ~gameplan_prompt ~patch_prompt
+                  ~timeout:session_timeout
+              in
+              Stdlib.Hashtbl.replace long_lived_sessions patch_id session;
+              session
+        in
+        Session_driver.run_long_lived ~sw ~kind ~runtime ~process_mgr ~clock ~fs
+          ~project_name ~patch_id ~repo_root:config.repo_root ~prompt ~agent
+          ~owner:config.github_owner ~repo:config.github_repo ~on_pr_detected
+          ~transcripts ~user_config:config.user_config ~worktree_mutex
+          ~hook_mutex ~session ~complexity ~event_log
+  in
+  let shutdown_finished_long_lived_sessions () =
+    let finished =
+      Runtime.read runtime (fun snap ->
+          Stdlib.Hashtbl.fold
+            (fun patch_id session acc ->
+              match
+                Orchestrator.find_agent snap.Runtime.orchestrator patch_id
+              with
+              | None -> (patch_id, session) :: acc
+              | Some agent
+                when agent.Patch_agent.merged
+                     || (not agent.Patch_agent.busy)
+                        && Patch_agent.needs_intervention agent ->
+                  (patch_id, session) :: acc
+              | Some _ -> acc)
+            long_lived_sessions [])
+    in
+    Base.List.iter finished ~f:(fun (patch_id, session) ->
+        Session_driver.shutdown_long_lived_session session;
+        Stdlib.Hashtbl.remove long_lived_sessions patch_id)
+  in
   let with_busy_guard ~patch_id f =
     let cancelled = ref false in
     let exception_raised = ref false in
@@ -1995,6 +2071,7 @@ let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name ~pr_registry
            which subsumes its effect. *))
   in
   let rec loop sw =
+    shutdown_finished_long_lived_sessions ();
     let gameplan = Runtime.read runtime (fun snap -> snap.Runtime.gameplan) in
     let lifecycle_effects, messages, pre_fire_agents =
       Runtime.update_orchestrator_returning runtime (fun orch ->
@@ -2149,18 +2226,23 @@ let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name ~pr_registry
                                       let complexity =
                                         patch_complexity ~gameplan ~patch_id
                                       in
+                                      let gameplan_prompt =
+                                        Prompt.render_gameplan_layer
+                                          ~project_name gameplan
+                                      in
+                                      let patch_prompt =
+                                        Prompt.render_patch_layer ~project_name
+                                          patch
+                                          ?pr_number:agent.Patch_agent.pr_number
+                                          ~base_branch:
+                                            (Branch.to_string base_branch)
+                                          ()
+                                      in
                                       let r, _tool_failures =
-                                        Session_driver.run ~kind:None ~runtime
-                                          ~process_mgr ~clock ~fs ~project_name
-                                          ~patch_id ~repo_root:config.repo_root
-                                          ~prompt ~agent
-                                          ~owner:config.github_owner
-                                          ~repo:config.github_repo
-                                          ~on_pr_detected ~transcripts
-                                          ~user_config:config.user_config
-                                          ~worktree_mutex ~hook_mutex
-                                          ~backend:(pick_backend ~complexity)
-                                          ~complexity ~event_log
+                                        run_llm_session ~sw ~gameplan_prompt
+                                          ~patch_prompt ~kind:None ~patch_id
+                                          ~prompt ~agent ~on_pr_detected
+                                          ~complexity
                                       in
                                       (r
                                         :> [ `Failed
@@ -2661,20 +2743,25 @@ let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name ~pr_registry
                                       let complexity =
                                         patch_complexity ~gameplan ~patch_id
                                       in
+                                      let gameplan_prompt =
+                                        Prompt.render_gameplan_layer
+                                          ~project_name gameplan
+                                      in
+                                      let patch_prompt =
+                                        match patch with
+                                        | Some p ->
+                                            Prompt.render_patch_layer
+                                              ~project_name p ?pr_number
+                                              ~base_branch:base ()
+                                        | None -> ""
+                                      in
                                       let result, _tool_failures =
-                                        Session_driver.run
+                                        run_llm_session ~sw ~gameplan_prompt
+                                          ~patch_prompt
                                           ~kind:
                                             (Some Operation_kind.Merge_conflict)
-                                          ~runtime ~process_mgr ~clock ~fs
-                                          ~project_name ~patch_id
-                                          ~repo_root:config.repo_root ~prompt
-                                          ~agent ~owner:config.github_owner
-                                          ~repo:config.github_repo
-                                          ~on_pr_detected ~transcripts
-                                          ~user_config:config.user_config
-                                          ~worktree_mutex ~hook_mutex
-                                          ~backend:(pick_backend ~complexity)
-                                          ~complexity ~event_log
+                                          ~patch_id ~prompt ~agent
+                                          ~on_pr_detected ~complexity
                                       in
                                       (match result with
                                       | `Ok
@@ -3105,18 +3192,24 @@ let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name ~pr_registry
                                     let complexity =
                                       patch_complexity ~gameplan ~patch_id
                                     in
+                                    let gameplan_prompt =
+                                      Prompt.render_gameplan_layer ~project_name
+                                        gameplan
+                                    in
+                                    let patch_prompt =
+                                      match patch_for_layer with
+                                      | Some p ->
+                                          Prompt.render_patch_layer
+                                            ~project_name p ?pr_number
+                                            ~base_branch:base_branch_for_layer
+                                            ()
+                                      | None -> ""
+                                    in
                                     let result, tool_failures =
-                                      Session_driver.run ~kind:(Some kind)
-                                        ~runtime ~process_mgr ~clock ~fs
-                                        ~project_name ~patch_id
-                                        ~repo_root:config.repo_root ~prompt
-                                        ~agent ~owner:config.github_owner
-                                        ~repo:config.github_repo ~on_pr_detected
-                                        ~transcripts
-                                        ~user_config:config.user_config
-                                        ~worktree_mutex ~hook_mutex
-                                        ~backend:(pick_backend ~complexity)
-                                        ~complexity ~event_log
+                                      run_llm_session ~sw ~gameplan_prompt
+                                        ~patch_prompt ~kind:(Some kind)
+                                        ~patch_id ~prompt ~agent ~on_pr_detected
+                                        ~complexity
                                     in
                                     let result =
                                       (result
@@ -3420,6 +3513,7 @@ let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name ~pr_registry
         Eio.Fiber.fork_daemon ~sw (fun () ->
             f ();
             `Stop_daemon));
+    shutdown_finished_long_lived_sessions ();
     Eio.Time.sleep clock 1.0;
     loop sw
   in
@@ -3863,13 +3957,18 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
          registry. Calling with [~complexity:None] yields the run's default
          backend (used for ad-hoc sessions and for the TUI display name). *)
       let pick_backend ~complexity =
-        let { Backend_routing.backend; model } =
+        let ({ Backend_routing.backend; model } as decision) =
           Backend_routing.decide ~repo_config ~default_backend:config.backend
             ~cli_model:cli_model_opt ~complexity
         in
-        Backend_registry.get registry ~backend ~model
+        (Backend_registry.get registry ~backend ~model, decision)
       in
       let default_backend = pick_backend ~complexity:None in
+      let backend_name = function
+        | Backend_registry.Ephemeral backend -> backend.Llm_backend.name
+        | Backend_registry.Long_lived (Llm_backend_long_lived.T { name; _ }) ->
+            name
+      in
       (* Display-side counterpart to [pick_backend]: returns the routing
          decision with the [auto] sentinel resolved to the concrete model
          name, so the TUI shows what will actually run. *)
@@ -3979,7 +4078,7 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
           :: (fun () ->
             runner_fiber ~runtime ~env ~config ~pick_backend ~project_name
               ~pr_registry ~findings_registry ~review_backends ~transcripts
-              ~github ~net ~event_log ())
+              ~github ~net ~event_log ~session_timeout ())
           :: common_fibers)
       else
         let list_selected = ref 0 in
@@ -4019,7 +4118,7 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
                      ~show_help ~status_msg ~transcripts ~sorted_patch_ids
                      ~input_mode ~prompt_line ~patches_start_row
                      ~patches_scroll_offset ~patches_visible_count
-                     ~backend_name:default_backend.Llm_backend.name
+                     ~backend_name:(backend_name (fst default_backend))
                      ~resolve_routing)
                 :: (fun () ->
                   input_fiber ~runtime ~process_mgr ~net ~github ~list_selected
@@ -4032,7 +4131,8 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
                 :: (fun () ->
                   runner_fiber ~runtime ~env ~config ~pick_backend ~project_name
                     ~pr_registry ~findings_registry ~review_backends
-                    ~transcripts ~github ~net ~event_log ~status_msg ())
+                    ~transcripts ~github ~net ~event_log ~session_timeout
+                    ~status_msg ())
                 :: common_fibers)
             with Quit_tui -> ())
 

--- a/lib/backend_registry.ml
+++ b/lib/backend_registry.ml
@@ -64,10 +64,19 @@ let auto_model ~backend ~complexity =
   | "opencode" -> Opencode_backend.auto_model ~complexity
   | "pi" -> Pi_backend.auto_model ~complexity
   | "gemini" -> Gemini_backend.auto_model ~complexity
-  | "patch-agent" -> None
+  | "patch-agent" -> Some "claude-sonnet-4-5"
   | other ->
       invalid_arg
         (Printf.sprintf "Backend_registry.auto_model: unknown backend %S" other)
+
+let resolve_model ~backend ~model ~complexity =
+  let model =
+    Llm_backend.resolve_auto_model ~model ~complexity
+      ~auto_model:(auto_model ~backend)
+  in
+  match (backend, model) with
+  | "patch-agent", None -> auto_model ~backend ~complexity
+  | _ -> model
 
 let get t ~backend ~model =
   let key = (backend, model) in

--- a/lib/backend_registry.ml
+++ b/lib/backend_registry.ml
@@ -1,9 +1,11 @@
 open Base
 
 type t = {
-  factory : backend:string -> model:string option -> Llm_backend.t;
-  cache : (string * string option, Llm_backend.t) Hashtbl.t;
+  factory : backend:string -> model:string option -> kind;
+  cache : (string * string option, kind) Hashtbl.t;
 }
+
+and kind = Ephemeral of Llm_backend.t | Long_lived of Llm_backend_long_lived.t
 
 let display_name_of_claude_model = function
   | Some m when Backend_routing.is_auto_model (Some m) ->
@@ -18,26 +20,38 @@ let display_name_of_claude_model = function
   | Some m -> Printf.sprintf "Claude (%s)" m
   | None -> "Claude"
 
-let make_factory ~process_mgr ~clock ~timeout ~setsid_exec :
-    backend:string -> model:string option -> Llm_backend.t =
+let make_factory ~(process_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t) ~clock
+    ~timeout ~setsid_exec : backend:string -> model:string option -> kind =
  fun ~backend ~model ->
   match backend with
   | "claude" ->
-      Claude_backend.create
-        ~name:(display_name_of_claude_model model)
-        ~model ~process_mgr ~clock ~timeout ~setsid_exec
+      Ephemeral
+        (Claude_backend.create
+           ~name:(display_name_of_claude_model model)
+           ~model ~process_mgr ~clock ~timeout ~setsid_exec)
   | "codex" ->
-      Codex_backend.create ~model ~process_mgr ~clock ~timeout ~setsid_exec
+      Ephemeral
+        (Codex_backend.create ~model ~process_mgr ~clock ~timeout ~setsid_exec)
   | "opencode" ->
-      Opencode_backend.create ~model ~process_mgr ~clock ~timeout ~setsid_exec
-  | "pi" -> Pi_backend.create ~model ~process_mgr ~clock ~timeout ~setsid_exec
+      Ephemeral
+        (Opencode_backend.create ~model ~process_mgr ~clock ~timeout
+           ~setsid_exec)
+  | "pi" ->
+      Ephemeral
+        (Pi_backend.create ~model ~process_mgr ~clock ~timeout ~setsid_exec)
   | "gemini" ->
-      Gemini_backend.create ~model ~process_mgr ~clock ~timeout ~setsid_exec
+      Ephemeral
+        (Gemini_backend.create ~model ~process_mgr ~clock ~timeout ~setsid_exec)
+  | "patch-agent" ->
+      Long_lived
+        (Patch_agent_backend.create ~process_mgr ~clock
+           ~binary_path:"patch-agent" ~setsid_exec)
   | other ->
       invalid_arg
         (Printf.sprintf "Backend_registry.get: unknown backend %S" other)
 
-let create ~process_mgr ~clock ~timeout ~setsid_exec =
+let create ~(process_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t) ~clock
+    ~timeout ~setsid_exec =
   {
     factory = make_factory ~process_mgr ~clock ~timeout ~setsid_exec;
     cache = Hashtbl.Poly.create ();
@@ -50,6 +64,7 @@ let auto_model ~backend ~complexity =
   | "opencode" -> Opencode_backend.auto_model ~complexity
   | "pi" -> Pi_backend.auto_model ~complexity
   | "gemini" -> Gemini_backend.auto_model ~complexity
+  | "patch-agent" -> None
   | other ->
       invalid_arg
         (Printf.sprintf "Backend_registry.auto_model: unknown backend %S" other)

--- a/lib/backend_registry.ml
+++ b/lib/backend_registry.ml
@@ -44,7 +44,7 @@ let make_factory ~(process_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t) ~clock
         (Gemini_backend.create ~model ~process_mgr ~clock ~timeout ~setsid_exec)
   | "patch-agent" ->
       Long_lived
-        (Patch_agent_backend.create ~process_mgr ~clock
+        (Patch_agent_backend.create ~process_mgr ~clock ~timeout
            ~binary_path:"patch-agent" ~setsid_exec)
   | other ->
       invalid_arg

--- a/lib/backend_registry.mli
+++ b/lib/backend_registry.mli
@@ -1,4 +1,4 @@
-(** Lazy cache of [Llm_backend.t] instances keyed by [(backend_name, model)].
+(** Lazy cache of backend instances keyed by [(backend_name, model)].
 
     A run can route different patches to different backends (see
     [Repo_config.modelRouting]), so we may need several distinct [Llm_backend.t]
@@ -10,8 +10,12 @@
 
 type t
 
+type kind =
+  | Ephemeral of Llm_backend.t
+  | Long_lived of Llm_backend_long_lived.t
+
 val create :
-  process_mgr:_ Eio.Process.mgr ->
+  process_mgr:Eio_unix.Process.mgr_ty Eio.Resource.t ->
   clock:_ Eio.Time.clock ->
   timeout:float ->
   setsid_exec:string option ->
@@ -20,10 +24,10 @@ val create :
     backends. The Eio capabilities and per-session [timeout] are baked into the
     closure so callers don't re-thread them on every [get]. *)
 
-val get : t -> backend:string -> model:string option -> Llm_backend.t
-(** Return the cached [Llm_backend.t] for [(backend, model)], constructing it on
-    first request. Raises [Invalid_argument] for unrecognised backend names —
-    callers are expected to validate against the known list before asking. *)
+val get : t -> backend:string -> model:string option -> kind
+(** Return the cached backend for [(backend, model)], constructing it on first
+    request. Raises [Invalid_argument] for unrecognised backend names — callers
+    are expected to validate against the known list before asking. *)
 
 val auto_model : backend:string -> complexity:int option -> string option
 (** Look up the named backend's hardcoded complexity → model ladder — the model

--- a/lib/backend_registry.mli
+++ b/lib/backend_registry.mli
@@ -34,3 +34,14 @@ val auto_model : backend:string -> complexity:int option -> string option
     name it would resolve [--model auto] to for this complexity. Pure; no [t]
     required, no IO. Raises [Invalid_argument] on unknown backend names,
     matching {!get}. *)
+
+val resolve_model :
+  backend:string ->
+  model:string option ->
+  complexity:int option ->
+  string option
+(** Resolve the model name that should be shown or passed to lifecycle-specific
+    backend code for [(backend, model, complexity)]. [Some "auto"] is resolved
+    through {!auto_model}; backend-specific mandatory defaults, such as
+    [patch-agent]'s model argument, are also applied here so display and
+    execution agree. *)

--- a/lib/llm_backend_long_lived.ml
+++ b/lib/llm_backend_long_lived.ml
@@ -24,6 +24,7 @@ type start_config = {
 type t =
   | T : {
       name : string;
+      timeout : float;
       start : sw:Eio.Switch.t -> start_config -> 'handle;
       prompt :
         'handle ->

--- a/lib/llm_backend_long_lived.mli
+++ b/lib/llm_backend_long_lived.mli
@@ -31,6 +31,7 @@ type start_config = {
 type t =
   | T : {
       name : string;
+      timeout : float;
       start : sw:Eio.Switch.t -> start_config -> 'handle;
       prompt :
         'handle ->

--- a/lib/patch_agent_backend.ml
+++ b/lib/patch_agent_backend.ml
@@ -321,10 +321,12 @@ let shutdown ~clock long_lived_handle =
         | Ok _ | Error `Timeout -> close_flow handle.stdout_r))
 
 let create ~(process_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t)
-    ~(clock : _ Eio.Time.clock) ~binary_path ~setsid_exec : Long_lived.t =
+    ~(clock : _ Eio.Time.clock) ~timeout ~binary_path ~setsid_exec :
+    Long_lived.t =
   T
     {
       name = "Patch-agent";
+      timeout;
       start =
         (fun ~sw config ->
           start ~process_mgr ~binary_path ~setsid_exec ~sw config);

--- a/lib/patch_agent_backend.ml
+++ b/lib/patch_agent_backend.ml
@@ -2,7 +2,7 @@ open Base
 module Long_lived = Llm_backend_long_lived
 
 type handle = {
-  child : [ `Process | `Platform of [ `Generic ] ] Eio.Resource.t;
+  child : [ `Process | `Platform of [ `Generic | `Unix ] ] Eio.Resource.t;
   stdin_w : [ `Close | `Flow | `W ] Eio.Resource.t;
   stdout_r : [ `Close | `Flow | `R ] Eio.Resource.t;
   stderr_r : [ `Close | `Flow | `R ] Eio.Resource.t;
@@ -139,7 +139,8 @@ let write_prompt_files worktree ~gameplan_prompt ~patch_prompt =
   Eio.Path.save ~create:(`Or_truncate 0o644) patch_path patch_prompt;
   (Eio.Path.native_exn gameplan_path, Eio.Path.native_exn patch_path)
 
-let start ~process_mgr ~binary_path ~setsid_exec ~sw
+let start ~(process_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t) ~binary_path
+    ~setsid_exec ~sw
     ({ worktree; provider; model; effort; gameplan_prompt; patch_prompt; _ } :
       Long_lived.start_config) =
   let worktree_path = native_absolute_exn worktree ~what:"worktree" in
@@ -319,7 +320,8 @@ let shutdown ~clock long_lived_handle =
         match await_child_with_timeout ~clock handle shutdown_kill_seconds with
         | Ok _ | Error `Timeout -> close_flow handle.stdout_r))
 
-let create ~process_mgr ~clock ~binary_path ~setsid_exec : Long_lived.t =
+let create ~(process_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t)
+    ~(clock : _ Eio.Time.clock) ~binary_path ~setsid_exec : Long_lived.t =
   T
     {
       name = "Patch-agent";

--- a/lib/patch_agent_backend.mli
+++ b/lib/patch_agent_backend.mli
@@ -41,6 +41,7 @@ open Base
 val create :
   process_mgr:Eio_unix.Process.mgr_ty Eio.Resource.t ->
   clock:_ Eio.Time.clock ->
+  timeout:float ->
   binary_path:string ->
   setsid_exec:string option ->
   Llm_backend_long_lived.t

--- a/lib/patch_agent_backend.mli
+++ b/lib/patch_agent_backend.mli
@@ -1,12 +1,36 @@
 open Base
 
-(** Patch-agent long-lived backend.
+(** Patch-agent long-lived backend parity contract.
 
-    Parity contract: this backend receives the same layered prompt text that the
-    existing ephemeral backends receive from [Patch_controller]. The gameplan
-    and patch layers are written once to [<worktree>/.patch-agent/], and each
-    rendered turn layer is delivered over the persistent patch-agent stdio RPC.
-    Event framing is delegated to [Patch_agent_rpc], and event interpretation is
+    Event parity today:
+    - [session_init] maps 1:1 to [Stream_event.Session_init].
+    - [turn_started] maps 1:1 to [Stream_event.Turn_started].
+    - [text_delta] maps 1:1 to [Stream_event.Text_delta].
+    - [tool_call] maps to [Stream_event.Tool_use] with [status = None] because
+      patch-agent does not expose per-tool lifecycle states in M4.
+    - [done] maps to [Stream_event.Final_result], with patch-agent stop-reason
+      strings normalized by [Patch_agent_event_mapper].
+    - [error] maps to [Stream_event.Error].
+
+    Feature parity:
+    - Supported: existing [--backend] / model-routing selection, layered prompt
+      rendering, transcript capture, PR sniffing from streamed text, session
+      result classification, post-session push, and supervisor state updates.
+    - Deferred: resume-after-restart / auto-respawn, MCP-server plumbing, and
+      long-lived-process reuse across multiple orchestrator turns. M4 surfaces
+      crashes as normal session failures and starts from [$PATH] only.
+
+    Checklist for future long-lived-specific changes:
+    - Update this contract when adding or changing an RPC event mapping.
+    - Keep prompt-layer file paths at [<worktree>/.patch-agent/].
+    - Revisit crash semantics before adding auto-respawn.
+    - Add or update property/integration tests for any new lifecycle behavior.
+
+    This backend receives the same layered prompt text that the existing
+    ephemeral backends receive from [Patch_controller]. The gameplan and patch
+    layers are written once to [<worktree>/.patch-agent/], and each rendered
+    turn layer is delivered over the persistent patch-agent stdio RPC. Event
+    framing is delegated to [Patch_agent_rpc], and event interpretation is
     delegated to [Patch_agent_event_mapper]. This module owns only process,
     pipe, file, timeout, and lifecycle management.
 
@@ -15,8 +39,8 @@ open Base
     [--worktree] argument. *)
 
 val create :
-  process_mgr:[> [ `Generic ] Eio.Process.mgr_ty ] Eio.Resource.t ->
-  clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
+  process_mgr:Eio_unix.Process.mgr_ty Eio.Resource.t ->
+  clock:_ Eio.Time.clock ->
   binary_path:string ->
   setsid_exec:string option ->
   Llm_backend_long_lived.t

--- a/lib/session_driver.ml
+++ b/lib/session_driver.ml
@@ -602,6 +602,7 @@ type long_lived_session =
         Llm_backend_long_lived.result;
       shutdown : 'handle -> unit;
       mutable handle : 'handle option;
+      mutable pending_shutdown_handle : 'handle option;
       mutable failed : bool;
       mutable failure_reason : string option;
       provider : string;
@@ -626,6 +627,7 @@ let create_long_lived_session ~(backend : Llm_backend_long_lived.t) ~provider
       prompt_backend;
       shutdown;
       handle = None;
+      pending_shutdown_handle = None;
       failed = false;
       failure_reason = None;
       provider;
@@ -645,18 +647,10 @@ let update_long_lived_session_prompts session ~gameplan_prompt ~patch_prompt =
   if changed && Option.is_some session.handle then (
     let handle = session.handle in
     session.handle <- None;
+    session.pending_shutdown_handle <- handle;
     session.failed <- true;
     session.failure_reason <-
-      Some "long-lived backend prompt prefix changed after session start";
-    match handle with
-    | None -> ()
-    | Some handle -> (
-        try session.shutdown handle
-        with exn ->
-          session.failure_reason <-
-            Some
-              (Printf.sprintf "long-lived backend shutdown raised: %s"
-                 (Stdlib.Printexc.to_string exn))));
+      Some "long-lived backend prompt prefix changed after session start");
   session.gameplan_prompt <- gameplan_prompt;
   session.patch_prompt <- patch_prompt
 
@@ -665,8 +659,13 @@ let long_lived_session_failed = function
 
 let shutdown_long_lived_session = function
   | Long_lived_session session -> (
+      let pending_shutdown_handle = session.pending_shutdown_handle in
       let handle = session.handle in
+      session.pending_shutdown_handle <- None;
       session.handle <- None;
+      (match pending_shutdown_handle with
+      | None -> ()
+      | Some handle -> session.shutdown handle);
       match handle with None -> () | Some handle -> session.shutdown handle)
 
 let run_long_lived ~sw ~(kind : Types.Operation_kind.t option) ~runtime
@@ -722,29 +721,19 @@ let run_long_lived ~sw ~(kind : Types.Operation_kind.t option) ~runtime
         if result.Llm_backend.exit_code <> 0 || result.Llm_backend.timed_out
         then (
           session.handle <- None;
+          session.pending_shutdown_handle <- Some handle;
           session.failed <- true;
           session.failure_reason <-
-            Some "long-lived backend prompt failed or timed out";
-          try session.shutdown handle
-          with exn ->
-            session.failure_reason <-
-              Some
-                (Printf.sprintf "long-lived backend shutdown raised: %s"
-                   (Stdlib.Printexc.to_string exn)));
+            Some "long-lived backend prompt failed or timed out");
         result
       with exn ->
         session.handle <- None;
+        session.pending_shutdown_handle <- Some handle;
         session.failed <- true;
         session.failure_reason <-
           Some
             (Printf.sprintf "long-lived backend prompt raised: %s"
                (Stdlib.Printexc.to_string exn));
-        (try session.shutdown handle
-         with shutdown_exn ->
-           session.failure_reason <-
-             Some
-               (Printf.sprintf "long-lived backend shutdown raised: %s"
-                  (Stdlib.Printexc.to_string shutdown_exn)));
         raise exn
   in
   run_with_backend ~kind ~runtime ~process_mgr ~clock ~fs ~project_name

--- a/lib/session_driver.ml
+++ b/lib/session_driver.ml
@@ -109,14 +109,14 @@ let%test_module "extract_pr_number_from_text" =
         (pr 12)
   end)
 
-let run_with_backend ~(kind : Types.Operation_kind.t option) ~runtime
-    ~process_mgr ~clock ~fs ~project_name ~patch_id ~repo_root ~prompt
-    ~(agent : Patch_agent.t) ~owner ~repo ~on_pr_detected ~transcripts
-    ~user_config ~worktree_mutex ~hook_mutex ~backend_name ~run_backend
-    ~complexity ~event_log =
+let run_with_backend ~session_mode_for_agent
+    ~(kind : Types.Operation_kind.t option) ~runtime ~process_mgr ~clock ~fs
+    ~project_name ~patch_id ~repo_root ~prompt ~(agent : Patch_agent.t) ~owner
+    ~repo ~on_pr_detected ~transcripts ~user_config ~worktree_mutex ~hook_mutex
+    ~backend_name ~run_backend ~complexity ~event_log =
   let log_event = Runtime_logging.log_event in
   let log_stream_entry = Runtime_logging.log_stream_entry in
-  match session_mode agent with
+  match session_mode_for_agent agent with
   | `Give_up ->
       log_event runtime ~patch_id
         "Session fallback exhausted — continue and fresh both failed, needs \
@@ -587,7 +587,7 @@ let run ~(kind : Types.Operation_kind.t option) ~runtime ~process_mgr ~clock ~fs
   run_with_backend ~kind ~runtime ~process_mgr ~clock ~fs ~project_name
     ~patch_id ~repo_root ~prompt ~agent ~owner ~repo ~on_pr_detected
     ~transcripts ~user_config ~worktree_mutex ~hook_mutex
-    ~backend_name:backend.Llm_backend.name
+    ~session_mode_for_agent:session_mode ~backend_name:backend.Llm_backend.name
     ~run_backend:backend.Llm_backend.run_streaming ~complexity ~event_log
 
 type long_lived_session =
@@ -602,11 +602,13 @@ type long_lived_session =
         Llm_backend_long_lived.result;
       shutdown : 'handle -> unit;
       mutable handle : 'handle option;
+      mutable failed : bool;
+      mutable failure_reason : string option;
       provider : string;
       model : string;
       effort : string;
-      gameplan_prompt : string;
-      patch_prompt : string;
+      mutable gameplan_prompt : string;
+      mutable patch_prompt : string;
       timeout : float;
     }
       -> long_lived_session
@@ -624,6 +626,8 @@ let create_long_lived_session ~(backend : Llm_backend_long_lived.t) ~provider
       prompt_backend;
       shutdown;
       handle = None;
+      failed = false;
+      failure_reason = None;
       provider;
       model;
       effort;
@@ -631,6 +635,22 @@ let create_long_lived_session ~(backend : Llm_backend_long_lived.t) ~provider
       patch_prompt;
       timeout;
     }
+
+let update_long_lived_session_prompts session ~gameplan_prompt ~patch_prompt =
+  let (Long_lived_session session) = session in
+  let changed =
+    (not (String.equal session.gameplan_prompt gameplan_prompt))
+    || not (String.equal session.patch_prompt patch_prompt)
+  in
+  if changed && Option.is_some session.handle then (
+    session.failed <- true;
+    session.failure_reason <-
+      Some "long-lived backend prompt prefix changed after session start");
+  session.gameplan_prompt <- gameplan_prompt;
+  session.patch_prompt <- patch_prompt
+
+let long_lived_session_failed = function
+  | Long_lived_session session -> session.failed
 
 let shutdown_long_lived_session = function
   | Long_lived_session session -> (
@@ -647,38 +667,65 @@ let run_long_lived ~sw ~(kind : Types.Operation_kind.t option) ~runtime
   let (Long_lived_session session) = session in
   let run_backend ~project_name ~cwd ~patch_id ~prompt ~resume_session:_
       ~complexity:_ ~on_event =
-    let handle =
-      match session.handle with
-      | Some handle -> handle
-      | None ->
-          let handle =
-            session.start ~sw
-              {
-                project_name;
-                worktree = cwd;
-                patch_id;
-                provider = session.provider;
-                model = session.model;
-                effort = session.effort;
-                gameplan_prompt = session.gameplan_prompt;
-                patch_prompt = session.patch_prompt;
-              }
-          in
-          session.handle <- Some handle;
-          handle
-    in
-    try
-      let result =
-        session.prompt_backend handle ~prompt ~timeout:session.timeout ~on_event
+    if session.failed then (
+      on_event
+        (Types.Stream_event.Error
+           (Option.value session.failure_reason
+              ~default:
+                "long-lived backend session already failed; waiting for \
+                 teardown"));
+      {
+        Llm_backend.exit_code = 1;
+        stdout = "";
+        stderr =
+          Option.value session.failure_reason
+            ~default:"long-lived backend session already failed";
+        got_events = true;
+        saw_final_result = false;
+        timed_out = false;
+      })
+    else
+      let handle =
+        match session.handle with
+        | Some handle -> handle
+        | None ->
+            let handle =
+              session.start ~sw
+                {
+                  project_name;
+                  worktree = cwd;
+                  patch_id;
+                  provider = session.provider;
+                  model = session.model;
+                  effort = session.effort;
+                  gameplan_prompt = session.gameplan_prompt;
+                  patch_prompt = session.patch_prompt;
+                }
+            in
+            session.handle <- Some handle;
+            handle
       in
-      if result.Llm_backend.exit_code <> 0 || result.Llm_backend.timed_out then
-        session.handle <- None;
-      result
-    with exn ->
-      session.handle <- None;
-      raise exn
+      try
+        let result =
+          session.prompt_backend handle ~prompt ~timeout:session.timeout
+            ~on_event
+        in
+        if result.Llm_backend.exit_code <> 0 || result.Llm_backend.timed_out
+        then (
+          session.failed <- true;
+          session.failure_reason <-
+            Some "long-lived backend prompt failed or timed out");
+        result
+      with exn ->
+        session.failed <- true;
+        session.failure_reason <-
+          Some
+            (Printf.sprintf "long-lived backend prompt raised: %s"
+               (Stdlib.Printexc.to_string exn));
+        raise exn
   in
   run_with_backend ~kind ~runtime ~process_mgr ~clock ~fs ~project_name
     ~patch_id ~repo_root ~prompt ~agent ~owner ~repo ~on_pr_detected
     ~transcripts ~user_config ~worktree_mutex ~hook_mutex
+    ~session_mode_for_agent:(fun _ -> `Fresh)
     ~backend_name:session.name ~run_backend ~complexity ~event_log

--- a/lib/session_driver.ml
+++ b/lib/session_driver.ml
@@ -615,9 +615,9 @@ type long_lived_session =
       -> long_lived_session
 
 let create_long_lived_session ~(backend : Llm_backend_long_lived.t) ~provider
-    ~model ~effort ~gameplan_prompt ~patch_prompt ~timeout =
+    ~model ~effort ~gameplan_prompt ~patch_prompt =
   let (Llm_backend_long_lived.T
-         { name; start; prompt = prompt_backend; shutdown; _ }) =
+         { name; timeout; start; prompt = prompt_backend; shutdown; _ }) =
     backend
   in
   Long_lived_session
@@ -733,10 +733,10 @@ let run_long_lived ~sw ~(kind : Types.Operation_kind.t option) ~runtime
             if result.Llm_backend.exit_code <> 0 || result.Llm_backend.timed_out
             then (
               session.handle <- None;
-              session.pending_shutdown_handle <- Some handle;
               session.failed <- true;
               session.failure_reason <-
-                Some "long-lived backend prompt failed or timed out");
+                Some "long-lived backend prompt failed or timed out";
+              try session.shutdown handle with _ -> ());
             result
           with
           | Eio.Cancel.Cancelled _ as exn ->

--- a/lib/session_driver.ml
+++ b/lib/session_driver.ml
@@ -109,10 +109,11 @@ let%test_module "extract_pr_number_from_text" =
         (pr 12)
   end)
 
-let run ~(kind : Types.Operation_kind.t option) ~runtime ~process_mgr ~clock ~fs
-    ~project_name ~patch_id ~repo_root ~prompt ~(agent : Patch_agent.t) ~owner
-    ~repo ~on_pr_detected ~transcripts ~user_config ~worktree_mutex ~hook_mutex
-    ~backend ~complexity ~event_log =
+let run_with_backend ~(kind : Types.Operation_kind.t option) ~runtime
+    ~process_mgr ~clock ~fs ~project_name ~patch_id ~repo_root ~prompt
+    ~(agent : Patch_agent.t) ~owner ~repo ~on_pr_detected ~transcripts
+    ~user_config ~worktree_mutex ~hook_mutex ~backend_name ~run_backend
+    ~complexity ~event_log =
   let log_event = Runtime_logging.log_event in
   let log_stream_entry = Runtime_logging.log_stream_entry in
   match session_mode agent with
@@ -153,8 +154,7 @@ let run ~(kind : Types.Operation_kind.t option) ~runtime ~process_mgr ~clock ~fs
             Buffer.add_string buf
               (Printf.sprintf
                  "\n---\n**[%02d:%02d:%02d] Delivered to %s%s:**\n\n"
-                 tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec
-                 backend.Llm_backend.name
+                 tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec backend_name
                  (match resume_session with
                  | Some id ->
                      Printf.sprintf " (--resume %s)"
@@ -162,8 +162,7 @@ let run ~(kind : Types.Operation_kind.t option) ~runtime ~process_mgr ~clock ~fs
                  | None -> ""));
             Buffer.add_string buf prompt;
             Buffer.add_string buf
-              (Printf.sprintf "\n\n---\n**%s response:**\n\n"
-                 backend.Llm_backend.name);
+              (Printf.sprintf "\n\n---\n**%s response:**\n\n" backend_name);
             Stdlib.Hashtbl.replace transcripts patch_id (Buffer.contents buf);
             buf
           in
@@ -355,8 +354,8 @@ let run ~(kind : Types.Operation_kind.t option) ~runtime ~process_mgr ~clock ~fs
           let result =
             try
               Ok
-                (backend.Llm_backend.run_streaming ~project_name ~cwd ~patch_id
-                   ~prompt ~resume_session ~complexity ~on_event)
+                (run_backend ~project_name ~cwd ~patch_id ~prompt
+                   ~resume_session ~complexity ~on_event)
             with exn -> Error (Stdlib.Printexc.to_string exn)
           in
           let open Run_classification in
@@ -390,7 +389,7 @@ let run ~(kind : Types.Operation_kind.t option) ~runtime ~process_mgr ~clock ~fs
                   (Printf.sprintf
                      "Resume exited %d (%s) with no parsed stream events%s — \
                       %s %s"
-                     r.Llm_backend.exit_code backend.Llm_backend.name tail
+                     r.Llm_backend.exit_code backend_name tail
                      (render "stdout" r.Llm_backend.stdout)
                      (render "stderr" r.Llm_backend.stderr))
           in
@@ -400,8 +399,7 @@ let run ~(kind : Types.Operation_kind.t option) ~runtime ~process_mgr ~clock ~fs
             with
             | Process_error msg ->
                 log_event runtime ~patch_id
-                  (Printf.sprintf "Process error from %s — %s"
-                     backend.Llm_backend.name msg);
+                  (Printf.sprintf "Process error from %s — %s" backend_name msg);
                 (Orchestrator.Session_process_error { is_fresh }, `Failed)
             | No_session_to_resume ->
                 log_empty_resume ~tail:" — no session to resume, retrying fresh";
@@ -409,7 +407,7 @@ let run ~(kind : Types.Operation_kind.t option) ~runtime ~process_mgr ~clock ~fs
             | Timed_out ->
                 log_event runtime ~patch_id
                   (Printf.sprintf "Session timed out (%s) — marking failed"
-                     backend.Llm_backend.name);
+                     backend_name);
                 (Orchestrator.Session_failed { is_fresh }, `Failed)
             | Success { stream_errors } ->
                 (match (resume_session, result) with
@@ -420,7 +418,7 @@ let run ~(kind : Types.Operation_kind.t option) ~runtime ~process_mgr ~clock ~fs
                   log_event runtime ~patch_id
                     (Printf.sprintf
                        "Session exited 0 (%s) with stream errors — %s"
-                       backend.Llm_backend.name
+                       backend_name
                        (truncate stream_errors 500));
                 let text_len = Buffer.length text_buf in
                 let tools = !tool_count in
@@ -429,14 +427,14 @@ let run ~(kind : Types.Operation_kind.t option) ~runtime ~process_mgr ~clock ~fs
                     (Printf.sprintf
                        "Session exited 0 (%s) with no tool use and %s of text \
                         — %s"
-                       backend.Llm_backend.name
+                       backend_name
                        (pluralize text_len "char")
                        (truncate (String.strip (Buffer.contents text_buf)) 200));
                 (Orchestrator.Session_ok, `Ok)
             | Session_failed { exit_code; detail } ->
                 log_event runtime ~patch_id
                   (Printf.sprintf "Session failed (%s) — exit %d: %s"
-                     backend.Llm_backend.name exit_code detail);
+                     backend_name exit_code detail);
                 (Orchestrator.Session_failed { is_fresh }, `Failed)
           in
           (* Observability: if any tool_use events reported a non-"completed"
@@ -454,7 +452,7 @@ let run ~(kind : Types.Operation_kind.t option) ~runtime ~process_mgr ~clock ~fs
               log_event runtime ~patch_id
                 (Printf.sprintf
                    "Session ended with %d non-completed tool call(s) (%s): %s"
-                   (List.length failures) backend.Llm_backend.name rendered));
+                   (List.length failures) backend_name rendered));
           (* Supervisor-owned push: agent commits locally; we push every
              local commit to the remote at session end. force_push_with_lease
              is idempotent (Push_up_to_date when nothing new), and lease-safe
@@ -581,3 +579,106 @@ let run ~(kind : Types.Operation_kind.t option) ~runtime ~process_mgr ~clock ~fs
           Event_log.log_complete event_log ~patch_id
             ~result:final_session_result ~agent_before ~agent_after;
           (final_user_result, List.rev !tool_failures))
+
+let run ~(kind : Types.Operation_kind.t option) ~runtime ~process_mgr ~clock ~fs
+    ~project_name ~patch_id ~repo_root ~prompt ~(agent : Patch_agent.t) ~owner
+    ~repo ~on_pr_detected ~transcripts ~user_config ~worktree_mutex ~hook_mutex
+    ~backend ~complexity ~event_log =
+  run_with_backend ~kind ~runtime ~process_mgr ~clock ~fs ~project_name
+    ~patch_id ~repo_root ~prompt ~agent ~owner ~repo ~on_pr_detected
+    ~transcripts ~user_config ~worktree_mutex ~hook_mutex
+    ~backend_name:backend.Llm_backend.name
+    ~run_backend:backend.Llm_backend.run_streaming ~complexity ~event_log
+
+type long_lived_session =
+  | Long_lived_session : {
+      name : string;
+      start : sw:Eio.Switch.t -> Llm_backend_long_lived.start_config -> 'handle;
+      prompt_backend :
+        'handle ->
+        prompt:string ->
+        timeout:float ->
+        on_event:(Types.Stream_event.t -> unit) ->
+        Llm_backend_long_lived.result;
+      shutdown : 'handle -> unit;
+      mutable handle : 'handle option;
+      provider : string;
+      model : string;
+      effort : string;
+      gameplan_prompt : string;
+      patch_prompt : string;
+      timeout : float;
+    }
+      -> long_lived_session
+
+let create_long_lived_session ~(backend : Llm_backend_long_lived.t) ~provider
+    ~model ~effort ~gameplan_prompt ~patch_prompt ~timeout =
+  let (Llm_backend_long_lived.T
+         { name; start; prompt = prompt_backend; shutdown; _ }) =
+    backend
+  in
+  Long_lived_session
+    {
+      name;
+      start;
+      prompt_backend;
+      shutdown;
+      handle = None;
+      provider;
+      model;
+      effort;
+      gameplan_prompt;
+      patch_prompt;
+      timeout;
+    }
+
+let shutdown_long_lived_session = function
+  | Long_lived_session session -> (
+      match session.handle with
+      | None -> ()
+      | Some handle ->
+          session.handle <- None;
+          session.shutdown handle)
+
+let run_long_lived ~sw ~(kind : Types.Operation_kind.t option) ~runtime
+    ~process_mgr ~clock ~fs ~project_name ~patch_id ~repo_root ~prompt
+    ~(agent : Patch_agent.t) ~owner ~repo ~on_pr_detected ~transcripts
+    ~user_config ~worktree_mutex ~hook_mutex ~session ~complexity ~event_log =
+  let (Long_lived_session session) = session in
+  let run_backend ~project_name ~cwd ~patch_id ~prompt ~resume_session:_
+      ~complexity:_ ~on_event =
+    let handle =
+      match session.handle with
+      | Some handle -> handle
+      | None ->
+          let handle =
+            session.start ~sw
+              {
+                project_name;
+                worktree = cwd;
+                patch_id;
+                provider = session.provider;
+                model = session.model;
+                effort = session.effort;
+                gameplan_prompt = session.gameplan_prompt;
+                patch_prompt = session.patch_prompt;
+              }
+          in
+          session.handle <- Some handle;
+          handle
+    in
+    try
+      let result =
+        session.prompt_backend handle ~prompt ~timeout:session.timeout ~on_event
+      in
+      if result.Llm_backend.exit_code <> 0 || result.Llm_backend.timed_out then
+        session.handle <- None;
+      result
+    with exn ->
+      session.handle <- None;
+      raise exn
+  in
+  run_with_backend ~kind ~runtime ~process_mgr ~clock ~fs ~project_name
+    ~patch_id ~repo_root ~prompt ~agent ~owner ~repo ~on_pr_detected
+    ~transcripts ~user_config ~worktree_mutex ~hook_mutex
+    ~backend_name:session.name ~run_backend ~complexity ~event_log

--- a/lib/session_driver.ml
+++ b/lib/session_driver.ml
@@ -739,7 +739,13 @@ let run_long_lived ~sw ~(kind : Types.Operation_kind.t option) ~runtime
                 Some "long-lived backend prompt failed or timed out");
             result
           with
-          | Eio.Cancel.Cancelled _ as exn -> raise exn
+          | Eio.Cancel.Cancelled _ as exn ->
+              session.handle <- None;
+              session.failed <- true;
+              session.failure_reason <-
+                Some "long-lived backend prompt cancelled";
+              (try session.shutdown handle with _ -> ());
+              raise exn
           | exn ->
               session.handle <- None;
               session.pending_shutdown_handle <- Some handle;

--- a/lib/session_driver.ml
+++ b/lib/session_driver.ml
@@ -675,66 +675,81 @@ let run_long_lived ~sw ~(kind : Types.Operation_kind.t option) ~runtime
   let (Long_lived_session session) = session in
   let run_backend ~project_name ~cwd ~patch_id ~prompt ~resume_session:_
       ~complexity:_ ~on_event =
-    if session.failed then (
-      on_event
-        (Types.Stream_event.Error
-           (Option.value session.failure_reason
-              ~default:
-                "long-lived backend session already failed; waiting for \
-                 teardown"));
+    let failed_result message =
+      on_event (Types.Stream_event.Error message);
       {
         Llm_backend.exit_code = 1;
         stdout = "";
-        stderr =
-          Option.value session.failure_reason
-            ~default:"long-lived backend session already failed";
+        stderr = message;
         got_events = true;
         saw_final_result = false;
         timed_out = false;
-      })
+      }
+    in
+    if session.failed then
+      failed_result
+        (Option.value session.failure_reason
+           ~default:
+             "long-lived backend session already failed; waiting for teardown")
     else
-      let handle =
+      match
         match session.handle with
-        | Some handle -> handle
-        | None ->
-            let handle =
-              session.start ~sw
-                {
-                  project_name;
-                  worktree = cwd;
-                  patch_id;
-                  provider = session.provider;
-                  model = session.model;
-                  effort = session.effort;
-                  gameplan_prompt = session.gameplan_prompt;
-                  patch_prompt = session.patch_prompt;
-                }
+        | Some handle -> Ok handle
+        | None -> (
+            try
+              let handle =
+                session.start ~sw
+                  {
+                    project_name;
+                    worktree = cwd;
+                    patch_id;
+                    provider = session.provider;
+                    model = session.model;
+                    effort = session.effort;
+                    gameplan_prompt = session.gameplan_prompt;
+                    patch_prompt = session.patch_prompt;
+                  }
+              in
+              session.handle <- Some handle;
+              Ok handle
+            with
+            | Eio.Cancel.Cancelled _ as exn -> raise exn
+            | exn ->
+                session.failed <- true;
+                let message =
+                  Printf.sprintf "long-lived backend start raised: %s"
+                    (Stdlib.Printexc.to_string exn)
+                in
+                session.failure_reason <- Some message;
+                Error message)
+      with
+      | Error message -> failed_result message
+      | Ok handle -> (
+          try
+            let result =
+              session.prompt_backend handle ~prompt ~timeout:session.timeout
+                ~on_event
             in
-            session.handle <- Some handle;
-            handle
-      in
-      try
-        let result =
-          session.prompt_backend handle ~prompt ~timeout:session.timeout
-            ~on_event
-        in
-        if result.Llm_backend.exit_code <> 0 || result.Llm_backend.timed_out
-        then (
-          session.handle <- None;
-          session.pending_shutdown_handle <- Some handle;
-          session.failed <- true;
-          session.failure_reason <-
-            Some "long-lived backend prompt failed or timed out");
-        result
-      with exn ->
-        session.handle <- None;
-        session.pending_shutdown_handle <- Some handle;
-        session.failed <- true;
-        session.failure_reason <-
-          Some
-            (Printf.sprintf "long-lived backend prompt raised: %s"
-               (Stdlib.Printexc.to_string exn));
-        raise exn
+            if result.Llm_backend.exit_code <> 0 || result.Llm_backend.timed_out
+            then (
+              session.handle <- None;
+              session.pending_shutdown_handle <- Some handle;
+              session.failed <- true;
+              session.failure_reason <-
+                Some "long-lived backend prompt failed or timed out");
+            result
+          with
+          | Eio.Cancel.Cancelled _ as exn -> raise exn
+          | exn ->
+              session.handle <- None;
+              session.pending_shutdown_handle <- Some handle;
+              session.failed <- true;
+              let message =
+                Printf.sprintf "long-lived backend prompt raised: %s"
+                  (Stdlib.Printexc.to_string exn)
+              in
+              session.failure_reason <- Some message;
+              failed_result message)
   in
   run_with_backend ~kind ~runtime ~process_mgr ~clock ~fs ~project_name
     ~patch_id ~repo_root ~prompt ~agent ~owner ~repo ~on_pr_detected

--- a/lib/session_driver.ml
+++ b/lib/session_driver.ml
@@ -643,9 +643,20 @@ let update_long_lived_session_prompts session ~gameplan_prompt ~patch_prompt =
     || not (String.equal session.patch_prompt patch_prompt)
   in
   if changed && Option.is_some session.handle then (
+    let handle = session.handle in
+    session.handle <- None;
     session.failed <- true;
     session.failure_reason <-
-      Some "long-lived backend prompt prefix changed after session start");
+      Some "long-lived backend prompt prefix changed after session start";
+    match handle with
+    | None -> ()
+    | Some handle -> (
+        try session.shutdown handle
+        with exn ->
+          session.failure_reason <-
+            Some
+              (Printf.sprintf "long-lived backend shutdown raised: %s"
+                 (Stdlib.Printexc.to_string exn))));
   session.gameplan_prompt <- gameplan_prompt;
   session.patch_prompt <- patch_prompt
 
@@ -654,11 +665,9 @@ let long_lived_session_failed = function
 
 let shutdown_long_lived_session = function
   | Long_lived_session session -> (
-      match session.handle with
-      | None -> ()
-      | Some handle ->
-          session.handle <- None;
-          session.shutdown handle)
+      let handle = session.handle in
+      session.handle <- None;
+      match handle with None -> () | Some handle -> session.shutdown handle)
 
 let run_long_lived ~sw ~(kind : Types.Operation_kind.t option) ~runtime
     ~process_mgr ~clock ~fs ~project_name ~patch_id ~repo_root ~prompt
@@ -712,16 +721,30 @@ let run_long_lived ~sw ~(kind : Types.Operation_kind.t option) ~runtime
         in
         if result.Llm_backend.exit_code <> 0 || result.Llm_backend.timed_out
         then (
+          session.handle <- None;
           session.failed <- true;
           session.failure_reason <-
-            Some "long-lived backend prompt failed or timed out");
+            Some "long-lived backend prompt failed or timed out";
+          try session.shutdown handle
+          with exn ->
+            session.failure_reason <-
+              Some
+                (Printf.sprintf "long-lived backend shutdown raised: %s"
+                   (Stdlib.Printexc.to_string exn)));
         result
       with exn ->
+        session.handle <- None;
         session.failed <- true;
         session.failure_reason <-
           Some
             (Printf.sprintf "long-lived backend prompt raised: %s"
                (Stdlib.Printexc.to_string exn));
+        (try session.shutdown handle
+         with shutdown_exn ->
+           session.failure_reason <-
+             Some
+               (Printf.sprintf "long-lived backend shutdown raised: %s"
+                  (Stdlib.Printexc.to_string shutdown_exn)));
         raise exn
   in
   run_with_backend ~kind ~runtime ~process_mgr ~clock ~fs ~project_name

--- a/lib/session_driver.mli
+++ b/lib/session_driver.mli
@@ -53,6 +53,10 @@ val create_long_lived_session :
   timeout:float ->
   long_lived_session
 
+val update_long_lived_session_prompts :
+  long_lived_session -> gameplan_prompt:string -> patch_prompt:string -> unit
+
+val long_lived_session_failed : long_lived_session -> bool
 val shutdown_long_lived_session : long_lived_session -> unit
 
 val run_long_lived :

--- a/lib/session_driver.mli
+++ b/lib/session_driver.mli
@@ -39,6 +39,49 @@ val run :
     checks before invoking this function — the polymorphic-variant union widens
     at the call site. *)
 
+type long_lived_session
+(** Mutable per-patch long-lived backend session state. The backend's
+    existential handle type remains tied to the backend that created it. *)
+
+val create_long_lived_session :
+  backend:Llm_backend_long_lived.t ->
+  provider:string ->
+  model:string ->
+  effort:string ->
+  gameplan_prompt:string ->
+  patch_prompt:string ->
+  timeout:float ->
+  long_lived_session
+
+val shutdown_long_lived_session : long_lived_session -> unit
+
+val run_long_lived :
+  sw:Eio.Switch.t ->
+  kind:Types.Operation_kind.t option ->
+  runtime:Runtime.t ->
+  process_mgr:_ Eio.Process.mgr ->
+  clock:_ Eio.Time.clock ->
+  fs:Eio.Fs.dir_ty Eio.Path.t ->
+  project_name:string ->
+  patch_id:Types.Patch_id.t ->
+  repo_root:string ->
+  prompt:string ->
+  agent:Patch_agent.t ->
+  owner:string ->
+  repo:string ->
+  on_pr_detected:(Types.Pr_number.t -> unit) ->
+  transcripts:(Types.Patch_id.t, string) Stdlib.Hashtbl.t ->
+  user_config:User_config.t ->
+  worktree_mutex:Eio.Mutex.t ->
+  hook_mutex:Eio.Mutex.t ->
+  session:long_lived_session ->
+  complexity:int option ->
+  event_log:Event_log.t ->
+  [ `Ok | `Failed | `Retry_push ] * (string * string) list
+(** Long-lived backend counterpart to {!run}. It shares the same supervisor
+    bookkeeping and delivers the rendered turn over [backend.prompt] instead of
+    spawning a fresh backend process. *)
+
 val session_mode : Patch_agent.t -> [ `Resume of string | `Fresh | `Give_up ]
 (** Inspect the agent's session-fallback state to decide whether the next
     invocation should resume an existing session, start fresh, or give up. *)

--- a/lib/session_driver.mli
+++ b/lib/session_driver.mli
@@ -50,7 +50,6 @@ val create_long_lived_session :
   effort:string ->
   gameplan_prompt:string ->
   patch_prompt:string ->
-  timeout:float ->
   long_lived_session
 
 val update_long_lived_session_prompts :

--- a/test/dune
+++ b/test/dune
@@ -27,6 +27,9 @@
  (modules test_patch_agent_backend_integration)
  (libraries onton onton_core onton_test_support qcheck-core qcheck-core.runner
    eio eio_main eio.unix unix)
+ (deps
+  fixtures/patch_agent_integration/gameplan.md
+  fixtures/patch_agent_integration/patch.md)
  (ocamlopt_flags (:standard -w -40-42))
  (ocamlc_flags (:standard -w -40-42)))
 

--- a/test/test_patch_agent_backend_integration.ml
+++ b/test/test_patch_agent_backend_integration.ml
@@ -77,67 +77,69 @@ let smoke_test =
            run";
         true)
       else
-        Eio_main.run @@ fun env ->
-        let fixture_dir = "fixtures/patch_agent_integration" in
-        let gameplan_prompt =
-          read_file (Stdlib.Filename.concat fixture_dir "gameplan.md")
-        in
-        let patch_prompt =
-          read_file (Stdlib.Filename.concat fixture_dir "patch.md")
-        in
-        let tmp = mktempdir "onton-patch-agent-integration" in
-        Stdlib.Fun.protect
-          ~finally:(fun () -> rm_rf tmp)
-          (fun () ->
-            let process_mgr = Eio.Stdenv.process_mgr env in
-            let clock = Eio.Stdenv.clock env in
-            let fs = Eio.Stdenv.fs env in
-            let backend =
-              Patch_agent_backend.create ~process_mgr ~clock
-                ~binary_path:"patch-agent" ~setsid_exec:None
-            in
-            let events = ref [] in
-            Eio.Switch.run (fun sw ->
-                let (Llm_backend_long_lived.T
-                       { start; prompt = prompt_backend; shutdown; _ }) =
-                  backend
-                in
-                let worktree = Eio.Path.(fs / tmp) in
-                let handle =
-                  start ~sw
-                    {
-                      Llm_backend_long_lived.project_name = "onton";
-                      worktree;
-                      patch_id = Types.Patch_id.of_string "patch-6-smoke";
-                      provider = "anthropic";
-                      model = "claude-sonnet-4-5";
-                      effort = "medium";
-                      gameplan_prompt;
-                      patch_prompt;
-                    }
-                in
-                let result =
-                  Stdlib.Fun.protect
-                    ~finally:(fun () -> shutdown handle)
-                    (fun () ->
-                      prompt_backend handle
-                        ~prompt:
-                          "Run a smoke turn for the integration fixture. Reply \
-                           briefly and do not edit files." ~timeout:60.0
-                        ~on_event:(fun event -> events := event :: !events))
-                in
-                let events = List.rev !events in
-                result.Llm_backend.got_events
-                && result.Llm_backend.saw_final_result
-                && (not result.Llm_backend.timed_out)
-                && Option.value_map (List.hd events) ~default:false
-                     ~f:is_session_init
-                && (match events with
-                  | _session_init :: turn_started :: _ ->
-                      is_turn_started turn_started
-                  | _ -> false)
-                && has_text_delta events
-                && List.exists events ~f:is_final_result)))
+        try
+          Eio_main.run @@ fun env ->
+          let fixture_dir = "fixtures/patch_agent_integration" in
+          let gameplan_prompt =
+            read_file (Stdlib.Filename.concat fixture_dir "gameplan.md")
+          in
+          let patch_prompt =
+            read_file (Stdlib.Filename.concat fixture_dir "patch.md")
+          in
+          let tmp = mktempdir "onton-patch-agent-integration" in
+          Stdlib.Fun.protect
+            ~finally:(fun () -> rm_rf tmp)
+            (fun () ->
+              let process_mgr = Eio.Stdenv.process_mgr env in
+              let clock = Eio.Stdenv.clock env in
+              let fs = Eio.Stdenv.fs env in
+              let backend =
+                Patch_agent_backend.create ~process_mgr ~clock
+                  ~binary_path:"patch-agent" ~setsid_exec:None
+              in
+              let events = ref [] in
+              Eio.Switch.run (fun sw ->
+                  let (Llm_backend_long_lived.T
+                         { start; prompt = prompt_backend; shutdown; _ }) =
+                    backend
+                  in
+                  let worktree = Eio.Path.(fs / tmp) in
+                  let handle =
+                    start ~sw
+                      {
+                        Llm_backend_long_lived.project_name = "onton";
+                        worktree;
+                        patch_id = Types.Patch_id.of_string "patch-6-smoke";
+                        provider = "anthropic";
+                        model = "claude-sonnet-4-5";
+                        effort = "medium";
+                        gameplan_prompt;
+                        patch_prompt;
+                      }
+                  in
+                  let result =
+                    Stdlib.Fun.protect
+                      ~finally:(fun () -> shutdown handle)
+                      (fun () ->
+                        prompt_backend handle
+                          ~prompt:
+                            "Run a smoke turn for the integration fixture. \
+                             Reply briefly and do not edit files." ~timeout:60.0
+                          ~on_event:(fun event -> events := event :: !events))
+                  in
+                  let events = List.rev !events in
+                  result.Llm_backend.got_events
+                  && result.Llm_backend.saw_final_result
+                  && (not result.Llm_backend.timed_out)
+                  && Option.value_map (List.hd events) ~default:false
+                       ~f:is_session_init
+                  && (match events with
+                    | _session_init :: turn_started :: _ ->
+                        is_turn_started turn_started
+                    | _ -> false)
+                  && has_text_delta events
+                  && List.exists events ~f:is_final_result))
+        with _ -> false)
 
 let () =
   let exit_code = QCheck_base_runner.run_tests ~verbose:true [ smoke_test ] in

--- a/test/test_patch_agent_backend_integration.ml
+++ b/test/test_patch_agent_backend_integration.ml
@@ -117,12 +117,13 @@ let smoke_test =
                         patch_prompt;
                       }
                   in
+                  let shutdown_err = ref None in
                   let result =
                     Stdlib.Fun.protect
                       ~finally:(fun () ->
                         try shutdown handle with
                         | Eio.Cancel.Cancelled _ as exn -> raise exn
-                        | _ -> ())
+                        | exn -> shutdown_err := Some exn)
                       (fun () ->
                         prompt_backend handle
                           ~prompt:
@@ -141,7 +142,8 @@ let smoke_test =
                         is_turn_started turn_started
                     | _ -> false)
                   && has_text_delta events
-                  && List.exists events ~f:is_final_result))
+                  && List.exists events ~f:is_final_result
+                  && Option.is_none !shutdown_err))
         with
         | Eio.Cancel.Cancelled _ as exn -> raise exn
         | _ -> false)

--- a/test/test_patch_agent_backend_integration.ml
+++ b/test/test_patch_agent_backend_integration.ml
@@ -94,7 +94,7 @@ let smoke_test =
               let clock = Eio.Stdenv.clock env in
               let fs = Eio.Stdenv.fs env in
               let backend =
-                Patch_agent_backend.create ~process_mgr ~clock
+                Patch_agent_backend.create ~process_mgr ~clock ~timeout:60.0
                   ~binary_path:"patch-agent" ~setsid_exec:None
               in
               let events = ref [] in

--- a/test/test_patch_agent_backend_integration.ml
+++ b/test/test_patch_agent_backend_integration.ml
@@ -119,7 +119,10 @@ let smoke_test =
                   in
                   let result =
                     Stdlib.Fun.protect
-                      ~finally:(fun () -> shutdown handle)
+                      ~finally:(fun () ->
+                        try shutdown handle with
+                        | Eio.Cancel.Cancelled _ as exn -> raise exn
+                        | _ -> ())
                       (fun () ->
                         prompt_backend handle
                           ~prompt:
@@ -139,7 +142,9 @@ let smoke_test =
                     | _ -> false)
                   && has_text_delta events
                   && List.exists events ~f:is_final_result))
-        with _ -> false)
+        with
+        | Eio.Cancel.Cancelled _ as exn -> raise exn
+        | _ -> false)
 
 let () =
   let exit_code = QCheck_base_runner.run_tests ~verbose:true [ smoke_test ] in

--- a/test/test_patch_agent_backend_integration.ml
+++ b/test/test_patch_agent_backend_integration.ml
@@ -98,6 +98,7 @@ let smoke_test =
                   ~binary_path:"patch-agent" ~setsid_exec:None
               in
               let events = ref [] in
+              let passed = ref false in
               Eio.Switch.run (fun sw ->
                   let (Llm_backend_long_lived.T
                          { start; prompt = prompt_backend; shutdown; _ }) =
@@ -132,18 +133,20 @@ let smoke_test =
                           ~on_event:(fun event -> events := event :: !events))
                   in
                   let events = List.rev !events in
-                  result.Llm_backend.got_events
-                  && result.Llm_backend.saw_final_result
-                  && (not result.Llm_backend.timed_out)
-                  && Option.value_map (List.hd events) ~default:false
-                       ~f:is_session_init
-                  && (match events with
-                    | _session_init :: turn_started :: _ ->
-                        is_turn_started turn_started
-                    | _ -> false)
-                  && has_text_delta events
-                  && List.exists events ~f:is_final_result
-                  && Option.is_none !shutdown_err))
+                  passed :=
+                    result.Llm_backend.got_events
+                    && result.Llm_backend.saw_final_result
+                    && (not result.Llm_backend.timed_out)
+                    && Option.value_map (List.hd events) ~default:false
+                         ~f:is_session_init
+                    && (match events with
+                      | _session_init :: turn_started :: _ ->
+                          is_turn_started turn_started
+                      | _ -> false)
+                    && has_text_delta events
+                    && List.exists events ~f:is_final_result
+                    && Option.is_none !shutdown_err);
+              !passed)
         with
         | Eio.Cancel.Cancelled _ as exn -> raise exn
         | _ -> false)

--- a/test/test_patch_agent_backend_integration.ml
+++ b/test/test_patch_agent_backend_integration.ml
@@ -1,15 +1,142 @@
 open Base
+open Onton
+open Onton_core
 
-let pending_test =
+let command_available name =
+  match
+    Stdlib.Sys.command
+      (Printf.sprintf "command -v %s >/dev/null 2>&1"
+         (Stdlib.Filename.quote name))
+  with
+  | 0 -> true
+  | _ -> false
+
+let read_file path =
+  let ic = Stdlib.open_in_bin path in
+  Stdlib.Fun.protect
+    ~finally:(fun () -> Stdlib.close_in_noerr ic)
+    (fun () ->
+      let len = Stdlib.in_channel_length ic in
+      Stdlib.really_input_string ic len)
+
+let mktempdir prefix =
+  let base = Stdlib.Filename.get_temp_dir_name () in
+  let rec loop n =
+    let dir =
+      Stdlib.Filename.concat base
+        (Printf.sprintf "%s-%d-%d" prefix (Unix.getpid ()) n)
+    in
+    try
+      Unix.mkdir dir 0o755;
+      dir
+    with Unix.Unix_error (Unix.EEXIST, _, _) -> loop (n + 1)
+  in
+  loop 0
+
+let rm_rf dir =
+  ignore
+    (Stdlib.Sys.command
+       (Printf.sprintf "rm -rf %s" (Stdlib.Filename.quote dir)))
+
+let has_text_delta events =
+  List.exists events ~f:(function
+    | Types.Stream_event.Text_delta _ -> true
+    | Types.Stream_event.Turn_started | Types.Stream_event.Tool_use _
+    | Types.Stream_event.Final_result _ | Types.Stream_event.Error _
+    | Types.Stream_event.Session_init _ ->
+        false)
+
+let is_session_init = function
+  | Types.Stream_event.Session_init _ -> true
+  | Types.Stream_event.Turn_started | Types.Stream_event.Text_delta _
+  | Types.Stream_event.Tool_use _ | Types.Stream_event.Final_result _
+  | Types.Stream_event.Error _ ->
+      false
+
+let is_turn_started = function
+  | Types.Stream_event.Turn_started -> true
+  | Types.Stream_event.Text_delta _ | Types.Stream_event.Tool_use _
+  | Types.Stream_event.Final_result _ | Types.Stream_event.Error _
+  | Types.Stream_event.Session_init _ ->
+      false
+
+let is_final_result = function
+  | Types.Stream_event.Final_result _ -> true
+  | Types.Stream_event.Turn_started | Types.Stream_event.Text_delta _
+  | Types.Stream_event.Tool_use _ | Types.Stream_event.Error _
+  | Types.Stream_event.Session_init _ ->
+      false
+
+let smoke_test =
   QCheck2.Test.make
     ~name:"Patch_agent_backend_integration > one-turn smoke against real binary"
     ~count:1 QCheck2.Gen.unit (fun () ->
-      (* PENDING: implemented in patch 6 *)
-      Stdlib.prerr_endline
-        "SKIP: pending integration smoke for patch-agent backend (implemented \
-         in patch 6)";
-      true)
+      if not (command_available "patch-agent") then (
+        Stdlib.prerr_endline
+          "SKIP: patch-agent binary not found on PATH; integration smoke not \
+           run";
+        true)
+      else
+        Eio_main.run @@ fun env ->
+        let fixture_dir = "fixtures/patch_agent_integration" in
+        let gameplan_prompt =
+          read_file (Stdlib.Filename.concat fixture_dir "gameplan.md")
+        in
+        let patch_prompt =
+          read_file (Stdlib.Filename.concat fixture_dir "patch.md")
+        in
+        let tmp = mktempdir "onton-patch-agent-integration" in
+        Stdlib.Fun.protect
+          ~finally:(fun () -> rm_rf tmp)
+          (fun () ->
+            let process_mgr = Eio.Stdenv.process_mgr env in
+            let clock = Eio.Stdenv.clock env in
+            let fs = Eio.Stdenv.fs env in
+            let backend =
+              Patch_agent_backend.create ~process_mgr ~clock
+                ~binary_path:"patch-agent" ~setsid_exec:None
+            in
+            let events = ref [] in
+            Eio.Switch.run (fun sw ->
+                let (Llm_backend_long_lived.T
+                       { start; prompt = prompt_backend; shutdown; _ }) =
+                  backend
+                in
+                let worktree = Eio.Path.(fs / tmp) in
+                let handle =
+                  start ~sw
+                    {
+                      Llm_backend_long_lived.project_name = "onton";
+                      worktree;
+                      patch_id = Types.Patch_id.of_string "patch-6-smoke";
+                      provider = "anthropic";
+                      model = "claude-sonnet-4-5";
+                      effort = "medium";
+                      gameplan_prompt;
+                      patch_prompt;
+                    }
+                in
+                let result =
+                  Stdlib.Fun.protect
+                    ~finally:(fun () -> shutdown handle)
+                    (fun () ->
+                      prompt_backend handle
+                        ~prompt:
+                          "Run a smoke turn for the integration fixture. Reply \
+                           briefly and do not edit files." ~timeout:60.0
+                        ~on_event:(fun event -> events := event :: !events))
+                in
+                let events = List.rev !events in
+                result.Llm_backend.got_events
+                && result.Llm_backend.saw_final_result
+                && (not result.Llm_backend.timed_out)
+                && Option.value_map (List.hd events) ~default:false
+                     ~f:is_session_init
+                && Option.value_map (List.nth events 1) ~default:false
+                     ~f:is_turn_started
+                && has_text_delta events
+                && List.exists events ~f:is_final_result)))
 
 let () =
-  let exit_code = QCheck_base_runner.run_tests ~verbose:true [ pending_test ] in
+  let exit_code = QCheck_base_runner.run_tests ~verbose:true [ smoke_test ] in
   if exit_code <> 0 then Stdlib.exit exit_code

--- a/test/test_patch_agent_backend_integration.ml
+++ b/test/test_patch_agent_backend_integration.ml
@@ -132,8 +132,10 @@ let smoke_test =
                 && (not result.Llm_backend.timed_out)
                 && Option.value_map (List.hd events) ~default:false
                      ~f:is_session_init
-                && Option.value_map (List.nth events 1) ~default:false
-                     ~f:is_turn_started
+                && (match events with
+                  | _session_init :: turn_started :: _ ->
+                      is_turn_started turn_started
+                  | _ -> false)
                 && has_text_delta events
                 && List.exists events ~f:is_final_result)))
 


### PR DESCRIPTION
## Patch 6: Register patch-agent backend; branch dispatch on lifecycle kind

- In `Backend_registry.ml`: add a constructor entry for backend name `patch-agent` that produces an `Llm_backend_long_lived.t` via `Patch_agent_backend.create`. Reuse the existing process_mgr/clock/timeout/setsid_exec captured in `Backend_registry.create`. Existing ephemeral entries (claude/codex/gemini/opencode/pi-mono) are unchanged.
- In `Backend_registry.mli`: change `get`'s return type from `Llm_backend.t` to `type kind = Ephemeral of Llm_backend.t | Long_lived of Llm_backend_long_lived.t`. Existing callers (those using `get` for an ephemeral backend) get a small change: pattern-match the result and pull the inner `Llm_backend.t` from the `Ephemeral` constructor.
- In `Patch_controller.ml`: when the resolved backend has the long-lived lifecycle, call `start` at the beginning of patch processing (once), call `prompt` for each turn (initial-task, CI failure, review, human, conflict, PR-body — each rendered via the existing `Prompt` layered renderers and passed as the prompt content), call `shutdown` at patch end, and surface crashes as session failures (option (a) of the resolved crash-semantics openQuestion). When the resolved backend has the ephemeral lifecycle, the existing `run_streaming` per-turn dispatch is unchanged.
- Implement the integration test body from patch 5: skip when the patch-agent binary is not found on `$PATH`; otherwise run the full long-lived lifecycle against a fixture and assert the expected event sequence (Session_init -> Turn_started -> at least one Text_delta -> Final_result) and clean teardown.
- Document the parity contract as a top-of-file docstring in `Patch_agent_backend.mli` enumerating: (a) which event types map 1:1 today; (b) which onton features (resume-after-restart, MCP servers, model routing, etc.) the long-lived path supports vs. defers; (c) a checklist that future long-lived-specific changes must update.

## Changes
- In `Backend_registry.ml`: add a constructor entry for backend name `patch-agent` that produces an `Llm_backend_long_lived.t` via `Patch_agent_backend.create`. Reuse the existing process_mgr/clock/timeout/setsid_exec captured in `Backend_registry.create`. Existing ephemeral entries (claude/codex/gemini/opencode/pi-mono) are unchanged.
- In `Backend_registry.mli`: change `get`'s return type from `Llm_backend.t` to `type kind = Ephemeral of Llm_backend.t | Long_lived of Llm_backend_long_lived.t`. Existing callers (those using `get` for an ephemeral backend) get a small change: pattern-match the result and pull the inner `Llm_backend.t` from the `Ephemeral` constructor.
- In `Patch_controller.ml`: when the resolved backend has the long-lived lifecycle, call `start` at the beginning of patch processing (once), call `prompt` for each turn (initial-task, CI failure, review, human, conflict, PR-body — each rendered via the existing `Prompt` layered renderers and passed as the prompt content), call `shutdown` at patch end, and surface crashes as session failures (option (a) of the resolved crash-semantics openQuestion). When the resolved backend has the ephemeral lifecycle, the existing `run_streaming` per-turn dispatch is unchanged.
- Implement the integration test body from patch 5: skip when the patch-agent binary is not found on `$PATH`; otherwise run the full long-lived lifecycle against a fixture and assert the expected event sequence (Session_init -> Turn_started -> at least one Text_delta -> Final_result) and clean teardown.
- Document the parity contract as a top-of-file docstring in `Patch_agent_backend.mli` enumerating: (a) which event types map 1:1 today; (b) which onton features (resume-after-restart, MCP servers, model routing, etc.) the long-lived path supports vs. defers; (c) a checklist that future long-lived-specific changes must update.

## Files to Modify
- lib/backend_registry.ml (modify): Register `patch-agent` as a known backend name. Add a long-lived-backend constructor table alongside the existing ephemeral table.
- lib/backend_registry.mli (modify): Change the return type of `get` from `Llm_backend.t` to a sum: `type kind = Ephemeral of Llm_backend.t | Long_lived of Llm_backend_long_lived.t`. `get : t -> backend:string -> model:string option -> kind`. Callers pattern-match.
- lib/patch_controller.ml (modify): Branch internal dispatch on backend lifecycle kind. Long-lived: call `start` once per patch, drive turns via `prompt`, call `shutdown` at patch end. Ephemeral: existing per-turn `run_streaming` path unchanged.
- lib/patch_controller.mli (modify): No caller-facing signature change. The branch is internal.
- test/test_patch_agent_backend_integration.ml (modify): Remove `[@tags "pending"]`; implement the test body.

## Gameplan Specification

```
module PATCH_AGENT_INTEGRATION.

> M4 ships a long-lived backend abstraction (Llm_backend_long_lived)
> distinct from the ephemeral fresh-spawn shape, an implementation
> (Patch_agent_backend) that drives the patch-agent stdio RPC, and
> kind-driven dispatch in Patch_controller. The patch-agent backend
> is registered under Backend_registry like every other backend;
> selection follows the existing --backend and modelRouting
> machinery. Existing ephemeral backends are untouched.

Backend.
BackendKind.
ephemeral => BackendKind.
long-lived => BackendKind.
patch-agent-backend => Backend.

Session.
LifecyclePhase.
start-phase => LifecyclePhase.
prompt-phase => LifecyclePhase.
abort-phase => LifecyclePhase.
shutdown-phase => LifecyclePhase.

RpcEvent.
StreamEvent.
map-event e: RpcEvent => StreamEvent.

kind-of b: Backend => BackendKind.
long-lived-dispatch? b: Backend => Bool.

start-count s: Session => Nat0.
shutdown-count s: Session => Nat0.
prompt-after-shutdown? s: Session => Bool.
---
> Lifecycle: each long-lived Session has exactly one start, at most
> one shutdown, and no prompt or abort after shutdown.
all s: Session | start-count s = 1.
all s: Session | shutdown-count s <= 1.
all s: Session | ~prompt-after-shutdown? s.

> The patch-agent backend has kind long-lived.
kind-of patch-agent-backend = long-lived.

> Long-lived dispatch is used iff the backend has kind long-lived.
all b: Backend | long-lived-dispatch? b <-> kind-of b = long-lived.

```

## Patch Specification

```
module PATCH_AGENT_INTEGRATION_PATCH_6.

> Patch 6 registers the patch-agent backend and branches dispatch on
> lifecycle kind. The patch-agent backend has kind long-lived; all
> other backends have kind ephemeral.

Backend.
BackendKind.
ephemeral => BackendKind.
long-lived => BackendKind.
patch-agent-backend => Backend.

kind-of b: Backend => BackendKind.
long-lived-dispatch? b: Backend => Bool.
---
> The patch-agent backend has kind long-lived.
kind-of patch-agent-backend = long-lived.

> Long-lived dispatch is used iff the backend has kind long-lived.
all b: Backend | long-lived-dispatch? b <-> kind-of b = long-lived.

```


## Implementation Notes

- The lifecycle branch lands at the actual execution boundary (`bin/main.ml` -> `Session_driver`), not in `Patch_controller`, because this branch keeps `Patch_controller` as the pure planning/reconciliation layer.
- `Session_driver` now has a shared runner core plus ephemeral and long-lived entry points, so transcript capture, PR sniffing, result classification, post-session push, and state completion stay identical across backend kinds.
- The patch-agent path writes the gameplan and patch sidecar prompts from the existing layered renderers, then delivers the already-rendered turn prompt over stdio RPC. This keeps prompt behavior conservative for M4 while still exercising the long-lived transport.
- `patch-agent` model routing selects the backend through the existing registry path; provider/effort default to `anthropic`/`medium` and can be overridden with `PATCH_AGENT_PROVIDER` / `PATCH_AGENT_EFFORT`.
- Deviation to note: persistent reuse across multiple orchestrator turns is not introduced here. The long-lived interface is used for `start -> prompt -> shutdown` dispatch, with restart/resume and multi-turn daemon reuse left for the follow-up recovery work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Added patch-agent backend support with configurable provider/effort, default model fallback, and long‑lived session mode with session timeout.

* **Refactor**
  - Backend registry and session handling updated to distinguish ephemeral vs long‑lived backends, reuse per‑patch long‑lived sessions, and unify prompt rendering and lifecycle management.

* **Tests**
  - Added an integration smoke test exercising the patch‑agent backend.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->