### PR TITLE
Plumb established precedents through gameplans and workstreams

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -3779,6 +3779,7 @@ let resolve_config ~project ~gameplan_path ~github_token ~backend ~model
             explicit_opinions = "";
             acceptance_criteria = [];
             open_questions = [];
+            functional_changes = [];
           }
       in
       let backend, model = resolve_backend_model ~backend ~model in

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -2360,10 +2360,15 @@ let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name ~pr_registry
                                         Prompt.render_gameplan_layer
                                           ~project_name gameplan
                                       in
+                                      let functional_changes =
+                                        Prompt.owned_functional_changes gameplan
+                                          patch
+                                      in
                                       let patch_prompt =
                                         Prompt.render_patch_layer ~project_name
                                           patch
                                           ?pr_number:agent.Patch_agent.pr_number
+                                          ~functional_changes
                                           ~base_branch:
                                             (Branch.to_string base_branch)
                                           ()
@@ -2880,8 +2885,13 @@ let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name ~pr_registry
                                       let patch_prompt =
                                         match patch with
                                         | Some p ->
+                                            let functional_changes =
+                                              Prompt.owned_functional_changes
+                                                gameplan p
+                                            in
                                             Prompt.render_patch_layer
                                               ~project_name p ?pr_number
+                                              ~functional_changes
                                               ~base_branch:base ()
                                         | None -> ""
                                       in
@@ -3329,8 +3339,13 @@ let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name ~pr_registry
                                     let patch_prompt =
                                       match patch_for_layer with
                                       | Some p ->
+                                          let functional_changes =
+                                            Prompt.owned_functional_changes
+                                              gameplan p
+                                          in
                                           Prompt.render_patch_layer
                                             ~project_name p ?pr_number
+                                            ~functional_changes
                                             ~base_branch:base_branch_for_layer
                                             ()
                                       | None -> ""

--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -673,6 +673,7 @@ let%test "reconcile_patch escalates repeated start discovery failures" =
             explicit_opinions = "";
             acceptance_criteria = [];
             open_questions = [];
+            functional_changes = [];
           }
       ~patch
   in
@@ -695,6 +696,7 @@ let%test "reconcile_patch enqueues pr_body after PR creation" =
         explicit_opinions = "";
         acceptance_criteria = [];
         open_questions = [];
+        functional_changes = [];
       }
   in
   let t, _ = reconcile_patch t ~project_name:"proj" ~gameplan:gp ~patch in
@@ -721,6 +723,7 @@ let%test "reconcile_patch requests ready-for-review after pr_body on main" =
             explicit_opinions = "";
             acceptance_criteria = [];
             open_questions = [];
+            functional_changes = [];
           }
       ~patch
   in
@@ -748,6 +751,7 @@ let%test "reconcile_patch emits no effects for merged agent" =
             explicit_opinions = "";
             acceptance_criteria = [];
             open_questions = [];
+            functional_changes = [];
           }
       ~patch
   in

--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -645,6 +645,7 @@ let make_orchestrator ~patch_id ~main_branch =
       test_stubs_introduced = [];
       test_stubs_implemented = [];
       complexity = None;
+      precedents = [];
     }
   in
   (patch, Orchestrator.create ~patches:[ patch ] ~main_branch)

--- a/lib/persistence.ml
+++ b/lib/persistence.ml
@@ -733,6 +733,7 @@ let%test_module "session_id_sidecars" =
           explicit_opinions = "";
           acceptance_criteria = [];
           open_questions = [];
+          functional_changes = [];
         }
 
     let snapshot ?(busy = false) ?llm_session_id () =

--- a/lib/persistence.ml
+++ b/lib/persistence.ml
@@ -718,6 +718,7 @@ let%test_module "session_id_sidecars" =
           test_stubs_introduced = [];
           test_stubs_implemented = [];
           complexity = None;
+          precedents = [];
         }
 
     let gameplan =

--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -194,8 +194,25 @@ let render_gameplan_layer ~(project_name : string) (gameplan : Gameplan.t) :
 |}
         vars)
 
+let format_functional_changes_section (fcs : Functional_change.t list) : string
+    =
+  if List.is_empty fcs then ""
+  else
+    let body =
+      List.map fcs ~f:(fun (fc : Functional_change.t) ->
+          Printf.sprintf "- **%s** — %s" fc.id fc.description)
+      |> String.concat ~sep:"\n"
+    in
+    "\n\
+     ## Functional Changes You Own\n\n\
+     These are the user-visible / behavioural changes assigned to this patch. \
+     Each is your responsibility — do not defer them to another patch, and do \
+     not stop until every one is delivered. The gameplan's enumeration is \
+     exhaustive and each change is owned by exactly one patch, so if a change \
+     appears here, no sibling patch will pick it up.\n\n" ^ body ^ "\n"
+
 let render_patch_layer ~(project_name : string) (patch : Patch.t) ?pr_number
-    ~(base_branch : string) () : string =
+    ?(functional_changes = []) ~(base_branch : string) () : string =
   let patch_id = Patch_id.to_string patch.Patch.id in
   let deps =
     match patch.Patch.dependencies with
@@ -259,6 +276,8 @@ The supervisor opens the draft PR after your first commit lands on the remote, w
       ("spec", patch.Patch.spec);
       ("acceptance_criteria", format_list patch.Patch.acceptance_criteria);
       ("files", format_list patch.Patch.files);
+      ( "functional_changes_section",
+        format_functional_changes_section functional_changes );
       ("changes_section", optional_list_section ~header:"Changes" patch.changes);
       ( "spec_section",
         if String.is_empty patch.spec then ""
@@ -327,7 +346,7 @@ The supervisor opens the draft PR after your first commit lands on the remote, w
 ## Your Task
 
 {{base_branch_note}}{{description}}
-{{changes_section}}{{files_section}}{{precedents_section}}{{test_stubs_introduced_section}}{{test_stubs_implemented_section}}{{spec_section}}{{acceptance_criteria_section}}
+{{functional_changes_section}}{{changes_section}}{{files_section}}{{precedents_section}}{{test_stubs_introduced_section}}{{test_stubs_implemented_section}}{{spec_section}}{{acceptance_criteria_section}}
 ## Git Instructions
 - Branch: {{branch}}
 - Base branch: {{base_branch}}
@@ -337,6 +356,12 @@ The supervisor opens the draft PR after your first commit lands on the remote, w
 |}
         vars)
 
+let owned_functional_changes (gameplan : Gameplan.t) (patch : Patch.t) :
+    Functional_change.t list =
+  List.filter gameplan.Gameplan.functional_changes
+    ~f:(fun (fc : Functional_change.t) ->
+      Patch_id.equal fc.Functional_change.owned_by patch.Patch.id)
+
 (* When all of [patch], [gameplan], [base_branch] are supplied, returns
    the gameplan+patch prefix; otherwise returns the empty string. Used by
    the layered turn-prompt composers to support callers that don't have a
@@ -345,11 +370,13 @@ let layered_prefix ~project_name ?pr_number ?patch ?gameplan ?base_branch
     ?agents_md () =
   match (patch, gameplan, base_branch) with
   | Some p, Some g, Some b ->
+      let functional_changes = owned_functional_changes g p in
       render_gameplan_layer ~project_name g
       ^ (match agents_md with
         | Some content -> agents_md_section (Some content)
         | None -> "")
-      ^ render_patch_layer ~project_name p ?pr_number ~base_branch:b ()
+      ^ render_patch_layer ~project_name p ?pr_number ~functional_changes
+          ~base_branch:b ()
   | _ -> ""
 
 let render_turn_layer_start ~(project_name : string) : string =
@@ -359,9 +386,11 @@ let render_turn_layer_start ~(project_name : string) : string =
 
 let render_patch_prompt ~(project_name : string) ?agents_md ?pr_number
     (patch : Patch.t) (gameplan : Gameplan.t) ~(base_branch : string) =
+  let functional_changes = owned_functional_changes gameplan patch in
   render_gameplan_layer ~project_name gameplan
   ^ agents_md_section agents_md
-  ^ render_patch_layer ~project_name patch ?pr_number ~base_branch ()
+  ^ render_patch_layer ~project_name patch ?pr_number ~functional_changes
+      ~base_branch ()
   ^ render_turn_layer_start ~project_name
 
 let render_spec_suffix (patch : Patch.t) (gameplan : Gameplan.t) : string =
@@ -402,6 +431,7 @@ let%test "render_spec_suffix: both empty" =
       solution_summary = "";
       final_state_spec = "";
       patches = [];
+      functional_changes = [];
       current_state_analysis = "";
       explicit_opinions = "";
       acceptance_criteria = [];
@@ -436,6 +466,7 @@ let%test "render_spec_suffix: gameplan spec only" =
       solution_summary = "";
       final_state_spec = "module FOO.\nsome spec";
       patches = [];
+      functional_changes = [];
       current_state_analysis = "";
       explicit_opinions = "";
       acceptance_criteria = [];
@@ -473,6 +504,7 @@ let%test "render_spec_suffix: patch spec only" =
       solution_summary = "";
       final_state_spec = "";
       patches = [];
+      functional_changes = [];
       current_state_analysis = "";
       explicit_opinions = "";
       acceptance_criteria = [];
@@ -510,6 +542,7 @@ let%test "render_spec_suffix: both present" =
       solution_summary = "";
       final_state_spec = "module FOO.\ngameplan spec";
       patches = [];
+      functional_changes = [];
       current_state_analysis = "";
       explicit_opinions = "";
       acceptance_criteria = [];
@@ -1159,6 +1192,7 @@ let%test "patch prompt includes title and deps" =
             };
             patch;
           ];
+        functional_changes = [];
       }
   in
   let result =
@@ -1233,6 +1267,7 @@ let%test "patch prompt static prefix is byte-identical across patches" =
         acceptance_criteria = [];
         open_questions = [];
         patches = [ patch_1; patch_2 ];
+        functional_changes = [];
       }
   in
   let prompt_1 =
@@ -1282,6 +1317,7 @@ let%test "agents_md content appears in static prefix when Some" =
         acceptance_criteria = [];
         open_questions = [];
         patches = [ patch ];
+        functional_changes = [];
       }
   in
   let prompt =
@@ -1327,6 +1363,7 @@ let%test "agents_md section is omitted when None" =
         acceptance_criteria = [];
         open_questions = [];
         patches = [ patch ];
+        functional_changes = [];
       }
   in
   let prompt =
@@ -1397,6 +1434,7 @@ let make_layer_test_fixture () =
         acceptance_criteria = [];
         open_questions = [];
         patches = [ patch_a; patch_b ];
+        functional_changes = [];
       }
   in
   (patch_a, patch_b, gameplan)
@@ -1522,6 +1560,52 @@ let%test
     render_patch_layer ~project_name:"onton" patch ~base_branch:"main" ()
   in
   not (String.is_substring rendered ~substring:"Established Precedents")
+
+let%test
+    "render_patch_prompt surfaces ONLY the owned functional changes for a patch"
+    =
+  let patch_a, patch_b, gameplan = make_layer_test_fixture () in
+  let gameplan : Gameplan.t =
+    {
+      gameplan with
+      functional_changes =
+        [
+          {
+            Functional_change.id = "FC-1";
+            description = "Behavior owned by patch A only";
+            owned_by = patch_a.Patch.id;
+          };
+          {
+            Functional_change.id = "FC-2";
+            description = "Behavior owned by patch B only";
+            owned_by = patch_b.Patch.id;
+          };
+        ];
+    }
+  in
+  let prompt_a =
+    render_patch_prompt ~project_name:"onton" patch_a gameplan
+      ~base_branch:"main"
+  in
+  let prompt_b =
+    render_patch_prompt ~project_name:"onton" patch_b gameplan
+      ~base_branch:"feat/patch-1"
+  in
+  String.is_substring prompt_a ~substring:"## Functional Changes You Own"
+  && String.is_substring prompt_a ~substring:"**FC-1**"
+  && String.is_substring prompt_a ~substring:"Behavior owned by patch A only"
+  && (not (String.is_substring prompt_a ~substring:"**FC-2**"))
+  && String.is_substring prompt_b ~substring:"**FC-2**"
+  && String.is_substring prompt_b ~substring:"Behavior owned by patch B only"
+  && not (String.is_substring prompt_b ~substring:"**FC-1**")
+
+let%test
+    "render_patch_layer omits Functional Changes section when patch owns none" =
+  let patch, _, _ = make_layer_test_fixture () in
+  let rendered =
+    render_patch_layer ~project_name:"onton" patch ~base_branch:"main" ()
+  in
+  not (String.is_substring rendered ~substring:"Functional Changes You Own")
 
 let%test "render_pr_description surfaces precedents when present" =
   let patch, _, gameplan = make_layer_test_fixture () in

--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -95,6 +95,31 @@ let optional_list_section ~header items =
   | [] -> ""
   | _ -> optional_section ~header (format_list items)
 
+let format_precedents (ps : Precedent.t list) : string =
+  if List.is_empty ps then ""
+  else
+    let body =
+      List.map ps ~f:(fun p ->
+          let url_part =
+            match p.Precedent.url with
+            | None | Some "" -> ""
+            | Some u -> Printf.sprintf " — %s" u
+          in
+          let why =
+            if String.is_empty p.why_applicable then ""
+            else " — " ^ p.why_applicable
+          in
+          Printf.sprintf "- **[%s] %s**%s%s" p.kind p.name url_part why)
+      |> String.concat ~sep:"\n"
+    in
+    "\n\
+     ## Established Precedents\n\n\
+     This patch should adopt the following proven techniques rather than \
+     rolling its own. Read the references when you need detail on the API \
+     shape or invariants they impose. Each entry names a library, algorithm, \
+     pattern, paper, RFC, doc, or blog post; the trailing sentence explains \
+     how it applies to this specific patch.\n\n" ^ body ^ "\n"
+
 let agents_md_section = function
   | Some content when not (String.is_empty (String.strip content)) ->
       "## Project Conventions (AGENTS.md)\n\n" ^ String.rstrip content ^ "\n\n"
@@ -281,6 +306,7 @@ The supervisor opens the draft PR after your first commit lands on the remote, w
           patch.acceptance_criteria );
       ( "files_section",
         optional_list_section ~header:"Files to Modify" patch.files );
+      ("precedents_section", format_precedents patch.Patch.precedents);
       ( "test_stubs_introduced_section",
         optional_list_section ~header:"Test Stubs Introduced"
           patch.test_stubs_introduced );
@@ -301,7 +327,7 @@ The supervisor opens the draft PR after your first commit lands on the remote, w
 ## Your Task
 
 {{base_branch_note}}{{description}}
-{{changes_section}}{{files_section}}{{test_stubs_introduced_section}}{{test_stubs_implemented_section}}{{spec_section}}{{acceptance_criteria_section}}
+{{changes_section}}{{files_section}}{{precedents_section}}{{test_stubs_introduced_section}}{{test_stubs_implemented_section}}{{spec_section}}{{acceptance_criteria_section}}
 ## Git Instructions
 - Branch: {{branch}}
 - Base branch: {{base_branch}}
@@ -366,6 +392,7 @@ let%test "render_spec_suffix: both empty" =
       test_stubs_introduced = [];
       test_stubs_implemented = [];
       complexity = None;
+      precedents = [];
     }
   in
   let gameplan =
@@ -399,6 +426,7 @@ let%test "render_spec_suffix: gameplan spec only" =
       test_stubs_introduced = [];
       test_stubs_implemented = [];
       complexity = None;
+      precedents = [];
     }
   in
   let gameplan =
@@ -435,6 +463,7 @@ let%test "render_spec_suffix: patch spec only" =
       test_stubs_introduced = [];
       test_stubs_implemented = [];
       complexity = None;
+      precedents = [];
     }
   in
   let gameplan =
@@ -471,6 +500,7 @@ let%test "render_spec_suffix: both present" =
       test_stubs_introduced = [];
       test_stubs_implemented = [];
       complexity = None;
+      precedents = [];
     }
   in
   let gameplan =
@@ -518,6 +548,7 @@ let render_pr_description ~(project_name : string) (patch : Patch.t)
           patch.acceptance_criteria );
       ( "files_section",
         optional_list_section ~header:"Files to Modify" patch.files );
+      ("precedents_section", format_precedents patch.Patch.precedents);
     ]
   in
   render_with_override ~project_name ~name:"pr_description" ~vars
@@ -526,7 +557,7 @@ let render_pr_description ~(project_name : string) (patch : Patch.t)
         {|## Patch {{patch_id}}: {{title}}
 
 {{description}}
-{{changes_section}}{{gameplan_spec_section}}{{patch_spec_section}}{{acceptance_criteria_section}}{{files_section}}|}
+{{changes_section}}{{gameplan_spec_section}}{{patch_spec_section}}{{acceptance_criteria_section}}{{files_section}}{{precedents_section}}|}
         vars)
 
 let render_pr_body_prompt ~(project_name : string) ~(pr_number : Pr_number.t)
@@ -1094,6 +1125,7 @@ let%test "patch prompt includes title and deps" =
         test_stubs_introduced = [];
         test_stubs_implemented = [];
         complexity = None;
+        precedents = [];
       }
   in
   let gameplan : Gameplan.t =
@@ -1123,6 +1155,7 @@ let%test "patch prompt includes title and deps" =
               test_stubs_introduced = [];
               test_stubs_implemented = [];
               complexity = None;
+              precedents = [];
             };
             patch;
           ];
@@ -1165,6 +1198,7 @@ let%test "patch prompt static prefix is byte-identical across patches" =
              gameplan";
           ];
         complexity = None;
+        precedents = [];
       }
   in
   let patch_2 : Patch.t =
@@ -1183,6 +1217,7 @@ let%test "patch prompt static prefix is byte-identical across patches" =
         test_stubs_introduced = [];
         test_stubs_implemented = [];
         complexity = None;
+        precedents = [];
       }
   in
   let gameplan : Gameplan.t =
@@ -1232,6 +1267,7 @@ let%test "agents_md content appears in static prefix when Some" =
         test_stubs_introduced = [];
         test_stubs_implemented = [];
         complexity = None;
+        precedents = [];
       }
   in
   let gameplan : Gameplan.t =
@@ -1276,6 +1312,7 @@ let%test "agents_md section is omitted when None" =
         test_stubs_introduced = [];
         test_stubs_implemented = [];
         complexity = None;
+        precedents = [];
       }
   in
   let gameplan : Gameplan.t =
@@ -1326,6 +1363,7 @@ let make_layer_test_fixture () =
         test_stubs_introduced = [];
         test_stubs_implemented = [];
         complexity = None;
+        precedents = [];
       }
   in
   let patch_b : Patch.t =
@@ -1344,6 +1382,7 @@ let make_layer_test_fixture () =
         test_stubs_introduced = [];
         test_stubs_implemented = [];
         complexity = None;
+        precedents = [];
       }
   in
   let gameplan : Gameplan.t =
@@ -1438,6 +1477,79 @@ let%test
   && String.is_prefix ci_unknown_prompt ~prefix
   && String.is_prefix review_prompt ~prefix
   && String.is_prefix conflict_prompt ~prefix
+
+let%test
+    "render_patch_layer surfaces precedents to the implementer when present" =
+  let patch, _, _ = make_layer_test_fixture () in
+  let patch_with_precedents : Patch.t =
+    {
+      patch with
+      precedents =
+        [
+          {
+            Precedent.kind = "library";
+            name = "Bindlib";
+            url = Some "https://github.com/rlepigre/ocaml-bindlib";
+            why_applicable =
+              "Use bind_mvar / unmbind so substitution composes via msubst.";
+          };
+          {
+            Precedent.kind = "algorithm";
+            name = "Tarjan 1972 strongly connected components";
+            url = None;
+            why_applicable = "Detect cycles in the dependency graph in O(V+E).";
+          };
+        ];
+    }
+  in
+  let rendered =
+    render_patch_layer ~project_name:"onton" patch_with_precedents
+      ~base_branch:"main" ()
+  in
+  String.is_substring rendered ~substring:"## Established Precedents"
+  && String.is_substring rendered ~substring:"**[library] Bindlib**"
+  && String.is_substring rendered
+       ~substring:"https://github.com/rlepigre/ocaml-bindlib"
+  && String.is_substring rendered
+       ~substring:"**[algorithm] Tarjan 1972 strongly connected components**"
+  && String.is_substring rendered
+       ~substring:"Detect cycles in the dependency graph"
+
+let%test
+    "render_patch_layer omits the Established Precedents section when empty" =
+  let patch, _, _ = make_layer_test_fixture () in
+  let rendered =
+    render_patch_layer ~project_name:"onton" patch ~base_branch:"main" ()
+  in
+  not (String.is_substring rendered ~substring:"Established Precedents")
+
+let%test "render_pr_description surfaces precedents when present" =
+  let patch, _, gameplan = make_layer_test_fixture () in
+  let patch_with_precedents : Patch.t =
+    {
+      patch with
+      precedents =
+        [
+          {
+            Precedent.kind = "library";
+            name = "Bindlib";
+            url = Some "https://github.com/rlepigre/ocaml-bindlib";
+            why_applicable = "Use bind_mvar / unmbind for binders.";
+          };
+        ];
+    }
+  in
+  let body =
+    render_pr_description ~project_name:"onton" patch_with_precedents gameplan
+  in
+  String.is_substring body ~substring:"## Established Precedents"
+  && String.is_substring body ~substring:"**[library] Bindlib**"
+  && String.is_substring body ~substring:"Use bind_mvar / unmbind for binders."
+
+let%test "render_pr_description omits Established Precedents when empty" =
+  let patch, _, gameplan = make_layer_test_fixture () in
+  let body = render_pr_description ~project_name:"onton" patch gameplan in
+  not (String.is_substring body ~substring:"Established Precedents")
 
 let%test "follow-up prompts without patch+gameplan emit only the turn layer" =
   let _, _, _gameplan = make_layer_test_fixture () in

--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -1434,7 +1434,16 @@ let make_layer_test_fixture () =
         acceptance_criteria = [];
         open_questions = [];
         patches = [ patch_a; patch_b ];
-        functional_changes = [];
+        functional_changes =
+          [
+            {
+              Functional_change.id = "FC-LAYER-1";
+              description =
+                "Patch A owns a behavior that must stay in the cache-stable \
+                 layer.";
+              owned_by = patch_a.Patch.id;
+            };
+          ];
       }
   in
   (patch_a, patch_b, gameplan)
@@ -1460,9 +1469,10 @@ let%test
   let patch_a, _, gameplan = make_layer_test_fixture () in
   let pr_number = Pr_number.of_int 7 in
   let g_layer = render_gameplan_layer ~project_name:"onton" gameplan in
+  let functional_changes = owned_functional_changes gameplan patch_a in
   let p_layer =
     render_patch_layer ~project_name:"onton" patch_a ~pr_number
-      ~base_branch:"main" ()
+      ~functional_changes ~base_branch:"main" ()
   in
   let agents_md = "Follow AGENTS.md.\nNever use *_exn." in
   let prefix = g_layer ^ agents_md_section (Some agents_md) ^ p_layer in
@@ -1601,9 +1611,11 @@ let%test
 
 let%test
     "render_patch_layer omits Functional Changes section when patch owns none" =
-  let patch, _, _ = make_layer_test_fixture () in
+  let _, patch, gameplan = make_layer_test_fixture () in
+  let functional_changes = owned_functional_changes gameplan patch in
   let rendered =
-    render_patch_layer ~project_name:"onton" patch ~base_branch:"main" ()
+    render_patch_layer ~project_name:"onton" patch ~functional_changes
+      ~base_branch:"main" ()
   in
   not (String.is_substring rendered ~substring:"Functional Changes You Own")
 

--- a/lib/prompt.mli
+++ b/lib/prompt.mli
@@ -48,6 +48,11 @@ val render_patch_layer :
     line. [functional_changes] should contain only the entries from
     [Gameplan.t.functional_changes] whose [owned_by] equals [Patch.t.id]. *)
 
+val owned_functional_changes : Gameplan.t -> Patch.t -> Functional_change.t list
+(** Returns the functional changes in the gameplan owned by this patch. Use this
+    when constructing patch layers directly, so composed and manually layered
+    prompts carry the same patch-stable content. *)
+
 val render_turn_layer_start : project_name:string -> string
 
 val render_turn_layer_review :

--- a/lib/prompt.mli
+++ b/lib/prompt.mli
@@ -37,13 +37,16 @@ val render_patch_layer :
   project_name:string ->
   Patch.t ->
   ?pr_number:Pr_number.t ->
+  ?functional_changes:Functional_change.t list ->
   base_branch:string ->
   unit ->
   string
 (** Patch-stable middle. Contains the patch heading, dependencies, base-branch
-    note, description, changes, files, test stubs, specification (with
-    Pantagruel guide), acceptance criteria, git identifiers, and PR
-    instructions. Ends with a trailing blank line. *)
+    note, description, the functional changes the patch owns (if any), changes,
+    files, test stubs, specification (with Pantagruel guide), acceptance
+    criteria, git identifiers, and PR instructions. Ends with a trailing blank
+    line. [functional_changes] should contain only the entries from
+    [Gameplan.t.functional_changes] whose [owned_by] equals [Patch.t.id]. *)
 
 val render_turn_layer_start : project_name:string -> string
 

--- a/lib_core/gameplan_parser.ml
+++ b/lib_core/gameplan_parser.ml
@@ -129,6 +129,31 @@ let json_string_list json key =
       List.filter_map items ~f:(function `String s -> Some s | _ -> None)
   | _ -> []
 
+let json_precedents json =
+  let open Yojson.Safe.Util in
+  match json |> member "precedents" with
+  | `List items ->
+      List.filter_map items ~f:(fun obj ->
+          match obj |> member "kind" with
+          | `String kind when not (String.is_empty kind) ->
+              let name =
+                match obj |> member "name" with `String s -> s | _ -> ""
+              in
+              let url =
+                match obj |> member "url" with
+                | `String s when not (String.is_empty s) -> Some s
+                | _ -> None
+              in
+              let why_applicable =
+                match obj |> member "whyApplicable" with
+                | `String s -> s
+                | _ -> ""
+              in
+              if String.is_empty name then None
+              else Some { Types.Precedent.kind; name; url; why_applicable }
+          | _ -> None)
+  | _ -> []
+
 let parse_json_string input =
   match
     try Ok (Yojson.Safe.from_string input)
@@ -287,6 +312,7 @@ let parse_json_string input =
                         | _ -> None)
                 | _ -> []
               in
+              let precedents = json_precedents p in
               {
                 Types.Patch.id;
                 title;
@@ -301,6 +327,7 @@ let parse_json_string input =
                 test_stubs_introduced;
                 test_stubs_implemented;
                 complexity;
+                precedents;
               })
         in
         match open_questions with
@@ -412,6 +439,7 @@ let%test_module "Gameplan_parser" =
               test_stubs_introduced = [];
               test_stubs_implemented = [];
               complexity = None;
+              precedents = [];
             };
         ]
       in
@@ -438,6 +466,7 @@ let%test_module "Gameplan_parser" =
             test_stubs_introduced = [];
             test_stubs_implemented = [];
             complexity = None;
+            precedents = [];
           }
       in
       let dep_graph = Map.of_alist_exn (module Types.Patch_id) [ (pid, []) ] in
@@ -581,6 +610,82 @@ let%test_module "Gameplan_parser" =
       match parse_json_string "{not valid json}" with
       | Ok _ -> false
       | Error _ -> true
+
+    let%test "parse_json_string: precedents are extracted with all four fields"
+        =
+      let input =
+        {|{
+          "projectName": "p",
+          "solutionSummary": "s",
+          "patches": [{
+            "number": 1,
+            "title": "A",
+            "changes": [],
+            "precedents": [
+              {"kind":"library","name":"Bindlib","url":"https://example.com","whyApplicable":"capture-avoiding subst"},
+              {"kind":"pattern","name":"Locally nameless","whyApplicable":"fallback design"}
+            ]
+          }],
+          "dependencyGraph": [{"patch": 1, "dependsOn": []}]
+        }|}
+      in
+      match parse_json_string input with
+      | Error _ -> false
+      | Ok result -> (
+          let p = List.hd_exn result.gameplan.patches in
+          match p.Types.Patch.precedents with
+          | [ a; b ] ->
+              String.equal a.Types.Precedent.kind "library"
+              && String.equal a.name "Bindlib"
+              && (match a.url with
+                | Some "https://example.com" -> true
+                | _ -> false)
+              && String.equal a.why_applicable "capture-avoiding subst"
+              && String.equal b.kind "pattern"
+              && String.equal b.name "Locally nameless"
+              && Option.is_none b.url
+          | _ -> false)
+
+    let%test "parse_json_string: missing precedents defaults to empty list" =
+      let input =
+        {|{
+          "projectName": "p",
+          "solutionSummary": "s",
+          "patches": [{"number": 1, "title": "A", "changes": []}],
+          "dependencyGraph": [{"patch": 1, "dependsOn": []}]
+        }|}
+      in
+      match parse_json_string input with
+      | Error _ -> false
+      | Ok result ->
+          let p = List.hd_exn result.gameplan.patches in
+          List.is_empty p.Types.Patch.precedents
+
+    let%test "parse_json_string: precedent without kind or name is skipped" =
+      let input =
+        {|{
+          "projectName": "p",
+          "solutionSummary": "s",
+          "patches": [{
+            "number": 1,
+            "title": "A",
+            "changes": [],
+            "precedents": [
+              {"name": "no kind", "whyApplicable": "x"},
+              {"kind": "library", "whyApplicable": "no name"},
+              {"kind": "library", "name": "OK", "whyApplicable": "ok"}
+            ]
+          }],
+          "dependencyGraph": [{"patch": 1, "dependsOn": []}]
+        }|}
+      in
+      match parse_json_string input with
+      | Error _ -> false
+      | Ok result -> (
+          let p = List.hd_exn result.gameplan.patches in
+          match p.Types.Patch.precedents with
+          | [ only ] -> String.equal only.Types.Precedent.name "OK"
+          | _ -> false)
 
     let%test "parse_json_string: cycle returns Error" =
       let input =

--- a/lib_core/gameplan_parser.ml
+++ b/lib_core/gameplan_parser.ml
@@ -41,6 +41,27 @@ let detect_cycle dep_graph =
   Map.iter_keys dep_graph ~f:visit;
   !found_cycle
 
+let validate_functional_changes ~patches ~functional_changes =
+  let patch_ids =
+    List.map patches ~f:(fun p -> p.Types.Patch.id)
+    |> Set.of_list (module Types.Patch_id)
+  in
+  let rec loop seen_ids = function
+    | [] -> Ok ()
+    | (fc : Types.Functional_change.t) :: rest ->
+        if String.is_empty fc.id then
+          Error "functionalChanges[].id must be a non-empty string"
+        else if Set.mem seen_ids fc.id then
+          Error (Printf.sprintf "Duplicate functionalChange id: %s" fc.id)
+        else if not (Set.mem patch_ids fc.owned_by) then
+          Error
+            (Printf.sprintf
+               "functionalChange %s is ownedBy nonexistent patch %s" fc.id
+               (Types.Patch_id.to_string fc.owned_by))
+        else loop (Set.add seen_ids fc.id) rest
+  in
+  loop (Set.empty (module String)) functional_changes
+
 let validate ~patches ~dep_graph =
   (* Check for invalid patch IDs *)
   let invalid_ids =
@@ -204,6 +225,44 @@ let parse_json_string input =
           | _ -> ""
         in
         let acceptance_criteria = json_string_list json "acceptanceCriteria" in
+        let functional_changes =
+          match json |> member "functionalChanges" with
+          | `Null -> []
+          | `List items ->
+              List.map items ~f:(fun obj ->
+                  let id =
+                    match obj |> member "id" with
+                    | `String s -> s
+                    | _ ->
+                        raise
+                          (Type_error
+                             ("functionalChanges[].id must be a string", obj))
+                  in
+                  let description =
+                    match obj |> member "description" with
+                    | `String s -> s
+                    | _ ->
+                        raise
+                          (Type_error
+                             ( "functionalChanges[].description must be a string",
+                               obj ))
+                  in
+                  let owned_by =
+                    match patch_id_of_json (obj |> member "ownedBy") with
+                    | Some id -> id
+                    | None ->
+                        raise
+                          (Type_error
+                             ( "functionalChanges[].ownedBy must be an integer \
+                                or alphanumeric patch id",
+                               obj ))
+                  in
+                  { Types.Functional_change.id; description; owned_by })
+          | _ ->
+              raise
+                (Type_error
+                   ("functionalChanges must be an array of objects", json))
+        in
         let open_questions =
           match json |> member "openQuestions" with
           | `Null -> []
@@ -346,23 +405,29 @@ let parse_json_string input =
         | [] -> (
             match validate ~patches ~dep_graph with
             | Error e -> Error e
-            | Ok () ->
-                Ok
-                  {
-                    gameplan =
+            | Ok () -> (
+                match
+                  validate_functional_changes ~patches ~functional_changes
+                with
+                | Error e -> Error e
+                | Ok () ->
+                    Ok
                       {
-                        Types.Gameplan.project_name;
-                        problem_statement;
-                        solution_summary;
-                        final_state_spec;
-                        patches;
-                        current_state_analysis;
-                        explicit_opinions;
-                        acceptance_criteria;
-                        open_questions;
-                      };
-                    dependency_graph = dep_graph;
-                  })
+                        gameplan =
+                          {
+                            Types.Gameplan.project_name;
+                            problem_statement;
+                            solution_summary;
+                            final_state_spec;
+                            patches;
+                            functional_changes;
+                            current_state_analysis;
+                            explicit_opinions;
+                            acceptance_criteria;
+                            open_questions;
+                          };
+                        dependency_graph = dep_graph;
+                      }))
       with Type_error (msg, _) ->
         Error (Printf.sprintf "JSON structure error: %s" msg))
 
@@ -742,6 +807,88 @@ let%test_module "Gameplan_parser" =
         }|}
       in
       match parse_json_string input with Ok _ -> true | Error _ -> false
+
+    let%test "parse_json_string: functionalChanges round-trip" =
+      let input =
+        {|{
+          "projectName": "p",
+          "solutionSummary": "s",
+          "patches": [
+            {"number": 1, "title": "A", "changes": []},
+            {"number": 2, "title": "B", "changes": []}
+          ],
+          "functionalChanges": [
+            {"id": "FC-1", "description": "Behavior X is added", "ownedBy": 1},
+            {"id": "FC-2", "description": "Behavior Y is added", "ownedBy": 2}
+          ],
+          "dependencyGraph": [
+            {"patch": 1, "dependsOn": []},
+            {"patch": 2, "dependsOn": [1]}
+          ]
+        }|}
+      in
+      match parse_json_string input with
+      | Error _ -> false
+      | Ok result -> (
+          match result.gameplan.functional_changes with
+          | [ a; b ] ->
+              String.equal a.Types.Functional_change.id "FC-1"
+              && String.equal a.description "Behavior X is added"
+              && String.equal (Types.Patch_id.to_string a.owned_by) "1"
+              && String.equal b.Types.Functional_change.id "FC-2"
+              && String.equal (Types.Patch_id.to_string b.owned_by) "2"
+          | _ -> false)
+
+    let%test "parse_json_string: functionalChanges missing defaults to empty" =
+      let input =
+        {|{
+          "projectName": "p",
+          "solutionSummary": "s",
+          "patches": [{"number": 1, "title": "A", "changes": []}],
+          "dependencyGraph": [{"patch": 1, "dependsOn": []}]
+        }|}
+      in
+      match parse_json_string input with
+      | Error _ -> false
+      | Ok result -> List.is_empty result.gameplan.functional_changes
+
+    let%test
+        "parse_json_string: functionalChange owned by nonexistent patch \
+         returns Error" =
+      let input =
+        {|{
+          "projectName": "p",
+          "solutionSummary": "s",
+          "patches": [{"number": 1, "title": "A", "changes": []}],
+          "functionalChanges": [
+            {"id": "FC-1", "description": "x", "ownedBy": 99}
+          ],
+          "dependencyGraph": [{"patch": 1, "dependsOn": []}]
+        }|}
+      in
+      match parse_json_string input with
+      | Ok _ -> false
+      | Error msg ->
+          String.is_substring msg ~substring:"FC-1"
+          && String.is_substring msg ~substring:"nonexistent patch"
+
+    let%test "parse_json_string: duplicate functionalChange id returns Error" =
+      let input =
+        {|{
+          "projectName": "p",
+          "solutionSummary": "s",
+          "patches": [{"number": 1, "title": "A", "changes": []}],
+          "functionalChanges": [
+            {"id": "FC-1", "description": "x", "ownedBy": 1},
+            {"id": "FC-1", "description": "y", "ownedBy": 1}
+          ],
+          "dependencyGraph": [{"patch": 1, "dependsOn": []}]
+        }|}
+      in
+      match parse_json_string input with
+      | Ok _ -> false
+      | Error msg ->
+          String.is_substring msg ~substring:"Duplicate functionalChange"
 
     let%test "parse_json_string: non-string open question returns Error" =
       let input =

--- a/lib_core/gameplan_parser.ml
+++ b/lib_core/gameplan_parser.ml
@@ -49,7 +49,7 @@ let validate_functional_changes ~patches ~functional_changes =
   let rec loop seen_ids = function
     | [] -> Ok ()
     | (fc : Types.Functional_change.t) :: rest ->
-        if String.is_empty fc.id then
+        if String.is_empty (String.strip fc.id) then
           Error "functionalChanges[].id must be a non-empty string"
         else if Set.mem seen_ids fc.id then
           Error (Printf.sprintf "Duplicate functionalChange id: %s" fc.id)
@@ -889,6 +889,25 @@ let%test_module "Gameplan_parser" =
       | Ok _ -> false
       | Error msg ->
           String.is_substring msg ~substring:"Duplicate functionalChange"
+
+    let%test
+        "parse_json_string: whitespace-only functionalChange id returns Error" =
+      let input =
+        {|{
+          "projectName": "p",
+          "solutionSummary": "s",
+          "patches": [{"number": 1, "title": "A", "changes": []}],
+          "functionalChanges": [
+            {"id": "  ", "description": "x", "ownedBy": 1}
+          ],
+          "dependencyGraph": [{"patch": 1, "dependsOn": []}]
+        }|}
+      in
+      match parse_json_string input with
+      | Ok _ -> false
+      | Error msg ->
+          String.is_substring msg
+            ~substring:"functionalChanges[].id must be a non-empty string"
 
     let%test "parse_json_string: non-string open question returns Error" =
       let input =

--- a/lib_core/types.ml
+++ b/lib_core/types.ml
@@ -250,6 +250,16 @@ module Stream_event = struct
   [@@deriving show, eq, sexp_of, compare, yojson]
 end
 
+module Functional_change = struct
+  type t = { id : string; description : string; owned_by : Patch_id.t }
+  [@@deriving show, eq, sexp_of, compare, yojson]
+  (** A functional/behavioural change the gameplan introduces. The
+      [functional_changes] array on [Gameplan.t] is exhaustive, and the mapping
+      via [owned_by] is total and single-valued: every change has exactly one
+      owning patch. Surfaced to the patch agent's prompt so the agent knows
+      which user-visible behaviors it must deliver. *)
+end
+
 module Gameplan = struct
   type t = {
     project_name : string;
@@ -257,6 +267,7 @@ module Gameplan = struct
     solution_summary : string;
     final_state_spec : string; [@yojson.default ""]
     patches : Patch.t list;
+    functional_changes : Functional_change.t list; [@yojson.default []]
     current_state_analysis : string; [@yojson.default ""]
     explicit_opinions : string; [@yojson.default ""]
     acceptance_criteria : string list; [@yojson.default []]

--- a/lib_core/types.ml
+++ b/lib_core/types.ml
@@ -129,6 +129,19 @@ module Comment = struct
   include Comparator.Make (T)
 end
 
+module Precedent = struct
+  type t = {
+    kind : string;
+    name : string;
+    url : string option; [@yojson.default None]
+    why_applicable : string; [@yojson.default ""]
+  }
+  [@@deriving show, eq, sexp_of, compare, yojson]
+  (** Established prior art (library, algorithm, pattern, paper, RFC, doc, blog
+      post) that a patch should adopt. Surfaced to the implementing agent in the
+      patch prompt so it can prefer proven techniques over rolling its own. *)
+end
+
 module Patch = struct
   type t = {
     id : Patch_id.t;
@@ -144,6 +157,7 @@ module Patch = struct
     test_stubs_introduced : string list; [@yojson.default []]
     test_stubs_implemented : string list; [@yojson.default []]
     complexity : int option; [@yojson.default None]
+    precedents : Precedent.t list; [@yojson.default []]
   }
   [@@deriving show, eq, sexp_of, compare, yojson]
 end

--- a/lib_core/types.mli
+++ b/lib_core/types.mli
@@ -101,6 +101,29 @@ module Comment : sig
   include Comparator.S with type t := t
 end
 
+module Precedent : sig
+  type t = {
+    kind : string;
+        (** One of "library", "algorithm", "pattern", "paper", "rfc-spec",
+            "documentation", "blog-post". Not validated at parse time; the
+            gameplan author chooses the most specific kind. *)
+    name : string;
+        (** Most-specific identifier (e.g. "Bindlib", "Tarjan 1972 strongly
+            connected components"). *)
+    url : string option; [@yojson.default None]
+        (** Canonical link to the reference. [None] when no stable URL exists.
+        *)
+    why_applicable : string; [@yojson.default ""]
+        (** 1-2 sentences explaining how this precedent informs THIS patch and
+            the concrete shape it imposes (API call, algorithm step, invariant).
+            Goes verbatim into the patch prompt. *)
+  }
+  [@@deriving show, eq, sexp_of, compare, yojson]
+  (** Established prior art the implementing agent should adopt for a given
+      patch rather than rolling its own. Surfaced to the patch prompt so the
+      agent can prefer proven libraries / algorithms / patterns. *)
+end
+
 module Patch : sig
   type t = {
     id : Patch_id.t;
@@ -120,6 +143,10 @@ module Patch : sig
             [--model auto] to pick a stronger model for harder patches. [None]
             for legacy gameplans missing the field; orchestrators should treat
             that as the highest available tier (be conservative). *)
+    precedents : Precedent.t list; [@yojson.default []]
+        (** Established prior art for this patch (libraries, algorithms,
+            patterns, papers). Empty list when the patch is bespoke project glue
+            with no relevant precedent. *)
   }
   [@@deriving show, eq, sexp_of, compare, yojson]
 end

--- a/lib_core/types.mli
+++ b/lib_core/types.mli
@@ -233,6 +233,26 @@ module Stream_event : sig
   [@@deriving show, eq, sexp_of, compare]
 end
 
+module Functional_change : sig
+  type t = {
+    id : string;
+        (** Stable identifier (e.g. ["FC-1"]) unique within the gameplan. *)
+    description : string;
+        (** Single observable outcome ("Merged patches are skipped"); not an
+            implementation step. Goes verbatim into the owning patch's prompt.
+        *)
+    owned_by : Patch_id.t;
+        (** The single patch responsible for delivering this change. *)
+  }
+  [@@deriving show, eq, sexp_of, compare, yojson]
+  (** A functional/behavioural change the gameplan introduces. The
+      [functional_changes] array on [Gameplan.t] is exhaustive, and the mapping
+      via [owned_by] is total and single-valued: every change has exactly one
+      owning patch, no shared ownership. Surfaced to the patch agent's prompt so
+      the agent knows which user-visible behaviors it must deliver and cannot
+      defer them to a sibling patch. *)
+end
+
 module Gameplan : sig
   type t = {
     project_name : string;
@@ -240,6 +260,11 @@ module Gameplan : sig
     solution_summary : string;
     final_state_spec : string; [@yojson.default ""]
     patches : Patch.t list;
+    functional_changes : Functional_change.t list; [@yojson.default []]
+        (** Exhaustive enumeration of the functional/behavioural changes the
+            gameplan introduces, each assigned to exactly one owning patch.
+            Defaults to [[]] for legacy gameplans that predate the field — in
+            that case no per-patch change list is surfaced. *)
     current_state_analysis : string; [@yojson.default ""]
     explicit_opinions : string; [@yojson.default ""]
     acceptance_criteria : string list; [@yojson.default []]

--- a/lib_test/test_generators.ml
+++ b/lib_test/test_generators.ml
@@ -256,6 +256,7 @@ let gen_gameplan =
             explicit_opinions = "";
             acceptance_criteria = [];
             open_questions = [];
+            functional_changes = [];
           })
       gen_patch_list_unique)
 
@@ -715,6 +716,7 @@ let make_test_gameplan patches =
       explicit_opinions = "";
       acceptance_criteria = [];
       open_questions = [];
+      functional_changes = [];
     }
 
 let pid_of_idx patches i =

--- a/lib_test/test_generators.ml
+++ b/lib_test/test_generators.ml
@@ -89,6 +89,7 @@ let gen_patch =
             test_stubs_introduced = [];
             test_stubs_implemented = [];
             complexity = None;
+            precedents = [];
           })
       gen_patch_id gen_title gen_branch gen_deps)
 
@@ -161,6 +162,7 @@ let gen_patch_list_linear =
                 test_stubs_introduced = [];
                 test_stubs_implemented = [];
                 complexity = None;
+                precedents = [];
               }))
       (int_range 1 8))
 
@@ -209,6 +211,7 @@ let gen_patch_dag =
               test_stubs_introduced = [];
               test_stubs_implemented = [];
               complexity = None;
+              precedents = [];
             }
         in
         gen_patches (i + 1) (patch :: acc)
@@ -229,6 +232,7 @@ let gen_patch_dag =
           test_stubs_introduced = [];
           test_stubs_implemented = [];
           complexity = None;
+          precedents = [];
         }
     in
     gen_patches 1 [ root ])
@@ -696,6 +700,7 @@ let mk_linear_patches n =
           test_stubs_introduced = [];
           test_stubs_implemented = [];
           complexity = None;
+          precedents = [];
         })
 
 let make_test_gameplan patches =

--- a/skills/write-gameplan/SKILL.md
+++ b/skills/write-gameplan/SKILL.md
@@ -55,6 +55,7 @@ All of these fields are **required** and must be present in every gameplan:
 | `currentStateAnalysis` | `string` | Where the codebase is now vs. where it needs to be |
 | `mergabilityStrategy` | `object` | `{ featureFlagStrategy, featureFlags, patchOrderingStrategy }` |
 | `requiredChanges` | `array` | `[{ file, line, description, signature }]` |
+| `functionalChanges` | `array` | `[{ id, description, ownedBy }]` — exhaustive, every entry assigned to exactly one patch. See [Functional Change Ownership](#functional-change-ownership). |
 | `acceptanceCriteria` | `string[]` | Each is a "done" condition |
 | `openQuestions` | `string[]` | Decisions for the team (empty array if none) |
 | `explicitOpinions` | `array` | `[{ opinion, rationale }]` |
@@ -103,6 +104,44 @@ Each patch includes a `classification` field:
 - `BEHAVIOR` — Changes observable behavior. Requires careful review. Should be as small as possible.
 
 **Goal**: Maximize `INFRA` and `GATED` patches. Minimize `BEHAVIOR` patches.
+
+## Functional Change Ownership
+
+A gameplan whose patches share responsibility for a behavioral change vaguely fails in a predictable way: each patch implementer reads the prose narrative, sees the change mentioned, and assumes a different patch owns it. The change falls through the cracks. The whole point of decomposing a gameplan into mergeable patches is defeated when a behavior is described as a gameplan-level concept that has no single named owner.
+
+The `functionalChanges` array prevents this. It is an **exhaustive enumeration** of every functional or behavioural delta the gameplan introduces, with each entry assigned to exactly one owning patch.
+
+### What goes here
+
+- Every observable behavior the system gains, loses, or changes as a result of this gameplan.
+- Every user-visible or API-visible change (new endpoint shape, new return value, new error path, removed deprecation).
+- Every change in protocol, contract, or invariant that downstream code can detect.
+
+What does **not** go here:
+
+- Pure refactors that have no observable effect (those still belong in `patches[].changes` as implementation steps).
+- File or signature edits (those belong in `requiredChanges`).
+- Internal helper introductions that are not callable from outside the module being changed.
+
+### The mapping
+
+Each `functionalChange` has `id` (`FC-1`, `FC-2`, …), a single-outcome `description`, and an `ownedBy` patch id. The mapping is:
+
+- **Total**: every functional change has an owner. No orphans.
+- **Single-valued**: exactly one patch owns each change. No shared ownership; co-owning a change is the failure mode this section is designed to prevent.
+- **Not strictly surjective**: an INFRA-only patch that introduces types or test stubs need not own any functional change. Most observable changes land on GATED or BEHAVIOR patches.
+
+If the same behavior is co-implemented by two patches, the change description is too coarse — split it into two changes (one per patch), each describing the slice that patch delivers.
+
+### How it surfaces to the patch agent
+
+Downstream consumers (notably onton's patch prompt renderer) read `functionalChanges` and inject the subset `ownedBy` each patch into that patch's agent prompt as an explicit "Functional Changes You Own" section. The implementing agent therefore sees the precise list of user-visible behaviors it is responsible for delivering, separate from its `changes` implementation steps. This is what closes the loophole — there is no longer prose-only behavior that no patch acknowledges.
+
+### Authoring guidance
+
+- Write each entry as the **outcome**, not the mechanism. "Merged patches are skipped instead of queued" is correct; "Add a merged-check branch to disposition" is an implementation step and belongs in `patches[].changes`.
+- Cross-check against `problemStatement`, `solutionSummary`, and `acceptanceCriteria`: every behavioral promise made there must correspond to at least one `functionalChange` entry. If you cannot point at the owning patch for a sentence in the problem statement, the gameplan has a gap.
+- Cross-check against `finalStateSpec`: every behavioral invariant in the spec should map to a functional change that introduces it (the spec says *what is true at the end*; the functional change says *which patch made it true*).
 
 ## Patch Complexity
 
@@ -236,7 +275,8 @@ After writing the gameplan JSON, verify:
 2. **Each spec MUST parse cleanly** — extract `spec`/`finalStateSpec` strings to temp files and validate them with the spec language's toolchain (see [Specification Language](#specification-language)). Fix any parse errors before finalizing. If the toolchain is not installed, flag it as a blocker — do NOT skip validation or fall back to manual review
 3. The dependency graph is a valid DAG
 4. All test stubs have corresponding implementations
-5. The mergability checklist passes
+5. **Functional change ownership is total and single-valued** — every `functionalChanges[i].id` is unique; every `functionalChanges[i].ownedBy` resolves to an existing `patches[].number`; no functional change appears unowned in prose. Re-read `problemStatement`, `solutionSummary`, `acceptanceCriteria`, and `finalStateSpec` and confirm every behavioral promise has a corresponding `functionalChanges` entry pointing at a single patch. Set `mergabilityChecklist.functionalChangesOwnedByExactlyOnePatch` to `true` only when this holds.
+6. The mergability checklist passes
 
 ## Resolving Open Questions
 

--- a/skills/write-gameplan/SKILL.md
+++ b/skills/write-gameplan/SKILL.md
@@ -31,6 +31,7 @@ A gameplan can be **standalone** or part of a **workstream** (a larger project s
 2. Identify which milestone this gameplan corresponds to
 3. Review the milestone's "Definition of Done" — this informs your acceptance criteria
 4. Ensure your gameplan leaves the codebase in a consistent state
+5. Read the workstream's `Established Precedents` section (plus any milestone-scoped precedents). For each precedent, identify the specific patches in this gameplan that consume it — touch its API, implement its algorithm, depend on its invariants — and attach it to those patches' `precedents` arrays. Do **not** blanket-copy workstream precedents onto every patch; only the ones that actually use the technique. See [Leveraging Established Precedents](#leveraging-established-precedents) for the per-patch shape.
 
 **If no workstream is provided**, treat this as a standalone gameplan.
 
@@ -66,7 +67,7 @@ All of these fields are **required** and must be present in every gameplan:
 
 ### Required Patch Fields
 
-Each patch object must have: `number`, `classification` (INFRA\|GATED\|BEHAVIOR), `complexity` (1\|2\|3), `title`, `files` (array of `{ path, action, description }`), `changes` (string array), `testStubsIntroduced` (string array or null), `testStubsImplemented` (string array or null), `spec` (string).
+Each patch object must have: `number`, `classification` (INFRA\|GATED\|BEHAVIOR), `complexity` (1\|2\|3), `title`, `files` (array of `{ path, action, description }`), `changes` (string array), `testStubsIntroduced` (string array or null), `testStubsImplemented` (string array or null), `spec` (string). Patches may also include an optional `precedents` array citing established libraries, algorithms, or patterns the patch should adopt — see [Leveraging Established Precedents](#leveraging-established-precedents).
 
 The inline `spec` and `finalStateSpec` string fields in the JSON are the **sole source of truth** for formal specifications. Do not maintain separate spec files alongside the gameplan. For verification, extract the strings and validate them with the spec language's toolchain (see [Specification Language](#specification-language) below). Do not persist the extracted files.
 
@@ -125,6 +126,47 @@ Do not assign complexity from the patch title alone. Before scoring:
 4. **Score based on the worst case among the changes the patch introduces**, not the median. A patch that mostly renames things but also adds one tricky lock should be scored on the lock.
 
 If after reading you cannot tell whether something is `2` or `3`, it is `3`. If you cannot tell whether something is `1` or `2`, it is `2`.
+
+## Leveraging Established Precedents
+
+Most non-trivial engineering problems have well-known solutions: a CS algorithm with a name, a library that already solves the hard part, a design pattern with documented trade-offs, an RFC that pins down the wire format. **When a patch is solving a problem that has established prior art, identify the precedent and attach it to that patch via the optional `precedents` field.** Prefer proven, robust techniques over rolling our own — and give the implementing agent enough of a reference that it can fetch more detail when it needs to.
+
+### When precedents apply
+
+A patch likely has a precedent worth citing whenever it touches an area with mature, named solutions. Common examples (not exhaustive):
+
+- **Variable binding / scope handling** — capture-avoiding substitution, alpha renaming, free-variable computation (named libraries exist for most languages; locally-nameless and de Bruijn indices are documented techniques).
+- **Parsing and lexing** — established parser generators and combinator libraries; standard error-recovery strategies (panic-mode, GLR).
+- **Graph algorithms** — Tarjan SCC, Dijkstra/A* shortest path, Kahn topological sort, Union-Find with path compression.
+- **Type systems** — Hindley–Milner / Algorithm W; bidirectional type-checking; row polymorphism.
+- **Distributed coordination** — Raft, consistent hashing, idempotency keys, the outbox pattern, sagas, vector clocks.
+- **Cryptography** — never roll your own. Cite the standard (RFC, NIST suite, IETF draft) and an audited library implementation.
+- **Concurrency** — battle-tested constructs (Michael–Scott queues, Treiber stacks, structured concurrency, CSP/actor model).
+- **Streaming / backpressure** — Reactive Streams, async iterator protocols, credit-based flow control.
+- **Schema and data migration** — expand/contract migrations, accretive change, dual-write/backfill/cutover patterns.
+- **State machines / workflow engines** — hierarchical state charts, event sourcing, deterministic replay.
+
+A patch may have **zero** precedents. Bespoke project glue (wiring two existing modules together, renaming a field, adding a config flag) usually does not warrant any citation. Do not manufacture references where none apply.
+
+### What to write
+
+Each precedent entry has four fields:
+
+- **`kind`** — one of `library`, `algorithm`, `pattern`, `paper`, `rfc-spec`, `documentation`, `blog-post`. Pick the most specific kind that fits.
+- **`name`** — the most precise identifier a reader will recognise. `"Tarjan 1972 strongly connected components"` is better than `"a graph algorithm"`; `"RFC 7519 JSON Web Tokens"` is better than `"JWT spec"`.
+- **`url`** — the canonical link (library homepage or repo, paper DOI or arXiv, RFC URL, official docs page). Required for kinds where a URL is the durable reference (`paper`, `rfc-spec`, `documentation`, `blog-post`); strongly preferred for libraries. Do not guess URLs — fetch the real one (e.g. `WebFetch`) or leave it `null`.
+- **`whyApplicable`** — 1-2 sentences explaining what part of *this specific patch* the precedent informs and the concrete shape it imposes. Not generic praise: name the API call, the algorithm step, or the invariant that the precedent supplies. The implementing agent reads this to decide whether to fetch the reference, so be specific.
+
+### Do real research, not name-dropping
+
+- **Do not invent precedents.** A false reference is worse than none — the implementing agent will waste tokens chasing something that doesn't exist or doesn't apply. If you are not confident a precedent applies, omit it.
+- **Verify the reference exists before citing.** Fetch the library docs, the paper abstract, or the RFC index when in doubt. Do not cite from memory if the project depends on the precedent being real.
+- **Prefer precedents with non-trivial real-world adoption** — libraries used in shipping projects, algorithms cited in production literature. Abandoned or experimental references are weak evidence.
+- **Cite at the level of the technique, not the buzzword.** If three libraries implement the same algorithm, the precedent might be the algorithm (kind: `algorithm`) with the recommended library named in `whyApplicable`. Conversely, if the value is the specific library's API design, the precedent is the library.
+
+### Where to attach
+
+Attach precedents at the **patch** level, on the specific patches the precedent informs — typically the patch that introduces a new dependency or implements the named technique, plus any consumers that need to call its API. A precedent that drives the whole gameplan should still be replicated on each patch that depends on it, so an implementing agent picking up Patch N alone has the reference in hand.
 
 ## Mergability Strategy
 

--- a/skills/write-gameplan/references/example.json
+++ b/skills/write-gameplan/references/example.json
@@ -49,6 +49,34 @@
     }
   ],
 
+  "functionalChanges": [
+    {
+      "id": "FC-1",
+      "description": "Patch_decision is callable as a pure module from outside main.ml — its decision functions can be exercised in isolation without instantiating a runner fiber or any Eio I/O.",
+      "ownedBy": 3
+    },
+    {
+      "id": "FC-2",
+      "description": "Merged patches are skipped (disposition = Skip) regardless of busy/ci-failure state.",
+      "ownedBy": 3
+    },
+    {
+      "id": "FC-3",
+      "description": "Busy patches are never delivered (disposition is Skip or Queue, never Deliver).",
+      "ownedBy": 3
+    },
+    {
+      "id": "FC-4",
+      "description": "Patches with ci_failure_count ≥ 3 require human intervention (needs_intervention = true).",
+      "ownedBy": 3
+    },
+    {
+      "id": "FC-5",
+      "description": "main.ml runner_fiber delegates every patch-lifecycle decision to Patch_decision — no inline merged/busy/CI-failure checks remain in I/O code paths.",
+      "ownedBy": 4
+    }
+  ],
+
   "acceptanceCriteria": [
     "Patch_decision module exists with pure functions for all decision points",
     "All decision functions are covered by QCheck2 property tests",
@@ -238,7 +266,8 @@
     "testMapImplPatchMatchesCode": true,
     "behaviorPatchesMinimal": true,
     "dependencyGraphOrdered": true,
-    "behaviorPatchesJustified": true
+    "behaviorPatchesJustified": true,
+    "functionalChangesOwnedByExactlyOnePatch": true
   },
 
   "mergabilityInsight": "3 of 4 patches are INFRA and can ship without changing observable behavior. Only Patch 4 changes behavior (wiring).",

--- a/skills/write-gameplan/references/example.json
+++ b/skills/write-gameplan/references/example.json
@@ -132,7 +132,21 @@
         "Patch_decision > CI failure cap at 3"
       ],
       "testStubsImplemented": null,
-      "spec": "module EXTRACT_DECISION_PATCH_2.\n\n> Patch 2 introduces test stubs only. No new invariants are\n> declared — stubs are pending markers implemented in Patch 3.\n> Redeclare Patch 1's types here so the module is self-contained.\n\nDisposition.\nskip => Disposition.\nqueue => Disposition.\ndeliver => Disposition.\n---\ntrue.\n"
+      "spec": "module EXTRACT_DECISION_PATCH_2.\n\n> Patch 2 introduces test stubs only. No new invariants are\n> declared — stubs are pending markers implemented in Patch 3.\n> Redeclare Patch 1's types here so the module is self-contained.\n\nDisposition.\nskip => Disposition.\nqueue => Disposition.\ndeliver => Disposition.\n---\ntrue.\n",
+      "precedents": [
+        {
+          "kind": "pattern",
+          "name": "Property-based testing (QuickCheck-style)",
+          "url": "https://www.cs.tufts.edu/~nr/cs257/archive/john-hughes/quick.pdf",
+          "whyApplicable": "Express each spec invariant as a universally-quantified property over a generator, not as point examples. The 'merged patch is always skipped' invariant becomes a `Test.make` with a generator for {merged, busy, ci_failure_count} triples — shrinking will surface the minimal counterexample if the implementation diverges from the spec."
+        },
+        {
+          "kind": "library",
+          "name": "QCheck2",
+          "url": "https://github.com/c-cube/qcheck",
+          "whyApplicable": "OCaml property-based testing library. Use `QCheck2.Test.make ~name ~count gen prop` for each stub; reach for `QCheck2.Gen.{bool, int_bound, oneofl}` to compose the input generators rather than writing custom samplers."
+        }
+      ]
     },
     {
       "number": 3,

--- a/skills/write-gameplan/references/gameplan-schema.json
+++ b/skills/write-gameplan/references/gameplan-schema.json
@@ -12,6 +12,7 @@
     "mergabilityStrategy",
     "currentStateAnalysis",
     "requiredChanges",
+    "functionalChanges",
     "acceptanceCriteria",
     "openQuestions",
     "explicitOpinions",
@@ -54,6 +55,11 @@
     "requiredChanges": {
       "type": "array",
       "items": { "$ref": "#/$defs/requiredChange" }
+    },
+    "functionalChanges": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/functionalChange" },
+      "description": "Exhaustive enumeration of the functional/behavioural changes this gameplan introduces, each assigned to exactly one owning patch. Use this to defeat the failure mode where a change is described prose-only in the problem/solution narrative and every patch implementer assumes some other patch owns it. The mapping is total on changes: every entry has an `ownedBy` patch. Multiple changes may map to the same patch; INFRA-only patches that introduce no observable change need not appear here. Downstream consumers (e.g. onton's patch prompt renderer) MUST surface the subset of functionalChanges ownedBy each patch in that patch's agent prompt, so the implementing agent knows exactly which user-visible behaviors are its responsibility."
     },
     "acceptanceCriteria": {
       "type": "array",
@@ -168,6 +174,26 @@
         },
         "activatedInPatch": {
           "$ref": "#/$defs/patchId"
+        }
+      },
+      "additionalProperties": false
+    },
+    "functionalChange": {
+      "type": "object",
+      "required": ["id", "description", "ownedBy"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^FC-[0-9]+$",
+          "description": "Stable identifier (e.g. 'FC-1', 'FC-2'), unique within the gameplan. Lets commits, PRs, and other artifacts cite the change by reference."
+        },
+        "description": {
+          "type": "string",
+          "description": "A single specific functional or behavioural change, phrased as an observable outcome ('Merged patches are skipped instead of queued', 'main.ml delegates lifecycle decisions to Patch_decision'). Not an implementation step. If a single description bundles multiple deltas, split into separate entries — granularity matters because the owning patch's agent will receive this exact text as the list of behaviors it must deliver."
+        },
+        "ownedBy": {
+          "$ref": "#/$defs/patchId",
+          "description": "The single patch responsible for delivering this change. Exactly one owner — no shared ownership, no orphans. The owning patch's agent prompt will list this change explicitly so the implementing agent cannot defer it to another patch."
         }
       },
       "additionalProperties": false
@@ -359,7 +385,8 @@
         "testMapImplPatchMatchesCode",
         "behaviorPatchesMinimal",
         "dependencyGraphOrdered",
-        "behaviorPatchesJustified"
+        "behaviorPatchesJustified",
+        "functionalChangesOwnedByExactlyOnePatch"
       ],
       "properties": {
         "featureFlagStrategyDocumented": { "type": "boolean" },
@@ -370,7 +397,11 @@
         "testMapImplPatchMatchesCode": { "type": "boolean" },
         "behaviorPatchesMinimal": { "type": "boolean" },
         "dependencyGraphOrdered": { "type": "boolean" },
-        "behaviorPatchesJustified": { "type": "boolean" }
+        "behaviorPatchesJustified": { "type": "boolean" },
+        "functionalChangesOwnedByExactlyOnePatch": {
+          "type": "boolean",
+          "description": "Every entry in functionalChanges has exactly one ownedBy patch, that patch exists, and the union of described behaviors covers every observable change implied by problemStatement/solutionSummary/acceptanceCriteria. No behavioral outcome is described in prose without a single named owner."
+        }
       },
       "additionalProperties": false
     }

--- a/skills/write-gameplan/references/gameplan-schema.json
+++ b/skills/write-gameplan/references/gameplan-schema.json
@@ -247,6 +247,35 @@
         "spec": {
           "type": "string",
           "description": "Formal specification source — invariants that hold after this patch. Focus on the delta — only what this patch introduces or changes. Each patch spec is self-contained — redeclare any domains/rules from prior patches that this patch references. For INFRA patches that only add types, the spec may declare domains and rules with no body propositions (the types themselves are the contribution). For BEHAVIOR patches, include invariants about the new behavior. Keep specs minimal — only what this patch guarantees, not the entire system."
+        },
+        "precedents": {
+          "type": ["array", "null"],
+          "items": { "$ref": "#/$defs/precedent" },
+          "description": "Established prior art (libraries, algorithms, patterns, papers, RFCs, canonical docs) that informs this patch. Cite concrete proven techniques the implementing agent should adopt rather than rolling its own. Null or omitted means no specific precedent applies (e.g. the patch is bespoke project glue). See SKILL.md's 'Leveraging Established Precedents' section for when and how to populate this."
+        }
+      },
+      "additionalProperties": false
+    },
+    "precedent": {
+      "type": "object",
+      "required": ["kind", "name", "whyApplicable"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["library", "algorithm", "pattern", "paper", "rfc-spec", "documentation", "blog-post"],
+          "description": "What kind of precedent this is. 'library' = an existing dependency to adopt directly; 'algorithm' = a named algorithm (e.g. Tarjan SCC, Hindley-Milner Algorithm W); 'pattern' = a well-known design pattern (e.g. outbox pattern, expand-contract migration); 'paper' = academic literature; 'rfc-spec' = standards (RFC, ECMA, NIST); 'documentation' = canonical vendor/maintainer docs; 'blog-post' = a respected practitioner write-up."
+        },
+        "name": {
+          "type": "string",
+          "description": "The most specific identifier the implementing agent will recognise (e.g. 'Bindlib', 'Tarjan 1972 strongly connected components', 'RFC 7519 JSON Web Tokens'). Avoid vague labels like 'a graph algorithm'."
+        },
+        "url": {
+          "type": ["string", "null"],
+          "description": "Canonical link to the precedent (library homepage / repo, paper DOI or arXiv URL, RFC URL, official docs page). Required for 'paper', 'rfc-spec', 'documentation', and 'blog-post' kinds where the URL is the durable reference. Omit only if no stable URL exists. Do not guess URLs — fetch the real one or leave it null."
+        },
+        "whyApplicable": {
+          "type": "string",
+          "description": "1-2 sentences: what part of THIS patch the precedent informs, and the concrete shape it imposes on the implementation. The implementing agent decides from this whether to read the reference, so be specific (e.g. 'Use bind_mvar / unmbind to construct and destructure quantifier binders' beats 'use for binders')."
         }
       },
       "additionalProperties": false

--- a/skills/write-gameplan/references/gameplan-schema.json
+++ b/skills/write-gameplan/references/gameplan-schema.json
@@ -285,6 +285,21 @@
     "precedent": {
       "type": "object",
       "required": ["kind", "name", "whyApplicable"],
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "kind": {
+                "enum": ["paper", "rfc-spec", "documentation", "blog-post"]
+              }
+            },
+            "required": ["kind"]
+          },
+          "then": {
+            "required": ["url"]
+          }
+        }
+      ],
       "properties": {
         "kind": {
           "type": "string",

--- a/skills/write-workstream/SKILL.md
+++ b/skills/write-workstream/SKILL.md
@@ -72,7 +72,7 @@ Common workstream-level precedent categories (not exhaustive):
 
 - **Concurrency**: Eio / Tokio / structured concurrency, CSP, actor model, Reactive Streams.
 - **Persistence and migration**: expand/contract migrations, event sourcing, the outbox pattern.
-- **Auth and crypto**: OAuth 2.1 / RFC 6749, PASETO, JWT/RFC 7519, audited libraries (libsodium, ring).
+- **Auth and crypto**: OAuth 2.0 / RFC 6749, PASETO, JWT/RFC 7519, audited libraries (libsodium, ring).
 - **Parsing**: parser generators (Menhir, ANTLR), combinator libraries, GLR.
 - **Type and binder handling**: Bindlib, locally-nameless representation, Hindley-Milner.
 - **Graph and search**: Tarjan SCC, Dijkstra, Union-Find with path compression.

--- a/skills/write-workstream/SKILL.md
+++ b/skills/write-workstream/SKILL.md
@@ -48,7 +48,38 @@ Once you understand the vision, explore the complexity:
 - What could go wrong?
 - Are there external dependencies (APIs, services, other teams)?
 
-### Phase 3: Define Milestones
+### Phase 3: Identify Established Precedents
+
+Most non-trivial workstreams cross territory that has well-known solutions in the CS literature or proven libraries in the industry. **Before designing milestones, identify the precedents that will shape multiple milestones, and write them down explicitly.** This is the workstream-level analogue of the per-patch `precedents` field in gameplans — the difference is scope: workstream precedents are cross-cutting choices that will reappear in many gameplans (the binder library, the migration pattern, the concurrency primitive, the auth standard), so they belong at the top of the document rather than scattered across patches.
+
+Work through these prompts with the user:
+
+- For each key challenge from Phase 2, ask: **has someone already solved this?** Is there a named algorithm, a maintained library, a documented pattern, an RFC, or an audited reference implementation?
+- For cross-cutting concerns (concurrency, persistence, auth, crypto, schema migration, distributed coordination, parsing, scheduling), ask which proven approach the workstream commits to.
+- For any "we're going to roll our own X" answer, push back: is there a real reason to roll our own, or is it just unfamiliarity with the prior art? Rolling your own is sometimes correct, but the decision should be conscious.
+
+**What counts as a workstream-level precedent**:
+
+- It applies across **multiple milestones** (otherwise it belongs on a specific patch when the gameplan is written).
+- It is a **load-bearing reference**: implementing agents will need to look up its API, algorithm steps, or invariants while writing code.
+- It has **non-trivial real-world adoption** — a library used in shipping projects, an algorithm cited in production literature, a pattern documented by recognised practitioners.
+
+**Do real research, not name-dropping**. If you are unsure whether a precedent exists or applies, say so — and either look it up with the user (web search, library docs, paper abstract) or leave it out. A confidently-cited fake reference is worse than no reference, because every downstream gameplan will inherit it.
+
+A workstream may legitimately have **zero** precedents — bespoke project work with no widely-known prior art is fine. Do not manufacture references.
+
+Common workstream-level precedent categories (not exhaustive):
+
+- **Concurrency**: Eio / Tokio / structured concurrency, CSP, actor model, Reactive Streams.
+- **Persistence and migration**: expand/contract migrations, event sourcing, the outbox pattern.
+- **Auth and crypto**: OAuth 2.1 / RFC 6749, PASETO, JWT/RFC 7519, audited libraries (libsodium, ring).
+- **Parsing**: parser generators (Menhir, ANTLR), combinator libraries, GLR.
+- **Type and binder handling**: Bindlib, locally-nameless representation, Hindley-Milner.
+- **Graph and search**: Tarjan SCC, Dijkstra, Union-Find with path compression.
+- **Testing**: property-based testing (QuickCheck), differential testing, snapshot testing.
+- **Distributed coordination**: Raft, vector clocks, idempotency keys, sagas.
+
+### Phase 4: Define Milestones
 
 Work with the user to break the work into milestones. For each potential milestone, validate:
 
@@ -57,7 +88,7 @@ Work with the user to break the work into milestones. For each potential milesto
 3. **What's the definition of done?** What is true about the codebase when this is complete?
 4. **What does it unlock?** What becomes possible after this milestone?
 
-### Phase 4: Sequence and Dependencies
+### Phase 5: Sequence and Dependencies
 
 Once milestones are identified, work out the order:
 
@@ -81,6 +112,9 @@ Each milestone should have:
 **Unlocks**:
 [What becomes possible after this milestone is done?]
 
+**Established Precedents** (if any milestone-scoped precedents apply):
+[Precedents that are scoped to THIS milestone rather than the whole workstream — e.g. a library or algorithm that only shows up in one milestone's patches. Use the same four-field shape (kind, name, url, why applicable) as the workstream-level Established Precedents section.]
+
 **Open Questions** (if any):
 [Questions that need to be answered before or during this gameplan]
 ```
@@ -93,10 +127,22 @@ Key sections:
 - **Vision** — 2-4 sentences describing end state and why it matters
 - **Current State** — where the codebase is today relative to the vision
 - **Key Challenges** — hardest parts or biggest unknowns
-- **Milestones** — sequenced with Definition of Done, pause points, unlocks
+- **Established Precedents** — cross-cutting libraries, algorithms, patterns, papers, or RFCs the workstream adopts; each with kind, name, URL, and why applicable
+- **Milestones** — sequenced with Definition of Done, pause points, unlocks, optional milestone-scoped precedents
 - **Dependency Graph** — milestone dependencies in tooling-compatible format
 - **Open Questions** — unresolved questions for the workstream
-- **Decisions Made** — key decisions with rationale
+- **Decisions Made** — key decisions that are NOT precedents (philosophy, rejected libraries, framing choices) with rationale
+
+## Handoff to write-gameplan
+
+Workstream-level precedents are not the final word — they are inputs to the per-milestone gameplans. When `write-gameplan` is invoked for a specific milestone with a workstream reference:
+
+1. It reads the workstream's `Established Precedents` section.
+2. For each precedent, it identifies which patches in that milestone actually consume it (touch the API, implement the algorithm, depend on the invariants).
+3. It attaches the precedent to those specific patches via the gameplan's per-patch `precedents` field — not blanket-copied onto every patch.
+4. Milestone-scoped precedents (if any) are handled the same way, restricted to patches within that milestone.
+
+Write the workstream-level precedents once, in this skill's output. Do not duplicate the same precedents into every milestone's section — the milestone block only carries precedents that are genuinely scoped to that milestone alone.
 
 ## Important Principles
 
@@ -109,6 +155,8 @@ Key sections:
 4. **Surface uncertainty early.** If there's a technical decision that could change the entire approach, that should be resolved in an early milestone, not assumed away.
 
 5. **Don't over-plan.** Later milestones can be less detailed than early ones. You'll learn things as you go.
+
+6. **Prefer proven precedents over rolling your own.** When a problem has well-known solutions in the literature or industry, cite them in the `Established Precedents` section so every downstream gameplan inherits the same proven design. Conscious decisions to roll your own are fine; cargo-cult avoidance of prior art is not.
 
 ## Recording
 

--- a/skills/write-workstream/references/workstream-format.md
+++ b/skills/write-workstream/references/workstream-format.md
@@ -14,6 +14,18 @@
 ## Key Challenges
 [Bullet list of the hardest parts or biggest unknowns]
 
+## Established Precedents
+
+Cross-cutting prior art (libraries, algorithms, patterns, papers, RFCs, canonical docs) this workstream adopts. Each entry is consumed by `write-gameplan` when a milestone is unpacked into patches — the relevant precedents are then attached to the specific patches that depend on them. Use the same four-field shape as per-patch precedents.
+
+- **[kind] Name** — [URL if a stable one exists]
+  [1-2 sentences: how this precedent applies across milestones and the concrete shape it imposes on implementation.]
+
+- **[kind] Name** — [URL]
+  [Why applicable.]
+
+`kind` is one of: `library`, `algorithm`, `pattern`, `paper`, `rfc-spec`, `documentation`, `blog-post`.
+
 ## Milestones
 
 ### Milestone 1: [gameplan-name-kebab-case]
@@ -25,6 +37,8 @@
 **Definition of Done**: ...
 **Why this is a safe pause point**: ...
 **Unlocks**: ...
+**Established Precedents** (milestone-scoped only):
+- **[kind] Name** — [URL] — [Why applicable for this milestone specifically.]
 **Open Questions** (if any): ...
 
 ## Dependency Graph
@@ -63,6 +77,20 @@ The OCaml project has a build skeleton (dune 3.21, OCaml 5.4, Jane Street ppx ec
 - **Property test coverage**: Comprehensive QCheck2 coverage from the start, with properties derived from the formal spec.
 - **Spec parity**: The formal spec defines invariants that must be explicit and machine-checkable in the implementation.
 - **Decision logic testability**: Pure decision logic must be separated from I/O for property testing.
+
+## Established Precedents
+
+- **library — Eio** — https://github.com/ocaml-multicore/eio
+  Structured-concurrency primitives (fibers, switches, cancellation, capability-based I/O) for the orchestrator main loop, poller, runner, and patch_agent. Prefer `Eio.Fiber.fork` / `Switch.run` over manual thread plumbing; pass capabilities (`#Eio.Stdenv.process_mgr`, `#Eio.Net.t`) explicitly rather than reaching for global state.
+
+- **pattern — Property-based testing (QuickCheck-style)** — https://www.cs.tufts.edu/~nr/cs257/archive/john-hughes/quick.pdf
+  Each Pantagruel rule produces at least one QCheck2 property — `forall x: T | P x` becomes a generator + property pair with shrinking. Derive properties from the spec, never from current OCaml behavior, so a divergence between code and spec surfaces as a test failure rather than being locked in.
+
+- **library — QCheck2** — https://github.com/c-cube/qcheck
+  OCaml property-based testing library. Use `QCheck2.Test.make ~name ~count gen prop`; reach for `QCheck2.Gen.{bool, int_bound, oneofl}` as composable generators. Shared generators live in `lib_test/test_generators.ml`.
+
+- **pattern — Functional core, imperative shell** — https://www.destroyallsoftware.com/screencasts/catalog/functional-core-imperative-shell
+  Pure decision modules (`Patch_decision`, `Spawn_logic`, `Reconciler`) sit beneath an imperative I/O shell in `main.ml`. Property-test the core; keep the shell minimal, dumb, and trivially auditable. Every milestone that touches decision logic extends the pure core, not the shell.
 
 ## Milestones
 
@@ -160,10 +188,10 @@ The OCaml project has a build skeleton (dune 3.21, OCaml 5.4, Jane Street ppx ec
 
 ## Decisions Made
 
+These are decisions that did NOT produce a citable precedent — rejected library choices, framing principles, and project philosophy. Accepted precedents (Eio, QCheck2, functional-core-imperative-shell, property-based testing) live in the `Established Precedents` section above.
+
 | Decision | Rationale |
 |----------|-----------|
-| Eio over Lwt | Eio provides structured concurrency (fibers, scopes). Lwt is callback-based and harder to reason about. |
-| Raw ANSI TUI | No OCaml TUI library supports the rendering model we need (incremental updates, alternate screen, raw key input). Rolling our own with Eio is simpler than fighting a library. |
-| QCheck2 from the start | Property tests derived from the formal spec catch more bugs than example-based tests and serve as machine-readable spec compliance evidence. |
-| Separate pure and I/O | Pure decision modules (Patch_decision, Spawn_logic, Reconciler) are extracted and tested independently. I/O code in main.ml is a thin wiring layer. |
-| Spec is source of truth | When the code disagrees with the formal spec, the code is wrong. Tests are derived from the spec, not from current behavior. |
+| Lwt rejected in favor of Eio | Lwt is callback-based and harder to reason about than Eio's structured fibers. Recorded here as a rejected alternative — the chosen precedent is documented in `Established Precedents`. |
+| Raw ANSI TUI (no library) | No OCaml TUI library supports the rendering model we need (incremental updates, alternate screen, raw key input). A conscious decision to roll our own — no precedent applies. Revisit if a suitable library emerges. |
+| Spec is source of truth | When the code disagrees with the formal spec, the code is wrong. Tests are derived from the spec, not from current behavior. Project philosophy rather than an external precedent. |

--- a/test/test_interleaving_properties.ml
+++ b/test/test_interleaving_properties.ml
@@ -1965,6 +1965,7 @@ let () =
             test_stubs_introduced = [];
             test_stubs_implemented = [];
             complexity = None;
+            precedents = [];
           }
         in
         let b : Patch.t =

--- a/test/test_onton.ml
+++ b/test/test_onton.ml
@@ -34,6 +34,7 @@ let () =
         explicit_opinions = "";
         acceptance_criteria = [];
         open_questions = [];
+        functional_changes = [];
       }
   in
   let _orch, _effects, actions =

--- a/test/test_onton.ml
+++ b/test/test_onton.ml
@@ -16,6 +16,7 @@ let () =
           test_stubs_introduced = [];
           test_stubs_implemented = [];
           complexity = None;
+          precedents = [];
         };
     ]
   in

--- a/test/test_orchestrator_properties.ml
+++ b/test/test_orchestrator_properties.ml
@@ -36,6 +36,7 @@ let make_gameplan patches =
       explicit_opinions = "";
       acceptance_criteria = [];
       open_questions = [];
+      functional_changes = [];
     }
 
 let tick orch ~patches =

--- a/test/test_patch_controller.ml
+++ b/test/test_patch_controller.ml
@@ -21,6 +21,7 @@ let make_patch pid branch =
       test_stubs_introduced = [];
       test_stubs_implemented = [];
       complexity = None;
+      precedents = [];
     }
 
 let make_gameplan patch =

--- a/test/test_patch_controller.ml
+++ b/test/test_patch_controller.ml
@@ -36,6 +36,7 @@ let make_gameplan patch =
       explicit_opinions = "";
       acceptance_criteria = [];
       open_questions = [];
+      functional_changes = [];
     }
 
 let make_orch patch agent =

--- a/test/test_patch_controller_state_machine.ml
+++ b/test/test_patch_controller_state_machine.ml
@@ -21,6 +21,7 @@ let make_patch pid branch =
       test_stubs_introduced = [];
       test_stubs_implemented = [];
       complexity = None;
+      precedents = [];
     }
 
 let make_gameplan patch =

--- a/test/test_patch_controller_state_machine.ml
+++ b/test/test_patch_controller_state_machine.ml
@@ -36,6 +36,7 @@ let make_gameplan patch =
       explicit_opinions = "";
       acceptance_criteria = [];
       open_questions = [];
+      functional_changes = [];
     }
 
 let messages_equal a b = List.equal Orchestrator.equal_patch_agent_message a b

--- a/test/test_persistence_properties.ml
+++ b/test/test_persistence_properties.ml
@@ -40,6 +40,7 @@ let gameplan_for_agent (agent : Onton_core.Patch_agent.t) =
       explicit_opinions = "";
       acceptance_criteria = [];
       open_questions = [];
+      functional_changes = [];
     }
 
 (** Compare two snapshots field by field. Orchestrator.t is opaque without [eq],
@@ -122,6 +123,7 @@ let () =
                 explicit_opinions = "";
                 acceptance_criteria = [];
                 open_questions = [];
+                functional_changes = [];
               }
           in
           let orchestrator =
@@ -254,6 +256,7 @@ let () =
                 explicit_opinions = "";
                 acceptance_criteria = [];
                 open_questions = [];
+                functional_changes = [];
               }
           in
           let main_branch = Branch.of_string "main" in
@@ -304,6 +307,7 @@ let () =
                 explicit_opinions = "";
                 acceptance_criteria = [];
                 open_questions = [];
+                functional_changes = [];
               }
           in
           let main_branch = Branch.of_string "main" in

--- a/test/test_persistence_properties.ml
+++ b/test/test_persistence_properties.ml
@@ -33,6 +33,7 @@ let gameplan_for_agent (agent : Onton_core.Patch_agent.t) =
             test_stubs_introduced = [];
             test_stubs_implemented = [];
             complexity = None;
+            precedents = [];
           };
         ];
       current_state_analysis = "";

--- a/test/test_poll_log_properties.ml
+++ b/test/test_poll_log_properties.ml
@@ -30,6 +30,7 @@ let make_patch pid branch =
       test_stubs_introduced = [];
       test_stubs_implemented = [];
       complexity = None;
+      precedents = [];
     }
 
 let make_orch patch agent =

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -14,6 +14,7 @@ let make_gameplan patches =
       explicit_opinions = "";
       acceptance_criteria = [];
       open_questions = [];
+      functional_changes = [];
     }
 
 let tick orch ~patches =

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -155,6 +155,7 @@ let () =
          test_stubs_introduced = [];
          test_stubs_implemented = [];
          complexity = None;
+         precedents = [];
        }
    in
    let a = Types.Patch_id.of_string "A" in
@@ -395,6 +396,7 @@ let () =
           test_stubs_introduced = [];
           test_stubs_implemented = [];
           complexity = None;
+          precedents = [];
         };
     ]
   in
@@ -455,6 +457,7 @@ let () =
         test_stubs_introduced = [];
         test_stubs_implemented = [];
         complexity = None;
+        precedents = [];
       }
   in
 
@@ -566,6 +569,7 @@ let () =
           test_stubs_introduced = [];
           test_stubs_implemented = [];
           complexity = None;
+          precedents = [];
         };
       Types.Patch.
         {
@@ -582,6 +586,7 @@ let () =
           test_stubs_introduced = [];
           test_stubs_implemented = [];
           complexity = None;
+          precedents = [];
         };
     ]
   in
@@ -630,6 +635,7 @@ let () =
             test_stubs_introduced = [];
             test_stubs_implemented = [];
             complexity = None;
+            precedents = [];
           };
       ]
     in
@@ -658,6 +664,7 @@ let () =
                 test_stubs_introduced = [];
                 test_stubs_implemented = [];
                 complexity = None;
+                precedents = [];
               };
           ]
         in
@@ -764,6 +771,7 @@ let () =
             test_stubs_introduced = [];
             test_stubs_implemented = [];
             complexity = None;
+            precedents = [];
           };
       ]
     in
@@ -829,6 +837,7 @@ let () =
                   test_stubs_introduced = [];
                   test_stubs_implemented = [];
                   complexity = None;
+                  precedents = [];
                 };
             ]
           in
@@ -905,6 +914,7 @@ let () =
             test_stubs_introduced = [];
             test_stubs_implemented = [];
             complexity = None;
+            precedents = [];
           };
       ]
     in

--- a/test/test_reconciler_properties.ml
+++ b/test/test_reconciler_properties.ml
@@ -550,6 +550,7 @@ let prop_reconcile_e2e_catches_drift =
           test_stubs_introduced = [];
           test_stubs_implemented = [];
           complexity = None;
+          precedents = [];
         }
       in
       let graph = Graph.of_patches [ patch ] in
@@ -590,6 +591,7 @@ let prop_reconcile_dedup_rebase =
           test_stubs_introduced = [];
           test_stubs_implemented = [];
           complexity = None;
+          precedents = [];
         }
       in
       let graph = Graph.of_patches [ patch ] in

--- a/test/test_runtime_create.ml
+++ b/test/test_runtime_create.ml
@@ -17,6 +17,7 @@ let () =
       explicit_opinions = "";
       acceptance_criteria = [];
       open_questions = [];
+      functional_changes = [];
     }
   in
   let snapshot =
@@ -49,6 +50,7 @@ let () =
       explicit_opinions = "";
       acceptance_criteria = [];
       open_questions = [];
+      functional_changes = [];
     }
   in
   let snapshot =

--- a/test/test_spawn_logic.ml
+++ b/test/test_spawn_logic.ml
@@ -24,6 +24,7 @@ let make_gameplan patches =
       explicit_opinions = "";
       acceptance_criteria = [];
       open_questions = [];
+      functional_changes = [];
     }
 
 (* ========== Helper: prepare orchestrator with PRs and queued ops ========== *)

--- a/test/test_worktree_missing_recovery.ml
+++ b/test/test_worktree_missing_recovery.ml
@@ -97,6 +97,7 @@ let () =
           test_stubs_introduced = [];
           test_stubs_implemented = [];
           complexity = None;
+          precedents = [];
         };
     ]
   in


### PR DESCRIPTION
## Summary
- Add an optional `precedents` array to each gameplan patch (kind / name / url / why_applicable). Surfaces proven libraries, algorithms, patterns, papers, RFCs, or docs to implementing agents so they prefer prior art over rolling their own.
- Update `write-gameplan` and `write-workstream` skills to identify precedents during planning, with anti-name-dropping guardrails and a documented workstream → gameplan → patch handoff (workstream-level precedents get routed onto the specific patches that consume them, not blanket-copied).
- Wire end-to-end through onton: types, JSON parser, patch-layer prompt renderer, and PR-description renderer. The `## Established Precedents` section now appears in every implementer prompt (start, CI, review, conflict) and the PR body when a patch has precedents attached, and is omitted cleanly when empty.

## Test plan
- [x] `dune build` succeeds
- [x] `dune runtest` passes including new inline tests:
  - `lib_core/gameplan_parser.ml`: full extraction of all 4 fields, default-to-empty when absent, skipping entries that lack `kind` or `name`
  - `lib/prompt.ml`: `render_patch_layer` and `render_pr_description` both surface precedents when present and omit the section when empty
- [x] Schema example (`skills/write-gameplan/references/example.json`) validates against the updated `gameplan-schema.json` (verified with `ajv --spec=draft2020`)
- [ ] Manual smoke: run onton against a real gameplan with `precedents` populated and confirm the section appears in the implementer prompt and PR body

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/262"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds “Established Precedents” to patches and enforces explicit functional-change ownership across gameplans. Patch prompts and PR bodies now show precedents, and each patch gets a “Functional Changes You Own” list of only its assigned changes; blank functional change IDs are rejected.

- **New Features**
  - Functional changes: added `Functional_change` and `Gameplan.t.functional_changes`; parser rejects duplicate or blank `id`s and `ownedBy` values that don’t match a real patch; patch prompts render only the owned changes across all patch-layer prompts.
  - Precedents: added `Precedent` and `Patch.t.precedents`; parser reads `kind`/`name`/`url`/`whyApplicable` and skips malformed entries; implementer prompts and PR bodies render “Established Precedents” only when present.
  - Schema/docs: new `functionalChange`/`precedent` defs, required top-level `functionalChanges`, optional per-patch `precedents`, `precedent.url` required for `paper`/`rfc-spec`/`documentation`/`blog-post`, and a `functionalChangesOwnedByExactlyOnePatch` checklist item. Example and skills docs updated with guidance, workstream-level precedents, and handoff to per-patch `precedents`.

- **Migration**
  - Add a top-level `functionalChanges` array with unique, non-empty `id`s and valid `ownedBy` values; update to the latest `gameplan-schema.json`.
  - Attach precedents only to patches that actually consume them (workstream → gameplan → specific patches).

<sup>Written for commit dacb38bc9f6039367518297bb732326f7aee9ace. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

