### PR TITLE
[ir1-ssa-contract] Patch 1: Add skipped IR1 SSA contract tests

### DIFF
--- a/tools/ts2pant/tests/ir1-ssa-contract.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-contract.test.mts
@@ -1,0 +1,23 @@
+import { describe, test } from "node:test";
+
+describe("ir1-ssa-contract", () => {
+  test.skip("allocates opaque versions with location metadata", () => {
+    // PENDING: Patch 2 will implement the SSA version contract.
+  });
+
+  test.skip("simplifies degenerate joins before constructing join nodes", () => {
+    // PENDING: Patch 2 will implement join simplification.
+  });
+
+  test.skip("models Map state as coordinated value and membership locations", () => {
+    // PENDING: Patch 2 will implement coordinated Map locations.
+  });
+
+  test.skip("models Set clear inside membership SSA value", () => {
+    // PENDING: Patch 2 will implement Set clear SSA encoding.
+  });
+
+  test.skip("exposes distinct loop-summary versions", () => {
+    // PENDING: Patch 2 will implement loop-summary versioning.
+  });
+});


### PR DESCRIPTION
## Patch 1: Add skipped IR1 SSA contract tests

- Create describe("ir1-ssa-contract", ...) in tools/ts2pant/tests/ir1-ssa-contract.test.mts.
- Add skipped tests for opaque version allocation with location metadata.
- Add skipped tests for degenerate join simplification and location-compatible join construction.
- Add skipped tests proving Map value and membership are represented as distinct coordinated locations.
- Add skipped tests proving Set clear is represented inside the Set membership SSA value.
- Add skipped tests proving foreach loop summaries produce distinct summary versions.
- Each skipped test should include a short PENDING comment naming Patch 2 as the implementation patch.

## Changes
- Create describe("ir1-ssa-contract", ...) in tools/ts2pant/tests/ir1-ssa-contract.test.mts.
- Add skipped tests for opaque version allocation with location metadata.
- Add skipped tests for degenerate join simplification and location-compatible join construction.
- Add skipped tests proving Map value and membership are represented as distinct coordinated locations.
- Add skipped tests proving Set clear is represented inside the Set membership SSA value.
- Add skipped tests proving foreach loop summaries produce distinct summary versions.
- Each skipped test should include a short PENDING comment naming Patch 2 as the implementation patch.

## Files to Modify
- tools/ts2pant/tests/ir1-ssa-contract.test.mts (create): Create node:test stubs with skip markers for the IR1 SSA type and constructor contract.

## Gameplan Specification

```
module IR1_SSA_CONTRACT.

IR1Program.
Construct.
Location.
Version.
Read.
Write.
Join.
LoopSummary.
Rule.
PropResult.
Diagnostic.

supported-constructs p: IR1Program => [Construct].
lowered-constructs p: IR1Program => [Construct].
diagnostics p: IR1Program => [Diagnostic].
diagnostic-construct d: Diagnostic => Construct.
writes p: IR1Program => [Write].
reads p: IR1Program => [Read].
joins p: IR1Program => [Join].
loop-summaries p: IR1Program => [LoopSummary].
write-location w: Write => Location.
write-version w: Write => Version.
read-location r: Read => Location.
read-version r: Read => Version.
read-dominated? p: IR1Program, r: Read => Bool.
join-location j: Join => Location.
then-version j: Join => Version.
else-version j: Join => Version.
join-version j: Join => Version.
summary-location s: LoopSummary => Location.
summary-version s: LoopSummary => Version.
initial-version l: Location => Version.
version-location v: Version => Location.
rule-of-location l: Location => Rule.
declared-rules p: IR1Program => [Rule].
modified-rules p: IR1Program => [Rule].
framed-rules p: IR1Program => [Rule].
emitted-props p: IR1Program => [PropResult].

---

all p: IR1Program, c in supported-constructs p |
  c in lowered-constructs p.

all p: IR1Program, d in diagnostics p |
  ~(diagnostic-construct d in supported-constructs p).

all p: IR1Program, w in writes p |
  version-location (write-version w) = write-location w.

all p: IR1Program, s in loop-summaries p |
  version-location (summary-version s) = summary-location s.

all l: Location |
  version-location (initial-version l) = l.

all p: IR1Program, w1 in writes p, w2 in writes p |
  write-version w1 = write-version w2 -> w1 = w2.

all p: IR1Program, r in reads p |
  read-dominated? p r and
  version-location (read-version r) = read-location r and
  (
    read-version r = initial-version (read-location r) or
    (some w in writes p |
      write-version w = read-version r and
      write-location w = read-location r) or
    (some s in loop-summaries p |
      summary-version s = read-version r and
      summary-location s = read-location r)
  ).

all p: IR1Program, j in joins p |
  version-location (then-version j) = join-location j and
  version-location (else-version j) = join-location j and
  version-location (join-version j) = join-location j.

all p: IR1Program, j in joins p |
  then-version j != else-version j and
  join-version j != then-version j and
  join-version j != else-version j.

all p: IR1Program, rule in modified-rules p |
  rule in declared-rules p and
  ~(rule in framed-rules p).

all p: IR1Program, rule in framed-rules p |
  rule in declared-rules p and
  ~(rule in modified-rules p).

all p: IR1Program, rule in declared-rules p |
  rule in modified-rules p or rule in framed-rules p.

all p: IR1Program, w in writes p |
  rule-of-location (write-location w) in modified-rules p.

all p: IR1Program, s in loop-summaries p |
  rule-of-location (summary-location s) in modified-rules p.

all p: IR1Program |
  #(lowered-constructs p) > 0 -> #(emitted-props p) > 0.

```

## Patch Specification

```
module IR1_SSA_CONTRACT_PATCH_1.

SsaContractTest.
Invariant.

covers-invariant t: SsaContractTest => Invariant.
implemented? t: SsaContractTest => Bool.

---

> Patch 1 introduces pending test declarations only. The tests may be skipped,
> but each test must name an invariant it is intended to cover.
all t: SsaContractTest | covers-invariant t = covers-invariant t.

```


## Implementation Notes

No additional notes: this patch is a test-only scaffold with skipped stubs, and it intentionally avoids changing IR1 behavior or production translation paths.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `tools/ts2pant/tests/ir1-ssa-contract.test.mts` with a skipped test suite defining the IR1 SSA contract. It documents pending invariants for opaque version allocation with location metadata, degenerate join simplification, Map value vs membership locations, Set clear encoding, and distinct loop-summary versions to be implemented in Patch 2.

<sup>Written for commit 0aae2d3c90cc10dc3b0ea4847712e3299ff73ea4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added placeholder test cases for upcoming feature enhancements in future patches.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flowglad/onton/pull/259)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->