### PR TITLE
Restore Claude OAuth auth and harden stale-session handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@
 
 The codebase is split into two dune libraries:
 
-- `lib_core/` — pure decision logic. Modules here are total functions of their inputs (parsers, state algebras, predicates, decision functions). `lib_core/dune` lists only `base`, `yojson`, `ppx_yojson_conv_lib` in `(libraries ...)`. The linker rejects any pure module that reaches for `eio`, `unix`, `cohttp-eio`, `tls-eio`, `mirage-crypto-rng.unix`, `ca-certs`, `lwt`, or any other effectful library.
+- `lib_core/` — pure decision logic. Modules here are total functions of their inputs (parsers, state algebras, predicates, decision functions). The split is about excluding effects, not about avoiding non-Base libraries: pure support libraries such as `re` are fine in `lib_core/dune`. The linker rejects any pure module that reaches for `eio`, `unix`, `cohttp-eio`, `tls-eio`, `mirage-crypto-rng.unix`, `ca-certs`, `lwt`, or any other effectful library.
 - `lib/` — effectful handlers. Process spawning, Eio fibers, FS, HTTP, locks. Handlers decode inputs from the effect world, call pure decisions, thread the returned state, and emit effects.
 
 Reference example: `Codex_cost` (pure, in `lib_core/`) plus `Codex_backend` (handler, in `lib/`). The handler reads `codex exec --json` lines, calls `Codex_cost.on_turn_completed`, threads the returned state, and emits stream events.
@@ -35,7 +35,7 @@ Reference example: `Codex_cost` (pure, in `lib_core/`) plus `Codex_backend` (han
 ### Rules for new code
 
 - Anything that is a pure function of its inputs — parsing, state transitions, predicates, decisions, classifications — goes in `lib_core/`. Default to the pure side; only put code in `lib/` when it needs an effect.
-- Do NOT add `eio`, `unix`, `cohttp-eio`, `tls-eio`, `mirage-crypto-rng.unix`, `ca-certs`, `lwt`, or any process/IO library to `lib_core/dune`. If a pure decision needs an effectful input (clock, env var, file contents), the handler in `lib/` reads it and passes it as an argument.
+- Do NOT add `eio`, `unix`, `cohttp-eio`, `tls-eio`, `mirage-crypto-rng.unix`, `ca-certs`, `lwt`, or any process/IO library to `lib_core/dune`. Pure helper dependencies are allowed when they keep decision logic total and testable. If a pure decision needs an effectful input (clock, env var, file contents), the handler in `lib/` reads it and passes it as an argument.
 - Pure modules must be **total** — decoders return zero/default values on malformed input, never raise. Use private types and `.mli` files to make invariants explicit (e.g. `cost_state` is private so monotonicity is enforced at construction).
 - Handler modules in `lib/` are thin: decode → call pure decision → thread state → emit. Resist putting decision logic inline in the handler; extract it into the pure module instead.
 

--- a/lib/claude_runner.ml
+++ b/lib/claude_runner.ml
@@ -22,19 +22,18 @@ let build_stream_args ~getenv_opt ~model ~complexity ~prompt ~minted_session_id
     ~complexity ~prompt ~minted_session_id ~resume_session
 
 let prepare_minted_session_id_with_env ~getenv_opt ~patch_id ~resume_session =
+  ignore (patch_id : Types.Patch_id.t);
+  (* Mint a session id when [ONTON_MINTED_SESSION_IDS=1] and there is no
+     resume id to fall back to.  The sidecar that lets a crashed supervisor
+     resume an in-flight session is written *deferred* by the stream-event
+     loop in [session_driver.ml] — only after the first [Text_delta] or
+     [Tool_use] proves claude has actually written a real conversation
+     turn.  Persisting eagerly here used to poison every later retry that
+     landed on a stub [.jsonl] (claude exits before content → sidecar
+     restored on startup → [--resume <stub>] → "No conversation found"). *)
   match (resume_session, getenv_opt "ONTON_MINTED_SESSION_IDS") with
   | Some _, _ | _, None | _, Some "" -> Ok None
-  | None, Some "1" -> (
-      match getenv_opt "ONTON_SNAPSHOT_PATH" with
-      | Some snapshot_path
-        when not (String.is_empty (String.strip snapshot_path)) ->
-          let session_id = Session_id.mint () in
-          Result.map
-            (Persistence.record_session_id ~snapshot_path ~patch_id ~session_id)
-            ~f:(fun () -> Some session_id)
-      | _ ->
-          Error
-            "ONTON_MINTED_SESSION_IDS=1 requires ONTON_SNAPSHOT_PATH to be set")
+  | None, Some "1" -> Ok (Some (Session_id.mint ()))
   | None, Some _ -> Ok None
 
 let prepare_minted_session_id =
@@ -128,16 +127,43 @@ let run_streaming ~model ~process_mgr ~clock ~timeout ~setsid_exec ~project_name
       Llm_backend.spawn_and_stream ~process_mgr ~clock ~timeout ~cwd ~env
         ~setsid_exec ~args ~process_line ~on_event
 
-let%test "prepare_minted_session_id errors when flag is on and path missing" =
+let%test
+    "prepare_minted_session_id mints when flag is on (no snapshot path \
+     required)" =
   let patch_id = Types.Patch_id.of_string "5" in
   let getenv_opt = function
     | "ONTON_MINTED_SESSION_IDS" -> Some "1"
-    | "ONTON_SNAPSHOT_PATH" -> None
     | _ -> None
   in
   match
     prepare_minted_session_id_with_env ~getenv_opt ~patch_id
       ~resume_session:None
   with
-  | Error _ -> true
-  | Ok _ -> false
+  | Ok (Some _) -> true
+  | Ok None -> false
+  | Error _ -> false
+
+let%test "prepare_minted_session_id returns None when flag is off" =
+  let patch_id = Types.Patch_id.of_string "5" in
+  let getenv_opt _ = None in
+  match
+    prepare_minted_session_id_with_env ~getenv_opt ~patch_id
+      ~resume_session:None
+  with
+  | Ok None -> true
+  | Ok (Some _) -> false
+  | Error _ -> false
+
+let%test "prepare_minted_session_id returns None when resume_session is set" =
+  let patch_id = Types.Patch_id.of_string "5" in
+  let getenv_opt = function
+    | "ONTON_MINTED_SESSION_IDS" -> Some "1"
+    | _ -> None
+  in
+  match
+    prepare_minted_session_id_with_env ~getenv_opt ~patch_id
+      ~resume_session:(Some "existing-id")
+  with
+  | Ok None -> true
+  | Ok (Some _) -> false
+  | Error _ -> false

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -651,7 +651,12 @@ let apply_session_result t patch_id result =
       let t = update_agent t patch_id ~f:Patch_agent.on_pre_session_failure in
       complete_failed t patch_id
   | Session_no_resume ->
-      let t = on_session_failure t patch_id ~is_fresh:false in
+      (* A resume that produced zero events ("No conversation found with
+         session ID …" against a stub .jsonl) is observationally equivalent
+         to "we never spoke to the LLM" — do NOT escalate the retry-budget
+         ladder.  Clearing [llm_session_id] forces the next iteration to
+         Fresh ([session_mode]), and a Fresh attempt can never produce
+         [Session_no_resume] (classifier requires [is_resume]), so no loop. *)
       let t =
         update_agent t patch_id ~f:(fun a ->
             Patch_agent.set_llm_session_id a None)

--- a/lib/persistence.ml
+++ b/lib/persistence.ml
@@ -34,26 +34,29 @@ let session_id_path ~snapshot_path ~patch_id =
     (Patch_id.to_string patch_id ^ ".txt")
 
 let sync_session_id_sidecars ~snapshot_path (snap : Runtime.snapshot) =
-  let ( let* ) r f = Result.bind r ~f in
+  (* Delete-only janitor.  Sidecar *writes* happen in the streaming loop
+     (session_driver.ml) the first time claude emits a Text_delta or
+     Tool_use — proving it wrote a real turn to its .jsonl.  Writing here
+     too would re-poison the resume path: a session that died after
+     Session_init but before any content would otherwise leave a sidecar
+     pointing at a stub .jsonl that future [--resume]s reject. *)
   try
     let dir = session_id_dir ~snapshot_path in
     Project_store.ensure_dir dir;
-    List.fold (Orchestrator.all_agents snap.Runtime.orchestrator) ~init:(Ok ())
-      ~f:(fun acc (agent : Patch_agent.t) ->
-        let* () = acc in
+    List.iter (Orchestrator.all_agents snap.Runtime.orchestrator)
+      ~f:(fun (agent : Patch_agent.t) ->
         let path =
           session_id_path ~snapshot_path ~patch_id:agent.Patch_agent.patch_id
         in
-        match agent.Patch_agent.llm_session_id with
-        | Some session_id -> write_file_atomically ~path ~content:session_id
-        | None ->
-            (* A fresh Claude session may have minted and persisted its ID
-               before the in-memory orchestrator has observed the first
-               stream event. While that session is still marked busy, preserve
-               any existing sidecar rather than deleting the crash-recovery
-               resume key. *)
-            if not agent.Patch_agent.busy then remove_if_exists path;
-            Ok ())
+        match (agent.Patch_agent.llm_session_id, agent.Patch_agent.busy) with
+        | None, false ->
+            (* The patch is idle and has no recorded id; clean up any stale
+               sidecar.  We do NOT delete while the patch is busy: an
+               in-flight session may have already written its sidecar from
+               the event loop. *)
+            remove_if_exists path
+        | None, true | Some _, _ -> ());
+    Ok ()
   with exn -> Error (Stdlib.Printexc.to_string exn)
 
 let overlay_session_id_sidecars ~snapshot_path (snap : Runtime.snapshot) =
@@ -813,10 +816,39 @@ let%test_module "session_id_sidecars" =
           | None -> false)
       | Error _ -> false
 
-    let%test "save surfaces sidecar write failures" =
+    (* sync_session_id_sidecars is delete-only: the event-loop in
+       session_driver.ml owns writes once claude has produced real content.
+       These two tests pin down the new contract. *)
+    let%test "save does not create sidecar for busy agent with llm_session_id" =
       with_temp_snapshot_path @@ fun snapshot_path ->
-      let blocking_path = session_id_dir ~snapshot_path in
-      ignore (write_file_atomically ~path:blocking_path ~content:"not a dir");
-      Result.is_error
-        (save ~path:snapshot_path (snapshot ~llm_session_id:"id" ()))
+      Result.is_ok
+        (save ~path:snapshot_path
+           (snapshot ~busy:true ~llm_session_id:"freshly-minted" ()))
+      &&
+      let path = session_id_path ~snapshot_path ~patch_id in
+      not (Stdlib.Sys.file_exists path)
+
+    let%test
+        "save deletes stale sidecar for non-busy agent without llm_session_id" =
+      with_temp_snapshot_path @@ fun snapshot_path ->
+      Result.is_ok (save ~path:snapshot_path (snapshot ()))
+      && Result.is_ok
+           (record_session_id ~snapshot_path ~patch_id ~session_id:"stale")
+      &&
+      let path = session_id_path ~snapshot_path ~patch_id in
+      Stdlib.Sys.file_exists path
+      && Result.is_ok (save ~path:snapshot_path (snapshot ()))
+      && not (Stdlib.Sys.file_exists path)
+
+    let%test
+        "save preserves sidecar for busy agent (event loop writes own copy)" =
+      with_temp_snapshot_path @@ fun snapshot_path ->
+      Result.is_ok (save ~path:snapshot_path (snapshot ~busy:true ()))
+      && Result.is_ok
+           (record_session_id ~snapshot_path ~patch_id ~session_id:"in-flight")
+      &&
+      let path = session_id_path ~snapshot_path ~patch_id in
+      Stdlib.Sys.file_exists path
+      && Result.is_ok (save ~path:snapshot_path (snapshot ~busy:true ()))
+      && Stdlib.Sys.file_exists path
   end)

--- a/lib/session_driver.ml
+++ b/lib/session_driver.ml
@@ -474,13 +474,13 @@ let run_with_backend ~session_mode_for_agent
                 (match resume_session with
                 | None -> ()
                 | Some session_id when safe_session_id session_id -> (
-                    let path =
-                      Spawn_env.claude_session_jsonl_path ~project_name
-                        ~patch_id ~worktree_path ~session_id
-                    in
-                    try Unix.unlink path with
-                    | Unix.Unix_error (Unix.ENOENT, _, _) -> ()
-                    | _ -> ())
+                    try
+                      let path =
+                        Spawn_env.claude_session_jsonl_path ~project_name
+                          ~patch_id ~worktree_path ~session_id
+                      in
+                      Unix.unlink path
+                    with _ -> ())
                 | Some session_id ->
                     log_event runtime ~patch_id
                       (Printf.sprintf

--- a/lib/session_driver.ml
+++ b/lib/session_driver.ml
@@ -141,6 +141,15 @@ let run_with_backend ~session_mode_for_agent
           (`Failed, [])
       | Some worktree_path ->
           let cwd = Eio.Path.(fs / worktree_path) in
+          (* Read once at session start so the per-event callback below can
+             persist the session id to the crash-recovery sidecar without
+             repeated env lookups.  When unset, the sidecar write is a no-op:
+             nothing to recover from on restart anyway. *)
+          let snapshot_path_opt =
+            match Stdlib.Sys.getenv_opt "ONTON_SNAPSHOT_PATH" with
+            | Some p when not (String.is_empty (String.strip p)) -> Some p
+            | _ -> None
+          in
           let text_buf =
             let buf = Buffer.create 4096 in
             (match Stdlib.Hashtbl.find_opt transcripts patch_id with
@@ -211,6 +220,22 @@ let run_with_backend ~session_mode_for_agent
               sync_transcript ())
           in
           let captured_session_id = ref None in
+          let content_gate = Content_gate.create () in
+          let maybe_persist_session_id () =
+            match (snapshot_path_opt, !captured_session_id) with
+            | Some snapshot_path, Some session_id -> (
+                match
+                  Persistence.record_session_id ~snapshot_path ~patch_id
+                    ~session_id
+                with
+                | Ok () -> ()
+                | Error msg ->
+                    log_event runtime ~patch_id
+                      (Printf.sprintf
+                         "Failed to record session_id sidecar for %s — %s"
+                         session_id msg))
+            | None, _ | _, None -> ()
+          in
           let backend_accepted_turn = ref false in
           let mark_backend_accepted_turn () =
             if not !backend_accepted_turn then (
@@ -230,6 +255,14 @@ let run_with_backend ~session_mode_for_agent
                   ())
           in
           let on_event (event : Types.Stream_event.t) =
+            (* Persist the crash-recovery sidecar lazily: only after claude
+               has *committed* a conversation turn to its .jsonl (first
+               Final_result event).  Streamed chunks (Text_delta, Tool_use)
+               can fire before the turn lands on disk — if the API errors
+               mid-turn, the .jsonl stays at its 124-byte header and a
+               sidecar pointing at it would poison every later --resume. *)
+            if Content_gate.should_persist content_gate event then
+              maybe_persist_session_id ();
             match event with
             (* Turn_started is the preferred signal; the arms below are
                fallbacks for backends that do not emit it. *)
@@ -407,6 +440,21 @@ let run_with_backend ~session_mode_for_agent
                   `Failed )
             | No_session_to_resume ->
                 log_empty_resume ~tail:" — no session to resume, retrying fresh";
+                (* Remove the stub .jsonl that claude refused to resume.
+                   Otherwise it sits in the per-patch projects dir forever and
+                   trips any future attempt that happens to target the same
+                   session id.  Best-effort: a missing file or a transient
+                   filesystem error must not interrupt the retry path. *)
+                (match resume_session with
+                | None -> ()
+                | Some session_id -> (
+                    let path =
+                      Spawn_env.claude_session_jsonl_path ~project_name
+                        ~patch_id ~worktree_path ~session_id
+                    in
+                    try Unix.unlink path with
+                    | Unix.Unix_error (Unix.ENOENT, _, _) -> ()
+                    | _ -> ()));
                 (Orchestrator.Session_no_resume, `Failed)
             | Timed_out ->
                 let detail =

--- a/lib/session_driver.ml
+++ b/lib/session_driver.ml
@@ -7,6 +7,22 @@ let pluralize ?plural n singular =
   let many = match plural with Some p -> p | None -> singular ^ "s" in
   Printf.sprintf "%d %s" n (if n = 1 then singular else many)
 
+let safe_session_id s =
+  (not (String.is_empty s))
+  && (not (String.is_substring s ~substring:".."))
+  && String.for_all s ~f:(fun c ->
+      Char.is_alphanum c || Char.equal c '-' || Char.equal c '_'
+      || Char.equal c '.')
+
+let%test "safe_session_id accepts ordinary claude ids" =
+  safe_session_id "abc-123_DEF.456"
+
+let%test "safe_session_id rejects traversal and separators" =
+  (not (safe_session_id "../abc"))
+  && (not (safe_session_id "abc/def"))
+  && (not (safe_session_id "abc\\def"))
+  && not (safe_session_id "")
+
 let session_mode (agent : Patch_agent.t) :
     [ `Resume of string | `Fresh | `Give_up ] =
   match agent.Patch_agent.session_fallback with
@@ -220,7 +236,7 @@ let run_with_backend ~session_mode_for_agent
               sync_transcript ())
           in
           let captured_session_id = ref None in
-          let content_gate = Content_gate.create () in
+          let content_gate = ref (Content_gate.create ()) in
           let maybe_persist_session_id () =
             match (snapshot_path_opt, !captured_session_id) with
             | Some snapshot_path, Some session_id -> (
@@ -255,134 +271,144 @@ let run_with_backend ~session_mode_for_agent
                   ())
           in
           let on_event (event : Types.Stream_event.t) =
+            let () =
+              match event with
+              (* Turn_started is the preferred signal; the arms below are
+                 fallbacks for backends that do not emit it. *)
+              | Types.Stream_event.Turn_started -> mark_backend_accepted_turn ()
+              | Types.Stream_event.Text_delta text ->
+                  mark_backend_accepted_turn ();
+                  let prev_len = Buffer.length text_buf in
+                  Buffer.add_string text_buf text;
+                  maybe_sync_transcript ();
+                  if not !pr_found then
+                    (* Anchor the tail window to [prev_len], NOT [new_len].
+                       We want the window to always cover the ENTIRE new chunk
+                       plus up to [pr_url_lookback] bytes back into the prior
+                       content (to catch a URL/digit run that spanned the
+                       chunk boundary). LLM stream chunks are routinely longer
+                       than [pr_url_lookback] (~62 bytes), so anchoring to
+                       [new_len] would shrink the window to the last
+                       [pr_url_lookback] bytes and miss URLs in the early part
+                       of long chunks. *)
+                    let offset = max 0 (prev_len - pr_url_lookback) in
+                    let tail =
+                      Buffer.To_string.sub text_buf ~pos:offset
+                        ~len:(Buffer.length text_buf - offset)
+                    in
+                    try_extract_pr tail
+              | Types.Stream_event.Tool_use { name; input; status } ->
+                  mark_backend_accepted_turn ();
+                  tool_count := !tool_count + 1;
+                  (* OpenCode emits pending → running → completed for a single
+                     tool call. Track only the latest unresolved status per tool
+                     name: clear on completed, replace on any other status.
+                     Otherwise a normal pending → completed lifecycle would
+                     leave a stale (name, "pending") entry that
+                     [classify_pr_body_respond] would misread as a blocked
+                     Write. *)
+                  (match status with
+                  | Some s when String.equal s "completed" ->
+                      tool_failures :=
+                        List.filter !tool_failures ~f:(fun (n, _) ->
+                            not (String.equal n name))
+                  | Some s ->
+                      let without =
+                        List.filter !tool_failures ~f:(fun (n, _) ->
+                            not (String.equal n name))
+                      in
+                      tool_failures := (name, s) :: without
+                  | None -> ());
+                  let summary =
+                    try
+                      let json = Yojson.Safe.from_string input in
+                      let field key =
+                        Yojson.Safe.Util.(member key json |> to_string_option)
+                      in
+                      let s =
+                        match name with
+                        | "Bash" -> field "command"
+                        | "Read" | "Write" -> field "file_path"
+                        | "Edit" -> field "file_path"
+                        | "Glob" -> field "pattern"
+                        | "Grep" -> field "pattern"
+                        | _ -> None
+                      in
+                      match s with Some v -> truncate v 80 | None -> ""
+                    with _ -> ""
+                  in
+                  let detail =
+                    if not (String.is_empty summary) then
+                      Printf.sprintf " %s" summary
+                    else ""
+                  in
+                  let sep =
+                    let len = Buffer.length text_buf in
+                    if len = 0 then ""
+                    else if
+                      len >= 2
+                      && Char.equal (Buffer.nth text_buf (len - 1)) '\n'
+                      && Char.equal (Buffer.nth text_buf (len - 2)) '\n'
+                    then ""
+                    else if Char.equal (Buffer.nth text_buf (len - 1)) '\n' then
+                      "\n"
+                    else "\n\n"
+                  in
+                  Buffer.add_string text_buf
+                    (Printf.sprintf "%s[tool: %s]%s\n" sep name detail);
+                  sync_transcript ();
+                  log_stream_entry runtime ~patch_id
+                    (Activity_log.Stream_entry.Tool_use (name, summary))
+              | Types.Stream_event.Final_result { stop_reason; _ } ->
+                  mark_backend_accepted_turn ();
+                  sync_transcript ();
+                  (* Final pass with end-of-stream semantics — catches PR URLs
+                     whose digit run terminates exactly at the buffer end (no
+                     trailing newline / next chunk to provide a non-digit
+                     terminator).
+
+                     Restricted to the same [pr_url_lookback] tail window the
+                     per-chunk path uses: scanning the full buffer would
+                     left-to-right match an earlier stub fragment (e.g. an
+                     abandoned [.../pull/12] from a mid-stream digit-boundary
+                     that the per-chunk path correctly returned [None] for),
+                     reporting the wrong PR if the real URL appears later in
+                     the same buffer. The per-chunk path already saw any URL
+                     that had a non-digit terminator during streaming, so the
+                     final pass only needs to cover what the tail window does. *)
+                  (if not !pr_found then
+                     let full = Buffer.contents text_buf in
+                     let len = String.length full in
+                     let offset = max 0 (len - pr_url_lookback) in
+                     let tail =
+                       String.sub full ~pos:offset ~len:(len - offset)
+                     in
+                     try_extract_pr ~at_end_of_stream:true tail);
+                  let reason = Types.Stop_reason.to_display stop_reason in
+                  log_stream_entry runtime ~patch_id
+                    (Activity_log.Stream_entry.Finished reason)
+              | Types.Stream_event.Error msg ->
+                  if Buffer.length error_buf > 0 then
+                    Buffer.add_char error_buf '\n';
+                  Buffer.add_string error_buf msg;
+                  log_stream_entry runtime ~patch_id
+                    (Activity_log.Stream_entry.Stream_error msg)
+              | Types.Stream_event.Session_init { session_id; _ } ->
+                  captured_session_id := Some session_id
+            in
             (* Persist the crash-recovery sidecar lazily: only after claude
                has *committed* a conversation turn to its .jsonl (first
                Final_result event).  Streamed chunks (Text_delta, Tool_use)
                can fire before the turn lands on disk — if the API errors
                mid-turn, the .jsonl stays at its 124-byte header and a
-               sidecar pointing at it would poison every later --resume. *)
-            if Content_gate.should_persist content_gate event then
-              maybe_persist_session_id ();
-            match event with
-            (* Turn_started is the preferred signal; the arms below are
-               fallbacks for backends that do not emit it. *)
-            | Types.Stream_event.Turn_started -> mark_backend_accepted_turn ()
-            | Types.Stream_event.Text_delta text ->
-                mark_backend_accepted_turn ();
-                let prev_len = Buffer.length text_buf in
-                Buffer.add_string text_buf text;
-                maybe_sync_transcript ();
-                if not !pr_found then
-                  (* Anchor the tail window to [prev_len], NOT [new_len].
-                     We want the window to always cover the ENTIRE new chunk
-                     plus up to [pr_url_lookback] bytes back into the prior
-                     content (to catch a URL/digit run that spanned the
-                     chunk boundary). LLM stream chunks are routinely longer
-                     than [pr_url_lookback] (~62 bytes), so anchoring to
-                     [new_len] would shrink the window to the last
-                     [pr_url_lookback] bytes and miss URLs in the early part
-                     of long chunks. *)
-                  let offset = max 0 (prev_len - pr_url_lookback) in
-                  let tail =
-                    Buffer.To_string.sub text_buf ~pos:offset
-                      ~len:(Buffer.length text_buf - offset)
-                  in
-                  try_extract_pr tail
-            | Types.Stream_event.Tool_use { name; input; status } ->
-                mark_backend_accepted_turn ();
-                tool_count := !tool_count + 1;
-                (* OpenCode emits pending → running → completed for a single
-                   tool call. Track only the latest unresolved status per tool
-                   name: clear on completed, replace on any other status.
-                   Otherwise a normal pending → completed lifecycle would leave
-                   a stale (name, "pending") entry that
-                   [classify_pr_body_respond] would misread as a blocked Write. *)
-                (match status with
-                | Some s when String.equal s "completed" ->
-                    tool_failures :=
-                      List.filter !tool_failures ~f:(fun (n, _) ->
-                          not (String.equal n name))
-                | Some s ->
-                    let without =
-                      List.filter !tool_failures ~f:(fun (n, _) ->
-                          not (String.equal n name))
-                    in
-                    tool_failures := (name, s) :: without
-                | None -> ());
-                let summary =
-                  try
-                    let json = Yojson.Safe.from_string input in
-                    let field key =
-                      Yojson.Safe.Util.(member key json |> to_string_option)
-                    in
-                    let s =
-                      match name with
-                      | "Bash" -> field "command"
-                      | "Read" | "Write" -> field "file_path"
-                      | "Edit" -> field "file_path"
-                      | "Glob" -> field "pattern"
-                      | "Grep" -> field "pattern"
-                      | _ -> None
-                    in
-                    match s with Some v -> truncate v 80 | None -> ""
-                  with _ -> ""
-                in
-                let detail =
-                  if not (String.is_empty summary) then
-                    Printf.sprintf " %s" summary
-                  else ""
-                in
-                let sep =
-                  let len = Buffer.length text_buf in
-                  if len = 0 then ""
-                  else if
-                    len >= 2
-                    && Char.equal (Buffer.nth text_buf (len - 1)) '\n'
-                    && Char.equal (Buffer.nth text_buf (len - 2)) '\n'
-                  then ""
-                  else if Char.equal (Buffer.nth text_buf (len - 1)) '\n' then
-                    "\n"
-                  else "\n\n"
-                in
-                Buffer.add_string text_buf
-                  (Printf.sprintf "%s[tool: %s]%s\n" sep name detail);
-                sync_transcript ();
-                log_stream_entry runtime ~patch_id
-                  (Activity_log.Stream_entry.Tool_use (name, summary))
-            | Types.Stream_event.Final_result { stop_reason; _ } ->
-                mark_backend_accepted_turn ();
-                sync_transcript ();
-                (* Final pass with end-of-stream semantics — catches PR URLs
-                   whose digit run terminates exactly at the buffer end (no
-                   trailing newline / next chunk to provide a non-digit
-                   terminator).
-
-                   Restricted to the same [pr_url_lookback] tail window the
-                   per-chunk path uses: scanning the full buffer would
-                   left-to-right match an earlier stub fragment (e.g. an
-                   abandoned [.../pull/12] from a mid-stream digit-boundary
-                   that the per-chunk path correctly returned [None] for),
-                   reporting the wrong PR if the real URL appears later in
-                   the same buffer. The per-chunk path already saw any URL
-                   that had a non-digit terminator during streaming, so the
-                   final pass only needs to cover what the tail window does. *)
-                (if not !pr_found then
-                   let full = Buffer.contents text_buf in
-                   let len = String.length full in
-                   let offset = max 0 (len - pr_url_lookback) in
-                   let tail = String.sub full ~pos:offset ~len:(len - offset) in
-                   try_extract_pr ~at_end_of_stream:true tail);
-                let reason = Types.Stop_reason.to_display stop_reason in
-                log_stream_entry runtime ~patch_id
-                  (Activity_log.Stream_entry.Finished reason)
-            | Types.Stream_event.Error msg ->
-                if Buffer.length error_buf > 0 then
-                  Buffer.add_char error_buf '\n';
-                Buffer.add_string error_buf msg;
-                log_stream_entry runtime ~patch_id
-                  (Activity_log.Stream_entry.Stream_error msg)
-            | Types.Stream_event.Session_init { session_id; _ } ->
-                captured_session_id := Some session_id
+               sidecar pointing at it would poison every later --resume.
+               Run this after the event dispatch so a same-batch Session_init
+               has already updated [captured_session_id]. *)
+            let next_gate, persist =
+              Content_gate.should_persist !content_gate event
+            in
+            content_gate := next_gate;
+            if persist then maybe_persist_session_id ()
           in
           let result =
             try
@@ -447,14 +473,19 @@ let run_with_backend ~session_mode_for_agent
                    filesystem error must not interrupt the retry path. *)
                 (match resume_session with
                 | None -> ()
-                | Some session_id -> (
+                | Some session_id when safe_session_id session_id -> (
                     let path =
                       Spawn_env.claude_session_jsonl_path ~project_name
                         ~patch_id ~worktree_path ~session_id
                     in
                     try Unix.unlink path with
                     | Unix.Unix_error (Unix.ENOENT, _, _) -> ()
-                    | _ -> ()));
+                    | _ -> ())
+                | Some session_id ->
+                    log_event runtime ~patch_id
+                      (Printf.sprintf
+                         "Skipping cleanup for unsafe Claude session id %S"
+                         session_id));
                 (Orchestrator.Session_no_resume, `Failed)
             | Timed_out ->
                 let detail =

--- a/lib/spawn_env.ml
+++ b/lib/spawn_env.ml
@@ -150,6 +150,31 @@ let per_patch_env_without_codex_home ~project_name ~patch_id =
     ~project_dir:(Project_store.project_dir project_name)
     ~patch_id
 
+(* Claude Code stores each conversation at
+   [<CLAUDE_CONFIG_DIR>/projects/<cwd-key>/<session-id>.jsonl], where
+   [cwd-key] is the absolute cwd path with every ["/"] replaced by ["-"].
+   When [claude --resume <id>] hits a stub (a session-init header with no
+   conversation turns, left behind by a session that failed before producing
+   content), the file remains on disk forever; this helper lets the caller
+   delete it after a [Session_no_resume] classification. *)
+let claude_project_dir_key ~worktree_path =
+  String.substr_replace_all worktree_path ~pattern:"/" ~with_:"-"
+
+let claude_session_jsonl_path_in_project_dir ~project_dir ~patch_id
+    ~worktree_path ~session_id =
+  let root = patch_root ~project_dir ~patch_id in
+  let claude_dir = backend_dir ~root ~backend:"claude" in
+  let key = claude_project_dir_key ~worktree_path in
+  Stdlib.Filename.concat
+    (Stdlib.Filename.concat (Stdlib.Filename.concat claude_dir "projects") key)
+    (session_id ^ ".jsonl")
+
+let claude_session_jsonl_path ~project_name ~patch_id ~worktree_path ~session_id
+    =
+  claude_session_jsonl_path_in_project_dir
+    ~project_dir:(Project_store.project_dir project_name)
+    ~patch_id ~worktree_path ~session_id
+
 let split_env_entry entry =
   match String.lsplit2 entry ~on:'=' with
   | Some (key, value) -> (key, value)
@@ -231,6 +256,23 @@ let%test "merged env contains per-patch overrides" =
   String.is_substring claude_a ~substring:"spawn-envs/patch-1/claude"
   && String.is_substring codex_a ~substring:"spawn-envs/patch-1/codex"
   && not (String.equal claude_a claude_b)
+
+let%test
+    "claude_session_jsonl_path: composes per-patch claude dir + cwd key + \
+     session id" =
+  let path =
+    claude_session_jsonl_path_in_project_dir ~project_dir:"/proj"
+      ~patch_id:(Types.Patch_id.of_string "42")
+      ~worktree_path:"/Users/x/worktrees/foo/patch-42"
+      ~session_id:"c9f311bc-7e1a-4b36-bc1f-940513fb75f9"
+  in
+  String.equal path
+    "/proj/spawn-envs/42/claude/projects/-Users-x-worktrees-foo-patch-42/c9f311bc-7e1a-4b36-bc1f-940513fb75f9.jsonl"
+
+let%test "claude_project_dir_key: replaces every slash with a dash" =
+  String.equal (claude_project_dir_key ~worktree_path:"/a/b/c") "-a-b-c"
+  && String.equal (claude_project_dir_key ~worktree_path:"/") "-"
+  && String.equal (claude_project_dir_key ~worktree_path:"") ""
 
 let%test "codex home override can be omitted" =
   with_temp_project_dir @@ fun project_dir ->

--- a/lib/spawn_env.mli
+++ b/lib/spawn_env.mli
@@ -25,3 +25,15 @@ val merge_env :
   base_env:string array -> overrides:(string * string) list -> string array
 (** Merge [overrides] into [base_env], replacing any existing entries with the
     same variable name. *)
+
+val claude_session_jsonl_path :
+  project_name:string ->
+  patch_id:Types.Patch_id.t ->
+  worktree_path:string ->
+  session_id:string ->
+  string
+(** Absolute path to a claude conversation file:
+    [<per-patch-CLAUDE_CONFIG_DIR>/projects/<cwd-key>/<session-id>.jsonl], where
+    [cwd-key] is [worktree_path] with every ["/"] replaced by ["-"] (claude's
+    internal projects-dir keying). Used to clean up stub files left behind when
+    [claude --resume] fails with "No conversation found". *)

--- a/lib_core/claude_event_parser.ml
+++ b/lib_core/claude_event_parser.ml
@@ -71,7 +71,24 @@ let budget_cap_args ~getenv_opt ~warn () =
                raw);
           [])
 
-let bare_args = [ "--bare" ]
+(* [--bare] tells claude to skip hooks/LSP/attribution/auto-memory/keychain
+   reads/CLAUDE.md auto-discovery — the isolation properties onton wants for
+   ephemeral patch-agent spawns.  It *also* restricts authentication to
+   [ANTHROPIC_API_KEY] or [apiKeyHelper] (via [--settings]): OAuth tokens
+   from [claude setup-token] (sk-ant-oat01-…) and macOS Keychain entries
+   are silently ignored.  Most onton users authenticate via subscription
+   OAuth, not API keys, so unconditionally passing [--bare] used to leave
+   every spawned claude reporting "Not logged in".
+
+   Emit [--bare] only when [ANTHROPIC_API_KEY] is present in the parent
+   env (which propagates to the spawned claude unchanged).  Without it,
+   omit [--bare] so claude falls back to its normal OAuth/Keychain path.
+   The cost is some user-state leakage into ephemeral sessions, which is
+   strictly less bad than not running at all. *)
+let bare_args ~getenv_opt =
+  match getenv_opt "ANTHROPIC_API_KEY" with
+  | Some k when not (String.is_empty (String.strip k)) -> [ "--bare" ]
+  | _ -> []
 
 let build_args ~getenv_opt ~warn ~model ~complexity ~prompt ~resume_session =
   let base = [ "claude" ] in
@@ -87,7 +104,7 @@ let build_args ~getenv_opt ~warn ~model ~complexity ~prompt ~resume_session =
       "--exclude-dynamic-system-prompt-sections";
     ]
     @ budget_cap_args ~getenv_opt ~warn ()
-    @ bare_args
+    @ bare_args ~getenv_opt
   in
   base @ model_args model @ prompt_args @ session_args @ flags
 
@@ -119,7 +136,7 @@ let build_stream_args ~getenv_opt ~warn ~model ~complexity ~prompt
       "--exclude-dynamic-system-prompt-sections";
     ]
     @ budget_cap_args ~getenv_opt ~warn ()
-    @ bare_args
+    @ bare_args ~getenv_opt
   in
   base @ model_args model @ minted_session_args @ prompt_args @ session_args
   @ flags
@@ -278,6 +295,13 @@ let parse_stream_event (line : string) : Types.Stream_event.t option =
 let no_env _ = None
 let ignore_warn _ = ()
 
+(* Test helper: model the env of an API-key user.  [bare_args] emits
+   [--bare] iff [ANTHROPIC_API_KEY] is present, so tests that exercise the
+   isolation-mode path use [with_api_key] in place of [no_env]. *)
+let with_api_key = function
+  | "ANTHROPIC_API_KEY" -> Some "sk-ant-api03-test"
+  | _ -> None
+
 let%test "auto_model: complexity 1 -> haiku" =
   Option.equal String.equal (auto_model ~complexity:(Some 1)) (Some "haiku")
 
@@ -307,7 +331,7 @@ let%test "max_turns_for: None -> 200" =
 
 let%test "build_args fresh (no resume, with model)" =
   let args =
-    build_args ~getenv_opt:no_env ~warn:ignore_warn ~model:(Some "sonnet")
+    build_args ~getenv_opt:with_api_key ~warn:ignore_warn ~model:(Some "sonnet")
       ~complexity:(Some 2) ~prompt:"do stuff" ~resume_session:None
   in
   List.equal String.equal args
@@ -328,7 +352,7 @@ let%test "build_args fresh (no resume, with model)" =
 
 let%test "build_args fresh (no resume, no model)" =
   let args =
-    build_args ~getenv_opt:no_env ~warn:ignore_warn ~model:None
+    build_args ~getenv_opt:with_api_key ~warn:ignore_warn ~model:None
       ~complexity:(Some 1) ~prompt:"do stuff" ~resume_session:None
   in
   List.equal String.equal args
@@ -347,7 +371,7 @@ let%test "build_args fresh (no resume, no model)" =
 
 let%test "build_args with resume session" =
   let args =
-    build_args ~getenv_opt:no_env ~warn:ignore_warn ~model:(Some "opus")
+    build_args ~getenv_opt:with_api_key ~warn:ignore_warn ~model:(Some "opus")
       ~complexity:(Some 3) ~prompt:"do stuff" ~resume_session:(Some "abc-123")
   in
   List.equal String.equal args
@@ -375,15 +399,30 @@ let%test "build_args includes --exclude-dynamic-system-prompt-sections" =
   in
   List.mem args "--exclude-dynamic-system-prompt-sections" ~equal:String.equal
 
-let%test "build_args includes --bare" =
+let%test "build_args includes --bare when ANTHROPIC_API_KEY is set" =
   List.mem
-    (build_args ~getenv_opt:no_env ~warn:ignore_warn ~model:None
+    (build_args ~getenv_opt:with_api_key ~warn:ignore_warn ~model:None
        ~complexity:None ~prompt:"do stuff" ~resume_session:None)
     "--bare" ~equal:String.equal
 
+let%test "build_args omits --bare without ANTHROPIC_API_KEY (OAuth path)" =
+  not
+    (List.mem
+       (build_args ~getenv_opt:no_env ~warn:ignore_warn ~model:None
+          ~complexity:None ~prompt:"do stuff" ~resume_session:None)
+       "--bare" ~equal:String.equal)
+
+let%test "build_args omits --bare when ANTHROPIC_API_KEY is empty/whitespace" =
+  let getenv_opt = function "ANTHROPIC_API_KEY" -> Some "   " | _ -> None in
+  not
+    (List.mem
+       (build_args ~getenv_opt ~warn:ignore_warn ~model:None ~complexity:None
+          ~prompt:"do stuff" ~resume_session:None)
+       "--bare" ~equal:String.equal)
+
 let%test "build_stream_args fresh (no resume, with model)" =
   let args =
-    build_stream_args ~getenv_opt:no_env ~warn:ignore_warn
+    build_stream_args ~getenv_opt:with_api_key ~warn:ignore_warn
       ~model:(Some "sonnet") ~complexity:(Some 2) ~prompt:"do stuff"
       ~minted_session_id:None ~resume_session:None
   in
@@ -406,7 +445,7 @@ let%test "build_stream_args fresh (no resume, with model)" =
 
 let%test "build_stream_args fresh (no resume, no model)" =
   let args =
-    build_stream_args ~getenv_opt:no_env ~warn:ignore_warn ~model:None
+    build_stream_args ~getenv_opt:with_api_key ~warn:ignore_warn ~model:None
       ~complexity:None ~prompt:"do stuff" ~minted_session_id:None
       ~resume_session:None
   in
@@ -427,9 +466,9 @@ let%test "build_stream_args fresh (no resume, no model)" =
 
 let%test "build_stream_args with resume session" =
   let args =
-    build_stream_args ~getenv_opt:no_env ~warn:ignore_warn ~model:(Some "opus")
-      ~complexity:(Some 1) ~prompt:"do stuff" ~minted_session_id:None
-      ~resume_session:(Some "abc-123")
+    build_stream_args ~getenv_opt:with_api_key ~warn:ignore_warn
+      ~model:(Some "opus") ~complexity:(Some 1) ~prompt:"do stuff"
+      ~minted_session_id:None ~resume_session:(Some "abc-123")
   in
   List.equal String.equal args
     [
@@ -460,7 +499,7 @@ let%test "build_stream_args includes --exclude-dynamic-system-prompt-sections" =
 
 let%test "build_stream_args emits --session-id when minted_session_id is Some" =
   let args =
-    build_stream_args ~getenv_opt:no_env ~warn:ignore_warn
+    build_stream_args ~getenv_opt:with_api_key ~warn:ignore_warn
       ~model:(Some "sonnet") ~complexity:None ~prompt:"do stuff"
       ~minted_session_id:(Some "123e4567-e89b-42d3-a456-426614174000")
       ~resume_session:None
@@ -493,16 +532,29 @@ let%test "build_stream_args rejects session-id plus resume together" =
   | _ -> false
   | exception Invalid_argument _ -> true
 
-let%test "build_stream_args includes --bare" =
+let%test "build_stream_args includes --bare when ANTHROPIC_API_KEY is set" =
   List.mem
-    (build_stream_args ~getenv_opt:no_env ~warn:ignore_warn ~model:None
+    (build_stream_args ~getenv_opt:with_api_key ~warn:ignore_warn ~model:None
        ~complexity:None ~prompt:"do stuff" ~minted_session_id:None
        ~resume_session:None)
     "--bare" ~equal:String.equal
 
+let%test "build_stream_args omits --bare without ANTHROPIC_API_KEY (OAuth path)"
+    =
+  not
+    (List.mem
+       (build_stream_args ~getenv_opt:no_env ~warn:ignore_warn ~model:None
+          ~complexity:None ~prompt:"do stuff" ~minted_session_id:None
+          ~resume_session:None)
+       "--bare" ~equal:String.equal)
+
 let%test
     "build_stream_args emits --max-budget-usd when ONTON_BUDGET_CAP_USD set" =
-  let getenv_opt = function "ONTON_BUDGET_CAP_USD" -> Some "10" | _ -> None in
+  let getenv_opt = function
+    | "ONTON_BUDGET_CAP_USD" -> Some "10"
+    | "ANTHROPIC_API_KEY" -> Some "sk-ant-api03-test"
+    | _ -> None
+  in
   let args =
     build_stream_args ~getenv_opt ~warn:ignore_warn ~model:(Some "sonnet")
       ~complexity:None ~prompt:"do stuff" ~minted_session_id:None

--- a/lib_core/content_gate.ml
+++ b/lib_core/content_gate.ml
@@ -14,27 +14,25 @@ open Base
     emits [Error] from the terminating "result" event instead, so the gate stays
     closed.
 
-    [should_persist] returns [true] exactly once — on the first [Final_result]
-    event — and [false] for everything else, including all events after the
-    first persist. *)
+    [should_persist] returns the next gate state plus a decision. The decision
+    is [true] exactly once — on the first [Final_result] event — and [false] for
+    everything else, including all events after the first persist. *)
 
-type t = { mutable persisted : bool }
+type t = Not_persisted | Persisted
 
-let create () = { persisted = false }
+let create () = Not_persisted
 
 let should_persist t (event : Types.Stream_event.t) =
-  if t.persisted then false
-  else
-    match event with
-    | Types.Stream_event.Final_result _ ->
-        t.persisted <- true;
-        true
-    | Types.Stream_event.Turn_started | Types.Stream_event.Session_init _
-    | Types.Stream_event.Text_delta _ | Types.Stream_event.Tool_use _
-    | Types.Stream_event.Error _ ->
-        false
+  match (t, event) with
+  | Persisted, _ -> (Persisted, false)
+  | Not_persisted, Types.Stream_event.Final_result _ -> (Persisted, true)
+  | ( Not_persisted,
+      ( Types.Stream_event.Turn_started | Types.Stream_event.Session_init _
+      | Types.Stream_event.Text_delta _ | Types.Stream_event.Tool_use _
+      | Types.Stream_event.Error _ ) ) ->
+      (Not_persisted, false)
 
-let has_persisted t = t.persisted
+let has_persisted = function Persisted -> true | Not_persisted -> false
 
 let test_session_init =
   Types.Stream_event.Session_init
@@ -48,29 +46,32 @@ let test_session_init =
 
 let%test "Session_init never triggers persist" =
   let g = create () in
-  (not (should_persist g test_session_init)) && not (has_persisted g)
+  let g, persist = should_persist g test_session_init in
+  (not persist) && not (has_persisted g)
 
 let%test "Turn_started never triggers persist" =
   let g = create () in
-  (not (should_persist g Types.Stream_event.Turn_started))
-  && not (has_persisted g)
+  let g, persist = should_persist g Types.Stream_event.Turn_started in
+  (not persist) && not (has_persisted g)
 
 let%test
     "Text_delta never triggers persist (chunks unflushed until Final_result)" =
   let g = create () in
-  (not (should_persist g (Types.Stream_event.Text_delta "hi")))
-  && not (has_persisted g)
+  let g, persist = should_persist g (Types.Stream_event.Text_delta "hi") in
+  (not persist) && not (has_persisted g)
 
 let%test "Tool_use never triggers persist (turn still in progress)" =
   let g = create () in
   let ev =
     Types.Stream_event.Tool_use { name = "Bash"; input = "{}"; status = None }
   in
-  (not (should_persist g ev)) && not (has_persisted g)
+  let g, persist = should_persist g ev in
+  (not persist) && not (has_persisted g)
 
 let%test "Error never triggers persist" =
   let g = create () in
-  not (should_persist g (Types.Stream_event.Error "boom"))
+  let _, persist = should_persist g (Types.Stream_event.Error "boom") in
+  not persist
 
 let%test "first Final_result triggers; subsequent calls return false" =
   let g = create () in
@@ -78,21 +79,23 @@ let%test "first Final_result triggers; subsequent calls return false" =
     Types.Stream_event.Final_result
       { text = "done"; stop_reason = Types.Stop_reason.End_turn }
   in
-  let first = should_persist g ev in
-  let second = should_persist g ev in
+  let g, first = should_persist g ev in
+  let g, second = should_persist g ev in
   first && (not second) && has_persisted g
 
 let%test "Final_result after a flurry of in-flight events triggers" =
   let g = create () in
-  ignore (should_persist g test_session_init);
-  ignore (should_persist g Types.Stream_event.Turn_started);
-  ignore (should_persist g (Types.Stream_event.Text_delta "streamed"));
-  ignore
-    (should_persist g
-       (Types.Stream_event.Tool_use
-          { name = "Bash"; input = "{}"; status = None }));
+  let g, _ = should_persist g test_session_init in
+  let g, _ = should_persist g Types.Stream_event.Turn_started in
+  let g, _ = should_persist g (Types.Stream_event.Text_delta "streamed") in
+  let g, _ =
+    should_persist g
+      (Types.Stream_event.Tool_use
+         { name = "Bash"; input = "{}"; status = None })
+  in
   let ev =
     Types.Stream_event.Final_result
       { text = "done"; stop_reason = Types.Stop_reason.End_turn }
   in
-  should_persist g ev && has_persisted g
+  let g, persist = should_persist g ev in
+  persist && has_persisted g

--- a/lib_core/content_gate.ml
+++ b/lib_core/content_gate.ml
@@ -1,0 +1,91 @@
+open Base
+
+(** One-shot gate that fires the first time the LLM has *committed* a
+    conversation turn to its [.jsonl] (the only thing claude can resume).
+
+    Subtlety this guards against: claude's stream-json carries text chunks
+    ([Text_delta]) and tool-call announcements ([Tool_use]) as they're
+    generated, but claude flushes them to the conversation file only when the
+    turn *completes*. If the API errors mid-turn, the streamed chunks are gone
+    and the [.jsonl] stays at its 124-byte [last-prompt] header. Persisting the
+    session-id sidecar at that point would poison every later [--resume] with
+    "No conversation found". [Final_result] (turn completed) is the earliest
+    event that proves at least one complete turn is on disk; the failure path
+    emits [Error] from the terminating "result" event instead, so the gate stays
+    closed.
+
+    [should_persist] returns [true] exactly once — on the first [Final_result]
+    event — and [false] for everything else, including all events after the
+    first persist. *)
+
+type t = { mutable persisted : bool }
+
+let create () = { persisted = false }
+
+let should_persist t (event : Types.Stream_event.t) =
+  if t.persisted then false
+  else
+    match event with
+    | Types.Stream_event.Final_result _ ->
+        t.persisted <- true;
+        true
+    | Types.Stream_event.Turn_started | Types.Stream_event.Session_init _
+    | Types.Stream_event.Text_delta _ | Types.Stream_event.Tool_use _
+    | Types.Stream_event.Error _ ->
+        false
+
+let has_persisted t = t.persisted
+
+let%test "Session_init never triggers persist" =
+  let g = create () in
+  (not
+     (should_persist g (Types.Stream_event.Session_init { session_id = "x" })))
+  && not (has_persisted g)
+
+let%test "Turn_started never triggers persist" =
+  let g = create () in
+  (not (should_persist g Types.Stream_event.Turn_started))
+  && not (has_persisted g)
+
+let%test
+    "Text_delta never triggers persist (chunks unflushed until Final_result)" =
+  let g = create () in
+  (not (should_persist g (Types.Stream_event.Text_delta "hi")))
+  && not (has_persisted g)
+
+let%test "Tool_use never triggers persist (turn still in progress)" =
+  let g = create () in
+  let ev =
+    Types.Stream_event.Tool_use { name = "Bash"; input = "{}"; status = None }
+  in
+  (not (should_persist g ev)) && not (has_persisted g)
+
+let%test "Error never triggers persist" =
+  let g = create () in
+  not (should_persist g (Types.Stream_event.Error "boom"))
+
+let%test "first Final_result triggers; subsequent calls return false" =
+  let g = create () in
+  let ev =
+    Types.Stream_event.Final_result
+      { text = "done"; stop_reason = Types.Stop_reason.End_turn }
+  in
+  let first = should_persist g ev in
+  let second = should_persist g ev in
+  first && (not second) && has_persisted g
+
+let%test "Final_result after a flurry of in-flight events triggers" =
+  let g = create () in
+  ignore
+    (should_persist g (Types.Stream_event.Session_init { session_id = "x" }));
+  ignore (should_persist g Types.Stream_event.Turn_started);
+  ignore (should_persist g (Types.Stream_event.Text_delta "streamed"));
+  ignore
+    (should_persist g
+       (Types.Stream_event.Tool_use
+          { name = "Bash"; input = "{}"; status = None }));
+  let ev =
+    Types.Stream_event.Final_result
+      { text = "done"; stop_reason = Types.Stop_reason.End_turn }
+  in
+  should_persist g ev && has_persisted g

--- a/lib_core/content_gate.ml
+++ b/lib_core/content_gate.ml
@@ -36,11 +36,19 @@ let should_persist t (event : Types.Stream_event.t) =
 
 let has_persisted t = t.persisted
 
+let test_session_init =
+  Types.Stream_event.Session_init
+    {
+      session_id = "x";
+      api_key_source = None;
+      model = None;
+      claude_code_version = None;
+      permission_mode = None;
+    }
+
 let%test "Session_init never triggers persist" =
   let g = create () in
-  (not
-     (should_persist g (Types.Stream_event.Session_init { session_id = "x" })))
-  && not (has_persisted g)
+  (not (should_persist g test_session_init)) && not (has_persisted g)
 
 let%test "Turn_started never triggers persist" =
   let g = create () in
@@ -76,8 +84,7 @@ let%test "first Final_result triggers; subsequent calls return false" =
 
 let%test "Final_result after a flurry of in-flight events triggers" =
   let g = create () in
-  ignore
-    (should_persist g (Types.Stream_event.Session_init { session_id = "x" }));
+  ignore (should_persist g test_session_init);
   ignore (should_persist g Types.Stream_event.Turn_started);
   ignore (should_persist g (Types.Stream_event.Text_delta "streamed"));
   ignore

--- a/lib_core/content_gate.mli
+++ b/lib_core/content_gate.mli
@@ -5,10 +5,10 @@ type t
 
 val create : unit -> t
 
-val should_persist : t -> Types.Stream_event.t -> bool
-(** Returns [true] exactly once — on the first [Text_delta] or [Tool_use] event
-    — and [false] for every other event (including all events after the first
-    persist). *)
+val should_persist : t -> Types.Stream_event.t -> t * bool
+(** Returns the next gate state and whether to persist now. The decision is
+    [true] exactly once — on the first [Final_result] event — and [false] for
+    every other event (including all events after the first persist). *)
 
 val has_persisted : t -> bool
 (** Whether [should_persist] has already returned [true] for this gate. *)

--- a/lib_core/content_gate.mli
+++ b/lib_core/content_gate.mli
@@ -1,0 +1,14 @@
+(** One-shot gate that signals the LLM has produced resumable conversation
+    content. See [content_gate.ml] for the why. *)
+
+type t
+
+val create : unit -> t
+
+val should_persist : t -> Types.Stream_event.t -> bool
+(** Returns [true] exactly once — on the first [Text_delta] or [Tool_use] event
+    — and [false] for every other event (including all events after the first
+    persist). *)
+
+val has_persisted : t -> bool
+(** Whether [should_persist] has already returned [true] for this gate. *)

--- a/test/test_backend_parser_totality.ml
+++ b/test/test_backend_parser_totality.ml
@@ -69,6 +69,33 @@ let totality ~name f =
         true
       with _ -> false)
 
+let strip_ansi_does_not_grow =
+  QCheck2.Test.make ~name:"claude strip_ansi does not grow output" ~count:1000
+    gen_string (fun line ->
+      try
+        String.length (Claude_event_parser.strip_ansi line)
+        <= String.length line
+      with _ -> false)
+
+let strip_ansi_removes_stray_controls =
+  QCheck2.Test.make ~name:"claude strip_ansi removes stray controls" ~count:1000
+    gen_string (fun line ->
+      try
+        Claude_event_parser.strip_ansi line
+        |> String.for_all ~f:(fun c ->
+            match Char.to_int c with
+            | 0x09 | 0x0a | 0x1b -> true
+            | n -> n > 0x1f)
+      with _ -> false)
+
+let strip_ansi_known_sequences =
+  QCheck2.Test.make ~name:"claude strip_ansi removes known ANSI sequences"
+    ~count:1 QCheck2.Gen.unit (fun () ->
+      let raw =
+        "\x1b[31mred\x1b[0m\r\n\x00plain\t\x1b]0;title\x07body\x1b(0x"
+      in
+      String.equal (Claude_event_parser.strip_ansi raw) "red\nplain\tbody")
+
 (* ─────────────────────────────────────────────────────────────────────────
    Tests
    ───────────────────────────────────────────────────────────────────────── *)
@@ -95,6 +122,9 @@ let () =
       totality ~name:"claude parse_stream_events total" claude_events;
       totality ~name:"claude strip_ansi total" claude_strip;
       totality ~name:"claude find_json_start total" claude_find_json;
+      strip_ansi_does_not_grow;
+      strip_ansi_removes_stray_controls;
+      strip_ansi_known_sequences;
     ]
   in
   let exit_code = QCheck_base_runner.run_tests ~verbose:true suite in

--- a/test/test_patch_controller_state_machine.ml
+++ b/test/test_patch_controller_state_machine.ml
@@ -499,12 +499,14 @@ let () =
             Orchestrator.apply_session_result orch pid
               Orchestrator.Session_no_resume
           in
-          (* Assert session_id cleared and fallback is Tried_fresh *)
+          (* Assert session_id cleared.  Fallback must remain
+             [Fresh_available]: a stub-resume that produced zero events did
+             not consume retry budget (Fix 1). *)
           let agent = Orchestrator.agent orch pid in
           Option.is_none agent.Patch_agent.llm_session_id
           && Onton_core.Patch_agent.equal_session_fallback
                agent.Patch_agent.session_fallback
-               Onton_core.Patch_agent.Tried_fresh
+               Onton_core.Patch_agent.Fresh_available
         with _ -> false
         end)
   in

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -876,6 +876,55 @@ let () =
         let a = Orchestrator.agent orch pid in
         Option.is_none a.Patch_agent.llm_session_id)
   in
+  (* A7: Session_no_resume from Fresh_available stays Fresh_available.
+     A stub-resume never spoke to the LLM — it must not consume retry budget. *)
+  let prop_a7_no_resume_does_not_escalate_from_fresh =
+    Test.make ~name:"A7: Session_no_resume preserves Fresh_available"
+      (Gen.return ()) (fun () ->
+        let orch, pid = mk_busy_orch () in
+        let orch = Orchestrator.set_llm_session_id orch pid (Some "stub-id") in
+        let orch =
+          Orchestrator.apply_session_result orch pid Session_no_resume
+        in
+        let a = Orchestrator.agent orch pid in
+        Patch_agent.equal_session_fallback a.Patch_agent.session_fallback
+          Patch_agent.Fresh_available)
+  in
+  (* A8: Session_no_resume from Tried_fresh stays Tried_fresh (no escalation
+     to Given_up). *)
+  let prop_a8_no_resume_does_not_escalate_from_tried_fresh =
+    Test.make ~name:"A8: Session_no_resume preserves Tried_fresh"
+      (Gen.return ()) (fun () ->
+        let orch, pid = mk_busy_orch () in
+        let orch = Orchestrator.set_tried_fresh orch pid in
+        let orch = Orchestrator.set_llm_session_id orch pid (Some "stub-id") in
+        let orch =
+          Orchestrator.apply_session_result orch pid Session_no_resume
+        in
+        let a = Orchestrator.agent orch pid in
+        Patch_agent.equal_session_fallback a.Patch_agent.session_fallback
+          Patch_agent.Tried_fresh)
+  in
+  (* A9: two consecutive Session_no_resume outcomes never reach Given_up.
+     Pin down the regression scenario: a poisoned sidecar pointing at a stub
+     would otherwise burn the budget on every retry. *)
+  let prop_a9_repeated_no_resume_never_gives_up =
+    Test.make ~name:"A9: repeated Session_no_resume does not reach Given_up"
+      (Gen.return ()) (fun () ->
+        let orch, pid = mk_busy_orch () in
+        let orch = Orchestrator.set_llm_session_id orch pid (Some "stub-a") in
+        let orch =
+          Orchestrator.apply_session_result orch pid Session_no_resume
+        in
+        let orch = Orchestrator.set_llm_session_id orch pid (Some "stub-b") in
+        let orch =
+          Orchestrator.apply_session_result orch pid Session_no_resume
+        in
+        let a = Orchestrator.agent orch pid in
+        not
+          (Patch_agent.equal_session_fallback a.Patch_agent.session_fallback
+             Patch_agent.Given_up))
+  in
   List.iter
     ~f:(fun t -> QCheck2.Test.check_exn t)
     [
@@ -885,8 +934,11 @@ let () =
       prop_a4_set_session_id_idempotent;
       prop_a5_fresh_failure_preserves_session_id;
       prop_a6_no_resume_clears_session_id;
+      prop_a7_no_resume_does_not_escalate_from_fresh;
+      prop_a8_no_resume_does_not_escalate_from_tried_fresh;
+      prop_a9_repeated_no_resume_never_gives_up;
     ];
-  Stdlib.print_endline "llm_session_id: all properties passed (A1-A6)"
+  Stdlib.print_endline "llm_session_id: all properties passed (A1-A9)"
 
 (* Session_push_failed semantics — distinguishes "LLM ran fine but commits
    didn't ship" from a genuine LLM failure. Pins down the three behaviors


### PR DESCRIPTION
## Summary

Two distinct but related fixes to Claude session handling on macOS:

- **`--bare` silently broke OAuth auth.** PR #258 added `CLAUDE_CODE_OAUTH_TOKEN` injection, but `--bare` (added three days earlier) restricts auth to `ANTHROPIC_API_KEY` only — every spawned claude reported "Not logged in · Please run /login". `bare_args` is now gated on `ANTHROPIC_API_KEY` presence, so OAuth users get normal auth and API-key users keep the isolation benefits.
- **Stale `.jsonl` stubs poisoned subsequent retries.** When claude failed before producing a turn, it left behind a 124-byte stub; the session id was eagerly persisted to the sidecar at mint time; the next iteration tried `--resume <stub-id>` and burned a `session_fallback` slot on the `No_session_to_resume` failure. Three layered fixes: don't escalate fallback on `Session_no_resume`, delete the stub `.jsonl` on resume failure, and defer sidecar writes until claude has committed a real turn (new pure `Content_gate` module fires on first `Final_result`).

## Test plan

- [x] `dune build` clean
- [x] `dune test` — full suite passes (pre-commit hook runs build + tests + format check)
- [x] New tests:
  - 6 claude_event_parser tests for the `--bare` gating + parser data preservation
  - A7/A8/A9 properties: `Session_no_resume` preserves `Fresh_available` / `Tried_fresh`; two consecutive `Session_no_resume` never reach `Given_up`
  - Updated F2 state-machine test: post-`Session_no_resume`, `session_fallback` stays `Fresh_available`
  - 7 `Content_gate` inline tests covering each `Stream_event` variant
  - `Spawn_env.claude_session_jsonl_path` path-composition tests
  - `Persistence.sync_session_id_sidecars` new delete-only contract tests (3)
  - `Claude_runner.prepare_minted_session_id` deferred-minting tests (3)
- [ ] Manual verification: relaunch onton, watch a patch deliver review-comments without "Not logged in" / "unknown error"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/275"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores Claude OAuth login on macOS and hardens session resume by safely cleaning up stub sessions and deferring session-id persistence. OAuth users can sign in again; retries no longer waste budget on “No conversation found” sessions.

- **Bug Fixes**
  - OAuth: only pass `--bare` when `ANTHROPIC_API_KEY` is set; otherwise use normal OAuth/Keychain auth.
  - Resume robustness:
    - Don’t escalate retry budget on `Session_no_resume`; clear `llm_session_id` to retry fresh.
    - On `No_session_to_resume`, best-effort delete stub `<session-id>.jsonl` via `Spawn_env.claude_session_jsonl_path`; skip unsafe IDs (validated with `safe_session_id`).
    - Defer session-id sidecar writes until the first committed turn (`Final_result`) using `lib_core/content_gate`; make `Persistence.sync_session_id_sidecars` delete-only and preserve sidecars for busy agents.
    - Mint session IDs when `ONTON_MINTED_SESSION_IDS=1` without requiring `ONTON_SNAPSHOT_PATH`; the event loop persists the sidecar after `Final_result`.

<sup>Written for commit c18a3d19257218d817c595a7d8a949b92a4f7a16. Summary will update on new commits. <a href="https://cubic.dev/pr/flowglad/onton/pull/275?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced session crash-recovery with improved handling of invalid resume scenarios

* **Bug Fixes**
  * Fixed retry-budget escalation when session resumption fails or produces no LLM output
  * Automatic cleanup of invalid session artifacts from failed resumes
  * Improved session state management to prevent unnecessary retry loops

* **Tests**
  * Extended test coverage for session recovery and retry-budget preservation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flowglad/onton/pull/275?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->