### PR TITLE
Add --prune flag to remove fully-merged projects

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -4305,6 +4305,151 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
                 :: common_fibers)
             with Quit_tui -> ())
 
+(** {1 Prune}
+
+    Remove every persisted project whose gameplan patches are all marked merged
+    in the saved snapshot. Operates only on the per-project data directory
+    (snapshot, events, gameplan, config, artifacts) — git worktrees under
+    [~/worktrees/<project>/] are left in place because they can contain
+    user-visible state (build outputs, untracked files) that the user may want
+    to inspect or reuse, and traversing a populated build tree is far slower
+    than removing the small data directory. Pruned projects are reported with
+    the worktree path so the user can decide whether to clean it up.
+
+    Skips any project whose lock is held by a live process — pruning state out
+    from under a running [onton] would invalidate its in-memory view. *)
+
+let rec remove_path path =
+  match Unix.lstat path with
+  | exception Unix.Unix_error (Unix.ENOENT, _, _) -> ()
+  | { Unix.st_kind = Unix.S_DIR; _ } -> (
+      let entries = Stdlib.Sys.readdir path in
+      Array.iter
+        (fun name -> remove_path (Stdlib.Filename.concat path name))
+        entries;
+      try Unix.rmdir path with Unix.Unix_error (Unix.ENOENT, _, _) -> ())
+  | {
+   Unix.st_kind =
+     ( Unix.S_REG | Unix.S_LNK | Unix.S_CHR | Unix.S_BLK | Unix.S_FIFO
+     | Unix.S_SOCK );
+   _;
+  } -> (
+      try Stdlib.Sys.remove path with Sys_error _ -> ())
+
+type prune_status =
+  | All_merged
+  | Not_merged
+  | No_patches
+  | No_snapshot
+  | Load_error of string
+
+let classify_project ~project_name =
+  let snap_path = Project_store.snapshot_path project_name in
+  if not (Stdlib.Sys.file_exists snap_path) then No_snapshot
+  else
+    match Persistence.load ~path:snap_path with
+    | Error msg -> Load_error msg
+    | Ok snap ->
+        let agents = Orchestrator.agents_map snap.Runtime.orchestrator in
+        let patches = snap.Runtime.gameplan.Gameplan.patches in
+        if Base.List.is_empty patches then No_patches
+        else
+          let all_merged =
+            Base.List.for_all patches ~f:(fun (p : Patch.t) ->
+                match Base.Map.find agents p.Patch.id with
+                | Some agent -> agent.Patch_agent.merged
+                | None -> false)
+          in
+          if all_merged then All_merged else Not_merged
+
+let worktree_root_for ~project_name =
+  let home =
+    match Stdlib.Sys.getenv_opt "HOME" with Some h -> h | None -> "."
+  in
+  Stdlib.Filename.concat home (Stdlib.Filename.concat "worktrees" project_name)
+
+(** Stored config records the gameplan-provided [project_name] verbatim, which
+    is what worktrees are keyed by under [~/worktrees/]. The data dir is keyed
+    by slug, so the worktree hint requires reading the config to recover the
+    original name — falling back to the slug if config is unreadable. *)
+let recover_project_name ~slug =
+  match Project_store.load_config ~project_name:slug with
+  | Ok cfg -> cfg.Project_store.project_name
+  | Error _ -> slug
+
+let run_prune () =
+  let slugs = Project_store.list_projects () in
+  if Base.List.is_empty slugs then (
+    Printf.printf "No stored projects to consider.\n";
+    Stdlib.exit 0);
+  let removed = ref [] in
+  let kept = ref [] in
+  let errors = ref [] in
+  Base.List.iter slugs ~f:(fun slug ->
+      (* [list_projects] returns slugs (already valid path components); the
+         data dir is keyed by slug and slugifying a slug is a no-op, so passing
+         the slug back through [project_dir] is correct. The recovered
+         [project_name] is only used for the worktree hint. *)
+      let project_name = recover_project_name ~slug in
+      let project_dir = Project_store.project_dir slug in
+      let acquired =
+        Project_lock.acquire ~project_dir ~on_stale:(fun pid ->
+            Printf.eprintf
+              "onton prune: reclaimed stale lock for %s (PID %d)\n%!"
+              project_name pid)
+      in
+      match acquired with
+      | Error (Project_lock.Held_by { pid; _ }) ->
+          kept := (project_name, Printf.sprintf "in use (PID %d)" pid) :: !kept
+      | Error (Project_lock.Io_error msg) ->
+          errors :=
+            (project_name, Printf.sprintf "lock error: %s" msg) :: !errors
+      | Ok lock ->
+          Fun.protect
+            ~finally:(fun () -> Project_lock.release lock)
+            (fun () ->
+              match classify_project ~project_name with
+              | All_merged -> (
+                  try
+                    remove_path project_dir;
+                    removed :=
+                      (project_name, worktree_root_for ~project_name)
+                      :: !removed
+                  with exn ->
+                    errors := (project_name, Printexc.to_string exn) :: !errors)
+              | Not_merged ->
+                  kept := (project_name, "has unmerged patches") :: !kept
+              | No_patches ->
+                  kept := (project_name, "gameplan has no patches") :: !kept
+              | No_snapshot ->
+                  kept := (project_name, "no snapshot — never ran") :: !kept
+              | Load_error msg ->
+                  kept :=
+                    (project_name, Printf.sprintf "snapshot load failed: %s" msg)
+                    :: !kept));
+  Base.List.iter (List.rev !removed) ~f:(fun (n, _) ->
+      Printf.printf "removed %s\n" n);
+  Base.List.iter (List.rev !kept) ~f:(fun (n, reason) ->
+      Printf.printf "kept    %s — %s\n" n reason);
+  Base.List.iter (List.rev !errors) ~f:(fun (n, msg) ->
+      Printf.eprintf "error   %s — %s\n" n msg);
+  Printf.printf "\n%s pruned, %d kept, %s.\n"
+    (pluralize (Base.List.length !removed) "project")
+    (Base.List.length !kept)
+    (pluralize (Base.List.length !errors) "error");
+  let leftover_worktrees =
+    Base.List.filter !removed ~f:(fun (_, p) -> Stdlib.Sys.file_exists p)
+  in
+  if not (Base.List.is_empty leftover_worktrees) then (
+    Printf.printf
+      "\n\
+       Worktree directories are not pruned automatically (they may contain \
+       build outputs).\n\
+       Remove them manually once they are no longer needed:\n";
+    Base.List.iter (List.rev leftover_worktrees) ~f:(fun (_, p) ->
+        Printf.printf "  rm -rf %s\n" p));
+  if not (Base.List.is_empty !errors) then Stdlib.exit 1
+
 let run ~project ~gameplan_path ~github_token ~backend ~model
     ~(main_branch : Branch.t option) ~poll_interval ~(repo_root : string option)
     ~max_concurrency ~headless ~no_lock =
@@ -4425,11 +4570,23 @@ let no_lock_arg =
            cannot be reclaimed automatically."
         ~env:(Cmd.Env.info "ONTON_NO_LOCK"))
 
+let prune_arg =
+  let open Cmdliner in
+  Arg.(
+    value & flag
+    & info [ "prune" ]
+        ~doc:
+          "Remove every stored project whose gameplan patches are all merged. \
+           Skips projects whose lock is held by a live onton process. Does not \
+           require any other arguments.")
+
 let main_cmd =
   let open Cmdliner in
   let run_cmd project gameplan_path github_token backend model main_branch
-      poll_interval repo_root max_concurrency headless upload_debug no_lock =
-    if upload_debug then (
+      poll_interval repo_root max_concurrency headless upload_debug no_lock
+      prune =
+    if prune then run_prune ()
+    else if upload_debug then (
       match project with
       | None ->
           Printf.eprintf
@@ -4459,7 +4616,8 @@ let main_cmd =
     Term.(
       const run_cmd $ project_arg $ gameplan_path_arg $ github_token_arg
       $ backend_arg $ model_arg $ main_branch_arg $ poll_interval_arg $ repo_arg
-      $ max_concurrency_arg $ headless_arg $ upload_debug_arg $ no_lock_arg)
+      $ max_concurrency_arg $ headless_arg $ upload_debug_arg $ no_lock_arg
+      $ prune_arg)
   in
   let info =
     Cmd.info "onton" ~version:Version.s

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -4343,8 +4343,8 @@ type prune_status =
   | No_snapshot
   | Load_error of string
 
-let classify_project ~project_name =
-  let snap_path = Project_store.snapshot_path project_name in
+let classify_project ~slug =
+  let snap_path = Project_store.snapshot_path slug in
   if not (Stdlib.Sys.file_exists snap_path) then No_snapshot
   else
     match Persistence.load ~path:snap_path with
@@ -4389,44 +4389,46 @@ let run_prune () =
       (* [list_projects] returns slugs (already valid path components); the
          data dir is keyed by slug and slugifying a slug is a no-op, so passing
          the slug back through [project_dir] is correct. The recovered
-         [project_name] is only used for the worktree hint. *)
-      let project_name = recover_project_name ~slug in
+         [project_name] is only used for reporting and the worktree hint. *)
       let project_dir = Project_store.project_dir slug in
       let acquired =
         Project_lock.acquire ~project_dir ~on_stale:(fun pid ->
             Printf.eprintf
-              "onton prune: reclaimed stale lock for %s (PID %d)\n%!"
-              project_name pid)
+              "onton prune: reclaimed stale lock for %s (PID %d)\n%!" slug pid)
       in
       match acquired with
       | Error (Project_lock.Held_by { pid; _ }) ->
+          let project_name = recover_project_name ~slug in
           kept := (project_name, Printf.sprintf "in use (PID %d)" pid) :: !kept
       | Error (Project_lock.Io_error msg) ->
+          let project_name = recover_project_name ~slug in
           errors :=
             (project_name, Printf.sprintf "lock error: %s" msg) :: !errors
-      | Ok lock ->
-          Fun.protect
-            ~finally:(fun () -> Project_lock.release lock)
-            (fun () ->
-              match classify_project ~project_name with
-              | All_merged -> (
-                  try
-                    remove_path project_dir;
-                    removed :=
-                      (project_name, worktree_root_for ~project_name)
-                      :: !removed
-                  with exn ->
-                    errors := (project_name, Printexc.to_string exn) :: !errors)
-              | Not_merged ->
-                  kept := (project_name, "has unmerged patches") :: !kept
-              | No_patches ->
-                  kept := (project_name, "gameplan has no patches") :: !kept
-              | No_snapshot ->
-                  kept := (project_name, "no snapshot — never ran") :: !kept
-              | Load_error msg ->
-                  kept :=
-                    (project_name, Printf.sprintf "snapshot load failed: %s" msg)
-                    :: !kept));
+      | Ok lock -> (
+          let status =
+            Fun.protect
+              ~finally:(fun () -> Project_lock.release lock)
+              (fun () -> classify_project ~slug)
+          in
+          let project_name = recover_project_name ~slug in
+          match status with
+          | All_merged -> (
+              try
+                remove_path project_dir;
+                removed :=
+                  (project_name, worktree_root_for ~project_name) :: !removed
+              with exn ->
+                errors := (project_name, Printexc.to_string exn) :: !errors)
+          | Not_merged ->
+              kept := (project_name, "has unmerged patches") :: !kept
+          | No_patches ->
+              kept := (project_name, "gameplan has no patches") :: !kept
+          | No_snapshot ->
+              kept := (project_name, "no snapshot — never ran") :: !kept
+          | Load_error msg ->
+              errors :=
+                (project_name, Printf.sprintf "snapshot load failed: %s" msg)
+                :: !errors));
   Base.List.iter (List.rev !removed) ~f:(fun (n, _) ->
       Printf.printf "removed %s\n" n);
   Base.List.iter (List.rev !kept) ~f:(fun (n, reason) ->

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -4349,18 +4349,13 @@ let classify_project ~slug =
   else
     match Persistence.load ~path:snap_path with
     | Error msg -> Load_error msg
-    | Ok snap ->
+    | Ok snap -> (
         let agents = Orchestrator.agents_map snap.Runtime.orchestrator in
         let patches = snap.Runtime.gameplan.Gameplan.patches in
-        if Base.List.is_empty patches then No_patches
-        else
-          let all_merged =
-            Base.List.for_all patches ~f:(fun (p : Patch.t) ->
-                match Base.Map.find agents p.Patch.id with
-                | Some agent -> agent.Patch_agent.merged
-                | None -> false)
-          in
-          if all_merged then All_merged else Not_merged
+        match Prune_decision.classify_snapshot ~patches ~agents with
+        | Prune_decision.All_merged -> All_merged
+        | Prune_decision.Not_merged -> Not_merged
+        | Prune_decision.No_patches -> No_patches)
 
 let worktree_root_for ~project_name =
   let home =

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -4400,27 +4400,33 @@ let run_prune () =
           errors :=
             (project_name, Printf.sprintf "lock error: %s" msg) :: !errors
       | Ok lock -> (
-          let status =
-            Fun.protect
-              ~finally:(fun () -> Project_lock.release lock)
-              (fun () -> classify_project ~slug)
-          in
           let project_name = recover_project_name ~slug in
-          match status with
-          | All_merged -> (
+          match
+            try
+              Ok
+                (Fun.protect
+                   ~finally:(fun () -> Project_lock.release lock)
+                   (fun () -> classify_project ~slug))
+            with exn -> Error (Printexc.to_string exn)
+          with
+          | Error msg ->
+              errors :=
+                (project_name, Printf.sprintf "snapshot classify failed: %s" msg)
+                :: !errors
+          | Ok All_merged -> (
               try
                 remove_path project_dir;
                 removed :=
                   (project_name, worktree_root_for ~project_name) :: !removed
               with exn ->
                 errors := (project_name, Printexc.to_string exn) :: !errors)
-          | Not_merged ->
+          | Ok Not_merged ->
               kept := (project_name, "has unmerged patches") :: !kept
-          | No_patches ->
+          | Ok No_patches ->
               kept := (project_name, "gameplan has no patches") :: !kept
-          | No_snapshot ->
+          | Ok No_snapshot ->
               kept := (project_name, "no snapshot — never ran") :: !kept
-          | Load_error msg ->
+          | Ok (Load_error msg) ->
               errors :=
                 (project_name, Printf.sprintf "snapshot load failed: %s" msg)
                 :: !errors));

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -4406,16 +4406,20 @@ let run_prune () =
               Ok
                 (Fun.protect
                    ~finally:(fun () -> Project_lock.release lock)
-                   (fun () -> classify_project ~slug))
+                   (fun () ->
+                     let status = classify_project ~slug in
+                     (match status with
+                     | All_merged -> remove_path project_dir
+                     | Not_merged | No_patches | No_snapshot | Load_error _ ->
+                         ());
+                     status))
             with exn -> Error (Printexc.to_string exn)
           with
           | Error msg ->
               errors :=
-                (project_name, Printf.sprintf "snapshot classify failed: %s" msg)
-                :: !errors
+                (project_name, Printf.sprintf "prune failed: %s" msg) :: !errors
           | Ok All_merged -> (
               try
-                remove_path project_dir;
                 removed :=
                   (project_name, worktree_root_for ~project_name) :: !removed
               with exn ->

--- a/lib_core/prune_decision.ml
+++ b/lib_core/prune_decision.ml
@@ -1,0 +1,17 @@
+open Base
+open Types
+
+type project_status = All_merged | Not_merged | No_patches
+[@@deriving show, eq, sexp_of, compare]
+
+let classify_snapshot ~(patches : Patch.t list)
+    ~(agents : Patch_agent.t Map.M(Patch_id).t) =
+  if List.is_empty patches then No_patches
+  else
+    let all_merged =
+      List.for_all patches ~f:(fun (p : Patch.t) ->
+          match Map.find agents p.Patch.id with
+          | Some agent -> agent.Patch_agent.merged
+          | None -> false)
+    in
+    if all_merged then All_merged else Not_merged

--- a/lib_core/prune_decision.mli
+++ b/lib_core/prune_decision.mli
@@ -1,0 +1,19 @@
+open Base
+open Types
+
+(** Pure decisions for pruning persisted project state. Handlers are responsible
+    for reading snapshots and locks; this module only classifies already-decoded
+    snapshot data. *)
+
+type project_status = All_merged | Not_merged | No_patches
+[@@deriving show, eq, sexp_of, compare]
+
+val classify_snapshot :
+  patches:Patch.t list ->
+  agents:Patch_agent.t Map.M(Patch_id).t ->
+  project_status
+(** Classify a decoded project snapshot for pruning.
+
+    A project is [All_merged] only when the gameplan has at least one patch and
+    every gameplan patch has a corresponding merged agent. Missing agents count
+    as [Not_merged]. *)

--- a/test/dune
+++ b/test/dune
@@ -190,6 +190,13 @@
  (ocamlc_flags (:standard -w -40-42)))
 
 (test
+ (name test_prune_decision_properties)
+ (modules test_prune_decision_properties)
+ (libraries onton_core qcheck-core qcheck-core.runner)
+ (ocamlopt_flags (:standard -w -40-42))
+ (ocamlc_flags (:standard -w -40-42)))
+
+(test
  (name test_patch_controller)
  (modules test_patch_controller)
  (libraries onton onton_core onton_test_support qcheck-core qcheck-core.runner)

--- a/test/test_prune_decision_properties.ml
+++ b/test/test_prune_decision_properties.ml
@@ -1,0 +1,154 @@
+open Base
+open Onton_core
+open Onton_core.Types
+
+let patch i =
+  Patch.
+    {
+      id = Patch_id.of_string (Printf.sprintf "patch-%d" i);
+      title = Printf.sprintf "Patch %d" i;
+      description = "";
+      branch = Branch.of_string (Printf.sprintf "branch-%d" i);
+      dependencies = [];
+      spec = "";
+      acceptance_criteria = [];
+      files = [];
+      classification = "";
+      changes = [];
+      test_stubs_introduced = [];
+      test_stubs_implemented = [];
+      complexity = None;
+      precedents = [];
+    }
+
+let agent_for_patch ?(merged = false) (p : Patch.t) =
+  let agent = Patch_agent.create ~branch:p.Patch.branch p.Patch.id in
+  if merged then Patch_agent.mark_merged agent else agent
+
+let agents_map agents =
+  List.fold agents
+    ~init:(Map.empty (module Patch_id))
+    ~f:(fun acc agent ->
+      Map.set acc ~key:agent.Patch_agent.patch_id ~data:agent)
+
+let gen_unique_patches =
+  QCheck2.Gen.(map (fun n -> List.init n ~f:patch) (int_range 0 20))
+
+let gen_patches_and_flags =
+  QCheck2.Gen.(
+    gen_unique_patches >>= fun patches ->
+    list_size (return (List.length patches)) bool >>= fun merged_flags ->
+    return (patches, merged_flags))
+
+let gen_patches_flags_and_extra =
+  QCheck2.Gen.(
+    gen_patches_and_flags >>= fun (patches, flags) ->
+    int_range 0 10 >>= fun extra_count ->
+    return (patches, flags, List.init extra_count ~f:(fun i -> patch (100 + i))))
+
+let classify patches agents =
+  Prune_decision.classify_snapshot ~patches ~agents:(agents_map agents)
+
+let () =
+  let open QCheck2 in
+  let prop_total =
+    Test.make ~name:"prune classify_snapshot is total" ~count:1000
+      gen_patches_flags_and_extra (fun (patches, flags, extra_patches) ->
+        try
+          let agents =
+            List.map2_exn patches flags ~f:(fun p merged ->
+                agent_for_patch ~merged p)
+            @ List.map extra_patches ~f:(agent_for_patch ~merged:true)
+          in
+          ignore (classify patches agents : Prune_decision.project_status);
+          true
+        with _ -> false)
+  in
+  let prop_empty_no_patches =
+    Test.make ~name:"prune empty gameplan is No_patches" ~count:200
+      gen_patches_flags_and_extra (fun (_, _, extra_patches) ->
+        let agents = List.map extra_patches ~f:(agent_for_patch ~merged:true) in
+        Prune_decision.equal_project_status (classify [] agents)
+          Prune_decision.No_patches)
+  in
+  let prop_all_merged_iff_all_present_merged =
+    Test.make
+      ~name:"prune non-empty is All_merged iff every patch agent is merged"
+      ~count:1000 gen_patches_and_flags (fun (patches, flags) ->
+        let agents =
+          List.map2_exn patches flags ~f:(fun p merged ->
+              agent_for_patch ~merged p)
+        in
+        let status = classify patches agents in
+        let expected_all_merged =
+          (not (List.is_empty patches)) && List.for_all flags ~f:(fun x -> x)
+        in
+        Bool.equal
+          (Prune_decision.equal_project_status status Prune_decision.All_merged)
+          expected_all_merged)
+  in
+  let prop_missing_agent_not_merged =
+    Test.make
+      ~name:"prune missing gameplan agent is Not_merged for non-empty patches"
+      ~count:500
+      Gen.(map (fun n -> List.init n ~f:patch) (int_range 1 20))
+      (fun patches ->
+        let agents =
+          match patches with
+          | [] -> []
+          | _ :: rest -> List.map rest ~f:(agent_for_patch ~merged:true)
+        in
+        Prune_decision.equal_project_status (classify patches agents)
+          Prune_decision.Not_merged)
+  in
+  let prop_irrelevant_agents_do_not_change =
+    Test.make ~name:"prune ignores agents outside the gameplan" ~count:1000
+      gen_patches_flags_and_extra (fun (patches, flags, extra_patches) ->
+        let base_agents =
+          List.map2_exn patches flags ~f:(fun p merged ->
+              agent_for_patch ~merged p)
+        in
+        let extra_agents =
+          List.map extra_patches ~f:(fun p -> agent_for_patch ~merged:false p)
+        in
+        Prune_decision.equal_project_status
+          (classify patches base_agents)
+          (classify patches (base_agents @ extra_agents)))
+  in
+  let prop_patch_order_invariant =
+    Test.make ~name:"prune classification is invariant under patch order"
+      ~count:1000 gen_patches_and_flags (fun (patches, flags) ->
+        let agents =
+          List.map2_exn patches flags ~f:(fun p merged ->
+              agent_for_patch ~merged p)
+        in
+        Prune_decision.equal_project_status (classify patches agents)
+          (classify (List.rev patches) agents))
+  in
+  let prop_duplicate_patch_ids_follow_same_agent =
+    Test.make
+      ~name:"prune duplicate patch ids are classified by their shared agent"
+      ~count:500 Gen.bool (fun merged ->
+        let p = patch 1 in
+        let patches = [ p; { p with title = "duplicate id" } ] in
+        let expected =
+          if merged then Prune_decision.All_merged
+          else Prune_decision.Not_merged
+        in
+        Prune_decision.equal_project_status
+          (classify patches [ agent_for_patch ~merged p ])
+          expected)
+  in
+  let suite =
+    [
+      prop_total;
+      prop_empty_no_patches;
+      prop_all_merged_iff_all_present_merged;
+      prop_missing_agent_not_merged;
+      prop_irrelevant_agents_do_not_change;
+      prop_patch_order_invariant;
+      prop_duplicate_patch_ids_follow_same_agent;
+    ]
+  in
+  let errcode = QCheck_base_runner.run_tests ~verbose:true suite in
+  if errcode <> 0 then Stdlib.exit errcode


### PR DESCRIPTION
## Summary
- New `--prune` global flag sweeps the onton data dir and removes every persisted project whose gameplan patches are all marked merged in the saved snapshot
- Skips any project whose advisory lock is held by a live onton process; reports per-project decisions with reasons (unmerged patches, no snapshot, schema drift, etc.)
- Only the project data directory is removed — worktrees under \`~/worktrees/<project>/\` are left in place (they can hold build outputs / untracked files), and their paths are printed as \`rm -rf\` hints

## Test plan
- [x] \`--help\` shows the new flag and doc string
- [x] Live run on real data dir pruned 11 stale projects; kept 24 with reasons; second run reports 0 to prune
- [x] Sandboxed run with \`ONTON_DATA_DIR\` against an empty dir: "No stored projects to consider."
- [x] Sandboxed run with a config-only (no snapshot) project: kept with "no snapshot — never ran"
- [ ] CI build + tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/274"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a global --prune flag that removes stored data for projects whose gameplan patches are all merged. Keeps worktrees, prints cleanup hints, and strengthens pruning with a pure decision module, property tests, and safer locking (lock held through deletion).

- New Features
  - Scans stored projects, deletes only the per-project data dir, and prints a summary plus rm -rf hints for ~/worktrees/<project>/.
  - Respects locks: skips live locks; reclaims stale locks with a notice.
  - Handles snapshot load/classify errors; exits non-zero on errors.
  - Flag runs standalone without other args.

- Bug Fixes
  - Correct slug vs project-name handling for data dirs and worktree hints.
  - Hold the project lock through classification and deletion to avoid races.

<sup>Written for commit a76fcc499b8f138301b681f9ce537252786768ce. Summary will update on new commits. <a href="https://cubic.dev/pr/flowglad/onton/pull/274?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--prune` command to scan and clean up stored projects
  * Identifies projects ready for cleanup when all patches are marked as merged
  * Removes persisted project data while preserving user worktree directories
  * Respects per-project locks and reports detailed outcomes with appropriate error signaling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flowglad/onton/pull/274?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->