### PR TITLE
[lift-forge-into-functor] Patch 2: Add Github.make returning (module Forge.S); both APIs coexist

### DIFF
--- a/lib/github.ml
+++ b/lib/github.ml
@@ -884,7 +884,8 @@ let%expect_test "show_error transport error includes endpoint" =
   Stdlib.print_endline (show_error err);
   [%expect {| GitHub API POST /graphql → transport error: connection refused |}]
 
-let make ~net ~token ~owner ~repo : (module Forge.S with type error = error) =
+let make ~net ~clock ~token ~owner ~repo :
+    (module Forge.S with type error = error) =
   let client = create ~token ~owner ~repo in
   let module M = struct
     type nonrec error = error
@@ -897,27 +898,29 @@ let make ~net ~token ~owner ~repo : (module Forge.S with type error = error) =
       | Merge_queued of string
       | Merge_unconfirmed
 
-    let pr_state pr_number = pr_state ~net client pr_number
+    let pr_state pr_number = pr_state ~net ~clock client pr_number
 
     let list_prs ~branch ?base ~state () =
       match base with
-      | None -> list_prs ~net client ~branch ~state ()
-      | Some base -> list_prs ~net client ~branch ~base:(Some base) ~state ()
+      | None -> list_prs ~net ~clock client ~branch ~state ()
+      | Some base ->
+          list_prs ~net ~clock client ~branch ~base:(Some base) ~state ()
 
     let update_pr_body ~pr_number ~body =
-      update_pr_body ~net client ~pr_number ~body
+      update_pr_body ~net ~clock client ~pr_number ~body
 
     let create_pull_request ~title ~head ~base ~body ~draft =
-      create_pull_request ~net client ~title ~head ~base ~body ~draft
+      create_pull_request ~net ~clock client ~title ~head ~base ~body ~draft
 
     let update_pr_base ~pr_number ~base =
-      update_pr_base ~net client ~pr_number ~base
+      update_pr_base ~net ~clock client ~pr_number ~base
 
-    let set_draft ~pr_number ~draft = set_draft ~net client ~pr_number ~draft
+    let set_draft ~pr_number ~draft =
+      set_draft ~net ~clock client ~pr_number ~draft
 
     let merge_pr ~pr_number ~merge_method =
-      merge_pr ~net client ~pr_number ~merge_method
+      merge_pr ~net ~clock client ~pr_number ~merge_method
 
-    let check_repo_access () = check_repo_access ~net client
+    let check_repo_access () = check_repo_access ~net ~clock client
   end in
   (module M)

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -900,7 +900,9 @@ let make ~net ~token ~owner ~repo : (module Forge.S with type error = error) =
     let pr_state pr_number = pr_state ~net client pr_number
 
     let list_prs ~branch ?base ~state () =
-      list_prs ~net client ~branch ?base ~state ()
+      match base with
+      | None -> list_prs ~net client ~branch ~state ()
+      | Some base -> list_prs ~net client ~branch ~base:(Some base) ~state ()
 
     let update_pr_body ~pr_number ~body =
       update_pr_body ~net client ~pr_number ~body

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -884,5 +884,38 @@ let%expect_test "show_error transport error includes endpoint" =
   Stdlib.print_endline (show_error err);
   [%expect {| GitHub API POST /graphql → transport error: connection refused |}]
 
-(* Forge.S no longer exposes the raw client or network capability, so the
-   conformance check moves to patch 2 when [make] can package them up. *)
+let make ~net ~token ~owner ~repo : (module Forge.S with type error = error) =
+  let client = create ~token ~owner ~repo in
+  let module M = struct
+    type nonrec error = error
+
+    let show_error = show_error
+    let owner = owner
+
+    type nonrec merge_result = merge_result =
+      | Merge_succeeded
+      | Merge_queued of string
+      | Merge_unconfirmed
+
+    let pr_state pr_number = pr_state ~net client pr_number
+
+    let list_prs ~branch ?base ~state () =
+      list_prs ~net client ~branch ?base ~state ()
+
+    let update_pr_body ~pr_number ~body =
+      update_pr_body ~net client ~pr_number ~body
+
+    let create_pull_request ~title ~head ~base ~body ~draft =
+      create_pull_request ~net client ~title ~head ~base ~body ~draft
+
+    let update_pr_base ~pr_number ~base =
+      update_pr_base ~net client ~pr_number ~base
+
+    let set_draft ~pr_number ~draft = set_draft ~net client ~pr_number ~draft
+
+    let merge_pr ~pr_number ~merge_method =
+      merge_pr ~net client ~pr_number ~merge_method
+
+    let check_repo_access () = check_repo_access ~net client
+  end in
+  (module M)

--- a/lib/github.mli
+++ b/lib/github.mli
@@ -171,6 +171,6 @@ val make :
   owner:string ->
   repo:string ->
   (module Forge.S with type error = error)
-(** [make ~net ~clock ~token ~owner ~repo] packages a GitHub-backed forge
-    module that closes over the network and time capabilities plus client
+(** [make ~net ~clock ~token ~owner ~repo] packages a GitHub-backed forge module
+    that closes over the network and time capabilities plus client
     configuration. *)

--- a/lib/github.mli
+++ b/lib/github.mli
@@ -163,3 +163,12 @@ val merge_pr :
 
 val owner : t -> string
 (** [owner t] returns the repository owner. *)
+
+val make :
+  net:_ Eio.Net.t ->
+  token:string ->
+  owner:string ->
+  repo:string ->
+  (module Forge.S with type error = error)
+(** [make ~net ~token ~owner ~repo] packages a GitHub-backed forge module that
+    closes over the network capability and client configuration. *)

--- a/lib/github.mli
+++ b/lib/github.mli
@@ -166,9 +166,11 @@ val owner : t -> string
 
 val make :
   net:_ Eio.Net.t ->
+  clock:_ Eio.Time.clock ->
   token:string ->
   owner:string ->
   repo:string ->
   (module Forge.S with type error = error)
-(** [make ~net ~token ~owner ~repo] packages a GitHub-backed forge module that
-    closes over the network capability and client configuration. *)
+(** [make ~net ~clock ~token ~owner ~repo] packages a GitHub-backed forge
+    module that closes over the network and time capabilities plus client
+    configuration. *)


### PR DESCRIPTION
## Patch 2: Add Github.make returning (module Forge.S); both APIs coexist

- In lib/github.ml, after the existing direct-style functions and %expect_test blocks, add `let make ~net ~token ~owner ~repo : (module Forge.S with type error = error) = ...`. The body constructs a Github.t via `create ~token ~owner ~repo`, then packages a first-class module whose operations close over `net` and the client: e.g., `let pr_state n = pr_state ~net client n`.
- Re-export the merge_result variant inside the packaged module using the existing Github.merge_result constructors (Merge_succeeded | Merge_queued of string | Merge_unconfirmed). Forge.S's merge_pr returns the Forge.S merge_result, which is structurally identical — the packaged module's `let merge_pr ...` calls `Github.merge_pr ~net client ~pr_number ~merge_method` and pattern-matches the result into Forge.S's variant.
- Add `let owner = owner` inside the packaged module — Forge.S exposes `val owner : string` (captured from construction).
- Replace the static assertion at lib/github.ml:862 with one that confirms the structure built by `make` satisfies the full Forge.S signature: `let (_ : (module Forge.S with type error = error)) = make ~net:(failwith "static-only") ~token:"" ~owner:"" ~repo:""` — no, this evaluates. Instead use a module-level assertion: define a `module type _ = (module type of Forge)` style check, or simply have the make function's return type annotation (`: (module Forge.S with type error = error)`) carry the constraint and let the type-checker enforce it.
- In lib/github.mli, add the `val make : ...` declaration. Leave every other declaration (`type t`, `val create`, `val pr_state`, `val list_prs`, etc.) unchanged — both APIs coexist until Patch 5.
- Run `dune build` and confirm everything compiles, both via the direct API (still used by main.ml and startup_reconciler at this stage) and via the new make-returning-module path.

## Changes
- In lib/github.ml, after the existing direct-style functions and %expect_test blocks, add `let make ~net ~token ~owner ~repo : (module Forge.S with type error = error) = ...`. The body constructs a Github.t via `create ~token ~owner ~repo`, then packages a first-class module whose operations close over `net` and the client: e.g., `let pr_state n = pr_state ~net client n`.
- Re-export the merge_result variant inside the packaged module using the existing Github.merge_result constructors (Merge_succeeded | Merge_queued of string | Merge_unconfirmed). Forge.S's merge_pr returns the Forge.S merge_result, which is structurally identical — the packaged module's `let merge_pr ...` calls `Github.merge_pr ~net client ~pr_number ~merge_method` and pattern-matches the result into Forge.S's variant.
- Add `let owner = owner` inside the packaged module — Forge.S exposes `val owner : string` (captured from construction).
- Replace the static assertion at lib/github.ml:862 with one that confirms the structure built by `make` satisfies the full Forge.S signature: `let (_ : (module Forge.S with type error = error)) = make ~net:(failwith "static-only") ~token:"" ~owner:"" ~repo:""` — no, this evaluates. Instead use a module-level assertion: define a `module type _ = (module type of Forge)` style check, or simply have the make function's return type annotation (`: (module Forge.S with type error = error)`) carry the constraint and let the type-checker enforce it.
- In lib/github.mli, add the `val make : ...` declaration. Leave every other declaration (`type t`, `val create`, `val pr_state`, `val list_prs`, etc.) unchanged — both APIs coexist until Patch 5.
- Run `dune build` and confirm everything compiles, both via the direct API (still used by main.ml and startup_reconciler at this stage) and via the new make-returning-module path.

## Files to Modify
- lib/github.ml (modify): Add `let make ~net ~token ~owner ~repo : (module Forge.S with type error = error) = let client = create ~token ~owner ~repo in let module M = struct type nonrec error = error let show_error = show_error let owner = owner type merge_result = Merge_succeeded | Merge_queued of string | Merge_unconfirmed let pr_state n = pr_state ~net client n |> ... let list_prs ~branch ?base ~state () = ... (* etc *) end in (module M)`. The existing direct-style functions remain — they are what the inner module M delegates to. Replace the existing single-operation static assertion with one that confirms M satisfies the full Forge.S.
- lib/github.mli (modify): Add `val make : net:_ Eio.Net.t -> token:string -> owner:string -> repo:string -> (module Forge.S with type error = error)`. Keep every existing declaration unchanged for now — Patch 5 prunes them once consumers have migrated.

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[documentation] Real World OCaml — First-Class Modules** — https://dev.realworldocaml.org/first-class-modules.html — First-class modules are the OCaml idiom for capturing a runtime value of polymorphic type (here, `_ Eio.Net.t`) inside a module. Use the `(module M : S)` packing syntax and the `(val ...)` unpacking syntax exactly as the chapter prescribes — the type annotation `(module Forge.S with type error = error)` on `make`'s return is what lets callers `let module F = (val ...)` and recover the abstract error type.

## Gameplan Specification

```
module LIFT_FORGE_INTO_FUNCTOR.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> Forge.S declares the full GitHub-callable surface (pr_state,
> list_prs, update_pr_body, create_pull_request, update_pr_base,
> set_draft, merge_pr, check_repo_access) plus show_error and the
> merge_result variant — without ~net or a client argument in any
> signature. Github.make is the sole public constructor for a
> Forge.S module value, capturing the network capability and the
> Github client at construction inside Eio_main.run.
> Startup_reconciler is a functor Make (F : Forge.S). bin/main.ml
> instantiates one Forge module at the composition root and threads
> no ~github (and no Forge-related ~net) through the helpers and
> fibers below it. lib/github.mli exposes only the constructor, the
> startup preflight, and the pure parsing helpers — direct-style
> Github operations are unreachable from outside the module.

Forge.
Github.
Reconciler.
PrNumber.
Branch.
MergeMethod.
PrState.
MergeResult.
Error.
Result.
Patch.
Helper.
Exported.
DraftStatus.

show-error e: Error => String.
owner-of f: Forge => String.
pr-state f: Forge, n: PrNumber => PrState.
list-prs f: Forge, b: Branch => [PrNumber].
update-pr-body f: Forge, n: PrNumber, body: String => Result.
create-pull-request f: Forge, t: String, head: Branch, base: Branch, body: String, draft: DraftStatus => PrNumber.
update-pr-base f: Forge, n: PrNumber, base: Branch => Result.
set-draft f: Forge, n: PrNumber, draft: DraftStatus => Result.
merge-pr f: Forge, n: PrNumber, m: MergeMethod => MergeResult.
check-repo-access f: Forge => Result.

make-forge token: String, repo-owner: String, repo: String => Forge.
make-reconciler f: Forge => Reconciler.
discover-pr r: Reconciler, b: Branch => PrNumber.
reconcile r: Reconciler, ps: [Patch] => Result.

helper-takes-github? h: Helper => Bool.
is-exported? sym: String => Bool.

execute-github-effects => Helper.
reconcile-and-execute-automerge => Helper.
apply-pr-body-artifact => Helper.
input-fiber => Helper.
poller-fiber => Helper.

---

> ══════════════════════════════════════════
> Forge constructor invariants
> ══════════════════════════════════════════
> The forge constructed from a given owner reports that owner.
all token: String, repo-owner: String, repo: String | owner-of (make-forge token repo-owner repo) = repo-owner.

> ══════════════════════════════════════════
> Composition-root invariants
> ══════════════════════════════════════════
> None of the migrated bin/main.ml helpers take ~github as a parameter.
all h: Helper | helper-takes-github? h = false.

> ══════════════════════════════════════════
> Module-boundary invariants
> ══════════════════════════════════════════
> Github.mli exposes the constructor and the pure helpers.
is-exported? "make" = true.
is-exported? "check_repo_access" = true.
is-exported? "show_error" = true.
is-exported? "response_error_message_contains" = true.
is-exported? "parse_response_json" = true.
is-exported? "parse_response" = true.
is-exported? "parse_rest_pr_list" = true.

> Direct-style operations are not exported.
is-exported? "pr_state" = false.
is-exported? "list_prs" = false.
is-exported? "update_pr_body" = false.
is-exported? "create_pull_request" = false.
is-exported? "update_pr_base" = false.
is-exported? "set_draft" = false.
is-exported? "merge_pr" = false.
is-exported? "create" = false.
is-exported? "owner" = false.

```

## Patch Specification

```
module LIFT_FORGE_INTO_FUNCTOR_PATCH_2.

> Patch 2 adds Github.make as the construction point that captures the
> network capability and the Github client into a first-class module
> satisfying Forge.S. The existing direct-style API remains for the
> moment — both can be used in parallel until consumers migrate.

Forge.
PrNumber.
MergeMethod.
PrState.
MergeResult.
Error.

show-error e: Error => String.
owner-of f: Forge => String.
pr-state f: Forge, n: PrNumber => PrState.
merge-pr f: Forge, n: PrNumber, m: MergeMethod => MergeResult.

make-forge token: String, repo-owner: String, repo: String => Forge.

---

> The constructor produces a Forge whose owner-of is the configured owner.
all token: String, repo-owner: String, repo: String | owner-of (make-forge token repo-owner repo) = repo-owner.

```


## Implementation Notes

- `make` relies on its explicit return type annotation to enforce `Forge.S`; I removed the old static assertion rather than replacing it with an evaluating fake constructor call. That keeps the signature check compile-time only and avoids introducing dead code.
- The packaged module re-exports `merge_result` as a manifest alias (`type nonrec merge_result = merge_result = ...`) instead of manually translating constructors. I started with a conversion function, but warning 41 made the constructor namespace ambiguity noisy; the alias preserves the intended surface while letting `merge_pr` delegate directly.
- No consumer migration is included here. `bin/main.ml` and `startup_reconciler` still use the direct API in this patch, so the build is only proving coexistence plus the new constructor’s type-checking path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Github.make that returns a first-class (module Forge.S) capturing ~net, ~clock, and the GitHub client. The direct API stays to allow a gradual shift to the Forge interface.

- **New Features**
  - `Github.make ~net ~clock ~token ~owner ~repo : (module Forge.S with type error = error)`.
  - Captures network, clock, and client; exposes `owner`, `show_error`, `merge_result`, and ops: `pr_state`, `list_prs`, `update_pr_body`, `create_pull_request`, `update_pr_base`, `set_draft`, `merge_pr`, `check_repo_access`.
  - `github.mli` exports `val make`; no other public API changes.

- **Bug Fixes**
  - `list_prs` in the packaged module now forwards the optional `base` argument correctly.

<sup>Written for commit 07c90628d9da4752d198251c14b22ae2e53005bc. Summary will update on new commits. <a href="https://cubic.dev/pr/flowglad/onton/pull/282?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

