### PR TITLE
[lift-forge-into-functor] Patch 5: Restrict lib/github.mli to only export make and pure helpers

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -4412,10 +4412,6 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
           Printf.eprintf "Error: cannot access GitHub repo %s/%s: %s\n"
             config.github_owner config.github_repo (Github.show_error err);
           Stdlib.exit 1);
-      (* Patch 3 still keeps the raw [github] client for direct GitHub calls
-         migrated in Patch 4. [Github.t] is currently immutable config, so this
-         temporary duplicate is benign; once those calls move behind Forge,
-         this composition root should construct only the Forge-backed client. *)
       let forge =
         Github.make ~net ~clock ~token:config.github_token
           ~owner:config.github_owner ~repo:config.github_repo

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -4412,6 +4412,10 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
           Printf.eprintf "Error: cannot access GitHub repo %s/%s: %s\n"
             config.github_owner config.github_repo (Github.show_error err);
           Stdlib.exit 1);
+      (* Patch 3 still keeps the raw [github] client for direct GitHub calls
+         migrated in Patch 4. [Github.t] is currently immutable config, so this
+         temporary duplicate is benign; once those calls move behind Forge,
+         this composition root should construct only the Forge-backed client. *)
       let forge =
         Github.make ~net ~clock ~token:config.github_token
           ~owner:config.github_owner ~repo:config.github_repo

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1995,11 +1995,11 @@ struct
           | Poll { patch_id; pr_number; was_merged } ->
               Some (patch_id, pr_number, was_merged))
       in
-      (* Phase 1a: parallel per-patch [Github.pr_state] fetch.
+      (* Phase 1a: parallel per-patch PR state fetch.
 
        This is the head-of-line-blocking fix: when one patch's TCP connect
-       is wedged in [SYN_SENT], [Github.pr_state] returns [Timeout] after
-       [Github.default_timeout] — and every other patch's fiber proceeds
+       is wedged in [SYN_SENT], the forge returns [Timeout] after the default
+       GitHub request timeout — and every other patch's fiber proceeds
        independently. *)
       let outcomes =
         Eio.Fiber.List.map ~max_fibers:16
@@ -2583,7 +2583,7 @@ struct
                                         in
                                         (* PR detection from stream text is a hint
                                      only — always confirmed via the GitHub
-                                     REST API (Github.list_prs) after the
+                                     REST API after the
                                      backend session finishes *)
                                         let on_pr_detected _pr_number = () in
                                         let complexity =
@@ -4400,22 +4400,17 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
       in
       Unix.putenv "ONTON_SNAPSHOT_PATH"
         (Project_store.snapshot_path project_name);
-      let github =
-        Github.create ~token:config.github_token ~owner:config.github_owner
-          ~repo:config.github_repo
-      in
       let net = Eio.Stdenv.net env in
       let clock = Eio.Stdenv.clock env in
-      (match Github.check_repo_access ~net ~clock github with
+      (match
+         Github.check_repo_access ~net ~clock ~token:config.github_token
+           ~owner:config.github_owner ~repo:config.github_repo ()
+       with
       | Ok () -> ()
       | Error err ->
           Printf.eprintf "Error: cannot access GitHub repo %s/%s: %s\n"
             config.github_owner config.github_repo (Github.show_error err);
           Stdlib.exit 1);
-      (* Patch 3 still keeps the raw [github] client for direct GitHub calls
-         migrated in Patch 4. [Github.t] is currently immutable config, so this
-         temporary duplicate is benign; once those calls move behind Forge,
-         this composition root should construct only the Forge-backed client. *)
       let forge =
         Github.make ~net ~clock ~token:config.github_token
           ~owner:config.github_owner ~repo:config.github_repo

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -125,7 +125,6 @@ let show_error = function
 type t = { token : string; owner : string; repo : string }
 
 let create ~token ~owner ~repo = { token; owner; repo }
-
 let with_client ~token ~owner ~repo ~f = f (create ~token ~owner ~repo)
 
 let graphql_query =

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -126,6 +126,8 @@ type t = { token : string; owner : string; repo : string }
 
 let create ~token ~owner ~repo = { token; owner; repo }
 
+let with_client ~token ~owner ~repo ~f = f (create ~token ~owner ~repo)
+
 let graphql_query =
   {|query($owner: String!, $repo: String!, $number: Int!) {
   repository(owner: $owner, name: $repo) {
@@ -532,11 +534,15 @@ let request ~net ~clock ?(timeout = default_timeout) t ~meth ~path ?(query = [])
   | Ok inner -> inner
   | Error `Timeout -> Error (Timeout { meth = meth_s; path; seconds = timeout })
 
-let check_repo_access ~net ~clock ?timeout t =
+let check_repo_access_internal ~net ~clock ?timeout t =
   let path = Printf.sprintf "/repos/%s/%s" t.owner t.repo in
   match request ~net ~clock ?timeout t ~meth:`GET ~path () with
   | Ok _ -> Ok ()
   | Error _ as e -> e
+
+let check_repo_access ~net ~clock ?timeout ~token ~owner ~repo () =
+  with_client ~token ~owner ~repo ~f:(fun client ->
+      check_repo_access_internal ~net ~clock ?timeout client)
 
 let pr_state ~net ~clock ?timeout t pr =
   let body = build_request_body t pr in
@@ -771,8 +777,6 @@ let merge_pr ~net ~clock ?timeout t ~pr_number ~merge_method =
   | Ok body -> Ok (interpret_merge_response body)
   | Error _ as e -> e
 
-let owner t = t.owner
-
 (* ── Inline tests ── *)
 
 let%test "parse_rest_pr_list open PR" =
@@ -921,6 +925,6 @@ let make ~net ~clock ~token ~owner ~repo :
     let merge_pr ~pr_number ~merge_method =
       merge_pr ~net ~clock client ~pr_number ~merge_method
 
-    let check_repo_access () = check_repo_access ~net ~clock client
+    let check_repo_access () = check_repo_access_internal ~net ~clock client
   end in
   (module M)

--- a/lib/github.mli
+++ b/lib/github.mli
@@ -171,6 +171,6 @@ val make :
   owner:string ->
   repo:string ->
   (module Forge.S with type error = error)
-(** [make ~net ~clock ~token ~owner ~repo] packages a GitHub-backed forge module
-    that closes over the network and time capabilities plus client
+(** [make ~net ~clock ~token ~owner ~repo] packages a GitHub-backed forge
+    module that closes over the network and time capabilities plus client
     configuration. *)

--- a/lib/github.mli
+++ b/lib/github.mli
@@ -42,10 +42,9 @@ val check_repo_access :
   unit ->
   (unit, error) Result.t
 (** [check_repo_access ~net ~clock ~token ~owner ~repo] verifies that the
-    configured token can access [owner/repo] via [GET /repos/:owner/:repo].
-    This is a startup preflight so missing tokens, expired credentials, SSO
-    gaps, and wrong repository names fail before long-running orchestration
-    starts. *)
+    configured token can access [owner/repo] via [GET /repos/:owner/:repo]. This
+    is a startup preflight so missing tokens, expired credentials, SSO gaps, and
+    wrong repository names fail before long-running orchestration starts. *)
 
 val parse_response_json :
   owner:string -> Yojson.Safe.t -> (Pr_state.t, error) Result.t

--- a/lib/github.mli
+++ b/lib/github.mli
@@ -171,6 +171,6 @@ val make :
   owner:string ->
   repo:string ->
   (module Forge.S with type error = error)
-(** [make ~net ~clock ~token ~owner ~repo] packages a GitHub-backed forge
-    module that closes over the network and time capabilities plus client
+(** [make ~net ~clock ~token ~owner ~repo] packages a GitHub-backed forge module
+    that closes over the network and time capabilities plus client
     configuration. *)

--- a/lib/github.mli
+++ b/lib/github.mli
@@ -27,11 +27,6 @@ val response_error_message_contains : string -> substring:string -> bool
     distinct 422 cases (e.g. "pull request already exists" vs "no commits
     between"). Pure; safe on malformed input. *)
 
-type t
-
-val create : token:string -> owner:string -> repo:string -> t
-(** [create ~token ~owner ~repo] creates a GitHub API client. *)
-
 val default_timeout : float
 (** Per-request timeout default, in seconds. Without a timeout, a TCP connect
     stuck in [SYN_SENT] (e.g. dropped packets, dead route) can block the calling
@@ -41,12 +36,16 @@ val check_repo_access :
   net:_ Eio.Net.t ->
   clock:_ Eio.Time.clock ->
   ?timeout:float ->
-  t ->
+  token:string ->
+  owner:string ->
+  repo:string ->
+  unit ->
   (unit, error) Result.t
-(** [check_repo_access ~net ~clock t] verifies that the configured token can
-    access [owner/repo] via [GET /repos/:owner/:repo]. This is a startup
-    preflight so missing tokens, expired credentials, SSO gaps, and wrong
-    repository names fail before long-running orchestration starts. *)
+(** [check_repo_access ~net ~clock ~token ~owner ~repo] verifies that the
+    configured token can access [owner/repo] via [GET /repos/:owner/:repo].
+    This is a startup preflight so missing tokens, expired credentials, SSO
+    gaps, and wrong repository names fail before long-running orchestration
+    starts. *)
 
 val parse_response_json :
   owner:string -> Yojson.Safe.t -> (Pr_state.t, error) Result.t
@@ -57,81 +56,10 @@ val parse_response_json :
 val parse_response : owner:string -> string -> (Pr_state.t, error) Result.t
 (** Parse a GitHub GraphQL response body string into a [Pr_state.t]. *)
 
-val pr_state :
-  net:_ Eio.Net.t ->
-  clock:_ Eio.Time.clock ->
-  ?timeout:float ->
-  t ->
-  Types.Pr_number.t ->
-  (Pr_state.t, error) Result.t
-(** [pr_state ~net ~clock client pr] fetches the current state of a pull request
-    via the GitHub GraphQL API over HTTPS. *)
-
 val parse_rest_pr_list :
   string -> ((Types.Pr_number.t * Types.Branch.t * bool) list, error) Result.t
 (** Parse the REST response from [GET /repos/:owner/:repo/pulls]. Returns
     non-CLOSED PRs as [(pr_number, base_branch, merged)]. Pure function. *)
-
-val list_prs :
-  net:_ Eio.Net.t ->
-  clock:_ Eio.Time.clock ->
-  ?timeout:float ->
-  t ->
-  branch:Types.Branch.t ->
-  ?base:Types.Branch.t option ->
-  state:[ `Open | `All ] ->
-  unit ->
-  ((Types.Pr_number.t * Types.Branch.t * bool) list, error) Result.t
-(** [list_prs ~net ~clock t ~branch ~state ()] lists PRs matching [branch] via
-    the GitHub REST API. Returns non-CLOSED PRs as [(number, base, merged)]. *)
-
-val update_pr_body :
-  net:_ Eio.Net.t ->
-  clock:_ Eio.Time.clock ->
-  ?timeout:float ->
-  t ->
-  pr_number:Types.Pr_number.t ->
-  body:string ->
-  (unit, error) Result.t
-(** [update_pr_body ~net ~clock t ~pr_number ~body] updates the PR description
-    via [PATCH /repos/:owner/:repo/pulls/:number]. *)
-
-val create_pull_request :
-  net:_ Eio.Net.t ->
-  clock:_ Eio.Time.clock ->
-  ?timeout:float ->
-  t ->
-  title:string ->
-  head:Types.Branch.t ->
-  base:Types.Branch.t ->
-  body:string ->
-  draft:bool ->
-  (Types.Pr_number.t, error) Result.t
-(** [create_pull_request ~net ~clock t ~title ~head ~base ~body ~draft] creates
-    a pull request via [POST /repos/:owner/:repo/pulls] and returns the new PR
-    number. *)
-
-val update_pr_base :
-  net:_ Eio.Net.t ->
-  clock:_ Eio.Time.clock ->
-  ?timeout:float ->
-  t ->
-  pr_number:Types.Pr_number.t ->
-  base:Types.Branch.t ->
-  (unit, error) Result.t
-(** [update_pr_base ~net ~clock t ~pr_number ~base] retargets the PR to [base]
-    via [PATCH /repos/:owner/:repo/pulls/:number]. *)
-
-val set_draft :
-  net:_ Eio.Net.t ->
-  clock:_ Eio.Time.clock ->
-  ?timeout:float ->
-  t ->
-  pr_number:Types.Pr_number.t ->
-  draft:bool ->
-  (unit, error) Result.t
-(** [set_draft ~net ~clock t ~pr_number ~draft] sets draft status via GraphQL
-    mutation. REST API does not support changing the draft field. *)
 
 type merge_result =
   | Merge_succeeded
@@ -144,25 +72,6 @@ type merge_result =
       (** Response was 2xx but did not include a parseable [merged] field. Treat
           as non-authoritative: don't mark merged, don't count as failure — the
           poller will observe the real PR state next cycle. *)
-
-val merge_pr :
-  net:_ Eio.Net.t ->
-  clock:_ Eio.Time.clock ->
-  ?timeout:float ->
-  t ->
-  pr_number:Types.Pr_number.t ->
-  merge_method:[ `Merge | `Squash | `Rebase ] ->
-  (merge_result, error) Result.t
-(** [merge_pr ~net ~clock t ~pr_number ~merge_method] merges a PR via
-    [PUT /repos/:owner/:repo/pulls/:number/merge]. A 2xx HTTP status does NOT
-    imply the merge completed: the caller must inspect the returned
-    [merge_result] to distinguish an actual merge from a queued request or an
-    unconfirmed response. Transport errors and 4xx/5xx statuses return an
-    [error]; the REST API returns 405 "Pull Request is not mergeable" when the
-    PR is not in a mergeable state. *)
-
-val owner : t -> string
-(** [owner t] returns the repository owner. *)
 
 val make :
   net:_ Eio.Net.t ->

--- a/lib_core/gameplan_parser.ml
+++ b/lib_core/gameplan_parser.ml
@@ -197,7 +197,7 @@ let parse_json_string input =
            to [""] so legacy gameplans without the keys keep loading; the
            [--gameplan] CLI path enforces the non-empty constraint at session
            start, and forge-specific format validation lives in the forge
-           backend, e.g. {!Onton.Github.validate_target}). *)
+           backend, e.g. {!Onton_core.Github_target.validate_target}). *)
         let repo_owner = optional_string "owner" in
         let repo_name = optional_string "repo" in
         let problem_statement =

--- a/lib_core/patch_decision.ml
+++ b/lib_core/patch_decision.ml
@@ -225,10 +225,10 @@ let respond_delivery ~(agent : Patch_agent.t) ~(kind : Operation_kind.t)
       (e.g. OpenCode's [--dir] sandbox rejecting a write to a path outside the
       worktree);
     - artifact outcome [`Patch_failed] — the notes were authored but the
-      subsequent forge PR-body update failed, so the PR body is stale.
-      Returning [`Pr_body_miss] lets the reconciler re-enqueue Pr_body; at cap
-      ([>=2]) the agent surfaces via [needs_intervention] so a persistent
-      delivery failure does not silently leave the PR description wrong.
+      subsequent forge PR-body update failed, so the PR body is stale. Returning
+      [`Pr_body_miss] lets the reconciler re-enqueue Pr_body; at cap ([>=2]) the
+      agent surfaces via [needs_intervention] so a persistent delivery failure
+      does not silently leave the PR description wrong.
 
     Everything else → [`Ok]: a missing/empty artifact with no Write tool_failure
     is the agent's deliberate choice not to add notes, and [`Ok] means delivery

--- a/lib_core/patch_decision.ml
+++ b/lib_core/patch_decision.ml
@@ -225,7 +225,7 @@ let respond_delivery ~(agent : Patch_agent.t) ~(kind : Operation_kind.t)
       (e.g. OpenCode's [--dir] sandbox rejecting a write to a path outside the
       worktree);
     - artifact outcome [`Patch_failed] — the notes were authored but the
-      subsequent [Github.update_pr_body] call failed, so the PR body is stale.
+      subsequent forge PR-body update failed, so the PR body is stale.
       Returning [`Pr_body_miss] lets the reconciler re-enqueue Pr_body; at cap
       ([>=2]) the agent surfaces via [needs_intervention] so a persistent
       delivery failure does not silently leave the PR description wrong.


### PR DESCRIPTION
## Patch 5: Restrict lib/github.mli to only export make and pure helpers

- Open lib/github.mli. Delete the declarations for `type t`, `val create`, `val pr_state`, `val list_prs`, `val update_pr_body`, `val create_pull_request`, `val update_pr_base`, `val set_draft`, `val merge_pr`, and `val owner`. Keep the rest.
- Confirm that lib/github.ml still type-checks against the restricted .mli — the let-bindings for the deleted functions stay (they're called internally by make), they just become module-private.
- Run `dune build`. If anything outside lib/github.ml/.mli still references the now-private functions, that's a leftover from Patch 4 — find and convert it to `Forge.*`.
- Search the tree: `grep -rn 'Github\.' lib bin lib_core --include='*.ml' --include='*.mli' | grep -v Github_target | grep -v Github_target_test`. The only remaining hits should be `Github.make`, `Github.show_error`, `Github.check_repo_access`, `Github.response_error_message_contains`, `Github.parse_response_json`, `Github.parse_response`, `Github.parse_rest_pr_list`, `Github.merge_result` references, `Github.error` references, and `Github.Http_error`/`Github.Json_parse_error`/`Github.Graphql_error`/`Github.Transport_error` constructor patterns (those stay because the error type is structurally exposed via its constructors). If any reference to a removed function survives, fix it.
- Run `dune runtest`. Existing %expect_test cases in lib/github.ml continue to work (they live inside the module, where private functions are still callable).
- Run `dune build @check` for the final type-check sweep.

## Changes
- Open lib/github.mli. Delete the declarations for `type t`, `val create`, `val pr_state`, `val list_prs`, `val update_pr_body`, `val create_pull_request`, `val update_pr_base`, `val set_draft`, `val merge_pr`, and `val owner`. Keep the rest.
- Confirm that lib/github.ml still type-checks against the restricted .mli — the let-bindings for the deleted functions stay (they're called internally by make), they just become module-private.
- Run `dune build`. If anything outside lib/github.ml/.mli still references the now-private functions, that's a leftover from Patch 4 — find and convert it to `Forge.*`.
- Search the tree: `grep -rn 'Github\.' lib bin lib_core --include='*.ml' --include='*.mli' | grep -v Github_target | grep -v Github_target_test`. The only remaining hits should be `Github.make`, `Github.show_error`, `Github.check_repo_access`, `Github.response_error_message_contains`, `Github.parse_response_json`, `Github.parse_response`, `Github.parse_rest_pr_list`, `Github.merge_result` references, `Github.error` references, and `Github.Http_error`/`Github.Json_parse_error`/`Github.Graphql_error`/`Github.Transport_error` constructor patterns (those stay because the error type is structurally exposed via its constructors). If any reference to a removed function survives, fix it.
- Run `dune runtest`. Existing %expect_test cases in lib/github.ml continue to work (they live inside the module, where private functions are still callable).
- Run `dune build @check` for the final type-check sweep.

## Files to Modify
- lib/github.mli (modify): Remove the declarations for `type t`, `val create`, `val pr_state`, `val list_prs`, `val update_pr_body`, `val create_pull_request`, `val update_pr_base`, `val set_draft`, `val merge_pr`, `val owner`. Keep `type error`, `val show_error`, `val response_error_message_contains`, `val parse_response_json`, `val parse_response`, `val parse_rest_pr_list`, `type merge_result`, `val check_repo_access`, and the newly-added `val make`.
- lib/github.ml (modify): The direct-style functions (pr_state, list_prs, update_pr_body, create_pull_request, update_pr_base, set_draft, merge_pr, owner, create) remain as let-bindings — they back the implementation of make's returned module — but they are no longer exposed by the .mli. The static assertion that the inner backend satisfies Forge.S stays. The %expect_test cases for show_error stay (they exercise direct-API functions but inside the .ml, where they're still accessible).

## Gameplan Specification

```
module LIFT_FORGE_INTO_FUNCTOR.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> Forge.S declares the full GitHub-callable surface (pr_state,
> list_prs, update_pr_body, create_pull_request, update_pr_base,
> set_draft, merge_pr, check_repo_access) plus show_error and the
> merge_result variant — without ~net or a client argument in any
> signature. Github.make is the sole public constructor for a
> Forge.S module value, capturing the network capability and the
> Github client at construction inside Eio_main.run.
> Startup_reconciler is a functor Make (F : Forge.S). bin/main.ml
> instantiates one Forge module at the composition root and threads
> no ~github (and no Forge-related ~net) through the helpers and
> fibers below it. lib/github.mli exposes only the constructor, the
> startup preflight, and the pure parsing helpers — direct-style
> Github operations are unreachable from outside the module.

Forge.
Github.
Reconciler.
PrNumber.
Branch.
MergeMethod.
PrState.
MergeResult.
Error.
Result.
Patch.
Helper.
Exported.
DraftStatus.

show-error e: Error => String.
owner-of f: Forge => String.
pr-state f: Forge, n: PrNumber => PrState.
list-prs f: Forge, b: Branch => [PrNumber].
update-pr-body f: Forge, n: PrNumber, body: String => Result.
create-pull-request f: Forge, t: String, head: Branch, base: Branch, body: String, draft: DraftStatus => PrNumber.
update-pr-base f: Forge, n: PrNumber, base: Branch => Result.
set-draft f: Forge, n: PrNumber, draft: DraftStatus => Result.
merge-pr f: Forge, n: PrNumber, m: MergeMethod => MergeResult.
check-repo-access f: Forge => Result.

make-forge token: String, repo-owner: String, repo: String => Forge.
make-reconciler f: Forge => Reconciler.
discover-pr r: Reconciler, b: Branch => PrNumber.
reconcile r: Reconciler, ps: [Patch] => Result.

helper-takes-github? h: Helper => Bool.
is-exported? sym: String => Bool.

execute-github-effects => Helper.
reconcile-and-execute-automerge => Helper.
apply-pr-body-artifact => Helper.
input-fiber => Helper.
poller-fiber => Helper.

---

> ══════════════════════════════════════════
> Forge constructor invariants
> ══════════════════════════════════════════
> The forge constructed from a given owner reports that owner.
all token: String, repo-owner: String, repo: String | owner-of (make-forge token repo-owner repo) = repo-owner.

> ══════════════════════════════════════════
> Composition-root invariants
> ══════════════════════════════════════════
> None of the migrated bin/main.ml helpers take ~github as a parameter.
all h: Helper | helper-takes-github? h = false.

> ══════════════════════════════════════════
> Module-boundary invariants
> ══════════════════════════════════════════
> Github.mli exposes the constructor and the pure helpers.
is-exported? "make" = true.
is-exported? "check_repo_access" = true.
is-exported? "show_error" = true.
is-exported? "response_error_message_contains" = true.
is-exported? "parse_response_json" = true.
is-exported? "parse_response" = true.
is-exported? "parse_rest_pr_list" = true.

> Direct-style operations are not exported.
is-exported? "pr_state" = false.
is-exported? "list_prs" = false.
is-exported? "update_pr_body" = false.
is-exported? "create_pull_request" = false.
is-exported? "update_pr_base" = false.
is-exported? "set_draft" = false.
is-exported? "merge_pr" = false.
is-exported? "create" = false.
is-exported? "owner" = false.

```

## Patch Specification

```
module LIFT_FORGE_INTO_FUNCTOR_PATCH_5.

> Patch 5 restricts the Github module's interface to the make
> constructor, the check_repo_access preflight, the pure parsing
> helpers, and the error/merge_result types. The direct-style
> operations against Github.t are no longer reachable from outside
> the module — Forge.S is the sole abstraction other code consumes.

Github.
Exported.

is-exported? sym: String => Bool.

make => Exported.
check-repo-access => Exported.
show-error => Exported.
response-error-message-contains => Exported.
parse-response-json => Exported.
parse-response => Exported.
parse-rest-pr-list => Exported.

---

> Github.make and check_repo_access are exported.
is-exported? "make" = true.
is-exported? "check_repo_access" = true.

> The direct-style operations are no longer exported.
is-exported? "pr_state" = false.
is-exported? "list_prs" = false.
is-exported? "merge_pr" = false.

```


## Implementation Notes

- `Github.check_repo_access` was reshaped to take `~token ~owner ~repo ()` instead of a raw `Github.t`. Once `type t` and `create` were removed from the public interface, the old preflight signature could no longer remain exported; this keeps the startup preflight explicit without re-exposing the client type.
- `lib/github.ml` still keeps the internal direct-style helpers and private client record exactly for `make`'s implementation. The refactor is at the module boundary, not a rewrite of the internal call structure.
- I cleaned a few stale comments/doc references that still named removed `Github.*` entry points so the required `grep` audit reflects real remaining dependencies rather than obsolete prose.
- `dune build` and `dune runtest` pass. `dune build @check` still fails on pre-existing repo-level issues outside this patch (`bin/check_repo_config.mli` / `bin/probe_findings_api.mli` CMI failures and `Cmdliner` missing for `bin/main.ml`), so this patch does not introduce a clean `@check` baseline.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts lib/github.mli to export only make, check_repo_access, and pure helpers; hides type t, owner accessor, and all direct GitHub operations. bin/main.ml runs the new preflight (token/owner/repo) and instantiates a single Forge.S; the startup reconciler is functorized over Forge.S.

- **Refactors**
  - Hide `type t`, `owner`, and direct ops; keep only `make`, `check_repo_access`, parse helpers, `merge_result`, and error/show helpers.
  - Reshape `check_repo_access` to `~token ~owner ~repo ()`; add internal `with_client` and `check_repo_access_internal`.
  - Capture `net` and `clock` in `Github.make`; returned module implements `Forge.S`.
  - `bin/main.ml`: remove `Github.create`; call preflight with `~token ~owner ~repo`, then instantiate one forge.
  - Tidy comments in `lib_core`; apply `ocamlformat` after rebase.

- **Migration**
  - Stop passing `Github.t` or using `Github.owner`. Build a forge via `let module F = (val Github.make ~net ~clock ~token ~owner ~repo)`.
  - Call `F.*` for PR operations. Use `Github.check_repo_access ~token ~owner ~repo ()` at startup.

<sup>Written for commit c199ce7c84ba16359d1343614c0023e25b9090ec. Summary will update on new commits. <a href="https://cubic.dev/pr/flowglad/onton/pull/287?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

