### PR TITLE
[replay-ready-diagnostics] Patch 3: Preserve Claude stream-json information that the parser currently discards

### DIFF
--- a/lib/patch_agent_event_mapper.ml
+++ b/lib/patch_agent_event_mapper.ml
@@ -23,7 +23,14 @@ let parse_stop_reason (raw : string) : Types.Stop_reason.t =
 let map_event (event : Patch_agent_rpc.event) : Types.Stream_event.t =
   match event with
   | Session_init { session_id; _ } ->
-      Types.Stream_event.Session_init { session_id }
+      Types.Stream_event.Session_init
+        {
+          session_id;
+          api_key_source = None;
+          model = None;
+          claude_code_version = None;
+          permission_mode = None;
+        }
   | Turn_started _ -> Types.Stream_event.Turn_started
   | Text_delta { delta } -> Types.Stream_event.Text_delta delta
   | Tool_call { name; input; _ } ->

--- a/lib/session_driver.ml
+++ b/lib/session_driver.ml
@@ -348,7 +348,7 @@ let run_with_backend ~session_mode_for_agent
                 Buffer.add_string error_buf msg;
                 log_stream_entry runtime ~patch_id
                   (Activity_log.Stream_entry.Stream_error msg)
-            | Types.Stream_event.Session_init { session_id } ->
+            | Types.Stream_event.Session_init { session_id; _ } ->
                 captured_session_id := Some session_id
           in
           let result =

--- a/lib_core/claude_event_parser.ml
+++ b/lib_core/claude_event_parser.ml
@@ -131,6 +131,23 @@ let find_json_start s =
   | Some 0 | None -> s
   | Some n -> String.drop_prefix s n
 
+let session_init_of_json json =
+  let open Yojson.Safe.Util in
+  match member "session_id" json |> to_string_option with
+  | None -> []
+  | Some session_id ->
+      [
+        Types.Stream_event.Session_init
+          {
+            session_id;
+            api_key_source = member "apiKeySource" json |> to_string_option;
+            model = member "model" json |> to_string_option;
+            claude_code_version =
+              member "claude_code_version" json |> to_string_option;
+            permission_mode = member "permissionMode" json |> to_string_option;
+          };
+      ]
+
 let parse_stream_events (line : string) : Types.Stream_event.t list =
   try
     let json = Yojson.Safe.from_string (find_json_start line) in
@@ -202,11 +219,7 @@ let parse_stream_events (line : string) : Types.Stream_event.t list =
           member "is_error" json |> to_bool_option
           |> Option.value ~default:false
         in
-        let session_init =
-          match member "session_id" json |> to_string_option with
-          | Some sid -> [ Types.Stream_event.Session_init { session_id = sid } ]
-          | None -> []
-        in
+        let session_init = session_init_of_json json in
         if is_error then
           let errors =
             match member "errors" json with
@@ -214,10 +227,17 @@ let parse_stream_events (line : string) : Types.Stream_event.t list =
                 List.filter_map items ~f:(fun item -> to_string_option item)
             | _ -> []
           in
+          let result_text =
+            member "result" json |> to_string_option
+            |> Option.map ~f:String.strip
+          in
           let msg =
             match errors with
-            | [] -> "unknown error"
-            | errs -> String.concat ~sep:"; " errs
+            | _ :: _ as errs -> String.concat ~sep:"; " errs
+            | [] -> (
+                match result_text with
+                | Some text when not (String.is_empty text) -> text
+                | _ -> "unknown error")
           in
           session_init @ [ Types.Stream_event.Error msg ]
         else
@@ -243,11 +263,7 @@ let parse_stream_events (line : string) : Types.Stream_event.t list =
     | Some "system" -> (
         let subtype = member "subtype" json |> to_string_option in
         match subtype with
-        | Some "init" -> (
-            match member "session_id" json |> to_string_option with
-            | Some session_id ->
-                [ Types.Stream_event.Session_init { session_id } ]
-            | None -> [])
+        | Some "init" -> session_init_of_json json
         | _ -> [])
     | _ -> []
   with
@@ -582,6 +598,25 @@ let%test "parse_stream_event error result" =
   Option.equal Types.Stream_event.equal (parse_stream_event line)
     (Some (Types.Stream_event.Error "bad session ID"))
 
+let%test "parse_stream_event result with empty errors uses result text" =
+  let line =
+    {|{"type":"result","is_error":true,"errors":[],"result":"auth unavailable"}|}
+  in
+  Option.equal Types.Stream_event.equal (parse_stream_event line)
+    (Some (Types.Stream_event.Error "auth unavailable"))
+
+let%test "parse_stream_event result with non-empty errors prefers errors array" =
+  let line =
+    {|{"type":"result","is_error":true,"errors":["first","second"],"result":"ignored"}|}
+  in
+  Option.equal Types.Stream_event.equal (parse_stream_event line)
+    (Some (Types.Stream_event.Error "first; second"))
+
+let%test "parse_stream_event result with both absent falls back to unknown error" =
+  let line = {|{"type":"result","is_error":true,"errors":[]}|} in
+  Option.equal Types.Stream_event.equal (parse_stream_event line)
+    (Some (Types.Stream_event.Error "unknown error"))
+
 let%test "parse_stream_event invalid json returns None" =
   Option.is_none (parse_stream_event "not json at all")
 
@@ -595,7 +630,30 @@ let%test "parse_stream_events extracts session_id from system/init" =
   List.equal Types.Stream_event.equal (parse_stream_events line)
     [
       Types.Stream_event.Session_init
-        { session_id = "d3c2d71e-0399-4ed3-810a-9c1edce7dd00" };
+        {
+          session_id = "d3c2d71e-0399-4ed3-810a-9c1edce7dd00";
+          api_key_source = None;
+          model = None;
+          claude_code_version = None;
+          permission_mode = None;
+        };
+    ]
+
+let%test "parse_stream_events Session_init carries apiKeySource/model/version/permissionMode"
+    =
+  let line =
+    {|{"type":"system","subtype":"init","session_id":"abc-123","apiKeySource":"project","model":"sonnet","claude_code_version":"2.1.144","permissionMode":"bypassPermissions"}|}
+  in
+  List.equal Types.Stream_event.equal (parse_stream_events line)
+    [
+      Types.Stream_event.Session_init
+        {
+          session_id = "abc-123";
+          api_key_source = Some "project";
+          model = Some "sonnet";
+          claude_code_version = Some "2.1.144";
+          permission_mode = Some "bypassPermissions";
+        };
     ]
 
 let%test "parse_stream_events ignores system events without init subtype" =
@@ -611,7 +669,16 @@ let%test "parse_stream_events tolerates leading garbage before JSON" =
     "^D\x08\x08{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"abc-123\",\"tools\":[]}"
   in
   List.equal Types.Stream_event.equal (parse_stream_events line)
-    [ Types.Stream_event.Session_init { session_id = "abc-123" } ]
+    [
+      Types.Stream_event.Session_init
+        {
+          session_id = "abc-123";
+          api_key_source = None;
+          model = None;
+          claude_code_version = None;
+          permission_mode = None;
+        };
+    ]
 
 let%test "parse_stream_events extracts session_id from result event" =
   let line =
@@ -619,7 +686,14 @@ let%test "parse_stream_events extracts session_id from result event" =
   in
   List.equal Types.Stream_event.equal (parse_stream_events line)
     [
-      Types.Stream_event.Session_init { session_id = "def-456" };
+      Types.Stream_event.Session_init
+        {
+          session_id = "def-456";
+          api_key_source = None;
+          model = None;
+          claude_code_version = None;
+          permission_mode = None;
+        };
       Types.Stream_event.Final_result
         { text = "done"; stop_reason = Types.Stop_reason.End_turn };
     ]

--- a/lib_core/claude_event_parser.ml
+++ b/lib_core/claude_event_parser.ml
@@ -605,14 +605,16 @@ let%test "parse_stream_event result with empty errors uses result text" =
   Option.equal Types.Stream_event.equal (parse_stream_event line)
     (Some (Types.Stream_event.Error "auth unavailable"))
 
-let%test "parse_stream_event result with non-empty errors prefers errors array" =
+let%test
+    "parse_stream_event result with non-empty errors prefers errors array" =
   let line =
     {|{"type":"result","is_error":true,"errors":["first","second"],"result":"ignored"}|}
   in
   Option.equal Types.Stream_event.equal (parse_stream_event line)
     (Some (Types.Stream_event.Error "first; second"))
 
-let%test "parse_stream_event result with both absent falls back to unknown error" =
+let%test
+    "parse_stream_event result with both absent falls back to unknown error" =
   let line = {|{"type":"result","is_error":true,"errors":[]}|} in
   Option.equal Types.Stream_event.equal (parse_stream_event line)
     (Some (Types.Stream_event.Error "unknown error"))
@@ -639,8 +641,9 @@ let%test "parse_stream_events extracts session_id from system/init" =
         };
     ]
 
-let%test "parse_stream_events Session_init carries apiKeySource/model/version/permissionMode"
-    =
+let%test
+    "parse_stream_events Session_init carries \
+     apiKeySource/model/version/permissionMode" =
   let line =
     {|{"type":"system","subtype":"init","session_id":"abc-123","apiKeySource":"project","model":"sonnet","claude_code_version":"2.1.144","permissionMode":"bypassPermissions"}|}
   in

--- a/lib_core/claude_event_parser.ml
+++ b/lib_core/claude_event_parser.ml
@@ -229,7 +229,7 @@ let parse_stream_events (line : string) : Types.Stream_event.t list =
           in
           let result_text =
             member "result" json |> to_string_option
-            |> Option.map ~f:String.strip
+            |> Option.map ~f:(fun text -> String.strip text)
           in
           let msg =
             match errors with

--- a/lib_core/claude_event_parser.ml
+++ b/lib_core/claude_event_parser.ml
@@ -262,9 +262,7 @@ let parse_stream_events (line : string) : Types.Stream_event.t list =
         [ Types.Stream_event.Error err ]
     | Some "system" -> (
         let subtype = member "subtype" json |> to_string_option in
-        match subtype with
-        | Some "init" -> session_init_of_json json
-        | _ -> [])
+        match subtype with Some "init" -> session_init_of_json json | _ -> [])
     | _ -> []
   with
   | Yojson.Json_error _ -> []
@@ -605,8 +603,8 @@ let%test "parse_stream_event result with empty errors uses result text" =
   Option.equal Types.Stream_event.equal (parse_stream_event line)
     (Some (Types.Stream_event.Error "auth unavailable"))
 
-let%test
-    "parse_stream_event result with non-empty errors prefers errors array" =
+let%test "parse_stream_event result with non-empty errors prefers errors array"
+    =
   let line =
     {|{"type":"result","is_error":true,"errors":["first","second"],"result":"ignored"}|}
   in

--- a/lib_core/codex_event_parser.ml
+++ b/lib_core/codex_event_parser.ml
@@ -66,7 +66,16 @@ let parse_event_with_cost_tracking ~model ~budget_cap_nano_usd ~cost_state line
         | Some "thread.started" -> (
             match member "thread_id" json |> to_string_option with
             | Some id when not (String.is_empty id) ->
-                ( [ Types.Stream_event.Session_init { session_id = id } ],
+                ( [
+                    Types.Stream_event.Session_init
+                      {
+                        session_id = id;
+                        api_key_source = None;
+                        model = None;
+                        claude_code_version = None;
+                        permission_mode = None;
+                      };
+                  ],
                   cost_state )
             | _ -> ([], cost_state))
         | Some "turn.started" ->
@@ -194,7 +203,13 @@ let%test "parse_event thread.started emits Session_init" =
   List.equal Types.Stream_event.equal (parse_event line)
     [
       Types.Stream_event.Session_init
-        { session_id = "019d91e0-5731-7182-ac68-19922a243e95" };
+        {
+          session_id = "019d91e0-5731-7182-ac68-19922a243e95";
+          api_key_source = None;
+          model = None;
+          claude_code_version = None;
+          permission_mode = None;
+        };
     ]
 
 let%test "parse_event thread.started without thread_id is ignored" =

--- a/lib_core/gemini_event_parser.ml
+++ b/lib_core/gemini_event_parser.ml
@@ -30,7 +30,16 @@ let parse_event (line : string) : Types.Stream_event.t list =
         | Some "init" -> (
             match member "session_id" json |> to_string_option with
             | Some id when not (String.is_empty id) ->
-                [ Types.Stream_event.Session_init { session_id = id } ]
+                [
+                  Types.Stream_event.Session_init
+                    {
+                      session_id = id;
+                      api_key_source = None;
+                      model = None;
+                      claude_code_version = None;
+                      permission_mode = None;
+                    };
+                ]
             | _ -> [])
         | Some "message" -> (
             let role = member "role" json |> to_string_option in
@@ -151,7 +160,16 @@ let%test "parse_event init" =
     {|{"type":"init","timestamp":"2026-04-13T14:16:47.453Z","session_id":"abc-123","model":"gemini-3-flash-preview"}|}
   in
   List.equal Types.Stream_event.equal (parse_event line)
-    [ Types.Stream_event.Session_init { session_id = "abc-123" } ]
+    [
+      Types.Stream_event.Session_init
+        {
+          session_id = "abc-123";
+          api_key_source = None;
+          model = None;
+          claude_code_version = None;
+          permission_mode = None;
+        };
+    ]
 
 let%test "parse_event assistant message" =
   let line =

--- a/lib_core/opencode_event_parser.ml
+++ b/lib_core/opencode_event_parser.ml
@@ -57,7 +57,14 @@ let parse_event (line : string) : Types.Stream_event.t list =
             | Some id when not (String.is_empty id) ->
                 [
                   Types.Stream_event.Turn_started;
-                  Types.Stream_event.Session_init { session_id = id };
+                  Types.Stream_event.Session_init
+                    {
+                      session_id = id;
+                      api_key_source = None;
+                      model = None;
+                      claude_code_version = None;
+                      permission_mode = None;
+                    };
                 ]
             | _ -> [])
         | Some "text" ->
@@ -265,7 +272,14 @@ let%test "parse_event step_start emits session_init" =
   List.equal Types.Stream_event.equal (parse_event line)
     [
       Types.Stream_event.Turn_started;
-      Types.Stream_event.Session_init { session_id = "ses_abc" };
+      Types.Stream_event.Session_init
+        {
+          session_id = "ses_abc";
+          api_key_source = None;
+          model = None;
+          claude_code_version = None;
+          permission_mode = None;
+        };
     ]
 
 let%test "parse_event step_finish stop" =

--- a/lib_core/types.ml
+++ b/lib_core/types.ml
@@ -246,7 +246,13 @@ module Stream_event = struct
     | Tool_use of { name : string; input : string; status : string option }
     | Final_result of { text : string; stop_reason : Stop_reason.t }
     | Error of string
-    | Session_init of { session_id : string }
+    | Session_init of {
+        session_id : string;
+        api_key_source : string option; [@yojson.default None]
+        model : string option; [@yojson.default None]
+        claude_code_version : string option; [@yojson.default None]
+        permission_mode : string option; [@yojson.default None]
+      }
   [@@deriving show, eq, sexp_of, compare, yojson]
 end
 

--- a/lib_core/types.mli
+++ b/lib_core/types.mli
@@ -229,7 +229,13 @@ module Stream_event : sig
       }
     | Final_result of { text : string; stop_reason : Stop_reason.t }
     | Error of string
-    | Session_init of { session_id : string }
+    | Session_init of {
+        session_id : string;
+        api_key_source : string option;
+        model : string option;
+        claude_code_version : string option;
+        permission_mode : string option;
+      }
   [@@deriving show, eq, sexp_of, compare]
 end
 

--- a/test/test_patch_agent_event_mapper.ml
+++ b/test/test_patch_agent_event_mapper.ml
@@ -69,7 +69,14 @@ let prop_session_id_preserved =
         (Patch_agent_event_mapper.map_event
            (Patch_agent_rpc.Session_init
               { session_id; model_id = "model"; provider = "provider" }))
-        (Types.Stream_event.Session_init { session_id }))
+        (Types.Stream_event.Session_init
+           {
+             session_id;
+             api_key_source = None;
+             model = None;
+             claude_code_version = None;
+             permission_mode = None;
+           }))
 
 let prop_tool_call_preserved =
   QCheck2.Test.make


### PR DESCRIPTION
## Patch 3: Preserve Claude stream-json information that the parser currently discards

- In lib_core/types.ml, change Session_init variant from { session_id : string } to { session_id : string; api_key_source : string option; model : string option; claude_code_version : string option; permission_mode : string option } with [@@deriving show, eq, sexp_of, compare, yojson]. Old JSON without the new fields must still deserialize.
- In claude_event_parser.ml at the Some "result" arm: when is_error=true, read result.result via member "result" json |> to_string_option. Prefer that text when non-empty; fall back to errors-array concat; final fallback 'unknown error'.
- In claude_event_parser.ml at the Some "system" / Some "init" arm and the Some "result" session_init construction: also read api_key_source / model / claude_code_version / permission_mode and pass to Session_init.
- Add inline let%test blocks: (i) result event with is_error=true + empty errors + non-empty result text → Error event with result text; (ii) result event with is_error=true + non-empty errors → Error with errors concat (errors wins to preserve old behavior on structured errors); (iii) result event with is_error=true + both empty → Error 'unknown error'; (iv) system/init event with all 4 new fields populated → Session_init carries them all.

## Changes
- In lib_core/types.ml, change Session_init variant from { session_id : string } to { session_id : string; api_key_source : string option; model : string option; claude_code_version : string option; permission_mode : string option } with [@@deriving show, eq, sexp_of, compare, yojson]. Old JSON without the new fields must still deserialize.
- In claude_event_parser.ml at the Some "result" arm: when is_error=true, read result.result via member "result" json |> to_string_option. Prefer that text when non-empty; fall back to errors-array concat; final fallback 'unknown error'.
- In claude_event_parser.ml at the Some "system" / Some "init" arm and the Some "result" session_init construction: also read api_key_source / model / claude_code_version / permission_mode and pass to Session_init.
- Add inline let%test blocks: (i) result event with is_error=true + empty errors + non-empty result text → Error event with result text; (ii) result event with is_error=true + non-empty errors → Error with errors concat (errors wins to preserve old behavior on structured errors); (iii) result event with is_error=true + both empty → Error 'unknown error'; (iv) system/init event with all 4 new fields populated → Session_init carries them all.

## Files to Modify
- lib_core/types.ml (modify): Extend Stream_event.Session_init with optional api_key_source / model / claude_code_version / permission_mode fields. All four are option to remain backwards-compatible with previously-recorded events and pre-2.1.144 claude versions.
- lib_core/claude_event_parser.ml (modify): Two changes: (a) when 'result' event has is_error=true, build the Error message from result.result text if non-empty; fall back to errors array concat; fall back to 'unknown error' only if both absent. (b) Parse the four new Session_init fields from both 'result' and 'system'→'init' event shapes.

## Gameplan Specification

```
module REPLAY_READY_DIAGNOSTICS.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> Onton's observability is unified through a single typed
> Event variant routed via pluggable Sinks.  Pure decision
> (route, interested_in) is separated from effectful handling
> (consume, emit).  Every claude spawn produces a self-
> contained on-disk artifact directory at sessions/<uuid>/
> sufficient to diagnose the spawn's outcome offline.  Each
> spawn is classified by a typed Subkind enum.  The
> --upload-debug bundle includes a top-level manifest.json
> with a per-patch most-recent-subkind summary and no raw
> secrets.

Event.
Sink.
Spawn.
Meta.
Subkind.

ok => Subkind.
auth-unavailable => Subkind.
api-error => Subkind.
network-error => Subkind.
timed-out => Subkind.
no-session-to-resume => Subkind.
empty-response => Subkind.
process-error => Subkind.
other => Subkind.

> Telemetry layer.
sink-name s: Sink => String.
interested-in? s: Sink, e: Event => Bool.
consumed? s: Sink, e: Event => Bool.
route sinks: [Sink], e: Event => [Sink].

> Spawn / artifact layer.
spawn-completed? sp: Spawn => Bool.
spawn-uuid sp: Spawn => String.
spawn-meta sp: Spawn => Meta.
spawn-subkind sp: Spawn => Subkind.
artifact-dir-for sp: Spawn => String.
meta-path-for sp: Spawn => String.
schema-version m: Meta => Nat0.
subkind-of m: Meta => Subkind.
on-disk? p: String => Bool.
---

> Telemetry route is pure: a sink is in the output iff it was in the input AND interested.
all sinks: [Sink], e: Event, s: Sink, s in route sinks e | s in sinks.
all sinks: [Sink], e: Event, s: Sink, s in route sinks e | interested-in? s e.
all sinks: [Sink], e: Event, s: Sink, s in sinks, interested-in? s e | s in route sinks e.

> Emit dispatches an event to every interested sink (captured as consumed?).
all sinks: [Sink], e: Event, s: Sink, s in route sinks e | consumed? s e.

> Every completed spawn produces a finalized artifact dir on disk.
all sp: Spawn, spawn-completed? sp | on-disk? (artifact-dir-for sp).
all sp: Spawn, spawn-completed? sp | on-disk? (meta-path-for sp).

> meta.json carries schema_version = 1 and the classified subkind.
all sp: Spawn, spawn-completed? sp | schema-version (spawn-meta sp) = 1.
all sp: Spawn, spawn-completed? sp | subkind-of (spawn-meta sp) = spawn-subkind sp.

where

> ══════════════════════════════════════════
> Bundle manifest
> ══════════════════════════════════════════

Bundle.
Manifest.
File.

manifest-of b: Bundle => Manifest.
manifest-version m: Manifest => Nat0.
files-in b: Bundle => [File].
file-contents f: File => String.
contains-secret? s: String => Bool.
---

> Every --upload-debug bundle has a versioned manifest.
all b: Bundle | manifest-version (manifest-of b) = 1.

> Bundles never contain raw secrets.
all b: Bundle, f: File, f in files-in b | ~ contains-secret? (file-contents f).

```

## Patch Specification

```
module REPLAY_READY_DIAGNOSTICS_PATCH_3.

> Patch 3 extends the parser to preserve information that was
> previously thrown away.  No behavioral change to onton's
> orchestrator — the new data is now available but unconsumed.

ResultEvent.
InitEvent.
ErrorMsgSource.

errors-source => ErrorMsgSource.
result-text-source => ErrorMsgSource.
fallback-source => ErrorMsgSource.

is-error? r: ResultEvent => Bool.
has-errors? r: ResultEvent => Bool.
has-result-text? r: ResultEvent => Bool.
error-msg-source r: ResultEvent => ErrorMsgSource.

has-api-key-source? i: InitEvent => Bool.
has-model? i: InitEvent => Bool.
has-claude-version? i: InitEvent => Bool.
has-permission-mode? i: InitEvent => Bool.
---

> When the result event has explicit errors, the message is from the errors array.
all r: ResultEvent, is-error? r, has-errors? r | error-msg-source r = errors-source.

> When the result event has no errors but has result text, the message is from the result text.
all r: ResultEvent, is-error? r, has-result-text? r | error-msg-source r = result-text-source.

```


## Implementation Notes

- The `Session_init` shape change required touching other backend parsers and the patch-agent mapper so they continue constructing `Stream_event.Session_init` explicitly with the new fields set to `None`. The patch remains behavior-neutral for non-Claude backends.
- I factored Claude `Session_init` extraction into a small local helper so the `system/init` and `result` paths read the same field set and cannot drift independently.
- Backward compatibility for persisted JSON is handled with `[@yojson.default None]` on the new optional fields in `types.ml`; the `.mli` just exposes the expanded record shape.
- One small parser choice worth calling out: `result.result` is stripped before the emptiness check, so whitespace-only payloads still fall through to structured errors or the `"unknown error"` fallback instead of being treated as meaningful text.
- I could not complete `dune build`/`dune runtest` in this environment because the configured OCaml toolchain and project deps were unavailable here (`ocamlc` was initially missing from `PATH`, and after loading the only installed switch, required libraries such as `re`, `yojson`, `eio_main`, `ppx_deriving.show`, and `qcheck-core` were not installed).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves Claude session-init metadata and improves error message handling in the stream parser. Extends `Session_init` and updates all parsers to stay backward-compatible with old JSON.

- **New Features**
  - Extend `Session_init` with optional `api_key_source`, `model`, `claude_code_version`, and `permission_mode`.
  - Parse and emit these from Claude `system/init` and `result` events; `codex`, `gemini`, `opencode`, and the patch agent now set them to `None`.
  - Use a shared helper to build `Session_init` to keep `system/init` and `result` in sync.

- **Bug Fixes**
  - For `result` events with `is_error=true`, message preference: errors array → trimmed `result` text → "unknown error".
  - Resolved a minor pattern-match warning in the Claude parser.

<sup>Written for commit db33d8291eadd0ccd3026b8299a7306d6dadf56b. Summary will update on new commits. <a href="https://cubic.dev/pr/flowglad/onton/pull/270?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Session initialization now consistently includes optional metadata (API key source, model, version, permission mode) across event handling for improved consistency.
* **Bug Fixes**
  * Error messages during result parsing now prefer structured error arrays, fall back to trimmed text, then to "unknown error" for clearer diagnostics.
* **Tests**
  * Unit tests updated to validate the expanded session-init shape and improved error-message behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flowglad/onton/pull/270?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->