### PR TITLE
Validate main_branch on origin; carry session-failure detail to events.jsonl

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,49 @@ Required property families:
 
 Worked example: `test/test_codex_cost_properties.ml` (26 properties × 100–500 cases each, covering pricing math, usage decoding totality, schema priority, cap-decision boundary, single-step decisions, and full interleavings).
 
+## Debug case investigation
+
+User-reported issues arrive with a case ID (e.g. `c1bd-9d8d-1732`). Bundles are
+uploaded by `lib/debug_upload.ml` to the Cloudflare R2 bucket `onton-debug`
+under the key `uploads/<case-id>.json`.
+
+Fetching:
+
+```
+wrangler r2 object get "onton-debug/uploads/<case-id>.json" --remote --file /tmp/case.json
+```
+
+`--remote` is required — without it wrangler reads the local simulator and the
+key won't be found.
+
+Bundle shape: top-level `{version, timestamp, project_name, onton_version,
+files}`. The `files` map carries string-encoded `config.json`, `events.jsonl`,
+`snapshot.json`, and (when present) `gameplan`. Extract with
+`jq -r '.files["events.jsonl"]' > /tmp/events.jsonl` etc.
+
+Pitfalls when reading a bundle:
+
+- `events.jsonl` is **append-only across onton restarts**. The same file can
+  carry events from multiple sessions separated by long gaps. Always check
+  the timestamp range first (`jq -r .ts | sort -u | head/tail`) and look for
+  multi-minute gaps — they mark a process restart, and config (e.g.
+  `main_branch`) may have changed across the gap. Don't conflate epochs.
+- `snapshot.json` is a point-in-time runtime view written every 5s by
+  `persistence_fiber`. It can lag the live runtime, and in some setups it
+  appears stale (empty `agents`, empty `activity_log`) while `events.jsonl`
+  clearly shows agent activity. When the snapshot disagrees with events,
+  trust the `agent_before`/`agent_after` fields embedded in each event for
+  ground-truth agent state at that timestamp.
+- `activity_log.events` (inside the snapshot) carries the human-readable
+  per-session error strings — `"Session failed (Claude) — exit 1: …"`,
+  rebase failure detail, etc. Check it before concluding that `complete`
+  events are opaque; `complete.result` only carries the structured
+  `session_result` (with `detail : string option` post-error-capture-fix).
+- `config.json` shows the persisted config. Compare its fields (especially
+  `main_branch` and `repo_root`) against the same fields in `agent_before`
+  across epochs — a mismatch usually means the user changed CLI flags
+  between runs.
+
 ## Reference
 - Reference implementation (Elixir): `../orchestrate-gameplan/`
 - Reference specification: `../orchestrate-gameplan/spec/anton.pant`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ under the key `uploads/<case-id>.json`.
 
 Fetching:
 
-```
+```bash
 wrangler r2 object get "onton-debug/uploads/<case-id>.json" --remote --file /tmp/case.json
 ```
 

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -42,6 +42,64 @@ let read_process_capture open_ic =
           status := Some s;
           Some (s, Buffer.contents buf))
 
+type process_capture = {
+  status : Unix.process_status;
+  stdout : string;
+  stderr : string;
+}
+
+let read_channel_all ic =
+  let buf = Buffer.create 128 in
+  (try
+     while true do
+       Buffer.add_char buf (input_char ic)
+     done
+   with End_of_file -> ());
+  Buffer.contents buf
+
+(** Run [git -C repo_root ...] using argv rather than the shell, capture stdout
+    and stderr, and close all process pipes on exception paths. *)
+let run_git_capture ~repo_root args =
+  let argv = Array.of_list ("git" :: "-C" :: repo_root :: args) in
+  let env = Unix.environment () in
+  match Unix.open_process_args_full "git" argv env with
+  | exception _ -> None
+  | in_ch, out_ch, err_ch ->
+      let status = ref None in
+      Stdlib.Fun.protect
+        ~finally:(fun () ->
+          if Option.is_none !status then
+            try ignore (Unix.close_process_full (in_ch, out_ch, err_ch))
+            with _ -> ())
+        (fun () ->
+          close_out_noerr out_ch;
+          let stdout = read_channel_all in_ch in
+          let stderr = read_channel_all err_ch in
+          let s = Unix.close_process_full (in_ch, out_ch, err_ch) in
+          status := Some s;
+          Some { status = s; stdout; stderr })
+
+let git_stdout ~repo_root args =
+  match run_git_capture ~repo_root args with
+  | Some { status = Unix.WEXITED 0; stdout; _ } ->
+      Some (Base.String.strip stdout)
+  | Some { status = Unix.WEXITED _; _ }
+  | Some { status = Unix.WSIGNALED _; _ }
+  | Some { status = Unix.WSTOPPED _; _ }
+  | None ->
+      None
+
+let git_success ~repo_root args = Option.is_some (git_stdout ~repo_root args)
+
+let format_git_failure { stdout; stderr; _ } =
+  let detail =
+    [ stderr; stdout ]
+    |> Base.List.map ~f:(fun s -> Base.String.strip s)
+    |> Base.List.filter ~f:(fun s -> not (Base.String.is_empty s))
+    |> String.concat "\n"
+  in
+  if Base.String.is_empty detail then "no output" else detail
+
 (** Infer GitHub owner/repo from [git remote get-url origin] in [repo_root].
     Parses both HTTPS and SSH remote URLs. Uses argv (no shell). *)
 let infer_owner_repo ~repo_root =
@@ -97,33 +155,17 @@ let infer_github_token () =
     "main" 3. [git rev-parse --verify refs/heads/master] → "master" 4. Fallback:
     "main" *)
 let infer_default_branch ~repo_root =
-  let run_git cmd =
-    try
-      match
-        read_process_capture (fun () ->
-            Unix.open_process_in
-              (Printf.sprintf "git -C %s %s 2>/dev/null"
-                 (Filename.quote repo_root) cmd))
-      with
-      | Some (Unix.WEXITED 0, out) -> Some (Base.String.strip out)
-      | Some (Unix.WEXITED _, _)
-      | Some (Unix.WSIGNALED _, _)
-      | Some (Unix.WSTOPPED _, _)
-      | None ->
-          None
-    with _ -> None
-  in
   let resolves ref_name =
-    Option.is_some
-      (run_git
-         (Printf.sprintf "rev-parse --verify %s" (Filename.quote ref_name)))
+    git_success ~repo_root [ "rev-parse"; "--verify"; ref_name ]
   in
   let head_probes () =
     if resolves "refs/heads/main" then "main"
     else if resolves "refs/heads/master" then "master"
     else "main"
   in
-  match run_git "symbolic-ref refs/remotes/origin/HEAD" with
+  match
+    git_stdout ~repo_root [ "symbolic-ref"; "refs/remotes/origin/HEAD" ]
+  with
   | Some ref_path ->
       let prefix = "refs/remotes/origin/" in
       let candidate =
@@ -180,49 +222,62 @@ let validate_resolved_config ~backend ~github_token ~github_owner ~github_repo
 
 (** Verify that the configured [main_branch] resolves as
     [refs/remotes/origin/<branch>] in the local clone. If the local tracking ref
-    is missing, attempt one [git fetch origin] and re-check. Returns an
-    actionable error when the branch cannot be resolved — e.g., when it was
-    renamed or deleted upstream and the stored config still names the old
-    branch. Without this guard the rebase loop in [Worktree.rebase_onto] would
-    fail every poll with [merge-base --is-ancestor: Not a valid object name] and
-    silently retry forever. *)
+    is missing, attempt one [git fetch origin] and re-check. That best-effort
+    fetch runs during startup and may block on a network round-trip when origin
+    is slow or unreachable. Returns an actionable error when the branch cannot
+    be resolved — e.g., when it was renamed or deleted upstream and the stored
+    config still names the old branch. Without this guard the rebase loop in
+    [Worktree.rebase_onto] would fail every poll with
+    [merge-base --is-ancestor: Not a valid object name] and silently retry
+    forever. *)
 let validate_branch_resolves ~repo_root ~main_branch =
-  let run_git cmd =
-    try
-      match
-        read_process_capture (fun () ->
-            Unix.open_process_in
-              (Printf.sprintf "git -C %s %s 2>/dev/null"
-                 (Filename.quote repo_root) cmd))
-      with
-      | Some (Unix.WEXITED 0, _) -> true
-      | Some (Unix.WEXITED _, _)
-      | Some (Unix.WSIGNALED _, _)
-      | Some (Unix.WSTOPPED _, _)
-      | None ->
-          false
-    with _ -> false
-  in
   let branch_str = Branch.to_string main_branch in
   let ref_name = "refs/remotes/origin/" ^ branch_str in
   let resolves () =
-    run_git (Printf.sprintf "rev-parse --verify %s" (Filename.quote ref_name))
+    git_success ~repo_root [ "rev-parse"; "--verify"; ref_name ]
   in
   if resolves () then Ok ()
   else
-    let _ : bool = run_git "fetch origin --quiet" in
-    if resolves () then Ok ()
-    else
-      Error
-        (Printf.sprintf
-           "configured main branch %S does not resolve as origin/%s in %s\n\
-           \  (the branch may have been renamed or deleted upstream, or the \
-            local clone has not fetched it).\n\
-           \  Refresh the local default and retry:\n\
-           \    git -C %s remote set-head origin -a\n\
-           \    git -C %s fetch --prune\n\
-           \  Or override at launch with --main-branch <name>."
-           branch_str branch_str repo_root repo_root repo_root)
+    let () = Printf.eprintf "onton: fetching origin to verify branch...\n%!" in
+    match run_git_capture ~repo_root [ "fetch"; "origin"; "--quiet" ] with
+    | Some { status = Unix.WEXITED 0; _ } ->
+        if resolves () then Ok ()
+        else
+          Error
+            (Printf.sprintf
+               "configured main branch %S does not resolve as origin/%s in %s\n\
+               \  (the branch may have been renamed or deleted upstream, or \
+                the local clone has not fetched it).\n\
+               \  Refresh the local default and retry:\n\
+               \    git -C %s remote set-head origin -a\n\
+               \    git -C %s fetch --prune\n\
+               \  Or override at launch with --main-branch <name>."
+               branch_str branch_str repo_root repo_root repo_root)
+    | Some ({ status = Unix.WEXITED _; _ } as failed)
+    | Some ({ status = Unix.WSIGNALED _; _ } as failed)
+    | Some ({ status = Unix.WSTOPPED _; _ } as failed) ->
+        Error
+          (Printf.sprintf
+             "configured main branch %S does not resolve as origin/%s in %s, \
+              and git fetch origin failed:\n\
+             \  %s\n\
+             \  Refresh the local default and retry:\n\
+             \    git -C %s remote set-head origin -a\n\
+             \    git -C %s fetch --prune\n\
+             \  Or override at launch with --main-branch <name>."
+             branch_str branch_str repo_root
+             (format_git_failure failed)
+             repo_root repo_root)
+    | None ->
+        Error
+          (Printf.sprintf
+             "configured main branch %S does not resolve as origin/%s in %s, \
+              and git fetch origin could not be started.\n\
+             \  Refresh the local default and retry:\n\
+             \    git -C %s remote set-head origin -a\n\
+             \    git -C %s fetch --prune\n\
+             \  Or override at launch with --main-branch <name>."
+             branch_str branch_str repo_root repo_root repo_root)
 
 (** {1 PR number registry}
 

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -90,9 +90,12 @@ let infer_github_token () =
       with _ -> "")
 
 (** Detect the default branch of a git repository. Tries: 1.
-    [git symbolic-ref refs/remotes/origin/HEAD] (fast, local) 2.
-    [git rev-parse --verify refs/heads/main] → "main" 3.
-    [git rev-parse --verify refs/heads/master] → "master" 4. Fallback: "main" *)
+    [git symbolic-ref refs/remotes/origin/HEAD], verifying the target tracking
+    ref actually resolves (origin/HEAD is set at clone time and is NOT refreshed
+    by [git fetch] — a stale value can point at a branch that has since been
+    renamed or deleted upstream). 2. [git rev-parse --verify refs/heads/main] →
+    "main" 3. [git rev-parse --verify refs/heads/master] → "master" 4. Fallback:
+    "main" *)
 let infer_default_branch ~repo_root =
   let run_git cmd =
     try
@@ -110,19 +113,26 @@ let infer_default_branch ~repo_root =
           None
     with _ -> None
   in
+  let resolves ref_name =
+    Option.is_some
+      (run_git
+         (Printf.sprintf "rev-parse --verify %s" (Filename.quote ref_name)))
+  in
+  let head_probes () =
+    if resolves "refs/heads/main" then "main"
+    else if resolves "refs/heads/master" then "master"
+    else "main"
+  in
   match run_git "symbolic-ref refs/remotes/origin/HEAD" with
   | Some ref_path ->
       let prefix = "refs/remotes/origin/" in
-      if Base.String.is_prefix ref_path ~prefix then
-        Base.String.chop_prefix_exn ref_path ~prefix
-      else ref_path
-  | None -> (
-      match run_git "rev-parse --verify refs/heads/main" with
-      | Some _ -> "main"
-      | None -> (
-          match run_git "rev-parse --verify refs/heads/master" with
-          | Some _ -> "master"
-          | None -> "main"))
+      let candidate =
+        if Base.String.is_prefix ref_path ~prefix then
+          Base.String.chop_prefix_exn ref_path ~prefix
+        else ref_path
+      in
+      if resolves (prefix ^ candidate) then candidate else head_probes ()
+  | None -> head_probes ()
 
 let default_backend = "claude"
 
@@ -167,6 +177,52 @@ let validate_resolved_config ~backend ~github_token ~github_owner ~github_repo
       ~f:(fun (cond, msg) -> if cond then Some msg else None)
   in
   match errors with [] -> Ok () | errs -> Error errs
+
+(** Verify that the configured [main_branch] resolves as
+    [refs/remotes/origin/<branch>] in the local clone. If the local tracking ref
+    is missing, attempt one [git fetch origin] and re-check. Returns an
+    actionable error when the branch cannot be resolved — e.g., when it was
+    renamed or deleted upstream and the stored config still names the old
+    branch. Without this guard the rebase loop in [Worktree.rebase_onto] would
+    fail every poll with [merge-base --is-ancestor: Not a valid object name] and
+    silently retry forever. *)
+let validate_branch_resolves ~repo_root ~main_branch =
+  let run_git cmd =
+    try
+      match
+        read_process_capture (fun () ->
+            Unix.open_process_in
+              (Printf.sprintf "git -C %s %s 2>/dev/null"
+                 (Filename.quote repo_root) cmd))
+      with
+      | Some (Unix.WEXITED 0, _) -> true
+      | Some (Unix.WEXITED _, _)
+      | Some (Unix.WSIGNALED _, _)
+      | Some (Unix.WSTOPPED _, _)
+      | None ->
+          false
+    with _ -> false
+  in
+  let branch_str = Branch.to_string main_branch in
+  let ref_name = "refs/remotes/origin/" ^ branch_str in
+  let resolves () =
+    run_git (Printf.sprintf "rev-parse --verify %s" (Filename.quote ref_name))
+  in
+  if resolves () then Ok ()
+  else
+    let _ : bool = run_git "fetch origin --quiet" in
+    if resolves () then Ok ()
+    else
+      Error
+        (Printf.sprintf
+           "configured main branch %S does not resolve as origin/%s in %s\n\
+           \  (the branch may have been renamed or deleted upstream, or the \
+            local clone has not fetched it).\n\
+           \  Refresh the local default and retry:\n\
+           \    git -C %s remote set-head origin -a\n\
+           \    git -C %s fetch --prune\n\
+           \  Or override at launch with --main-branch <name>."
+           branch_str branch_str repo_root repo_root repo_root)
 
 (** {1 PR number registry}
 
@@ -3846,6 +3902,14 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
       Base.List.iter errs ~f:(fun e -> Printf.eprintf "Error: %s\n" e);
       Stdlib.exit 1
   | Ok () ->
+      (match
+         validate_branch_resolves ~repo_root:config.repo_root
+           ~main_branch:config.main_branch
+       with
+      | Ok () -> ()
+      | Error msg ->
+          Printf.eprintf "Error: %s\n" msg;
+          Stdlib.exit 1);
       (* Preflight: ensure RLIMIT_NOFILE is high enough for [max_concurrency]
          long-lived backend subprocesses (each holding 3 pipes = 6 FDs),
          parallel git subprocesses, HTTPS connections, the activity log,

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -577,9 +577,9 @@ let apply_conflict_push_result t patch_id decision
 
 type session_result =
   | Session_ok
-  | Session_process_error of { is_fresh : bool }
+  | Session_process_error of { is_fresh : bool; detail : string option }
   | Session_no_resume
-  | Session_failed of { is_fresh : bool }
+  | Session_failed of { is_fresh : bool; detail : string option }
   | Session_give_up
   | Session_worktree_missing
   | Session_push_failed
@@ -646,7 +646,7 @@ let apply_session_result t patch_id result =
       let t = clear_session_fallback t patch_id in
       (* A healthy session that pushed commits clears the no-commits counter. *)
       update_agent t patch_id ~f:Patch_agent.reset_no_commits_push_count
-  | Session_process_error { is_fresh } ->
+  | Session_process_error { is_fresh; _ } ->
       let t = on_session_failure t patch_id ~is_fresh in
       let t = update_agent t patch_id ~f:Patch_agent.on_pre_session_failure in
       complete_failed t patch_id
@@ -657,7 +657,7 @@ let apply_session_result t patch_id result =
             Patch_agent.set_llm_session_id a None)
       in
       complete_failed t patch_id
-  | Session_failed { is_fresh } ->
+  | Session_failed { is_fresh; _ } ->
       let t = on_session_failure t patch_id ~is_fresh in
       complete_failed t patch_id
   | Session_give_up ->

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -158,11 +158,15 @@ val add_agent :
 
 (** {2 Persistence support} *)
 
+(** [detail] carries the same formatted reason that [session_driver] writes to
+    the activity log (truncated to ~500 chars) — backend, exit code, stderr
+    excerpt. It surfaces in [events.jsonl] via [show_session_result] so
+    [debug_upload] bundles are self-diagnosing. *)
 type session_result =
   | Session_ok
-  | Session_process_error of { is_fresh : bool }
+  | Session_process_error of { is_fresh : bool; detail : string option }
   | Session_no_resume
-  | Session_failed of { is_fresh : bool }
+  | Session_failed of { is_fresh : bool; detail : string option }
   | Session_give_up
   | Session_worktree_missing
   | Session_push_failed

--- a/lib/session_driver.ml
+++ b/lib/session_driver.ml
@@ -398,17 +398,24 @@ let run_with_backend ~session_mode_for_agent
               classify ~is_resume:(Option.is_some resume_session) outcome
             with
             | Process_error msg ->
-                log_event runtime ~patch_id
-                  (Printf.sprintf "Process error from %s — %s" backend_name msg);
-                (Orchestrator.Session_process_error { is_fresh }, `Failed)
+                let detail =
+                  Printf.sprintf "Process error from %s — %s" backend_name msg
+                in
+                log_event runtime ~patch_id detail;
+                ( Orchestrator.Session_process_error
+                    { is_fresh; detail = Some detail },
+                  `Failed )
             | No_session_to_resume ->
                 log_empty_resume ~tail:" — no session to resume, retrying fresh";
                 (Orchestrator.Session_no_resume, `Failed)
             | Timed_out ->
-                log_event runtime ~patch_id
-                  (Printf.sprintf "Session timed out (%s) — marking failed"
-                     backend_name);
-                (Orchestrator.Session_failed { is_fresh }, `Failed)
+                let detail =
+                  Printf.sprintf "Session timed out (%s) — marking failed"
+                    backend_name
+                in
+                log_event runtime ~patch_id detail;
+                ( Orchestrator.Session_failed { is_fresh; detail = Some detail },
+                  `Failed )
             | Success { stream_errors } ->
                 (match (resume_session, result) with
                 | Some _, Ok r when not r.Llm_backend.got_events ->
@@ -432,10 +439,14 @@ let run_with_backend ~session_mode_for_agent
                        (truncate (String.strip (Buffer.contents text_buf)) 200));
                 (Orchestrator.Session_ok, `Ok)
             | Session_failed { exit_code; detail } ->
-                log_event runtime ~patch_id
-                  (Printf.sprintf "Session failed (%s) — exit %d: %s"
-                     backend_name exit_code detail);
-                (Orchestrator.Session_failed { is_fresh }, `Failed)
+                let formatted =
+                  Printf.sprintf "Session failed (%s) — exit %d: %s"
+                    backend_name exit_code detail
+                in
+                log_event runtime ~patch_id formatted;
+                ( Orchestrator.Session_failed
+                    { is_fresh; detail = Some formatted },
+                  `Failed )
           in
           (* Observability: if any tool_use events reported a non-"completed"
              status (OpenCode's sandbox/rejection/pending states), summarize

--- a/lib_test/test_generators.ml
+++ b/lib_test/test_generators.ml
@@ -652,10 +652,15 @@ let gen_session_result =
       [
         return Onton.Orchestrator.Session_ok;
         map
-          (fun b -> Onton.Orchestrator.Session_process_error { is_fresh = b })
+          (fun b ->
+            Onton.Orchestrator.Session_process_error
+              { is_fresh = b; detail = None })
           bool;
         return Onton.Orchestrator.Session_no_resume;
-        map (fun b -> Onton.Orchestrator.Session_failed { is_fresh = b }) bool;
+        map
+          (fun b ->
+            Onton.Orchestrator.Session_failed { is_fresh = b; detail = None })
+          bool;
         return Onton.Orchestrator.Session_give_up;
         return Onton.Orchestrator.Session_worktree_missing;
         return Onton.Orchestrator.Session_push_failed;

--- a/test/test_action_outcome_properties.ml
+++ b/test/test_action_outcome_properties.ml
@@ -264,11 +264,11 @@ let () =
 let () =
   let failed_results =
     [
-      Orchestrator.Session_process_error { is_fresh = false };
-      Orchestrator.Session_process_error { is_fresh = true };
+      Orchestrator.Session_process_error { is_fresh = false; detail = None };
+      Orchestrator.Session_process_error { is_fresh = true; detail = None };
       Orchestrator.Session_no_resume;
-      Orchestrator.Session_failed { is_fresh = false };
-      Orchestrator.Session_failed { is_fresh = true };
+      Orchestrator.Session_failed { is_fresh = false; detail = None };
+      Orchestrator.Session_failed { is_fresh = true; detail = None };
       Orchestrator.Session_give_up;
     ]
   in

--- a/test/test_interleaving_properties.ml
+++ b/test/test_interleaving_properties.ml
@@ -389,14 +389,16 @@ let apply_reconcile orch patches =
 
 let to_session_result = function
   | Sess_ok -> Orchestrator.Session_ok
-  | Sess_failed_fresh -> Orchestrator.Session_failed { is_fresh = true }
-  | Sess_failed_resume -> Orchestrator.Session_failed { is_fresh = false }
+  | Sess_failed_fresh ->
+      Orchestrator.Session_failed { is_fresh = true; detail = None }
+  | Sess_failed_resume ->
+      Orchestrator.Session_failed { is_fresh = false; detail = None }
   | Sess_give_up -> Orchestrator.Session_give_up
   | Sess_worktree_missing -> Orchestrator.Session_worktree_missing
   | Sess_process_error_fresh ->
-      Orchestrator.Session_process_error { is_fresh = true }
+      Orchestrator.Session_process_error { is_fresh = true; detail = None }
   | Sess_process_error_resume ->
-      Orchestrator.Session_process_error { is_fresh = false }
+      Orchestrator.Session_process_error { is_fresh = false; detail = None }
   | Sess_no_resume -> Orchestrator.Session_no_resume
 
 let stub_conflict_info : Worktree.conflict_info =
@@ -1278,7 +1280,8 @@ let () =
         (* First process error *)
         let orch =
           Orchestrator.apply_session_result orch pid
-            (Orchestrator.Session_process_error { is_fresh = true })
+            (Orchestrator.Session_process_error
+               { is_fresh = true; detail = None })
         in
         let a = Orchestrator.agent orch pid in
         if Patch_agent.needs_intervention a then
@@ -1287,7 +1290,8 @@ let () =
         let orch = Orchestrator.fire orch (Orchestrator.Start (pid, main)) in
         let orch =
           Orchestrator.apply_session_result orch pid
-            (Orchestrator.Session_process_error { is_fresh = true })
+            (Orchestrator.Session_process_error
+               { is_fresh = true; detail = None })
         in
         let a = Orchestrator.agent orch pid in
         Patch_agent.needs_intervention a)
@@ -2206,13 +2210,13 @@ let session_failure_for_state (a : Patch_agent.t) =
       match a.Patch_agent.llm_session_id with
       | Some _ ->
           (* Would attempt Resume → fails *)
-          Orchestrator.Session_failed { is_fresh = false }
+          Orchestrator.Session_failed { is_fresh = false; detail = None }
       | None ->
           (* Would attempt Fresh → fails *)
-          Orchestrator.Session_failed { is_fresh = true })
+          Orchestrator.Session_failed { is_fresh = true; detail = None })
   | Patch_agent.Tried_fresh ->
       (* Would attempt Fresh → fails *)
-      Orchestrator.Session_failed { is_fresh = true }
+      Orchestrator.Session_failed { is_fresh = true; detail = None }
   | Patch_agent.Given_up -> Orchestrator.Session_give_up
 
 (** Run one full Respond(Human) pipeline iteration: fire → apply_session_result
@@ -2367,7 +2371,7 @@ let () =
         let first = session_failure_for_state a0 in
         let is_resume_failure =
           Orchestrator.equal_session_result first
-            (Orchestrator.Session_failed { is_fresh = false })
+            (Orchestrator.Session_failed { is_fresh = false; detail = None })
         in
         if not is_resume_failure then
           QCheck2.Test.fail_reportf

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -1002,10 +1002,13 @@ let () =
     Gen.oneof
       [
         Gen.map
-          (fun b -> Orchestrator.Session_process_error { is_fresh = b })
+          (fun b ->
+            Orchestrator.Session_process_error { is_fresh = b; detail = None })
           Gen.bool;
         Gen.return Orchestrator.Session_no_resume;
-        Gen.map (fun b -> Orchestrator.Session_failed { is_fresh = b }) Gen.bool;
+        Gen.map
+          (fun b -> Orchestrator.Session_failed { is_fresh = b; detail = None })
+          Gen.bool;
         Gen.return Orchestrator.Session_give_up;
         Gen.return Orchestrator.Session_worktree_missing;
         Gen.return Orchestrator.Session_push_failed;


### PR DESCRIPTION
## Summary

Two bug fixes from a debug-case investigation (cases `c1bd-9d8d-1732`, `5bef-405c-5c93`, `26a2-1e26-4079`), plus an AGENTS.md section that documents how to handle case IDs.

- **Branch validation.** `infer_default_branch` no longer returns the target of a stale `refs/remotes/origin/HEAD` symbolic ref without verifying it resolves. A new `validate_branch_resolves` runs at startup (after `validate_resolved_config`, before the FD preflight) and exits cleanly with a `git remote set-head` / `--main-branch` remediation when `origin/<main_branch>` is missing. Catches the case-1 rebase loop where every poll fired `Rebase ("...", "master")` and failed with `merge-base --is-ancestor: Not a valid object name origin/master`.

- **Session-failure detail capture.** `Orchestrator.session_result` carries `detail : string option` on `Session_failed` and `Session_process_error`. `session_driver` populates it with the same formatted string already written to the activity log, so `complete` events in `events.jsonl` carry the exit code / stderr excerpt. Catches the case-2 / case-3 instant-`Session_failed` pattern where the `complete` event read only `Session_failed {is_fresh = true}` and an investigator had to crack open `snapshot.json` to find the underlying cause (sometimes the snapshot was empty, leaving no signal at all).

- **AGENTS.md.** New "Debug case investigation" section: where bundles live (`onton-debug/uploads/<id>.json`), how to fetch them (`wrangler ... --remote`), bundle shape, and the pitfalls we hit — append-only `events.jsonl` mixing epochs, lagging `snapshot.json`, `activity_log` as the pre-fix source-of-truth for per-session errors.

## Test plan

- [x] `dune build` clean (fatal warnings on)
- [x] `dune runtest` — all property/state-machine/backend-smoke tests pass
- [x] `dune fmt` clean
- [ ] Manual: stale `origin/HEAD` clone → expect actionable startup error rather than rebase loop
- [ ] Manual: trigger a Claude session failure → expect `detail = (Some "...")` in next `events.jsonl` `complete` event

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/256"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents rebase loops by verifying the configured default branch resolves on `origin` at startup and adds failure detail to `events.jsonl` for faster debugging. Also adds a short guide in `AGENTS.md` for investigating debug cases.

- **Bug Fixes**
  - Validate `origin/<main_branch>` on startup and handle stale `origin/HEAD`: verify the target resolves, probe local `main`/`master` if not, attempt one `git fetch origin`, then exit with actionable steps (includes stderr) if unresolved.
  - Carry failure details through `Session_failed` and `Session_process_error` (including timeouts), so `complete` events in `events.jsonl` include the backend, exit code, and stderr excerpt.

- **Migration**
  - If startup errors with missing `origin/<main_branch>`, run:
    - `git remote set-head origin -a`
    - `git fetch --prune`
  - Or start with `--main-branch <name>`.

<sup>Written for commit 4499437221885273d040a135beba66667070ebe3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Debug case investigation" guide for downloading and interpreting debug bundles, including bundle layout, event/read patterns across restarts, reconciling snapshots with events, human-readable activity logs, and comparing persisted configs across epochs.

* **Bug Fixes**
  * Strengthened default-branch validation with a quiet fetch fallback and clearer actionable startup error messages.
  * Improved session failure reporting to include richer, more informative details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->