### PR TITLE
[replay-ready-diagnostics] Patch 2: Add Telemetry core (typed Event variant + Sink interface + pure router + registry)

### DIFF
--- a/lib/telemetry_dispatch.ml
+++ b/lib/telemetry_dispatch.ml
@@ -21,9 +21,14 @@ let emit event =
           sink.Telemetry.Sink.name (Exn.to_string exn))
 
 let with_sink ~sink body =
-  register_sink sink;
+  let old =
+    Stdlib.Mutex.protect mutex (fun () ->
+        let prev = !registry in
+        registry := sink :: prev;
+        prev)
+  in
   Exn.protect ~f:body ~finally:(fun () ->
-      unregister_sink ~name:sink.Telemetry.Sink.name)
+      Stdlib.Mutex.protect mutex (fun () -> registry := old))
 
 let test_event =
   Telemetry.Event.Free_form

--- a/lib/telemetry_dispatch.ml
+++ b/lib/telemetry_dispatch.ml
@@ -1,0 +1,88 @@
+open Base
+
+let registry : Telemetry.Sink.t list ref = ref []
+let mutex = Stdlib.Mutex.create ()
+
+let register_sink sink =
+  Stdlib.Mutex.protect mutex (fun () -> registry := sink :: !registry)
+
+let unregister_sink ~name =
+  Stdlib.Mutex.protect mutex (fun () ->
+      registry :=
+        List.filter !registry ~f:(fun sink ->
+            not (String.equal sink.Telemetry.Sink.name name)))
+
+let emit event =
+  let snapshot = Stdlib.Mutex.protect mutex (fun () -> !registry) in
+  List.iter (Telemetry.route ~sinks:snapshot event) ~f:(fun sink ->
+      try sink.Telemetry.Sink.consume event
+      with exn ->
+        Stdlib.Printf.eprintf "telemetry: sink %s raised %s\n%!"
+          sink.Telemetry.Sink.name (Exn.to_string exn))
+
+let with_sink ~sink body =
+  register_sink sink;
+  Exn.protect ~f:body ~finally:(fun () ->
+      unregister_sink ~name:sink.Telemetry.Sink.name)
+
+let test_event =
+  Telemetry.Event.Free_form
+    {
+      patch_id = Some (Types.Patch_id.of_string "patch-2");
+      level = Info;
+      message = "hello";
+    }
+
+let test_sink ?(consume = fun _ -> ()) name interested_in =
+  { Telemetry.Sink.name; interested_in; consume }
+
+let with_registry_replaced sinks body =
+  let old =
+    Stdlib.Mutex.protect mutex (fun () ->
+        let prev = !registry in
+        registry := sinks;
+        prev)
+  in
+  Exn.protect ~f:body ~finally:(fun () ->
+      Stdlib.Mutex.protect mutex (fun () -> registry := old))
+
+let%test "emit dispatches once per interested sink, never to uninterested sinks"
+    =
+  let interested_count = ref 0 in
+  let uninterested_count = ref 0 in
+  let interested =
+    test_sink "interested"
+      (fun _ -> true)
+      ~consume:(fun _ -> Int.incr interested_count)
+  in
+  let uninterested =
+    test_sink "uninterested"
+      (fun _ -> false)
+      ~consume:(fun _ -> Int.incr uninterested_count)
+  in
+  with_registry_replaced [ interested; uninterested ] (fun () ->
+      emit test_event);
+  !interested_count = 1 && !uninterested_count = 0
+
+let%test "emit is a no-op when no sinks are registered" =
+  with_registry_replaced [] (fun () -> emit test_event);
+  true
+
+let%test "emit is a no-op when no registered sink is interested" =
+  let consumed = ref 0 in
+  let sink =
+    test_sink "uninterested"
+      (fun _ -> false)
+      ~consume:(fun _ -> Int.incr consumed)
+  in
+  with_registry_replaced [ sink ] (fun () -> emit test_event);
+  !consumed = 0
+
+let%test "sink exceptions in consume do not propagate to emit's caller" =
+  let sink =
+    test_sink "raising" (fun _ -> true) ~consume:(fun _ -> failwith "boom")
+  in
+  try
+    with_registry_replaced [ sink ] (fun () -> emit test_event);
+    true
+  with _ -> false

--- a/lib/telemetry_dispatch.mli
+++ b/lib/telemetry_dispatch.mli
@@ -1,0 +1,6 @@
+open Base
+
+val register_sink : Telemetry.Sink.t -> unit
+val unregister_sink : name:string -> unit
+val emit : Telemetry.Event.t -> unit
+val with_sink : sink:Telemetry.Sink.t -> (unit -> 'a) -> 'a

--- a/lib/telemetry_dispatch.mli
+++ b/lib/telemetry_dispatch.mli
@@ -1,5 +1,3 @@
-open Base
-
 val register_sink : Telemetry.Sink.t -> unit
 val unregister_sink : name:string -> unit
 val emit : Telemetry.Event.t -> unit

--- a/lib_core/telemetry.ml
+++ b/lib_core/telemetry.ml
@@ -1,0 +1,212 @@
+open Base
+open Ppx_yojson_conv_lib.Yojson_conv.Primitives
+
+module Event = struct
+  type level = Trace | Debug | Info | Warning | Error
+  [@@deriving show, eq, yojson]
+
+  type json = Yojson.Safe.t
+
+  let pp_json formatter json =
+    Stdlib.Format.pp_print_string formatter (Yojson.Safe.to_string json)
+
+  let json_of_yojson json = json
+  let yojson_of_json json = json
+
+  type channel = [ `Stdout | `Stderr ] [@@deriving show, yojson]
+
+  type t =
+    | Poll of { patch_id : Types.Patch_id.t; payload : json }
+    | Action of {
+        patch_id : Types.Patch_id.t;
+        session_uuid : string option;
+        payload : json;
+      }
+    | Complete of {
+        patch_id : Types.Patch_id.t;
+        session_uuid : string option;
+        subkind : Failure_subkind.t;
+        payload : json;
+      }
+    | Stream of {
+        patch_id : Types.Patch_id.t;
+        session_uuid : string;
+        channel : channel;
+        raw : string;
+      }
+    | Spawn_started of {
+        patch_id : Types.Patch_id.t;
+        session_uuid : string;
+        prompt : string;
+        argv : string list;
+        env_redacted : string array;
+      }
+    | Spawn_finalized of {
+        patch_id : Types.Patch_id.t;
+        session_uuid : string;
+        meta : json;
+      }
+    | Free_form of {
+        patch_id : Types.Patch_id.t option;
+        level : level;
+        message : string;
+      }
+  [@@deriving show, yojson]
+end
+
+module Sink = struct
+  type t = {
+    name : string;
+    interested_in : Event.t -> bool;
+    consume : Event.t -> unit;
+  }
+end
+
+let route ~sinks event =
+  List.filter sinks ~f:(fun sink -> sink.Sink.interested_in event)
+
+let registry : Sink.t list ref = ref []
+let mutex = Stdlib.Mutex.create ()
+
+let register_sink sink =
+  Stdlib.Mutex.protect mutex (fun () -> registry := sink :: !registry)
+
+let unregister_sink ~name =
+  Stdlib.Mutex.protect mutex (fun () ->
+      registry :=
+        List.filter !registry ~f:(fun sink ->
+            not (String.equal sink.Sink.name name)))
+
+let emit event =
+  let snapshot = Stdlib.Mutex.protect mutex (fun () -> !registry) in
+  List.iter (route ~sinks:snapshot event) ~f:(fun sink ->
+      try sink.Sink.consume event
+      with exn ->
+        Stdlib.Printf.eprintf "telemetry: sink %s raised %s\n%!" sink.Sink.name
+          (Exn.to_string exn))
+
+let with_sink ~sink body =
+  register_sink sink;
+  Exn.protect ~f:body ~finally:(fun () -> unregister_sink ~name:sink.Sink.name)
+
+let test_event =
+  Event.Free_form
+    {
+      patch_id = Some (Types.Patch_id.of_string "patch-2");
+      level = Info;
+      message = "hello";
+    }
+
+let test_sink ?(consume = fun _ -> ()) name interested_in =
+  { Sink.name; interested_in; consume }
+
+let with_registry_replaced sinks body =
+  let old = Stdlib.Mutex.protect mutex (fun () -> !registry) in
+  Stdlib.Mutex.protect mutex (fun () -> registry := sinks);
+  Exn.protect ~f:body ~finally:(fun () ->
+      Stdlib.Mutex.protect mutex (fun () -> registry := old))
+
+let names sinks = List.map sinks ~f:(fun sink -> sink.Sink.name)
+
+let%test "route is pure — same inputs always produce the same output" =
+  let calls = ref 0 in
+  let sinks =
+    [
+      test_sink "yes" (fun _ ->
+          Int.incr calls;
+          true);
+      test_sink "no" (fun _ ->
+          Int.incr calls;
+          false);
+    ]
+  in
+  let first = route ~sinks test_event in
+  let second = route ~sinks test_event in
+  List.equal String.equal (names first) (names second) && !calls = 4
+
+let%test "route returns exactly the sinks whose interested_in is true" =
+  let interested = test_sink "interested" (fun _ -> true) in
+  let uninterested = test_sink "uninterested" (fun _ -> false) in
+  let sinks = [ uninterested; interested ] in
+  List.equal String.equal (names (route ~sinks test_event)) [ "interested" ]
+
+let%test "emit dispatches once per interested sink, never to uninterested sinks"
+    =
+  let interested_count = ref 0 in
+  let uninterested_count = ref 0 in
+  let interested =
+    test_sink "interested"
+      (fun _ -> true)
+      ~consume:(fun _ -> Int.incr interested_count)
+  in
+  let uninterested =
+    test_sink "uninterested"
+      (fun _ -> false)
+      ~consume:(fun _ -> Int.incr uninterested_count)
+  in
+  with_registry_replaced [ interested; uninterested ] (fun () ->
+      emit test_event);
+  !interested_count = 1 && !uninterested_count = 0
+
+let%test "emit is a no-op when no sinks are registered" =
+  with_registry_replaced [] (fun () -> emit test_event);
+  true
+
+let%test "emit is a no-op when no registered sink is interested" =
+  let consumed = ref 0 in
+  let sink =
+    test_sink "uninterested"
+      (fun _ -> false)
+      ~consume:(fun _ -> Int.incr consumed)
+  in
+  with_registry_replaced [ sink ] (fun () -> emit test_event);
+  !consumed = 0
+
+let%test "sink exceptions in consume do not propagate to emit's caller" =
+  let sink =
+    test_sink "raising" (fun _ -> true) ~consume:(fun _ -> failwith "boom")
+  in
+  try
+    with_registry_replaced [ sink ] (fun () -> emit test_event);
+    true
+  with _ -> false
+
+let%test "Event.t yojson roundtrip preserves every variant" =
+  let patch_id = Types.Patch_id.of_string "patch-2" in
+  let events =
+    [
+      Event.Poll { patch_id; payload = `Assoc [ ("kind", `String "poll") ] };
+      Action { patch_id; session_uuid = Some "uuid"; payload = `List [] };
+      Complete
+        {
+          patch_id;
+          session_uuid = None;
+          subkind = Failure_subkind.Network_error;
+          payload = `Bool true;
+        };
+      Stream { patch_id; session_uuid = "uuid"; channel = `Stdout; raw = "{}" };
+      Stream { patch_id; session_uuid = "uuid"; channel = `Stderr; raw = "err" };
+      Spawn_started
+        {
+          patch_id;
+          session_uuid = "uuid";
+          prompt = "prompt";
+          argv = [ "claude"; "--json" ];
+          env_redacted = [| "ANTHROPIC_API_KEY=<redacted>" |];
+        };
+      Spawn_finalized
+        {
+          patch_id;
+          session_uuid = "uuid";
+          meta = `Assoc [ ("schema_version", `Int 1) ];
+        };
+      Free_form { patch_id = None; level = Warning; message = "message" };
+    ]
+  in
+  List.for_all events ~f:(fun event ->
+      match Event.t_of_yojson (Event.yojson_of_t event) with
+      | event' ->
+          phys_equal event event'
+          || Yojson.Safe.equal (Event.yojson_of_t event)
+               (Event.yojson_of_t event')
+      | exception _ -> false)

--- a/lib_core/telemetry.ml
+++ b/lib_core/telemetry.ml
@@ -65,30 +65,6 @@ end
 let route ~sinks event =
   List.filter sinks ~f:(fun sink -> sink.Sink.interested_in event)
 
-let registry : Sink.t list ref = ref []
-let mutex = Stdlib.Mutex.create ()
-
-let register_sink sink =
-  Stdlib.Mutex.protect mutex (fun () -> registry := sink :: !registry)
-
-let unregister_sink ~name =
-  Stdlib.Mutex.protect mutex (fun () ->
-      registry :=
-        List.filter !registry ~f:(fun sink ->
-            not (String.equal sink.Sink.name name)))
-
-let emit event =
-  let snapshot = Stdlib.Mutex.protect mutex (fun () -> !registry) in
-  List.iter (route ~sinks:snapshot event) ~f:(fun sink ->
-      try sink.Sink.consume event
-      with exn ->
-        Stdlib.Printf.eprintf "telemetry: sink %s raised %s\n%!" sink.Sink.name
-          (Exn.to_string exn))
-
-let with_sink ~sink body =
-  register_sink sink;
-  Exn.protect ~f:body ~finally:(fun () -> unregister_sink ~name:sink.Sink.name)
-
 let test_event =
   Event.Free_form
     {
@@ -100,76 +76,21 @@ let test_event =
 let test_sink ?(consume = fun _ -> ()) name interested_in =
   { Sink.name; interested_in; consume }
 
-let with_registry_replaced sinks body =
-  let old = Stdlib.Mutex.protect mutex (fun () -> !registry) in
-  Stdlib.Mutex.protect mutex (fun () -> registry := sinks);
-  Exn.protect ~f:body ~finally:(fun () ->
-      Stdlib.Mutex.protect mutex (fun () -> registry := old))
-
 let names sinks = List.map sinks ~f:(fun sink -> sink.Sink.name)
 
 let%test "route is pure — same inputs always produce the same output" =
-  let calls = ref 0 in
   let sinks =
-    [
-      test_sink "yes" (fun _ ->
-          Int.incr calls;
-          true);
-      test_sink "no" (fun _ ->
-          Int.incr calls;
-          false);
-    ]
+    [ test_sink "yes" (fun _ -> true); test_sink "no" (fun _ -> false) ]
   in
   let first = route ~sinks test_event in
   let second = route ~sinks test_event in
-  List.equal String.equal (names first) (names second) && !calls = 4
+  List.equal String.equal (names first) (names second)
 
 let%test "route returns exactly the sinks whose interested_in is true" =
   let interested = test_sink "interested" (fun _ -> true) in
   let uninterested = test_sink "uninterested" (fun _ -> false) in
   let sinks = [ uninterested; interested ] in
   List.equal String.equal (names (route ~sinks test_event)) [ "interested" ]
-
-let%test "emit dispatches once per interested sink, never to uninterested sinks"
-    =
-  let interested_count = ref 0 in
-  let uninterested_count = ref 0 in
-  let interested =
-    test_sink "interested"
-      (fun _ -> true)
-      ~consume:(fun _ -> Int.incr interested_count)
-  in
-  let uninterested =
-    test_sink "uninterested"
-      (fun _ -> false)
-      ~consume:(fun _ -> Int.incr uninterested_count)
-  in
-  with_registry_replaced [ interested; uninterested ] (fun () ->
-      emit test_event);
-  !interested_count = 1 && !uninterested_count = 0
-
-let%test "emit is a no-op when no sinks are registered" =
-  with_registry_replaced [] (fun () -> emit test_event);
-  true
-
-let%test "emit is a no-op when no registered sink is interested" =
-  let consumed = ref 0 in
-  let sink =
-    test_sink "uninterested"
-      (fun _ -> false)
-      ~consume:(fun _ -> Int.incr consumed)
-  in
-  with_registry_replaced [ sink ] (fun () -> emit test_event);
-  !consumed = 0
-
-let%test "sink exceptions in consume do not propagate to emit's caller" =
-  let sink =
-    test_sink "raising" (fun _ -> true) ~consume:(fun _ -> failwith "boom")
-  in
-  try
-    with_registry_replaced [ sink ] (fun () -> emit test_event);
-    true
-  with _ -> false
 
 let%test "Event.t yojson roundtrip preserves every variant" =
   let patch_id = Types.Patch_id.of_string "patch-2" in

--- a/lib_core/telemetry.mli
+++ b/lib_core/telemetry.mli
@@ -52,7 +52,3 @@ module Sink : sig
 end
 
 val route : sinks:Sink.t list -> Event.t -> Sink.t list
-val register_sink : Sink.t -> unit
-val unregister_sink : name:string -> unit
-val emit : Event.t -> unit
-val with_sink : sink:Sink.t -> (unit -> 'a) -> 'a

--- a/lib_core/telemetry.mli
+++ b/lib_core/telemetry.mli
@@ -1,5 +1,3 @@
-open Base
-
 module Event : sig
   type level = Trace | Debug | Info | Warning | Error
   [@@deriving show, eq, yojson]

--- a/lib_core/telemetry.mli
+++ b/lib_core/telemetry.mli
@@ -1,0 +1,58 @@
+open Base
+
+module Event : sig
+  type level = Trace | Debug | Info | Warning | Error
+  [@@deriving show, eq, yojson]
+
+  type t =
+    | Poll of { patch_id : Types.Patch_id.t; payload : Yojson.Safe.t }
+    | Action of {
+        patch_id : Types.Patch_id.t;
+        session_uuid : string option;
+        payload : Yojson.Safe.t;
+      }
+    | Complete of {
+        patch_id : Types.Patch_id.t;
+        session_uuid : string option;
+        subkind : Failure_subkind.t;
+        payload : Yojson.Safe.t;
+      }
+    | Stream of {
+        patch_id : Types.Patch_id.t;
+        session_uuid : string;
+        channel : [ `Stdout | `Stderr ];
+        raw : string;
+      }
+    | Spawn_started of {
+        patch_id : Types.Patch_id.t;
+        session_uuid : string;
+        prompt : string;
+        argv : string list;
+        env_redacted : string array;
+      }
+    | Spawn_finalized of {
+        patch_id : Types.Patch_id.t;
+        session_uuid : string;
+        meta : Yojson.Safe.t;
+      }
+    | Free_form of {
+        patch_id : Types.Patch_id.t option;
+        level : level;
+        message : string;
+      }
+  [@@deriving show, yojson]
+end
+
+module Sink : sig
+  type t = {
+    name : string;
+    interested_in : Event.t -> bool;
+    consume : Event.t -> unit;
+  }
+end
+
+val route : sinks:Sink.t list -> Event.t -> Sink.t list
+val register_sink : Sink.t -> unit
+val unregister_sink : name:string -> unit
+val emit : Event.t -> unit
+val with_sink : sink:Sink.t -> (unit -> 'a) -> 'a


### PR DESCRIPTION
## Patch 2: Add Telemetry core (typed Event variant + Sink interface + pure router + registry)

- module Event: type level = Trace | Debug | Info | Warning | Error [@@deriving show, eq, yojson]. type t = | Poll of { patch_id; payload } | Action of { patch_id; session_uuid : string option; payload } | Complete of { patch_id; session_uuid : string option; subkind : Failure_subkind.t; payload } | Stream of { patch_id; session_uuid; channel : [ `Stdout | `Stderr ]; raw : string } | Spawn_started of { patch_id; session_uuid; prompt; argv : string list; env_redacted : string array } | Spawn_finalized of { patch_id; session_uuid; meta : Yojson.Safe.t } | Free_form of { patch_id : Types.Patch_id.t option; level; message } [@@deriving show, yojson].
- module Sink: type t = { name : string; interested_in : Event.t -> bool; consume : Event.t -> unit }.
- Pure router: let route ~sinks event = List.filter sinks ~f:(fun s -> s.Sink.interested_in event). No I/O, no side effects.
- Process-global registry: let registry : Sink.t list ref = ref [] and mutex = Mutex.create (). register_sink / unregister_sink ~name acquire the mutex and mutate.
- Effectful emit: let emit event = let snapshot = Mutex.protect mutex (fun () -> !registry) in List.iter (route ~sinks:snapshot event) ~f:(fun s -> try s.Sink.consume event with exn -> Stdio.eprintf "telemetry: sink %s raised %s\n%!" s.Sink.name (Printexc.to_string exn)).
- Add with_sink ~sink body : 'a — scope helper for tests that register/unregister around a body.
- Add inline let%test blocks: (i) route is pure — same inputs always produce the same output, no observable side effects; (ii) route returns exactly the sinks whose interested_in is true; (iii) emit dispatches once per interested sink, never to uninterested sinks; (iv) emit is a no-op when no sinks are registered; (v) emit is a no-op when no registered sink is interested; (vi) sink exceptions in consume do not propagate to emit's caller; (vii) Event.t yojson roundtrip preserves every variant.

## Changes
- module Event: type level = Trace | Debug | Info | Warning | Error [@@deriving show, eq, yojson]. type t = | Poll of { patch_id; payload } | Action of { patch_id; session_uuid : string option; payload } | Complete of { patch_id; session_uuid : string option; subkind : Failure_subkind.t; payload } | Stream of { patch_id; session_uuid; channel : [ `Stdout | `Stderr ]; raw : string } | Spawn_started of { patch_id; session_uuid; prompt; argv : string list; env_redacted : string array } | Spawn_finalized of { patch_id; session_uuid; meta : Yojson.Safe.t } | Free_form of { patch_id : Types.Patch_id.t option; level; message } [@@deriving show, yojson].
- module Sink: type t = { name : string; interested_in : Event.t -> bool; consume : Event.t -> unit }.
- Pure router: let route ~sinks event = List.filter sinks ~f:(fun s -> s.Sink.interested_in event). No I/O, no side effects.
- Process-global registry: let registry : Sink.t list ref = ref [] and mutex = Mutex.create (). register_sink / unregister_sink ~name acquire the mutex and mutate.
- Effectful emit: let emit event = let snapshot = Mutex.protect mutex (fun () -> !registry) in List.iter (route ~sinks:snapshot event) ~f:(fun s -> try s.Sink.consume event with exn -> Stdio.eprintf "telemetry: sink %s raised %s\n%!" s.Sink.name (Printexc.to_string exn)).
- Add with_sink ~sink body : 'a — scope helper for tests that register/unregister around a body.
- Add inline let%test blocks: (i) route is pure — same inputs always produce the same output, no observable side effects; (ii) route returns exactly the sinks whose interested_in is true; (iii) emit dispatches once per interested sink, never to uninterested sinks; (iv) emit is a no-op when no sinks are registered; (v) emit is a no-op when no registered sink is interested; (vi) sink exceptions in consume do not propagate to emit's caller; (vii) Event.t yojson roundtrip preserves every variant.

## Files to Modify
- lib_core/telemetry.ml (create): Typed Event.t variant covering every observability emission; Sink.t record with name + pure interested_in + effectful consume; route (pure) filters sinks by interested_in; emit (effectful) dispatches to interested sinks via the registry; register_sink/unregister_sink mutate a process-global ref under Mutex protection.
- lib_core/telemetry.mli (create): Public interface.

## Gameplan Specification

```
module REPLAY_READY_DIAGNOSTICS.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> Onton's observability is unified through a single typed
> Event variant routed via pluggable Sinks.  Pure decision
> (route, interested_in) is separated from effectful handling
> (consume, emit).  Every claude spawn produces a self-
> contained on-disk artifact directory at sessions/<uuid>/
> sufficient to diagnose the spawn's outcome offline.  Each
> spawn is classified by a typed Subkind enum.  The
> --upload-debug bundle includes a top-level manifest.json
> with a per-patch most-recent-subkind summary and no raw
> secrets.

Event.
Sink.
Spawn.
Meta.
Subkind.

ok => Subkind.
auth-unavailable => Subkind.
api-error => Subkind.
network-error => Subkind.
timed-out => Subkind.
no-session-to-resume => Subkind.
empty-response => Subkind.
process-error => Subkind.
other => Subkind.

> Telemetry layer.
sink-name s: Sink => String.
interested-in? s: Sink, e: Event => Bool.
consumed? s: Sink, e: Event => Bool.
route sinks: [Sink], e: Event => [Sink].

> Spawn / artifact layer.
spawn-completed? sp: Spawn => Bool.
spawn-uuid sp: Spawn => String.
spawn-meta sp: Spawn => Meta.
spawn-subkind sp: Spawn => Subkind.
artifact-dir-for sp: Spawn => String.
meta-path-for sp: Spawn => String.
schema-version m: Meta => Nat0.
subkind-of m: Meta => Subkind.
on-disk? p: String => Bool.
---

> Telemetry route is pure: a sink is in the output iff it was in the input AND interested.
all sinks: [Sink], e: Event, s: Sink, s in route sinks e | s in sinks.
all sinks: [Sink], e: Event, s: Sink, s in route sinks e | interested-in? s e.
all sinks: [Sink], e: Event, s: Sink, s in sinks, interested-in? s e | s in route sinks e.

> Emit dispatches an event to every interested sink (captured as consumed?).
all sinks: [Sink], e: Event, s: Sink, s in route sinks e | consumed? s e.

> Every completed spawn produces a finalized artifact dir on disk.
all sp: Spawn, spawn-completed? sp | on-disk? (artifact-dir-for sp).
all sp: Spawn, spawn-completed? sp | on-disk? (meta-path-for sp).

> meta.json carries schema_version = 1 and the classified subkind.
all sp: Spawn, spawn-completed? sp | schema-version (spawn-meta sp) = 1.
all sp: Spawn, spawn-completed? sp | subkind-of (spawn-meta sp) = spawn-subkind sp.

where

> ══════════════════════════════════════════
> Bundle manifest
> ══════════════════════════════════════════

Bundle.
Manifest.
File.

manifest-of b: Bundle => Manifest.
manifest-version m: Manifest => Nat0.
files-in b: Bundle => [File].
file-contents f: File => String.
contains-secret? s: String => Bool.
---

> Every --upload-debug bundle has a versioned manifest.
all b: Bundle | manifest-version (manifest-of b) = 1.

> Bundles never contain raw secrets.
all b: Bundle, f: File, f in files-in b | ~ contains-secret? (file-contents f).

```

## Patch Specification

```
module REPLAY_READY_DIAGNOSTICS_PATCH_2.

> Patch 2 introduces the Telemetry layer: a single typed Event
> variant that every observability emission converges through,
> a Sink interface with pure interested_in and effectful consume,
> a pure route function, and an effectful emit dispatcher.

Event.
Sink.
Level.

trace => Level.
debug => Level.
info => Level.
warning => Level.
error => Level.

sink-name s: Sink => String.
interested-in? s: Sink, e: Event => Bool.
consumed? s: Sink, e: Event => Bool.

route sinks: [Sink], e: Event => [Sink].
---

> route is pure: a sink is in the output iff it was in the input AND it is interested.
all sinks: [Sink], e: Event, s: Sink, s in route sinks e | s in sinks.
all sinks: [Sink], e: Event, s: Sink, s in route sinks e | interested-in? s e.
all sinks: [Sink], e: Event, s: Sink, s in sinks, interested-in? s e | s in route sinks e.

> emit dispatches an event to every interested sink (the effect captured by consumed?).
all sinks: [Sink], e: Event, s: Sink, s in route sinks e | consumed? s e.

```


## Implementation Notes

- `Telemetry` stays in `lib_core` per the patch plan, but the registry/emit path is intentionally effectful; the pure boundary is the `route` function and sink predicate contract.
- I used `Stdlib.Mutex` and `Stdlib.Printf.eprintf` explicitly because `open Base` makes unqualified stdlib modules deprecated under fatal warnings, and adding `stdio` would widen dependencies.
- `Yojson.Safe.t` payload/meta fields are passed through unchanged with local JSON converters, so future sinks can preserve arbitrary diagnostic payloads without schema loss.
- Inline tests include a private `with_registry_replaced` helper to isolate global registry state without exposing a test-only reset function in the public interface.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Telemetry core with typed events, a pure router, and a separate `Telemetry_dispatch` module for thread-safe sink registration and emission. This unifies observability behind a single entry point while keeping routing pure and side effects isolated.

- **New Features**
  - Typed `Event.t` (Poll, Action, Complete, Stream, Spawn_started, Spawn_finalized, Free_form) with levels (Trace–Error) and Yojson support.
  - `Sink.t` with `name`, pure `interested_in`, and effectful `consume`.
  - Pure `route ~sinks` that filters by `interested_in` (no I/O).
  - Exception-safe `emit` that dispatches only to interested sinks and logs sink errors.

- **Refactors**
  - Split effectful parts into `Telemetry_dispatch`: process-global registry with `register_sink`/`unregister_sink`, `emit`, and a scoped `with_sink` helper that restores the exact registry snapshot; core remains pure.
  - Tightened `telemetry.mli` and `telemetry_dispatch.mli` (no module opens) to avoid namespace leaks.

<sup>Written for commit 73ea20df142d2b9740fefef5fce586bc34879872. Summary will update on new commits. <a href="https://cubic.dev/pr/flowglad/onton/pull/272?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

