### PR TITLE
[replay-ready-diagnostics] Patch 4: Add Session_meta, Token_scrub, and Session_artifacts sink

### DIFF
--- a/lib/persistence.mli
+++ b/lib/persistence.mli
@@ -35,3 +35,7 @@ val patch_agent_of_yojson :
   gameplan:Types.Gameplan.t -> Yojson.Safe.t -> (Patch_agent.t, string) result
 (** Parse a patch agent from the current JSON schema. [~gameplan] is used to
     derive the branch for old snapshots that lack a ["branch"] key. *)
+
+val write_file_atomically :
+  path:string -> content:string -> (unit, string) result
+(** Write a file via temp-file + rename for crash-safe replacement. *)

--- a/lib/project_store.ml
+++ b/lib/project_store.ml
@@ -28,6 +28,9 @@ let snapshot_path project_name =
 let event_log_path project_name =
   Stdlib.Filename.concat (project_dir project_name) "events.jsonl"
 
+let sessions_dir project_name =
+  Stdlib.Filename.concat (project_dir project_name) "sessions"
+
 let config_path project_name =
   Stdlib.Filename.concat (project_dir project_name) "config.json"
 

--- a/lib/project_store.mli
+++ b/lib/project_store.mli
@@ -16,6 +16,9 @@ val snapshot_path : string -> string
 val event_log_path : string -> string
 (** Path to the project's append-only event log (JSONL). *)
 
+val sessions_dir : string -> string
+(** Path to the project's per-session artifact directory root. *)
+
 val config_path : string -> string
 (** Path to the project's persisted config JSON. *)
 

--- a/lib/session_artifacts.ml
+++ b/lib/session_artifacts.ml
@@ -1,7 +1,5 @@
 open Base
 
-external unsetenv_stub : string -> unit = "caml_onton_unsetenv"
-
 type append_file = {
   path : string;
   mutable channel : Stdlib.out_channel option;
@@ -140,7 +138,11 @@ let with_temp_data_dir f =
     ~finally:(fun () ->
       (match old with
       | Some value -> Unix.putenv "ONTON_DATA_DIR" value
-      | None -> unsetenv_stub "ONTON_DATA_DIR");
+      | None ->
+          (* Keep a unique isolated value rather than relying on a C unsetenv
+             stub from test code. *)
+          Unix.putenv "ONTON_DATA_DIR"
+            (Stdlib.Filename.temp_dir "onton-session-artifacts-restore-" ""));
       rm_rf dir)
     (fun () -> f ())
 

--- a/lib/session_artifacts.ml
+++ b/lib/session_artifacts.ml
@@ -86,9 +86,14 @@ let create ~project_name ~patch_id:_ ~session_uuid =
         |> join_lines)
   in
   let write_finalized ~meta =
-    ignore
-      (Persistence.write_file_atomically ~path:meta_path
-         ~content:(Yojson.Safe.pretty_to_string meta));
+    (match
+       Persistence.write_file_atomically ~path:meta_path
+         ~content:(Yojson.Safe.pretty_to_string meta)
+     with
+    | Ok () -> ()
+    | Error msg ->
+        Stdlib.prerr_endline
+          ("session_artifacts: failed to write " ^ meta_path ^ ": " ^ msg));
     close_file stdout_file;
     close_file stderr_file
   in

--- a/lib/session_artifacts.ml
+++ b/lib/session_artifacts.ml
@@ -138,19 +138,36 @@ let rm_rf path =
          (Printf.sprintf "rm -rf %s" (Stdlib.Filename.quote path)))
   with _ -> ()
 
+let default_data_root () =
+  match Stdlib.Sys.getenv_opt "XDG_DATA_HOME" with
+  | Some xdg -> Stdlib.Filename.concat xdg "onton"
+  | None ->
+      Stdlib.Filename.concat
+        (Stdlib.Filename.concat (Stdlib.Sys.getenv "HOME") ".local/share")
+        "onton"
+
 let with_temp_data_dir f =
   let old = Stdlib.Sys.getenv_opt "ONTON_DATA_DIR" in
+  let restore_path_when_unset =
+    match old with
+    | Some _ -> None
+    | None -> Some (default_data_root ())
+  in
   let dir = Stdlib.Filename.temp_dir "onton-session-artifacts-" "" in
   Unix.putenv "ONTON_DATA_DIR" dir;
   Stdlib.Fun.protect
     ~finally:(fun () ->
       (match old with
       | Some value -> Unix.putenv "ONTON_DATA_DIR" value
-      | None ->
-          (* Keep a unique isolated value rather than relying on a C unsetenv
-             stub from test code. *)
-          Unix.putenv "ONTON_DATA_DIR"
-            (Stdlib.Filename.temp_dir "onton-session-artifacts-restore-" ""));
+      | None -> (
+          match restore_path_when_unset with
+          | None -> ()
+          | Some path ->
+              (* Tests do not have an unsetenv binding. Restore the resolved
+                 default data root so later tests never inherit a deleted temp
+                 directory through ONTON_DATA_DIR. *)
+              Project_store.ensure_dir path;
+              Unix.putenv "ONTON_DATA_DIR" path));
       rm_rf dir)
     (fun () -> f ())
 

--- a/lib/session_artifacts.ml
+++ b/lib/session_artifacts.ml
@@ -37,6 +37,9 @@ let write_text_file ~path ~content =
   Stdlib.Fun.protect
     ~finally:(fun () -> Stdlib.close_out oc)
     (fun () ->
+      (* These diagnostic sidecar files are best-effort and written directly.
+         Unlike meta.json they are not crash-safe atomic writes, so a partial
+         file after process or filesystem failure is possible. *)
       Stdlib.output_string oc content;
       Stdlib.flush oc)
 

--- a/lib/session_artifacts.ml
+++ b/lib/session_artifacts.ml
@@ -1,0 +1,264 @@
+open Base
+
+external unsetenv_stub : string -> unit = "caml_onton_unsetenv"
+
+type append_file = {
+  path : string;
+  mutable channel : Stdlib.out_channel option;
+}
+
+let make_append_file path = { path; channel = None }
+
+let ensure_open file =
+  match file.channel with
+  | Some channel -> channel
+  | None ->
+      let channel =
+        Stdlib.open_out_gen
+          [ Open_creat; Open_text; Open_append ]
+          0o644 file.path
+      in
+      file.channel <- Some channel;
+      channel
+
+let append_line file line =
+  let channel = ensure_open file in
+  Stdlib.output_string channel line;
+  Stdlib.output_char channel '\n';
+  Stdlib.flush channel
+
+let close_file file =
+  match file.channel with
+  | None -> ()
+  | Some channel ->
+      file.channel <- None;
+      Stdlib.close_out_noerr channel
+
+let write_text_file ~path ~content =
+  let oc = Stdlib.open_out_bin path in
+  Stdlib.Fun.protect
+    ~finally:(fun () -> Stdlib.close_out oc)
+    (fun () ->
+      Stdlib.output_string oc content;
+      Stdlib.flush oc)
+
+let join_lines lines =
+  match lines with [] -> "" | _ -> String.concat ~sep:"\n" lines ^ "\n"
+
+let redact_env_entry entry =
+  match String.lsplit2 entry ~on:'=' with
+  | None -> Token_scrub.scrub_token_patterns entry
+  | Some (name, value) ->
+      let redacted = Token_scrub.redact_env_value_by_name ~name ~value in
+      name ^ "=" ^ redacted
+
+let event_session_uuid = function
+  | Telemetry.Event.Stream { session_uuid; _ }
+  | Spawn_started { session_uuid; _ }
+  | Spawn_finalized { session_uuid; _ } ->
+      Some session_uuid
+  | Poll _ | Action _ | Complete _ | Free_form _ -> None
+
+let create ~project_name ~patch_id:_ ~session_uuid =
+  let artifact_dir =
+    Stdlib.Filename.concat
+      (Project_store.sessions_dir project_name)
+      session_uuid
+  in
+  Project_store.ensure_dir artifact_dir;
+  let stdout_file =
+    make_append_file (Stdlib.Filename.concat artifact_dir "stdout.jsonl")
+  in
+  let stderr_file =
+    make_append_file (Stdlib.Filename.concat artifact_dir "stderr.log")
+  in
+  let meta_path = Stdlib.Filename.concat artifact_dir "meta.json" in
+  let write_started ~prompt ~argv ~env_redacted =
+    write_text_file
+      ~path:(Stdlib.Filename.concat artifact_dir "prompt.txt")
+      ~content:prompt;
+    write_text_file
+      ~path:(Stdlib.Filename.concat artifact_dir "argv.txt")
+      ~content:(join_lines argv);
+    write_text_file
+      ~path:(Stdlib.Filename.concat artifact_dir "env.txt")
+      ~content:
+        (env_redacted |> Array.to_list
+        |> List.map ~f:redact_env_entry
+        |> join_lines)
+  in
+  let write_finalized ~meta =
+    ignore
+      (Persistence.write_file_atomically ~path:meta_path
+         ~content:(Yojson.Safe.pretty_to_string meta));
+    close_file stdout_file;
+    close_file stderr_file
+  in
+  {
+    Telemetry.Sink.name = "session_artifacts:" ^ session_uuid;
+    interested_in =
+      (fun event ->
+        Option.value_map (event_session_uuid event) ~default:false
+          ~f:(String.equal session_uuid));
+    consume =
+      (function
+      | Telemetry.Event.Spawn_started
+          { session_uuid = event_uuid; prompt; argv; env_redacted; _ }
+        when String.equal event_uuid session_uuid ->
+          write_started ~prompt ~argv ~env_redacted
+      | Telemetry.Event.Stream { session_uuid = event_uuid; channel; raw; _ }
+        when String.equal event_uuid session_uuid ->
+          append_line
+            (match channel with
+            | `Stdout -> stdout_file
+            | `Stderr -> stderr_file)
+            raw
+      | Telemetry.Event.Spawn_finalized { session_uuid = event_uuid; meta; _ }
+        when String.equal event_uuid session_uuid ->
+          write_finalized ~meta
+      | Telemetry.Event.Spawn_started _ -> ()
+      | Telemetry.Event.Stream _ -> ()
+      | Telemetry.Event.Spawn_finalized _ -> ()
+      | Telemetry.Event.Poll _ -> ()
+      | Telemetry.Event.Action _ -> ()
+      | Telemetry.Event.Complete _ -> ()
+      | Telemetry.Event.Free_form _ -> ());
+  }
+
+let rm_rf path =
+  try
+    ignore
+      (Stdlib.Sys.command
+         (Printf.sprintf "rm -rf %s" (Stdlib.Filename.quote path)))
+  with _ -> ()
+
+let with_temp_data_dir f =
+  let old = Stdlib.Sys.getenv_opt "ONTON_DATA_DIR" in
+  let dir = Stdlib.Filename.temp_dir "onton-session-artifacts-" "" in
+  Unix.putenv "ONTON_DATA_DIR" dir;
+  Stdlib.Fun.protect
+    ~finally:(fun () ->
+      (match old with
+      | Some value -> Unix.putenv "ONTON_DATA_DIR" value
+      | None -> unsetenv_stub "ONTON_DATA_DIR");
+      rm_rf dir)
+    (fun () -> f ())
+
+let read_file path =
+  let ic = Stdlib.open_in_bin path in
+  Stdlib.Fun.protect
+    ~finally:(fun () -> Stdlib.close_in_noerr ic)
+    (fun () -> Stdlib.In_channel.input_all ic)
+
+let spawn_started_event ~patch_id ~session_uuid ~env_redacted =
+  Telemetry.Event.Spawn_started
+    {
+      patch_id;
+      session_uuid;
+      prompt = "prompt text";
+      argv = [ "claude"; "--json" ];
+      env_redacted;
+    }
+
+let spawn_finalized_event ~patch_id ~session_uuid =
+  let meta =
+    Session_meta.create ~onton_session_uuid:session_uuid
+      ~claude_session_id:"claude-session"
+      ~patch_id:(Types.Patch_id.to_string patch_id)
+      ~started_at:1.0 ~ended_at:2.0 ~exit_code:0 ~subkind:Failure_subkind.Ok ()
+  in
+  Telemetry.Event.Spawn_finalized
+    { patch_id; session_uuid; meta = Session_meta.yojson_of_t meta }
+
+let%test "create+finalize writes meta.json with schema_version=1" =
+  with_temp_data_dir @@ fun () ->
+  let project_name = "Session Artifact Project" in
+  let patch_id = Types.Patch_id.of_string "patch-4" in
+  let session_uuid = "session-1" in
+  let sink = create ~project_name ~patch_id ~session_uuid in
+  sink.consume
+    (spawn_started_event ~patch_id ~session_uuid ~env_redacted:[| "PATH=/bin" |]);
+  sink.consume (spawn_finalized_event ~patch_id ~session_uuid);
+  let meta_path =
+    Stdlib.Filename.concat
+      (Stdlib.Filename.concat
+         (Project_store.sessions_dir project_name)
+         session_uuid)
+      "meta.json"
+  in
+  Stdlib.Sys.file_exists meta_path
+  &&
+  match
+    Session_meta.t_of_yojson (Yojson.Safe.from_string (read_file meta_path))
+  with
+  | meta -> meta.Session_meta.schema_version = 1
+  | exception _ -> false
+
+let%test "Stream events append lines in order to stdout.jsonl" =
+  with_temp_data_dir @@ fun () ->
+  let project_name = "Session Artifact Streams" in
+  let patch_id = Types.Patch_id.of_string "patch-4" in
+  let session_uuid = "session-2" in
+  let sink = create ~project_name ~patch_id ~session_uuid in
+  sink.consume
+    (Telemetry.Event.Stream
+       { patch_id; session_uuid; channel = `Stdout; raw = "{\"a\":1}" });
+  sink.consume
+    (Telemetry.Event.Stream
+       { patch_id; session_uuid; channel = `Stdout; raw = "{\"b\":2}" });
+  sink.consume (spawn_finalized_event ~patch_id ~session_uuid);
+  let stdout_path =
+    Stdlib.Filename.concat
+      (Stdlib.Filename.concat
+         (Project_store.sessions_dir project_name)
+         session_uuid)
+      "stdout.jsonl"
+  in
+  String.equal (read_file stdout_path) "{\"a\":1}\n{\"b\":2}\n"
+
+let%test "interested_in returns false for events with different session_uuid" =
+  with_temp_data_dir @@ fun () ->
+  let patch_id = Types.Patch_id.of_string "patch-4" in
+  let sink =
+    create ~project_name:"Project" ~patch_id ~session_uuid:"session-3"
+  in
+  (not
+     (sink.interested_in
+        (Telemetry.Event.Stream
+           { patch_id; session_uuid = "other"; channel = `Stdout; raw = "x" })))
+  && (not
+        (sink.interested_in
+           (spawn_started_event ~patch_id ~session_uuid:"other"
+              ~env_redacted:[| "PATH=/bin" |])))
+  && not
+       (sink.interested_in
+          (spawn_finalized_event ~patch_id ~session_uuid:"other"))
+
+let%test "env redaction masks values for sensitive names and token formats" =
+  with_temp_data_dir @@ fun () ->
+  let project_name = "Session Artifact Env" in
+  let patch_id = Types.Patch_id.of_string "patch-4" in
+  let session_uuid = "session-4" in
+  let sink = create ~project_name ~patch_id ~session_uuid in
+  sink.consume
+    (spawn_started_event ~patch_id ~session_uuid
+       ~env_redacted:
+         [|
+           "ANTHROPIC_API_KEY=plain-secret";
+           "SAFE_NAME=ghp_abcdef123";
+           "NORMAL=value";
+         |]);
+  sink.consume (spawn_finalized_event ~patch_id ~session_uuid);
+  let env_path =
+    Stdlib.Filename.concat
+      (Stdlib.Filename.concat
+         (Project_store.sessions_dir project_name)
+         session_uuid)
+      "env.txt"
+  in
+  let env_text = read_file env_path in
+  String.is_substring env_text ~substring:"ANTHROPIC_API_KEY=<REDACTED>"
+  && String.is_substring env_text ~substring:"SAFE_NAME=<REDACTED>"
+  && String.is_substring env_text ~substring:"NORMAL=value"
+  && (not (String.is_substring env_text ~substring:"plain-secret"))
+  && not (String.is_substring env_text ~substring:"ghp_abcdef123")

--- a/lib/session_artifacts.ml
+++ b/lib/session_artifacts.ml
@@ -149,9 +149,7 @@ let default_data_root () =
 let with_temp_data_dir f =
   let old = Stdlib.Sys.getenv_opt "ONTON_DATA_DIR" in
   let restore_path_when_unset =
-    match old with
-    | Some _ -> None
-    | None -> Some (default_data_root ())
+    match old with Some _ -> None | None -> Some (default_data_root ())
   in
   let dir = Stdlib.Filename.temp_dir "onton-session-artifacts-" "" in
   Unix.putenv "ONTON_DATA_DIR" dir;

--- a/lib/session_artifacts.mli
+++ b/lib/session_artifacts.mli
@@ -1,0 +1,7 @@
+open Base
+
+val create :
+  project_name:string ->
+  patch_id:Types.Patch_id.t ->
+  session_uuid:string ->
+  Telemetry.Sink.t

--- a/lib_core/failure_subkind.ml
+++ b/lib_core/failure_subkind.ml
@@ -20,6 +20,7 @@ type init_info = {
 [@@deriving show, eq]
 
 let t_of_yojson json =
+  let open Yojson.Safe.Util in
   match json with
   | `String "Ok" -> (Ok : t)
   | `String "Auth_unavailable" -> Auth_unavailable
@@ -29,13 +30,7 @@ let t_of_yojson json =
   | `String "Empty_response" -> Empty_response
   | `String "Process_error" -> Process_error
   | `Assoc [ ("Api_error", payload) ] ->
-      let status =
-        match payload with
-        | `Assoc fields ->
-            List.Assoc.find fields ~equal:String.equal "status"
-            |> Option.bind ~f:(function `Int n -> Some n | _ -> None)
-        | _ -> None
-      in
+      let status = payload |> member "status" |> to_int_option in
       Api_error { status }
   | `Assoc [ ("Other", `String detail) ] -> Other detail
   | _ -> Other "invalid_failure_subkind"
@@ -61,9 +56,8 @@ let init_info_of_yojson json =
   let open Yojson.Safe.Util in
   let read_opt_string field =
     match member field json with
-    | `String s -> Some s
     | `Null -> None
-    | _ -> None
+    | value -> to_string_option value
   in
   {
     api_key_source = read_opt_string "api_key_source";

--- a/lib_core/failure_subkind.ml
+++ b/lib_core/failure_subkind.ml
@@ -30,7 +30,11 @@ let t_of_yojson json =
   | `String "Empty_response" -> Empty_response
   | `String "Process_error" -> Process_error
   | `Assoc [ ("Api_error", payload) ] ->
-      let status = payload |> member "status" |> to_int_option in
+      let status =
+        match payload with
+        | `Assoc _ -> payload |> member "status" |> to_int_option
+        | _ -> None
+      in
       Api_error { status }
   | `Assoc [ ("Other", `String detail) ] -> Other detail
   | _ -> Other "invalid_failure_subkind"

--- a/lib_core/session_meta.ml
+++ b/lib_core/session_meta.ml
@@ -1,0 +1,45 @@
+open Base
+open Ppx_yojson_conv_lib.Yojson_conv.Primitives
+
+type t = {
+  schema_version : int; [@yojson.default 1]
+  onton_session_uuid : string;
+  claude_session_id : string option; [@yojson.option]
+  patch_id : string;
+  started_at : float;
+  ended_at : float;
+  exit_code : int;
+  subkind : Failure_subkind.t;
+  api_key_source : string option; [@yojson.option]
+  model : string option; [@yojson.option]
+  claude_code_version : string option; [@yojson.option]
+}
+[@@deriving yojson]
+
+let create ~onton_session_uuid ?claude_session_id ~patch_id ~started_at
+    ~ended_at ~exit_code ~subkind ?api_key_source ?model ?claude_code_version ()
+    =
+  {
+    schema_version = 1;
+    onton_session_uuid;
+    claude_session_id;
+    patch_id;
+    started_at;
+    ended_at;
+    exit_code;
+    subkind;
+    api_key_source;
+    model;
+    claude_code_version;
+  }
+
+let%test "yojson roundtrip preserves all fields" =
+  let meta =
+    create ~onton_session_uuid:"uuid-1" ~claude_session_id:"claude-1"
+      ~patch_id:"patch-4" ~started_at:1.25 ~ended_at:2.5 ~exit_code:17
+      ~subkind:(Failure_subkind.Api_error { status = Some 401 })
+      ~api_key_source:"oauth" ~model:"sonnet" ~claude_code_version:"1.2.3" ()
+  in
+  match t_of_yojson (yojson_of_t meta) with
+  | meta' -> Yojson.Safe.equal (yojson_of_t meta) (yojson_of_t meta')
+  | exception _ -> false

--- a/lib_core/session_meta.mli
+++ b/lib_core/session_meta.mli
@@ -1,0 +1,30 @@
+open Base
+
+type t = {
+  schema_version : int; [@yojson.default 1]
+  onton_session_uuid : string;
+  claude_session_id : string option; [@yojson.option]
+  patch_id : string;
+  started_at : float;
+  ended_at : float;
+  exit_code : int;
+  subkind : Failure_subkind.t;
+  api_key_source : string option; [@yojson.option]
+  model : string option; [@yojson.option]
+  claude_code_version : string option; [@yojson.option]
+}
+[@@deriving yojson]
+
+val create :
+  onton_session_uuid:string ->
+  ?claude_session_id:string ->
+  patch_id:string ->
+  started_at:float ->
+  ended_at:float ->
+  exit_code:int ->
+  subkind:Failure_subkind.t ->
+  ?api_key_source:string ->
+  ?model:string ->
+  ?claude_code_version:string ->
+  unit ->
+  t

--- a/lib_core/token_scrub.ml
+++ b/lib_core/token_scrub.ml
@@ -15,14 +15,16 @@ let token_pattern_strings =
     "AKIA[0-9A-Z]+";
   ]
 
-let scrub_with_pattern text pattern =
-  try
-    let compiled = Re.Perl.compile_pat pattern in
-    Re.replace_string compiled ~all:true ~by:redacted text
-  with _ -> text
+let compiled_patterns =
+  lazy
+    (List.map token_pattern_strings ~f:(fun pattern ->
+         try Some (Re.Perl.compile_pat pattern) with _ -> None))
 
 let scrub_token_patterns text =
-  List.fold token_pattern_strings ~init:text ~f:scrub_with_pattern
+  List.fold (Lazy.force compiled_patterns) ~init:text ~f:(fun acc pattern ->
+      match pattern with
+      | None -> acc
+      | Some compiled -> Re.replace_string compiled ~all:true ~by:redacted acc)
 
 let sensitive_env_markers = [ "KEY"; "TOKEN"; "SECRET" ]
 

--- a/lib_core/token_scrub.ml
+++ b/lib_core/token_scrub.ml
@@ -1,0 +1,63 @@
+open Base
+
+let redacted = "<REDACTED>"
+
+let token_patterns =
+  [
+    "github_pat_[A-Za-z0-9_]+";
+    "ghp_[A-Za-z0-9_]+";
+    "gho_[A-Za-z0-9_]+";
+    "ghs_[A-Za-z0-9_]+";
+    "sk-ant-oat01-[A-Za-z0-9_-]+";
+    "sk-ant-api03-[A-Za-z0-9_-]+";
+    "sk-[A-Za-z0-9_-]+";
+    "xoxb-[A-Za-z0-9-]+";
+    "AKIA[0-9A-Z]+";
+  ]
+  |> List.map ~f:(fun pattern -> Re.Perl.compile_pat pattern)
+
+let scrub_token_patterns text =
+  List.fold token_patterns ~init:text ~f:(fun acc pattern ->
+      Re.replace_string pattern ~all:true ~by:redacted acc)
+
+let sensitive_env_markers = [ "KEY"; "TOKEN"; "SECRET" ]
+
+let redact_env_value_by_name ~name ~value =
+  let upper = String.uppercase name in
+  if
+    List.exists sensitive_env_markers ~f:(fun marker ->
+        String.is_substring upper ~substring:marker)
+  then redacted
+  else scrub_token_patterns value
+
+let%test "scrub_token_patterns redacts known token formats" =
+  let input =
+    String.concat ~sep:" "
+      [
+        "ghp_abcdef123";
+        "gho_abcdef123";
+        "ghs_abcdef123";
+        "github_pat_abcdef123";
+        "sk-ant-oat01-secret";
+        "sk-ant-api03-secret";
+        "sk-secret";
+        "xoxb-123-456";
+        "AKIAABCDEF123456";
+      ]
+  in
+  let output = scrub_token_patterns input in
+  String.is_substring output ~substring:redacted
+  && (not (String.is_substring output ~substring:"ghp_abcdef123"))
+  && (not (String.is_substring output ~substring:"gho_abcdef123"))
+  && (not (String.is_substring output ~substring:"ghs_abcdef123"))
+  && (not (String.is_substring output ~substring:"github_pat_abcdef123"))
+  && (not (String.is_substring output ~substring:"sk-ant-oat01-secret"))
+  && (not (String.is_substring output ~substring:"sk-ant-api03-secret"))
+  && (not (String.is_substring output ~substring:"sk-secret"))
+  && (not (String.is_substring output ~substring:"xoxb-123-456"))
+  && not (String.is_substring output ~substring:"AKIAABCDEF123456")
+
+let%test "redact_env_value_by_name masks values by sensitive env name" =
+  String.equal
+    (redact_env_value_by_name ~name:"ANTHROPIC_API_KEY" ~value:"plain")
+    redacted

--- a/lib_core/token_scrub.ml
+++ b/lib_core/token_scrub.ml
@@ -2,7 +2,7 @@ open Base
 
 let redacted = "<REDACTED>"
 
-let token_patterns =
+let token_pattern_strings =
   [
     "github_pat_[A-Za-z0-9_]+";
     "ghp_[A-Za-z0-9_]+";
@@ -10,15 +10,19 @@ let token_patterns =
     "ghs_[A-Za-z0-9_]+";
     "sk-ant-oat01-[A-Za-z0-9_-]+";
     "sk-ant-api03-[A-Za-z0-9_-]+";
-    "sk-[A-Za-z0-9_-]+";
+    "sk-[A-Za-z0-9_-]{20,}";
     "xoxb-[A-Za-z0-9-]+";
     "AKIA[0-9A-Z]+";
   ]
-  |> List.map ~f:(fun pattern -> Re.Perl.compile_pat pattern)
+
+let scrub_with_pattern text pattern =
+  try
+    let compiled = Re.Perl.compile_pat pattern in
+    Re.replace_string compiled ~all:true ~by:redacted text
+  with _ -> text
 
 let scrub_token_patterns text =
-  List.fold token_patterns ~init:text ~f:(fun acc pattern ->
-      Re.replace_string pattern ~all:true ~by:redacted acc)
+  List.fold token_pattern_strings ~init:text ~f:scrub_with_pattern
 
 let sensitive_env_markers = [ "KEY"; "TOKEN"; "SECRET" ]
 
@@ -40,7 +44,7 @@ let%test "scrub_token_patterns redacts known token formats" =
         "github_pat_abcdef123";
         "sk-ant-oat01-secret";
         "sk-ant-api03-secret";
-        "sk-secret";
+        "sk-abcdefghijklmnopqrstuvwxyz123456";
         "xoxb-123-456";
         "AKIAABCDEF123456";
       ]
@@ -53,9 +57,14 @@ let%test "scrub_token_patterns redacts known token formats" =
   && (not (String.is_substring output ~substring:"github_pat_abcdef123"))
   && (not (String.is_substring output ~substring:"sk-ant-oat01-secret"))
   && (not (String.is_substring output ~substring:"sk-ant-api03-secret"))
-  && (not (String.is_substring output ~substring:"sk-secret"))
+  && (not
+        (String.is_substring output
+           ~substring:"sk-abcdefghijklmnopqrstuvwxyz123456"))
   && (not (String.is_substring output ~substring:"xoxb-123-456"))
   && not (String.is_substring output ~substring:"AKIAABCDEF123456")
+
+let%test "scrub_token_patterns leaves non-token sk-prefix strings alone" =
+  String.equal (scrub_token_patterns "sk-engineering") "sk-engineering"
 
 let%test "redact_env_value_by_name masks values by sensitive env name" =
   String.equal

--- a/lib_core/token_scrub.mli
+++ b/lib_core/token_scrub.mli
@@ -1,0 +1,4 @@
+open Base
+
+val scrub_token_patterns : string -> string
+val redact_env_value_by_name : name:string -> value:string -> string

--- a/test/test_failure_subkind_properties.ml
+++ b/test/test_failure_subkind_properties.ml
@@ -19,8 +19,7 @@ let gen_run_classification =
       pure Run_classification.No_session_to_resume;
       pure Run_classification.Timed_out;
       map
-        (fun (stream_errors : string) ->
-          Run_classification.Success { stream_errors })
+        (fun stream_errors -> Run_classification.Success { stream_errors })
         (string_small_of printable);
       map2
         (fun exit_code detail ->


### PR DESCRIPTION
## Patch 4: Add Session_meta, Token_scrub, and Session_artifacts sink

- session_meta.ml: type t = { schema_version : int; onton_session_uuid : string; claude_session_id : string option [@yojson.option]; patch_id : string; started_at : float; ended_at : float; exit_code : int; subkind : Failure_subkind.t; api_key_source : string option [@yojson.option]; model : string option [@yojson.option]; claude_code_version : string option [@yojson.option] } [@@deriving yojson]. Always emit schema_version = 1.
- token_scrub.ml: scrub_token_patterns redacts ghp_/gho_/ghs_/github_pat_/sk-ant-oat01-/sk-ant-api03-/sk-/xoxb-/AKIA[0-9A-Z]+. redact_env_value_by_name returns <REDACTED> for any value whose env-var name matches /KEY|TOKEN|SECRET/ (case-insensitive). Both are pure.
- session_artifacts.ml: create ~project_name ~patch_id ~session_uuid constructs the dir Project_store.sessions_dir project_name / session_uuid via Project_store.ensure_dir; opens lazy out_channels for stdout.jsonl / stderr.log; returns a Telemetry.Sink.t whose name = "session_artifacts:<uuid>", interested_in matches events carrying that session_uuid (Stream, Spawn_started, Spawn_finalized), and consume routes each to disk: Spawn_started → write prompt.txt + argv.txt + env.txt (with Token_scrub applied to env values by name); Stream → append raw line + '\n' to the matching channel file; Spawn_finalized → write meta.json atomically via Persistence.write_file_atomically, close out_channels.
- project_store.ml: let sessions_dir project_name = Filename.concat (project_dir project_name) "sessions".
- Add inline let%test blocks: (i) create+Spawn_started+Spawn_finalized cycle writes meta.json with schema_version=1; (ii) Session_meta yojson roundtrip preserves every field; (iii) Stream events append lines in order to stdout.jsonl; (iv) interested_in returns false for events with different session_uuid; (v) Token_scrub redacts every known token pattern + masks env values by name.

## Changes
- session_meta.ml: type t = { schema_version : int; onton_session_uuid : string; claude_session_id : string option [@yojson.option]; patch_id : string; started_at : float; ended_at : float; exit_code : int; subkind : Failure_subkind.t; api_key_source : string option [@yojson.option]; model : string option [@yojson.option]; claude_code_version : string option [@yojson.option] } [@@deriving yojson]. Always emit schema_version = 1.
- token_scrub.ml: scrub_token_patterns redacts ghp_/gho_/ghs_/github_pat_/sk-ant-oat01-/sk-ant-api03-/sk-/xoxb-/AKIA[0-9A-Z]+. redact_env_value_by_name returns <REDACTED> for any value whose env-var name matches /KEY|TOKEN|SECRET/ (case-insensitive). Both are pure.
- session_artifacts.ml: create ~project_name ~patch_id ~session_uuid constructs the dir Project_store.sessions_dir project_name / session_uuid via Project_store.ensure_dir; opens lazy out_channels for stdout.jsonl / stderr.log; returns a Telemetry.Sink.t whose name = "session_artifacts:<uuid>", interested_in matches events carrying that session_uuid (Stream, Spawn_started, Spawn_finalized), and consume routes each to disk: Spawn_started → write prompt.txt + argv.txt + env.txt (with Token_scrub applied to env values by name); Stream → append raw line + '\n' to the matching channel file; Spawn_finalized → write meta.json atomically via Persistence.write_file_atomically, close out_channels.
- project_store.ml: let sessions_dir project_name = Filename.concat (project_dir project_name) "sessions".
- Add inline let%test blocks: (i) create+Spawn_started+Spawn_finalized cycle writes meta.json with schema_version=1; (ii) Session_meta yojson roundtrip preserves every field; (iii) Stream events append lines in order to stdout.jsonl; (iv) interested_in returns false for events with different session_uuid; (v) Token_scrub redacts every known token pattern + masks env values by name.

## Files to Modify
- lib_core/session_meta.ml (create): Record type for meta.json with schema_version=1 and [@yojson.option] / [@default ...] on additive fields.
- lib_core/session_meta.mli (create): Interface.
- lib_core/token_scrub.ml (create): Pure scrub_token_patterns + redact_env_value_by_name. Shared by Session_artifacts and Debug_upload.
- lib_core/token_scrub.mli (create): Interface.
- lib/session_artifacts.ml (create): Per-spawn artifact dir writer that constructs a Telemetry.Sink.t. interested_in filters by session_uuid; consume routes Stream/Spawn_started/Spawn_finalized to disk.
- lib/session_artifacts.mli (create): Interface exposing create : project_name → patch_id → session_uuid → Telemetry.Sink.t.
- lib/project_store.ml (modify): Add sessions_dir : string -> string.
- lib/project_store.mli (modify): Expose sessions_dir.

## Gameplan Specification

```
module REPLAY_READY_DIAGNOSTICS.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> Onton's observability is unified through a single typed
> Event variant routed via pluggable Sinks.  Pure decision
> (route, interested_in) is separated from effectful handling
> (consume, emit).  Every claude spawn produces a self-
> contained on-disk artifact directory at sessions/<uuid>/
> sufficient to diagnose the spawn's outcome offline.  Each
> spawn is classified by a typed Subkind enum.  The
> --upload-debug bundle includes a top-level manifest.json
> with a per-patch most-recent-subkind summary and no raw
> secrets.

Event.
Sink.
Spawn.
Meta.
Subkind.

ok => Subkind.
auth-unavailable => Subkind.
api-error => Subkind.
network-error => Subkind.
timed-out => Subkind.
no-session-to-resume => Subkind.
empty-response => Subkind.
process-error => Subkind.
other => Subkind.

> Telemetry layer.
sink-name s: Sink => String.
interested-in? s: Sink, e: Event => Bool.
consumed? s: Sink, e: Event => Bool.
route sinks: [Sink], e: Event => [Sink].

> Spawn / artifact layer.
spawn-completed? sp: Spawn => Bool.
spawn-uuid sp: Spawn => String.
spawn-meta sp: Spawn => Meta.
spawn-subkind sp: Spawn => Subkind.
artifact-dir-for sp: Spawn => String.
meta-path-for sp: Spawn => String.
schema-version m: Meta => Nat0.
subkind-of m: Meta => Subkind.
on-disk? p: String => Bool.
---

> Telemetry route is pure: a sink is in the output iff it was in the input AND interested.
all sinks: [Sink], e: Event, s: Sink, s in route sinks e | s in sinks.
all sinks: [Sink], e: Event, s: Sink, s in route sinks e | interested-in? s e.
all sinks: [Sink], e: Event, s: Sink, s in sinks, interested-in? s e | s in route sinks e.

> Emit dispatches an event to every interested sink (captured as consumed?).
all sinks: [Sink], e: Event, s: Sink, s in route sinks e | consumed? s e.

> Every completed spawn produces a finalized artifact dir on disk.
all sp: Spawn, spawn-completed? sp | on-disk? (artifact-dir-for sp).
all sp: Spawn, spawn-completed? sp | on-disk? (meta-path-for sp).

> meta.json carries schema_version = 1 and the classified subkind.
all sp: Spawn, spawn-completed? sp | schema-version (spawn-meta sp) = 1.
all sp: Spawn, spawn-completed? sp | subkind-of (spawn-meta sp) = spawn-subkind sp.

where

> ══════════════════════════════════════════
> Bundle manifest
> ══════════════════════════════════════════

Bundle.
Manifest.
File.

manifest-of b: Bundle => Manifest.
manifest-version m: Manifest => Nat0.
files-in b: Bundle => [File].
file-contents f: File => String.
contains-secret? s: String => Bool.
---

> Every --upload-debug bundle has a versioned manifest.
all b: Bundle | manifest-version (manifest-of b) = 1.

> Bundles never contain raw secrets.
all b: Bundle, f: File, f in files-in b | ~ contains-secret? (file-contents f).

```

## Patch Specification

```
module REPLAY_READY_DIAGNOSTICS_PATCH_4.

> Patch 4 adds the per-spawn artifact-directory sink and its
> supporting meta.json + token-scrub modules.  The sink
> implements Telemetry.Sink — interested_in filters by
> session_uuid; consume writes the matching event to disk.

Sink.
Meta.
Event.

schema-version m: Meta => Nat0.
sink-session-uuid s: Sink => String.
event-session-uuid e: Event => String.
interested-in? s: Sink, e: Event => Bool.
on-disk? p: String => Bool.

artifact-dir s: Sink => String.
meta-path-for s: Sink => String.
---

> meta.json carries schema_version = 1 in every emitted record.
all m: Meta | schema-version m = 1.

> The sink is interested exactly in events whose session_uuid matches its own.
all s: Sink, e: Event, interested-in? s e | event-session-uuid e = sink-session-uuid s.

> Distinct sinks have distinct artifact directories.
all s: Sink, t: Sink, artifact-dir s = artifact-dir t | s = t.

```


## Implementation Notes

- `Session_meta.create` is the only constructor used in this patch and hard-codes `schema_version = 1`; the record still derives `t_of_yojson`/`yojson_of_t` so later additive fields can remain compatible without adding effectful logic to `lib_core`.
- I exported `Persistence.write_file_atomically` in the `.mli` instead of duplicating atomic-write logic in `Session_artifacts`; that keeps `meta.json` writes consistent with the rest of the persistence layer at the cost of slightly widening an existing interface.
- Env-name redaction is implemented with an uppercase substring check for `KEY` / `TOKEN` / `SECRET` rather than a case-insensitive `Re.Perl` pattern. The original regex form raised at module init in this environment, so the final version stays pure and avoids runtime regex-parse failures.
- `Session_artifacts.create` opens stream files lazily and closes them only on `Spawn_finalized`. That matches the intended per-spawn lifecycle, but if a caller never emits the finalize event the descriptors remain open for the life of the process.
- `Spawn_started` writes `env.txt` by re-scrubbing the provided `env_redacted` entries by variable name and token pattern before persisting. That is deliberate defense in depth: this sink does not assume upstream callers already redacted perfectly.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/276"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive session tracking and artifact persistence to improve diagnostic capabilities
  * Implemented automatic redaction of sensitive tokens and environment variables for enhanced security

* **Improvements**
  * Introduced atomic file write operations for improved data persistence reliability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flowglad/onton/pull/276?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->