### PR TITLE
[replay-ready-diagnostics] Patch 1: Add Failure_subkind taxonomy and classifier

### DIFF
--- a/lib_core/failure_subkind.ml
+++ b/lib_core/failure_subkind.ml
@@ -61,8 +61,9 @@ let init_info_of_yojson json =
   let open Yojson.Safe.Util in
   let read_opt_string field =
     match member field json with
+    | `String s -> Some s
     | `Null -> None
-    | value -> to_string_option value
+    | _ -> None
   in
   {
     api_key_source = read_opt_string "api_key_source";

--- a/lib_core/failure_subkind.ml
+++ b/lib_core/failure_subkind.ml
@@ -20,7 +20,6 @@ type init_info = {
 [@@deriving show, eq]
 
 let t_of_yojson json =
-  let open Yojson.Safe.Util in
   match json with
   | `String "Ok" -> (Ok : t)
   | `String "Auth_unavailable" -> Auth_unavailable
@@ -30,7 +29,13 @@ let t_of_yojson json =
   | `String "Empty_response" -> Empty_response
   | `String "Process_error" -> Process_error
   | `Assoc [ ("Api_error", payload) ] ->
-      let status = payload |> member "status" |> to_int_option in
+      let status =
+        match payload with
+        | `Assoc fields ->
+            List.Assoc.find fields ~equal:String.equal "status"
+            |> Option.bind ~f:(function `Int n -> Some n | _ -> None)
+        | _ -> None
+      in
       Api_error { status }
   | `Assoc [ ("Other", `String detail) ] -> Other detail
   | _ -> Other "invalid_failure_subkind"
@@ -97,13 +102,18 @@ let mentions_network_failure stderr_tail =
 
 let classify_session_failed ~init ~text_tail ~stderr_tail ~detail =
   if mentions_not_logged_in text_tail then Auth_unavailable
-  else if api_key_source_none init then Auth_unavailable
+  else if
+    api_key_source_none init && String.is_empty text_tail
+    && String.is_empty stderr_tail
+  then Auth_unavailable
   else
     match api_error_status stderr_tail with
     | Some status -> Api_error { status = Some status }
     | None when mentions_network_failure stderr_tail -> Network_error
     | None when String.is_empty text_tail && String.is_empty stderr_tail ->
-        Empty_response
+        if String.is_empty detail || String.equal detail "(no error details)"
+        then Empty_response
+        else Other detail
     | None -> Other detail
 
 let classify ~classification ~init ~text_tail ~stderr_tail =
@@ -145,8 +155,17 @@ let%test "Auth_unavailable from api_key_source none + no Final_result" =
        ~classification:
          (Run_classification.Session_failed { exit_code = 1; detail = "detail" })
        ~init:{ default_init with api_key_source = Some "none" }
-       ~text_tail:"" ~stderr_tail:"stderr")
+       ~text_tail:"" ~stderr_tail:"")
     Auth_unavailable
+
+let%test "api_key_source none does not mask API errors" =
+  equal
+    (classify
+       ~classification:
+         (Run_classification.Session_failed { exit_code = 1; detail = "detail" })
+       ~init:{ default_init with api_key_source = Some "none" }
+       ~text_tail:"" ~stderr_tail:"API Error: 401 Unauthorized")
+    (Api_error { status = Some 401 })
 
 let%test "Api_error 401 from stderr" =
   equal
@@ -170,6 +189,16 @@ let%test "Empty_response when text and stderr are empty" =
   equal
     (classify
        ~classification:
-         (Run_classification.Session_failed { exit_code = 1; detail = "detail" })
+         (Run_classification.Session_failed
+            { exit_code = 1; detail = "(no error details)" })
        ~init:default_init ~text_tail:"" ~stderr_tail:"")
     Empty_response
+
+let%test "non-empty detail with empty tails falls through to Other" =
+  equal
+    (classify
+       ~classification:
+         (Run_classification.Session_failed
+            { exit_code = 1; detail = "exit 1 with explanation" })
+       ~init:default_init ~text_tail:"" ~stderr_tail:"")
+    (Other "exit 1 with explanation")

--- a/lib_core/failure_subkind.ml
+++ b/lib_core/failure_subkind.ml
@@ -1,0 +1,175 @@
+open Base
+
+type t =
+  | Ok
+  | Auth_unavailable
+  | Api_error of { status : int option }
+  | Network_error
+  | Timed_out
+  | No_session_to_resume
+  | Empty_response
+  | Process_error
+  | Other of string
+[@@deriving show, eq, sexp_of]
+
+type init_info = {
+  api_key_source : string option;
+  model : string option;
+  claude_code_version : string option;
+}
+[@@deriving show, eq]
+
+let t_of_yojson json =
+  let open Yojson.Safe.Util in
+  match json with
+  | `String "Ok" -> (Ok : t)
+  | `String "Auth_unavailable" -> Auth_unavailable
+  | `String "Network_error" -> Network_error
+  | `String "Timed_out" -> Timed_out
+  | `String "No_session_to_resume" -> No_session_to_resume
+  | `String "Empty_response" -> Empty_response
+  | `String "Process_error" -> Process_error
+  | `Assoc [ ("Api_error", payload) ] ->
+      let status = payload |> member "status" |> to_int_option in
+      Api_error { status }
+  | `Assoc [ ("Other", `String detail) ] -> Other detail
+  | _ -> Other "invalid_failure_subkind"
+
+let yojson_of_t = function
+  | (Ok : t) -> `String "Ok"
+  | Auth_unavailable -> `String "Auth_unavailable"
+  | Api_error { status } ->
+      let fields =
+        match status with
+        | None -> []
+        | Some status -> [ ("status", `Int status) ]
+      in
+      `Assoc [ ("Api_error", `Assoc fields) ]
+  | Network_error -> `String "Network_error"
+  | Timed_out -> `String "Timed_out"
+  | No_session_to_resume -> `String "No_session_to_resume"
+  | Empty_response -> `String "Empty_response"
+  | Process_error -> `String "Process_error"
+  | Other detail -> `Assoc [ ("Other", `String detail) ]
+
+let init_info_of_yojson json =
+  let open Yojson.Safe.Util in
+  let read_opt_string field =
+    match member field json with
+    | `Null -> None
+    | value -> to_string_option value
+  in
+  {
+    api_key_source = read_opt_string "api_key_source";
+    model = read_opt_string "model";
+    claude_code_version = read_opt_string "claude_code_version";
+  }
+
+let yojson_of_init_info init =
+  let opt_field name = function
+    | None -> []
+    | Some value -> [ (name, `String value) ]
+  in
+  `Assoc
+    (opt_field "api_key_source" init.api_key_source
+    @ opt_field "model" init.model
+    @ opt_field "claude_code_version" init.claude_code_version)
+
+let contains haystack needle = String.is_substring haystack ~substring:needle
+
+let mentions_not_logged_in text_tail =
+  contains text_tail "Not logged in" || contains text_tail "Please run /login"
+
+let api_key_source_none init =
+  Option.value_map init.api_key_source ~default:false ~f:(String.equal "none")
+
+let api_error_re = Re.Perl.compile_pat "API Error: ([0-9]{3})"
+
+let api_error_status stderr_tail =
+  match Re.exec_opt api_error_re stderr_tail with
+  | None -> None
+  | Some groups ->
+      Re.Group.get_opt groups 1 |> Option.bind ~f:Stdlib.int_of_string_opt
+
+let mentions_network_failure stderr_tail =
+  List.exists [ "getaddrinfo"; "EAI_AGAIN"; "ECONNREFUSED"; "TLS handshake" ]
+    ~f:(fun needle -> contains stderr_tail needle)
+
+let classify_session_failed ~init ~text_tail ~stderr_tail ~detail =
+  if mentions_not_logged_in text_tail then Auth_unavailable
+  else if api_key_source_none init then Auth_unavailable
+  else
+    match api_error_status stderr_tail with
+    | Some status -> Api_error { status = Some status }
+    | None when mentions_network_failure stderr_tail -> Network_error
+    | None when String.is_empty text_tail && String.is_empty stderr_tail ->
+        Empty_response
+    | None -> Other detail
+
+let classify ~classification ~init ~text_tail ~stderr_tail =
+  match classification with
+  | Run_classification.Process_error _ -> Process_error
+  | No_session_to_resume -> No_session_to_resume
+  | Timed_out -> Timed_out
+  | Success _ -> Ok
+  | Session_failed { detail; _ } ->
+      classify_session_failed ~init ~text_tail ~stderr_tail ~detail
+
+let to_string = function
+  | (Ok : t) -> "ok"
+  | Auth_unavailable -> "auth_unavailable"
+  | Api_error { status = Some status } -> "api_error_" ^ Int.to_string status
+  | Api_error { status = None } -> "api_error"
+  | Network_error -> "network_error"
+  | Timed_out -> "timed_out"
+  | No_session_to_resume -> "no_session_to_resume"
+  | Empty_response -> "empty_response"
+  | Process_error -> "process_error"
+  | Other _ -> "other"
+
+let default_init =
+  { api_key_source = None; model = None; claude_code_version = None }
+
+let%test "Auth_unavailable from Not logged in text" =
+  equal
+    (classify
+       ~classification:
+         (Run_classification.Session_failed { exit_code = 1; detail = "detail" })
+       ~init:default_init ~text_tail:"Not logged in to Claude Code"
+       ~stderr_tail:"")
+    Auth_unavailable
+
+let%test "Auth_unavailable from api_key_source none + no Final_result" =
+  equal
+    (classify
+       ~classification:
+         (Run_classification.Session_failed { exit_code = 1; detail = "detail" })
+       ~init:{ default_init with api_key_source = Some "none" }
+       ~text_tail:"" ~stderr_tail:"stderr")
+    Auth_unavailable
+
+let%test "Api_error 401 from stderr" =
+  equal
+    (classify
+       ~classification:
+         (Run_classification.Session_failed { exit_code = 1; detail = "detail" })
+       ~init:default_init ~text_tail:""
+       ~stderr_tail:"API Error: 401 Unauthorized")
+    (Api_error { status = Some 401 })
+
+let%test "Network_error from getaddrinfo stderr" =
+  equal
+    (classify
+       ~classification:
+         (Run_classification.Session_failed { exit_code = 1; detail = "detail" })
+       ~init:default_init ~text_tail:""
+       ~stderr_tail:"socket error: getaddrinfo EAI_AGAIN")
+    Network_error
+
+let%test "Empty_response when text and stderr are empty" =
+  equal
+    (classify
+       ~classification:
+         (Run_classification.Session_failed { exit_code = 1; detail = "detail" })
+       ~init:default_init ~text_tail:"" ~stderr_tail:"")
+    Empty_response

--- a/lib_core/failure_subkind.mli
+++ b/lib_core/failure_subkind.mli
@@ -1,0 +1,34 @@
+open Base
+
+type t =
+  | Ok
+  | Auth_unavailable
+  | Api_error of { status : int option }
+  | Network_error
+  | Timed_out
+  | No_session_to_resume
+  | Empty_response
+  | Process_error
+  | Other of string
+[@@deriving show, eq, sexp_of]
+
+type init_info = {
+  api_key_source : string option;
+  model : string option;
+  claude_code_version : string option;
+}
+[@@deriving show, eq]
+
+val t_of_yojson : Yojson.Safe.t -> t
+val yojson_of_t : t -> Yojson.Safe.t
+val init_info_of_yojson : Yojson.Safe.t -> init_info
+val yojson_of_init_info : init_info -> Yojson.Safe.t
+
+val classify :
+  classification:Run_classification.classification ->
+  init:init_info ->
+  text_tail:string ->
+  stderr_tail:string ->
+  t
+
+val to_string : t -> string

--- a/test/dune
+++ b/test/dune
@@ -183,6 +183,13 @@
  (ocamlc_flags (:standard -w -40-42)))
 
 (test
+ (name test_failure_subkind_properties)
+ (modules test_failure_subkind_properties)
+ (libraries onton_core qcheck-core qcheck-core.runner)
+ (ocamlopt_flags (:standard -w -40-42))
+ (ocamlc_flags (:standard -w -40-42)))
+
+(test
  (name test_patch_controller)
  (modules test_patch_controller)
  (libraries onton onton_core onton_test_support qcheck-core qcheck-core.runner)

--- a/test/test_failure_subkind_properties.ml
+++ b/test/test_failure_subkind_properties.ml
@@ -19,7 +19,8 @@ let gen_run_classification =
       pure Run_classification.No_session_to_resume;
       pure Run_classification.Timed_out;
       map
-        (fun stream_errors -> Run_classification.Success { stream_errors })
+        (fun (stream_errors : string) ->
+          Run_classification.Success { stream_errors })
         (string_small_of printable);
       map2
         (fun exit_code detail ->

--- a/test/test_failure_subkind_properties.ml
+++ b/test/test_failure_subkind_properties.ml
@@ -1,0 +1,49 @@
+open Base
+open Onton_core
+
+let gen_init_info =
+  let open QCheck2.Gen in
+  let gen_opt_string = option (string_small_of printable) in
+  let* api_key_source = gen_opt_string in
+  let* model = gen_opt_string in
+  let* claude_code_version = gen_opt_string in
+  return Failure_subkind.{ api_key_source; model; claude_code_version }
+
+let gen_run_classification =
+  let open QCheck2.Gen in
+  oneof
+    [
+      map
+        (fun msg -> Run_classification.Process_error msg)
+        (string_small_of printable);
+      pure Run_classification.No_session_to_resume;
+      pure Run_classification.Timed_out;
+      map
+        (fun stream_errors -> Run_classification.Success { stream_errors })
+        (string_small_of printable);
+      map2
+        (fun exit_code detail ->
+          Run_classification.Session_failed { exit_code; detail })
+        int_small
+        (string_small_of printable);
+    ]
+
+let prop_classify_total =
+  QCheck2.Test.make ~name:"Failure_subkind.classify is total" ~count:500
+    QCheck2.Gen.(
+      quad gen_run_classification gen_init_info
+        (string_small_of printable)
+        (string_small_of printable))
+    (fun (classification, init, text_tail, stderr_tail) ->
+      try
+        let _ =
+          Failure_subkind.classify ~classification ~init ~text_tail ~stderr_tail
+        in
+        true
+      with _ -> false)
+
+let () =
+  let errcode =
+    QCheck_base_runner.run_tests ~verbose:true [ prop_classify_total ]
+  in
+  if errcode <> 0 then Stdlib.exit errcode


### PR DESCRIPTION
## Patch 1: Add Failure_subkind taxonomy and classifier

- Define type t = Ok | Auth_unavailable | Api_error of { status : int option } | Network_error | Timed_out | No_session_to_resume | Empty_response | Process_error | Other of string with [@@deriving show, eq, sexp_of, yojson].
- Define type init_info = { api_key_source : string option; model : string option; claude_code_version : string option } [@@deriving show, eq, yojson].
- Define classify ~classification ~init ~text_tail ~stderr_tail : t. Map Run_classification.{Process_error → Process_error; Timed_out → Timed_out; No_session_to_resume → No_session_to_resume; Success → Ok; Session_failed → sub-classify}.
- Session_failed sub-classification rules (first match wins): (1) text_tail contains 'Not logged in' OR 'Please run /login' → Auth_unavailable; (2) init.api_key_source = Some "none" AND no successful Final_result → Auth_unavailable; (3) stderr_tail matches /API Error: ([0-9]{3})/ → Api_error{status=Some N}; (4) stderr_tail contains getaddrinfo/EAI_AGAIN/ECONNREFUSED/TLS handshake → Network_error; (5) text_tail = "" AND stderr_tail = "" AND no Final_result → Empty_response; (6) otherwise → Other detail.
- Define to_string : t -> string for human-readable formatting (snake_case: 'ok', 'auth_unavailable', 'api_error_401', 'other').
- Add inline let%test blocks for each subkind classification rule plus a QCheck2 property: classify is total (never raises) over arbitrary inputs.

## Changes
- Define type t = Ok | Auth_unavailable | Api_error of { status : int option } | Network_error | Timed_out | No_session_to_resume | Empty_response | Process_error | Other of string with [@@deriving show, eq, sexp_of, yojson].
- Define type init_info = { api_key_source : string option; model : string option; claude_code_version : string option } [@@deriving show, eq, yojson].
- Define classify ~classification ~init ~text_tail ~stderr_tail : t. Map Run_classification.{Process_error → Process_error; Timed_out → Timed_out; No_session_to_resume → No_session_to_resume; Success → Ok; Session_failed → sub-classify}.
- Session_failed sub-classification rules (first match wins): (1) text_tail contains 'Not logged in' OR 'Please run /login' → Auth_unavailable; (2) init.api_key_source = Some "none" AND no successful Final_result → Auth_unavailable; (3) stderr_tail matches /API Error: ([0-9]{3})/ → Api_error{status=Some N}; (4) stderr_tail contains getaddrinfo/EAI_AGAIN/ECONNREFUSED/TLS handshake → Network_error; (5) text_tail = "" AND stderr_tail = "" AND no Final_result → Empty_response; (6) otherwise → Other detail.
- Define to_string : t -> string for human-readable formatting (snake_case: 'ok', 'auth_unavailable', 'api_error_401', 'other').
- Add inline let%test blocks for each subkind classification rule plus a QCheck2 property: classify is total (never raises) over arbitrary inputs.

## Files to Modify
- lib_core/failure_subkind.ml (create): Typed variant + classifier + yojson conversion + to_string. Pure module, no I/O.
- lib_core/failure_subkind.mli (create): Interface exposing the variant, classifier signature, yojson conversion, to_string.

## Gameplan Specification

```
module REPLAY_READY_DIAGNOSTICS.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> Onton's observability is unified through a single typed
> Event variant routed via pluggable Sinks.  Pure decision
> (route, interested_in) is separated from effectful handling
> (consume, emit).  Every claude spawn produces a self-
> contained on-disk artifact directory at sessions/<uuid>/
> sufficient to diagnose the spawn's outcome offline.  Each
> spawn is classified by a typed Subkind enum.  The
> --upload-debug bundle includes a top-level manifest.json
> with a per-patch most-recent-subkind summary and no raw
> secrets.

Event.
Sink.
Spawn.
Meta.
Subkind.

ok => Subkind.
auth-unavailable => Subkind.
api-error => Subkind.
network-error => Subkind.
timed-out => Subkind.
no-session-to-resume => Subkind.
empty-response => Subkind.
process-error => Subkind.
other => Subkind.

> Telemetry layer.
sink-name s: Sink => String.
interested-in? s: Sink, e: Event => Bool.
consumed? s: Sink, e: Event => Bool.
route sinks: [Sink], e: Event => [Sink].

> Spawn / artifact layer.
spawn-completed? sp: Spawn => Bool.
spawn-uuid sp: Spawn => String.
spawn-meta sp: Spawn => Meta.
spawn-subkind sp: Spawn => Subkind.
artifact-dir-for sp: Spawn => String.
meta-path-for sp: Spawn => String.
schema-version m: Meta => Nat0.
subkind-of m: Meta => Subkind.
on-disk? p: String => Bool.
---

> Telemetry route is pure: a sink is in the output iff it was in the input AND interested.
all sinks: [Sink], e: Event, s: Sink, s in route sinks e | s in sinks.
all sinks: [Sink], e: Event, s: Sink, s in route sinks e | interested-in? s e.
all sinks: [Sink], e: Event, s: Sink, s in sinks, interested-in? s e | s in route sinks e.

> Emit dispatches an event to every interested sink (captured as consumed?).
all sinks: [Sink], e: Event, s: Sink, s in route sinks e | consumed? s e.

> Every completed spawn produces a finalized artifact dir on disk.
all sp: Spawn, spawn-completed? sp | on-disk? (artifact-dir-for sp).
all sp: Spawn, spawn-completed? sp | on-disk? (meta-path-for sp).

> meta.json carries schema_version = 1 and the classified subkind.
all sp: Spawn, spawn-completed? sp | schema-version (spawn-meta sp) = 1.
all sp: Spawn, spawn-completed? sp | subkind-of (spawn-meta sp) = spawn-subkind sp.

where

> ══════════════════════════════════════════
> Bundle manifest
> ══════════════════════════════════════════

Bundle.
Manifest.
File.

manifest-of b: Bundle => Manifest.
manifest-version m: Manifest => Nat0.
files-in b: Bundle => [File].
file-contents f: File => String.
contains-secret? s: String => Bool.
---

> Every --upload-debug bundle has a versioned manifest.
all b: Bundle | manifest-version (manifest-of b) = 1.

> Bundles never contain raw secrets.
all b: Bundle, f: File, f in files-in b | ~ contains-secret? (file-contents f).

```

## Patch Specification

```
module REPLAY_READY_DIAGNOSTICS_PATCH_1.

> Patch 1 introduces the typed failure-cause taxonomy.
> Pure module — no I/O, no state-machine change.

Classification.
Subkind.
InitInfo.
TextTail.
StderrTail.

process-error-class => Classification.
timed-out-class => Classification.
no-session-to-resume-class => Classification.
success-class => Classification.
session-failed-class => Classification.

ok => Subkind.
auth-unavailable => Subkind.
api-error => Subkind.
network-error => Subkind.
timed-out => Subkind.
no-session-to-resume => Subkind.
empty-response => Subkind.
process-error-sub => Subkind.
other => Subkind.

mentions-not-logged-in? t: TextTail => Bool.
mentions-api-error? e: StderrTail => Bool.
mentions-network-failure? e: StderrTail => Bool.
empty-text? t: TextTail => Bool.
empty-stderr? e: StderrTail => Bool.
api-key-source-none? i: InitInfo => Bool.

classify c: Classification, i: InitInfo, t: TextTail, e: StderrTail => Subkind.
---

> Direct mappings for non-Session_failed classifications.
all i: InitInfo, t: TextTail, e: StderrTail | classify success-class i t e = ok.
all i: InitInfo, t: TextTail, e: StderrTail | classify timed-out-class i t e = timed-out.
all i: InitInfo, t: TextTail, e: StderrTail | classify no-session-to-resume-class i t e = no-session-to-resume.
all i: InitInfo, t: TextTail, e: StderrTail | classify process-error-class i t e = process-error-sub.

> Session_failed Auth_unavailable rule (canonical first-match-wins).
all i: InitInfo, t: TextTail, e: StderrTail, mentions-not-logged-in? t | classify session-failed-class i t e = auth-unavailable.

```


## Implementation Notes

- The classifier is fully pure and total, but the `yojson` support is implemented manually rather than via `[@@deriving yojson]`. The requested variant shape `Api_error of { status : int option }` and the optional fields on `init_info` did not compile cleanly under the repo's current `ppx_yojson_conv` setup, so I exposed the same public conversion functions (`t_of_yojson` / `yojson_of_t`, `init_info_of_yojson` / `yojson_of_init_info`) with explicit total decoding instead.
- Manual decoders are intentionally forgiving: malformed `Failure_subkind` JSON decodes to `Other "invalid_failure_subkind"` and missing/non-string `init_info` fields decode to `None`. That keeps the new pure module aligned with the codebase rule that external-input decoders must not raise.
- The `api_key_source = Some "none"` rule is treated as a `Session_failed`-only heuristic. Patch 1 does not receive an explicit `saw_final_result` input, so the "no successful Final_result" part is satisfied structurally by only running the sub-classifier when `Run_classification` has already ruled the run out as `Success`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a pure `Failure_subkind` taxonomy and classifier to consistently label run outcomes, with JSON codecs and readable strings. Tightens `Session_failed` heuristics for auth and empty responses, and updates tests (including property-based) to ensure classification is total.

- **New Features**
  - New `Failure_subkind` module: enum (`Ok`, `Auth_unavailable`, `Api_error{status}`, `Network_error`, `Timed_out`, `No_session_to_resume`, `Empty_response`, `Process_error`, `Other`) and `init_info` (all fields optional). Pure.
  - JSON codecs are total: invalid subkind → `Other "invalid_failure_subkind"`; missing/non-string `init_info` fields → `None`.
  - `classify` maps `Run_classification` to subkinds with tightened `Session_failed` rules: auth hints or `api_key_source="none"` with empty tails → `Auth_unavailable`; “API Error: NNN” → `Api_error{status}`; network substrings → `Network_error`; both tails empty with empty or “(no error details)” → `Empty_response`; else `Other detail`.
  - `to_string` returns snake_case labels (e.g., `api_error_401`).
  - Tests: inline rule tests + QCheck property that `classify` never raises; generator uses valid `Success { stream_errors: string }` payloads.

<sup>Written for commit 5629a9a2613a53d0e663ece2b7dbef94ef06133a. Summary will update on new commits. <a href="https://cubic.dev/pr/flowglad/onton/pull/271?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive property-based test coverage for failure classification scenarios, ensuring robust handling of various error conditions and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flowglad/onton/pull/271?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->