### PR TITLE
Bound GitHub poll cycle with per-call timeout and per-patch fan-out

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -443,7 +443,7 @@ end
 
 (** Execute declarative GitHub effects and record successful observations back
     into durable state. *)
-let execute_github_effects ~runtime ~net ~github effects =
+let execute_github_effects ~runtime ~net ~clock ~github effects =
   Base.List.iter effects ~f:(fun github_effect ->
       let label =
         match github_effect with
@@ -460,9 +460,9 @@ let execute_github_effects ~runtime ~net ~github effects =
         let result =
           match github_effect with
           | Patch_controller.Set_pr_draft { patch_id = _; pr_number; draft } ->
-              Github.set_draft ~net github ~pr_number ~draft
+              Github.set_draft ~net ~clock github ~pr_number ~draft
           | Patch_controller.Set_pr_base { patch_id = _; pr_number; base } ->
-              Github.update_pr_base ~net github ~pr_number ~base
+              Github.update_pr_base ~net ~clock github ~pr_number ~base
         in
         match result with
         | Ok () ->
@@ -579,7 +579,7 @@ let log_event runtime ?patch_id msg =
     runner tick fires. Retries continue until the consecutive failure cap is
     reached, at which point reconciliation stops issuing merge calls until the
     user toggles automerge off/on. *)
-let reconcile_and_execute_automerge ~runtime ~net ~github =
+let reconcile_and_execute_automerge ~runtime ~net ~clock ~github =
   let now = Unix.gettimeofday () in
   let decisions =
     Runtime.update_orchestrator_returning runtime (fun orch ->
@@ -689,7 +689,8 @@ let reconcile_and_execute_automerge ~runtime ~net ~github =
           else
             try
               match
-                Github.merge_pr ~net github ~pr_number ~merge_method:`Squash
+                Github.merge_pr ~net ~clock github ~pr_number
+                  ~merge_method:`Squash
               with
               | Ok Github.Merge_succeeded ->
                   inflight_cleared := true;
@@ -759,7 +760,7 @@ let read_artifact_file = read_optional_file
     session-level signals (e.g. a Missing artifact alongside a failed Write tool
     call indicates the agent was blocked mid-call, not that it chose to skip
     notes). *)
-let apply_pr_body_artifact ~runtime ~net ~github ~project_name ~patch_id
+let apply_pr_body_artifact ~runtime ~net ~clock ~github ~project_name ~patch_id
     ~pr_number ~patch ~gameplan : [ `Ok | `Missing | `Empty | `Patch_failed ] =
   let artifact_path =
     Project_store.pr_body_artifact_path ~project_name ~patch_id
@@ -784,7 +785,7 @@ let apply_pr_body_artifact ~runtime ~net ~github ~project_name ~patch_id
         Printf.sprintf "%s%s\n\n## Implementation Notes\n\n%s" description
           spec_suffix (String.trim notes)
       in
-      match Github.update_pr_body ~net github ~pr_number ~body with
+      match Github.update_pr_body ~net ~clock github ~pr_number ~body with
       | Ok () ->
           log_event runtime ~patch_id
             (Printf.sprintf "pr-body: PATCHed PR #%d"
@@ -1015,10 +1016,10 @@ let normalize_paste text =
   let text = Base.String.tr text ~target:'\n' ~replacement:' ' in
   Base.String.tr text ~target:'\r' ~replacement:' '
 
-let input_fiber ~runtime ~process_mgr ~net ~github ~list_selected ~detail_scroll
-    ~detail_follow ~timeline_scroll ~detail_scrolls ~view_mode ~pr_registry
-    ~project_name ~show_help ~status_msg ~sorted_patch_ids ~input_mode
-    ~prompt_line ~patches_start_row ~patches_scroll_offset
+let input_fiber ~runtime ~process_mgr ~net ~clock ~github ~list_selected
+    ~detail_scroll ~detail_follow ~timeline_scroll ~detail_scrolls ~view_mode
+    ~pr_registry ~project_name ~show_help ~status_msg ~sorted_patch_ids
+    ~input_mode ~prompt_line ~patches_start_row ~patches_scroll_offset
     ~patches_visible_count ~owner ~repo ~resolve_routing =
   let buf = Tui_input.Edit_buffer.create () in
   let selected_pid () =
@@ -1234,7 +1235,7 @@ let input_fiber ~runtime ~process_mgr ~net ~github ~list_selected ~detail_scroll
                               text = Printf.sprintf "Fetching PR #%d…" n;
                               expires_at = None;
                             };
-                        match Github.pr_state ~net github pr_number with
+                        match Github.pr_state ~net ~clock github pr_number with
                         | Error err ->
                             status_msg := None;
                             log_event runtime ~patch_id
@@ -1891,10 +1892,34 @@ let poll_review_backends ~net ~clock ~runtime ~patch_id ~findings_registry
                 };
               { f with Review_service.id = key }))
 
+(** Translate a [Github] result into a [Poll_outcome.t]. Pure-modulo-show;
+    the boundary lets [Poll_cycle.classify] reason about timeouts the same
+    way it reasons about other failures, which is the invariant the
+    interleaving property tests exercise. *)
+let poll_outcome_of_github_result ~timeout = function
+  | Ok pr_state -> Poll_outcome.Ok_pr_state pr_state
+  | Error (Github.Transport_error { msg; _ })
+    when Base.String.is_substring msg ~substring:"timed out after" ->
+      Poll_outcome.Timed_out { seconds = timeout }
+  | Error (Github.Transport_error { msg; _ }) ->
+      Poll_outcome.Transport_failed { msg }
+  | Error (Github.Http_error { status; body; _ }) ->
+      Poll_outcome.Http_failed { status; msg = body }
+  | Error (Github.Graphql_error msgs) -> Poll_outcome.Graphql_failed msgs
+  | Error (Github.Json_parse_error msg) -> Poll_outcome.Json_parse_failed msg
+
 let poller_fiber ~runtime ~clock ~net ~process_mgr ~github ~config ~project_name
     ~pr_registry ~branch_of ~event_log ~review_backends ~findings_registry =
   let main = config.main_branch in
   let skip_logged : (Patch_id.t, bool) Hashtbl.t = Hashtbl.create 16 in
+  let skip_logged_mutex = Eio.Mutex.create () in
+  let mark_skip_logged patch_id =
+    Eio.Mutex.use_rw ~protect:true skip_logged_mutex (fun () ->
+        if Hashtbl.mem skip_logged patch_id then false
+        else (
+          Hashtbl.replace skip_logged patch_id true;
+          true))
+  in
   let rec loop () =
     let intents =
       Runtime.read runtime (fun snap ->
@@ -1916,138 +1941,155 @@ let poller_fiber ~runtime ~clock ~net ~process_mgr ~github ~config ~project_name
                          })
               else None))
     in
-    (* Phase 1: I/O — collect poll observations outside the lock *)
+    (* Handle Skip_no_pr intents up front — they need no network I/O. *)
+    let poll_intents =
+      Base.List.filter_map intents ~f:(function
+        | Skip_no_pr patch_id ->
+            if mark_skip_logged patch_id then
+              log_event runtime ~patch_id
+                "Skipping poll — no PR number registered";
+            None
+        | Poll { patch_id; pr_number; was_merged } ->
+            Some (patch_id, pr_number, was_merged))
+    in
+    (* Phase 1a: parallel per-patch [Github.pr_state] fetch.
+
+       This is the head-of-line-blocking fix: when one patch's TCP connect
+       is wedged in [SYN_SENT], [Github.pr_state] returns
+       [Transport_error "timed out after Ns"] after [Github.default_timeout]
+       — and every other patch's fiber proceeds independently. *)
+    let outcomes =
+      Eio.Fiber.List.map ~max_fibers:16
+        (fun (patch_id, pr_number, was_merged) ->
+          let outcome =
+            poll_outcome_of_github_result ~timeout:Github.default_timeout
+              (Github.pr_state ~net ~clock github pr_number)
+          in
+          (patch_id, pr_number, was_merged, outcome))
+        poll_intents
+    in
+    (* Phase 1b: pure classification. *)
+    let plans =
+      Base.List.map outcomes
+        ~f:(fun (patch_id, pr_number, was_merged, outcome) ->
+          let cls =
+            Poll_cycle.classify { patch_id; pr_number; was_merged; outcome }
+          in
+          (patch_id, pr_number, cls))
+    in
+    (* Phase 1c: per-patch effectful tail. Builds observations from
+       [Apply_pr_state] plans, handles [Rediscover_pr] / [Skip_fork] /
+       [Log_error]. *)
     let observations =
-      Base.List.filter_map intents ~f:(fun intent ->
-          match intent with
-          | Skip_no_pr patch_id ->
-              if not (Hashtbl.mem skip_logged patch_id) then (
-                Hashtbl.replace skip_logged patch_id true;
-                log_event runtime ~patch_id
-                  "Skipping poll — no PR number registered");
+      Base.List.filter_map plans ~f:(fun (patch_id, pr_number, cls) ->
+          match cls with
+          | Poll_cycle.Log_error { message } ->
+              log_event runtime ~patch_id message;
               None
-          | Poll { patch_id; pr_number; was_merged } -> (
-              match Github.pr_state ~net github pr_number with
-              | Error err ->
+          | Poll_cycle.Skip_fork _ ->
+              if mark_skip_logged patch_id then
+                log_event runtime ~patch_id
+                  (Printf.sprintf
+                     "Skipping PR #%d — fork PRs are not supported"
+                     (Pr_number.to_int pr_number));
+              None
+          | Poll_cycle.Rediscover_pr { head_branch } ->
+              log_event runtime ~patch_id
+                (Printf.sprintf "PR #%d closed — looking for replacement"
+                   (Pr_number.to_int pr_number));
+              let branch =
+                match head_branch with
+                | Some b -> b
+                | None ->
+                    Runtime.read runtime (fun snap ->
+                        match
+                          Orchestrator.find_agent snap.Runtime.orchestrator
+                            patch_id
+                        with
+                        | Some agent -> agent.Patch_agent.branch
+                        | None -> branch_of patch_id)
+              in
+              (match
+                 Startup_reconciler.discover_pr ~net ~clock ~github ~branch
+               with
+              | Ok (Some (new_pr, base_branch, merged)) ->
                   log_event runtime ~patch_id
-                    (Printf.sprintf "Poll error — %s" (Github.show_error err));
-                  None
-              | Ok pr_state when Pr_state.is_fork pr_state ->
-                  if not (Hashtbl.mem skip_logged patch_id) then (
-                    Hashtbl.replace skip_logged patch_id true;
-                    log_event runtime ~patch_id
-                      (Printf.sprintf
-                         "Skipping PR #%d — fork PRs are not supported"
-                         (Pr_number.to_int pr_number)));
-                  None
-              | Ok pr_state ->
-                  (* Augment the GitHub-derived [pr_state] with findings from
-                     every configured review backend. Failures are logged
-                     but non-fatal — a flaky review service shouldn't stop
-                     the rest of the poll cycle. *)
-                  let findings =
-                    if Base.List.is_empty review_backends then []
+                    (Printf.sprintf "Switched to PR #%d"
+                       (Pr_number.to_int new_pr));
+                  Pr_registry.register pr_registry ~patch_id ~pr_number:new_pr;
+                  Runtime.update_orchestrator runtime (fun orch ->
+                      Patch_controller.apply_replacement_pr orch patch_id
+                        ~pr_number:new_pr ~base_branch ~merged)
+              | Ok None ->
+                  log_event runtime ~patch_id
+                    "No open PR found — cleared stale PR state, will create \
+                     on next session";
+                  Pr_registry.unregister pr_registry ~patch_id;
+                  Runtime.update_orchestrator runtime (fun orch ->
+                      Orchestrator.clear_pr orch patch_id)
+              | Error msg ->
+                  log_event runtime ~patch_id
+                    (Printf.sprintf "PR re-discovery failed — %s" msg));
+              None
+          | Poll_cycle.Apply_pr_state
+              { pr_state; poll_result; ci_checks_truncated } ->
+              (* Augment with findings from every configured review backend.
+                 Failures inside [poll_review_backends] are logged but
+                 non-fatal. *)
+              let findings =
+                if Base.List.is_empty review_backends then []
+                else
+                  poll_review_backends ~net ~clock ~runtime ~patch_id
+                    ~findings_registry ~review_backends
+                    ~owner:config.github_owner ~repo:config.github_repo
+                    ~pr_number:(Pr_number.to_int pr_number)
+              in
+              let pr_state = { pr_state with Pr_state.findings } in
+              let branch_in_root =
+                match pr_state.Pr_state.head_branch with
+                | Some b ->
+                    Worktree.is_checked_out_in_repo_root ~process_mgr
+                      ~repo_root:config.repo_root b
+                | None -> false
+              in
+              let failed_ci =
+                Base.List.filter poll_result.Poller.ci_checks
+                  ~f:(fun (c : Ci_check.t) ->
+                    Base.List.mem Patch_decision.failure_conclusions
+                      c.Ci_check.conclusion ~equal:Base.String.equal)
+              in
+              let worktree_candidate =
+                let agent =
+                  Runtime.read runtime (fun snap ->
+                      Orchestrator.find_agent snap.Runtime.orchestrator
+                        patch_id)
+                in
+                match agent with
+                | None -> None
+                | Some agent ->
+                    if Option.is_some agent.Patch_agent.worktree_path then None
                     else
-                      poll_review_backends ~net ~clock ~runtime ~patch_id
-                        ~findings_registry ~review_backends
-                        ~owner:config.github_owner ~repo:config.github_repo
-                        ~pr_number:(Pr_number.to_int pr_number)
-                  in
-                  let pr_state = { pr_state with Pr_state.findings } in
-                  let poll_result = Poller.poll ~was_merged pr_state in
-                  (* PR was closed — re-discover the current open PR.
-                     This path does its own I/O and separate atomic update;
-                     it doesn't participate in the batched update below. *)
-                  if poll_result.Poller.closed then (
-                    log_event runtime ~patch_id
-                      (Printf.sprintf "PR #%d closed — looking for replacement"
-                         (Pr_number.to_int pr_number));
-                    let branch =
-                      match pr_state.Pr_state.head_branch with
-                      | Some b -> b
-                      | None ->
-                          Runtime.read runtime (fun snap ->
-                              match
-                                Orchestrator.find_agent
-                                  snap.Runtime.orchestrator patch_id
-                              with
-                              | Some agent -> agent.Patch_agent.branch
-                              | None -> branch_of patch_id)
-                    in
-                    (match
-                       Startup_reconciler.discover_pr ~net ~github ~branch
-                     with
-                    | Ok (Some (new_pr, base_branch, merged)) ->
-                        log_event runtime ~patch_id
-                          (Printf.sprintf "Switched to PR #%d"
-                             (Pr_number.to_int new_pr));
-                        Pr_registry.register pr_registry ~patch_id
-                          ~pr_number:new_pr;
-                        Runtime.update_orchestrator runtime (fun orch ->
-                            Patch_controller.apply_replacement_pr orch patch_id
-                              ~pr_number:new_pr ~base_branch ~merged)
-                    | Ok None ->
-                        log_event runtime ~patch_id
-                          "No open PR found — cleared stale PR state, will \
-                           create on next session";
-                        Pr_registry.unregister pr_registry ~patch_id;
-                        Runtime.update_orchestrator runtime (fun orch ->
-                            Orchestrator.clear_pr orch patch_id)
-                    | Error msg ->
-                        log_event runtime ~patch_id
-                          (Printf.sprintf "PR re-discovery failed — %s" msg));
-                    None)
-                  else
-                    let branch_in_root =
-                      match pr_state.Pr_state.head_branch with
-                      | Some b ->
-                          Worktree.is_checked_out_in_repo_root ~process_mgr
-                            ~repo_root:config.repo_root b
-                      | None -> false
-                    in
-                    let failed_ci =
-                      Base.List.filter poll_result.Poller.ci_checks
-                        ~f:(fun (c : Ci_check.t) ->
-                          Base.List.mem Patch_decision.failure_conclusions
-                            c.Ci_check.conclusion ~equal:Base.String.equal)
-                    in
-                    let worktree_candidate =
-                      let agent =
-                        Runtime.read runtime (fun snap ->
-                            Orchestrator.find_agent snap.Runtime.orchestrator
-                              patch_id)
+                      let path =
+                        resolve_worktree_path ~process_mgr
+                          ~repo_root:config.repo_root ~project_name ~patch_id
+                          ~agent ()
                       in
-                      match agent with
-                      | None -> None
-                      | Some agent ->
-                          if Option.is_some agent.Patch_agent.worktree_path then
-                            None
-                          else
-                            let path =
-                              resolve_worktree_path ~process_mgr
-                                ~repo_root:config.repo_root ~project_name
-                                ~patch_id ~agent ()
-                            in
-                            let default =
-                              Worktree.worktree_dir ~project_name ~patch_id
-                            in
-                            if not (String.equal path default) then Some path
-                            else None
-                    in
-                    let observation =
-                      Patch_controller.
-                        {
-                          poll_result;
-                          base_branch = pr_state.Pr_state.base_branch;
-                          branch_in_root;
-                          worktree_path = worktree_candidate;
-                        }
-                    in
-                    Some
-                      ( patch_id,
-                        observation,
-                        failed_ci,
-                        pr_state.Pr_state.ci_checks_truncated )))
+                      let default =
+                        Worktree.worktree_dir ~project_name ~patch_id
+                      in
+                      if not (String.equal path default) then Some path
+                      else None
+              in
+              let observation =
+                Patch_controller.
+                  {
+                    poll_result;
+                    base_branch = pr_state.Pr_state.base_branch;
+                    branch_in_root;
+                    worktree_path = worktree_candidate;
+                  }
+              in
+              Some (patch_id, observation, failed_ci, ci_checks_truncated))
     in
     (* Phase 2: Single atomic update — apply all poll results + reconcile.
        This prevents the runner from seeing an intermediate state where
@@ -2397,7 +2439,7 @@ let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name ~pr_registry
           in
           (orch, (effects, List.rev dispatched, pre_fire_agents)))
     in
-    execute_github_effects ~runtime ~net ~github lifecycle_effects;
+    execute_github_effects ~runtime ~net ~clock ~github lifecycle_effects;
     (* Log dispatched actions to event log *)
     Base.List.iter messages ~f:(fun (msg : Orchestrator.patch_agent_message) ->
         let action = Orchestrator.message_action msg in
@@ -2589,7 +2631,7 @@ let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name ~pr_registry
                                 ^ Prompt.render_spec_suffix patch gameplan
                               in
                               (match
-                                 Github.create_pull_request ~net github
+                                 Github.create_pull_request ~net ~clock github
                                    ~title:pr_title ~head:patch.Patch.branch
                                    ~base:fresh_base ~body:pr_body ~draft:true
                                with
@@ -2617,7 +2659,7 @@ let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name ~pr_registry
                                          etc.) propagate with the original
                                          error message. *)
                                       match
-                                        Github.list_prs ~net github
+                                        Github.list_prs ~net ~clock github
                                           ~branch:patch.Patch.branch ~base:None
                                           ~state:`Open ()
                                       with
@@ -2809,7 +2851,7 @@ let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name ~pr_registry
                           log_event runtime ~patch_id
                             (if is_ci then "Fetching fresh CI state from GitHub"
                              else "Fetching fresh review comments from GitHub");
-                          match Github.pr_state ~net github pr_num with
+                          match Github.pr_state ~net ~clock github pr_num with
                           | Ok pr_state -> Some pr_state
                           | Error _err ->
                               log_event runtime ~patch_id
@@ -3545,8 +3587,9 @@ let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name ~pr_registry
                                           in
                                           let artifact_outcome =
                                             apply_pr_body_artifact ~runtime ~net
-                                              ~github ~project_name ~patch_id
-                                              ~pr_number:pr ~patch ~gameplan
+                                              ~clock ~github ~project_name
+                                              ~patch_id ~pr_number:pr ~patch
+                                              ~gameplan
                                           in
                                           match
                                             Patch_decision
@@ -3670,9 +3713,10 @@ let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name ~pr_registry
                                           | Some patch ->
                                               Some
                                                 (apply_pr_body_artifact ~runtime
-                                                   ~net ~github ~project_name
-                                                   ~patch_id ~pr_number:pr
-                                                   ~patch ~gameplan)
+                                                   ~net ~clock ~github
+                                                   ~project_name ~patch_id
+                                                   ~pr_number:pr ~patch
+                                                   ~gameplan)
                                           | None ->
                                               log_event runtime ~patch_id
                                                 "pr-body: skipping \
@@ -3816,7 +3860,7 @@ let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name ~pr_registry
            switch teardown propagates normally; swallow any other exception
            to the activity log so a single bad tick can't kill the fiber
            permanently and leave automerge silently disabled. *)
-        (try reconcile_and_execute_automerge ~runtime ~net ~github with
+        (try reconcile_and_execute_automerge ~runtime ~net ~clock ~github with
         | Eio.Cancel.Cancelled _ as exn -> raise exn
         | exn ->
             log_event runtime
@@ -4275,7 +4319,8 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
           ~repo:config.github_repo
       in
       let net = Eio.Stdenv.net env in
-      (match Github.check_repo_access ~net github with
+      let clock = Eio.Stdenv.clock env in
+      (match Github.check_repo_access ~net ~clock github with
       | Ok () -> ()
       | Error err ->
           Printf.eprintf "Error: cannot access GitHub repo %s/%s: %s\n"
@@ -4388,7 +4433,7 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
       in
       let reconciliation_fiber () =
         let startup =
-          Startup_reconciler.reconcile ~net ~github
+          Startup_reconciler.reconcile ~net ~clock ~github
             ~patches:gameplan.Gameplan.patches ~repo_root:config.repo_root
             ~process_mgr ~agents:pre_agents
             ~pre_recovered_worktrees:pre_worktrees ()
@@ -4517,13 +4562,14 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
                      ~backend_name:(backend_name (fst default_backend))
                      ~resolve_routing)
                 :: (fun () ->
-                  input_fiber ~runtime ~process_mgr ~net ~github ~list_selected
-                    ~detail_scroll ~detail_follow ~timeline_scroll
-                    ~detail_scrolls ~view_mode ~pr_registry ~project_name
-                    ~show_help ~status_msg ~sorted_patch_ids ~input_mode
-                    ~prompt_line ~patches_start_row ~patches_scroll_offset
-                    ~patches_visible_count ~owner:config.github_owner
-                    ~repo:config.github_repo ~resolve_routing)
+                  input_fiber ~runtime ~process_mgr ~net ~clock ~github
+                    ~list_selected ~detail_scroll ~detail_follow
+                    ~timeline_scroll ~detail_scrolls ~view_mode ~pr_registry
+                    ~project_name ~show_help ~status_msg ~sorted_patch_ids
+                    ~input_mode ~prompt_line ~patches_start_row
+                    ~patches_scroll_offset ~patches_visible_count
+                    ~owner:config.github_owner ~repo:config.github_repo
+                    ~resolve_routing)
                 :: (fun () ->
                   runner_fiber ~runtime ~env ~config ~pick_backend ~project_name
                     ~pr_registry ~findings_registry ~review_backends

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1896,11 +1896,9 @@ let poll_review_backends ~net ~clock ~runtime ~patch_id ~findings_registry
     boundary lets [Poll_cycle.classify] reason about timeouts the same way it
     reasons about other failures, which is the invariant the interleaving
     property tests exercise. *)
-let poll_outcome_of_github_result ~timeout = function
+let poll_outcome_of_github_result = function
   | Ok pr_state -> Poll_outcome.Ok_pr_state pr_state
-  | Error (Github.Transport_error { msg; _ })
-    when Base.String.is_substring msg ~substring:"timed out after" ->
-      Poll_outcome.Timed_out { seconds = timeout }
+  | Error (Github.Timeout { seconds; _ }) -> Poll_outcome.Timed_out { seconds }
   | Error (Github.Transport_error { msg; _ }) ->
       Poll_outcome.Transport_failed { msg }
   | Error (Github.Http_error { status; body; _ }) ->
@@ -1955,14 +1953,14 @@ let poller_fiber ~runtime ~clock ~net ~process_mgr ~github ~config ~project_name
     (* Phase 1a: parallel per-patch [Github.pr_state] fetch.
 
        This is the head-of-line-blocking fix: when one patch's TCP connect
-       is wedged in [SYN_SENT], [Github.pr_state] returns
-       [Transport_error "timed out after Ns"] after [Github.default_timeout]
-       — and every other patch's fiber proceeds independently. *)
+       is wedged in [SYN_SENT], [Github.pr_state] returns [Timeout] after
+       [Github.default_timeout] — and every other patch's fiber proceeds
+       independently. *)
     let outcomes =
       Eio.Fiber.List.map ~max_fibers:16
         (fun (patch_id, pr_number, was_merged) ->
           let outcome =
-            poll_outcome_of_github_result ~timeout:Github.default_timeout
+            poll_outcome_of_github_result
               (Github.pr_state ~net ~clock github pr_number)
           in
           (patch_id, pr_number, was_merged, outcome))
@@ -2697,7 +2695,7 @@ let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name ~pr_registry
                                                 patch_id))
                                   | Github.Http_error _
                                   | Github.Json_parse_error _
-                                  | Github.Graphql_error _
+                                  | Github.Graphql_error _ | Github.Timeout _
                                   | Github.Transport_error _ ->
                                       log_event runtime ~patch_id
                                         (Printf.sprintf

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1892,10 +1892,10 @@ let poll_review_backends ~net ~clock ~runtime ~patch_id ~findings_registry
                 };
               { f with Review_service.id = key }))
 
-(** Translate a [Github] result into a [Poll_outcome.t]. Pure-modulo-show;
-    the boundary lets [Poll_cycle.classify] reason about timeouts the same
-    way it reasons about other failures, which is the invariant the
-    interleaving property tests exercise. *)
+(** Translate a [Github] result into a [Poll_outcome.t]. Pure-modulo-show; the
+    boundary lets [Poll_cycle.classify] reason about timeouts the same way it
+    reasons about other failures, which is the invariant the interleaving
+    property tests exercise. *)
 let poll_outcome_of_github_result ~timeout = function
   | Ok pr_state -> Poll_outcome.Ok_pr_state pr_state
   | Error (Github.Transport_error { msg; _ })
@@ -1989,8 +1989,7 @@ let poller_fiber ~runtime ~clock ~net ~process_mgr ~github ~config ~project_name
           | Poll_cycle.Skip_fork _ ->
               if mark_skip_logged patch_id then
                 log_event runtime ~patch_id
-                  (Printf.sprintf
-                     "Skipping PR #%d — fork PRs are not supported"
+                  (Printf.sprintf "Skipping PR #%d — fork PRs are not supported"
                      (Pr_number.to_int pr_number));
               None
           | Poll_cycle.Rediscover_pr { head_branch } ->
@@ -2022,8 +2021,8 @@ let poller_fiber ~runtime ~clock ~net ~process_mgr ~github ~config ~project_name
                         ~pr_number:new_pr ~base_branch ~merged)
               | Ok None ->
                   log_event runtime ~patch_id
-                    "No open PR found — cleared stale PR state, will create \
-                     on next session";
+                    "No open PR found — cleared stale PR state, will create on \
+                     next session";
                   Pr_registry.unregister pr_registry ~patch_id;
                   Runtime.update_orchestrator runtime (fun orch ->
                       Orchestrator.clear_pr orch patch_id)
@@ -2061,8 +2060,7 @@ let poller_fiber ~runtime ~clock ~net ~process_mgr ~github ~config ~project_name
               let worktree_candidate =
                 let agent =
                   Runtime.read runtime (fun snap ->
-                      Orchestrator.find_agent snap.Runtime.orchestrator
-                        patch_id)
+                      Orchestrator.find_agent snap.Runtime.orchestrator patch_id)
                 in
                 match agent with
                 | None -> None

--- a/lib/forge.ml
+++ b/lib/forge.ml
@@ -10,5 +10,10 @@ module type S = sig
   val show_error : error -> string
 
   val pr_state :
-    net:_ Eio.Net.t -> t -> Types.Pr_number.t -> (Pr_state.t, error) Result.t
+    net:_ Eio.Net.t ->
+    clock:_ Eio.Time.clock ->
+    ?timeout:float ->
+    t ->
+    Types.Pr_number.t ->
+    (Pr_state.t, error) Result.t
 end

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -4,6 +4,7 @@ type error =
   | Http_error of { meth : string; path : string; status : int; body : string }
   | Json_parse_error of string
   | Graphql_error of string list
+  | Timeout of { meth : string; path : string; seconds : float }
   | Transport_error of { meth : string; path : string; msg : string }
 
 (* Extract GitHub's "message" field and validation details from a JSON error
@@ -114,6 +115,9 @@ let show_error = function
         (permission_hint status)
   | Transport_error { meth; path; msg } ->
       Printf.sprintf "GitHub API %s %s → transport error: %s" meth path msg
+  | Timeout { meth; path; seconds } ->
+      Printf.sprintf "GitHub API %s %s → request timed out after %.0fs" meth
+        path seconds
   | Json_parse_error msg -> Printf.sprintf "GitHub API JSON parse error: %s" msg
   | Graphql_error msgs ->
       Printf.sprintf "GitHub GraphQL error: %s" (String.concat ~sep:"; " msgs)
@@ -526,14 +530,7 @@ let request ~net ~clock ?(timeout = default_timeout) t ~meth ~path ?(query = [])
   in
   match Eio.Time.with_timeout clock timeout (fun () -> Ok (do_request ())) with
   | Ok inner -> inner
-  | Error `Timeout ->
-      Error
-        (Transport_error
-           {
-             meth = meth_s;
-             path;
-             msg = Printf.sprintf "request timed out after %.0fs" timeout;
-           })
+  | Error `Timeout -> Error (Timeout { meth = meth_s; path; seconds = timeout })
 
 let check_repo_access ~net ~clock ?timeout t =
   let path = Printf.sprintf "/repos/%s/%s" t.owner t.repo in

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -461,8 +461,8 @@ let meth_to_string = function
   | `PATCH -> "PATCH"
   | `PUT -> "PUT"
 
-let request ~net ~clock ?(timeout = default_timeout) t ~meth ~path
-    ?(query = []) ?body () =
+let request ~net ~clock ?(timeout = default_timeout) t ~meth ~path ?(query = [])
+    ?body () =
   let meth_s = meth_to_string meth in
   let do_request () : (string, error) Result.t =
     try
@@ -543,7 +543,9 @@ let check_repo_access ~net ~clock ?timeout t =
 
 let pr_state ~net ~clock ?timeout t pr =
   let body = build_request_body t pr in
-  match request ~net ~clock ?timeout t ~meth:`POST ~path:"/graphql" ~body () with
+  match
+    request ~net ~clock ?timeout t ~meth:`POST ~path:"/graphql" ~body ()
+  with
   | Ok resp_str -> parse_response ~owner:t.owner resp_str
   | Error _ as e -> e
 
@@ -608,9 +610,7 @@ let update_pr_body ~net ~clock ?timeout t ~pr_number ~body =
       (Types.Pr_number.to_int pr_number)
   in
   let req_body = `Assoc [ ("body", `String body) ] |> Yojson.Safe.to_string in
-  match
-    request ~net ~clock ?timeout t ~meth:`PATCH ~path ~body:req_body ()
-  with
+  match request ~net ~clock ?timeout t ~meth:`PATCH ~path ~body:req_body () with
   | Ok _ -> Ok ()
   | Error _ as e -> e
 
@@ -649,9 +649,7 @@ let update_pr_base ~net ~clock ?timeout t ~pr_number ~base =
     `Assoc [ ("base", `String (Types.Branch.to_string base)) ]
     |> Yojson.Safe.to_string
   in
-  match
-    request ~net ~clock ?timeout t ~meth:`PATCH ~path ~body:req_body ()
-  with
+  match request ~net ~clock ?timeout t ~meth:`PATCH ~path ~body:req_body () with
   | Ok _ -> Ok ()
   | Error _ as e -> e
 

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -448,6 +448,11 @@ let https_fun tls_config uri flow =
 
 let max_response_size = 1_000_000
 
+(** Default per-request timeout, in seconds. Matches review_service_client.
+    Without a timeout, a TCP connect stuck in SYN_SENT can block the calling
+    fiber indefinitely — which is how the poll loop wedged in production. *)
+let default_timeout = 30.0
+
 (** Internal: execute an HTTP request against api.github.com. Returns the raw
     response body on 2xx, [Http_error] otherwise. *)
 let meth_to_string = function
@@ -456,70 +461,89 @@ let meth_to_string = function
   | `PATCH -> "PATCH"
   | `PUT -> "PUT"
 
-let request ~net t ~meth ~path ?(query = []) ?body () =
+let request ~net ~clock ?(timeout = default_timeout) t ~meth ~path
+    ?(query = []) ?body () =
   let meth_s = meth_to_string meth in
-  try
-    Mirage_crypto_rng_unix.use_default ();
-    Result.bind
-      (Result.map_error (https_config ()) ~f:(fun msg ->
-           Transport_error { meth = meth_s; path; msg }))
-      ~f:(fun tls_config ->
-        let client =
-          Cohttp_eio.Client.make ~https:(Some (https_fun tls_config)) net
-        in
-        let uri =
-          Uri.of_string ("https://api.github.com" ^ path) |> fun u ->
-          Uri.add_query_params u query
-        in
-        let headers =
-          Http.Header.of_list
-            [
-              ("Authorization", "Bearer " ^ t.token);
-              ("Content-Type", "application/json");
-              ("Accept", "application/vnd.github+json");
-              ("User-Agent", "onton/0.1.0");
-              ("X-GitHub-Api-Version", "2022-11-28");
-            ]
-        in
-        Eio.Switch.run @@ fun sw ->
-        let resp, resp_body =
-          match meth with
-          | `GET -> Cohttp_eio.Client.get client ~sw ~headers uri
-          | `POST ->
-              let body =
-                Cohttp_eio.Body.of_string (Option.value body ~default:"{}")
-              in
-              Cohttp_eio.Client.post client ~sw ~headers ~body uri
-          | `PATCH ->
-              let body =
-                Cohttp_eio.Body.of_string (Option.value body ~default:"{}")
-              in
-              Cohttp_eio.Client.patch client ~sw ~headers ~body uri
-          | `PUT ->
-              let body =
-                Cohttp_eio.Body.of_string (Option.value body ~default:"{}")
-              in
-              Cohttp_eio.Client.put client ~sw ~headers ~body uri
-        in
-        let status = Http.Response.status resp |> Http.Status.to_int in
-        let resp_str =
-          Eio.Buf_read.(
-            of_flow ~max_size:max_response_size resp_body |> take_all)
-        in
-        if status >= 200 && status < 300 then Ok resp_str
-        else Error (Http_error { meth = meth_s; path; status; body = resp_str }))
-  with exn ->
-    Error (Transport_error { meth = meth_s; path; msg = Exn.to_string exn })
+  let do_request () : (string, error) Result.t =
+    try
+      Mirage_crypto_rng_unix.use_default ();
+      Result.bind
+        (Result.map_error (https_config ()) ~f:(fun msg ->
+             Transport_error { meth = meth_s; path; msg }))
+        ~f:(fun tls_config ->
+          let client =
+            Cohttp_eio.Client.make ~https:(Some (https_fun tls_config)) net
+          in
+          let uri =
+            Uri.of_string ("https://api.github.com" ^ path) |> fun u ->
+            Uri.add_query_params u query
+          in
+          let headers =
+            Http.Header.of_list
+              [
+                ("Authorization", "Bearer " ^ t.token);
+                ("Content-Type", "application/json");
+                ("Accept", "application/vnd.github+json");
+                ("User-Agent", "onton/0.1.0");
+                ("X-GitHub-Api-Version", "2022-11-28");
+              ]
+          in
+          Eio.Switch.run @@ fun sw ->
+          let resp, resp_body =
+            match meth with
+            | `GET -> Cohttp_eio.Client.get client ~sw ~headers uri
+            | `POST ->
+                let body =
+                  Cohttp_eio.Body.of_string (Option.value body ~default:"{}")
+                in
+                Cohttp_eio.Client.post client ~sw ~headers ~body uri
+            | `PATCH ->
+                let body =
+                  Cohttp_eio.Body.of_string (Option.value body ~default:"{}")
+                in
+                Cohttp_eio.Client.patch client ~sw ~headers ~body uri
+            | `PUT ->
+                let body =
+                  Cohttp_eio.Body.of_string (Option.value body ~default:"{}")
+                in
+                Cohttp_eio.Client.put client ~sw ~headers ~body uri
+          in
+          let status = Http.Response.status resp |> Http.Status.to_int in
+          let resp_str =
+            Eio.Buf_read.(
+              of_flow ~max_size:max_response_size resp_body |> take_all)
+          in
+          if status >= 200 && status < 300 then Ok resp_str
+          else
+            Error (Http_error { meth = meth_s; path; status; body = resp_str }))
+    with
+    | Eio.Cancel.Cancelled _ as exn ->
+        (* Don't swallow cancellation — let [with_timeout] convert it to a
+           [`Timeout] result so the caller sees a proper timeout error. *)
+        raise exn
+    | exn ->
+        Error (Transport_error { meth = meth_s; path; msg = Exn.to_string exn })
+  in
+  match Eio.Time.with_timeout clock timeout (fun () -> Ok (do_request ())) with
+  | Ok inner -> inner
+  | Error `Timeout ->
+      Error
+        (Transport_error
+           {
+             meth = meth_s;
+             path;
+             msg = Printf.sprintf "request timed out after %.0fs" timeout;
+           })
 
-let check_repo_access ~net t =
+let check_repo_access ~net ~clock ?timeout t =
   let path = Printf.sprintf "/repos/%s/%s" t.owner t.repo in
-  match request ~net t ~meth:`GET ~path () with
+  match request ~net ~clock ?timeout t ~meth:`GET ~path () with
   | Ok _ -> Ok ()
   | Error _ as e -> e
 
-let pr_state ~net t pr =
+let pr_state ~net ~clock ?timeout t pr =
   let body = build_request_body t pr in
-  match request ~net t ~meth:`POST ~path:"/graphql" ~body () with
+  match request ~net ~clock ?timeout t ~meth:`POST ~path:"/graphql" ~body () with
   | Ok resp_str -> parse_response ~owner:t.owner resp_str
   | Error _ as e -> e
 
@@ -559,7 +583,7 @@ let parse_rest_pr_list body =
   | Yojson.Safe.Util.Type_error (msg, _) -> Error (Json_parse_error msg)
 
 (** List PRs for a branch via REST API. Returns non-CLOSED PRs. *)
-let list_prs ~net t ~branch ?(base = None) ~state () =
+let list_prs ~net ~clock ?timeout t ~branch ?(base = None) ~state () =
   let state_str = match state with `Open -> "open" | `All -> "all" in
   let query =
     [
@@ -573,23 +597,25 @@ let list_prs ~net t ~branch ?(base = None) ~state () =
     | None -> []
   in
   let path = Printf.sprintf "/repos/%s/%s/pulls" t.owner t.repo in
-  match request ~net t ~meth:`GET ~path ~query () with
+  match request ~net ~clock ?timeout t ~meth:`GET ~path ~query () with
   | Ok body -> parse_rest_pr_list body
   | Error _ as e -> e
 
 (** Update the body (description) of a PR via REST API. *)
-let update_pr_body ~net t ~pr_number ~body =
+let update_pr_body ~net ~clock ?timeout t ~pr_number ~body =
   let path =
     Printf.sprintf "/repos/%s/%s/pulls/%d" t.owner t.repo
       (Types.Pr_number.to_int pr_number)
   in
   let req_body = `Assoc [ ("body", `String body) ] |> Yojson.Safe.to_string in
-  match request ~net t ~meth:`PATCH ~path ~body:req_body () with
+  match
+    request ~net ~clock ?timeout t ~meth:`PATCH ~path ~body:req_body ()
+  with
   | Ok _ -> Ok ()
   | Error _ as e -> e
 
 (** Create a draft pull request via REST API. Returns the new PR number. *)
-let create_pull_request ~net t ~title ~head ~base ~body ~draft =
+let create_pull_request ~net ~clock ?timeout t ~title ~head ~base ~body ~draft =
   let path = Printf.sprintf "/repos/%s/%s/pulls" t.owner t.repo in
   let req_body =
     `Assoc
@@ -602,7 +628,7 @@ let create_pull_request ~net t ~title ~head ~base ~body ~draft =
       ]
     |> Yojson.Safe.to_string
   in
-  match request ~net t ~meth:`POST ~path ~body:req_body () with
+  match request ~net ~clock ?timeout t ~meth:`POST ~path ~body:req_body () with
   | Error _ as e -> e
   | Ok resp_str -> (
       try
@@ -614,7 +640,7 @@ let create_pull_request ~net t ~title ~head ~base ~body ~draft =
       | Yojson.Safe.Util.Type_error (msg, _) -> Error (Json_parse_error msg))
 
 (** Update the base (target) branch of a PR via REST API. *)
-let update_pr_base ~net t ~pr_number ~base =
+let update_pr_base ~net ~clock ?timeout t ~pr_number ~base =
   let path =
     Printf.sprintf "/repos/%s/%s/pulls/%d" t.owner t.repo
       (Types.Pr_number.to_int pr_number)
@@ -623,17 +649,19 @@ let update_pr_base ~net t ~pr_number ~base =
     `Assoc [ ("base", `String (Types.Branch.to_string base)) ]
     |> Yojson.Safe.to_string
   in
-  match request ~net t ~meth:`PATCH ~path ~body:req_body () with
+  match
+    request ~net ~clock ?timeout t ~meth:`PATCH ~path ~body:req_body ()
+  with
   | Ok _ -> Ok ()
   | Error _ as e -> e
 
 (** Fetch the GraphQL node ID for a PR via REST API. *)
-let pr_node_id ~net t ~pr_number =
+let pr_node_id ~net ~clock ?timeout t ~pr_number =
   let path =
     Printf.sprintf "/repos/%s/%s/pulls/%d" t.owner t.repo
       (Types.Pr_number.to_int pr_number)
   in
-  match request ~net t ~meth:`GET ~path () with
+  match request ~net ~clock ?timeout t ~meth:`GET ~path () with
   | Error _ as e -> e
   | Ok body -> (
       try
@@ -648,8 +676,8 @@ let pr_node_id ~net t ~pr_number =
 
 (** Set or unset draft status on a PR via GraphQL mutation. REST API does not
     support changing the draft field. *)
-let set_draft ~net t ~pr_number ~draft =
-  Result.bind (pr_node_id ~net t ~pr_number) ~f:(fun node_id ->
+let set_draft ~net ~clock ?timeout t ~pr_number ~draft =
+  Result.bind (pr_node_id ~net ~clock ?timeout t ~pr_number) ~f:(fun node_id ->
       let mutation =
         if draft then "convertPullRequestToDraft"
         else "markPullRequestReadyForReview"
@@ -667,7 +695,10 @@ let set_draft ~net t ~pr_number ~draft =
           ]
         |> Yojson.Safe.to_string
       in
-      match request ~net t ~meth:`POST ~path:"/graphql" ~body:req_body () with
+      match
+        request ~net ~clock ?timeout t ~meth:`POST ~path:"/graphql"
+          ~body:req_body ()
+      with
       | Ok resp -> (
           try
             let json = Yojson.Safe.from_string resp in
@@ -727,7 +758,7 @@ let interpret_merge_response body =
 (** Merge a pull request via the REST API. Maps to
     [PUT /repos/:owner/:repo/pulls/:number/merge]. Returns the parsed
     [merge_result] on 2xx or an [error] on transport/4xx/5xx failures. *)
-let merge_pr ~net t ~pr_number ~merge_method =
+let merge_pr ~net ~clock ?timeout t ~pr_number ~merge_method =
   let path =
     Printf.sprintf "/repos/%s/%s/pulls/%d/merge" t.owner t.repo
       (Types.Pr_number.to_int pr_number)
@@ -741,7 +772,7 @@ let merge_pr ~net t ~pr_number ~merge_method =
   let req_body =
     `Assoc [ ("merge_method", `String method_str) ] |> Yojson.Safe.to_string
   in
-  match request ~net t ~meth:`PUT ~path ~body:req_body () with
+  match request ~net ~clock ?timeout t ~meth:`PUT ~path ~body:req_body () with
   | Ok body -> Ok (interpret_merge_response body)
   | Error _ as e -> e
 

--- a/lib/github.mli
+++ b/lib/github.mli
@@ -33,8 +33,8 @@ val create : token:string -> owner:string -> repo:string -> t
 
 val default_timeout : float
 (** Per-request timeout default, in seconds. Without a timeout, a TCP connect
-    stuck in [SYN_SENT] (e.g. dropped packets, dead route) can block the
-    calling fiber indefinitely. *)
+    stuck in [SYN_SENT] (e.g. dropped packets, dead route) can block the calling
+    fiber indefinitely. *)
 
 val check_repo_access :
   net:_ Eio.Net.t ->
@@ -63,8 +63,8 @@ val pr_state :
   t ->
   Types.Pr_number.t ->
   (Pr_state.t, error) Result.t
-(** [pr_state ~net ~clock client pr] fetches the current state of a pull
-    request via the GitHub GraphQL API over HTTPS. *)
+(** [pr_state ~net ~clock client pr] fetches the current state of a pull request
+    via the GitHub GraphQL API over HTTPS. *)
 
 val parse_rest_pr_list :
   string -> ((Types.Pr_number.t * Types.Branch.t * bool) list, error) Result.t
@@ -118,8 +118,8 @@ val update_pr_base :
   pr_number:Types.Pr_number.t ->
   base:Types.Branch.t ->
   (unit, error) Result.t
-(** [update_pr_base ~net ~clock t ~pr_number ~base] retargets the PR to
-    [base] via [PATCH /repos/:owner/:repo/pulls/:number]. *)
+(** [update_pr_base ~net ~clock t ~pr_number ~base] retargets the PR to [base]
+    via [PATCH /repos/:owner/:repo/pulls/:number]. *)
 
 val set_draft :
   net:_ Eio.Net.t ->

--- a/lib/github.mli
+++ b/lib/github.mli
@@ -11,14 +11,15 @@ type error =
   | Http_error of { meth : string; path : string; status : int; body : string }
   | Json_parse_error of string
   | Graphql_error of string list
+  | Timeout of { meth : string; path : string; seconds : float }
   | Transport_error of { meth : string; path : string; msg : string }
 
 val show_error : error -> string
 (** Render an error as a human-readable string. Includes the HTTP method and
-    path for [Http_error]/[Transport_error], extracts GitHub's "message" field
-    and validation details from the response body, and appends a hint about PAT
-    scopes for 401/403/404 so users can fix permission problems without
-    guesswork. *)
+    path for [Http_error]/[Timeout]/[Transport_error], extracts GitHub's
+    "message" field and validation details from the response body, and appends a
+    hint about PAT scopes for 401/403/404 so users can fix permission problems
+    without guesswork. *)
 
 val response_error_message_contains : string -> substring:string -> bool
 (** Returns [true] if any human-meaningful field in a GitHub error response body

--- a/lib/github.mli
+++ b/lib/github.mli
@@ -31,11 +31,21 @@ type t
 val create : token:string -> owner:string -> repo:string -> t
 (** [create ~token ~owner ~repo] creates a GitHub API client. *)
 
-val check_repo_access : net:_ Eio.Net.t -> t -> (unit, error) Result.t
-(** [check_repo_access ~net t] verifies that the configured token can access
-    [owner/repo] via [GET /repos/:owner/:repo]. This is a startup preflight so
-    missing tokens, expired credentials, SSO gaps, and wrong repository names
-    fail before long-running orchestration starts. *)
+val default_timeout : float
+(** Per-request timeout default, in seconds. Without a timeout, a TCP connect
+    stuck in [SYN_SENT] (e.g. dropped packets, dead route) can block the
+    calling fiber indefinitely. *)
+
+val check_repo_access :
+  net:_ Eio.Net.t ->
+  clock:_ Eio.Time.clock ->
+  ?timeout:float ->
+  t ->
+  (unit, error) Result.t
+(** [check_repo_access ~net ~clock t] verifies that the configured token can
+    access [owner/repo] via [GET /repos/:owner/:repo]. This is a startup
+    preflight so missing tokens, expired credentials, SSO gaps, and wrong
+    repository names fail before long-running orchestration starts. *)
 
 val parse_response_json :
   owner:string -> Yojson.Safe.t -> (Pr_state.t, error) Result.t
@@ -47,9 +57,14 @@ val parse_response : owner:string -> string -> (Pr_state.t, error) Result.t
 (** Parse a GitHub GraphQL response body string into a [Pr_state.t]. *)
 
 val pr_state :
-  net:_ Eio.Net.t -> t -> Types.Pr_number.t -> (Pr_state.t, error) Result.t
-(** [pr_state ~net client pr] fetches the current state of a pull request via
-    the GitHub GraphQL API over HTTPS. *)
+  net:_ Eio.Net.t ->
+  clock:_ Eio.Time.clock ->
+  ?timeout:float ->
+  t ->
+  Types.Pr_number.t ->
+  (Pr_state.t, error) Result.t
+(** [pr_state ~net ~clock client pr] fetches the current state of a pull
+    request via the GitHub GraphQL API over HTTPS. *)
 
 val parse_rest_pr_list :
   string -> ((Types.Pr_number.t * Types.Branch.t * bool) list, error) Result.t
@@ -58,26 +73,32 @@ val parse_rest_pr_list :
 
 val list_prs :
   net:_ Eio.Net.t ->
+  clock:_ Eio.Time.clock ->
+  ?timeout:float ->
   t ->
   branch:Types.Branch.t ->
   ?base:Types.Branch.t option ->
   state:[ `Open | `All ] ->
   unit ->
   ((Types.Pr_number.t * Types.Branch.t * bool) list, error) Result.t
-(** [list_prs ~net t ~branch ~state ()] lists PRs matching [branch] via the
-    GitHub REST API. Returns non-CLOSED PRs as [(number, base, merged)]. *)
+(** [list_prs ~net ~clock t ~branch ~state ()] lists PRs matching [branch] via
+    the GitHub REST API. Returns non-CLOSED PRs as [(number, base, merged)]. *)
 
 val update_pr_body :
   net:_ Eio.Net.t ->
+  clock:_ Eio.Time.clock ->
+  ?timeout:float ->
   t ->
   pr_number:Types.Pr_number.t ->
   body:string ->
   (unit, error) Result.t
-(** [update_pr_body ~net t ~pr_number ~body] updates the PR description via
-    [PATCH /repos/:owner/:repo/pulls/:number]. *)
+(** [update_pr_body ~net ~clock t ~pr_number ~body] updates the PR description
+    via [PATCH /repos/:owner/:repo/pulls/:number]. *)
 
 val create_pull_request :
   net:_ Eio.Net.t ->
+  clock:_ Eio.Time.clock ->
+  ?timeout:float ->
   t ->
   title:string ->
   head:Types.Branch.t ->
@@ -85,27 +106,31 @@ val create_pull_request :
   body:string ->
   draft:bool ->
   (Types.Pr_number.t, error) Result.t
-(** [create_pull_request ~net t ~title ~head ~base ~body ~draft] creates a pull
-    request via [POST /repos/:owner/:repo/pulls] and returns the new PR number.
-*)
+(** [create_pull_request ~net ~clock t ~title ~head ~base ~body ~draft] creates
+    a pull request via [POST /repos/:owner/:repo/pulls] and returns the new PR
+    number. *)
 
 val update_pr_base :
   net:_ Eio.Net.t ->
+  clock:_ Eio.Time.clock ->
+  ?timeout:float ->
   t ->
   pr_number:Types.Pr_number.t ->
   base:Types.Branch.t ->
   (unit, error) Result.t
-(** [update_pr_base ~net t ~pr_number ~base] retargets the PR to [base] via
-    [PATCH /repos/:owner/:repo/pulls/:number]. *)
+(** [update_pr_base ~net ~clock t ~pr_number ~base] retargets the PR to
+    [base] via [PATCH /repos/:owner/:repo/pulls/:number]. *)
 
 val set_draft :
   net:_ Eio.Net.t ->
+  clock:_ Eio.Time.clock ->
+  ?timeout:float ->
   t ->
   pr_number:Types.Pr_number.t ->
   draft:bool ->
   (unit, error) Result.t
-(** [set_draft ~net t ~pr_number ~draft] sets draft status via GraphQL mutation.
-    REST API does not support changing the draft field. *)
+(** [set_draft ~net ~clock t ~pr_number ~draft] sets draft status via GraphQL
+    mutation. REST API does not support changing the draft field. *)
 
 type merge_result =
   | Merge_succeeded
@@ -121,11 +146,13 @@ type merge_result =
 
 val merge_pr :
   net:_ Eio.Net.t ->
+  clock:_ Eio.Time.clock ->
+  ?timeout:float ->
   t ->
   pr_number:Types.Pr_number.t ->
   merge_method:[ `Merge | `Squash | `Rebase ] ->
   (merge_result, error) Result.t
-(** [merge_pr ~net t ~pr_number ~merge_method] merges a PR via
+(** [merge_pr ~net ~clock t ~pr_number ~merge_method] merges a PR via
     [PUT /repos/:owner/:repo/pulls/:number/merge]. A 2xx HTTP status does NOT
     imply the merge completed: the caller must inspect the returned
     [merge_result] to distinguish an actual merge from a queued request or an

--- a/lib/startup_reconciler.ml
+++ b/lib/startup_reconciler.ml
@@ -26,8 +26,8 @@ type t = {
 
 (** Query GitHub REST API for a branch, returning discovery info for the first
     non-CLOSED PR. *)
-let discover_pr ~net ~github ~branch =
-  match Github.list_prs ~net github ~branch ~state:`All () with
+let discover_pr ~net ~clock ~github ~branch =
+  match Github.list_prs ~net ~clock github ~branch ~state:`All () with
   | Ok [] -> Ok None
   | Ok ((pr_number, base_branch, merged) :: _) ->
       Ok (Some (pr_number, base_branch, merged))
@@ -66,12 +66,12 @@ let find_stale_busy ~agents =
   List.filter_map agents ~f:(fun (agent : Patch_agent.t) ->
       if agent.busy then Some agent.patch_id else None)
 
-let reconcile ~net ~github ~patches ?(repo_root = ".") ?process_mgr
+let reconcile ~net ~clock ~github ~patches ?(repo_root = ".") ?process_mgr
     ?(agents = []) ?pre_recovered_worktrees () =
   let results =
     Eio.Fiber.List.map ~max_fibers:8
       (fun (patch : Patch.t) ->
-        let r = discover_pr ~net ~github ~branch:patch.branch in
+        let r = discover_pr ~net ~clock ~github ~branch:patch.branch in
         (patch, r))
       patches
   in

--- a/lib/startup_reconciler.mli
+++ b/lib/startup_reconciler.mli
@@ -48,6 +48,7 @@ type t = {
 
 val discover_pr :
   net:_ Eio.Net.t ->
+  clock:_ Eio.Time.clock ->
   github:Github.t ->
   branch:Branch.t ->
   ((Pr_number.t * Branch.t * bool) option, string) Result.t
@@ -65,6 +66,7 @@ val recover_worktrees :
 
 val reconcile :
   net:_ Eio.Net.t ->
+  clock:_ Eio.Time.clock ->
   github:Github.t ->
   patches:Patch.t list ->
   ?repo_root:string ->

--- a/lib_core/poll_cycle.ml
+++ b/lib_core/poll_cycle.ml
@@ -1,0 +1,154 @@
+open Base
+open Types
+
+(** Pure planning layer between the effectful per-patch poll driver and the
+    orchestrator state machine.
+
+    The poll cycle has a hard separation between an effectful side (per-patch
+    HTTPS call, with [Eio.Time.with_timeout]) and a pure side (turning each
+    patch's outcome into an orchestrator action). This module is the pure
+    side. It exists so the per-patch-isolation guarantee can be property-
+    tested without an event loop: if one patch's poll times out, every other
+    patch's classification must be identical to the run where that patch was
+    excluded. *)
+
+type input = {
+  patch_id : Patch_id.t;
+  pr_number : Pr_number.t;
+  was_merged : bool;
+  outcome : Poll_outcome.t;
+}
+[@@deriving show, eq]
+
+type classification =
+  | Apply_pr_state of {
+      pr_state : Pr_state.t;
+      poll_result : Poller.t;
+      ci_checks_truncated : bool;
+    }
+      (** Successful, non-fork, non-closed poll. The driver should build a
+          [Patch_controller.observation] (filling in branch_in_root and
+          worktree_path from effectful checks) and apply via
+          [Patch_controller.apply_poll_result]. *)
+  | Skip_fork of { head_branch : Branch.t option }
+      (** [pr_state.is_fork] was true. The driver should log once per patch
+          and do nothing else. *)
+  | Rediscover_pr of { head_branch : Branch.t option }
+      (** [pr_state.closed] was true. The driver must call [discover_pr] to
+          find a replacement PR (effectful — separate I/O path). *)
+  | Log_error of { message : string }
+      (** Transport / timeout / HTTP / GraphQL / parse error. The driver
+          logs the message; the orchestrator state for this patch is
+          unchanged this tick. *)
+[@@deriving show, eq]
+
+let classify (input : input) : classification =
+  match input.outcome with
+  | Poll_outcome.Ok_pr_state pr_state when Pr_state.is_fork pr_state ->
+      Skip_fork { head_branch = pr_state.Pr_state.head_branch }
+  | Poll_outcome.Ok_pr_state pr_state ->
+      let poll_result = Poller.poll ~was_merged:input.was_merged pr_state in
+      if poll_result.Poller.closed then
+        Rediscover_pr { head_branch = pr_state.Pr_state.head_branch }
+      else
+        Apply_pr_state
+          {
+            pr_state;
+            poll_result;
+            ci_checks_truncated = pr_state.Pr_state.ci_checks_truncated;
+          }
+  | Poll_outcome.Timed_out { seconds } ->
+      Log_error
+        {
+          message =
+            Printf.sprintf "Poll error — request timed out after %.0fs" seconds;
+        }
+  | Poll_outcome.Transport_failed { msg } ->
+      Log_error
+        { message = Printf.sprintf "Poll error — transport error: %s" msg }
+  | Poll_outcome.Http_failed { status; msg } ->
+      Log_error
+        { message = Printf.sprintf "Poll error — HTTP %d: %s" status msg }
+  | Poll_outcome.Graphql_failed msgs ->
+      Log_error
+        {
+          message =
+            Printf.sprintf "Poll error — GraphQL: %s"
+              (String.concat ~sep:"; " msgs);
+        }
+  | Poll_outcome.Json_parse_failed msg ->
+      Log_error
+        { message = Printf.sprintf "Poll error — JSON parse: %s" msg }
+
+let plan inputs : (Patch_id.t * Pr_number.t * classification) list =
+  List.map inputs ~f:(fun input ->
+      (input.patch_id, input.pr_number, classify input))
+
+(* ── Inline property hooks ── *)
+
+let%test "classify is total over Timed_out" =
+  let pr_number = Pr_number.of_int 1 in
+  let patch_id = Patch_id.of_string "p1" in
+  match
+    classify
+      {
+        patch_id;
+        pr_number;
+        was_merged = false;
+        outcome = Poll_outcome.Timed_out { seconds = 30.0 };
+      }
+  with
+  | Log_error _ -> true
+  | Apply_pr_state _ | Skip_fork _ | Rediscover_pr _ -> false
+
+let%test "classify of Transport_failed is Log_error" =
+  match
+    classify
+      {
+        patch_id = Patch_id.of_string "p1";
+        pr_number = Pr_number.of_int 1;
+        was_merged = false;
+        outcome = Poll_outcome.Transport_failed { msg = "connection refused" };
+      }
+  with
+  | Log_error { message } -> String.is_substring message ~substring:"transport"
+  | Apply_pr_state _ | Skip_fork _ | Rediscover_pr _ -> false
+
+let%test "plan preserves input order" =
+  let mk i outcome =
+    {
+      patch_id = Patch_id.of_string (Printf.sprintf "p%d" i);
+      pr_number = Pr_number.of_int i;
+      was_merged = false;
+      outcome;
+    }
+  in
+  let inputs =
+    [
+      mk 1 (Poll_outcome.Timed_out { seconds = 30.0 });
+      mk 2 (Poll_outcome.Transport_failed { msg = "foo" });
+      mk 3 (Poll_outcome.Http_failed { status = 500; msg = "bar" });
+    ]
+  in
+  let ids = List.map (plan inputs) ~f:(fun (pid, _, _) -> pid) in
+  List.equal Patch_id.equal ids
+    [
+      Patch_id.of_string "p1";
+      Patch_id.of_string "p2";
+      Patch_id.of_string "p3";
+    ]
+
+let%test "classify ignores other patches in the list" =
+  (* The signature of [classify] takes a single input, so this is a typing
+     guarantee — but assert the invariant explicitly anyway: classifying
+     the same input twice in different surrounding contexts yields the
+     same answer. *)
+  let input =
+    {
+      patch_id = Patch_id.of_string "p1";
+      pr_number = Pr_number.of_int 1;
+      was_merged = false;
+      outcome = Poll_outcome.Timed_out { seconds = 30.0 };
+    }
+  in
+  equal_classification (classify input) (classify input)

--- a/lib_core/poll_cycle.ml
+++ b/lib_core/poll_cycle.ml
@@ -6,11 +6,11 @@ open Types
 
     The poll cycle has a hard separation between an effectful side (per-patch
     HTTPS call, with [Eio.Time.with_timeout]) and a pure side (turning each
-    patch's outcome into an orchestrator action). This module is the pure
-    side. It exists so the per-patch-isolation guarantee can be property-
-    tested without an event loop: if one patch's poll times out, every other
-    patch's classification must be identical to the run where that patch was
-    excluded. *)
+    patch's outcome into an orchestrator action). This module is the pure side.
+    It exists so the per-patch-isolation guarantee can be property tested
+    without an event loop: if one patch's poll times out, every other patch's
+    classification must be identical to the run where that patch was excluded.
+*)
 
 type input = {
   patch_id : Patch_id.t;
@@ -31,15 +31,15 @@ type classification =
           worktree_path from effectful checks) and apply via
           [Patch_controller.apply_poll_result]. *)
   | Skip_fork of { head_branch : Branch.t option }
-      (** [pr_state.is_fork] was true. The driver should log once per patch
-          and do nothing else. *)
+      (** [pr_state.is_fork] was true. The driver should log once per patch and
+          do nothing else. *)
   | Rediscover_pr of { head_branch : Branch.t option }
-      (** [pr_state.closed] was true. The driver must call [discover_pr] to
-          find a replacement PR (effectful — separate I/O path). *)
+      (** [pr_state.closed] was true. The driver must call [discover_pr] to find
+          a replacement PR (effectful — separate I/O path). *)
   | Log_error of { message : string }
-      (** Transport / timeout / HTTP / GraphQL / parse error. The driver
-          logs the message; the orchestrator state for this patch is
-          unchanged this tick. *)
+      (** Transport / timeout / HTTP / GraphQL / parse error. The driver logs
+          the message; the orchestrator state for this patch is unchanged this
+          tick. *)
 [@@deriving show, eq]
 
 let classify (input : input) : classification =
@@ -77,8 +77,7 @@ let classify (input : input) : classification =
               (String.concat ~sep:"; " msgs);
         }
   | Poll_outcome.Json_parse_failed msg ->
-      Log_error
-        { message = Printf.sprintf "Poll error — JSON parse: %s" msg }
+      Log_error { message = Printf.sprintf "Poll error — JSON parse: %s" msg }
 
 let plan inputs : (Patch_id.t * Pr_number.t * classification) list =
   List.map inputs ~f:(fun input ->
@@ -133,9 +132,7 @@ let%test "plan preserves input order" =
   let ids = List.map (plan inputs) ~f:(fun (pid, _, _) -> pid) in
   List.equal Patch_id.equal ids
     [
-      Patch_id.of_string "p1";
-      Patch_id.of_string "p2";
-      Patch_id.of_string "p3";
+      Patch_id.of_string "p1"; Patch_id.of_string "p2"; Patch_id.of_string "p3";
     ]
 
 let%test "classify ignores other patches in the list" =

--- a/lib_core/poll_cycle.mli
+++ b/lib_core/poll_cycle.mli
@@ -1,0 +1,40 @@
+open Types
+
+(** Pure planning layer between the effectful per-patch poll driver and the
+    orchestrator state machine.
+
+    Encodes the per-patch isolation guarantee in the type system:
+    [classify] consumes a single [input] and produces a single
+    [classification], so the output for patch X cannot depend on any other
+    patch's outcome. Property tests assert the corresponding behavioural
+    invariant — substituting any subset of inputs with [Timed_out] leaves
+    every other patch's classification unchanged. *)
+
+type input = {
+  patch_id : Patch_id.t;
+  pr_number : Pr_number.t;
+  was_merged : bool;
+  outcome : Poll_outcome.t;
+}
+[@@deriving show, eq]
+
+type classification =
+  | Apply_pr_state of {
+      pr_state : Pr_state.t;
+      poll_result : Poller.t;
+      ci_checks_truncated : bool;
+    }
+  | Skip_fork of { head_branch : Branch.t option }
+  | Rediscover_pr of { head_branch : Branch.t option }
+  | Log_error of { message : string }
+[@@deriving show, eq]
+
+val classify : input -> classification
+(** [classify input] is total: it returns a [classification] for every
+    possible [outcome], never raises, never observes any state outside
+    [input]. *)
+
+val plan :
+  input list -> (Patch_id.t * Pr_number.t * classification) list
+(** [plan inputs] applies [classify] to each input in order. Pure;
+    order-preserving; per-patch independent. *)

--- a/lib_core/poll_cycle.mli
+++ b/lib_core/poll_cycle.mli
@@ -3,12 +3,12 @@ open Types
 (** Pure planning layer between the effectful per-patch poll driver and the
     orchestrator state machine.
 
-    Encodes the per-patch isolation guarantee in the type system:
-    [classify] consumes a single [input] and produces a single
-    [classification], so the output for patch X cannot depend on any other
-    patch's outcome. Property tests assert the corresponding behavioural
-    invariant — substituting any subset of inputs with [Timed_out] leaves
-    every other patch's classification unchanged. *)
+    Encodes the per-patch isolation guarantee in the type system: [classify]
+    consumes a single [input] and produces a single [classification], so the
+    output for patch X cannot depend on any other patch's outcome. Property
+    tests assert the corresponding behavioural invariant — substituting any
+    subset of inputs with [Timed_out] leaves every other patch's classification
+    unchanged. *)
 
 type input = {
   patch_id : Patch_id.t;
@@ -30,11 +30,9 @@ type classification =
 [@@deriving show, eq]
 
 val classify : input -> classification
-(** [classify input] is total: it returns a [classification] for every
-    possible [outcome], never raises, never observes any state outside
-    [input]. *)
+(** [classify input] is total: it returns a [classification] for every possible
+    [outcome], never raises, never observes any state outside [input]. *)
 
-val plan :
-  input list -> (Patch_id.t * Pr_number.t * classification) list
+val plan : input list -> (Patch_id.t * Pr_number.t * classification) list
 (** [plan inputs] applies [classify] to each input in order. Pure;
     order-preserving; per-patch independent. *)

--- a/lib_core/poll_outcome.ml
+++ b/lib_core/poll_outcome.ml
@@ -1,0 +1,31 @@
+open Base
+
+(** Per-patch terminal outcome of a single GitHub poll attempt.
+
+    The effectful poll driver translates [Github.error] and the success
+    case into this typed variant before crossing into the pure planning
+    layer. That boundary lets [Poll_cycle.classify] be tested with
+    property interleavings without spinning up a real HTTP client.
+
+    The [Timed_out] variant exists specifically to model the failure mode
+    that wedged the production poller (TCP [SYN_SENT] never returning):
+    the effectful driver must convert hangs to [Timed_out] within a
+    bounded interval, so the pure layer never has to reason about
+    infinite waits. *)
+type t =
+  | Ok_pr_state of Pr_state.t
+      (** The GitHub call returned a parsed [Pr_state.t]. Downstream
+          classification may still treat this as a no-op (fork, closed). *)
+  | Transport_failed of { msg : string }
+      (** Network-layer failure (TLS, DNS, connection refused, etc.). *)
+  | Timed_out of { seconds : float }
+      (** The effectful driver gave up after [seconds]. The TCP connect
+          may still be in [SYN_SENT] under the hood — what matters is
+          that the pure layer sees a value. *)
+  | Http_failed of { status : int; msg : string }
+      (** GitHub returned a non-2xx status. *)
+  | Graphql_failed of string list
+      (** GraphQL response carried [errors[]] messages. *)
+  | Json_parse_failed of string
+      (** Response body did not parse as the expected JSON shape. *)
+[@@deriving show, eq]

--- a/lib_core/poll_outcome.ml
+++ b/lib_core/poll_outcome.ml
@@ -2,16 +2,15 @@ open Base
 
 (** Per-patch terminal outcome of a single GitHub poll attempt.
 
-    The effectful poll driver translates [Github.error] and the success
-    case into this typed variant before crossing into the pure planning
-    layer. That boundary lets [Poll_cycle.classify] be tested with
-    property interleavings without spinning up a real HTTP client.
+    The effectful poll driver translates [Github.error] and the success case
+    into this typed variant before crossing into the pure planning layer. That
+    boundary lets [Poll_cycle.classify] be tested with property interleavings
+    without spinning up a real HTTP client.
 
-    The [Timed_out] variant exists specifically to model the failure mode
-    that wedged the production poller (TCP [SYN_SENT] never returning):
-    the effectful driver must convert hangs to [Timed_out] within a
-    bounded interval, so the pure layer never has to reason about
-    infinite waits. *)
+    The [Timed_out] variant exists specifically to model the failure mode that
+    wedged the production poller (TCP [SYN_SENT] never returning): the effectful
+    driver must convert hangs to [Timed_out] within a bounded interval, so the
+    pure layer never has to reason about infinite waits. *)
 type t =
   | Ok_pr_state of Pr_state.t
       (** The GitHub call returned a parsed [Pr_state.t]. Downstream
@@ -19,9 +18,9 @@ type t =
   | Transport_failed of { msg : string }
       (** Network-layer failure (TLS, DNS, connection refused, etc.). *)
   | Timed_out of { seconds : float }
-      (** The effectful driver gave up after [seconds]. The TCP connect
-          may still be in [SYN_SENT] under the hood — what matters is
-          that the pure layer sees a value. *)
+      (** The effectful driver gave up after [seconds]. The TCP connect may
+          still be in [SYN_SENT] under the hood — what matters is that the pure
+          layer sees a value. *)
   | Http_failed of { status : int; msg : string }
       (** GitHub returned a non-2xx status. *)
   | Graphql_failed of string list

--- a/lib_core/poll_outcome.mli
+++ b/lib_core/poll_outcome.mli
@@ -1,9 +1,9 @@
 (** Per-patch terminal outcome of a single GitHub poll attempt.
 
-    The effectful poll driver translates [Github.error] and the success
-    case into this typed variant before handing off to the pure
-    [Poll_cycle.classify]. Modeling timeouts as a normal variant lets
-    the planning layer reason about hangs as bounded events.
+    The effectful poll driver translates [Github.error] and the success case
+    into this typed variant before handing off to the pure
+    [Poll_cycle.classify]. Modeling timeouts as a normal variant lets the
+    planning layer reason about hangs as bounded events.
 
     See {!Poll_cycle} for the pure consumer and the per-patch isolation
     properties that this typing enables. *)

--- a/lib_core/poll_outcome.mli
+++ b/lib_core/poll_outcome.mli
@@ -1,0 +1,17 @@
+(** Per-patch terminal outcome of a single GitHub poll attempt.
+
+    The effectful poll driver translates [Github.error] and the success
+    case into this typed variant before handing off to the pure
+    [Poll_cycle.classify]. Modeling timeouts as a normal variant lets
+    the planning layer reason about hangs as bounded events.
+
+    See {!Poll_cycle} for the pure consumer and the per-patch isolation
+    properties that this typing enables. *)
+type t =
+  | Ok_pr_state of Pr_state.t
+  | Transport_failed of { msg : string }
+  | Timed_out of { seconds : float }
+  | Http_failed of { status : int; msg : string }
+  | Graphql_failed of string list
+  | Json_parse_failed of string
+[@@deriving show, eq]

--- a/test/dune
+++ b/test/dune
@@ -134,6 +134,13 @@
  (libraries onton_core onton_test_support qcheck-core))
 
 (test
+ (name test_poll_cycle_properties)
+ (modules test_poll_cycle_properties)
+ (libraries onton onton_core onton_test_support qcheck-core qcheck-core.runner)
+ (ocamlopt_flags (:standard -w -40-42))
+ (ocamlc_flags (:standard -w -40-42)))
+
+(test
  (name test_tui_scheduling)
  (modules test_tui_scheduling)
  (libraries onton onton_core eio eio_main eio.unix unix))

--- a/test/dune
+++ b/test/dune
@@ -136,7 +136,7 @@
 (test
  (name test_poll_cycle_properties)
  (modules test_poll_cycle_properties)
- (libraries onton onton_core onton_test_support qcheck-core qcheck-core.runner)
+ (libraries onton_core onton_test_support qcheck-core qcheck-core.runner)
  (ocamlopt_flags (:standard -w -40-42))
  (ocamlc_flags (:standard -w -40-42)))
 

--- a/test/test_poll_cycle_properties.ml
+++ b/test/test_poll_cycle_properties.ml
@@ -1,0 +1,258 @@
+open Base
+open Onton
+open Onton_core
+open Onton_core.Types
+
+(** Property tests for [Poll_cycle.classify] / [Poll_cycle.plan].
+
+    The poll cycle is split into:
+    - an effectful per-patch driver (one fiber per patch, with
+      [Eio.Time.with_timeout] around the HTTPS call) that translates the
+      result into a {!Poll_outcome.t};
+    - a pure [Poll_cycle.classify] / [Poll_cycle.plan] that turns the
+      outcome into a [classification].
+
+    These properties exercise the pure side under arbitrary
+    {!Poll_outcome.t} interleavings to assert the guarantees the production
+    bug exploited: a hang on one patch cannot leak into another patch's
+    state, and the planning layer is total over the entire outcome
+    variant. *)
+
+(* -- Generators -- *)
+
+let gen_patch_id =
+  QCheck2.Gen.(map (fun i -> Patch_id.of_string (Printf.sprintf "p%d" i)) nat)
+
+let gen_pr_number = QCheck2.Gen.(map Pr_number.of_int (int_range 1 9999))
+let gen_was_merged = QCheck2.Gen.bool
+
+let gen_pr_state = Onton_test_support.Test_generators.gen_pr_state
+
+let gen_outcome =
+  let open QCheck2.Gen in
+  let timed_out = map (fun s -> Poll_outcome.Timed_out { seconds = s })
+    (float_range 1.0 60.0) in
+  let transport =
+    map (fun msg -> Poll_outcome.Transport_failed { msg })
+      (string_size (int_range 0 32)) in
+  let http =
+    map2 (fun status msg -> Poll_outcome.Http_failed { status; msg })
+      (oneof_list [ 400; 401; 403; 404; 422; 500; 502; 503 ])
+      (string_size (int_range 0 32)) in
+  let graphql =
+    map (fun msgs -> Poll_outcome.Graphql_failed msgs)
+      (list_size (int_range 0 4) (string_size (int_range 0 16))) in
+  let parse =
+    map (fun msg -> Poll_outcome.Json_parse_failed msg)
+      (string_size (int_range 0 32)) in
+  let ok = map (fun pr -> Poll_outcome.Ok_pr_state pr) gen_pr_state in
+  oneof [ ok; timed_out; transport; http; graphql; parse ]
+
+let gen_input =
+  let open QCheck2.Gen in
+  let* patch_id = gen_patch_id in
+  let* pr_number = gen_pr_number in
+  let* was_merged = gen_was_merged in
+  let* outcome = gen_outcome in
+  return Poll_cycle.{ patch_id; pr_number; was_merged; outcome }
+
+(* Dedupe by patch_id within a list — distinct patches per cycle. *)
+let dedupe_by_patch_id (inputs : Poll_cycle.input list) =
+  let seen = Hash_set.create (module Patch_id) in
+  List.filter inputs ~f:(fun i ->
+      if Hash_set.mem seen i.Poll_cycle.patch_id then false
+      else (
+        Hash_set.add seen i.Poll_cycle.patch_id;
+        true))
+
+let gen_inputs =
+  QCheck2.Gen.(
+    let* inputs = list_size (int_range 0 12) gen_input in
+    return (dedupe_by_patch_id inputs))
+
+(* -- Properties -- *)
+
+let print_inputs (inputs : Poll_cycle.input list) =
+  Printf.sprintf "[%s]"
+    (String.concat ~sep:"; "
+       (List.map inputs ~f:(fun i ->
+            Printf.sprintf "(%s,#%d,%s)"
+              (Patch_id.to_string i.Poll_cycle.patch_id)
+              (Pr_number.to_int i.Poll_cycle.pr_number)
+              (Poll_outcome.show i.Poll_cycle.outcome))))
+
+let prop_totality =
+  let open QCheck2 in
+  Test.make ~name:"Poll_cycle.classify is total over all outcomes" ~count:2000
+    ~print:(fun i ->
+      Printf.sprintf "(%s,%s)"
+        (Patch_id.to_string i.Poll_cycle.patch_id)
+        (Poll_outcome.show i.Poll_cycle.outcome))
+    gen_input
+    (fun input ->
+      try
+        let _ = Poll_cycle.classify input in
+        true
+      with _ -> false)
+
+let prop_plan_preserves_length =
+  let open QCheck2 in
+  Test.make ~name:"Poll_cycle.plan output has the same length as input"
+    ~count:500 ~print:print_inputs gen_inputs (fun inputs ->
+      let plans = Poll_cycle.plan inputs in
+      List.length plans = List.length inputs)
+
+let prop_plan_preserves_order =
+  let open QCheck2 in
+  Test.make ~name:"Poll_cycle.plan preserves input ordering by patch_id"
+    ~count:500 ~print:print_inputs gen_inputs (fun inputs ->
+      let input_ids =
+        List.map inputs ~f:(fun i -> i.Poll_cycle.patch_id)
+      in
+      let plan_ids =
+        List.map (Poll_cycle.plan inputs) ~f:(fun (pid, _, _) -> pid)
+      in
+      List.equal Patch_id.equal input_ids plan_ids)
+
+let prop_classify_per_input_only =
+  (* Per-patch isolation: classify's output for a given input is identical no
+     matter what surrounds it. This is automatic from the type signature
+     (classify : input -> classification) but asserts it behaviourally. *)
+  let open QCheck2 in
+  Test.make
+    ~name:
+      "Poll_cycle.classify output is determined solely by its own input \
+       (per-patch isolation)"
+    ~count:500
+    ~print:(fun (input, surrounding) ->
+      Printf.sprintf "input=(%s,%s); surrounding=%s"
+        (Patch_id.to_string input.Poll_cycle.patch_id)
+        (Poll_outcome.show input.Poll_cycle.outcome)
+        (print_inputs surrounding))
+    (Gen.pair gen_input gen_inputs)
+    (fun (input, surrounding) ->
+      let plans_with =
+        Poll_cycle.plan (input :: List.filter surrounding ~f:(fun i ->
+                                       not
+                                         (Patch_id.equal i.Poll_cycle.patch_id
+                                            input.Poll_cycle.patch_id)))
+      in
+      let plans_alone = Poll_cycle.plan [ input ] in
+      match (plans_with, plans_alone) with
+      | (pid1, _, cls1) :: _, [ (pid2, _, cls2) ] ->
+          Patch_id.equal pid1 pid2 && Poll_cycle.equal_classification cls1 cls2
+      | _ -> false)
+
+let prop_timeout_substitution_isolates =
+  (* THE central property: substituting any patch's outcome with [Timed_out]
+     leaves every OTHER patch's classification unchanged.
+
+     This is the property whose violation was the bug — the production poller
+     blocked all patches on one stuck connect. With the new fan-out, each
+     patch's outcome is independent; the pure planning layer must reflect
+     that. *)
+  let open QCheck2 in
+  Test.make
+    ~name:
+      "substituting Timed_out for any subset leaves other patches' \
+       classifications unchanged"
+    ~count:500
+    ~print:(fun (inputs, mask) ->
+      Printf.sprintf "inputs=%s; mask=[%s]" (print_inputs inputs)
+        (String.concat ~sep:";" (List.map mask ~f:Bool.to_string)))
+    Gen.(
+      let* inputs = gen_inputs in
+      let* mask = list_size (return (List.length inputs)) bool in
+      return (inputs, mask))
+    (fun (inputs, mask) ->
+      let mask =
+        List.take mask (List.length inputs)
+        @ List.init
+            (Int.max 0 (List.length inputs - List.length mask))
+            ~f:(fun _ -> false)
+      in
+      let timeout =
+        Poll_outcome.Timed_out { seconds = Github.default_timeout }
+      in
+      let substituted =
+        List.map2_exn inputs mask ~f:(fun input replace ->
+            if replace then { input with Poll_cycle.outcome = timeout }
+            else input)
+      in
+      let plans_orig = Poll_cycle.plan inputs in
+      let plans_sub = Poll_cycle.plan substituted in
+      List.for_all2_exn plans_orig plans_sub
+        ~f:(fun (pid1, _, cls1) (pid2, _, cls2) ->
+          if not (Patch_id.equal pid1 pid2) then false
+          else
+            let was_substituted =
+              let n =
+                List.findi inputs ~f:(fun _ i ->
+                    Patch_id.equal i.Poll_cycle.patch_id pid1)
+                |> Option.map ~f:fst |> Option.value ~default:(-1)
+              in
+              n >= 0 && List.nth_exn mask n
+            in
+            if was_substituted then
+              (* If the patch was substituted, its classification may differ —
+                 but it must be Log_error (since timeouts always classify as
+                 Log_error). That's a separate sub-property. *)
+              match cls2 with
+              | Poll_cycle.Log_error _ -> true
+              | Apply_pr_state _ | Skip_fork _ | Rediscover_pr _ -> false
+            else Poll_cycle.equal_classification cls1 cls2))
+
+let prop_permutation_invariance =
+  (* Reordering inputs yields the same multiset of (patch_id, classification)
+     pairs. Combined with order preservation, this is a sanity check on
+     plan = List.map classify. *)
+  let open QCheck2 in
+  Test.make
+    ~name:
+      "Poll_cycle.plan is permutation-invariant on (patch_id, classification) \
+       multiset" ~count:500 ~print:print_inputs gen_inputs (fun inputs ->
+      let shuffled = List.rev inputs in
+      let key_set plans =
+        List.map plans ~f:(fun (pid, _, cls) ->
+            (Patch_id.to_string pid, Poll_cycle.show_classification cls))
+        |> List.sort ~compare:(fun (a1, b1) (a2, b2) ->
+               match String.compare a1 a2 with
+               | 0 -> String.compare b1 b2
+               | n -> n)
+      in
+      List.equal
+        (fun (a1, b1) (a2, b2) -> String.equal a1 a2 && String.equal b1 b2)
+        (key_set (Poll_cycle.plan inputs))
+        (key_set (Poll_cycle.plan shuffled)))
+
+let prop_timeout_always_log_error =
+  let open QCheck2 in
+  Test.make ~name:"Poll_cycle.classify of Timed_out is always Log_error"
+    ~count:1000
+    Gen.(pair gen_patch_id (float_range 0.0 600.0))
+    (fun (patch_id, seconds) ->
+      let input =
+        Poll_cycle.
+          {
+            patch_id;
+            pr_number = Pr_number.of_int 1;
+            was_merged = false;
+            outcome = Poll_outcome.Timed_out { seconds };
+          }
+      in
+      match Poll_cycle.classify input with
+      | Log_error { message } ->
+          Base.String.is_substring message ~substring:"timed out"
+      | Apply_pr_state _ | Skip_fork _ | Rediscover_pr _ -> false)
+
+let () =
+  QCheck_base_runner.run_tests_main
+    [
+      prop_totality;
+      prop_plan_preserves_length;
+      prop_plan_preserves_order;
+      prop_classify_per_input_only;
+      prop_timeout_substitution_isolates;
+      prop_permutation_invariance;
+      prop_timeout_always_log_error;
+    ]

--- a/test/test_poll_cycle_properties.ml
+++ b/test/test_poll_cycle_properties.ml
@@ -7,16 +7,15 @@ open Onton_core.Types
 
     The poll cycle is split into:
     - an effectful per-patch driver (one fiber per patch, with
-      [Eio.Time.with_timeout] around the HTTPS call) that translates the
-      result into a {!Poll_outcome.t};
-    - a pure [Poll_cycle.classify] / [Poll_cycle.plan] that turns the
-      outcome into a [classification].
+      [Eio.Time.with_timeout] around the HTTPS call) that translates the result
+      into a {!Poll_outcome.t};
+    - a pure [Poll_cycle.classify] / [Poll_cycle.plan] that turns the outcome
+      into a [classification].
 
-    These properties exercise the pure side under arbitrary
-    {!Poll_outcome.t} interleavings to assert the guarantees the production
-    bug exploited: a hang on one patch cannot leak into another patch's
-    state, and the planning layer is total over the entire outcome
-    variant. *)
+    These properties exercise the pure side under arbitrary {!Poll_outcome.t}
+    interleavings to assert the guarantees the production bug exploited: a hang
+    on one patch cannot leak into another patch's state, and the planning layer
+    is total over the entire outcome variant. *)
 
 (* -- Generators -- *)
 
@@ -25,26 +24,34 @@ let gen_patch_id =
 
 let gen_pr_number = QCheck2.Gen.(map Pr_number.of_int (int_range 1 9999))
 let gen_was_merged = QCheck2.Gen.bool
-
 let gen_pr_state = Onton_test_support.Test_generators.gen_pr_state
 
 let gen_outcome =
   let open QCheck2.Gen in
-  let timed_out = map (fun s -> Poll_outcome.Timed_out { seconds = s })
-    (float_range 1.0 60.0) in
+  let timed_out =
+    map (fun s -> Poll_outcome.Timed_out { seconds = s }) (float_range 1.0 60.0)
+  in
   let transport =
-    map (fun msg -> Poll_outcome.Transport_failed { msg })
-      (string_size (int_range 0 32)) in
+    map
+      (fun msg -> Poll_outcome.Transport_failed { msg })
+      (string_size (int_range 0 32))
+  in
   let http =
-    map2 (fun status msg -> Poll_outcome.Http_failed { status; msg })
+    map2
+      (fun status msg -> Poll_outcome.Http_failed { status; msg })
       (oneof_list [ 400; 401; 403; 404; 422; 500; 502; 503 ])
-      (string_size (int_range 0 32)) in
+      (string_size (int_range 0 32))
+  in
   let graphql =
-    map (fun msgs -> Poll_outcome.Graphql_failed msgs)
-      (list_size (int_range 0 4) (string_size (int_range 0 16))) in
+    map
+      (fun msgs -> Poll_outcome.Graphql_failed msgs)
+      (list_size (int_range 0 4) (string_size (int_range 0 16)))
+  in
   let parse =
-    map (fun msg -> Poll_outcome.Json_parse_failed msg)
-      (string_size (int_range 0 32)) in
+    map
+      (fun msg -> Poll_outcome.Json_parse_failed msg)
+      (string_size (int_range 0 32))
+  in
   let ok = map (fun pr -> Poll_outcome.Ok_pr_state pr) gen_pr_state in
   oneof [ ok; timed_out; transport; http; graphql; parse ]
 
@@ -106,9 +113,7 @@ let prop_plan_preserves_order =
   let open QCheck2 in
   Test.make ~name:"Poll_cycle.plan preserves input ordering by patch_id"
     ~count:500 ~print:print_inputs gen_inputs (fun inputs ->
-      let input_ids =
-        List.map inputs ~f:(fun i -> i.Poll_cycle.patch_id)
-      in
+      let input_ids = List.map inputs ~f:(fun i -> i.Poll_cycle.patch_id) in
       let plan_ids =
         List.map (Poll_cycle.plan inputs) ~f:(fun (pid, _, _) -> pid)
       in
@@ -132,10 +137,12 @@ let prop_classify_per_input_only =
     (Gen.pair gen_input gen_inputs)
     (fun (input, surrounding) ->
       let plans_with =
-        Poll_cycle.plan (input :: List.filter surrounding ~f:(fun i ->
-                                       not
-                                         (Patch_id.equal i.Poll_cycle.patch_id
-                                            input.Poll_cycle.patch_id)))
+        Poll_cycle.plan
+          (input
+          :: List.filter surrounding ~f:(fun i ->
+              not
+                (Patch_id.equal i.Poll_cycle.patch_id input.Poll_cycle.patch_id))
+          )
       in
       let plans_alone = Poll_cycle.plan [ input ] in
       match (plans_with, plans_alone) with
@@ -216,9 +223,7 @@ let prop_permutation_invariance =
         List.map plans ~f:(fun (pid, _, cls) ->
             (Patch_id.to_string pid, Poll_cycle.show_classification cls))
         |> List.sort ~compare:(fun (a1, b1) (a2, b2) ->
-               match String.compare a1 a2 with
-               | 0 -> String.compare b1 b2
-               | n -> n)
+            match String.compare a1 a2 with 0 -> String.compare b1 b2 | n -> n)
       in
       List.equal
         (fun (a1, b1) (a2, b2) -> String.equal a1 a2 && String.equal b1 b2)

--- a/test/test_poll_cycle_properties.ml
+++ b/test/test_poll_cycle_properties.ml
@@ -1,5 +1,4 @@
 open Base
-open Onton
 open Onton_core
 open Onton_core.Types
 
@@ -178,9 +177,8 @@ let prop_timeout_substitution_isolates =
             (Int.max 0 (List.length inputs - List.length mask))
             ~f:(fun _ -> false)
       in
-      let timeout =
-        Poll_outcome.Timed_out { seconds = Github.default_timeout }
-      in
+      let timeout_s = 30.0 in
+      let timeout = Poll_outcome.Timed_out { seconds = timeout_s } in
       let substituted =
         List.map2_exn inputs mask ~f:(fun input replace ->
             if replace then { input with Poll_cycle.outcome = timeout }


### PR DESCRIPTION
## Summary

- **Root cause**: `lib/github.ml`'s `request` had no `Eio.Time.with_timeout` wrap, so a TCP connect stuck in `SYN_SENT` blocked the poll fiber forever. Wedged a live orchestrator in production this morning (`events.jsonl` frozen at the moment of the stuck connect; PR went green afterwards, automerge never fired).
- **Compounding bug**: `poller_fiber`'s per-patch `List.filter_map` was sequential — one hung `Github.pr_state` froze every other patch's poll, even before the timeout was missing.
- **Fix**: wrap `Github.request` in `Eio.Time.with_timeout` (30s default, matches `review_service_client`), thread `~clock` through every public `Github.*` function and call site, and fan out per-patch polls with `Eio.Fiber.List.map ~max_fibers:16` so a hang on one patch doesn't block the others.
- **Architecture**: per-patch outcomes flow through a typed `Poll_outcome.t` variant into a pure `Poll_cycle.classify : input -> classification`, splitting the effectful HTTPS call from the planning decision.

## Architecture

| Layer | Before | After |
|---|---|---|
| `Github.request` | `Switch.run`, no clock | `Switch.run` inside `Eio.Time.with_timeout`; `\`Timeout` → `Transport_error` |
| Poll cycle driver | sequential `List.filter_map` | `Eio.Fiber.List.map ~max_fibers:16` — per-patch isolation |
| Outcome → orchestrator update | inlined in `poller_fiber` | new pure `Poll_outcome.t` + `Poll_cycle.classify` |

The per-patch-isolation guarantee lives in the type signature: `classify : input -> classification` can't observe any other patch's outcome. The property tests in `test_poll_cycle_properties.ml` (500–2000 trials each) assert the behavioural counterpart:

- **Totality** — `classify` never raises over any `Poll_outcome.t`.
- **Per-input isolation** — `classify` output for a given input is identical regardless of surrounding inputs.
- **Timeout-substitution isolation (the central one)** — substituting `Timed_out` for any subset of patches leaves every other patch's classification unchanged. This is the guarantee whose violation was the production bug.
- **Permutation invariance**, **order preservation**, **length preservation**, **Timed_out → Log_error**.

## Test plan

- [x] `dune build` clean
- [x] `dune runtest` exits 0 — full suite including new property tests at 500–2000 trials each, all existing tests, and inline tests on the new modules
- [x] New `test/test_poll_cycle_properties.ml` runs 7 properties; all pass under the default QCheck2 seed and several random seeds
- [ ] Verify on a live orchestrator that a deliberately blocked outbound to api.github.com (e.g. `pfctl` block) yields a `Transport_error: request timed out after 30s` log entry per patch within ~30s, and that other patches keep polling
- [ ] Once landed, kill the wedged orchestrator (PID 35569 on my box) and relaunch from this build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/284"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a 30s per-request timeout to all GitHub API calls and run per‑patch polls in parallel so one hung request can’t wedge the orchestrator. Timeouts are now explicit (`Github.Timeout`), and per‑patch planning is pure and isolated.

- **Bug Fixes**
  - Wrapped `Github.request` in `Eio.Time.with_timeout` (30s via `Github.default_timeout`); timeouts return `Github.Timeout` with “request timed out after Ns”.
  - Parallelized per‑patch `Github.pr_state` with `Eio.Fiber.List.map ~max_fibers:16`; a timed‑out patch logs while others keep polling.
  - Applied the same timeout to startup repo access preflight and PR discovery; skip/fork logs are emitted once per patch.

- **Refactors**
  - Threaded `~clock` and optional `?timeout` through all `Github.*`, `Startup_reconciler.*`, and `Forge.S.pr_state` APIs and updated call sites.
  - Added a pure planning layer: `Poll_outcome` (typed outcomes) and `Poll_cycle.classify` (per‑patch decisions). New property tests assert totality, per‑patch isolation, timeout‑substitution invariance, and order/length preservation.

<sup>Written for commit 27d9386e32410408b120b2b63d51331dac269cf4. Summary will update on new commits. <a href="https://cubic.dev/pr/flowglad/onton/pull/284?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

