### PR TITLE
Require owner/repo on gameplans; isolate GitHub specifics

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -100,26 +100,99 @@ let format_git_failure { stdout; stderr; _ } =
   in
   if Base.String.is_empty detail then "no output" else detail
 
-(** Infer GitHub owner/repo from [git remote get-url origin] in [repo_root].
-    Parses both HTTPS and SSH remote URLs. Uses argv (no shell). *)
+(** Infer the forge owner/repo from [git remote get-url origin] in [repo_root].
+    Delegates URL parsing to {!Onton_core.Github_target.infer_owner_repo_from_url}
+    so the regex that pins the host stays in the forge module. *)
 let infer_owner_repo ~repo_root =
   try
     match run_git_capture ~repo_root [ "remote"; "get-url"; "origin" ] with
-    | Some { status = Unix.WEXITED 0; stdout; _ } -> (
-        let url = Base.String.strip stdout in
-        let re =
-          Re.Pcre.re {|github\.com[:/]([^/]+)/([^/\s]+?)(?:\.git)?/?$|}
-          |> Re.compile
-        in
-        match Re.exec_opt re url with
-        | Some g -> Some (Re.Group.get g 1, Re.Group.get g 2)
-        | None -> None)
+    | Some { status = Unix.WEXITED 0; stdout; _ } ->
+        Github_target.infer_owner_repo_from_url stdout
     | Some { status = Unix.WEXITED _; _ }
     | Some { status = Unix.WSIGNALED _; _ }
     | Some { status = Unix.WSTOPPED _; _ }
     | None ->
         None
   with _ -> None
+
+(** Spawn [git] (not [git -C ...]) with a clean environment, capture stdout and
+    stderr. Used for [git clone] before any working tree exists. *)
+let run_git_no_cwd args =
+  let argv = Array.of_list ("git" :: args) in
+  let env = Git_env.clean_env () in
+  match Unix.open_process_args_full "git" argv env with
+  | exception _ -> None
+  | in_ch, out_ch, err_ch ->
+      let status = ref None in
+      Stdlib.Fun.protect
+        ~finally:(fun () ->
+          if Option.is_none !status then
+            try ignore (Unix.close_process_full (in_ch, out_ch, err_ch))
+            with _ -> ())
+        (fun () ->
+          close_out_noerr out_ch;
+          let stdout = read_channel_all in_ch in
+          let stderr = read_channel_all err_ch in
+          let s = Unix.close_process_full (in_ch, out_ch, err_ch) in
+          status := Some s;
+          Some { status = s; stdout; stderr })
+
+(** Clone [owner/repo] from GitHub into [target_dir] (which must not exist
+    yet). Authentication piggybacks on [Git_env.clean_env]'s [GIT_ASKPASS]
+    helper, so [Git_env.set_github_token] must have been called first if the
+    repo is private. Uses [--filter=blob:none] for a partial clone — only
+    fetched objects are downloaded lazily, which is the right tradeoff for
+    onton's worktree-per-patch usage pattern. *)
+let clone_managed_repo ~owner ~repo ~target_dir =
+  Project_store.ensure_dir (Stdlib.Filename.dirname target_dir);
+  let url = Github_target.clone_url ~owner ~repo in
+  match
+    run_git_no_cwd [ "clone"; "--filter=blob:none"; url; target_dir ]
+  with
+  | Some { status = Unix.WEXITED 0; _ } -> Ok ()
+  | Some ({ status = Unix.WEXITED _; _ } as cap)
+  | Some ({ status = Unix.WSIGNALED _; _ } as cap)
+  | Some ({ status = Unix.WSTOPPED _; _ } as cap) ->
+      Error
+        (Printf.sprintf "git clone %s/%s failed: %s" owner repo
+           (format_git_failure cap))
+  | None -> Error (Printf.sprintf "git clone %s/%s: could not spawn" owner repo)
+
+(** Fetch the [origin] remote in an existing onton-managed repo. Best-effort —
+    a network-down resume should not fail the whole session. *)
+let fetch_managed_repo ~repo_root =
+  match run_git_capture ~repo_root [ "fetch"; "--prune"; "origin" ] with
+  | Some { status = Unix.WEXITED 0; _ } -> Ok ()
+  | Some ({ status = Unix.WEXITED _; _ } as cap)
+  | Some ({ status = Unix.WSIGNALED _; _ } as cap)
+  | Some ({ status = Unix.WSTOPPED _; _ } as cap) ->
+      Error
+        (Printf.sprintf "git fetch in %s failed: %s" repo_root
+           (format_git_failure cap))
+  | None -> Error (Printf.sprintf "git fetch in %s: could not spawn" repo_root)
+
+(** Ensure the onton-managed checkout for [project_name] is present and
+    up-to-date. Clones if absent, fetches if present. Authenticates via
+    [Git_env]'s configured token. *)
+let ensure_managed_repo ~project_name ~token ~owner ~repo =
+  Git_env.set_github_token token;
+  let repo_root = Project_store.managed_repo_dir project_name in
+  if
+    Stdlib.Sys.file_exists repo_root
+    && Stdlib.Sys.is_directory (Stdlib.Filename.concat repo_root ".git")
+  then
+    match fetch_managed_repo ~repo_root with
+    | Ok () -> Ok repo_root
+    | Error msg ->
+        (* Log to stderr but don't abort — the user may be offline and the
+           local clone may already have everything they need. *)
+        Printf.eprintf
+          "onton: warning: %s (continuing with existing local clone)\n%!" msg;
+        Ok repo_root
+  else
+    match clone_managed_repo ~owner ~repo ~target_dir:repo_root with
+    | Ok () -> Ok repo_root
+    | Error msg -> Error msg
 
 (** Resolve GitHub token: check GITHUB_TOKEN env var, then try [gh auth token].
     Uses argv (no shell). *)
@@ -3782,20 +3855,21 @@ let resolve_config ~project ~gameplan_path ~github_token ~backend ~model
         if Base.String.is_empty owner || Base.String.is_empty repo then "adhoc"
         else Printf.sprintf "%s-%s" owner repo
       in
-      let gameplan =
-        Gameplan.
-          {
-            project_name;
-            problem_statement = "";
-            solution_summary = "";
-            final_state_spec = "";
-            patches = [];
-            current_state_analysis = "";
-            explicit_opinions = "";
-            acceptance_criteria = [];
-            open_questions = [];
-            functional_changes = [];
-          }
+      let gameplan : Gameplan.t =
+        {
+          project_name;
+          repo_owner = owner;
+          repo_name = repo;
+          problem_statement = "";
+          solution_summary = "";
+          final_state_spec = "";
+          patches = [];
+          current_state_analysis = "";
+          explicit_opinions = "";
+          acceptance_criteria = [];
+          open_questions = [];
+          functional_changes = [];
+        }
       in
       let backend, model = resolve_backend_model ~backend ~model in
       let main_branch = resolve_branch ~repo_root main_branch in
@@ -3823,42 +3897,88 @@ let resolve_config ~project ~gameplan_path ~github_token ~backend ~model
   | _, Some gp_path -> (
       match Gameplan_parser.parse_file gp_path with
       | Error msg -> Error [ Printf.sprintf "Error parsing gameplan: %s" msg ]
-      | Ok parsed ->
+      | Ok parsed -> (
           let gameplan = parsed.Gameplan_parser.gameplan in
           let project_name =
             match project with
             | Some p -> p
             | None -> gameplan.Gameplan.project_name
           in
-          let repo_root = repo_root_for_fresh in
-          let token, owner, repo =
-            resolve_github_credentials ~github_token ~repo_root
+          let owner = Base.String.strip gameplan.Gameplan.repo_owner in
+          let repo = Base.String.strip gameplan.Gameplan.repo_name in
+          let target_error =
+            if Base.String.is_empty owner || Base.String.is_empty repo then
+              Some
+                (Printf.sprintf
+                   "Gameplan %s is missing required top-level `owner` and/or \
+                    `repo`. Every gameplan must declare exactly one \
+                    repository — see skills/write-gameplan/SKILL.md §\"One \
+                    Repo Per Gameplan\"."
+                   gp_path)
+            else
+              match Github_target.validate_target ~owner ~repo with
+              | Ok () -> None
+              | Error msg ->
+                  Some
+                    (Printf.sprintf
+                       "Gameplan %s declares an invalid GitHub target: %s"
+                       gp_path msg)
           in
-          let backend, model = resolve_backend_model ~backend ~model in
-          let main_branch = resolve_branch ~repo_root main_branch in
-          Project_store.save_config ~project_name ~github_token:token
-            ~github_owner:owner ~github_repo:repo ~backend ~model
-            ~main_branch:(Branch.to_string main_branch)
-            ~poll_interval ~repo_root ~max_concurrency;
-          Project_store.save_gameplan_source ~project_name ~source_path:gp_path;
-          let config =
-            {
-              project = Some project_name;
-              backend;
-              model;
-              github_token = token;
-              github_owner = owner;
-              github_repo = repo;
-              main_branch;
-              poll_interval;
-              repo_root;
-              max_concurrency;
-              headless;
-              user_config =
-                User_config.load ~github_owner:owner ~github_repo:repo;
-            }
-          in
-          with_snapshot_load ~project_name config gameplan)
+          match target_error with
+          | Some msg -> Error [ msg ]
+          | None -> (
+            (* [--repo] is ignored when [--gameplan] is passed: the gameplan
+               itself is the source of truth for which repo to operate on, and
+               onton manages its own checkout under the project data dir. *)
+            (match repo_root with
+            | Some user_repo when not (Base.String.is_empty user_repo) ->
+                Printf.eprintf
+                  "onton: --repo %s ignored when --gameplan is set; using \
+                   onton-managed checkout for %s/%s\n\
+                   %!"
+                  user_repo owner repo
+            | _ -> ());
+            let token =
+              let t = Base.String.strip github_token in
+              if Base.String.is_empty t then infer_github_token () else t
+            in
+            match
+              ensure_managed_repo ~project_name ~token ~owner ~repo
+            with
+            | Error msg ->
+                Error
+                  [
+                    Printf.sprintf
+                      "Could not prepare onton-managed checkout for %s/%s: %s"
+                      owner repo msg;
+                  ]
+            | Ok repo_root ->
+                let backend, model = resolve_backend_model ~backend ~model in
+                let main_branch = resolve_branch ~repo_root main_branch in
+                Project_store.save_config ~project_name ~github_token:token
+                  ~github_owner:owner ~github_repo:repo ~backend ~model
+                  ~main_branch:(Branch.to_string main_branch)
+                  ~poll_interval ~repo_root ~max_concurrency;
+                Project_store.save_gameplan_source ~project_name
+                  ~source_path:gp_path;
+                let config =
+                  {
+                    project = Some project_name;
+                    backend;
+                    model;
+                    github_token = token;
+                    github_owner = owner;
+                    github_repo = repo;
+                    main_branch;
+                    poll_interval;
+                    repo_root;
+                    max_concurrency;
+                    headless;
+                    user_config =
+                      User_config.load ~github_owner:owner ~github_repo:repo;
+                  }
+                in
+                with_snapshot_load ~project_name config gameplan)))
   | Some proj, None -> (
       if not (Project_store.project_exists proj) then
         Error
@@ -3914,18 +4034,42 @@ let resolve_config ~project ~gameplan_path ~github_token ~backend ~model
                     resolve_github_credentials ~github_token:token_from_stored
                       ~repo_root
                   in
+                  (* Precedence on resume: gameplan > stored config > inferred
+                     from git remote. Gameplan-authored sessions have non-empty
+                     owner/repo in the parsed gameplan and they are the
+                     source-of-truth. Legacy sessions have empty values there
+                     and fall through to the stored config (backfill path),
+                     then to inference. *)
+                  let pick_owner_repo gp stored_v inferred_v =
+                    let s = Base.String.strip gp in
+                    if not (Base.String.is_empty s) then s
+                    else
+                      let s = Base.String.strip stored_v in
+                      if Base.String.is_empty s then inferred_v else s
+                  in
                   let owner =
-                    let s =
-                      Base.String.strip stored.Project_store.github_owner
-                    in
-                    if Base.String.is_empty s then inferred_owner else s
+                    pick_owner_repo gameplan.Gameplan.repo_owner
+                      stored.Project_store.github_owner inferred_owner
                   in
                   let repo =
-                    let s =
-                      Base.String.strip stored.Project_store.github_repo
-                    in
-                    if Base.String.is_empty s then inferred_repo else s
+                    pick_owner_repo gameplan.Gameplan.repo_name
+                      stored.Project_store.github_repo inferred_repo
                   in
+                  (* If the stored repo_root is the onton-managed checkout for
+                     this project, refresh it from origin before continuing.
+                     Best-effort: an offline resume should still proceed. *)
+                  (if String.equal repo_root
+                       (Project_store.managed_repo_dir proj)
+                  then
+                     match
+                       ensure_managed_repo ~project_name:proj ~token ~owner
+                         ~repo
+                     with
+                     | Ok _ -> ()
+                     | Error msg ->
+                         Printf.eprintf
+                           "onton: warning: %s (resuming with local state)\n%!"
+                           msg);
                   let branch =
                     match main_branch with
                     | Some b -> b

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -57,6 +57,18 @@ let read_channel_all ic =
    with End_of_file -> ());
   Buffer.contents buf
 
+let close_fd_noerr fd = try Unix.close fd with _ -> ()
+let unlink_noerr path = try Stdlib.Sys.remove path with _ -> ()
+let iter_option opt ~f = match opt with Some x -> f x | None -> ()
+
+let read_file_noerr path =
+  match open_in_bin path with
+  | exception _ -> ""
+  | ic ->
+      Stdlib.Fun.protect
+        ~finally:(fun () -> close_in_noerr ic)
+        (fun () -> read_channel_all ic)
+
 (** Run [git -C repo_root ...] using argv rather than the shell, capture stdout
     and stderr, and close all process pipes on exception paths. *)
 let run_git_capture ~repo_root args =
@@ -121,34 +133,57 @@ let infer_owner_repo ~repo_root =
 let run_git_no_cwd args =
   let argv = Array.of_list ("git" :: args) in
   let env = Git_env.clean_env () in
-  match Unix.open_process_args_full "git" argv env with
+  match Stdlib.Filename.temp_file "onton-git-stderr-" ".log" with
   | exception _ -> None
-  | in_ch, out_ch, err_ch -> (
-      let status = ref None in
-      let capture =
-        match
-          Stdlib.Fun.protect
-            ~finally:(fun () ->
-              if Option.is_none !status then
-                try
-                  status :=
-                    Some (Unix.close_process_full (in_ch, out_ch, err_ch))
-                with _ -> ())
-            (fun () ->
-              close_out_noerr out_ch;
-              let stdout = read_channel_all in_ch in
-              let stderr = read_channel_all err_ch in
-              Some (stdout, stderr))
-        with
-        | result -> result
-        | exception _ -> None
-      in
-      match capture with
-      | None -> None
-      | Some (stdout, stderr) -> (
-          match !status with
-          | Some s -> Some { status = s; stdout; stderr }
-          | None -> None))
+  | err_path -> (
+      let stdin_fd = ref None in
+      let stdout_rd = ref None in
+      let stdout_wr = ref None in
+      let stdout_ic = ref None in
+      let err_fd = ref None in
+      let pid = ref None in
+      match
+        Stdlib.Fun.protect
+          ~finally:(fun () ->
+            iter_option !stdout_ic ~f:close_in_noerr;
+            iter_option !stdout_rd ~f:close_fd_noerr;
+            iter_option !stdout_wr ~f:close_fd_noerr;
+            iter_option !stdin_fd ~f:close_fd_noerr;
+            iter_option !err_fd ~f:close_fd_noerr;
+            iter_option !pid ~f:(fun p ->
+                try ignore (Unix.waitpid [] p) with _ -> ());
+            unlink_noerr err_path)
+          (fun () ->
+            let stdin = Unix.openfile "/dev/null" [ Unix.O_RDONLY ] 0 in
+            stdin_fd := Some stdin;
+            let rd, wr = Unix.pipe () in
+            stdout_rd := Some rd;
+            stdout_wr := Some wr;
+            let err =
+              Unix.openfile err_path [ Unix.O_WRONLY; Unix.O_TRUNC ] 0o600
+            in
+            err_fd := Some err;
+            let child = Unix.create_process_env "git" argv env stdin wr err in
+            pid := Some child;
+            close_fd_noerr stdin;
+            stdin_fd := None;
+            close_fd_noerr wr;
+            stdout_wr := None;
+            close_fd_noerr err;
+            err_fd := None;
+            let ic = Unix.in_channel_of_descr rd in
+            stdout_rd := None;
+            stdout_ic := Some ic;
+            let stdout = read_channel_all ic in
+            close_in_noerr ic;
+            stdout_ic := None;
+            let _, status = Unix.waitpid [] child in
+            pid := None;
+            let stderr = read_file_noerr err_path in
+            Some { status; stdout; stderr })
+      with
+      | result -> result
+      | exception _ -> None)
 
 (** Clone [owner/repo] from GitHub into [target_dir] (which must not exist yet).
     Authentication piggybacks on [Git_env.clean_env]'s [GIT_ASKPASS] helper, so

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -224,11 +224,18 @@ let ensure_managed_repo ~project_name ~token ~owner ~repo =
   Git_env.set_github_token token;
   let repo_root = Project_store.managed_repo_dir project_name in
   let git_dir = Stdlib.Filename.concat repo_root ".git" in
+  let repo_root_exists = Stdlib.Sys.file_exists repo_root in
   let has_git_dir =
     try Stdlib.Sys.file_exists git_dir && Stdlib.Sys.is_directory git_dir
     with _ -> false
   in
-  if Stdlib.Sys.file_exists repo_root && has_git_dir then (
+  let repo_root_is_dir =
+    try Stdlib.Sys.is_directory repo_root with _ -> false
+  in
+  let repo_root_is_empty =
+    try Array.length (Stdlib.Sys.readdir repo_root) = 0 with _ -> false
+  in
+  if repo_root_exists && has_git_dir then (
     match fetch_managed_repo ~repo_root with
     | Ok () -> Ok repo_root
     | Error msg ->
@@ -237,6 +244,18 @@ let ensure_managed_repo ~project_name ~token ~owner ~repo =
         Printf.eprintf
           "onton: warning: %s (continuing with existing local clone)\n%!" msg;
         Ok repo_root)
+  else if repo_root_exists && not repo_root_is_dir then
+    Error
+      (Printf.sprintf
+         "Managed checkout path %s exists but is not a directory; remove it \
+          and retry"
+         repo_root)
+  else if repo_root_exists && not repo_root_is_empty then
+    Error
+      (Printf.sprintf
+         "Managed checkout path %s exists but is not a git checkout and is not \
+          empty; remove it and retry"
+         repo_root)
   else
     match clone_managed_repo ~owner ~repo ~target_dir:repo_root with
     | Ok () -> Ok repo_root
@@ -4108,15 +4127,26 @@ let resolve_config ~project ~gameplan_path ~github_token ~backend ~model
                      String.equal repo_root
                        (Project_store.managed_repo_dir proj)
                    then
-                     match
-                       ensure_managed_repo ~project_name:proj ~token ~owner
-                         ~repo
-                     with
-                     | Ok _ -> ()
-                     | Error msg ->
-                         Printf.eprintf
-                           "onton: warning: %s (resuming with local state)\n%!"
-                           msg);
+                     if
+                       Base.String.is_empty (Base.String.strip owner)
+                       || Base.String.is_empty (Base.String.strip repo)
+                     then
+                       Printf.eprintf
+                         "onton: warning: stored project %S has no GitHub \
+                          owner/repo; skipping managed checkout refresh\n\
+                          %!"
+                         proj
+                     else
+                       match
+                         ensure_managed_repo ~project_name:proj ~token ~owner
+                           ~repo
+                       with
+                       | Ok _ -> ()
+                       | Error msg ->
+                           Printf.eprintf
+                             "onton: warning: %s (resuming with local state)\n\
+                              %!"
+                             msg);
                   let branch =
                     match main_branch with
                     | Some b -> b

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -101,8 +101,9 @@ let format_git_failure { stdout; stderr; _ } =
   if Base.String.is_empty detail then "no output" else detail
 
 (** Infer the forge owner/repo from [git remote get-url origin] in [repo_root].
-    Delegates URL parsing to {!Onton_core.Github_target.infer_owner_repo_from_url}
-    so the regex that pins the host stays in the forge module. *)
+    Delegates URL parsing to
+    {!Onton_core.Github_target.infer_owner_repo_from_url} so the regex that pins
+    the host stays in the forge module. *)
 let infer_owner_repo ~repo_root =
   try
     match run_git_capture ~repo_root [ "remote"; "get-url"; "origin" ] with
@@ -137,18 +138,16 @@ let run_git_no_cwd args =
           status := Some s;
           Some { status = s; stdout; stderr })
 
-(** Clone [owner/repo] from GitHub into [target_dir] (which must not exist
-    yet). Authentication piggybacks on [Git_env.clean_env]'s [GIT_ASKPASS]
-    helper, so [Git_env.set_github_token] must have been called first if the
-    repo is private. Uses [--filter=blob:none] for a partial clone — only
-    fetched objects are downloaded lazily, which is the right tradeoff for
-    onton's worktree-per-patch usage pattern. *)
+(** Clone [owner/repo] from GitHub into [target_dir] (which must not exist yet).
+    Authentication piggybacks on [Git_env.clean_env]'s [GIT_ASKPASS] helper, so
+    [Git_env.set_github_token] must have been called first if the repo is
+    private. Uses [--filter=blob:none] for a partial clone — only fetched
+    objects are downloaded lazily, which is the right tradeoff for onton's
+    worktree-per-patch usage pattern. *)
 let clone_managed_repo ~owner ~repo ~target_dir =
   Project_store.ensure_dir (Stdlib.Filename.dirname target_dir);
   let url = Github_target.clone_url ~owner ~repo in
-  match
-    run_git_no_cwd [ "clone"; "--filter=blob:none"; url; target_dir ]
-  with
+  match run_git_no_cwd [ "clone"; "--filter=blob:none"; url; target_dir ] with
   | Some { status = Unix.WEXITED 0; _ } -> Ok ()
   | Some ({ status = Unix.WEXITED _; _ } as cap)
   | Some ({ status = Unix.WSIGNALED _; _ } as cap)
@@ -158,8 +157,8 @@ let clone_managed_repo ~owner ~repo ~target_dir =
            (format_git_failure cap))
   | None -> Error (Printf.sprintf "git clone %s/%s: could not spawn" owner repo)
 
-(** Fetch the [origin] remote in an existing onton-managed repo. Best-effort —
-    a network-down resume should not fail the whole session. *)
+(** Fetch the [origin] remote in an existing onton-managed repo. Best-effort — a
+    network-down resume should not fail the whole session. *)
 let fetch_managed_repo ~repo_root =
   match run_git_capture ~repo_root [ "fetch"; "--prune"; "origin" ] with
   | Some { status = Unix.WEXITED 0; _ } -> Ok ()
@@ -180,7 +179,7 @@ let ensure_managed_repo ~project_name ~token ~owner ~repo =
   if
     Stdlib.Sys.file_exists repo_root
     && Stdlib.Sys.is_directory (Stdlib.Filename.concat repo_root ".git")
-  then
+  then (
     match fetch_managed_repo ~repo_root with
     | Ok () -> Ok repo_root
     | Error msg ->
@@ -188,7 +187,7 @@ let ensure_managed_repo ~project_name ~token ~owner ~repo =
            local clone may already have everything they need. *)
         Printf.eprintf
           "onton: warning: %s (continuing with existing local clone)\n%!" msg;
-        Ok repo_root
+        Ok repo_root)
   else
     match clone_managed_repo ~owner ~repo ~target_dir:repo_root with
     | Ok () -> Ok repo_root
@@ -3911,9 +3910,9 @@ let resolve_config ~project ~gameplan_path ~github_token ~backend ~model
               Some
                 (Printf.sprintf
                    "Gameplan %s is missing required top-level `owner` and/or \
-                    `repo`. Every gameplan must declare exactly one \
-                    repository — see skills/write-gameplan/SKILL.md §\"One \
-                    Repo Per Gameplan\"."
+                    `repo`. Every gameplan must declare exactly one repository \
+                    — see skills/write-gameplan/SKILL.md §\"One Repo Per \
+                    Gameplan\"."
                    gp_path)
             else
               match Github_target.validate_target ~owner ~repo with
@@ -3927,58 +3926,56 @@ let resolve_config ~project ~gameplan_path ~github_token ~backend ~model
           match target_error with
           | Some msg -> Error [ msg ]
           | None -> (
-            (* [--repo] is ignored when [--gameplan] is passed: the gameplan
+              (* [--repo] is ignored when [--gameplan] is passed: the gameplan
                itself is the source of truth for which repo to operate on, and
                onton manages its own checkout under the project data dir. *)
-            (match repo_root with
-            | Some user_repo when not (Base.String.is_empty user_repo) ->
-                Printf.eprintf
-                  "onton: --repo %s ignored when --gameplan is set; using \
-                   onton-managed checkout for %s/%s\n\
-                   %!"
-                  user_repo owner repo
-            | _ -> ());
-            let token =
-              let t = Base.String.strip github_token in
-              if Base.String.is_empty t then infer_github_token () else t
-            in
-            match
-              ensure_managed_repo ~project_name ~token ~owner ~repo
-            with
-            | Error msg ->
-                Error
-                  [
-                    Printf.sprintf
-                      "Could not prepare onton-managed checkout for %s/%s: %s"
-                      owner repo msg;
-                  ]
-            | Ok repo_root ->
-                let backend, model = resolve_backend_model ~backend ~model in
-                let main_branch = resolve_branch ~repo_root main_branch in
-                Project_store.save_config ~project_name ~github_token:token
-                  ~github_owner:owner ~github_repo:repo ~backend ~model
-                  ~main_branch:(Branch.to_string main_branch)
-                  ~poll_interval ~repo_root ~max_concurrency;
-                Project_store.save_gameplan_source ~project_name
-                  ~source_path:gp_path;
-                let config =
-                  {
-                    project = Some project_name;
-                    backend;
-                    model;
-                    github_token = token;
-                    github_owner = owner;
-                    github_repo = repo;
-                    main_branch;
-                    poll_interval;
-                    repo_root;
-                    max_concurrency;
-                    headless;
-                    user_config =
-                      User_config.load ~github_owner:owner ~github_repo:repo;
-                  }
-                in
-                with_snapshot_load ~project_name config gameplan)))
+              (match repo_root with
+              | Some user_repo when not (Base.String.is_empty user_repo) ->
+                  Printf.eprintf
+                    "onton: --repo %s ignored when --gameplan is set; using \
+                     onton-managed checkout for %s/%s\n\
+                     %!"
+                    user_repo owner repo
+              | _ -> ());
+              let token =
+                let t = Base.String.strip github_token in
+                if Base.String.is_empty t then infer_github_token () else t
+              in
+              match ensure_managed_repo ~project_name ~token ~owner ~repo with
+              | Error msg ->
+                  Error
+                    [
+                      Printf.sprintf
+                        "Could not prepare onton-managed checkout for %s/%s: %s"
+                        owner repo msg;
+                    ]
+              | Ok repo_root ->
+                  let backend, model = resolve_backend_model ~backend ~model in
+                  let main_branch = resolve_branch ~repo_root main_branch in
+                  Project_store.save_config ~project_name ~github_token:token
+                    ~github_owner:owner ~github_repo:repo ~backend ~model
+                    ~main_branch:(Branch.to_string main_branch)
+                    ~poll_interval ~repo_root ~max_concurrency;
+                  Project_store.save_gameplan_source ~project_name
+                    ~source_path:gp_path;
+                  let config =
+                    {
+                      project = Some project_name;
+                      backend;
+                      model;
+                      github_token = token;
+                      github_owner = owner;
+                      github_repo = repo;
+                      main_branch;
+                      poll_interval;
+                      repo_root;
+                      max_concurrency;
+                      headless;
+                      user_config =
+                        User_config.load ~github_owner:owner ~github_repo:repo;
+                    }
+                  in
+                  with_snapshot_load ~project_name config gameplan)))
   | Some proj, None -> (
       if not (Project_store.project_exists proj) then
         Error
@@ -4058,9 +4055,10 @@ let resolve_config ~project ~gameplan_path ~github_token ~backend ~model
                   (* If the stored repo_root is the onton-managed checkout for
                      this project, refresh it from origin before continuing.
                      Best-effort: an offline resume should still proceed. *)
-                  (if String.equal repo_root
+                  (if
+                     String.equal repo_root
                        (Project_store.managed_repo_dir proj)
-                  then
+                   then
                      match
                        ensure_managed_repo ~project_name:proj ~token ~owner
                          ~repo

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -123,20 +123,32 @@ let run_git_no_cwd args =
   let env = Git_env.clean_env () in
   match Unix.open_process_args_full "git" argv env with
   | exception _ -> None
-  | in_ch, out_ch, err_ch ->
+  | in_ch, out_ch, err_ch -> (
       let status = ref None in
-      Stdlib.Fun.protect
-        ~finally:(fun () ->
-          if Option.is_none !status then
-            try ignore (Unix.close_process_full (in_ch, out_ch, err_ch))
-            with _ -> ())
-        (fun () ->
-          close_out_noerr out_ch;
-          let stdout = read_channel_all in_ch in
-          let stderr = read_channel_all err_ch in
-          let s = Unix.close_process_full (in_ch, out_ch, err_ch) in
-          status := Some s;
-          Some { status = s; stdout; stderr })
+      let capture =
+        match
+          Stdlib.Fun.protect
+            ~finally:(fun () ->
+              if Option.is_none !status then
+                try
+                  status :=
+                    Some (Unix.close_process_full (in_ch, out_ch, err_ch))
+                with _ -> ())
+            (fun () ->
+              close_out_noerr out_ch;
+              let stdout = read_channel_all in_ch in
+              let stderr = read_channel_all err_ch in
+              Some (stdout, stderr))
+        with
+        | result -> result
+        | exception _ -> None
+      in
+      match capture with
+      | None -> None
+      | Some (stdout, stderr) -> (
+          match !status with
+          | Some s -> Some { status = s; stdout; stderr }
+          | None -> None))
 
 (** Clone [owner/repo] from GitHub into [target_dir] (which must not exist yet).
     Authentication piggybacks on [Git_env.clean_env]'s [GIT_ASKPASS] helper, so
@@ -176,10 +188,12 @@ let fetch_managed_repo ~repo_root =
 let ensure_managed_repo ~project_name ~token ~owner ~repo =
   Git_env.set_github_token token;
   let repo_root = Project_store.managed_repo_dir project_name in
-  if
-    Stdlib.Sys.file_exists repo_root
-    && Stdlib.Sys.is_directory (Stdlib.Filename.concat repo_root ".git")
-  then (
+  let git_dir = Stdlib.Filename.concat repo_root ".git" in
+  let has_git_dir =
+    try Stdlib.Sys.file_exists git_dir && Stdlib.Sys.is_directory git_dir
+    with _ -> false
+  in
+  if Stdlib.Sys.file_exists repo_root && has_git_dir then (
     match fetch_managed_repo ~repo_root with
     | Ok () -> Ok repo_root
     | Error msg ->

--- a/lib/github.mli
+++ b/lib/github.mli
@@ -2,8 +2,8 @@
 
     Queries the GitHub GraphQL API for PR/world state. Satisfies {!Forge.S}.
 
-    Pure GitHub-target logic (identifier validation, URL formatting, remote
-    URL parsing) lives in {!Onton_core.Github_target} so the rules can be
+    Pure GitHub-target logic (identifier validation, URL formatting, remote URL
+    parsing) lives in {!Onton_core.Github_target} so the rules can be
     property-tested without spawning subprocesses; this module owns the
     effectful HTTP and network surface. *)
 

--- a/lib/github.mli
+++ b/lib/github.mli
@@ -1,6 +1,11 @@
 (** GitHub forge implementation.
 
-    Queries the GitHub GraphQL API for PR/world state. Satisfies {!Forge.S}. *)
+    Queries the GitHub GraphQL API for PR/world state. Satisfies {!Forge.S}.
+
+    Pure GitHub-target logic (identifier validation, URL formatting, remote
+    URL parsing) lives in {!Onton_core.Github_target} so the rules can be
+    property-tested without spawning subprocesses; this module owns the
+    effectful HTTP and network surface. *)
 
 type error =
   | Http_error of { meth : string; path : string; status : int; body : string }

--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -668,6 +668,8 @@ let%test "reconcile_patch escalates repeated start discovery failures" =
         Gameplan.
           {
             project_name = "proj";
+            repo_owner = "";
+            repo_name = "";
             problem_statement = "";
             solution_summary = "";
             final_state_spec = "";
@@ -691,6 +693,8 @@ let%test "reconcile_patch enqueues pr_body after PR creation" =
     Gameplan.
       {
         project_name = "proj";
+        repo_owner = "";
+        repo_name = "";
         problem_statement = "";
         solution_summary = "";
         final_state_spec = "";
@@ -718,6 +722,8 @@ let%test "reconcile_patch requests ready-for-review after pr_body on main" =
         Gameplan.
           {
             project_name = "proj";
+            repo_owner = "";
+            repo_name = "";
             problem_statement = "";
             solution_summary = "";
             final_state_spec = "";
@@ -746,6 +752,8 @@ let%test "reconcile_patch emits no effects for merged agent" =
         Gameplan.
           {
             project_name = "proj";
+            repo_owner = "";
+            repo_name = "";
             problem_statement = "";
             solution_summary = "";
             final_state_spec = "";

--- a/lib/persistence.ml
+++ b/lib/persistence.ml
@@ -725,6 +725,8 @@ let%test_module "session_id_sidecars" =
       Gameplan.
         {
           project_name = "sidecar-test";
+          repo_owner = "";
+          repo_name = "";
           problem_statement = "";
           solution_summary = "";
           final_state_spec = "";

--- a/lib/project_store.ml
+++ b/lib/project_store.ml
@@ -25,6 +25,9 @@ let project_dir project_name =
 let snapshot_path project_name =
   Stdlib.Filename.concat (project_dir project_name) "snapshot.json"
 
+let managed_repo_dir project_name =
+  Stdlib.Filename.concat (project_dir project_name) "repo"
+
 let event_log_path project_name =
   Stdlib.Filename.concat (project_dir project_name) "events.jsonl"
 

--- a/lib/project_store.mli
+++ b/lib/project_store.mli
@@ -13,6 +13,14 @@ val project_dir : string -> string
 val snapshot_path : string -> string
 (** Path to the project's persisted snapshot JSON. *)
 
+val managed_repo_dir : string -> string
+(** Path to the project's onton-managed git checkout
+    ([<project-dir>/repo]). Sessions started via [--gameplan] take their
+    [owner]/[repo] from the gameplan as source-of-truth; onton clones the repo
+    into this directory (or fetches it on resume) and uses it as the source for
+    all worktrees. Sessions started ad-hoc (no [--gameplan]) continue to use a
+    user-provided checkout and do not populate this path. *)
+
 val event_log_path : string -> string
 (** Path to the project's append-only event log (JSONL). *)
 

--- a/lib/project_store.mli
+++ b/lib/project_store.mli
@@ -14,12 +14,12 @@ val snapshot_path : string -> string
 (** Path to the project's persisted snapshot JSON. *)
 
 val managed_repo_dir : string -> string
-(** Path to the project's onton-managed git checkout
-    ([<project-dir>/repo]). Sessions started via [--gameplan] take their
-    [owner]/[repo] from the gameplan as source-of-truth; onton clones the repo
-    into this directory (or fetches it on resume) and uses it as the source for
-    all worktrees. Sessions started ad-hoc (no [--gameplan]) continue to use a
-    user-provided checkout and do not populate this path. *)
+(** Path to the project's onton-managed git checkout ([<project-dir>/repo]).
+    Sessions started via [--gameplan] take their [owner]/[repo] from the
+    gameplan as source-of-truth; onton clones the repo into this directory (or
+    fetches it on resume) and uses it as the source for all worktrees. Sessions
+    started ad-hoc (no [--gameplan]) continue to use a user-provided checkout
+    and do not populate this path. *)
 
 val event_log_path : string -> string
 (** Path to the project's append-only event log (JSONL). *)

--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -427,6 +427,8 @@ let%test "render_spec_suffix: both empty" =
   let gameplan =
     {
       Gameplan.project_name = "";
+      repo_owner = "";
+      repo_name = "";
       problem_statement = "";
       solution_summary = "";
       final_state_spec = "";
@@ -462,6 +464,8 @@ let%test "render_spec_suffix: gameplan spec only" =
   let gameplan =
     {
       Gameplan.project_name = "";
+      repo_owner = "";
+      repo_name = "";
       problem_statement = "";
       solution_summary = "";
       final_state_spec = "module FOO.\nsome spec";
@@ -500,6 +504,8 @@ let%test "render_spec_suffix: patch spec only" =
   let gameplan =
     {
       Gameplan.project_name = "";
+      repo_owner = "";
+      repo_name = "";
       problem_statement = "";
       solution_summary = "";
       final_state_spec = "";
@@ -538,6 +544,8 @@ let%test "render_spec_suffix: both present" =
   let gameplan =
     {
       Gameplan.project_name = "";
+      repo_owner = "";
+      repo_name = "";
       problem_statement = "";
       solution_summary = "";
       final_state_spec = "module FOO.\ngameplan spec";
@@ -1165,6 +1173,8 @@ let%test "patch prompt includes title and deps" =
     Gameplan.
       {
         project_name = "onton-port";
+        repo_owner = "flowglad";
+        repo_name = "onton";
         problem_statement = "Port Anton to OCaml.";
         solution_summary = "Use Eio for concurrency.";
         final_state_spec = "";
@@ -1258,6 +1268,8 @@ let%test "patch prompt static prefix is byte-identical across patches" =
     Gameplan.
       {
         project_name = "onton";
+        repo_owner = "flowglad";
+        repo_name = "onton";
         problem_statement = "Prompt cache hit rate is low.\n\n## Patch notes";
         solution_summary = "Move shared prompt content into a stable prefix.";
         final_state_spec = "module HEADLESS_CACHE_TUNING.\n\n## Patch state.";
@@ -1309,6 +1321,8 @@ let%test "agents_md content appears in static prefix when Some" =
     Gameplan.
       {
         project_name = "onton";
+        repo_owner = "flowglad";
+        repo_name = "onton";
         problem_statement = "Prompt cache hit rate is low.";
         solution_summary = "Keep shared content in a stable prefix.";
         final_state_spec = "";
@@ -1355,6 +1369,8 @@ let%test "agents_md section is omitted when None" =
     Gameplan.
       {
         project_name = "onton";
+        repo_owner = "flowglad";
+        repo_name = "onton";
         problem_statement = "Prompt cache hit rate is low.";
         solution_summary = "Keep shared content in a stable prefix.";
         final_state_spec = "";
@@ -1426,6 +1442,8 @@ let make_layer_test_fixture () =
     Gameplan.
       {
         project_name = "onton";
+        repo_owner = "flowglad";
+        repo_name = "onton";
         problem_statement = "Prompts mix gameplan, patch, and turn content.";
         solution_summary = "Compose three layers in a fixed order.";
         final_state_spec = "module THREE_LAYERS.";

--- a/lib_core/gameplan_parser.ml
+++ b/lib_core/gameplan_parser.ml
@@ -942,7 +942,8 @@ let%test_module "Gameplan_parser" =
           String.equal result.gameplan.repo_owner "flowglad"
           && String.equal result.gameplan.repo_name "onton"
 
-    let%test "parse_json_string: missing owner/repo defaults to empty (legacy)" =
+    let%test "parse_json_string: missing owner/repo defaults to empty (legacy)"
+        =
       let input =
         {|{
           "projectName": "p",
@@ -957,8 +958,9 @@ let%test_module "Gameplan_parser" =
           String.is_empty result.gameplan.repo_owner
           && String.is_empty result.gameplan.repo_name
 
-    let%test "parse_json_string: owner accepts any non-empty string \
-              (forge-specific validation lives in the forge backend)" =
+    let%test
+        "parse_json_string: owner accepts any non-empty string (forge-specific \
+         validation lives in the forge backend)" =
       let input =
         {|{
           "projectName": "p",

--- a/lib_core/gameplan_parser.ml
+++ b/lib_core/gameplan_parser.ml
@@ -186,6 +186,20 @@ let parse_json_string input =
       let open Yojson.Safe.Util in
       try
         let project_name = json |> member "projectName" |> to_string in
+        let optional_string key =
+          match json |> member key with
+          | `String s -> Base.String.strip s
+          | `Null -> ""
+          | _ -> raise (Type_error (key ^ " must be a string", json))
+        in
+        (* [repo_owner] and [repo_name] are forge-agnostic at this layer —
+           we only enforce non-empty when present (empty strings are normalised
+           to [""] so legacy gameplans without the keys keep loading; the
+           [--gameplan] CLI path enforces the non-empty constraint at session
+           start, and forge-specific format validation lives in the forge
+           backend, e.g. {!Onton.Github.validate_target}). *)
+        let repo_owner = optional_string "owner" in
+        let repo_name = optional_string "repo" in
         let problem_statement =
           match json |> member "problemStatement" with
           | `String s -> s
@@ -416,6 +430,8 @@ let parse_json_string input =
                         gameplan =
                           {
                             Types.Gameplan.project_name;
+                            repo_owner;
+                            repo_name;
                             problem_statement;
                             solution_summary;
                             final_state_spec;
@@ -908,6 +924,70 @@ let%test_module "Gameplan_parser" =
       | Error msg ->
           String.is_substring msg
             ~substring:"functionalChanges[].id must be a non-empty string"
+
+    let%test "parse_json_string: owner/repo round-trip when present" =
+      let input =
+        {|{
+          "projectName": "p",
+          "owner": "flowglad",
+          "repo": "onton",
+          "solutionSummary": "s",
+          "patches": [{"number": 1, "title": "A", "changes": []}],
+          "dependencyGraph": [{"patch": 1, "dependsOn": []}]
+        }|}
+      in
+      match parse_json_string input with
+      | Error _ -> false
+      | Ok result ->
+          String.equal result.gameplan.repo_owner "flowglad"
+          && String.equal result.gameplan.repo_name "onton"
+
+    let%test "parse_json_string: missing owner/repo defaults to empty (legacy)" =
+      let input =
+        {|{
+          "projectName": "p",
+          "solutionSummary": "s",
+          "patches": [{"number": 1, "title": "A", "changes": []}],
+          "dependencyGraph": [{"patch": 1, "dependsOn": []}]
+        }|}
+      in
+      match parse_json_string input with
+      | Error _ -> false
+      | Ok result ->
+          String.is_empty result.gameplan.repo_owner
+          && String.is_empty result.gameplan.repo_name
+
+    let%test "parse_json_string: owner accepts any non-empty string \
+              (forge-specific validation lives in the forge backend)" =
+      let input =
+        {|{
+          "projectName": "p",
+          "owner": "group/subgroup",
+          "repo": "thing.repo",
+          "solutionSummary": "s",
+          "patches": [{"number": 1, "title": "A", "changes": []}],
+          "dependencyGraph": [{"patch": 1, "dependsOn": []}]
+        }|}
+      in
+      match parse_json_string input with
+      | Error _ -> false
+      | Ok result ->
+          String.equal result.gameplan.repo_owner "group/subgroup"
+          && String.equal result.gameplan.repo_name "thing.repo"
+
+    let%test "parse_json_string: owner non-string returns Error" =
+      let input =
+        {|{
+          "projectName": "p",
+          "owner": 42,
+          "solutionSummary": "s",
+          "patches": [{"number": 1, "title": "A", "changes": []}],
+          "dependencyGraph": [{"patch": 1, "dependsOn": []}]
+        }|}
+      in
+      match parse_json_string input with
+      | Ok _ -> false
+      | Error msg -> String.is_substring msg ~substring:"owner"
 
     let%test "parse_json_string: non-string open question returns Error" =
       let input =

--- a/lib_core/github_target.ml
+++ b/lib_core/github_target.ml
@@ -20,12 +20,15 @@ let validate_owner s =
 let validate_repo s =
   let s = String.strip s in
   if String.is_empty s then Error "repo is empty"
+  else if String.is_suffix (String.lowercase s) ~suffix:".git" then
+    Error (Printf.sprintf "repo %S must not end with .git" s)
   else if Re.execp repo_re s then Ok ()
   else
     Error
       (Printf.sprintf
          "repo %S must match ^[A-Za-z0-9][A-Za-z0-9._-]{0,99}$ (GitHub repo: \
-          1–100 chars, alphanumeric or .-_, first char not punctuation)"
+          1–100 chars, alphanumeric or .-_, first char not punctuation, not \
+          ending in .git)"
          s)
 
 let validate_target ~owner ~repo =
@@ -60,6 +63,9 @@ let%test "validate_repo accepts onton" = Result.is_ok (validate_repo "onton")
 
 let%test "validate_repo accepts dots and dashes" =
   Result.is_ok (validate_repo "my.repo-name_v2")
+
+let%test "validate_repo rejects dot-git suffix" =
+  Result.is_error (validate_repo "my-repo.git")
 
 let%test "validate_repo rejects space" =
   Result.is_error (validate_repo "bad name")

--- a/lib_core/github_target.ml
+++ b/lib_core/github_target.ml
@@ -1,10 +1,7 @@
 open Base
 
-let owner_re =
-  Re.Pcre.re {|^[A-Za-z0-9][A-Za-z0-9-]{0,38}$|} |> Re.compile
-
-let repo_re =
-  Re.Pcre.re {|^[A-Za-z0-9][A-Za-z0-9._-]{0,99}$|} |> Re.compile
+let owner_re = Re.Pcre.re {|^[A-Za-z0-9][A-Za-z0-9-]{0,38}$|} |> Re.compile
+let repo_re = Re.Pcre.re {|^[A-Za-z0-9][A-Za-z0-9._-]{0,99}$|} |> Re.compile
 
 let remote_url_re =
   Re.Pcre.re {|github\.com[:/]([^/]+)/([^/\s]+?)(?:\.git)?/?$|} |> Re.compile
@@ -58,11 +55,8 @@ let%test "validate_owner rejects leading dash" =
 let%test "validate_owner rejects slash" =
   Result.is_error (validate_owner "foo/bar")
 
-let%test "validate_owner rejects empty" =
-  Result.is_error (validate_owner "")
-
-let%test "validate_repo accepts onton" =
-  Result.is_ok (validate_repo "onton")
+let%test "validate_owner rejects empty" = Result.is_error (validate_owner "")
+let%test "validate_repo accepts onton" = Result.is_ok (validate_repo "onton")
 
 let%test "validate_repo accepts dots and dashes" =
   Result.is_ok (validate_repo "my.repo-name_v2")

--- a/lib_core/github_target.ml
+++ b/lib_core/github_target.ml
@@ -1,0 +1,95 @@
+open Base
+
+let owner_re =
+  Re.Pcre.re {|^[A-Za-z0-9][A-Za-z0-9-]{0,38}$|} |> Re.compile
+
+let repo_re =
+  Re.Pcre.re {|^[A-Za-z0-9][A-Za-z0-9._-]{0,99}$|} |> Re.compile
+
+let remote_url_re =
+  Re.Pcre.re {|github\.com[:/]([^/]+)/([^/\s]+?)(?:\.git)?/?$|} |> Re.compile
+
+let validate_owner s =
+  let s = String.strip s in
+  if String.is_empty s then Error "owner is empty"
+  else if Re.execp owner_re s then Ok ()
+  else
+    Error
+      (Printf.sprintf
+         "owner %S must match ^[A-Za-z0-9][A-Za-z0-9-]{0,38}$ (GitHub handle: \
+          1–39 chars, alphanumeric or dash, first char not a dash)"
+         s)
+
+let validate_repo s =
+  let s = String.strip s in
+  if String.is_empty s then Error "repo is empty"
+  else if Re.execp repo_re s then Ok ()
+  else
+    Error
+      (Printf.sprintf
+         "repo %S must match ^[A-Za-z0-9][A-Za-z0-9._-]{0,99}$ (GitHub repo: \
+          1–100 chars, alphanumeric or .-_, first char not punctuation)"
+         s)
+
+let validate_target ~owner ~repo =
+  match validate_owner owner with
+  | Error _ as e -> e
+  | Ok () -> validate_repo repo
+
+let clone_url ~owner ~repo =
+  Printf.sprintf "https://github.com/%s/%s.git" owner repo
+
+let infer_owner_repo_from_url url =
+  let url = String.strip url in
+  match Re.exec_opt remote_url_re url with
+  | Some g -> Some (Re.Group.get g 1, Re.Group.get g 2)
+  | None -> None
+
+(* Basic spot-check tests stay inline; the cross-cutting properties
+   (totality, regex consistency, round-trip with [clone_url]) live in
+   [test/test_github_target_properties.ml]. *)
+
+let%test "validate_owner accepts flowglad" =
+  Result.is_ok (validate_owner "flowglad")
+
+let%test "validate_owner rejects leading dash" =
+  Result.is_error (validate_owner "-bad")
+
+let%test "validate_owner rejects slash" =
+  Result.is_error (validate_owner "foo/bar")
+
+let%test "validate_owner rejects empty" =
+  Result.is_error (validate_owner "")
+
+let%test "validate_repo accepts onton" =
+  Result.is_ok (validate_repo "onton")
+
+let%test "validate_repo accepts dots and dashes" =
+  Result.is_ok (validate_repo "my.repo-name_v2")
+
+let%test "validate_repo rejects space" =
+  Result.is_error (validate_repo "bad name")
+
+let%test "validate_target reports owner error first" =
+  match validate_target ~owner:"" ~repo:"" with
+  | Error msg -> String.is_substring msg ~substring:"owner"
+  | Ok () -> false
+
+let%test "clone_url is https github.com path" =
+  String.equal
+    (clone_url ~owner:"flowglad" ~repo:"onton")
+    "https://github.com/flowglad/onton.git"
+
+let%test "infer_owner_repo_from_url parses https with .git" =
+  match infer_owner_repo_from_url "https://github.com/flowglad/onton.git" with
+  | Some ("flowglad", "onton") -> true
+  | _ -> false
+
+let%test "infer_owner_repo_from_url parses ssh" =
+  match infer_owner_repo_from_url "git@github.com:flowglad/onton.git" with
+  | Some ("flowglad", "onton") -> true
+  | _ -> false
+
+let%test "infer_owner_repo_from_url returns None for non-github" =
+  Option.is_none
+    (infer_owner_repo_from_url "https://gitlab.com/flowglad/onton.git")

--- a/lib_core/github_target.mli
+++ b/lib_core/github_target.mli
@@ -1,20 +1,20 @@
 (** Pure GitHub forge target logic.
 
-    [owner] and [repo] are generic git-forge concepts; this module captures
-    the GitHub-specific rules for validating, formatting, and parsing them —
-    nothing else in [onton_core] needs to know GitHub. The functions are
-    total and side-effect-free, so they can be exhaustively property-tested
-    without spawning subprocesses or hitting the network. *)
+    [owner] and [repo] are generic git-forge concepts; this module captures the
+    GitHub-specific rules for validating, formatting, and parsing them — nothing
+    else in [onton_core] needs to know GitHub. The functions are total and
+    side-effect-free, so they can be exhaustively property-tested without
+    spawning subprocesses or hitting the network. *)
 
 val validate_owner : string -> (unit, string) Result.t
-(** Validate a string as a GitHub user/org handle: 1–39 characters,
-    alphanumeric or dash, first character not a dash. The string is stripped
-    before validation, so leading/trailing whitespace is forgiven. *)
+(** Validate a string as a GitHub user/org handle: 1–39 characters, alphanumeric
+    or dash, first character not a dash. The string is stripped before
+    validation, so leading/trailing whitespace is forgiven. *)
 
 val validate_repo : string -> (unit, string) Result.t
 (** Validate a string as a GitHub repository name: 1–100 characters,
-    alphanumeric or [.] [-] [_], first character not punctuation. The string
-    is stripped before validation. *)
+    alphanumeric or [.] [-] [_], first character not punctuation. The string is
+    stripped before validation. *)
 
 val validate_target : owner:string -> repo:string -> (unit, string) Result.t
 (** Combined owner + repo validation. Returns the first [Error] encountered
@@ -27,7 +27,7 @@ val clone_url : owner:string -> repo:string -> string
     [Onton.Git_env.set_github_token]. *)
 
 val infer_owner_repo_from_url : string -> (string * string) option
-(** Parse a GitHub remote URL (HTTPS or SSH) and extract [(owner, repo)].
-    Strips a trailing [.git] suffix and trailing slash. Returns [None] for
-    URLs that do not name a [github.com] host or whose path does not have
-    the [/owner/repo] shape. Total — never raises. *)
+(** Parse a GitHub remote URL (HTTPS or SSH) and extract [(owner, repo)]. Strips
+    a trailing [.git] suffix and trailing slash. Returns [None] for URLs that do
+    not name a [github.com] host or whose path does not have the [/owner/repo]
+    shape. Total — never raises. *)

--- a/lib_core/github_target.mli
+++ b/lib_core/github_target.mli
@@ -1,0 +1,33 @@
+(** Pure GitHub forge target logic.
+
+    [owner] and [repo] are generic git-forge concepts; this module captures
+    the GitHub-specific rules for validating, formatting, and parsing them —
+    nothing else in [onton_core] needs to know GitHub. The functions are
+    total and side-effect-free, so they can be exhaustively property-tested
+    without spawning subprocesses or hitting the network. *)
+
+val validate_owner : string -> (unit, string) Result.t
+(** Validate a string as a GitHub user/org handle: 1–39 characters,
+    alphanumeric or dash, first character not a dash. The string is stripped
+    before validation, so leading/trailing whitespace is forgiven. *)
+
+val validate_repo : string -> (unit, string) Result.t
+(** Validate a string as a GitHub repository name: 1–100 characters,
+    alphanumeric or [.] [-] [_], first character not punctuation. The string
+    is stripped before validation. *)
+
+val validate_target : owner:string -> repo:string -> (unit, string) Result.t
+(** Combined owner + repo validation. Returns the first [Error] encountered
+    (owner checked before repo) so a single error suffices to identify the
+    offending half. *)
+
+val clone_url : owner:string -> repo:string -> string
+(** HTTPS clone URL [https://github.com/<owner>/<repo>.git]. The URL itself
+    never carries credentials; authentication is supplied out-of-band via
+    [Onton.Git_env.set_github_token]. *)
+
+val infer_owner_repo_from_url : string -> (string * string) option
+(** Parse a GitHub remote URL (HTTPS or SSH) and extract [(owner, repo)].
+    Strips a trailing [.git] suffix and trailing slash. Returns [None] for
+    URLs that do not name a [github.com] host or whose path does not have
+    the [/owner/repo] shape. Total — never raises. *)

--- a/lib_core/github_target.mli
+++ b/lib_core/github_target.mli
@@ -14,7 +14,8 @@ val validate_owner : string -> (unit, string) Result.t
 val validate_repo : string -> (unit, string) Result.t
 (** Validate a string as a GitHub repository name: 1–100 characters,
     alphanumeric or [.] [-] [_], first character not punctuation. The string is
-    stripped before validation. *)
+    stripped before validation. Names ending in [.git] are rejected so
+    {!clone_url} cannot produce a double-[.git] suffix. *)
 
 val validate_target : owner:string -> repo:string -> (unit, string) Result.t
 (** Combined owner + repo validation. Returns the first [Error] encountered

--- a/lib_core/types.ml
+++ b/lib_core/types.ml
@@ -269,6 +269,8 @@ end
 module Gameplan = struct
   type t = {
     project_name : string;
+    repo_owner : string; [@yojson.default ""]
+    repo_name : string; [@yojson.default ""]
     problem_statement : string;
     solution_summary : string;
     final_state_spec : string; [@yojson.default ""]

--- a/lib_core/types.mli
+++ b/lib_core/types.mli
@@ -264,13 +264,13 @@ module Gameplan : sig
     project_name : string;
     repo_owner : string; [@yojson.default ""]
         (** Repository owner on the git forge (user, org, group). A gameplan
-            applies to exactly one repository; cross-repo work requires
-            multiple gameplans. Forge-specific validation (e.g. GitHub's
-            handle format) is performed by the forge backend module — this
-            field is only structurally required to be non-empty. Defaults to
-            [""] for legacy gameplans that predate the field; callers
-            consuming this for a fresh run must reject empties, while the
-            resume path backfills from stored config. *)
+            applies to exactly one repository; cross-repo work requires multiple
+            gameplans. Forge-specific validation (e.g. GitHub's handle format)
+            is performed by the forge backend module — this field is only
+            structurally required to be non-empty. Defaults to [""] for legacy
+            gameplans that predate the field; callers consuming this for a fresh
+            run must reject empties, while the resume path backfills from stored
+            config. *)
     repo_name : string; [@yojson.default ""]
         (** Repository name on the git forge (paired with [repo_owner]). See
             [repo_owner] for the empty-default rationale. *)

--- a/lib_core/types.mli
+++ b/lib_core/types.mli
@@ -262,6 +262,18 @@ end
 module Gameplan : sig
   type t = {
     project_name : string;
+    repo_owner : string; [@yojson.default ""]
+        (** Repository owner on the git forge (user, org, group). A gameplan
+            applies to exactly one repository; cross-repo work requires
+            multiple gameplans. Forge-specific validation (e.g. GitHub's
+            handle format) is performed by the forge backend module — this
+            field is only structurally required to be non-empty. Defaults to
+            [""] for legacy gameplans that predate the field; callers
+            consuming this for a fresh run must reject empties, while the
+            resume path backfills from stored config. *)
+    repo_name : string; [@yojson.default ""]
+        (** Repository name on the git forge (paired with [repo_owner]). See
+            [repo_owner] for the empty-default rationale. *)
     problem_statement : string;
     solution_summary : string;
     final_state_spec : string; [@yojson.default ""]

--- a/lib_test/test_generators.ml
+++ b/lib_test/test_generators.ml
@@ -248,6 +248,8 @@ let gen_gameplan =
         Gameplan.
           {
             project_name = "test-project";
+            repo_owner = "";
+            repo_name = "";
             problem_statement = "test problem";
             solution_summary = "test solution";
             final_state_spec = "";
@@ -708,6 +710,8 @@ let make_test_gameplan patches =
   Gameplan.
     {
       project_name = "test-project";
+      repo_owner = "";
+      repo_name = "";
       problem_statement = "";
       solution_summary = "";
       final_state_spec = "";

--- a/skills/write-gameplan/SKILL.md
+++ b/skills/write-gameplan/SKILL.md
@@ -9,6 +9,14 @@ Create a structured, machine-readable gameplan for a complex codebase change. Th
 
 **Core principle**: It should be 5-10x easier to review a gameplan than the code it produces.
 
+## One Repo Per Gameplan
+
+Every gameplan pertains to **exactly one repository on a git forge** (GitHub, GitLab, Gitea, etc.), declared by the required top-level `owner` and `repo` fields. The orchestrator (e.g. onton) clones that repo and runs every patch's agent inside isolated worktrees off of it — so paths in `patches[].files[].path` and `requiredChanges[].file` are resolved **relative to the repo root** and may not escape it (e.g. `../other-repo/x.ts` is disallowed; the worktree has no notion of "next to my checkout").
+
+`owner` and `repo` are forge-agnostic at this layer — the schema only checks that they are non-empty strings. The forge backend the orchestrator is configured for will enforce any format rules it requires (for example, GitHub rejects handles longer than 39 characters); that validation happens at session start, not at gameplan-authoring time.
+
+**If the change spans multiple repositories**, write **multiple gameplans** — one per repo — each with a distinct `projectName` (e.g. `auth-shared` and `auth-app`) and the appropriate `owner`/`repo`. If the gameplans coordinate (one must merge before another can be implemented), express that coupling at the workstream level: name each gameplan as a separate milestone in the workstream and use `priorMilestones` / `unlocks` to capture the ordering. Never bundle cross-repo work into a single gameplan and never use repo-relative `../sibling-repo/...` paths.
+
 ## Specification File (Optional)
 
 The user may provide a path to a **specification file** (typically a `.pant` file or any text file) containing behavioural invariants that apply to the overall gameplan. These are pre-written formal or informal constraints the implementation must satisfy.
@@ -48,6 +56,8 @@ All of these fields are **required** and must be present in every gameplan:
 | Field | Type | Description |
 |-------|------|-------------|
 | `projectName` | `string` | Kebab-case, used in branch names and PR titles |
+| `owner` | `string` | Repository owner on the git forge (user, org, group). Non-empty; forge-specific format rules are enforced by the orchestrator at session start. See [One Repo Per Gameplan](#one-repo-per-gameplan) |
+| `repo` | `string` | Repository name on the git forge (paired with `owner`). All file paths in this gameplan are interpreted relative to this repo's root |
 | `specFile` | `string \| null` | Path to the specification file the user provided, if any |
 | `workstream` | `object \| null` | `{ name, milestone, priorMilestones, unlocks }` — null if standalone |
 | `problemStatement` | `string` | 2-4 sentences: what problem, why it matters |

--- a/skills/write-gameplan/references/example.json
+++ b/skills/write-gameplan/references/example.json
@@ -1,6 +1,9 @@
 {
   "projectName": "extract-patch-decision",
 
+  "owner": "flowglad",
+  "repo": "onton",
+
   "specFile": "spec/onton.pant",
 
   "workstream": {

--- a/skills/write-gameplan/references/gameplan-schema.json
+++ b/skills/write-gameplan/references/gameplan-schema.json
@@ -5,6 +5,8 @@
   "type": "object",
   "required": [
     "projectName",
+    "owner",
+    "repo",
     "specFile",
     "workstream",
     "problemStatement",
@@ -29,6 +31,16 @@
       "type": "string",
       "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
       "description": "Short kebab-case identifier. Used in branch names (zax--<projectName>), PR titles ([<projectName>] Patch N: <title>), and file paths (gameplans/<projectName>.json)."
+    },
+    "owner": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Repository owner on the git forge (user, organization, group). The gameplan applies to exactly one repository — if a change spans repos, write multiple gameplans, one per repo, each with a distinct projectName. Forge-specific format rules (e.g. GitHub's 1–39-character handle pattern) are enforced by the forge backend at session start, not by this schema."
+    },
+    "repo": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Repository name on the git forge (paired with owner). All patches[].files[].path and requiredChanges[].file paths in this gameplan are interpreted relative to this repo's root; paths escaping the root (e.g. '../other-repo/x.ts') are disallowed."
     },
     "specFile": {
       "type": ["string", "null"],

--- a/test/dune
+++ b/test/dune
@@ -41,6 +41,13 @@
  (ocamlc_flags (:standard -w -40-42)))
 
 (test
+ (name test_github_target_properties)
+ (modules test_github_target_properties)
+ (libraries onton_core qcheck-core qcheck-core.runner)
+ (ocamlopt_flags (:standard -w -40-42))
+ (ocamlc_flags (:standard -w -40-42)))
+
+(test
  (name test_backend_parser_totality)
  (modules test_backend_parser_totality)
  (libraries onton_core qcheck-core qcheck-core.runner yojson)

--- a/test/test_github_target_properties.ml
+++ b/test/test_github_target_properties.ml
@@ -1,0 +1,314 @@
+open Base
+open Onton_core
+
+(** Property + interleaving tests for {!Github_target}.
+
+    The functions under test are total and pure: validators consume any
+    string and never raise; [clone_url] is a string formatter; and
+    [infer_owner_repo_from_url] is a parser. Properties pin down the rules
+    (regex consistency, totality, round-trip with [clone_url], idempotence
+    of [validate_target] on validated input) so future refactors don't
+    silently drift away from them. *)
+
+(* ---------- Generators ---------- *)
+
+(* Reasonable identifier alphabet: alphanumeric plus the punctuation classes
+   the GitHub rules touch (dash, dot, underscore) plus a few characters that
+   should always be rejected (space, slash, colon, ampersand). *)
+let gen_ident_char =
+  QCheck2.Gen.oneof_list
+    [
+      'a'; 'b'; 'c'; 'z'; 'A'; 'Z'; '0'; '5'; '9'; '-'; '.'; '_'; ' '; '/'; ':';
+      '&';
+    ]
+
+let gen_ident_string =
+  QCheck2.Gen.(string_size ~gen:gen_ident_char (int_range 0 60))
+
+(* Strings drawn from any printable byte range, including unicode-like
+   sequences and control chars (modulo printable). Used to prove validators
+   and the URL parser are total — they must never raise on adversarial
+   input. *)
+let gen_arbitrary_string =
+  QCheck2.Gen.(string_size ~gen:printable (int_range 0 200))
+
+(* A "valid GitHub handle" generator: 1–39 chars, first alphanumeric, body
+   alphanumeric-or-dash. Used to assert that validation accepts the entire
+   valid space, not just a few hard-coded examples. *)
+let gen_valid_owner =
+  let open QCheck2.Gen in
+  let first =
+    oneof_list
+      [
+        'a'; 'b'; 'c'; 'd'; 'e'; 'f'; 'g'; 'h'; 'i'; 'j'; 'k'; 'l'; 'm'; 'n';
+        'o'; 'p'; 'q'; 'r'; 's'; 't'; 'u'; 'v'; 'w'; 'x'; 'y'; 'z'; 'A'; 'B';
+        'C'; 'D'; 'E'; 'F'; 'G'; 'H'; '0'; '1'; '2'; '3'; '4'; '5'; '6'; '7';
+        '8'; '9';
+      ]
+  in
+  let rest_char =
+    oneof_list
+      [
+        'a'; 'b'; 'c'; 'd'; 'e'; 'z'; 'A'; 'M'; 'Z'; '0'; '1'; '5'; '9'; '-';
+      ]
+  in
+  let* len_minus_one = int_range 0 38 in
+  let* head = first in
+  let* tail = string_size ~gen:rest_char (return len_minus_one) in
+  return (String.of_char head ^ tail)
+
+let gen_valid_repo =
+  let open QCheck2.Gen in
+  let first =
+    oneof_list
+      [
+        'a'; 'b'; 'c'; 'd'; 'e'; 'f'; 'g'; 'h'; 'i'; 'j'; 'k'; 'l'; 'm'; 'n';
+        'o'; 'p'; 'q'; 'r'; 's'; 't'; 'u'; 'v'; 'w'; 'x'; 'y'; 'z'; 'A'; 'B';
+        'M'; '0'; '1'; '5'; '9';
+      ]
+  in
+  let rest_char =
+    oneof_list
+      [
+        'a'; 'b'; 'c'; 'm'; 'z'; 'Q'; 'Z'; '0'; '5'; '9'; '-'; '.'; '_';
+      ]
+  in
+  let* len_minus_one = int_range 0 99 in
+  let* head = first in
+  let* tail = string_size ~gen:rest_char (return len_minus_one) in
+  return (String.of_char head ^ tail)
+
+(* ---------- Totality properties ---------- *)
+
+let prop_validate_owner_total =
+  QCheck2.Test.make ~name:"validate_owner: total on arbitrary input"
+    gen_arbitrary_string
+    (fun s ->
+      match Github_target.validate_owner s with Ok _ | Error _ -> true)
+
+let prop_validate_repo_total =
+  QCheck2.Test.make ~name:"validate_repo: total on arbitrary input"
+    gen_arbitrary_string
+    (fun s ->
+      match Github_target.validate_repo s with Ok _ | Error _ -> true)
+
+let prop_validate_target_total =
+  QCheck2.Test.make ~name:"validate_target: total on arbitrary input pairs"
+    QCheck2.Gen.(pair gen_arbitrary_string gen_arbitrary_string)
+    (fun (owner, repo) ->
+      match Github_target.validate_target ~owner ~repo with
+      | Ok _ | Error _ -> true)
+
+let prop_infer_url_total =
+  QCheck2.Test.make ~name:"infer_owner_repo_from_url: total on arbitrary input"
+    gen_arbitrary_string
+    (fun s ->
+      match Github_target.infer_owner_repo_from_url s with
+      | Some _ | None -> true)
+
+let prop_clone_url_total =
+  QCheck2.Test.make ~name:"clone_url: total"
+    QCheck2.Gen.(pair gen_ident_string gen_ident_string)
+    (fun (owner, repo) ->
+      let _ = Github_target.clone_url ~owner ~repo in
+      true)
+
+(* ---------- Acceptance properties: every valid handle / repo is accepted ---------- *)
+
+let prop_valid_owner_accepted =
+  QCheck2.Test.make ~name:"validate_owner: accepts every valid handle shape"
+    gen_valid_owner
+    (fun s -> Result.is_ok (Github_target.validate_owner s))
+
+let prop_valid_repo_accepted =
+  QCheck2.Test.make ~name:"validate_repo: accepts every valid repo shape"
+    gen_valid_repo
+    (fun s -> Result.is_ok (Github_target.validate_repo s))
+
+(* ---------- Rejection properties: structural negatives ---------- *)
+
+let prop_empty_owner_rejected =
+  QCheck2.Test.make ~name:"validate_owner: rejects whitespace-only" QCheck2.Gen.unit
+    (fun () ->
+      Result.is_error (Github_target.validate_owner "")
+      && Result.is_error (Github_target.validate_owner "   ")
+      && Result.is_error (Github_target.validate_owner "\t\n "))
+
+let prop_empty_repo_rejected =
+  QCheck2.Test.make ~name:"validate_repo: rejects whitespace-only" QCheck2.Gen.unit
+    (fun () ->
+      Result.is_error (Github_target.validate_repo "")
+      && Result.is_error (Github_target.validate_repo "   "))
+
+let prop_owner_with_slash_rejected =
+  QCheck2.Test.make
+    ~name:"validate_owner: rejects any handle containing '/'"
+    QCheck2.Gen.(triple gen_valid_owner gen_valid_owner (int_range 1 5))
+    (fun (a, b, n) ->
+      let s = a ^ String.make n '/' ^ b in
+      Result.is_error (Github_target.validate_owner s))
+
+let prop_owner_with_space_rejected =
+  QCheck2.Test.make
+    ~name:"validate_owner: rejects any handle containing whitespace inside"
+    QCheck2.Gen.(pair gen_valid_owner gen_valid_owner)
+    (fun (a, b) ->
+      let s = a ^ " " ^ b in
+      Result.is_error (Github_target.validate_owner s))
+
+let prop_owner_too_long_rejected =
+  QCheck2.Test.make
+    ~name:"validate_owner: rejects strings longer than 39 chars"
+    QCheck2.Gen.(int_range 40 200)
+    (fun n ->
+      let s = String.make n 'a' in
+      Result.is_error (Github_target.validate_owner s))
+
+let prop_repo_too_long_rejected =
+  QCheck2.Test.make
+    ~name:"validate_repo: rejects strings longer than 100 chars"
+    QCheck2.Gen.(int_range 101 300)
+    (fun n ->
+      let s = String.make n 'a' in
+      Result.is_error (Github_target.validate_repo s))
+
+(* ---------- Composition properties ---------- *)
+
+let prop_validate_target_short_circuits_on_owner =
+  QCheck2.Test.make
+    ~name:
+      "validate_target: reports owner error when owner is invalid, regardless \
+       of repo"
+    QCheck2.Gen.(pair gen_arbitrary_string gen_arbitrary_string)
+    (fun (owner, repo) ->
+      match Github_target.validate_owner owner with
+      | Error owner_err -> (
+          match Github_target.validate_target ~owner ~repo with
+          | Error combined_err -> String.equal combined_err owner_err
+          | Ok () -> false (* owner valid => combined valid; contradiction *))
+      | Ok () -> true (* property is conditional on owner being invalid *))
+
+let prop_validate_target_passes_iff_both_pass =
+  QCheck2.Test.make
+    ~name:"validate_target: Ok iff both validate_owner and validate_repo Ok"
+    QCheck2.Gen.(pair gen_arbitrary_string gen_arbitrary_string)
+    (fun (owner, repo) ->
+      let both_ok =
+        Result.is_ok (Github_target.validate_owner owner)
+        && Result.is_ok (Github_target.validate_repo repo)
+      in
+      Bool.equal both_ok
+        (Result.is_ok (Github_target.validate_target ~owner ~repo)))
+
+(* ---------- URL round-trip ---------- *)
+
+let prop_clone_url_roundtrips =
+  QCheck2.Test.make
+    ~name:
+      "infer_owner_repo_from_url (clone_url ~owner ~repo) = Some (owner, repo) \
+       for valid pairs"
+    QCheck2.Gen.(pair gen_valid_owner gen_valid_repo)
+    (fun (owner, repo) ->
+      let url = Github_target.clone_url ~owner ~repo in
+      match Github_target.infer_owner_repo_from_url url with
+      | Some (o, r) -> String.equal o owner && String.equal r repo
+      | None -> false)
+
+let prop_clone_url_format =
+  QCheck2.Test.make ~name:"clone_url starts with https://github.com/"
+    QCheck2.Gen.(pair gen_ident_string gen_ident_string)
+    (fun (owner, repo) ->
+      String.is_prefix
+        (Github_target.clone_url ~owner ~repo)
+        ~prefix:"https://github.com/")
+
+let prop_clone_url_ends_dot_git =
+  QCheck2.Test.make ~name:"clone_url ends with .git"
+    QCheck2.Gen.(pair gen_ident_string gen_ident_string)
+    (fun (owner, repo) ->
+      String.is_suffix (Github_target.clone_url ~owner ~repo) ~suffix:".git")
+
+let prop_infer_non_github_rejected =
+  QCheck2.Test.make
+    ~name:"infer_owner_repo_from_url: returns None for non-github hosts"
+    QCheck2.Gen.(pair gen_valid_owner gen_valid_repo)
+    (fun (owner, repo) ->
+      let bad_hosts =
+        [
+          Printf.sprintf "https://gitlab.com/%s/%s.git" owner repo;
+          Printf.sprintf "https://bitbucket.org/%s/%s.git" owner repo;
+          Printf.sprintf "https://example.com/%s/%s" owner repo;
+        ]
+      in
+      List.for_all bad_hosts ~f:(fun u ->
+          Option.is_none (Github_target.infer_owner_repo_from_url u)))
+
+(* ---------- Interleaving: validate_target is idempotent on its own input ---------- *)
+
+let prop_validate_target_idempotent =
+  QCheck2.Test.make
+    ~name:"validate_target ∘ trim is fixed-point for already-valid pairs"
+    QCheck2.Gen.(pair gen_valid_owner gen_valid_repo)
+    (fun (owner, repo) ->
+      match Github_target.validate_target ~owner ~repo with
+      | Ok () -> (
+          let owner' = String.strip owner in
+          let repo' = String.strip repo in
+          match
+            Github_target.validate_target ~owner:owner' ~repo:repo'
+          with
+          | Ok () -> true
+          | Error _ -> false)
+      | Error _ -> false)
+
+(* Interleaving with surrounding whitespace: leading and trailing whitespace
+   must not change the verdict for any input string. The validators document
+   that they strip first; this property exercises the contract. *)
+let prop_validate_owner_strips =
+  QCheck2.Test.make
+    ~name:"validate_owner: surrounding whitespace doesn't change the verdict"
+    QCheck2.Gen.(pair gen_arbitrary_string (int_range 0 5))
+    (fun (s, n) ->
+      let pad = String.make n ' ' in
+      Bool.equal
+        (Result.is_ok (Github_target.validate_owner s))
+        (Result.is_ok (Github_target.validate_owner (pad ^ s ^ pad))))
+
+let prop_validate_repo_strips =
+  QCheck2.Test.make
+    ~name:"validate_repo: surrounding whitespace doesn't change the verdict"
+    QCheck2.Gen.(pair gen_arbitrary_string (int_range 0 5))
+    (fun (s, n) ->
+      let pad = String.make n ' ' in
+      Bool.equal
+        (Result.is_ok (Github_target.validate_repo s))
+        (Result.is_ok (Github_target.validate_repo (pad ^ s ^ pad))))
+
+let () =
+  let tests =
+    [
+      prop_validate_owner_total;
+      prop_validate_repo_total;
+      prop_validate_target_total;
+      prop_infer_url_total;
+      prop_clone_url_total;
+      prop_valid_owner_accepted;
+      prop_valid_repo_accepted;
+      prop_empty_owner_rejected;
+      prop_empty_repo_rejected;
+      prop_owner_with_slash_rejected;
+      prop_owner_with_space_rejected;
+      prop_owner_too_long_rejected;
+      prop_repo_too_long_rejected;
+      prop_validate_target_short_circuits_on_owner;
+      prop_validate_target_passes_iff_both_pass;
+      prop_clone_url_roundtrips;
+      prop_clone_url_format;
+      prop_clone_url_ends_dot_git;
+      prop_infer_non_github_rejected;
+      prop_validate_target_idempotent;
+      prop_validate_owner_strips;
+      prop_validate_repo_strips;
+    ]
+  in
+  Stdlib.exit (QCheck_base_runner.run_tests ~verbose:false tests)

--- a/test/test_github_target_properties.ml
+++ b/test/test_github_target_properties.ml
@@ -244,20 +244,20 @@ let prop_repo_too_long_rejected =
       let s = String.make n 'a' in
       Result.is_error (Github_target.validate_repo s))
 
+let prop_repo_dot_git_suffix_rejected =
+  QCheck2.Test.make ~name:"validate_repo: rejects repo names ending in .git"
+    gen_valid_repo (fun repo ->
+      Result.is_error (Github_target.validate_repo (repo ^ ".git")))
+
 (* ---------- Composition properties ---------- *)
 
 let prop_validate_target_short_circuits_on_owner =
   QCheck2.Test.make
-    ~name:
-      "validate_target: reports owner error when owner is invalid, regardless \
-       of repo"
+    ~name:"validate_target: rejects invalid owner, regardless of repo"
     QCheck2.Gen.(pair gen_arbitrary_string gen_arbitrary_string)
     (fun (owner, repo) ->
       match Github_target.validate_owner owner with
-      | Error owner_err -> (
-          match Github_target.validate_target ~owner ~repo with
-          | Error combined_err -> String.equal combined_err owner_err
-          | Ok () -> false (* owner valid => combined valid; contradiction *))
+      | Error _ -> Result.is_error (Github_target.validate_target ~owner ~repo)
       | Ok () -> true (* property is conditional on owner being invalid *))
 
 let prop_validate_target_passes_iff_both_pass =
@@ -370,6 +370,7 @@ let () =
       prop_owner_with_space_rejected;
       prop_owner_too_long_rejected;
       prop_repo_too_long_rejected;
+      prop_repo_dot_git_suffix_rejected;
       prop_validate_target_short_circuits_on_owner;
       prop_validate_target_passes_iff_both_pass;
       prop_clone_url_roundtrips;

--- a/test/test_github_target_properties.ml
+++ b/test/test_github_target_properties.ml
@@ -3,12 +3,12 @@ open Onton_core
 
 (** Property + interleaving tests for {!Github_target}.
 
-    The functions under test are total and pure: validators consume any
-    string and never raise; [clone_url] is a string formatter; and
+    The functions under test are total and pure: validators consume any string
+    and never raise; [clone_url] is a string formatter; and
     [infer_owner_repo_from_url] is a parser. Properties pin down the rules
-    (regex consistency, totality, round-trip with [clone_url], idempotence
-    of [validate_target] on validated input) so future refactors don't
-    silently drift away from them. *)
+    (regex consistency, totality, round-trip with [clone_url], idempotence of
+    [validate_target] on validated input) so future refactors don't silently
+    drift away from them. *)
 
 (* ---------- Generators ---------- *)
 
@@ -18,7 +18,21 @@ open Onton_core
 let gen_ident_char =
   QCheck2.Gen.oneof_list
     [
-      'a'; 'b'; 'c'; 'z'; 'A'; 'Z'; '0'; '5'; '9'; '-'; '.'; '_'; ' '; '/'; ':';
+      'a';
+      'b';
+      'c';
+      'z';
+      'A';
+      'Z';
+      '0';
+      '5';
+      '9';
+      '-';
+      '.';
+      '_';
+      ' ';
+      '/';
+      ':';
       '&';
     ]
 
@@ -40,17 +54,55 @@ let gen_valid_owner =
   let first =
     oneof_list
       [
-        'a'; 'b'; 'c'; 'd'; 'e'; 'f'; 'g'; 'h'; 'i'; 'j'; 'k'; 'l'; 'm'; 'n';
-        'o'; 'p'; 'q'; 'r'; 's'; 't'; 'u'; 'v'; 'w'; 'x'; 'y'; 'z'; 'A'; 'B';
-        'C'; 'D'; 'E'; 'F'; 'G'; 'H'; '0'; '1'; '2'; '3'; '4'; '5'; '6'; '7';
-        '8'; '9';
+        'a';
+        'b';
+        'c';
+        'd';
+        'e';
+        'f';
+        'g';
+        'h';
+        'i';
+        'j';
+        'k';
+        'l';
+        'm';
+        'n';
+        'o';
+        'p';
+        'q';
+        'r';
+        's';
+        't';
+        'u';
+        'v';
+        'w';
+        'x';
+        'y';
+        'z';
+        'A';
+        'B';
+        'C';
+        'D';
+        'E';
+        'F';
+        'G';
+        'H';
+        '0';
+        '1';
+        '2';
+        '3';
+        '4';
+        '5';
+        '6';
+        '7';
+        '8';
+        '9';
       ]
   in
   let rest_char =
     oneof_list
-      [
-        'a'; 'b'; 'c'; 'd'; 'e'; 'z'; 'A'; 'M'; 'Z'; '0'; '1'; '5'; '9'; '-';
-      ]
+      [ 'a'; 'b'; 'c'; 'd'; 'e'; 'z'; 'A'; 'M'; 'Z'; '0'; '1'; '5'; '9'; '-' ]
   in
   let* len_minus_one = int_range 0 38 in
   let* head = first in
@@ -62,16 +114,44 @@ let gen_valid_repo =
   let first =
     oneof_list
       [
-        'a'; 'b'; 'c'; 'd'; 'e'; 'f'; 'g'; 'h'; 'i'; 'j'; 'k'; 'l'; 'm'; 'n';
-        'o'; 'p'; 'q'; 'r'; 's'; 't'; 'u'; 'v'; 'w'; 'x'; 'y'; 'z'; 'A'; 'B';
-        'M'; '0'; '1'; '5'; '9';
+        'a';
+        'b';
+        'c';
+        'd';
+        'e';
+        'f';
+        'g';
+        'h';
+        'i';
+        'j';
+        'k';
+        'l';
+        'm';
+        'n';
+        'o';
+        'p';
+        'q';
+        'r';
+        's';
+        't';
+        'u';
+        'v';
+        'w';
+        'x';
+        'y';
+        'z';
+        'A';
+        'B';
+        'M';
+        '0';
+        '1';
+        '5';
+        '9';
       ]
   in
   let rest_char =
     oneof_list
-      [
-        'a'; 'b'; 'c'; 'm'; 'z'; 'Q'; 'Z'; '0'; '5'; '9'; '-'; '.'; '_';
-      ]
+      [ 'a'; 'b'; 'c'; 'm'; 'z'; 'Q'; 'Z'; '0'; '5'; '9'; '-'; '.'; '_' ]
   in
   let* len_minus_one = int_range 0 99 in
   let* head = first in
@@ -82,14 +162,12 @@ let gen_valid_repo =
 
 let prop_validate_owner_total =
   QCheck2.Test.make ~name:"validate_owner: total on arbitrary input"
-    gen_arbitrary_string
-    (fun s ->
+    gen_arbitrary_string (fun s ->
       match Github_target.validate_owner s with Ok _ | Error _ -> true)
 
 let prop_validate_repo_total =
   QCheck2.Test.make ~name:"validate_repo: total on arbitrary input"
-    gen_arbitrary_string
-    (fun s ->
+    gen_arbitrary_string (fun s ->
       match Github_target.validate_repo s with Ok _ | Error _ -> true)
 
 let prop_validate_target_total =
@@ -101,8 +179,7 @@ let prop_validate_target_total =
 
 let prop_infer_url_total =
   QCheck2.Test.make ~name:"infer_owner_repo_from_url: total on arbitrary input"
-    gen_arbitrary_string
-    (fun s ->
+    gen_arbitrary_string (fun s ->
       match Github_target.infer_owner_repo_from_url s with
       | Some _ | None -> true)
 
@@ -117,32 +194,29 @@ let prop_clone_url_total =
 
 let prop_valid_owner_accepted =
   QCheck2.Test.make ~name:"validate_owner: accepts every valid handle shape"
-    gen_valid_owner
-    (fun s -> Result.is_ok (Github_target.validate_owner s))
+    gen_valid_owner (fun s -> Result.is_ok (Github_target.validate_owner s))
 
 let prop_valid_repo_accepted =
   QCheck2.Test.make ~name:"validate_repo: accepts every valid repo shape"
-    gen_valid_repo
-    (fun s -> Result.is_ok (Github_target.validate_repo s))
+    gen_valid_repo (fun s -> Result.is_ok (Github_target.validate_repo s))
 
 (* ---------- Rejection properties: structural negatives ---------- *)
 
 let prop_empty_owner_rejected =
-  QCheck2.Test.make ~name:"validate_owner: rejects whitespace-only" QCheck2.Gen.unit
-    (fun () ->
+  QCheck2.Test.make ~name:"validate_owner: rejects whitespace-only"
+    QCheck2.Gen.unit (fun () ->
       Result.is_error (Github_target.validate_owner "")
       && Result.is_error (Github_target.validate_owner "   ")
       && Result.is_error (Github_target.validate_owner "\t\n "))
 
 let prop_empty_repo_rejected =
-  QCheck2.Test.make ~name:"validate_repo: rejects whitespace-only" QCheck2.Gen.unit
-    (fun () ->
+  QCheck2.Test.make ~name:"validate_repo: rejects whitespace-only"
+    QCheck2.Gen.unit (fun () ->
       Result.is_error (Github_target.validate_repo "")
       && Result.is_error (Github_target.validate_repo "   "))
 
 let prop_owner_with_slash_rejected =
-  QCheck2.Test.make
-    ~name:"validate_owner: rejects any handle containing '/'"
+  QCheck2.Test.make ~name:"validate_owner: rejects any handle containing '/'"
     QCheck2.Gen.(triple gen_valid_owner gen_valid_owner (int_range 1 5))
     (fun (a, b, n) ->
       let s = a ^ String.make n '/' ^ b in
@@ -157,16 +231,14 @@ let prop_owner_with_space_rejected =
       Result.is_error (Github_target.validate_owner s))
 
 let prop_owner_too_long_rejected =
-  QCheck2.Test.make
-    ~name:"validate_owner: rejects strings longer than 39 chars"
+  QCheck2.Test.make ~name:"validate_owner: rejects strings longer than 39 chars"
     QCheck2.Gen.(int_range 40 200)
     (fun n ->
       let s = String.make n 'a' in
       Result.is_error (Github_target.validate_owner s))
 
 let prop_repo_too_long_rejected =
-  QCheck2.Test.make
-    ~name:"validate_repo: rejects strings longer than 100 chars"
+  QCheck2.Test.make ~name:"validate_repo: rejects strings longer than 100 chars"
     QCheck2.Gen.(int_range 101 300)
     (fun n ->
       let s = String.make n 'a' in
@@ -254,9 +326,7 @@ let prop_validate_target_idempotent =
       | Ok () -> (
           let owner' = String.strip owner in
           let repo' = String.strip repo in
-          match
-            Github_target.validate_target ~owner:owner' ~repo:repo'
-          with
+          match Github_target.validate_target ~owner:owner' ~repo:repo' with
           | Ok () -> true
           | Error _ -> false)
       | Error _ -> false)

--- a/test/test_onton.ml
+++ b/test/test_onton.ml
@@ -26,6 +26,8 @@ let () =
     Onton_core.Types.Gameplan.
       {
         project_name = "test-project";
+        repo_owner = "";
+        repo_name = "";
         problem_statement = "";
         solution_summary = "";
         final_state_spec = "";

--- a/test/test_orchestrator_properties.ml
+++ b/test/test_orchestrator_properties.ml
@@ -28,6 +28,8 @@ let make_gameplan patches =
   Gameplan.
     {
       project_name = "test-project";
+      repo_owner = "";
+      repo_name = "";
       problem_statement = "";
       solution_summary = "";
       final_state_spec = "";

--- a/test/test_patch_controller.ml
+++ b/test/test_patch_controller.ml
@@ -28,6 +28,8 @@ let make_gameplan patch =
   Gameplan.
     {
       project_name = "test-project";
+      repo_owner = "";
+      repo_name = "";
       problem_statement = "";
       solution_summary = "";
       final_state_spec = "";

--- a/test/test_patch_controller_state_machine.ml
+++ b/test/test_patch_controller_state_machine.ml
@@ -28,6 +28,8 @@ let make_gameplan patch =
   Gameplan.
     {
       project_name = "test-project";
+      repo_owner = "";
+      repo_name = "";
       problem_statement = "";
       solution_summary = "";
       final_state_spec = "";

--- a/test/test_persistence_properties.ml
+++ b/test/test_persistence_properties.ml
@@ -14,6 +14,8 @@ let gameplan_for_agent (agent : Onton_core.Patch_agent.t) =
   Gameplan.
     {
       project_name = "t";
+      repo_owner = "";
+      repo_name = "";
       problem_statement = "t";
       solution_summary = "t";
       final_state_spec = "";
@@ -115,6 +117,8 @@ let () =
             Gameplan.
               {
                 project_name = "t";
+                repo_owner = "";
+                repo_name = "";
                 problem_statement = "t";
                 solution_summary = "t";
                 final_state_spec = "";
@@ -248,6 +252,8 @@ let () =
             Gameplan.
               {
                 project_name = "adhoc";
+                repo_owner = "";
+                repo_name = "";
                 problem_statement = "";
                 solution_summary = "";
                 final_state_spec = "";
@@ -299,6 +305,8 @@ let () =
             Gameplan.
               {
                 project_name = "adhoc-stack";
+                repo_owner = "";
+                repo_name = "";
                 problem_statement = "";
                 solution_summary = "";
                 final_state_spec = "";

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -6,6 +6,8 @@ let make_gameplan patches =
   Types.Gameplan.
     {
       project_name = "test-project";
+      repo_owner = "";
+      repo_name = "";
       problem_statement = "";
       solution_summary = "";
       final_state_spec = "";

--- a/test/test_runtime_create.ml
+++ b/test/test_runtime_create.ml
@@ -9,6 +9,8 @@ let () =
   let gameplan =
     {
       Gameplan.project_name = "test";
+      repo_owner = "";
+      repo_name = "";
       problem_statement = "";
       solution_summary = "";
       final_state_spec = "";
@@ -42,6 +44,8 @@ let () =
   let gameplan =
     {
       Gameplan.project_name = "test";
+      repo_owner = "";
+      repo_name = "";
       problem_statement = "";
       solution_summary = "";
       final_state_spec = "";

--- a/test/test_spawn_logic.ml
+++ b/test/test_spawn_logic.ml
@@ -16,6 +16,8 @@ let make_gameplan patches =
   Gameplan.
     {
       project_name = "test-project";
+      repo_owner = "";
+      repo_name = "";
       problem_statement = "";
       solution_summary = "";
       final_state_spec = "";


### PR DESCRIPTION
## Summary

- Every gameplan now declares the single repository it applies to via required top-level `owner` and `repo` fields. When `--gameplan` is passed, onton uses those as the source of truth — clones into `~/.local/share/onton/<project>/repo/` and runs all worktrees from there, ignoring any user-provided checkout.
- At the gameplan layer `owner` and `repo` are forge-agnostic: the JSON schema only requires `minLength: 1` and the parser only checks non-empty. GitHub-specific format rules (handle pattern, repo-name pattern), clone URL format, and remote URL parsing move to a new pure module `Onton_core.Github_target` and are covered by 22 QCheck properties.
- Legacy sessions whose stored gameplans predate the fields still parse (empty defaults); resume backfills `owner`/`repo` from `config.json`'s `github_owner`/`github_repo`.

## Motivation

A real session livelocked: patch 2 of `just-bash-lazy-s3-fs` launched the agent 41 times in a row and produced zero commits because the gameplan referenced `../just-bash/...` — a sibling-repo path that did not resolve inside the worktree. The orchestrator (correctly) saw no diff vs. base, refused to open a PR, and re-launched the agent indefinitely. Requiring an explicit `owner`/`repo` on the gameplan, and clamping per-patch paths to that repo, prevents the entire class.

## Module split (pure ⇄ effectful)

- **Pure (lib_core)**: `Github_target.{validate_owner, validate_repo, validate_target, clone_url, infer_owner_repo_from_url}` — total, side-effect-free, regex-based. Exhaustively property-tested (totality on arbitrary input, acceptance of every valid handle/repo shape, structural negatives, `validate_target` Ok ⇔ both halves Ok, `clone_url ∘ parse` round-trip, whitespace-strip idempotence).
- **Effectful (bin/main.ml)**: git subprocess invocation (`clone_managed_repo`, `fetch_managed_repo`, `ensure_managed_repo`) and the orchestrator entry point. These call `Github_target.*` for URL/identifier decisions.

`lib/github.ml` retains the GitHub HTTP/network surface; nothing GitHub-specific leaks beyond it or `lib_core/github_target.ml`.

## Test plan

- [x] `dune build` and `dune runtest` are green (22 new QCheck properties for `Github_target` + existing suite)
- [x] `ajv-cli` validates the updated `references/example.json` against the loosened schema
- [x] `onton --gameplan <missing-owner>` aborts with a forge-agnostic error pointing at the SKILL section
- [x] `onton --gameplan <malformed-owner>` aborts with a GitHub-specific error from the forge backend
- [x] Legacy stored gameplan (`just-bash-lazy-s3-fs/gameplan.json`) parses with empty defaults; resume backfills from stored config
- [ ] Manual end-to-end: drive a fresh gameplan-driven session against a small repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require explicit `owner` and `repo` in every gameplan and run all patches from an onton‑managed checkout to prevent cross‑repo path issues and the observed livelock. GitHub target rules are isolated in a pure module; clone/fetch are hardened with safe pipes and edge‑case handling, with best‑effort refresh on resume.

- **New Features**
  - Gameplans declare one repository via top-level `owner` and `repo`. With `--gameplan`, these are the source of truth; onton clones into `<data>/<project>/repo` and runs all worktrees there, ignoring any `--repo` checkout (prints a note).
  - Patch paths resolve relative to that repo; cross-repo paths (e.g. `../sibling/...`) are disallowed.
  - Added pure `Onton_core.Github_target` with `validate_owner`, `validate_repo`, `validate_target`, `clone_url`, and `infer_owner_repo_from_url`; covered by 23 QCheck properties (totality, valid-shape acceptance, structural negatives, round‑trip, whitespace-strip).
  - Effectful helpers for `git clone --filter=blob:none` and `git fetch` use a clean env; `clone` writes stderr to a temp file to avoid pipe deadlocks and closes all pipes on exceptions. Managed checkout edge cases are handled with clear errors (non-dir or non-empty paths) and warnings (offline fetch), and remote URL inference delegates to the pure parser. On resume, auto-fetch is best‑effort and only performed for the onton-managed path (missing owner/repo skips refresh with a warning).

- **Migration**
  - New gameplans must include non-empty `owner` and `repo`; enforced at session start by the forge backend with clear errors referencing the SKILL.
  - Legacy sessions still load (empty defaults). Resume precedence: gameplan > stored `config.json` (`github_owner`/`github_repo`) > remote inference. When `--gameplan` is provided, `--repo` is ignored; managed checkouts auto-fetch before continuing and must not pre-exist as a non-git or non-empty directory (remove and retry).

<sup>Written for commit 494035b0a9f2f457a40e0e8f7394e5e616812e0c. Summary will update on new commits. <a href="https://cubic.dev/pr/flowglad/onton/pull/277?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

