### PR TITLE
Inject CLAUDE_CODE_OAUTH_TOKEN into per-patch env on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,8 +210,12 @@ claude setup-token
 
 # 2. Save it where onton will pick it up. Mode 0600 — it's a credential.
 mkdir -p ~/.config/onton
-umask 077 && printf %s "PASTE-TOKEN-HERE" > ~/.config/onton/claude-oauth-token
+install -m 600 /dev/null ~/.config/onton/claude-oauth-token
+cat > ~/.config/onton/claude-oauth-token
+chmod 600 ~/.config/onton/claude-oauth-token
 ```
+
+Paste the token at the `cat` prompt, then press `Ctrl-D`.
 
 Onton checks `CLAUDE_CODE_OAUTH_TOKEN` in the parent env first (for users who
 prefer to export it from their shell rc), falling back to

--- a/README.md
+++ b/README.md
@@ -188,6 +188,37 @@ gh pr list --limit 1  # smoke-test repo access
 If you'd rather keep `gh`'s token separate from onton's, set `GITHUB_TOKEN`
 explicitly and `gh` will prefer that variable too — keeping both in sync.
 
+### Coding-agent authentication
+
+Onton spawns each patch in an isolated config dir (`spawn-envs/<patch_id>/{claude,codex,opencode}`)
+so that concurrent agents don't fight over a single auth file during token
+refresh. It then seeds those dirs with symlinks to the user's real auth files.
+This works transparently on Linux (file-based credentials) and on macOS for
+codex / opencode, but not for **Claude Code on macOS**: Claude stores its
+OAuth credential in the macOS Keychain, and a per-patch `CLAUDE_CONFIG_DIR`
+prevents the spawned Claude from finding that Keychain entry. The result is
+`Not logged in · Please run /login` even though `claude` works fine in your
+own shell.
+
+The fix is to give onton a long-lived OAuth token to inject as
+`CLAUDE_CODE_OAUTH_TOKEN` (precedence #5 in [Claude Code's credential
+docs](https://code.claude.com/docs/en/iam#authentication-precedence)).
+
+```sh
+# 1. Generate a 1-year token from your existing subscription (browser OAuth).
+claude setup-token
+
+# 2. Save it where onton will pick it up. Mode 0600 — it's a credential.
+mkdir -p ~/.config/onton
+umask 077 && printf %s "PASTE-TOKEN-HERE" > ~/.config/onton/claude-oauth-token
+```
+
+Onton checks `CLAUDE_CODE_OAUTH_TOKEN` in the parent env first (for users who
+prefer to export it from their shell rc), falling back to
+`$XDG_CONFIG_HOME/onton/claude-oauth-token` (or `~/.config/onton/claude-oauth-token`).
+Linux users don't need this — the symlinked `.credentials.json` handles auth —
+but the token file works there too if you'd rather use it.
+
 ### Optional: per-repo and project state directories
 
 Onton writes to two locations on disk. Neither requires setup but both are

--- a/lib/spawn_env.ml
+++ b/lib/spawn_env.ml
@@ -12,7 +12,8 @@ let backend_dir ~root ~backend = Stdlib.Filename.concat root backend
    form (regular file, dir, or existing symlink): the backend CLI may have
    replaced the symlink with a freshly-written file (e.g. atomic-rename token
    refresh) and we must not clobber that real state. Skip if [src] is missing:
-   the user may not be logged in to that backend. *)
+   the user may not be logged in to that backend (or, on macOS, Claude stores
+   its credential in the Keychain — see [resolve_claude_oauth_token_with]). *)
 let seed_link ~src ~dst =
   let dst_exists =
     match Unix.lstat dst with
@@ -40,6 +41,54 @@ let resolve_user_config_dir ~env_var ~home_subpath =
       | Some home when not (String.is_empty home) ->
           Some (Stdlib.Filename.concat (absolutize home) home_subpath)
       | _ -> None)
+
+(* On macOS, Claude Code stores its OAuth token in the macOS Keychain rather
+   than in [.credentials.json]. The Keychain lookup is scoped such that
+   pointing Claude at a per-patch [CLAUDE_CONFIG_DIR] makes it report
+   "Not logged in" even when the user has a valid Keychain entry. The
+   documented escape hatch is [CLAUDE_CODE_OAUTH_TOKEN] (precedence #5 in
+   docs), generated via [claude setup-token]. We read it from the shell env
+   (preferred) or fall back to [$XDG_CONFIG_HOME/onton/claude-oauth-token]
+   (or [~/.config/onton/claude-oauth-token]). *)
+let resolve_claude_oauth_token_with ~getenv_opt ~read_token_file =
+  match getenv_opt "CLAUDE_CODE_OAUTH_TOKEN" with
+  | Some t when not (String.is_empty (String.strip t)) -> None
+  | _ ->
+      let xdg_dir =
+        match getenv_opt "XDG_CONFIG_HOME" with
+        | Some d when not (String.is_empty d) -> Some d
+        | _ ->
+            Option.map (getenv_opt "HOME") ~f:(fun home ->
+                Stdlib.Filename.concat home ".config")
+      in
+      Option.bind xdg_dir ~f:(fun dir ->
+          let path = Stdlib.Filename.concat dir "onton/claude-oauth-token" in
+          match read_token_file path with
+          | None -> None
+          | Some s ->
+              let t = String.strip s in
+              if String.is_empty t then None else Some t)
+
+let read_token_file_opt path =
+  try
+    let ic = Stdlib.open_in path in
+    Stdlib.Fun.protect
+      ~finally:(fun () -> Stdlib.close_in_noerr ic)
+      (fun () ->
+        let len = Stdlib.in_channel_length ic in
+        let buf = Stdlib.Bytes.create len in
+        Stdlib.really_input ic buf 0 len;
+        Some (Stdlib.Bytes.to_string buf))
+  with _ -> None
+
+let resolve_claude_oauth_token () =
+  resolve_claude_oauth_token_with ~getenv_opt:Stdlib.Sys.getenv_opt
+    ~read_token_file:read_token_file_opt
+
+let claude_oauth_token_overrides () =
+  match resolve_claude_oauth_token () with
+  | None -> []
+  | Some token -> [ ("CLAUDE_CODE_OAUTH_TOKEN", token) ]
 
 (* Seed the per-patch config dirs with symlinks to the user's real auth files.
    Symlinks (not copies) are better than stale snapshots, but they are still not
@@ -83,6 +132,7 @@ let per_patch_env_in_project_dir ~project_dir ~patch_id =
     ("CODEX_HOME", codex_dir);
     ("OPENCODE_CONFIG_DIR", opencode_dir);
   ]
+  @ claude_oauth_token_overrides ()
 
 let per_patch_env_without_codex_home_in_project_dir ~project_dir ~patch_id =
   per_patch_env_in_project_dir ~project_dir ~patch_id
@@ -326,3 +376,64 @@ let%test "resolve_user_config_dir absolutizes relative env and HOME paths" =
        (Stdlib.Filename.concat
           (Stdlib.Filename.concat cwd "relative-home")
           ".config/onton")
+
+let%test "resolve_claude_oauth_token: env var present → no override" =
+  let getenv_opt = function
+    | "CLAUDE_CODE_OAUTH_TOKEN" -> Some "shell-tok"
+    | _ -> None
+  in
+  let read_token_file _ = Some "file-tok" in
+  Option.is_none (resolve_claude_oauth_token_with ~getenv_opt ~read_token_file)
+
+let%test "resolve_claude_oauth_token: empty env var falls back to file" =
+  let getenv_opt = function
+    | "CLAUDE_CODE_OAUTH_TOKEN" -> Some "   "
+    | "HOME" -> Some "/h"
+    | _ -> None
+  in
+  let read_token_file = function
+    | "/h/.config/onton/claude-oauth-token" -> Some "file-tok"
+    | _ -> None
+  in
+  match resolve_claude_oauth_token_with ~getenv_opt ~read_token_file with
+  | Some "file-tok" -> true
+  | _ -> false
+
+let%test "resolve_claude_oauth_token: HOME-based fallback strips whitespace" =
+  let getenv_opt = function "HOME" -> Some "/h" | _ -> None in
+  let read_token_file = function
+    | "/h/.config/onton/claude-oauth-token" -> Some "  tok\n"
+    | _ -> None
+  in
+  match resolve_claude_oauth_token_with ~getenv_opt ~read_token_file with
+  | Some "tok" -> true
+  | _ -> false
+
+let%test "resolve_claude_oauth_token: XDG_CONFIG_HOME wins over HOME" =
+  let getenv_opt = function
+    | "XDG_CONFIG_HOME" -> Some "/x"
+    | "HOME" -> Some "/h"
+    | _ -> None
+  in
+  let read_token_file = function
+    | "/x/onton/claude-oauth-token" -> Some "xdg-tok"
+    | _ -> None
+  in
+  match resolve_claude_oauth_token_with ~getenv_opt ~read_token_file with
+  | Some "xdg-tok" -> true
+  | _ -> false
+
+let%test "resolve_claude_oauth_token: missing file → None" =
+  let getenv_opt = function "HOME" -> Some "/h" | _ -> None in
+  let read_token_file _ = None in
+  Option.is_none (resolve_claude_oauth_token_with ~getenv_opt ~read_token_file)
+
+let%test "resolve_claude_oauth_token: empty file → None" =
+  let getenv_opt = function "HOME" -> Some "/h" | _ -> None in
+  let read_token_file _ = Some "   \n" in
+  Option.is_none (resolve_claude_oauth_token_with ~getenv_opt ~read_token_file)
+
+let%test "resolve_claude_oauth_token: no HOME, no XDG → None" =
+  let getenv_opt _ = None in
+  let read_token_file _ = Some "tok" in
+  Option.is_none (resolve_claude_oauth_token_with ~getenv_opt ~read_token_file)

--- a/lib/spawn_env.ml
+++ b/lib/spawn_env.ml
@@ -57,9 +57,11 @@ let resolve_claude_oauth_token_with ~getenv_opt ~read_token_file =
       let xdg_dir =
         match getenv_opt "XDG_CONFIG_HOME" with
         | Some d when not (String.is_empty d) -> Some d
-        | _ ->
-            Option.map (getenv_opt "HOME") ~f:(fun home ->
-                Stdlib.Filename.concat home ".config")
+        | _ -> (
+            match getenv_opt "HOME" with
+            | Some home when not (String.is_empty home) ->
+                Some (Stdlib.Filename.concat home ".config")
+            | _ -> None)
       in
       Option.bind xdg_dir ~f:(fun dir ->
           let path = Stdlib.Filename.concat dir "onton/claude-oauth-token" in
@@ -435,5 +437,10 @@ let%test "resolve_claude_oauth_token: empty file → None" =
 
 let%test "resolve_claude_oauth_token: no HOME, no XDG → None" =
   let getenv_opt _ = None in
+  let read_token_file _ = Some "tok" in
+  Option.is_none (resolve_claude_oauth_token_with ~getenv_opt ~read_token_file)
+
+let%test "resolve_claude_oauth_token: empty HOME is missing" =
+  let getenv_opt = function "HOME" -> Some "" | _ -> None in
   let read_token_file _ = Some "tok" in
   Option.is_none (resolve_claude_oauth_token_with ~getenv_opt ~read_token_file)

--- a/lib/spawn_env.ml
+++ b/lib/spawn_env.ml
@@ -52,7 +52,7 @@ let resolve_user_config_dir ~env_var ~home_subpath =
    (or [~/.config/onton/claude-oauth-token]). *)
 let resolve_claude_oauth_token_with ~getenv_opt ~read_token_file =
   match getenv_opt "CLAUDE_CODE_OAUTH_TOKEN" with
-  | Some t when not (String.is_empty (String.strip t)) -> None
+  | Some t when not (String.is_empty (String.strip t)) -> Some (String.strip t)
   | _ ->
       let xdg_dir =
         match getenv_opt "XDG_CONFIG_HOME" with
@@ -379,13 +379,15 @@ let%test "resolve_user_config_dir absolutizes relative env and HOME paths" =
           (Stdlib.Filename.concat cwd "relative-home")
           ".config/onton")
 
-let%test "resolve_claude_oauth_token: env var present → no override" =
+let%test "resolve_claude_oauth_token: env var present wins" =
   let getenv_opt = function
     | "CLAUDE_CODE_OAUTH_TOKEN" -> Some "shell-tok"
     | _ -> None
   in
   let read_token_file _ = Some "file-tok" in
-  Option.is_none (resolve_claude_oauth_token_with ~getenv_opt ~read_token_file)
+  match resolve_claude_oauth_token_with ~getenv_opt ~read_token_file with
+  | Some "shell-tok" -> true
+  | _ -> false
 
 let%test "resolve_claude_oauth_token: empty env var falls back to file" =
   let getenv_opt = function

--- a/lib/spawn_env.mli
+++ b/lib/spawn_env.mli
@@ -3,7 +3,17 @@ val per_patch_env :
 (** Per-patch config-dir overrides for headless agent CLIs. Creates the backing
     directories under the project store before returning:
     [spawn-envs/<patch_id>/{claude,codex,opencode}]. Also seeds each per-patch
-    dir with a symlink to the user's real auth file. *)
+    dir with a symlink to the user's real auth file (a no-op when the user's
+    file does not exist — e.g. macOS Claude, where credentials live in the
+    Keychain rather than [~/.claude/.credentials.json]).
+
+    On macOS, scoping [CLAUDE_CONFIG_DIR] makes Claude unable to find the
+    Keychain-stored OAuth credential, so [per_patch_env] also injects
+    [CLAUDE_CODE_OAUTH_TOKEN] when one is available. The token is sourced from
+    the parent process env if already set; otherwise read from
+    [$XDG_CONFIG_HOME/onton/claude-oauth-token] (or
+    [~/.config/onton/claude-oauth-token]). Generate the token once via
+    [claude setup-token] and write it to that file (mode 0600). *)
 
 val per_patch_env_without_codex_home :
   project_name:string -> patch_id:Types.Patch_id.t -> (string * string) list


### PR DESCRIPTION
## Summary

- On macOS, Claude stores its OAuth credential in the Keychain rather than `.credentials.json`. Onton's per-patch `CLAUDE_CONFIG_DIR` scoping breaks the Keychain lookup, so every spawned `claude` reports `Not logged in · Please run /login` even when the user's shell session is logged in fine.
- Inject `CLAUDE_CODE_OAUTH_TOKEN` (precedence #5 in [Claude's auth docs](https://code.claude.com/docs/en/iam#authentication-precedence)) into the per-patch env when one is available — first from the parent env, then from `$XDG_CONFIG_HOME/onton/claude-oauth-token`. Users generate the token once via `claude setup-token`. Linux/Windows users are unaffected since file-based credentials still work for them.
- Added 7 unit tests for `resolve_claude_oauth_token_with`: env-var precedence, file fallback, whitespace stripping, XDG vs HOME, missing file, empty file, no-config case.
- Documented setup in README under a new "Coding-agent authentication" section.
- Left `seed_link` alone — its `src_exists` guard already prevents creating dangling symlinks; existing stale ones in `~/.local/share/onton/*/spawn-envs/*/claude/` are a one-time `find -L … -delete` cleanup, not a code-level concern.

## Test plan

- [x] `dune build` clean
- [x] `dune runtest` — all existing tests pass plus the 7 new ones
- [x] Format check passes (pre-commit hook)
- [ ] Reviewer to verify: with `~/.config/onton/claude-oauth-token` populated from `claude setup-token`, the rebuilt onton successfully spawns claude on macOS without the "Not logged in" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/258"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes macOS Claude auth in per-patch envs by resolving and injecting `CLAUDE_CODE_OAUTH_TOKEN` into spawned envs, preferring the parent env and falling back to `$XDG_CONFIG_HOME/onton/claude-oauth-token` (or `~/.config/...`). This stops spawned `claude` from showing “Not logged in” while keeping Linux/Windows behavior unchanged.

- **Bug Fixes**
  - Made token resolution self-contained in `spawn_env`: read from env first; else from config file; trims whitespace; XDG over HOME; safe on missing/empty files.
  - Injects the resolved token into per-patch `CLAUDE_CONFIG_DIR`; added unit tests and README guidance.

- **Migration**
  - Run `claude setup-token`, then save it to `~/.config/onton/claude-oauth-token` (mode 0600).
  - Or export `CLAUDE_CODE_OAUTH_TOKEN` in your shell.

<sup>Written for commit 682487298fc86ef3fffdcdc7ccb8622e5062fdbe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

