### PR TITLE
Prevent interactive git credential prompts

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -104,13 +104,9 @@ let format_git_failure { stdout; stderr; _ } =
     Parses both HTTPS and SSH remote URLs. Uses argv (no shell). *)
 let infer_owner_repo ~repo_root =
   try
-    match
-      read_process_capture (fun () ->
-          Unix.open_process_args_in "git"
-            [| "git"; "-C"; repo_root; "remote"; "get-url"; "origin" |])
-    with
-    | Some (Unix.WEXITED 0, out) -> (
-        let url = Base.String.strip out in
+    match run_git_capture ~repo_root [ "remote"; "get-url"; "origin" ] with
+    | Some { status = Unix.WEXITED 0; stdout; _ } -> (
+        let url = Base.String.strip stdout in
         let re =
           Re.Pcre.re {|github\.com[:/]([^/]+)/([^/\s]+?)(?:\.git)?/?$|}
           |> Re.compile
@@ -118,9 +114,9 @@ let infer_owner_repo ~repo_root =
         match Re.exec_opt re url with
         | Some g -> Some (Re.Group.get g 1, Re.Group.get g 2)
         | None -> None)
-    | Some (Unix.WEXITED _, _)
-    | Some (Unix.WSIGNALED _, _)
-    | Some (Unix.WSTOPPED _, _)
+    | Some { status = Unix.WEXITED _; _ }
+    | Some { status = Unix.WSIGNALED _; _ }
+    | Some { status = Unix.WSTOPPED _; _ }
     | None ->
         None
   with _ -> None

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -61,7 +61,7 @@ let read_channel_all ic =
     and stderr, and close all process pipes on exception paths. *)
 let run_git_capture ~repo_root args =
   let argv = Array.of_list ("git" :: "-C" :: repo_root :: args) in
-  let env = Unix.environment () in
+  let env = Git_env.clean_env () in
   match Unix.open_process_args_full "git" argv env with
   | exception _ -> None
   | in_ch, out_ch, err_ch ->
@@ -3960,6 +3960,7 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
       Base.List.iter errs ~f:(fun e -> Printf.eprintf "Error: %s\n" e);
       Stdlib.exit 1
   | Ok () ->
+      Git_env.set_github_token config.github_token;
       (match
          validate_branch_resolves ~repo_root:config.repo_root
            ~main_branch:config.main_branch
@@ -4040,6 +4041,13 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
         Github.create ~token:config.github_token ~owner:config.github_owner
           ~repo:config.github_repo
       in
+      let net = Eio.Stdenv.net env in
+      (match Github.check_repo_access ~net github with
+      | Ok () -> ()
+      | Error err ->
+          Printf.eprintf "Error: cannot access GitHub repo %s/%s: %s\n"
+            config.github_owner config.github_repo (Github.show_error err);
+          Stdlib.exit 1);
       let pr_registry = Pr_registry.create () in
       (* Seed registry from any agents that already have a PR number — covers
          both gameplan patches restored from a snapshot and ad-hoc agents. The
@@ -4125,7 +4133,6 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
               ~model:dec.Backend_routing.model ~complexity;
         }
       in
-      let net = Eio.Stdenv.net env in
       let stdout = Eio.Stdenv.stdout env in
       (* Capture agent state and worktree list BEFORE launching concurrent
          fibers, so the reconciler sees the pre-session state rather than racing

--- a/lib/git_env.ml
+++ b/lib/git_env.ml
@@ -1,6 +1,67 @@
 open Base
 
+let configured_github_token = ref None
+
+let set_github_token token =
+  let token = String.strip token in
+  if not (String.is_empty token) then configured_github_token := Some token
+
+let askpass_script =
+  Stdlib.Lazy.from_fun (fun () ->
+      let path =
+        Stdlib.Filename.concat
+          (Stdlib.Filename.get_temp_dir_name ())
+          "onton-git-askpass.sh"
+      in
+      let body =
+        {|#!/bin/sh
+case "$1" in
+  *Username*)
+    printf '%s\n' 'x-access-token'
+    ;;
+  *Password*)
+    if [ -n "$GITHUB_TOKEN" ]; then
+      printf '%s\n' "$GITHUB_TOKEN"
+    elif [ -n "$GH_TOKEN" ]; then
+      printf '%s\n' "$GH_TOKEN"
+    else
+      GH_PROMPT_DISABLED=1 gh auth token 2>/dev/null
+    fi
+    ;;
+  *)
+    printf '\n'
+    ;;
+esac
+|}
+      in
+      let oc = Stdlib.open_out path in
+      Stdlib.Fun.protect
+        ~finally:(fun () -> Stdlib.close_out_noerr oc)
+        (fun () -> Stdlib.output_string oc body);
+      (try Unix.chmod path 0o700 with _ -> ());
+      path)
+
+let is_env_binding name s = String.is_prefix s ~prefix:(name ^ "=")
+
+let with_configured_token env =
+  match !configured_github_token with
+  | None -> env
+  | Some token ->
+      let env =
+        List.filter env ~f:(fun s -> not (is_env_binding "GITHUB_TOKEN" s))
+      in
+      ("GITHUB_TOKEN=" ^ token) :: env
+
 let clean_env () =
+  let askpass = Stdlib.Lazy.force askpass_script in
   Unix.environment () |> Array.to_list
   |> List.filter ~f:(fun s -> not (String.is_prefix s ~prefix:"GIT_"))
+  |> with_configured_token
+  |> List.append
+       [
+         "GIT_TERMINAL_PROMPT=0";
+         "GIT_ASKPASS=" ^ askpass;
+         "GCM_INTERACTIVE=never";
+         "GH_PROMPT_DISABLED=1";
+       ]
   |> Array.of_list

--- a/lib/git_env.ml
+++ b/lib/git_env.ml
@@ -8,10 +8,10 @@ let set_github_token token =
 
 let askpass_script =
   Stdlib.Lazy.from_fun (fun () ->
-      let path =
-        Stdlib.Filename.concat
-          (Stdlib.Filename.get_temp_dir_name ())
-          "onton-git-askpass.sh"
+      let path, oc =
+        Stdlib.Filename.open_temp_file
+          ~temp_dir:(Stdlib.Filename.get_temp_dir_name ())
+          "onton-git-askpass-" ".sh"
       in
       let body =
         {|#!/bin/sh
@@ -34,11 +34,10 @@ case "$1" in
 esac
 |}
       in
-      let oc = Stdlib.open_out path in
       Stdlib.Fun.protect
         ~finally:(fun () -> Stdlib.close_out_noerr oc)
         (fun () -> Stdlib.output_string oc body);
-      (try Unix.chmod path 0o700 with _ -> ());
+      Unix.chmod path 0o700;
       path)
 
 let is_env_binding name s = String.is_prefix s ~prefix:(name ^ "=")
@@ -48,15 +47,28 @@ let with_configured_token env =
   | None -> env
   | Some token ->
       let env =
-        List.filter env ~f:(fun s -> not (is_env_binding "GITHUB_TOKEN" s))
+        List.filter env ~f:(fun s ->
+            not (is_env_binding "GITHUB_TOKEN" s || is_env_binding "GH_TOKEN" s))
       in
       ("GITHUB_TOKEN=" ^ token) :: env
 
 let clean_env () =
   let askpass = Stdlib.Lazy.force askpass_script in
+  let fixed_env_names =
+    [
+      "GIT_TERMINAL_PROMPT";
+      "GIT_ASKPASS";
+      "GCM_INTERACTIVE";
+      "GH_PROMPT_DISABLED";
+    ]
+  in
   Unix.environment () |> Array.to_list
   |> List.filter ~f:(fun s -> not (String.is_prefix s ~prefix:"GIT_"))
+  |> List.filter ~f:(fun s ->
+      not (List.exists fixed_env_names ~f:(fun name -> is_env_binding name s)))
   |> with_configured_token
+  (* These fixed bindings are installed after the broad GIT_* scrub so the git
+     subprocess receives only the noninteractive Git variables we install. *)
   |> List.append
        [
          "GIT_TERMINAL_PROMPT=0";

--- a/lib/git_env.mli
+++ b/lib/git_env.mli
@@ -14,4 +14,14 @@ val clean_env : unit -> string array
 
     onton only spawns git for repository queries, not for authoring commits, so
     stripping [GIT_AUTHOR_*] / [GIT_COMMITTER_*] along with the rest is harmless
-    and keeps the isolation boundary simple. *)
+    and keeps the isolation boundary simple.
+
+    The returned environment also disables terminal prompts and installs a
+    controlled HTTPS askpass helper. For GitHub remotes, the helper supplies the
+    token configured by {!set_github_token}, an inherited [GITHUB_TOKEN] or
+    [GH_TOKEN], or a noninteractive [gh auth token] result. *)
+
+val set_github_token : string -> unit
+(** [set_github_token token] makes [token] available to future [clean_env ()]
+    results for supervised git HTTPS authentication. Empty tokens are ignored.
+*)

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -6,38 +6,68 @@ type error =
   | Graphql_error of string list
   | Transport_error of { meth : string; path : string; msg : string }
 
-(* Extract GitHub's "message" field from a JSON error body, falling back to the
-   raw body (truncated) when parsing fails. GitHub 4xx responses always include
-   this field with a human-readable explanation. *)
+(* Extract GitHub's "message" field and validation details from a JSON error
+   body, falling back to the raw body (truncated) when parsing fails. GitHub 422
+   responses often put the useful cause in [errors[].message] while the top-level
+   message is only "Validation Failed". *)
 let extract_github_message body =
   let truncate s =
     if String.length s <= 200 then s else String.sub s ~pos:0 ~len:200 ^ "…"
   in
   try
     let json = Yojson.Safe.from_string body in
-    match Yojson.Safe.Util.(json |> member "message" |> to_string_option) with
-    | Some msg -> msg
-    | None -> truncate body
+    let top_message =
+      Yojson.Safe.Util.(json |> member "message" |> to_string_option)
+    in
+    let validation_messages =
+      match Yojson.Safe.Util.(json |> member "errors") with
+      | `List errors ->
+          List.filter_map errors ~f:(fun err ->
+              Yojson.Safe.Util.(err |> member "message" |> to_string_option))
+      | _ -> []
+    in
+    let messages =
+      Option.to_list top_message @ validation_messages
+      |> List.dedup_and_sort ~compare:String.compare
+    in
+    match messages with
+    | [] -> truncate body
+    | [ msg ] -> msg
+    | msgs -> String.concat ~sep:": " msgs
   with _ -> truncate body
 
-(* Returns [true] if any [errors[].message] in a GitHub 422 validation response
-   body contains [substring] (case-insensitive). 422 covers many distinct
-   validation cases (no commits between head/base, head doesn't exist, branch
-   already has PR, etc.) — callers use this to discriminate which one. Pure;
-   safe on malformed input (returns false). *)
-let response_error_message_contains body ~substring =
+let response_error_messages body =
   try
     let json = Yojson.Safe.from_string body in
-    let errors = Yojson.Safe.Util.(json |> member "errors" |> to_list) in
-    let needle = String.lowercase substring in
-    List.exists errors ~f:(fun err ->
-        match
-          Yojson.Safe.Util.(err |> member "message" |> to_string_option)
-        with
-        | None -> false
-        | Some msg ->
-            String.is_substring (String.lowercase msg) ~substring:needle)
-  with _ -> false
+    let top_message =
+      Yojson.Safe.Util.(json |> member "message" |> to_string_option)
+    in
+    let validation_messages =
+      match Yojson.Safe.Util.(json |> member "errors") with
+      | `List errors ->
+          List.concat_map errors ~f:(fun err ->
+              [
+                Yojson.Safe.Util.(err |> member "message" |> to_string_option);
+                Yojson.Safe.Util.(err |> member "code" |> to_string_option);
+                Yojson.Safe.Util.(err |> member "field" |> to_string_option);
+                Yojson.Safe.Util.(err |> member "resource" |> to_string_option);
+              ]
+              |> List.filter_opt)
+      | _ -> []
+    in
+    Option.to_list top_message @ validation_messages
+  with _ -> []
+
+(* Returns [true] if any human-meaningful field in a GitHub error response
+   contains [substring] (case-insensitive). 422 covers many distinct validation
+   cases (no commits between head/base, head doesn't exist, branch already has
+   PR, etc.) — callers use this to discriminate which one. Pure; safe on
+   malformed input (returns false). *)
+let response_error_message_contains body ~substring =
+  let needle = String.lowercase substring in
+  response_error_messages body
+  |> List.exists ~f:(fun msg ->
+      String.is_substring (String.lowercase msg) ~substring:needle)
 
 let%test "response_error_message_contains: empty body returns false" =
   not (response_error_message_contains "" ~substring:"already exists")
@@ -46,6 +76,16 @@ let%test "response_error_message_contains: matches errors[].message substring" =
   response_error_message_contains
     {|{"message":"Validation Failed","errors":[{"resource":"PullRequest","code":"custom","message":"A pull request already exists for foo/bar:branch."}]}|}
     ~substring:"pull request already exists"
+
+let%test "response_error_message_contains: matches top-level message substring"
+    =
+  response_error_message_contains {|{"message":"Already exists"}|}
+    ~substring:"already exists"
+
+let%test "response_error_message_contains: matches errors[].code substring" =
+  response_error_message_contains
+    {|{"message":"Validation Failed","errors":[{"resource":"PullRequest","code":"already_exists","field":"head"}]}|}
+    ~substring:"already_exists"
 
 let%test "response_error_message_contains: no match for unrelated error" =
   not
@@ -473,6 +513,12 @@ let request ~net t ~meth ~path ?(query = []) ?body () =
   with exn ->
     Error (Transport_error { meth = meth_s; path; msg = Exn.to_string exn })
 
+let check_repo_access ~net t =
+  let path = Printf.sprintf "/repos/%s/%s" t.owner t.repo in
+  match request ~net t ~meth:`GET ~path () with
+  | Ok _ -> Ok ()
+  | Error _ as e -> e
+
 let pr_state ~net t pr =
   let body = build_request_body t pr in
   match request ~net t ~meth:`POST ~path:"/graphql" ~body () with
@@ -783,6 +829,21 @@ let%expect_test "show_error includes endpoint + permission hint on 403" =
   Stdlib.print_endline (show_error err);
   [%expect
     {| GitHub API PATCH /repos/foo/bar/pulls/42 → HTTP 403: Resource not accessible by integration — check your GH PAT scopes (classic: `repo`; fine-grained: Pull requests read/write, Contents read, Metadata read) |}]
+
+let%expect_test "show_error includes GitHub 422 validation details" =
+  let err =
+    Http_error
+      {
+        meth = "POST";
+        path = "/repos/foo/bar/pulls";
+        status = 422;
+        body =
+          {|{"message":"Validation Failed","errors":[{"resource":"PullRequest","code":"custom","message":"No commits between main and feature."}]}|};
+      }
+  in
+  Stdlib.print_endline (show_error err);
+  [%expect
+    {| GitHub API POST /repos/foo/bar/pulls → HTTP 422: No commits between main and feature.: Validation Failed |}]
 
 let%expect_test "show_error falls back to raw body when not JSON" =
   let err =

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -26,10 +26,8 @@ let extract_github_message body =
               Yojson.Safe.Util.(err |> member "message" |> to_string_option))
       | _ -> []
     in
-    let messages =
-      Option.to_list top_message @ validation_messages
-      |> List.dedup_and_sort ~compare:String.compare
-    in
+    let messages = validation_messages @ Option.to_list top_message in
+    let messages = List.stable_dedup messages ~compare:String.compare in
     match messages with
     | [] -> truncate body
     | [ msg ] -> msg

--- a/lib/github.mli
+++ b/lib/github.mli
@@ -11,19 +11,26 @@ type error =
 val show_error : error -> string
 (** Render an error as a human-readable string. Includes the HTTP method and
     path for [Http_error]/[Transport_error], extracts GitHub's "message" field
-    from the response body, and appends a hint about PAT scopes for 401/403/404
-    so users can fix permission problems without guesswork. *)
+    and validation details from the response body, and appends a hint about PAT
+    scopes for 401/403/404 so users can fix permission problems without
+    guesswork. *)
 
 val response_error_message_contains : string -> substring:string -> bool
-(** Returns [true] if any [errors[].message] in a GitHub validation response
-    body contains [substring] (case-insensitive). Use this to discriminate
-    between distinct 422 cases (e.g. "pull request already exists" vs "no
-    commits between"). Pure; safe on malformed input. *)
+(** Returns [true] if any human-meaningful field in a GitHub error response body
+    contains [substring] (case-insensitive). Use this to discriminate between
+    distinct 422 cases (e.g. "pull request already exists" vs "no commits
+    between"). Pure; safe on malformed input. *)
 
 type t
 
 val create : token:string -> owner:string -> repo:string -> t
 (** [create ~token ~owner ~repo] creates a GitHub API client. *)
+
+val check_repo_access : net:_ Eio.Net.t -> t -> (unit, error) Result.t
+(** [check_repo_access ~net t] verifies that the configured token can access
+    [owner/repo] via [GET /repos/:owner/:repo]. This is a startup preflight so
+    missing tokens, expired credentials, SSO gaps, and wrong repository names
+    fail before long-running orchestration starts. *)
 
 val parse_response_json :
   owner:string -> Yojson.Safe.t -> (Pr_state.t, error) Result.t

--- a/test/dune
+++ b/test/dune
@@ -105,6 +105,11 @@
  (libraries onton onton_core qcheck-core))
 
 (test
+ (name test_git_env)
+ (modules test_git_env)
+ (libraries onton unix))
+
+(test
  (name test_persistence_properties)
  (modules test_persistence_properties)
  (libraries onton onton_core onton_test_support qcheck-core qcheck-core.runner yojson)

--- a/test/test_git_env.ml
+++ b/test/test_git_env.ml
@@ -1,5 +1,7 @@
 open Onton
 
+external unsetenv_stub : string -> unit = "caml_onton_unsetenv"
+
 let env_list () = Git_env.clean_env () |> Array.to_list
 
 let binding name s =
@@ -18,26 +20,46 @@ let value name env =
       else None)
     env
 
+let count name env = List.length (List.filter (binding name) env)
+
+let restore_env name old_value =
+  match old_value with
+  | Some value -> Unix.putenv name value
+  | None -> unsetenv_stub name
+
 let assert_true label cond = if not cond then failwith label
 
 let test_clean_env_scrubs_git_and_installs_auth () =
   let old_git_dir = Sys.getenv_opt "GIT_DIR" in
+  let old_gh_token = Sys.getenv_opt "GH_TOKEN" in
+  let old_gcm_interactive = Sys.getenv_opt "GCM_INTERACTIVE" in
+  let old_gh_prompt_disabled = Sys.getenv_opt "GH_PROMPT_DISABLED" in
   Unix.putenv "GIT_DIR" "/tmp/wrong-repo";
+  Unix.putenv "GH_TOKEN" "stale-token";
+  Unix.putenv "GCM_INTERACTIVE" "always";
+  Unix.putenv "GH_PROMPT_DISABLED" "0";
   Fun.protect
     ~finally:(fun () ->
-      match old_git_dir with
-      | Some value -> Unix.putenv "GIT_DIR" value
-      | None -> Unix.putenv "GIT_DIR" "")
+      restore_env "GIT_DIR" old_git_dir;
+      restore_env "GH_TOKEN" old_gh_token;
+      restore_env "GCM_INTERACTIVE" old_gcm_interactive;
+      restore_env "GH_PROMPT_DISABLED" old_gh_prompt_disabled)
     (fun () ->
       Git_env.set_github_token " configured-token ";
       let env = env_list () in
       assert_true "GIT_DIR scrubbed" (not (List.exists (binding "GIT_DIR") env));
+      assert_true "stale GH_TOKEN scrubbed"
+        (not (List.exists (binding "GH_TOKEN") env));
       assert_true "terminal prompts disabled"
         (List.exists (String.equal "GIT_TERMINAL_PROMPT=0") env);
       assert_true "credential manager noninteractive"
         (List.exists (String.equal "GCM_INTERACTIVE=never") env);
+      assert_true "credential manager binding is unique"
+        (count "GCM_INTERACTIVE" env = 1);
       assert_true "gh prompts disabled"
         (List.exists (String.equal "GH_PROMPT_DISABLED=1") env);
+      assert_true "gh prompt binding is unique"
+        (count "GH_PROMPT_DISABLED" env = 1);
       (match value "GIT_ASKPASS" env with
       | Some path -> assert_true "askpass script exists" (Sys.file_exists path)
       | None -> failwith "GIT_ASKPASS missing");

--- a/test/test_git_env.ml
+++ b/test/test_git_env.ml
@@ -1,0 +1,50 @@
+open Onton
+
+let env_list () = Git_env.clean_env () |> Array.to_list
+
+let binding name s =
+  let prefix = name ^ "=" in
+  String.length s >= String.length prefix
+  && String.equal (String.sub s 0 (String.length prefix)) prefix
+
+let value name env =
+  let prefix = name ^ "=" in
+  List.find_map
+    (fun s ->
+      if binding name s then
+        Some
+          (String.sub s (String.length prefix)
+             (String.length s - String.length prefix))
+      else None)
+    env
+
+let assert_true label cond = if not cond then failwith label
+
+let test_clean_env_scrubs_git_and_installs_auth () =
+  let old_git_dir = Sys.getenv_opt "GIT_DIR" in
+  Unix.putenv "GIT_DIR" "/tmp/wrong-repo";
+  Fun.protect
+    ~finally:(fun () ->
+      match old_git_dir with
+      | Some value -> Unix.putenv "GIT_DIR" value
+      | None -> Unix.putenv "GIT_DIR" "")
+    (fun () ->
+      Git_env.set_github_token " configured-token ";
+      let env = env_list () in
+      assert_true "GIT_DIR scrubbed" (not (List.exists (binding "GIT_DIR") env));
+      assert_true "terminal prompts disabled"
+        (List.exists (String.equal "GIT_TERMINAL_PROMPT=0") env);
+      assert_true "credential manager noninteractive"
+        (List.exists (String.equal "GCM_INTERACTIVE=never") env);
+      assert_true "gh prompts disabled"
+        (List.exists (String.equal "GH_PROMPT_DISABLED=1") env);
+      (match value "GIT_ASKPASS" env with
+      | Some path -> assert_true "askpass script exists" (Sys.file_exists path)
+      | None -> failwith "GIT_ASKPASS missing");
+      match value "GITHUB_TOKEN" env with
+      | Some token ->
+          assert_true "configured token trimmed"
+            (String.equal token "configured-token")
+      | None -> failwith "GITHUB_TOKEN missing")
+
+let () = test_clean_env_scrubs_git_and_installs_auth ()


### PR DESCRIPTION
## Summary
- make supervised git subprocesses noninteractive with GIT_TERMINAL_PROMPT=0 and an askpass helper
- wire the resolved GitHub token into the git environment used by startup checks, fetches, and pushes
- add a regression test for the git environment contract

## Verification
- opam exec -- dune build
- opam exec -- dune runtest
- opam exec -- dune fmt

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/260"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops interactive Git credential prompts and runs every git subprocess with a scrubbed, noninteractive env and a single configured GitHub token. Adds a startup repo access check and clearer GitHub error messages to fail fast on bad tokens, SSO, or wrong repos.

- **Bug Fixes**
  - Use `Git_env.clean_env()` for all git calls (including origin URL lookup).
  - Disable prompts and install a controlled HTTPS askpass; scrub all `GIT_*` plus existing `GIT_TERMINAL_PROMPT`, `GIT_ASKPASS`, `GCM_INTERACTIVE`, `GH_PROMPT_DISABLED`, then set `GIT_TERMINAL_PROMPT=0`, `GCM_INTERACTIVE=never`, `GH_PROMPT_DISABLED=1`.
  - Inject the trimmed configured token via `Git_env.set_github_token` (exported as `GITHUB_TOKEN`) and remove any inherited `GITHUB_TOKEN`/`GH_TOKEN` to avoid mixing; improve GitHub errors by including top-level and validation details and matching across `message`/`code`/`field`/`resource`.

- **New Features**
  - Add `Github.check_repo_access` and call it at startup to validate `owner/repo`.
  - Add `test_git_env.ml` to lock the git env contract (scrubbing, uniqueness of fixed vars, askpass presence, token trim).

<sup>Written for commit 3c2b0ca8e2e6ed465b0cd06e4140d8c7b67fcf84. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Startup now verifies access to the configured GitHub repository and exits early on access failures.
  * Non-interactive GitHub token support is installed for git operations to prevent credential prompts.
  * Configured GitHub token from config is applied earlier in startup to enable preflight checks.

* **Improvements**
  * Improved extraction and presentation of GitHub API error details.

* **Tests**
  * Added tests for the cleaned non-interactive git environment and token behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flowglad/onton/pull/260)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->