### PR TITLE
Show timestamps in overview Activity block

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -381,6 +381,7 @@ let activity_entries_of_log ?(limit = 10) (log : Activity_log.t) =
           patch_id =
             Base.Option.map e.Activity_log.Event.patch_id ~f:Patch_id.to_string;
           message = e.Activity_log.Event.message;
+          timestamp = e.Activity_log.Event.timestamp;
         })
     ~map_transition:(fun (t : Activity_log.Transition_entry.t) ->
       Tui.Transition
@@ -390,6 +391,7 @@ let activity_entries_of_log ?(limit = 10) (log : Activity_log.t) =
           to_status = t.Activity_log.Transition_entry.to_status;
           to_label = Tui.label t.Activity_log.Transition_entry.to_status;
           action = t.Activity_log.Transition_entry.action;
+          timestamp = t.Activity_log.Transition_entry.timestamp;
         })
     ~map_stream:(fun (s : Activity_log.Stream_entry.t) ->
       Tui.Event
@@ -397,6 +399,7 @@ let activity_entries_of_log ?(limit = 10) (log : Activity_log.t) =
           patch_id =
             Some (Patch_id.to_string s.Activity_log.Stream_entry.patch_id);
           message = format_stream_kind s.Activity_log.Stream_entry.kind;
+          timestamp = s.Activity_log.Stream_entry.timestamp;
         })
   |> Base.List.map ~f:snd
 

--- a/lib/tui.ml
+++ b/lib/tui.ml
@@ -283,8 +283,9 @@ type activity_entry =
       to_status : display_status;
       to_label : string;
       action : string;
+      timestamp : float;
     }
-  | Event of { patch_id : string option; message : string }
+  | Event of { patch_id : string option; message : string; timestamp : float }
 [@@warning "-37"]
 
 (** {1 Patch view — derived per-patch rendering data} *)
@@ -619,6 +620,10 @@ let render_summary ~backend_name (views : patch_view list) =
   in
   Term.styled [ Term.Sgr.dim ] (" " ^ String.concat ~sep:" │ " parts)
 
+let format_activity_ts ts =
+  let tm = Unix.localtime ts in
+  Printf.sprintf "%02d:%02d:%02d" tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec
+
 let render_activity (entries : activity_entry list) =
   if List.is_empty entries then []
   else
@@ -626,19 +631,24 @@ let render_activity (entries : activity_entry list) =
     let lines =
       List.map entries ~f:(fun entry ->
           match entry with
-          | Transition { patch_id; from_label; to_status; to_label; action } ->
-              Printf.sprintf "  %s: %s → %s (%s)"
+          | Transition
+              { patch_id; from_label; to_status; to_label; action; timestamp }
+            ->
+              Printf.sprintf "  %s  %s: %s → %s (%s)"
+                (Term.styled [ Term.Sgr.dim ] (format_activity_ts timestamp))
                 (Term.styled [ Term.Sgr.dim ] patch_id)
                 from_label
                 (styled_status to_status to_label)
                 (Term.styled [ Term.Sgr.dim ] action)
-          | Event { patch_id; message } ->
+          | Event { patch_id; message; timestamp } ->
               let prefix =
                 match patch_id with
                 | Some pid -> Term.styled [ Term.Sgr.dim ] (pid ^ ": ")
                 | None -> ""
               in
-              Printf.sprintf "  %s%s" prefix
+              Printf.sprintf "  %s  %s%s"
+                (Term.styled [ Term.Sgr.dim ] (format_activity_ts timestamp))
+                prefix
                 (Term.styled [ Term.Sgr.dim ] message))
     in
     header :: lines
@@ -887,13 +897,14 @@ let render_timeline ~width ~scroll (entries : activity_entry list) =
     List.map visible ~f:(fun entry ->
         let row =
           match entry with
-          | Transition { patch_id; from_label; to_status; to_label; action } ->
+          | Transition { patch_id; from_label; to_status; to_label; action; _ }
+            ->
               Printf.sprintf "  %s: %s → %s (%s)"
                 (Term.styled [ Term.Sgr.dim ] patch_id)
                 from_label
                 (styled_status to_status to_label)
                 (Term.styled [ Term.Sgr.dim ] action)
-          | Event { patch_id; message } ->
+          | Event { patch_id; message; _ } ->
               let prefix =
                 match patch_id with
                 | Some pid -> Term.styled [ Term.Sgr.dim ] (pid ^ ": ")

--- a/lib/tui.ml
+++ b/lib/tui.ml
@@ -621,8 +621,11 @@ let render_summary ~backend_name (views : patch_view list) =
   Term.styled [ Term.Sgr.dim ] (" " ^ String.concat ~sep:" │ " parts)
 
 let format_activity_ts ts =
-  let tm = Unix.localtime ts in
-  Printf.sprintf "%02d:%02d:%02d" tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec
+  match try Some (Unix.localtime ts) with _ -> None with
+  | None -> "--:--:--"
+  | Some tm ->
+      Printf.sprintf "%02d:%02d:%02d" tm.Unix.tm_hour tm.Unix.tm_min
+        tm.Unix.tm_sec
 
 let render_activity (entries : activity_entry list) =
   if List.is_empty entries then []

--- a/lib/tui.mli
+++ b/lib/tui.mli
@@ -79,8 +79,9 @@ type activity_entry =
       to_status : display_status;
       to_label : string;
       action : string;
+      timestamp : float;
     }
-  | Event of { patch_id : string option; message : string }
+  | Event of { patch_id : string option; message : string; timestamp : float }
 
 (** {2 Patch view} *)
 


### PR DESCRIPTION
## Summary
- Adds a `timestamp : float` field to `Tui.activity_entry` (both `Transition` and `Event`) and threads each entry's source timestamp from `Activity_log` through `activity_entries_of_log`.
- `render_activity` (List_view's Activity panel) now prefixes each line with a dim `HH:MM:SS` formatted via `Unix.localtime` (system-local timezone).
- `render_timeline` is intentionally unchanged — scope was just the overview.

## Test plan
- [ ] `dune build` — clean
- [ ] `dune runtest` — all suites pass
- [ ] Run the TUI against a live project; confirm the Activity block under the patches list shows times next to each entry and they match `events.jsonl` timestamps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/257"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds timestamps to activity entries and shows them as HH:MM:SS (local time) at the start of each line in the overview Activity panel. Timeline view rendering is unchanged.

- **Bug Fixes**
  - Guarded timestamp formatting; shows "--:--:--" if local-time conversion fails.

- **Migration**
  - `Tui.activity_entry` now includes `timestamp: float` on both `Transition` and `Event`. Update pattern matches accordingly.

<sup>Written for commit 99b0faa7bb9a120f02e1326eb237bceaafd635dc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Activity log entries now display timestamps in HH:MM:SS format, providing temporal context for both transitions and events in the activity view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->