### PR TITLE
Drop untagged raw stream lines from activity log

### DIFF
--- a/lib/activity_log_sink.ml
+++ b/lib/activity_log_sink.ml
@@ -4,11 +4,14 @@ let sink ~update () =
         update (fun log ->
             Activity_log.add_event log
               (Activity_log.Event.create ~timestamp:0. ?patch_id message))
-    | Stream { patch_id; raw; channel; _ } ->
-        let kind = Activity_log.stream_kind_of_raw ~channel raw in
-        update (fun log ->
-            Activity_log.add_stream_entry log
-              (Activity_log.Stream_entry.create ~timestamp:0. ~patch_id ~kind))
+    | Stream { patch_id; raw; channel; _ } -> (
+        match Activity_log.stream_kind_of_raw ~channel raw with
+        | None -> ()
+        | Some kind ->
+            update (fun log ->
+                Activity_log.add_stream_entry log
+                  (Activity_log.Stream_entry.create ~timestamp:0. ~patch_id
+                     ~kind)))
     | Poll _ | Action _ | Complete _ | Spawn_started _ | Spawn_finalized _ -> ()
   in
   {

--- a/lib_core/activity_log.ml
+++ b/lib_core/activity_log.ml
@@ -54,14 +54,9 @@ let add_event t event = { t with events = event :: t.events }
 let add_stream_entry t entry =
   { t with stream_entries = entry :: t.stream_entries }
 
-let stream_kind_of_raw ~channel raw =
-  let fallback () =
-    match channel with
-    | `Stdout -> Stream_entry.Text_chunk raw
-    | `Stderr -> Stream_entry.Stream_error raw
-  in
+let stream_kind_of_raw ~channel:_ raw =
   match Yojson.Safe.from_string raw with
-  | exception _ -> fallback ()
+  | exception _ -> None
   | `Assoc fields -> (
       let find_string name =
         List.find_map fields ~f:(function
@@ -70,20 +65,24 @@ let stream_kind_of_raw ~channel raw =
       in
       match find_string "activity_log_kind" with
       | Some "tool_use" ->
-          Stream_entry.Tool_use
-            ( Option.value (find_string "name") ~default:"",
-              Option.value (find_string "input") ~default:"" )
+          Some
+            (Stream_entry.Tool_use
+               ( Option.value (find_string "name") ~default:"",
+                 Option.value (find_string "input") ~default:"" ))
       | Some "text_chunk" ->
-          Stream_entry.Text_chunk
-            (Option.value (find_string "text") ~default:"")
+          Some
+            (Stream_entry.Text_chunk
+               (Option.value (find_string "text") ~default:""))
       | Some "finished" ->
-          Stream_entry.Finished
-            (Option.value (find_string "reason") ~default:"")
+          Some
+            (Stream_entry.Finished
+               (Option.value (find_string "reason") ~default:""))
       | Some "stream_error" ->
-          Stream_entry.Stream_error
-            (Option.value (find_string "message") ~default:"")
-      | _ -> fallback ())
-  | _ -> fallback ()
+          Some
+            (Stream_entry.Stream_error
+               (Option.value (find_string "message") ~default:""))
+      | _ -> None)
+  | _ -> None
 
 let recent_transitions t ~limit = List.take t.transitions limit
 let recent_events t ~limit = List.take t.events limit

--- a/lib_core/activity_log.mli
+++ b/lib_core/activity_log.mli
@@ -86,7 +86,10 @@ val trim : t -> max:int -> t
     sessions. *)
 
 val stream_kind_of_raw :
-  channel:[ `Stdout | `Stderr ] -> string -> Stream_entry.kind
-(** Decode a raw telemetry stream line into the activity-log entry kind, falling
-    back to channel-specific text/error entries when the line is not one of the
-    activity-log JSON envelopes. *)
+  channel:[ `Stdout | `Stderr ] -> string -> Stream_entry.kind option
+(** Decode a raw telemetry stream line into the activity-log entry kind. Returns
+    [None] for lines that are not [activity_log_kind]-tagged envelopes — those
+    are the raw child-process stdout/stderr lines emitted by [Llm_backend] for
+    replay diagnostics, and must not leak into the user-facing activity pane.
+    [channel] is currently unused but kept in the signature so the sink can
+    route in the future without another API churn. *)

--- a/test/test_telemetry_migration.ml
+++ b/test/test_telemetry_migration.ml
@@ -102,7 +102,10 @@ let test_activity_log_free_form () =
         (Printf.sprintf "expected one activity event, got %d"
            (List.length events))
 
-let test_activity_log_stream () =
+let test_activity_log_stream_drops_untagged () =
+  (* Raw child-process stdout/stderr lines (codex envelopes, "Tool Bash …", …)
+     are emitted by Llm_backend for replay diagnostics. They must not reach the
+     user-facing Activity pane. *)
   let log = ref Activity_log.empty in
   let update f = log := f !log in
   let patch_id = Types.Patch_id.of_string "patch-5" in
@@ -114,15 +117,52 @@ let test_activity_log_stream () =
              patch_id;
              session_uuid = Some "session-uuid";
              channel = `Stdout;
-             raw = "chunk";
+             raw = {|{"type":"turn.completed"}|};
+           });
+      Onton.Telemetry_dispatch.emit
+        (Telemetry.Event.Stream
+           {
+             patch_id;
+             session_uuid = Some "session-uuid";
+             channel = `Stderr;
+             raw = "Tool Bash — /bin/zsh -lc 'ls'";
+           }));
+  match Activity_log.recent_stream_entries !log ~limit:1 with
+  | [] -> ()
+  | entries ->
+      fail
+        (Printf.sprintf "expected zero stream entries, got %d"
+           (List.length entries))
+
+let test_activity_log_stream_accepts_tagged () =
+  let log = ref Activity_log.empty in
+  let update f = log := f !log in
+  let patch_id = Types.Patch_id.of_string "patch-5" in
+  let tagged =
+    Yojson.Safe.to_string
+      (`Assoc
+         [
+           ("activity_log_kind", `String "finished");
+           ("reason", `String "ended turn");
+         ])
+  in
+  Onton.Telemetry_dispatch.with_sink
+    ~sink:(Onton.Activity_log_sink.sink ~update ()) (fun () ->
+      Onton.Telemetry_dispatch.emit
+        (Telemetry.Event.Stream
+           {
+             patch_id;
+             session_uuid = Some "session-uuid";
+             channel = `Stdout;
+             raw = tagged;
            }));
   match Activity_log.recent_stream_entries !log ~limit:1 with
   | [ entry ] -> (
       match entry.Activity_log.Stream_entry.kind with
-      | Activity_log.Stream_entry.Text_chunk "chunk" -> ()
+      | Activity_log.Stream_entry.Finished "ended turn" -> ()
+      | Activity_log.Stream_entry.Finished _
       | Activity_log.Stream_entry.Text_chunk _
       | Activity_log.Stream_entry.Tool_use _
-      | Activity_log.Stream_entry.Finished _
       | Activity_log.Stream_entry.Stream_error _ ->
           fail
             (Printf.sprintf "unexpected stream entry %s"
@@ -179,5 +219,6 @@ let test_pre_migration_events_jsonl_loads () =
 let () =
   test_event_log_complete ();
   test_activity_log_free_form ();
-  test_activity_log_stream ();
+  test_activity_log_stream_drops_untagged ();
+  test_activity_log_stream_accepts_tagged ();
   test_pre_migration_events_jsonl_loads ()


### PR DESCRIPTION
## Summary
- `Llm_backend.spawn_and_stream` started emitting a `Telemetry.Event.Stream` for every child stdout/stderr line in the replay-ready-diagnostics migration so `session_artifacts.ml` can persist them for replay.
- `Activity_log_sink` was also subscribed to `Stream` events; `Activity_log.stream_kind_of_raw` fell back to `Text_chunk raw` / `Stream_error raw` for any line lacking an `activity_log_kind` marker, so raw codex envelopes (`{"type":"turn.completed",...}`) and stderr like `Tool Bash — /bin/zsh -lc '…'` leaked into the TUI Activity pane.
- `stream_kind_of_raw` now returns `Stream_entry.kind option`, returning `None` for untagged lines; the sink drops those. Only entries from `Runtime_logging.log_stream_entry` (Tool_use / Finished / Stream_error / PR-detected text) reach the activity log. Session artifacts / replay are unaffected.

## Test plan
- [x] `dune runtest`
- [x] `dune exec test/test_telemetry_migration.exe`
  - new `test_activity_log_stream_drops_untagged` asserts a raw codex JSON line and a plain stderr line produce zero activity-log entries
  - new `test_activity_log_stream_accepts_tagged` asserts a tagged `activity_log_kind=finished` envelope produces the expected `Finished` entry
- [ ] Eyeball the TUI Activity pane during a live run — confirm `{"type":"turn.completed",…}` / `Tool Bash —` lines no longer appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/285"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop logging untagged stdout/stderr stream lines to the Activity Log to remove noisy codex JSON and "Tool Bash" messages from the TUI. Only `activity_log_kind`-tagged envelopes are logged; replay diagnostics are unchanged.

- **Bug Fixes**
  - `stream_kind_of_raw` now returns `Stream_entry.kind option`; untagged lines return `None`.
  - `Activity_log_sink` drops `None`, logging only tagged `tool_use`/`text_chunk`/`finished`/`stream_error`.
  - Added tests to ensure untagged lines are ignored and tagged lines are recorded.

<sup>Written for commit 3b2767ade60af56d7fc555ef343860588026536c. Summary will update on new commits. <a href="https://cubic.dev/pr/flowglad/onton/pull/285?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Activity log stream entries are now properly filtered to exclude untagged or malformed payloads, preventing child-process diagnostics from being incorrectly recorded as user-facing entries.
  * Improved error handling for malformed or unparseable stream data.

* **Tests**
  * Enhanced tests to verify correct filtering of stream entries and handling of properly tagged versus untagged payloads.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flowglad/onton/pull/285?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->