### PR TITLE
Require operational considerations in gameplans

### DIFF
--- a/skills/write-gameplan/SKILL.md
+++ b/skills/write-gameplan/SKILL.md
@@ -53,6 +53,7 @@ All of these fields are **required** and must be present in every gameplan:
 | `problemStatement` | `string` | 2-4 sentences: what problem, why it matters |
 | `solutionSummary` | `string` | 3-5 sentences: high-level approach |
 | `currentStateAnalysis` | `string` | Where the codebase is now vs. where it needs to be |
+| `operationalConsiderations` | `object` | `{ externalSystemAccess, crossRuntimeContracts, failureBehavior, concurrencyAndIdempotency, rollbackStrategy }` — see [Operational Considerations](#operational-considerations) |
 | `mergabilityStrategy` | `object` | `{ featureFlagStrategy, featureFlags, patchOrderingStrategy }` |
 | `requiredChanges` | `array` | `[{ file, line, description, signature }]` |
 | `functionalChanges` | `array` | `[{ id, description, ownedBy }]` — exhaustive, every entry assigned to exactly one patch. See [Functional Change Ownership](#functional-change-ownership). |
@@ -142,6 +143,30 @@ Downstream consumers (notably onton's patch prompt renderer) read `functionalCha
 - Write each entry as the **outcome**, not the mechanism. "Merged patches are skipped instead of queued" is correct; "Add a merged-check branch to disposition" is an implementation step and belongs in `patches[].changes`.
 - Cross-check against `problemStatement`, `solutionSummary`, and `acceptanceCriteria`: every behavioral promise made there must correspond to at least one `functionalChange` entry. If you cannot point at the owning patch for a sentence in the problem statement, the gameplan has a gap.
 - Cross-check against `finalStateSpec`: every behavioral invariant in the spec should map to a functional change that introduces it (the spec says *what is true at the end*; the functional change says *which patch made it true*).
+
+## Operational Considerations
+
+Beyond *what changes*, a gameplan must engage with *how the system behaves operationally* under the change. These concerns share a failure shape: vague descriptions get scattered across patches, every patch author assumes some other patch owns the decision, and the question surfaces in production. The `operationalConsiderations` schema field is required and contains five sub-fields — each is a required string. The schema enforces presence; the rubric below makes each response substantive. A sub-field may state "not applicable" with a brief justification when the gameplan genuinely does not touch that surface, but it must be present and engage with this gameplan's actual code.
+
+### `externalSystemAccess`
+
+When a gameplan newly depends on an external system (object storage, database the runtime doesn't currently reach, third-party API, queue, secret store, internal service), the runtime executing the new code must be able to reach it in production. Audit the existing access posture of that runtime (direct SDK with ambient IAM, presigned URL handed in by another service, broker proxy, VPC endpoint, etc.), pick an access mode, and assign one patch to own the wiring — IAM grant, new endpoint, presigned-URL minting path, network policy, secret rotation. Be especially suspicious of newly-invented `*Client` / `*Transport` interfaces — they are where an undecided access-mode question hides. Sentinel classes whose existence encodes a *lack* of access (e.g. a `PresignedOnly*` adapter) are signals that the runtime cannot hold the underlying credentials. The chosen capability should appear as a `functionalChange` owned by that patch, not just as an interface parameter.
+
+### `crossRuntimeContracts`
+
+Any data format crossing a runtime boundary (queue payloads, DB rows read or written by separate services, S3 object schemas, RPC return types, event payloads) is a contract. When the gameplan changes one side, identify the producer and consumer runtimes, name which side this gameplan touches, and explain how the other side stays in sync — patched in the same gameplan, or made forward/backward-compatible with an explicit migration plan. Failure mode: producer ships, consumer breaks silently, and the gap is not visible from any single patch's `files` array.
+
+### `failureBehavior`
+
+For each new dependency or runtime path, describe behavior under realistic failure: dependency slow/throttling/5xx/garbage, retry storms, partial writes, timeouts, oversized inputs, expired credentials. State which failures are handled deliberately (documented recovery path or error surface) and which are intentionally left to the caller or operator. Failure mode: only the happy path is tested against a fake, and production discovers the rest.
+
+### `concurrencyAndIdempotency`
+
+Any new code path entered concurrently or under retry (queue workers, scheduled jobs, race-able write paths, parallel access to the same DB row or S3 key) has a concurrency contract: locking, idempotency keys, ordering guarantees, deduplication. State it explicitly. Failure mode: a quiet double-write or deadlock that only manifests under production load.
+
+### `rollbackStrategy`
+
+For stateful changes (DB schema, data writes, materialized artifacts, mutations to external systems), describe the rollback story: if a patch must be reverted after data is written, what's the recovery path? Expand/contract migrations, backfill plans, opt-in flags that wind down gracefully, compensating writes. Failure mode: assuming forward-only and stranding data in a half-migrated state.
 
 ## Patch Complexity
 
@@ -276,7 +301,8 @@ After writing the gameplan JSON, verify:
 3. The dependency graph is a valid DAG
 4. All test stubs have corresponding implementations
 5. **Functional change ownership is total and single-valued** — every `functionalChanges[i].id` is unique; every `functionalChanges[i].ownedBy` resolves to an existing `patches[].number`; no functional change appears unowned in prose. Re-read `problemStatement`, `solutionSummary`, `acceptanceCriteria`, and `finalStateSpec` and confirm every behavioral promise has a corresponding `functionalChanges` entry pointing at a single patch. Set `mergabilityChecklist.functionalChangesOwnedByExactlyOnePatch` to `true` only when this holds.
-6. The mergability checklist passes
+6. **Operational considerations are substantive** — the schema requires every sub-field of `operationalConsiderations` to be present, but presence is not engagement. For each sub-field, confirm the response names concrete surfaces in *this* gameplan (specific runtimes, formats, code paths, stateful writes) rather than generic platitudes. A sub-field may say "not applicable" only when the gameplan genuinely does not touch that surface, and only with a brief justification grounded in the actual changes. See [Operational Considerations](#operational-considerations).
+7. The mergability checklist passes
 
 ## Resolving Open Questions
 

--- a/skills/write-gameplan/references/example.json
+++ b/skills/write-gameplan/references/example.json
@@ -22,6 +22,14 @@
 
   "currentStateAnalysis": "main.ml contains runner_fiber (lines 941-1171) which mixes Eio I/O with pure decision logic: checking if a patch is merged, busy, has conflicts, CI failures, etc. The same patterns repeat across on_poll_result, on_human_message, and on_ci_status handlers. There is no pure decision module — decisions are inline pattern matches inside effectful code.",
 
+  "operationalConsiderations": {
+    "externalSystemAccess": "Not applicable. This refactor moves decision logic between in-process OCaml modules; no new external system is introduced. The decision functions consume record fields (merged, busy, ci_failure_count) that runner_fiber already populates from its existing inputs.",
+    "crossRuntimeContracts": "Not applicable. Patch_decision is internal to the onton binary — its functions are not called from another runtime, its types are not serialized to disk or wire, and its results are consumed within the same OCaml process that invokes them.",
+    "failureBehavior": "Patch_decision functions are total over their input domain (algebraic types and bounded ints), so they introduce no new I/O failure surface. Patch 4's wiring leaves the surrounding error paths in runner_fiber unchanged — replacing inline pattern matches with pure function calls cannot fail in ways the inline code could not.",
+    "concurrencyAndIdempotency": "Not applicable. Patch_decision is a pure module — its functions have no side effects and no shared state. Concurrent or repeated invocation returns identical results for identical inputs. The wiring patch does not change runner_fiber's Eio concurrency structure.",
+    "rollbackStrategy": "Not applicable. No stateful changes are made — no DB schema, no data writes, no external mutations. Rolling back means reverting the commits; runner_fiber returns to its previous inline-decision form with no data consequences."
+  },
+
   "requiredChanges": [
     {
       "file": "lib/patch_decision.ml",

--- a/skills/write-gameplan/references/example.json
+++ b/skills/write-gameplan/references/example.json
@@ -275,7 +275,8 @@
     "behaviorPatchesMinimal": true,
     "dependencyGraphOrdered": true,
     "behaviorPatchesJustified": true,
-    "functionalChangesOwnedByExactlyOnePatch": true
+    "functionalChangesOwnedByExactlyOnePatch": true,
+    "operationalConsiderationsSubstantive": true
   },
 
   "mergabilityInsight": "3 of 4 patches are INFRA and can ship without changing observable behavior. Only Patch 4 changes behavior (wiring).",

--- a/skills/write-gameplan/references/gameplan-schema.json
+++ b/skills/write-gameplan/references/gameplan-schema.json
@@ -458,7 +458,7 @@
         },
         "operationalConsiderationsSubstantive": {
           "type": "boolean",
-          "description": "Each operationalConsiderations sub-field (rolloutNotes, observability, rollbackPlan) engages concretely with this gameplan's specifics rather than issuing generic platitudes. Vague boilerplate like 'monitor for errors' or 'roll back if needed' without gameplan-specific detail does not qualify."
+          "description": "Each operationalConsiderations sub-field (externalSystemAccess, crossRuntimeContracts, failureBehavior, concurrencyAndIdempotency, rollbackStrategy) engages concretely with this gameplan's specifics rather than issuing generic platitudes. Vague boilerplate like 'not applicable' without a gameplan-specific justification, or phrases like 'monitor for errors' / 'roll back if needed' without naming actual code paths, do not qualify."
         }
       },
       "additionalProperties": false

--- a/skills/write-gameplan/references/gameplan-schema.json
+++ b/skills/write-gameplan/references/gameplan-schema.json
@@ -11,6 +11,7 @@
     "solutionSummary",
     "mergabilityStrategy",
     "currentStateAnalysis",
+    "operationalConsiderations",
     "requiredChanges",
     "functionalChanges",
     "acceptanceCriteria",
@@ -51,6 +52,9 @@
     "currentStateAnalysis": {
       "type": "string",
       "description": "Where the codebase is now vs. where it needs to be."
+    },
+    "operationalConsiderations": {
+      "$ref": "#/$defs/operationalConsiderations"
     },
     "requiredChanges": {
       "type": "array",
@@ -113,6 +117,40 @@
           "items": { "type": "string" }
         },
         "unlocks": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "operationalConsiderations": {
+      "type": "object",
+      "required": [
+        "externalSystemAccess",
+        "crossRuntimeContracts",
+        "failureBehavior",
+        "concurrencyAndIdempotency",
+        "rollbackStrategy"
+      ],
+      "description": "Operational/architectural concerns the gameplan must explicitly engage with. Each sub-field is a required string and may state 'not applicable' with a brief justification when this gameplan does not touch that surface — but the field must be present. The intent is to defeat the failure mode where a consequential decision (access mode, concurrency contract, rollback path, etc.) is elided in prose and surfaces only when an implementing agent hits it under deadline. See the 'Operational Considerations' section of SKILL.md for the failure pattern and authoring rubric for each sub-field.",
+      "properties": {
+        "externalSystemAccess": {
+          "type": "string",
+          "description": "For every external system (object storage, database the runtime doesn't currently reach, third-party API, queue, secret store, internal service) the gameplan newly depends on: name the runtime(s) executing the new code, the current access posture of those runtimes (direct SDK with ambient IAM, presigned URL from another service, broker proxy, VPC endpoint, etc.), the chosen access mode for this gameplan, and the patch that owns bringing that capability online (IAM grant, new endpoint, presigned-URL minting path, network policy). Be especially suspicious of newly-invented *Client/*Transport interfaces — they are exactly where an undecided access-mode question hides. Look for sentinel classes whose existence encodes a lack of access (e.g. a PresignedOnly* adapter). State 'not applicable' only if the gameplan adds no new external dependency."
+        },
+        "crossRuntimeContracts": {
+          "type": "string",
+          "description": "For every data format crossing a runtime boundary (queue payloads, DB rows read/written by separate services, S3 object schemas, RPC return types, event payloads) that this gameplan changes or introduces: name the producer and consumer runtimes, identify which side this gameplan touches, and explain how the other side stays in sync — either patched in the same gameplan, or made forward/backward-compatible with an explicit migration/deprecation plan. Failure mode: the producer ships, the consumer breaks silently."
+        },
+        "failureBehavior": {
+          "type": "string",
+          "description": "For each new dependency or runtime path the gameplan introduces, describe behavior under realistic failure modes: dependency slow/throttling/5xx/garbage, retry storms, partial writes, timeouts, oversized inputs, expired credentials. State which failures the gameplan handles deliberately (with a documented recovery path or error surface) and which it leaves to the caller or operator. Failure mode: only the happy path is tested, and production discovers the rest."
+        },
+        "concurrencyAndIdempotency": {
+          "type": "string",
+          "description": "For any new code path that can be entered concurrently or under retry (queue workers, scheduled jobs, race-able write paths, parallel access to the same DB row or S3 key), specify the concurrency contract: locking discipline, idempotency keys, ordering guarantees, deduplication strategy. Failure mode: a quiet double-write or deadlock that only manifests under production load. State 'not applicable' only if no new code path can be entered concurrently or retried."
+        },
+        "rollbackStrategy": {
+          "type": "string",
+          "description": "For stateful changes (DB schema, data writes, materialized artifacts, mutations to external systems), describe the rollback story: if a patch must be reverted after data is written, what is the recovery path? Expand/contract migrations, backfill plans, opt-in flags that wind down gracefully, compensating writes, etc. Failure mode: assuming forward-only and stranding data in a half-migrated state. State 'not applicable' only if no patch makes a stateful change."
+        }
       },
       "additionalProperties": false
     },

--- a/skills/write-gameplan/references/gameplan-schema.json
+++ b/skills/write-gameplan/references/gameplan-schema.json
@@ -439,7 +439,8 @@
         "behaviorPatchesMinimal",
         "dependencyGraphOrdered",
         "behaviorPatchesJustified",
-        "functionalChangesOwnedByExactlyOnePatch"
+        "functionalChangesOwnedByExactlyOnePatch",
+        "operationalConsiderationsSubstantive"
       ],
       "properties": {
         "featureFlagStrategyDocumented": { "type": "boolean" },
@@ -454,6 +455,10 @@
         "functionalChangesOwnedByExactlyOnePatch": {
           "type": "boolean",
           "description": "Every entry in functionalChanges has exactly one ownedBy patch, that patch exists, and the union of described behaviors covers every observable change implied by problemStatement/solutionSummary/acceptanceCriteria. No behavioral outcome is described in prose without a single named owner."
+        },
+        "operationalConsiderationsSubstantive": {
+          "type": "boolean",
+          "description": "Each operationalConsiderations sub-field (rolloutNotes, observability, rollbackPlan) engages concretely with this gameplan's specifics rather than issuing generic platitudes. Vague boilerplate like 'monitor for errors' or 'roll back if needed' without gameplan-specific detail does not qualify."
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
## Summary

- Adds a required `operationalConsiderations` object to the gameplan schema with five required string sub-fields: `externalSystemAccess`, `crossRuntimeContracts`, `failureBehavior`, `concurrencyAndIdempotency`, `rollbackStrategy`.
- Each sub-field carries an authoring rubric in its schema description and matching prose color in the new "Operational Considerations" section of SKILL.md. The schema enforces presence; the prose explains the failure pattern each sub-field defends against.
- Updates `example.json` to demonstrate the field end-to-end for a pure-refactor case, where every sub-field is legitimately "not applicable" but each response cites specific code rather than a generic platitude.

## Motivating incident

A lazy-S3 gameplan defined an `S3PrefixClient` interface and shipped seven patches consuming it, while the consuming runtime explicitly cannot reach S3 — the repo even has a `PresignedOnly*` sentinel class whose existence encodes that boundary. The skill had no defense against this: an undecided architectural decision hid behind a parameterised interface, every patch author assumed some other patch owned it, and the question would have surfaced only when an implementing agent tried to wire the transport. The same failure shape applies to cross-runtime contracts, failure behavior under realistic conditions, concurrency contracts, and rollback paths for stateful changes — hence one schema field with five sub-fields rather than a bespoke section per concern.

A sub-field may state "not applicable" with a brief justification when the gameplan genuinely does not touch that surface. The example demonstrates this pattern for a pure refactor (no I/O, no external system, no stateful writes).

## Schema-breaking note

`operationalConsiderations` is now required at the top level, so historical gameplans written before this change will fail schema validation. Most are already executed or in flight, so the practical impact is limited to anyone re-validating an old plan — fixable per-file if it comes up.

## Test plan

- [x] `ajv validate` against the updated schema confirms `example.json` is valid
- [x] Pre-commit hooks (dune build / runtest / format check) pass on the OCaml side — no parser or prompt code touched, so the changes are skill-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/269"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require a new `operationalConsiderations` object in the gameplan schema to make operational decisions explicit and avoid hidden architectural gaps. Add a checklist flag to confirm the answers are substantive, and fix the checklist description to reference the correct sub-field names.

- **New Features**
  - Schema: add required `operationalConsiderations` with `externalSystemAccess`, `crossRuntimeContracts`, `failureBehavior`, `concurrencyAndIdempotency`, `rollbackStrategy`. Each is a required string; “not applicable” allowed with a brief, code-grounded justification.
  - Checklist: add `mergabilityChecklist.operationalConsiderationsSubstantive` to back the SKILL.md verification step; docs updated; `references/example.json` sets it to `true`.

- **Migration**
  - Schema-breaking: older gameplans will fail validation until they add `operationalConsiderations`.
  - To adopt: add the object with all five fields and provide specific justifications where “not applicable” is used, then set the new checklist flag after review.

<sup>Written for commit ea38fafbc09e36a60e0e4e389d81a4923766252d. Summary will update on new commits. <a href="https://cubic.dev/pr/flowglad/onton/pull/269?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Gameplans now require an "Operational Considerations" section covering external system access, cross-runtime contracts, failure behavior, concurrency/idempotency, and rollback strategy.
  * Example gameplan updated to include a concrete operationalConsiderations block.
  * Verification/mergability checklist updated to require and validate that operational considerations are substantive and engage with the gameplan's actual surfaces.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flowglad/onton/pull/269?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->