### PR TITLE
Avoid re-enqueuing delivered CI failures

### DIFF
--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -115,6 +115,7 @@ let apply_poll_result t patch_id
           t)
       else t
   in
+  let t = Orchestrator.set_ci_checks t patch_id poll_result.ci_checks in
   let agent_before = Orchestrator.agent t patch_id in
   let t =
     List.fold poll_result.queue ~init:t ~f:(fun acc kind ->
@@ -144,6 +145,9 @@ let apply_poll_result t patch_id
             | Patch_decision.Ci_fix_in_progress ->
                 log "CI fix in progress — skipping";
                 acc
+            | Patch_decision.Ci_already_delivered ->
+                log "CI failure already delivered — skipping";
+                acc
             | Patch_decision.Cap_reached ->
                 log "CI failure cap reached (>=3) — skipping CI enqueue";
                 acc)
@@ -170,7 +174,6 @@ let apply_poll_result t patch_id
       log "Marked as ready for review";
     t
   in
-  let t = Orchestrator.set_ci_checks t patch_id poll_result.ci_checks in
   let t =
     Orchestrator.set_checks_passing t patch_id poll_result.checks_passing
   in

--- a/lib_core/patch_decision.ml
+++ b/lib_core/patch_decision.ml
@@ -39,18 +39,11 @@ type ci_decision =
   | Ci_already_queued  (** Ci already in queue — no action needed. *)
   | Ci_fix_in_progress
       (** Agent is already fixing CI — suppress until checks pass. *)
+  | Ci_already_delivered
+      (** Every currently failing check with a stable run id was already
+          delivered to the agent. *)
   | Cap_reached  (** CI failure count >= 3 — do not enqueue, flag. *)
 [@@deriving show, eq, sexp_of, compare]
-
-let on_ci_failure (a : Patch_agent.t) : ci_decision =
-  if a.ci_failure_count >= 3 then Cap_reached
-  else if
-    a.busy
-    && Option.equal Operation_kind.equal a.current_op (Some Operation_kind.Ci)
-  then Ci_fix_in_progress
-  else if List.mem a.queue Operation_kind.Ci ~equal:Operation_kind.equal then
-    Ci_already_queued
-  else Enqueue_ci
 
 type human_decision =
   | Enqueue_human  (** Queue human feedback for processing. *)
@@ -125,6 +118,23 @@ let filter_undelivered_ci_failures (agent : Patch_agent.t) : Ci_check.t list =
         | None -> true
         | Some id ->
             not (List.mem agent.delivered_ci_run_ids id ~equal:Int.equal))
+
+let on_ci_failure (a : Patch_agent.t) : ci_decision =
+  if a.ci_failure_count >= 3 then Cap_reached
+  else if
+    a.busy
+    && Option.equal Operation_kind.equal a.current_op (Some Operation_kind.Ci)
+  then Ci_fix_in_progress
+  else if List.mem a.queue Operation_kind.Ci ~equal:Operation_kind.equal then
+    Ci_already_queued
+  else
+    let has_known_failure = List.exists a.ci_checks ~f:Ci_check.is_failure in
+    let has_undelivered_failure =
+      not (List.is_empty (filter_undelivered_ci_failures a))
+    in
+    if has_known_failure && not has_undelivered_failure then
+      Ci_already_delivered
+    else Enqueue_ci
 
 let respond_delivery ~(agent : Patch_agent.t) ~(kind : Operation_kind.t)
     ~(pre_fire_agent : Patch_agent.t option)

--- a/lib_core/patch_decision.ml
+++ b/lib_core/patch_decision.ml
@@ -132,9 +132,15 @@ let on_ci_failure (a : Patch_agent.t) : ci_decision =
     let has_undelivered_failure =
       not (List.is_empty (filter_undelivered_ci_failures a))
     in
-    if has_known_failure && not has_undelivered_failure then
-      Ci_already_delivered
-    else Enqueue_ci
+    match (has_known_failure, has_undelivered_failure) with
+    | true, false -> Ci_already_delivered
+    | false, _ ->
+        (* The poll queue can report a CI failure before GitHub has returned
+           the failed check rows. With no stable run id available to dedup
+           against [delivered_ci_run_ids], keep the signal deliverable instead
+           of dropping it as already delivered. *)
+        Enqueue_ci
+    | true, true -> Enqueue_ci
 
 let respond_delivery ~(agent : Patch_agent.t) ~(kind : Operation_kind.t)
     ~(pre_fire_agent : Patch_agent.t option)

--- a/lib_core/patch_decision.mli
+++ b/lib_core/patch_decision.mli
@@ -28,6 +28,9 @@ type ci_decision =
   | Ci_already_queued  (** Ci already in queue — no action needed. *)
   | Ci_fix_in_progress
       (** Agent is already fixing CI — suppress until checks pass. *)
+  | Ci_already_delivered
+      (** Every currently failing check with a stable run id was already
+          delivered to the agent. *)
   | Cap_reached  (** CI failure count >= 3 — do not enqueue, flag. *)
 [@@deriving show, eq, sexp_of, compare]
 

--- a/test/test_patch_controller.ml
+++ b/test/test_patch_controller.ml
@@ -602,6 +602,68 @@ let () =
           ~equal:Operation_kind.equal)
   in
 
+  let prop_delivered_ci_run_does_not_reenqueue =
+    Test.make
+      ~name:
+        "patch_controller: delivered failing CI run is not re-enqueued from \
+         poll"
+      ~count:200
+      Gen.(triple gen_patch_id gen_branch (int_range 1 1_000_000))
+      (fun (pid, branch, run_id) ->
+        let patch = make_patch pid branch in
+        let check =
+          Ci_check.
+            {
+              name = "ts2pant";
+              conclusion = "failure";
+              details_url = None;
+              description = None;
+              started_at = None;
+              id = Some run_id;
+            }
+        in
+        let agent =
+          Patch_agent.restore ~patch_id:pid ~branch
+            ~pr_number:(Some (Pr_number.of_int 42))
+            ~has_session:true ~busy:false ~merged:false ~queue:[]
+            ~satisfies:false ~changed:true ~has_conflict:false
+            ~base_branch:(Some main) ~notified_base_branch:(Some main)
+            ~ci_failure_count:1 ~session_fallback:Patch_agent.Fresh_available
+            ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
+            ~merge_ready:false ~is_draft:false ~pr_body_delivered:true
+            ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
+            ~conflict_noop_count:0 ~no_commits_push_count:0
+            ~branch_rebased_onto:None ~checks_passing:false ~current_op:None
+            ~current_op_state:Patch_agent.Queued ~current_message_id:None
+            ~generation:0 ~worktree_path:None ~branch_blocked:false
+            ~llm_session_id:None ~automerge_enabled:false
+            ~automerge_deadline:None ~automerge_inflight:false
+            ~automerge_failure_count:0 ~delivered_ci_run_ids:[ run_id ]
+        in
+        let orch = make_orch patch agent in
+        let poll =
+          Poller.
+            {
+              queue = [ Operation_kind.Ci ];
+              merged = false;
+              closed = false;
+              is_draft = false;
+              has_conflict = false;
+              merge_ready = false;
+              checks_passing = false;
+              ci_checks = [ check ];
+            }
+        in
+        let orch, _logs, _newly_blocked =
+          Patch_controller.apply_poll_result orch pid
+            (make_poll_observation poll)
+        in
+        let agent = Orchestrator.agent orch pid in
+        not
+          (List.mem agent.Patch_agent.queue Operation_kind.Ci
+             ~equal:Operation_kind.equal))
+  in
+
   let prop_poll_result_persists_world_flags =
     Test.make ~name:"patch_controller: poll result persists checks_passing flag"
       ~count:200
@@ -988,6 +1050,7 @@ let () =
       prop_poll_to_controller_promotes_ready_after_pr_body;
       prop_poll_ci_failure_never_erases_pr_body_followup;
       prop_idle_ci_failure_count_allows_reenqueue;
+      prop_delivered_ci_run_does_not_reenqueue;
       prop_poll_result_persists_world_flags;
       prop_poll_observation_updates_branch_metadata;
       prop_mixed_cycle_converges_for_bootstrap_patch;

--- a/test/test_patch_decision.ml
+++ b/test/test_patch_decision.ml
@@ -141,6 +141,52 @@ let () =
           let a = respond a Operation_kind.Ci in
           let a = complete a in
           equal_ci_decision (on_ci_failure a) Enqueue_ci);
+      Test.make
+        ~name:
+          "on_ci_failure: all known failing run ids delivered -> already \
+           delivered"
+        Gen.(triple gen_pid gen_branch (int_range 1 1_000_000))
+        (fun (pid, br, run_id) ->
+          let check =
+            Ci_check.
+              {
+                name = "test";
+                conclusion = "failure";
+                details_url = None;
+                description = None;
+                started_at = None;
+                id = Some run_id;
+              }
+          in
+          let a =
+            with_pr pid br |> fun a ->
+            set_ci_checks a [ check ] |> fun a ->
+            record_delivered_ci_run_ids a [ run_id ]
+          in
+          equal_ci_decision (on_ci_failure a) Ci_already_delivered);
+      Test.make
+        ~name:
+          "on_ci_failure: id-less failing check remains deliverable after \
+           delivered ids"
+        Gen.(pair gen_pid gen_branch)
+        (fun (pid, br) ->
+          let check =
+            Ci_check.
+              {
+                name = "legacy-status";
+                conclusion = "failure";
+                details_url = None;
+                description = None;
+                started_at = None;
+                id = None;
+              }
+          in
+          let a =
+            with_pr pid br |> fun a ->
+            set_ci_checks a [ check ] |> fun a ->
+            record_delivered_ci_run_ids a [ 1 ]
+          in
+          equal_ci_decision (on_ci_failure a) Enqueue_ci);
       (* ---- on_human_message: fresh queue -> Enqueue_human ---- *)
       Test.make ~name:"on_human_message: no Human in queue -> Enqueue_human"
         Gen.(pair gen_pid gen_branch)

--- a/test/test_patch_decision.ml
+++ b/test/test_patch_decision.ml
@@ -170,7 +170,7 @@ let () =
            delivered ids"
         Gen.(pair gen_pid gen_branch)
         (fun (pid, br) ->
-          let check =
+          let id_less_check =
             Ci_check.
               {
                 name = "legacy-status";
@@ -181,9 +181,20 @@ let () =
                 id = None;
               }
           in
+          let delivered_check =
+            Ci_check.
+              {
+                name = "delivered-workflow";
+                conclusion = "failure";
+                details_url = None;
+                description = None;
+                started_at = None;
+                id = Some 1;
+              }
+          in
           let a =
             with_pr pid br |> fun a ->
-            set_ci_checks a [ check ] |> fun a ->
+            set_ci_checks a [ id_less_check; delivered_check ] |> fun a ->
             record_delivered_ci_run_ids a [ 1 ]
           in
           equal_ci_decision (on_ci_failure a) Enqueue_ci);


### PR DESCRIPTION
## Summary
- refresh CI checks before poll-time CI enqueue decisions
- skip enqueueing CI when all stable failing run IDs were already delivered
- cover delivered-run and id-less check behavior in decision/controller tests

## Verification
- dune build
- dune runtest

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/261"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents duplicate CI work by skipping enqueue when all failing checks with stable run IDs were already delivered. Reduces CI noise and queue churn during poll.

- **Bug Fixes**
  - Persist CI checks before making poll-time enqueue decisions in the controller.
  - Add `Ci_already_delivered` decision: if failures exist but all known failing run IDs were delivered, do not enqueue.
  - Keep id-less failing checks deliverable.
  - Add property tests for decision and controller covering delivered runs and id-less checks.

<sup>Written for commit 74c2650d6f2bffc36d65b25e4793a60ca231f726. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where CI failures that had already been delivered were being re-enqueued, preventing duplicate processing
  * Optimized CI check update timing for improved operation sequencing

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flowglad/onton/pull/261)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->