### PR TITLE
[lift-forge-into-functor] Patch 3: Convert Startup_reconciler to a functor over Forge.S; rewire its caller

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -19,6 +19,11 @@ type config = {
   user_config : User_config.t;
 }
 
+module type STARTUP_RECONCILER = sig
+  val discover_pr :
+    branch:Branch.t -> ((Pr_number.t * Branch.t * bool) option, string) Result.t
+end
+
 (** Run a subprocess, capture stdout, and guarantee the pipe is closed on any
     exception path. Returns the exit status and captured output, or [None] if
     opening the pipe itself raised. *)
@@ -1906,8 +1911,9 @@ let poll_outcome_of_github_result = function
   | Error (Github.Graphql_error msgs) -> Poll_outcome.Graphql_failed msgs
   | Error (Github.Json_parse_error msg) -> Poll_outcome.Json_parse_failed msg
 
-let poller_fiber ~runtime ~clock ~net ~process_mgr ~github ~config ~project_name
-    ~pr_registry ~branch_of ~event_log ~review_backends ~findings_registry =
+let poller_fiber (module StartupReconciler : STARTUP_RECONCILER) ~runtime ~clock
+    ~net ~process_mgr ~github ~config ~project_name ~pr_registry ~branch_of
+    ~event_log ~review_backends ~findings_registry =
   let main = config.main_branch in
   let skip_logged : (Patch_id.t, bool) Hashtbl.t = Hashtbl.create 16 in
   let skip_logged_mutex = Eio.Mutex.create () in
@@ -2006,9 +2012,7 @@ let poller_fiber ~runtime ~clock ~net ~process_mgr ~github ~config ~project_name
                         | Some agent -> agent.Patch_agent.branch
                         | None -> branch_of patch_id)
               in
-              (match
-                 Startup_reconciler.discover_pr ~net ~clock ~github ~branch
-               with
+              (match StartupReconciler.discover_pr ~branch with
               | Ok (Some (new_pr, base_branch, merged)) ->
                   log_event runtime ~patch_id
                     (Printf.sprintf "Switched to PR #%d"
@@ -4322,6 +4326,12 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
           Printf.eprintf "Error: cannot access GitHub repo %s/%s: %s\n"
             config.github_owner config.github_repo (Github.show_error err);
           Stdlib.exit 1);
+      let forge =
+        Github.make ~net ~clock ~token:config.github_token
+          ~owner:config.github_owner ~repo:config.github_repo
+      in
+      let module Forge = (val forge) in
+      let module Reconciler = Startup_reconciler.Make (Forge) in
       let pr_registry = Pr_registry.create () in
       (* Seed registry from any agents that already have a PR number — covers
          both gameplan patches restored from a snapshot and ad-hoc agents. The
@@ -4429,9 +4439,8 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
       in
       let reconciliation_fiber () =
         let startup =
-          Startup_reconciler.reconcile ~net ~clock ~github
-            ~patches:gameplan.Gameplan.patches ~repo_root:config.repo_root
-            ~process_mgr ~agents:pre_agents
+          Reconciler.reconcile ~patches:gameplan.Gameplan.patches
+            ~repo_root:config.repo_root ~process_mgr ~agents:pre_agents
             ~pre_recovered_worktrees:pre_worktrees ()
         in
         let errored_ids =
@@ -4502,8 +4511,10 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
         [
           reconciliation_fiber;
           (fun () ->
-            poller_fiber ~runtime ~clock ~net ~process_mgr ~github ~config
-              ~project_name ~pr_registry ~branch_of ~event_log ~review_backends
+            poller_fiber
+              (module Reconciler : STARTUP_RECONCILER)
+              ~runtime ~clock ~net ~process_mgr ~github ~config ~project_name
+              ~pr_registry ~branch_of ~event_log ~review_backends
               ~findings_registry);
           (fun () ->
             persistence_fiber ~runtime ~clock ~project_name ~transcripts);

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -4326,6 +4326,10 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
           Printf.eprintf "Error: cannot access GitHub repo %s/%s: %s\n"
             config.github_owner config.github_repo (Github.show_error err);
           Stdlib.exit 1);
+      (* Patch 3 still keeps the raw [github] client for direct GitHub calls
+         migrated in Patch 4. [Github.t] is currently immutable config, so this
+         temporary duplicate is benign; once those calls move behind Forge,
+         this composition root should construct only the Forge-backed client. *)
       let forge =
         Github.make ~net ~clock ~token:config.github_token
           ~owner:config.github_owner ~repo:config.github_repo

--- a/lib/startup_reconciler.ml
+++ b/lib/startup_reconciler.ml
@@ -24,15 +24,6 @@ type t = {
 }
 [@@deriving show, eq]
 
-(** Query GitHub REST API for a branch, returning discovery info for the first
-    non-CLOSED PR. *)
-let discover_pr ~net ~clock ~github ~branch =
-  match Github.list_prs ~net ~clock github ~branch ~state:`All () with
-  | Ok [] -> Ok None
-  | Ok ((pr_number, base_branch, merged) :: _) ->
-      Ok (Some (pr_number, base_branch, merged))
-  | Error err -> Error (Github.show_error err)
-
 (** Discover existing worktrees and match them to patches by branch name.
     Returns matched worktrees and an optional error string if listing failed. *)
 let recover_worktrees ~process_mgr ~repo_root ~patches =
@@ -66,38 +57,49 @@ let find_stale_busy ~agents =
   List.filter_map agents ~f:(fun (agent : Patch_agent.t) ->
       if agent.busy then Some agent.patch_id else None)
 
-let reconcile ~net ~clock ~github ~patches ?(repo_root = ".") ?process_mgr
-    ?(agents = []) ?pre_recovered_worktrees () =
-  let results =
-    Eio.Fiber.List.map ~max_fibers:8
-      (fun (patch : Patch.t) ->
-        let r = discover_pr ~net ~clock ~github ~branch:patch.branch in
-        (patch, r))
-      patches
-  in
-  let discovered, errors =
-    List.fold results ~init:([], [])
-      ~f:(fun (discovered, errors) (patch, result) ->
-        match result with
-        | Ok (Some (pr_number, base_branch, merged)) ->
-            ( { patch_id = patch.Patch.id; pr_number; base_branch; merged }
-              :: discovered,
-              errors )
-        | Ok None -> (discovered, errors)
-        | Error err -> (discovered, (patch.Patch.id, err) :: errors))
-  in
-  let recovered_worktrees, worktree_error =
-    match (pre_recovered_worktrees, process_mgr) with
-    | Some wts, _ -> (wts, None)
-    | None, Some pm -> recover_worktrees ~process_mgr:pm ~repo_root ~patches
-    | None, None ->
-        ([], Some "worktree recovery skipped: no process_mgr provided")
-  in
-  let reset_pending = find_stale_busy ~agents in
-  {
-    discovered = List.rev discovered;
-    recovered_worktrees;
-    reset_pending;
-    errors = List.rev errors;
-    worktree_errors = Option.to_list worktree_error;
-  }
+module Make (F : Forge.S) = struct
+  (** Query GitHub REST API for a branch, returning discovery info for the first
+      non-CLOSED PR. *)
+  let discover_pr ~branch =
+    match F.list_prs ~branch ~state:`All () with
+    | Ok [] -> Ok None
+    | Ok ((pr_number, base_branch, merged) :: _) ->
+        Ok (Some (pr_number, base_branch, merged))
+    | Error err -> Error (F.show_error err)
+
+  let reconcile ~patches ?(repo_root = ".") ?process_mgr ?(agents = [])
+      ?pre_recovered_worktrees () =
+    let results =
+      Eio.Fiber.List.map ~max_fibers:8
+        (fun (patch : Patch.t) ->
+          let r = discover_pr ~branch:patch.branch in
+          (patch, r))
+        patches
+    in
+    let discovered, errors =
+      List.fold results ~init:([], [])
+        ~f:(fun (discovered, errors) (patch, result) ->
+          match result with
+          | Ok (Some (pr_number, base_branch, merged)) ->
+              ( { patch_id = patch.Patch.id; pr_number; base_branch; merged }
+                :: discovered,
+                errors )
+          | Ok None -> (discovered, errors)
+          | Error err -> (discovered, (patch.Patch.id, err) :: errors))
+    in
+    let recovered_worktrees, worktree_error =
+      match (pre_recovered_worktrees, process_mgr) with
+      | Some wts, _ -> (wts, None)
+      | None, Some pm -> recover_worktrees ~process_mgr:pm ~repo_root ~patches
+      | None, None ->
+          ([], Some "worktree recovery skipped: no process_mgr provided")
+    in
+    let reset_pending = find_stale_busy ~agents in
+    {
+      discovered = List.rev discovered;
+      recovered_worktrees;
+      reset_pending;
+      errors = List.rev errors;
+      worktree_errors = Option.to_list worktree_error;
+    }
+end

--- a/lib/startup_reconciler.mli
+++ b/lib/startup_reconciler.mli
@@ -46,15 +46,6 @@ type t = {
     contains per-patch PR discovery failures. [worktree_errors] contains global
     worktree listing failures (not per-patch). *)
 
-val discover_pr :
-  net:_ Eio.Net.t ->
-  clock:_ Eio.Time.clock ->
-  github:Github.t ->
-  branch:Branch.t ->
-  ((Pr_number.t * Branch.t * bool) option, string) Result.t
-(** Query the GitHub REST API for a branch, returning the first non-CLOSED PR as
-    [(pr_number, base_branch, merged)] or [None]. *)
-
 val recover_worktrees :
   process_mgr:_ Eio.Process.mgr ->
   repo_root:string ->
@@ -64,21 +55,25 @@ val recover_worktrees :
     Returns matched worktrees and an optional error string if listing failed.
     Can be called before [reconcile] to capture worktree state early. *)
 
-val reconcile :
-  net:_ Eio.Net.t ->
-  clock:_ Eio.Time.clock ->
-  github:Github.t ->
-  patches:Patch.t list ->
-  ?repo_root:string ->
-  ?process_mgr:_ Eio.Process.mgr ->
-  ?agents:Patch_agent.t list ->
-  ?pre_recovered_worktrees:worktree_recovery list ->
-  unit ->
-  t
-(** [reconcile ~net ~github ~patches ?repo_root ?process_mgr ?agents
-     ?pre_recovered_worktrees ()] queries GitHub REST API for each patch's
-    branch to find existing PRs and identifies stale busy agents from [agents]
-    (default [[]]). When [pre_recovered_worktrees] is provided, uses it directly
-    instead of scanning the filesystem (avoids racing with concurrent worktree
-    creation). Otherwise discovers worktrees under [repo_root] (default ["."])
-    using [process_mgr]. *)
+module Make (_ : Forge.S) : sig
+  val discover_pr :
+    branch:Branch.t -> ((Pr_number.t * Branch.t * bool) option, string) Result.t
+  (** Query the GitHub REST API for a branch, returning the first non-CLOSED PR
+      as [(pr_number, base_branch, merged)] or [None]. *)
+
+  val reconcile :
+    patches:Patch.t list ->
+    ?repo_root:string ->
+    ?process_mgr:_ Eio.Process.mgr ->
+    ?agents:Patch_agent.t list ->
+    ?pre_recovered_worktrees:worktree_recovery list ->
+    unit ->
+    t
+  (** [reconcile ~patches ?repo_root ?process_mgr ?agents
+       ?pre_recovered_worktrees ()] queries GitHub REST API for each patch's
+      branch to find existing PRs and identifies stale busy agents from [agents]
+      (default [[]]). When [pre_recovered_worktrees] is provided, uses it
+      directly instead of scanning the filesystem (avoids racing with concurrent
+      worktree creation). Otherwise discovers worktrees under [repo_root]
+      (default ["."]) using [process_mgr]. *)
+end


### PR DESCRIPTION
## Patch 3: Convert Startup_reconciler to a functor over Forge.S; rewire its caller

- Open lib/startup_reconciler.ml. Identify the body that wraps discover_pr and reconcile (the two functions that call Github.list_prs). Wrap them in `module Make (F : Forge.S) = struct ... end`.
- Inside the functor body, replace `Github.list_prs ~net github ~branch ~state:`All ()` with `F.list_prs ~branch ~state:`All ()`. Replace `Github.show_error err` with `F.show_error err` (the error type is abstract but show_error is part of Forge.S).
- Move the type definitions (pr_discovery, worktree_recovery, t) outside the functor — they don't depend on F.
- Leave recover_worktrees as a free function in the outer module — it never used Github.
- Update lib/startup_reconciler.mli to expose `module Make (F : Forge.S) : sig val discover_pr : branch:Branch.t -> ((Pr_number.t * Branch.t * bool) option, string) Result.t val reconcile : patches:Patch.t list -> ?repo_root:string -> ?process_mgr:_ Eio.Process.mgr -> ?agents:Patch_agent.t list -> ?pre_recovered_worktrees:worktree_recovery list -> unit -> t end`. Remove the previous free-function `discover_pr` and `reconcile` declarations.
- In bin/main.ml at the composition root inside Eio_main.run (where `let github = ...` is bound at line 4273), construct `let forge = Github.make ~net ~token ~owner ~repo in let module Forge = (val forge) in let module Reconciler = Startup_reconciler.Make(Forge) in`. The let-module statements MUST come after Github.check_repo_access — keep that preflight unchanged.
- Update the call at line 4391: `Startup_reconciler.reconcile ~net ~github ~patches ...` becomes `Reconciler.reconcile ~patches ...`. Drop ~net and ~github from this call.
- Update the call inside poller_fiber at line 1978: `Startup_reconciler.discover_pr ~net ~github ~branch` becomes `Reconciler.discover_pr ~branch`. If poller_fiber's scope doesn't see Reconciler, pass Reconciler in as a parameter to poller_fiber — but this will be cleaned up in Patch 4 anyway when poller_fiber's whole signature is overhauled.
- Run `dune build`. The remaining direct calls in bin/main.ml to Github.* (execute_github_effects, etc.) still use the direct API — that's expected and is fixed in Patch 4.

## Changes
- Open lib/startup_reconciler.ml. Identify the body that wraps discover_pr and reconcile (the two functions that call Github.list_prs). Wrap them in `module Make (F : Forge.S) = struct ... end`.
- Inside the functor body, replace `Github.list_prs ~net github ~branch ~state:`All ()` with `F.list_prs ~branch ~state:`All ()`. Replace `Github.show_error err` with `F.show_error err` (the error type is abstract but show_error is part of Forge.S).
- Move the type definitions (pr_discovery, worktree_recovery, t) outside the functor — they don't depend on F.
- Leave recover_worktrees as a free function in the outer module — it never used Github.
- Update lib/startup_reconciler.mli to expose `module Make (F : Forge.S) : sig val discover_pr : branch:Branch.t -> ((Pr_number.t * Branch.t * bool) option, string) Result.t val reconcile : patches:Patch.t list -> ?repo_root:string -> ?process_mgr:_ Eio.Process.mgr -> ?agents:Patch_agent.t list -> ?pre_recovered_worktrees:worktree_recovery list -> unit -> t end`. Remove the previous free-function `discover_pr` and `reconcile` declarations.
- In bin/main.ml at the composition root inside Eio_main.run (where `let github = ...` is bound at line 4273), construct `let forge = Github.make ~net ~token ~owner ~repo in let module Forge = (val forge) in let module Reconciler = Startup_reconciler.Make(Forge) in`. The let-module statements MUST come after Github.check_repo_access — keep that preflight unchanged.
- Update the call at line 4391: `Startup_reconciler.reconcile ~net ~github ~patches ...` becomes `Reconciler.reconcile ~patches ...`. Drop ~net and ~github from this call.
- Update the call inside poller_fiber at line 1978: `Startup_reconciler.discover_pr ~net ~github ~branch` becomes `Reconciler.discover_pr ~branch`. If poller_fiber's scope doesn't see Reconciler, pass Reconciler in as a parameter to poller_fiber — but this will be cleaned up in Patch 4 anyway when poller_fiber's whole signature is overhauled.
- Run `dune build`. The remaining direct calls in bin/main.ml to Github.* (execute_github_effects, etc.) still use the direct API — that's expected and is fixed in Patch 4.

## Files to Modify
- lib/startup_reconciler.ml (modify): Wrap the body in `module Make (F : Forge.S) = struct ... end`. Inside, rewrite discover_pr to take only ~branch (no ~net, no ~github) and call F.list_prs / F.show_error. Rewrite reconcile likewise. Keep recover_worktrees as a free function outside the functor (it never touched GitHub).
- lib/startup_reconciler.mli (modify): Replace `val discover_pr : net:_ Eio.Net.t -> github:Github.t -> ...` and `val reconcile : net:_ Eio.Net.t -> github:Github.t -> ...` with `module Make (F : Forge.S) : sig val discover_pr : ... val reconcile : ... end`. Keep recover_worktrees, the types (pr_discovery, worktree_recovery, t), and recover_worktrees's free-function signature unchanged.
- bin/main.ml (modify): At the composition root inside Eio_main.run (around line 4273), after `let github = Github.create ...` and the check_repo_access preflight, add `let forge = Github.make ~net ~token:config.github_token ~owner:config.github_owner ~repo:config.github_repo in let module Forge = (val forge) in let module Reconciler = Startup_reconciler.Make(Forge) in`. Update the existing `Startup_reconciler.reconcile ~net ~github ~patches ...` call (around line 4391) to `Reconciler.reconcile ~patches ...`. Update the inline `Startup_reconciler.discover_pr ~net ~github ~branch` call at line 1978 to `Reconciler.discover_pr ~branch` (this requires the Reconciler module to be in scope at that call site — verify the let-module is hoisted high enough; otherwise plumb Reconciler in as a parameter to poller_fiber).

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[documentation] Real World OCaml — Functors** — https://dev.realworldocaml.org/functors.html — The chapter's `module Make (M : S) : T = struct ... end` pattern is exactly the shape Startup_reconciler.Make needs. Use it to confirm idioms for the functor's return signature (whether to declare it explicitly or let the body's type infer it) and how to expose only the functor in the .mli while keeping helper types outside it.

## Gameplan Specification

```
module LIFT_FORGE_INTO_FUNCTOR.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> Forge.S declares the full GitHub-callable surface (pr_state,
> list_prs, update_pr_body, create_pull_request, update_pr_base,
> set_draft, merge_pr, check_repo_access) plus show_error and the
> merge_result variant — without ~net or a client argument in any
> signature. Github.make is the sole public constructor for a
> Forge.S module value, capturing the network capability and the
> Github client at construction inside Eio_main.run.
> Startup_reconciler is a functor Make (F : Forge.S). bin/main.ml
> instantiates one Forge module at the composition root and threads
> no ~github (and no Forge-related ~net) through the helpers and
> fibers below it. lib/github.mli exposes only the constructor, the
> startup preflight, and the pure parsing helpers — direct-style
> Github operations are unreachable from outside the module.

Forge.
Github.
Reconciler.
PrNumber.
Branch.
MergeMethod.
PrState.
MergeResult.
Error.
Result.
Patch.
Helper.
Exported.
DraftStatus.

show-error e: Error => String.
owner-of f: Forge => String.
pr-state f: Forge, n: PrNumber => PrState.
list-prs f: Forge, b: Branch => [PrNumber].
update-pr-body f: Forge, n: PrNumber, body: String => Result.
create-pull-request f: Forge, t: String, head: Branch, base: Branch, body: String, draft: DraftStatus => PrNumber.
update-pr-base f: Forge, n: PrNumber, base: Branch => Result.
set-draft f: Forge, n: PrNumber, draft: DraftStatus => Result.
merge-pr f: Forge, n: PrNumber, m: MergeMethod => MergeResult.
check-repo-access f: Forge => Result.

make-forge token: String, repo-owner: String, repo: String => Forge.
make-reconciler f: Forge => Reconciler.
discover-pr r: Reconciler, b: Branch => PrNumber.
reconcile r: Reconciler, ps: [Patch] => Result.

helper-takes-github? h: Helper => Bool.
is-exported? sym: String => Bool.

execute-github-effects => Helper.
reconcile-and-execute-automerge => Helper.
apply-pr-body-artifact => Helper.
input-fiber => Helper.
poller-fiber => Helper.

---

> ══════════════════════════════════════════
> Forge constructor invariants
> ══════════════════════════════════════════
> The forge constructed from a given owner reports that owner.
all token: String, repo-owner: String, repo: String | owner-of (make-forge token repo-owner repo) = repo-owner.

> ══════════════════════════════════════════
> Composition-root invariants
> ══════════════════════════════════════════
> None of the migrated bin/main.ml helpers take ~github as a parameter.
all h: Helper | helper-takes-github? h = false.

> ══════════════════════════════════════════
> Module-boundary invariants
> ══════════════════════════════════════════
> Github.mli exposes the constructor and the pure helpers.
is-exported? "make" = true.
is-exported? "check_repo_access" = true.
is-exported? "show_error" = true.
is-exported? "response_error_message_contains" = true.
is-exported? "parse_response_json" = true.
is-exported? "parse_response" = true.
is-exported? "parse_rest_pr_list" = true.

> Direct-style operations are not exported.
is-exported? "pr_state" = false.
is-exported? "list_prs" = false.
is-exported? "update_pr_body" = false.
is-exported? "create_pull_request" = false.
is-exported? "update_pr_base" = false.
is-exported? "set_draft" = false.
is-exported? "merge_pr" = false.
is-exported? "create" = false.
is-exported? "owner" = false.

```

## Patch Specification

```
module LIFT_FORGE_INTO_FUNCTOR_PATCH_3.

> Patch 3 functorises Startup_reconciler over Forge.S. The reconcile
> and discover_pr operations no longer take a network capability or a
> github client argument — the functor closes over the forge module
> instantiated at the composition root.

Forge.
Reconciler.
Patch.
Branch.
PrNumber.
Result.

make-reconciler f: Forge => Reconciler.
discover-pr r: Reconciler, b: Branch => PrNumber.
reconcile r: Reconciler, ps: [Patch] => Result.

---

> Reconciler operations close over the Forge — no per-call capability arg.
> The composition root in bin/main.ml constructs exactly one Reconciler
> from the one Forge that wraps the one Github client.
true.

```


## Implementation Notes

- `poller_fiber` already used the existing `Reconciler` decision module internally, so the startup reconciler functor is passed in as a first-class module and unpacked as `StartupReconciler` inside the fiber to avoid shadowing those references.
- The `.mli` uses `module Make (_ : Forge.S)` because the functor parameter is intentionally absent from the result signature; this avoids fatal warning 67 while keeping the implementation functor parameter named and used.
- I also ran `dune runtest` in addition to the required `dune build`; both passed, and `dune fmt` only promoted a line-wrap change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Converted `Startup_reconciler` into the functor `Startup_reconciler.Make (F : Forge.S)` and updated `bin/main.ml` to build a single `Forge`/`Reconciler` at the composition root. Calls now close over the forge and drop `~net`, `~clock`, and `~github`.

- **Refactors**
  - Moved `discover_pr` and `reconcile` into `module Make (F : Forge.S)`; replaced `Github.list_prs`/`Github.show_error` with `F.list_prs`/`F.show_error`.
  - Kept `pr_discovery`, `worktree_recovery`, `t`, and `recover_worktrees` outside; `.mli` now exposes only the functor.
  - In `bin/main.ml`, created `forge` via `Github.make ~net ~clock ~token ~owner ~repo`, then `module Forge = (val forge)` and `module Reconciler = Startup_reconciler.Make(Forge)`. Kept the raw `github` client temporarily; added a code comment explaining this duplication until Patch 4 migrates remaining calls.
  - Added `STARTUP_RECONCILER` and updated `poller_fiber` to take a first-class module; use `StartupReconciler.discover_pr ~branch`. Switched reconciliation to `Reconciler.reconcile`.

- **Migration**
  - Replace `Startup_reconciler.discover_pr ~net ~clock ~github ~branch` with `Reconciler.discover_pr ~branch`.
  - Replace `Startup_reconciler.reconcile ~net ~clock ~github ~patches ...` with `Reconciler.reconcile ~patches ...`.
  - Instantiate `Forge`/`Reconciler` after `Github.check_repo_access`; pass `(module Reconciler : STARTUP_RECONCILER)` into `poller_fiber`. Other direct `Github.*` calls remain for now.

<sup>Written for commit 55437f40c4d2e412e3eb78dc2bec6664465eb474. Summary will update on new commits. <a href="https://cubic.dev/pr/flowglad/onton/pull/283?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal restructuring of PR discovery and reconciliation logic. No user-visible behavior changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flowglad/onton/pull/283?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->