### PR TITLE
Add gameplan context resources

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -3976,6 +3976,7 @@ let resolve_config ~project ~gameplan_path ~github_token ~backend ~model
           acceptance_criteria = [];
           open_questions = [];
           functional_changes = [];
+          context_resources = [];
         }
       in
       let backend, model = resolve_backend_model ~backend ~model in

--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -649,6 +649,7 @@ let make_orchestrator ~patch_id ~main_branch =
       test_stubs_implemented = [];
       complexity = None;
       precedents = [];
+      required_context = [];
     }
   in
   (patch, Orchestrator.create ~patches:[ patch ] ~main_branch)
@@ -679,6 +680,7 @@ let%test "reconcile_patch escalates repeated start discovery failures" =
             acceptance_criteria = [];
             open_questions = [];
             functional_changes = [];
+            context_resources = [];
           }
       ~patch
   in
@@ -704,6 +706,7 @@ let%test "reconcile_patch enqueues pr_body after PR creation" =
         acceptance_criteria = [];
         open_questions = [];
         functional_changes = [];
+        context_resources = [];
       }
   in
   let t, _ = reconcile_patch t ~project_name:"proj" ~gameplan:gp ~patch in
@@ -733,6 +736,7 @@ let%test "reconcile_patch requests ready-for-review after pr_body on main" =
             acceptance_criteria = [];
             open_questions = [];
             functional_changes = [];
+            context_resources = [];
           }
       ~patch
   in
@@ -763,6 +767,7 @@ let%test "reconcile_patch emits no effects for merged agent" =
             acceptance_criteria = [];
             open_questions = [];
             functional_changes = [];
+            context_resources = [];
           }
       ~patch
   in

--- a/lib/persistence.ml
+++ b/lib/persistence.ml
@@ -722,6 +722,7 @@ let%test_module "session_id_sidecars" =
           test_stubs_implemented = [];
           complexity = None;
           precedents = [];
+          required_context = [];
         }
 
     let gameplan =
@@ -739,6 +740,7 @@ let%test_module "session_id_sidecars" =
           acceptance_criteria = [];
           open_questions = [];
           functional_changes = [];
+          context_resources = [];
         }
 
     let snapshot ?(busy = false) ?llm_session_id () =

--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -120,6 +120,31 @@ let format_precedents (ps : Precedent.t list) : string =
      pattern, paper, RFC, doc, or blog post; the trailing sentence explains \
      how it applies to this specific patch.\n\n" ^ body ^ "\n"
 
+let format_context_resources (resources : Context_resource.t list) : string =
+  if List.is_empty resources then ""
+  else
+    let body =
+      List.map resources ~f:(fun r ->
+          let paths =
+            match r.Context_resource.paths with
+            | [] -> "Paths/references: none listed"
+            | paths -> "Paths/references: " ^ String.concat paths ~sep:", "
+          in
+          let why =
+            if String.is_empty r.why then "Why authoritative: not specified"
+            else "Why authoritative: " ^ r.why
+          in
+          Printf.sprintf "- **%s** (`%s`)\n  - %s\n  - %s" r.id r.kind paths why)
+      |> String.concat ~sep:"\n"
+    in
+    "\n\
+     ## Required Context Before Editing\n\n\
+     Read these authoritative resources before making code changes. Trust this \
+     named context over stale or ambiguous patch prose. Search and read the \
+     listed paths/references before choosing an implementation approach, and \
+     avoid starting a parallel implementation until you have checked them.\n\n"
+    ^ body ^ "\n"
+
 let agents_md_section = function
   | Some content when not (String.is_empty (String.strip content)) ->
       "## Project Conventions (AGENTS.md)\n\n" ^ String.rstrip content ^ "\n\n"
@@ -212,7 +237,8 @@ let format_functional_changes_section (fcs : Functional_change.t list) : string
      appears here, no sibling patch will pick it up.\n\n" ^ body ^ "\n"
 
 let render_patch_layer ~(project_name : string) (patch : Patch.t) ?pr_number
-    ?(functional_changes = []) ~(base_branch : string) () : string =
+    ?(functional_changes = []) ?(context_resources = []) ~(base_branch : string)
+    () : string =
   let patch_id = Patch_id.to_string patch.Patch.id in
   let deps =
     match patch.Patch.dependencies with
@@ -278,6 +304,7 @@ The supervisor opens the draft PR after your first commit lands on the remote, w
       ("files", format_list patch.Patch.files);
       ( "functional_changes_section",
         format_functional_changes_section functional_changes );
+      ("context_resources_section", format_context_resources context_resources);
       ("changes_section", optional_list_section ~header:"Changes" patch.changes);
       ( "spec_section",
         if String.is_empty patch.spec then ""
@@ -346,7 +373,7 @@ The supervisor opens the draft PR after your first commit lands on the remote, w
 ## Your Task
 
 {{base_branch_note}}{{description}}
-{{functional_changes_section}}{{changes_section}}{{files_section}}{{precedents_section}}{{test_stubs_introduced_section}}{{test_stubs_implemented_section}}{{spec_section}}{{acceptance_criteria_section}}
+{{functional_changes_section}}{{context_resources_section}}{{changes_section}}{{files_section}}{{precedents_section}}{{test_stubs_introduced_section}}{{test_stubs_implemented_section}}{{spec_section}}{{acceptance_criteria_section}}
 ## Git Instructions
 - Branch: {{branch}}
 - Base branch: {{base_branch}}
@@ -362,6 +389,12 @@ let owned_functional_changes (gameplan : Gameplan.t) (patch : Patch.t) :
     ~f:(fun (fc : Functional_change.t) ->
       Patch_id.equal fc.Functional_change.owned_by patch.Patch.id)
 
+let required_context_resources (gameplan : Gameplan.t) (patch : Patch.t) :
+    Context_resource.t list =
+  List.filter gameplan.Gameplan.context_resources
+    ~f:(fun (r : Context_resource.t) ->
+      List.mem patch.Patch.required_context r.id ~equal:String.equal)
+
 (* When all of [patch], [gameplan], [base_branch] are supplied, returns
    the gameplan+patch prefix; otherwise returns the empty string. Used by
    the layered turn-prompt composers to support callers that don't have a
@@ -371,12 +404,13 @@ let layered_prefix ~project_name ?pr_number ?patch ?gameplan ?base_branch
   match (patch, gameplan, base_branch) with
   | Some p, Some g, Some b ->
       let functional_changes = owned_functional_changes g p in
+      let context_resources = required_context_resources g p in
       render_gameplan_layer ~project_name g
       ^ (match agents_md with
         | Some content -> agents_md_section (Some content)
         | None -> "")
       ^ render_patch_layer ~project_name p ?pr_number ~functional_changes
-          ~base_branch:b ()
+          ~context_resources ~base_branch:b ()
   | _ -> ""
 
 let render_turn_layer_start ~(project_name : string) : string =
@@ -387,10 +421,11 @@ let render_turn_layer_start ~(project_name : string) : string =
 let render_patch_prompt ~(project_name : string) ?agents_md ?pr_number
     (patch : Patch.t) (gameplan : Gameplan.t) ~(base_branch : string) =
   let functional_changes = owned_functional_changes gameplan patch in
+  let context_resources = required_context_resources gameplan patch in
   render_gameplan_layer ~project_name gameplan
   ^ agents_md_section agents_md
   ^ render_patch_layer ~project_name patch ?pr_number ~functional_changes
-      ~base_branch ()
+      ~context_resources ~base_branch ()
   ^ render_turn_layer_start ~project_name
 
 let render_spec_suffix (patch : Patch.t) (gameplan : Gameplan.t) : string =
@@ -422,6 +457,7 @@ let%test "render_spec_suffix: both empty" =
       test_stubs_implemented = [];
       complexity = None;
       precedents = [];
+      required_context = [];
     }
   in
   let gameplan =
@@ -434,6 +470,7 @@ let%test "render_spec_suffix: both empty" =
       final_state_spec = "";
       patches = [];
       functional_changes = [];
+      context_resources = [];
       current_state_analysis = "";
       explicit_opinions = "";
       acceptance_criteria = [];
@@ -459,6 +496,7 @@ let%test "render_spec_suffix: gameplan spec only" =
       test_stubs_implemented = [];
       complexity = None;
       precedents = [];
+      required_context = [];
     }
   in
   let gameplan =
@@ -471,6 +509,7 @@ let%test "render_spec_suffix: gameplan spec only" =
       final_state_spec = "module FOO.\nsome spec";
       patches = [];
       functional_changes = [];
+      context_resources = [];
       current_state_analysis = "";
       explicit_opinions = "";
       acceptance_criteria = [];
@@ -499,6 +538,7 @@ let%test "render_spec_suffix: patch spec only" =
       test_stubs_implemented = [];
       complexity = None;
       precedents = [];
+      required_context = [];
     }
   in
   let gameplan =
@@ -511,6 +551,7 @@ let%test "render_spec_suffix: patch spec only" =
       final_state_spec = "";
       patches = [];
       functional_changes = [];
+      context_resources = [];
       current_state_analysis = "";
       explicit_opinions = "";
       acceptance_criteria = [];
@@ -539,6 +580,7 @@ let%test "render_spec_suffix: both present" =
       test_stubs_implemented = [];
       complexity = None;
       precedents = [];
+      required_context = [];
     }
   in
   let gameplan =
@@ -551,6 +593,7 @@ let%test "render_spec_suffix: both present" =
       final_state_spec = "module FOO.\ngameplan spec";
       patches = [];
       functional_changes = [];
+      context_resources = [];
       current_state_analysis = "";
       explicit_opinions = "";
       acceptance_criteria = [];
@@ -636,6 +679,7 @@ What to include:
 - Anything surprising or non-obvious about the approach.
 - Deviations from the original plan (if any).
 - Important details a reviewer should know.
+- A short `Spec/Evidence Mapping` when applicable: spec clause or acceptance criterion satisfied, code path implementing it, required context resource consulted, and test/static check proving it if available.
 
 Do not repeat information already in the description or specs above — add only what's new.
 
@@ -1167,6 +1211,7 @@ let%test "patch prompt includes title and deps" =
         test_stubs_implemented = [];
         complexity = None;
         precedents = [];
+        required_context = [];
       }
   in
   let gameplan : Gameplan.t =
@@ -1199,10 +1244,12 @@ let%test "patch prompt includes title and deps" =
               test_stubs_implemented = [];
               complexity = None;
               precedents = [];
+              required_context = [];
             };
             patch;
           ];
         functional_changes = [];
+        context_resources = [];
       }
   in
   let result =
@@ -1243,6 +1290,7 @@ let%test "patch prompt static prefix is byte-identical across patches" =
           ];
         complexity = None;
         precedents = [];
+        required_context = [];
       }
   in
   let patch_2 : Patch.t =
@@ -1262,6 +1310,7 @@ let%test "patch prompt static prefix is byte-identical across patches" =
         test_stubs_implemented = [];
         complexity = None;
         precedents = [];
+        required_context = [];
       }
   in
   let gameplan : Gameplan.t =
@@ -1280,6 +1329,7 @@ let%test "patch prompt static prefix is byte-identical across patches" =
         open_questions = [];
         patches = [ patch_1; patch_2 ];
         functional_changes = [];
+        context_resources = [];
       }
   in
   let prompt_1 =
@@ -1315,6 +1365,7 @@ let%test "agents_md content appears in static prefix when Some" =
         test_stubs_implemented = [];
         complexity = None;
         precedents = [];
+        required_context = [];
       }
   in
   let gameplan : Gameplan.t =
@@ -1332,6 +1383,7 @@ let%test "agents_md content appears in static prefix when Some" =
         open_questions = [];
         patches = [ patch ];
         functional_changes = [];
+        context_resources = [];
       }
   in
   let prompt =
@@ -1363,6 +1415,7 @@ let%test "agents_md section is omitted when None" =
         test_stubs_implemented = [];
         complexity = None;
         precedents = [];
+        required_context = [];
       }
   in
   let gameplan : Gameplan.t =
@@ -1380,6 +1433,7 @@ let%test "agents_md section is omitted when None" =
         open_questions = [];
         patches = [ patch ];
         functional_changes = [];
+        context_resources = [];
       }
   in
   let prompt =
@@ -1417,6 +1471,7 @@ let make_layer_test_fixture () =
         test_stubs_implemented = [];
         complexity = None;
         precedents = [];
+        required_context = [];
       }
   in
   let patch_b : Patch.t =
@@ -1436,6 +1491,7 @@ let make_layer_test_fixture () =
         test_stubs_implemented = [];
         complexity = None;
         precedents = [];
+        required_context = [];
       }
   in
   let gameplan : Gameplan.t =
@@ -1462,6 +1518,7 @@ let make_layer_test_fixture () =
               owned_by = patch_a.Patch.id;
             };
           ];
+        context_resources = [];
       }
   in
   (patch_a, patch_b, gameplan)
@@ -1636,6 +1693,62 @@ let%test
       ~base_branch:"main" ()
   in
   not (String.is_substring rendered ~substring:"Functional Changes You Own")
+
+let%test
+    "render_patch_prompt surfaces only required context resources for patch" =
+  let patch_a, patch_b, gameplan = make_layer_test_fixture () in
+  let patch_a = { patch_a with required_context = [ "ctx-a" ] } in
+  let patch_b = { patch_b with required_context = [ "ctx-b" ] } in
+  let gameplan : Gameplan.t =
+    {
+      gameplan with
+      patches = [ patch_a; patch_b ];
+      context_resources =
+        [
+          {
+            Context_resource.id = "ctx-a";
+            kind = "existing-implementation";
+            paths = [ "lib/current.ml"; "test/test_current.ml" ];
+            why = "This is the behavior Patch A must preserve.";
+            consumed_by = [ patch_a.Patch.id ];
+          };
+          {
+            Context_resource.id = "ctx-b";
+            kind = "reference-doc";
+            paths = [ "docs/reference.md" ];
+            why = "This belongs only to Patch B.";
+            consumed_by = [ patch_b.Patch.id ];
+          };
+        ];
+    }
+  in
+  let prompt_a =
+    render_patch_prompt ~project_name:"onton" patch_a gameplan
+      ~base_branch:"main"
+  in
+  String.is_substring prompt_a ~substring:"## Required Context Before Editing"
+  && String.is_substring prompt_a ~substring:"**ctx-a**"
+  && String.is_substring prompt_a ~substring:"lib/current.ml"
+  && String.is_substring prompt_a
+       ~substring:"This is the behavior Patch A must preserve."
+  && String.is_substring prompt_a
+       ~substring:
+         "Read these authoritative resources before making code changes"
+  && String.is_substring prompt_a
+       ~substring:"Trust this named context over stale or ambiguous patch prose"
+  && String.is_substring prompt_a
+       ~substring:"avoid starting a parallel implementation"
+  && not (String.is_substring prompt_a ~substring:"**ctx-b**")
+
+let%test
+    "render_patch_layer omits Required Context section when no resources apply"
+    =
+  let patch, _, _ = make_layer_test_fixture () in
+  let rendered =
+    render_patch_layer ~project_name:"onton" patch ~base_branch:"main" ()
+  in
+  not
+    (String.is_substring rendered ~substring:"Required Context Before Editing")
 
 let%test "render_pr_description surfaces precedents when present" =
   let patch, _, gameplan = make_layer_test_fixture () in

--- a/lib/prompt.mli
+++ b/lib/prompt.mli
@@ -38,6 +38,7 @@ val render_patch_layer :
   Patch.t ->
   ?pr_number:Pr_number.t ->
   ?functional_changes:Functional_change.t list ->
+  ?context_resources:Context_resource.t list ->
   base_branch:string ->
   unit ->
   string
@@ -46,12 +47,18 @@ val render_patch_layer :
     files, test stubs, specification (with Pantagruel guide), acceptance
     criteria, git identifiers, and PR instructions. Ends with a trailing blank
     line. [functional_changes] should contain only the entries from
-    [Gameplan.t.functional_changes] whose [owned_by] equals [Patch.t.id]. *)
+    [Gameplan.t.functional_changes] whose [owned_by] equals [Patch.t.id].
+    [context_resources] should contain only resources whose IDs appear in this
+    patch's [required_context]. *)
 
 val owned_functional_changes : Gameplan.t -> Patch.t -> Functional_change.t list
 (** Returns the functional changes in the gameplan owned by this patch. Use this
     when constructing patch layers directly, so composed and manually layered
     prompts carry the same patch-stable content. *)
+
+val required_context_resources :
+  Gameplan.t -> Patch.t -> Context_resource.t list
+(** Returns the authoritative context resources required by this patch. *)
 
 val render_turn_layer_start : project_name:string -> string
 

--- a/lib_core/gameplan_parser.ml
+++ b/lib_core/gameplan_parser.ml
@@ -86,9 +86,9 @@ let validate_context_resources ~patches ~context_resources =
         let stripped = String.strip id in
         if String.is_empty stripped then
           Error "contextResources[].id must be a non-empty string"
-        else if Set.mem seen id then
-          Error (Printf.sprintf "Duplicate contextResource id: %s" id)
-        else check_ids (Set.add seen id) rest
+        else if Set.mem seen stripped then
+          Error (Printf.sprintf "Duplicate contextResource id: %s" stripped)
+        else check_ids (Set.add seen stripped) rest
   in
   match check_ids (Set.empty (module String)) resource_ids with
   | Error e -> Error e

--- a/lib_core/gameplan_parser.ml
+++ b/lib_core/gameplan_parser.ml
@@ -245,7 +245,14 @@ let json_string_list json key =
 let json_patch_id_list json key =
   let open Yojson.Safe.Util in
   match json |> member key with
-  | `List items -> List.filter_map items ~f:patch_id_of_json
+  | `List items ->
+      List.map items ~f:(fun item ->
+          match patch_id_of_json item with
+          | Some id -> id
+          | None ->
+              raise
+                (Type_error
+                   (Printf.sprintf "%s[] must contain only patch IDs" key, item)))
   | _ -> []
 
 let json_precedents json =

--- a/lib_core/gameplan_parser.ml
+++ b/lib_core/gameplan_parser.ml
@@ -242,6 +242,22 @@ let json_string_list json key =
       List.filter_map items ~f:(function `String s -> Some s | _ -> None)
   | _ -> []
 
+let json_required_string_list json key =
+  let open Yojson.Safe.Util in
+  match json |> member key with
+  | `Null -> []
+  | `List items ->
+      List.map items ~f:(fun item ->
+          match item with
+          | `String s -> s
+          | _ ->
+              raise
+                (Type_error
+                   (Printf.sprintf "%s[] must contain only strings" key, item)))
+  | value ->
+      raise
+        (Type_error (Printf.sprintf "%s must be an array of strings" key, value))
+
 let json_patch_id_list json key =
   let open Yojson.Safe.Util in
   match json |> member key with
@@ -527,7 +543,9 @@ let parse_json_string input =
                 | _ -> []
               in
               let precedents = json_precedents p in
-              let required_context = json_string_list p "requiredContext" in
+              let required_context =
+                json_required_string_list p "requiredContext"
+              in
               {
                 Types.Patch.id;
                 title;

--- a/lib_core/gameplan_parser.ml
+++ b/lib_core/gameplan_parser.ml
@@ -245,6 +245,7 @@ let json_string_list json key =
 let json_patch_id_list json key =
   let open Yojson.Safe.Util in
   match json |> member key with
+  | `Null -> []
   | `List items ->
       List.map items ~f:(fun item ->
           match patch_id_of_json item with
@@ -253,7 +254,10 @@ let json_patch_id_list json key =
               raise
                 (Type_error
                    (Printf.sprintf "%s[] must contain only patch IDs" key, item)))
-  | _ -> []
+  | value ->
+      raise
+        (Type_error
+           (Printf.sprintf "%s must be an array of patch IDs" key, value))
 
 let json_precedents json =
   let open Yojson.Safe.Util in
@@ -389,7 +393,7 @@ let parse_json_string input =
               List.map items ~f:(fun obj ->
                   let id =
                     match obj |> member "id" with
-                    | `String s -> s
+                    | `String s -> String.strip s
                     | _ ->
                         raise
                           (Type_error

--- a/lib_core/gameplan_parser.ml
+++ b/lib_core/gameplan_parser.ml
@@ -62,6 +62,98 @@ let validate_functional_changes ~patches ~functional_changes =
   in
   loop (Set.empty (module String)) functional_changes
 
+let valid_context_resource_kinds =
+  [
+    "existing-implementation";
+    "contract";
+    "predecessor";
+    "reference-doc";
+    "test-or-static-check";
+    "external-reference";
+  ]
+
+let validate_context_resources ~patches ~context_resources =
+  let patch_ids =
+    List.map patches ~f:(fun p -> p.Types.Patch.id)
+    |> Set.of_list (module Types.Patch_id)
+  in
+  let resource_ids =
+    List.map context_resources ~f:(fun r -> r.Types.Context_resource.id)
+  in
+  let rec check_ids seen = function
+    | [] -> Ok ()
+    | id :: rest ->
+        let stripped = String.strip id in
+        if String.is_empty stripped then
+          Error "contextResources[].id must be a non-empty string"
+        else if Set.mem seen id then
+          Error (Printf.sprintf "Duplicate contextResource id: %s" id)
+        else check_ids (Set.add seen id) rest
+  in
+  match check_ids (Set.empty (module String)) resource_ids with
+  | Error e -> Error e
+  | Ok () -> (
+      let resource_id_set = Set.of_list (module String) resource_ids in
+      match
+        List.find_map context_resources ~f:(fun r ->
+            if
+              not
+                (List.mem valid_context_resource_kinds r.kind
+                   ~equal:String.equal)
+            then
+              Some
+                (Printf.sprintf "contextResource %s has invalid kind %S" r.id
+                   r.kind)
+            else
+              List.find_map r.consumed_by ~f:(fun patch_id ->
+                  if Set.mem patch_ids patch_id then None
+                  else
+                    Some
+                      (Printf.sprintf
+                         "contextResource %s consumedBy nonexistent patch %s"
+                         r.id
+                         (Types.Patch_id.to_string patch_id))))
+      with
+      | Some e -> Error e
+      | None -> (
+          match
+            List.find_map patches ~f:(fun p ->
+                List.find_map p.Types.Patch.required_context ~f:(fun id ->
+                    if Set.mem resource_id_set id then None
+                    else
+                      Some
+                        (Printf.sprintf
+                           "Patch %s requiredContext references nonexistent \
+                            contextResource %s"
+                           (Types.Patch_id.to_string p.id)
+                           id)))
+          with
+          | Some e -> Error e
+          | None -> (
+              match
+                List.find_map patches ~f:(fun p ->
+                    List.find_map context_resources ~f:(fun r ->
+                        let patch_id = p.Types.Patch.id in
+                        let listed_in_patch =
+                          List.mem p.required_context r.id ~equal:String.equal
+                        in
+                        let listed_in_resource =
+                          List.mem r.consumed_by patch_id
+                            ~equal:Types.Patch_id.equal
+                        in
+                        if Bool.equal listed_in_patch listed_in_resource then
+                          None
+                        else
+                          Some
+                            (Printf.sprintf
+                               "Patch %s requiredContext must match \
+                                contextResource %s consumedBy"
+                               (Types.Patch_id.to_string patch_id)
+                               r.id)))
+              with
+              | Some e -> Error e
+              | None -> Ok ())))
+
 let validate ~patches ~dep_graph =
   (* Check for invalid patch IDs *)
   let invalid_ids =
@@ -148,6 +240,12 @@ let json_string_list json key =
   match json |> member key with
   | `List items ->
       List.filter_map items ~f:(function `String s -> Some s | _ -> None)
+  | _ -> []
+
+let json_patch_id_list json key =
+  let open Yojson.Safe.Util in
+  match json |> member key with
+  | `List items -> List.filter_map items ~f:patch_id_of_json
   | _ -> []
 
 let json_precedents json =
@@ -277,6 +375,38 @@ let parse_json_string input =
                 (Type_error
                    ("functionalChanges must be an array of objects", json))
         in
+        let context_resources =
+          match json |> member "contextResources" with
+          | `Null -> []
+          | `List items ->
+              List.map items ~f:(fun obj ->
+                  let id =
+                    match obj |> member "id" with
+                    | `String s -> s
+                    | _ ->
+                        raise
+                          (Type_error
+                             ("contextResources[].id must be a string", obj))
+                  in
+                  let kind =
+                    match obj |> member "kind" with
+                    | `String s -> s
+                    | _ ->
+                        raise
+                          (Type_error
+                             ("contextResources[].kind must be a string", obj))
+                  in
+                  let paths = json_string_list obj "paths" in
+                  let why =
+                    match obj |> member "why" with `String s -> s | _ -> ""
+                  in
+                  let consumed_by = json_patch_id_list obj "consumedBy" in
+                  { Types.Context_resource.id; kind; paths; why; consumed_by })
+          | _ ->
+              raise
+                (Type_error
+                   ("contextResources must be an array of objects", json))
+        in
         let open_questions =
           match json |> member "openQuestions" with
           | `Null -> []
@@ -386,6 +516,7 @@ let parse_json_string input =
                 | _ -> []
               in
               let precedents = json_precedents p in
+              let required_context = json_string_list p "requiredContext" in
               {
                 Types.Patch.id;
                 title;
@@ -401,6 +532,7 @@ let parse_json_string input =
                 test_stubs_implemented;
                 complexity;
                 precedents;
+                required_context;
               })
         in
         match open_questions with
@@ -424,26 +556,32 @@ let parse_json_string input =
                   validate_functional_changes ~patches ~functional_changes
                 with
                 | Error e -> Error e
-                | Ok () ->
-                    Ok
-                      {
-                        gameplan =
+                | Ok () -> (
+                    match
+                      validate_context_resources ~patches ~context_resources
+                    with
+                    | Error e -> Error e
+                    | Ok () ->
+                        Ok
                           {
-                            Types.Gameplan.project_name;
-                            repo_owner;
-                            repo_name;
-                            problem_statement;
-                            solution_summary;
-                            final_state_spec;
-                            patches;
-                            functional_changes;
-                            current_state_analysis;
-                            explicit_opinions;
-                            acceptance_criteria;
-                            open_questions;
-                          };
-                        dependency_graph = dep_graph;
-                      }))
+                            gameplan =
+                              {
+                                Types.Gameplan.project_name;
+                                repo_owner;
+                                repo_name;
+                                problem_statement;
+                                solution_summary;
+                                final_state_spec;
+                                patches;
+                                functional_changes;
+                                context_resources;
+                                current_state_analysis;
+                                explicit_opinions;
+                                acceptance_criteria;
+                                open_questions;
+                              };
+                            dependency_graph = dep_graph;
+                          })))
       with Type_error (msg, _) ->
         Error (Printf.sprintf "JSON structure error: %s" msg))
 
@@ -521,6 +659,7 @@ let%test_module "Gameplan_parser" =
               test_stubs_implemented = [];
               complexity = None;
               precedents = [];
+              required_context = [];
             };
         ]
       in
@@ -548,6 +687,7 @@ let%test_module "Gameplan_parser" =
             test_stubs_implemented = [];
             complexity = None;
             precedents = [];
+            required_context = [];
           }
       in
       let dep_graph = Map.of_alist_exn (module Types.Patch_id) [ (pid, []) ] in
@@ -741,6 +881,147 @@ let%test_module "Gameplan_parser" =
       | Ok result ->
           let p = List.hd_exn result.gameplan.patches in
           List.is_empty p.Types.Patch.precedents
+
+    let%test
+        "parse_json_string: contextResources and requiredContext round-trip" =
+      let input =
+        {|{
+          "projectName": "p",
+          "solutionSummary": "s",
+          "contextResources": [
+            {
+              "id": "parser-contract",
+              "kind": "contract",
+              "paths": ["lib_core/gameplan_parser.mli", "docs/gameplan.md"],
+              "why": "Defines parser compatibility guarantees.",
+              "consumedBy": [1]
+            }
+          ],
+          "patches": [
+            {
+              "number": 1,
+              "title": "A",
+              "changes": [],
+              "requiredContext": ["parser-contract"]
+            }
+          ],
+          "dependencyGraph": [{"patch": 1, "dependsOn": []}]
+        }|}
+      in
+      match parse_json_string input with
+      | Error msg ->
+          Stdlib.Printf.eprintf "parse error: %s\n" msg;
+          false
+      | Ok result -> (
+          match
+            (result.gameplan.context_resources, result.gameplan.patches)
+          with
+          | [ resource ], [ patch ] ->
+              String.equal resource.Types.Context_resource.id "parser-contract"
+              && String.equal resource.kind "contract"
+              && List.equal String.equal resource.paths
+                   [ "lib_core/gameplan_parser.mli"; "docs/gameplan.md" ]
+              && String.equal resource.why
+                   "Defines parser compatibility guarantees."
+              && List.equal Types.Patch_id.equal resource.consumed_by
+                   [ Types.Patch_id.of_string "1" ]
+              && List.equal String.equal patch.Types.Patch.required_context
+                   [ "parser-contract" ]
+          | _ -> false)
+
+    let%test
+        "parse_json_string: missing context fields default to empty for legacy"
+        =
+      let input =
+        {|{
+          "projectName": "p",
+          "solutionSummary": "s",
+          "patches": [{"number": 1, "title": "A", "changes": []}],
+          "dependencyGraph": [{"patch": 1, "dependsOn": []}]
+        }|}
+      in
+      match parse_json_string input with
+      | Error _ -> false
+      | Ok result -> (
+          match result.gameplan.patches with
+          | [ patch ] ->
+              List.is_empty result.gameplan.context_resources
+              && List.is_empty patch.Types.Patch.required_context
+          | _ -> false)
+
+    let%test "parse_json_string: duplicate contextResource id returns Error" =
+      let input =
+        {|{
+          "projectName": "p",
+          "solutionSummary": "s",
+          "contextResources": [
+            {"id": "ctx", "kind": "contract", "paths": [], "why": "", "consumedBy": []},
+            {"id": "ctx", "kind": "contract", "paths": [], "why": "", "consumedBy": []}
+          ],
+          "patches": [{"number": 1, "title": "A", "changes": []}],
+          "dependencyGraph": [{"patch": 1, "dependsOn": []}]
+        }|}
+      in
+      match parse_json_string input with
+      | Ok _ -> false
+      | Error msg ->
+          String.is_substring msg ~substring:"Duplicate contextResource"
+
+    let%test
+        "parse_json_string: missing requiredContext reference returns Error" =
+      let input =
+        {|{
+          "projectName": "p",
+          "solutionSummary": "s",
+          "contextResources": [],
+          "patches": [
+            {"number": 1, "title": "A", "changes": [], "requiredContext": ["missing"]}
+          ],
+          "dependencyGraph": [{"patch": 1, "dependsOn": []}]
+        }|}
+      in
+      match parse_json_string input with
+      | Ok _ -> false
+      | Error msg ->
+          String.is_substring msg
+            ~substring:"requiredContext references nonexistent"
+
+    let%test "parse_json_string: nonexistent consumedBy patch returns Error" =
+      let input =
+        {|{
+          "projectName": "p",
+          "solutionSummary": "s",
+          "contextResources": [
+            {"id": "ctx", "kind": "contract", "paths": [], "why": "", "consumedBy": [2]}
+          ],
+          "patches": [{"number": 1, "title": "A", "changes": []}],
+          "dependencyGraph": [{"patch": 1, "dependsOn": []}]
+        }|}
+      in
+      match parse_json_string input with
+      | Ok _ -> false
+      | Error msg ->
+          String.is_substring msg ~substring:"consumedBy nonexistent patch"
+
+    let%test
+        "parse_json_string: requiredContext and consumedBy mismatch returns \
+         Error" =
+      let input =
+        {|{
+          "projectName": "p",
+          "solutionSummary": "s",
+          "contextResources": [
+            {"id": "ctx", "kind": "contract", "paths": [], "why": "", "consumedBy": [1]}
+          ],
+          "patches": [{"number": 1, "title": "A", "changes": []}],
+          "dependencyGraph": [{"patch": 1, "dependsOn": []}]
+        }|}
+      in
+      match parse_json_string input with
+      | Ok _ -> false
+      | Error msg ->
+          String.is_substring msg
+            ~substring:"requiredContext must match contextResource"
 
     let%test "parse_json_string: precedent without kind or name is skipped" =
       let input =

--- a/lib_core/types.ml
+++ b/lib_core/types.ml
@@ -142,6 +142,17 @@ module Precedent = struct
       patch prompt so it can prefer proven techniques over rolling its own. *)
 end
 
+module Context_resource = struct
+  type t = {
+    id : string;
+    kind : string;
+    paths : string list; [@yojson.default []]
+    why : string; [@yojson.default ""]
+    consumed_by : Patch_id.t list; [@yojson.default []]
+  }
+  [@@deriving show, eq, sexp_of, compare, yojson]
+end
+
 module Patch = struct
   type t = {
     id : Patch_id.t;
@@ -158,6 +169,7 @@ module Patch = struct
     test_stubs_implemented : string list; [@yojson.default []]
     complexity : int option; [@yojson.default None]
     precedents : Precedent.t list; [@yojson.default []]
+    required_context : string list; [@yojson.default []]
   }
   [@@deriving show, eq, sexp_of, compare, yojson]
 end
@@ -276,6 +288,7 @@ module Gameplan = struct
     final_state_spec : string; [@yojson.default ""]
     patches : Patch.t list;
     functional_changes : Functional_change.t list; [@yojson.default []]
+    context_resources : Context_resource.t list; [@yojson.default []]
     current_state_analysis : string; [@yojson.default ""]
     explicit_opinions : string; [@yojson.default ""]
     acceptance_criteria : string list; [@yojson.default []]

--- a/lib_core/types.mli
+++ b/lib_core/types.mli
@@ -124,6 +124,27 @@ module Precedent : sig
       agent can prefer proven libraries / algorithms / patterns. *)
 end
 
+module Context_resource : sig
+  type t = {
+    id : string;
+        (** Stable non-empty identifier referenced by patches'
+            [required_context] arrays. *)
+    kind : string;
+        (** One of ["existing-implementation"], ["contract"], ["predecessor"],
+            ["reference-doc"], ["test-or-static-check"], or
+            ["external-reference"]. *)
+    paths : string list; [@yojson.default []]
+        (** Repo-relative paths or external references the implementing agent
+            must read before editing. *)
+    why : string; [@yojson.default ""]
+        (** Why this resource is authoritative for consuming patches. *)
+    consumed_by : Patch_id.t list; [@yojson.default []]
+        (** Patches that must receive this resource in their prompt. Must agree
+            with each consuming patch's [required_context]. *)
+  }
+  [@@deriving show, eq, sexp_of, compare, yojson]
+end
+
 module Patch : sig
   type t = {
     id : Patch_id.t;
@@ -147,6 +168,9 @@ module Patch : sig
         (** Established prior art for this patch (libraries, algorithms,
             patterns, papers). Empty list when the patch is bespoke project glue
             with no relevant precedent. *)
+    required_context : string list; [@yojson.default []]
+        (** IDs from [Gameplan.context_resources] that this patch must read
+            before editing. Defaults to [[]] for legacy gameplans. *)
   }
   [@@deriving show, eq, sexp_of, compare, yojson]
 end
@@ -283,6 +307,10 @@ module Gameplan : sig
             gameplan introduces, each assigned to exactly one owning patch.
             Defaults to [[]] for legacy gameplans that predate the field — in
             that case no per-patch change list is surfaced. *)
+    context_resources : Context_resource.t list; [@yojson.default []]
+        (** Authoritative existing code, contracts, docs, tests, or external
+            references that patch agents must consult before editing. Defaults
+            to [[]] for legacy gameplans. *)
     current_state_analysis : string; [@yojson.default ""]
     explicit_opinions : string; [@yojson.default ""]
     acceptance_criteria : string list; [@yojson.default []]

--- a/lib_test/git_env.ml
+++ b/lib_test/git_env.ml
@@ -70,7 +70,8 @@ let run_git ~cwd args =
 let init_repo dir =
   run_git ~cwd:dir [ "init"; "-q"; "-b"; "main" ];
   run_git ~cwd:dir [ "config"; "user.email"; "test@example.com" ];
-  run_git ~cwd:dir [ "config"; "user.name"; "test" ]
+  run_git ~cwd:dir [ "config"; "user.name"; "test" ];
+  run_git ~cwd:dir [ "config"; "commit.gpgsign"; "false" ]
 
 let rm_rf dir =
   let cmd = Printf.sprintf "rm -rf %s" (Stdlib.Filename.quote dir) in

--- a/lib_test/test_generators.ml
+++ b/lib_test/test_generators.ml
@@ -90,6 +90,7 @@ let gen_patch =
             test_stubs_implemented = [];
             complexity = None;
             precedents = [];
+            required_context = [];
           })
       gen_patch_id gen_title gen_branch gen_deps)
 
@@ -163,6 +164,7 @@ let gen_patch_list_linear =
                 test_stubs_implemented = [];
                 complexity = None;
                 precedents = [];
+                required_context = [];
               }))
       (int_range 1 8))
 
@@ -212,6 +214,7 @@ let gen_patch_dag =
               test_stubs_implemented = [];
               complexity = None;
               precedents = [];
+              required_context = [];
             }
         in
         gen_patches (i + 1) (patch :: acc)
@@ -233,6 +236,7 @@ let gen_patch_dag =
           test_stubs_implemented = [];
           complexity = None;
           precedents = [];
+          required_context = [];
         }
     in
     gen_patches 1 [ root ])
@@ -259,6 +263,7 @@ let gen_gameplan =
             acceptance_criteria = [];
             open_questions = [];
             functional_changes = [];
+            context_resources = [];
           })
       gen_patch_list_unique)
 
@@ -704,6 +709,7 @@ let mk_linear_patches n =
           test_stubs_implemented = [];
           complexity = None;
           precedents = [];
+          required_context = [];
         })
 
 let make_test_gameplan patches =
@@ -721,6 +727,7 @@ let make_test_gameplan patches =
       acceptance_criteria = [];
       open_questions = [];
       functional_changes = [];
+      context_resources = [];
     }
 
 let pid_of_idx patches i =

--- a/skills/write-gameplan/SKILL.md
+++ b/skills/write-gameplan/SKILL.md
@@ -91,6 +91,7 @@ All of these fields are **required** and must be present in every gameplan:
 | `mergabilityStrategy` | `object` | `{ featureFlagStrategy, featureFlags, patchOrderingStrategy }` |
 | `requiredChanges` | `array` | `[{ file, line, description, signature }]` |
 | `functionalChanges` | `array` | `[{ id, description, ownedBy }]` — exhaustive, every entry assigned to exactly one patch. See [Functional Change Ownership](#functional-change-ownership). |
+| `contextResources` | `array` | `[{ id, kind, paths, why, consumedBy }]` — authoritative context specific patches must read before editing. See [Context Resources](#context-resources). |
 | `acceptanceCriteria` | `string[]` | Each is a "done" condition |
 | `openQuestions` | `string[]` | Decisions for the team (empty array if none) |
 | `explicitOpinions` | `array` | `[{ opinion, rationale }]` |
@@ -103,9 +104,36 @@ All of these fields are **required** and must be present in every gameplan:
 
 ### Required Patch Fields
 
-Each patch object must have: `number`, `classification` (INFRA\|GATED\|BEHAVIOR), `complexity` (1\|2\|3), `title`, `files` (array of `{ path, action, description }`), `changes` (string array), `testStubsIntroduced` (string array or null), `testStubsImplemented` (string array or null), `spec` (string). Patches may also include an optional `precedents` array citing established libraries, algorithms, or patterns the patch should adopt — see [Leveraging Established Precedents](#leveraging-established-precedents).
+Each patch object must have: `number`, `classification` (INFRA\|GATED\|BEHAVIOR), `complexity` (1\|2\|3), `title`, `files` (array of `{ path, action, description }`), `changes` (string array), `requiredContext` (string array), `testStubsIntroduced` (string array or null), `testStubsImplemented` (string array or null), `spec` (string). Patches may also include an optional `precedents` array citing established libraries, algorithms, or patterns the patch should adopt — see [Leveraging Established Precedents](#leveraging-established-precedents).
 
 The inline `spec` and `finalStateSpec` string fields in the JSON are the **sole source of truth** for formal specifications. Do not maintain separate spec files alongside the gameplan. For verification, extract the strings and validate them with the spec language's toolchain (see [Specification Language](#specification-language) below). Do not persist the extracted files.
+
+## Context Resources
+
+`contextResources` names authoritative context that an implementing patch agent must read before editing. This is for existing code, contracts, docs, tests, or predecessor surfaces that constrain implementation. It is not a dumping ground for general background.
+
+Allowed `kind` values:
+
+- `existing-implementation` — current code path or helper whose behavior should be reused or preserved.
+- `contract` — API, protocol, schema, interface, spec clause, or cross-runtime contract the patch must honor.
+- `predecessor` — old surface being retired, replaced, or migrated away from.
+- `reference-doc` — repo documentation or canonical maintainer docs describing the intended behavior.
+- `test-or-static-check` — tests, fixtures, evals, linters, or static checks that define expected behavior.
+- `external-reference` — external URL, standard, or vendor document that is authoritative for this patch.
+
+Each resource has `id`, `kind`, `paths`, `why`, and `consumedBy`. Each patch has `requiredContext`, an array of resource IDs. The routing must match in both directions: if `contextResources[].consumedBy` includes patch `3`, then patch `3` must include that resource ID in `requiredContext`, and vice versa. Attach resources only to patches that actually consume them.
+
+### When context is required
+
+Require context resources for patches that:
+
+- write docs, evals, test harnesses, adapters, replacement implementations, or policy logic;
+- retire, replace, or preserve behavior from an old surface;
+- describe an implementation or contract in documentation;
+- implement one side of a cross-runtime/API/schema contract;
+- depend on an existing test/static check as the source of truth.
+
+Docs, evals, and reference patches must name the implementation or contract they describe. Adapter/replacement patches must name the predecessor and the target contract. If a context resource defines a contract that a patch preserves, the relevant per-patch `spec` should cite that contract in its invariants.
 
 ## Formal Specifications
 
@@ -129,6 +157,8 @@ Each patch has a spec module describing the invariants that must hold after THAT
 - Preconditions that the patch assumes (from prior patches)
 
 **Spec-writing guidance**: Use progressive disclosure (top-down structure). Never guess domain details — if something is unclear, note it in `openQuestions`.
+
+Every functional change should map to at least one per-patch or final-state spec clause when the chosen spec language can express it. If a context resource defines a contract the patch preserves, name that contract in the spec prose/invariant so implementers and reviewers can trace the resource to the code obligation.
 
 ## Patch Classification
 
@@ -335,9 +365,11 @@ After writing the gameplan JSON, verify:
 3. The dependency graph is a valid DAG
 4. All test stubs have corresponding implementations
 5. **Functional change ownership is total and single-valued** — every `functionalChanges[i].id` is unique; every `functionalChanges[i].ownedBy` resolves to an existing `patches[].number`; no functional change appears unowned in prose. Re-read `problemStatement`, `solutionSummary`, `acceptanceCriteria`, and `finalStateSpec` and confirm every behavioral promise has a corresponding `functionalChanges` entry pointing at a single patch. Set `mergabilityChecklist.functionalChangesOwnedByExactlyOnePatch` to `true` only when this holds.
-6. **Operational considerations are substantive** — the schema requires every sub-field of `operationalConsiderations` to be present, but presence is not engagement. For each sub-field, confirm the response names concrete surfaces in *this* gameplan (specific runtimes, formats, code paths, stateful writes) rather than generic platitudes. A sub-field may say "not applicable" only when the gameplan genuinely does not touch that surface, and only with a brief justification grounded in the actual changes. See [Operational Considerations](#operational-considerations).
-7. **Atomicity holds** — re-read [Atomicity Constraint](#atomicity-constraint-read-this-first) and walk the patch list. Confirm that no patch is conditional on the outcome of another, no patch description or `changes` step expects a human to act between patches (flip a flag, run a script, observe a metric, decide a branch), and no patch implies an observation/soak window before the next one runs. If any of these slipped in, the work must be re-decomposed as a multi-milestone workstream via [[write-workstream]] — do not patch around it inside the gameplan. Set `mergabilityChecklist.gameplanIsAtomicAndAutonomous` to `true` only when this check passes.
-8. The mergability checklist passes
+6. **Context routing is exact** — every `contextResources[i].id` is unique and non-empty; every `requiredContext` entry resolves to an existing resource; every `consumedBy` patch exists; and each resource's `consumedBy` list exactly matches the patches whose `requiredContext` includes that resource ID. Confirm docs/evals/reference patches name the implementation or contract they describe.
+7. **Spec/evidence mapping is complete where applicable** — for each functional change, identify the spec or acceptance criterion it satisfies, the patch that implements it, the required context resource consulted (if any), and the test/static check expected to prove it.
+8. **Operational considerations are substantive** — the schema requires every sub-field of `operationalConsiderations` to be present, but presence is not engagement. For each sub-field, confirm the response names concrete surfaces in *this* gameplan (specific runtimes, formats, code paths, stateful writes) rather than generic platitudes. A sub-field may say "not applicable" only when the gameplan genuinely does not touch that surface, and only with a brief justification grounded in the actual changes. See [Operational Considerations](#operational-considerations).
+9. **Atomicity holds** — re-read [Atomicity Constraint](#atomicity-constraint-read-this-first) and walk the patch list. Confirm that no patch is conditional on the outcome of another, no patch description or `changes` step expects a human to act between patches (flip a flag, run a script, observe a metric, decide a branch), and no patch implies an observation/soak window before the next one runs. If any of these slipped in, the work must be re-decomposed as a multi-milestone workstream via [[write-workstream]] — do not patch around it inside the gameplan. Set `mergabilityChecklist.gameplanIsAtomicAndAutonomous` to `true` only when this check passes.
+10. The mergability checklist passes
 
 ## Resolving Open Questions
 

--- a/skills/write-gameplan/references/example.json
+++ b/skills/write-gameplan/references/example.json
@@ -88,6 +88,23 @@
     }
   ],
 
+  "contextResources": [
+    {
+      "id": "current-runner-fiber-decisions",
+      "kind": "existing-implementation",
+      "paths": ["bin/main.ml"],
+      "why": "runner_fiber currently contains the inline lifecycle decisions that Patch_decision must preserve and Patch 4 must replace.",
+      "consumedBy": [3, 4]
+    },
+    {
+      "id": "patch-decision-property-contract",
+      "kind": "contract",
+      "paths": ["spec/onton.pant", "test/test_patch_decision.ml"],
+      "why": "The formal spec and property tests define the decision invariants that Patch 3 implements.",
+      "consumedBy": [2, 3]
+    }
+  ],
+
   "acceptanceCriteria": [
     "Patch_decision module exists with pure functions for all decision points",
     "All decision functions are covered by QCheck2 property tests",
@@ -139,6 +156,7 @@
         "Add val disposition : merged:bool -> busy:bool -> disposition (placeholder)",
         "Add val needs_intervention : ci_failure_count:int -> bool (placeholder)"
       ],
+      "requiredContext": [],
       "testStubsIntroduced": null,
       "testStubsImplemented": null,
       "spec": "module EXTRACT_DECISION_PATCH_1.\n\n> Patch 1 introduces type declarations only.\n> No behavioral invariants — the contribution is the type structure itself.\n\nDisposition.\nskip => Disposition.\nqueue => Disposition.\ndeliver => Disposition.\n---\ntrue.\n"
@@ -165,6 +183,7 @@
         "Add pending test: busy patch is never delivered (spec: busy? p -> disposition p ~= deliver)",
         "Add pending test: CI failure count >= 3 requires intervention (spec: ci-failure-count p >= 3 -> needs-intervention? p)"
       ],
+      "requiredContext": ["patch-decision-property-contract"],
       "testStubsIntroduced": [
         "Patch_decision > merged patch is always skipped",
         "Patch_decision > busy patch is never delivered",
@@ -209,6 +228,7 @@
         "Implement needs_intervention: ci_failure_count >= 3 -> true, else -> false",
         "Enable all QCheck2 tests from Patch 2"
       ],
+      "requiredContext": ["current-runner-fiber-decisions", "patch-decision-property-contract"],
       "testStubsIntroduced": null,
       "testStubsImplemented": [
         "Patch_decision > merged patch is always skipped",
@@ -234,6 +254,7 @@
         "In CI failure handler (~line 1050): replace inline ci_failure_count >= 3 check with Patch_decision.needs_intervention",
         "Remove now-dead local helper functions that duplicated decision logic"
       ],
+      "requiredContext": ["current-runner-fiber-decisions"],
       "testStubsIntroduced": null,
       "testStubsImplemented": null,
       "spec": "module EXTRACT_DECISION_PATCH_4.\n\n> Patch 4 wires the pure decision module into main.ml.\n> The behavioral invariant: main.ml delegates all lifecycle\n> decisions to Patch_decision — no inline decision logic remains.\n\nPatch.\nRunnerFiber.\ninline-decisions rf: RunnerFiber, p: Patch => Nat0.\n---\n> All decision points in runner_fiber use Patch_decision.\nall rf: RunnerFiber, p: Patch | inline-decisions rf p = 0.\n"

--- a/skills/write-gameplan/references/gameplan-schema.json
+++ b/skills/write-gameplan/references/gameplan-schema.json
@@ -16,6 +16,7 @@
     "operationalConsiderations",
     "requiredChanges",
     "functionalChanges",
+    "contextResources",
     "acceptanceCriteria",
     "openQuestions",
     "explicitOpinions",
@@ -76,6 +77,11 @@
       "type": "array",
       "items": { "$ref": "#/$defs/functionalChange" },
       "description": "Exhaustive enumeration of the functional/behavioural changes this gameplan introduces, each assigned to exactly one owning patch. Use this to defeat the failure mode where a change is described prose-only in the problem/solution narrative and every patch implementer assumes some other patch owns it. The mapping is total on changes: every entry has an `ownedBy` patch. Multiple changes may map to the same patch; INFRA-only patches that introduce no observable change need not appear here. Downstream consumers (e.g. onton's patch prompt renderer) MUST surface the subset of functionalChanges ownedBy each patch in that patch's agent prompt, so the implementing agent knows exactly which user-visible behaviors are its responsibility."
+    },
+    "contextResources": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/contextResource" },
+      "description": "Authoritative existing implementations, contracts, predecessor surfaces, reference docs, tests/static checks, or external references that specific patches must read before editing. Attach resources only to patches that consume them: each resource's consumedBy list must match those patches' requiredContext arrays."
     },
     "acceptanceCriteria": {
       "type": "array",
@@ -286,7 +292,7 @@
     },
     "patch": {
       "type": "object",
-      "required": ["number", "classification", "complexity", "title", "files", "changes", "spec"],
+      "required": ["number", "classification", "complexity", "title", "files", "changes", "requiredContext", "spec"],
       "properties": {
         "number": {
           "$ref": "#/$defs/patchId"
@@ -310,6 +316,11 @@
           "items": { "type": "string" },
           "description": "Each item is a specific change to make."
         },
+        "requiredContext": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "description": "IDs from top-level contextResources this patch must read before editing. Use an empty array when the patch has no authoritative context beyond the patch prose. Must match contextResources[].consumedBy routing."
+        },
         "testStubsIntroduced": {
           "type": ["array", "null"],
           "items": { "type": "string" },
@@ -328,6 +339,37 @@
           "type": ["array", "null"],
           "items": { "$ref": "#/$defs/precedent" },
           "description": "Established prior art (libraries, algorithms, patterns, papers, RFCs, canonical docs) that informs this patch. Cite concrete proven techniques the implementing agent should adopt rather than rolling its own. Null or omitted means no specific precedent applies (e.g. the patch is bespoke project glue). See SKILL.md's 'Leveraging Established Precedents' section for when and how to populate this."
+        }
+      },
+      "additionalProperties": false
+    },
+    "contextResource": {
+      "type": "object",
+      "required": ["id", "kind", "paths", "why", "consumedBy"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Stable identifier referenced by patches[].requiredContext."
+        },
+        "kind": {
+          "type": "string",
+          "enum": ["existing-implementation", "contract", "predecessor", "reference-doc", "test-or-static-check", "external-reference"],
+          "description": "Why this resource is authoritative."
+        },
+        "paths": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "description": "Repo-relative paths or external references the patch agent should read. For external references, use stable URLs or canonical identifiers."
+        },
+        "why": {
+          "type": "string",
+          "description": "Why this resource is authoritative and what contract, behavior, or precedent it constrains."
+        },
+        "consumedBy": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/patchId" },
+          "description": "Patch IDs that consume this resource. Must match each consuming patch's requiredContext array."
         }
       },
       "additionalProperties": false

--- a/test/test_interleaving_properties.ml
+++ b/test/test_interleaving_properties.ml
@@ -1966,6 +1966,7 @@ let () =
             test_stubs_implemented = [];
             complexity = None;
             precedents = [];
+            required_context = [];
           }
         in
         let b : Patch.t =

--- a/test/test_onton.ml
+++ b/test/test_onton.ml
@@ -17,6 +17,7 @@ let () =
           test_stubs_implemented = [];
           complexity = None;
           precedents = [];
+          required_context = [];
         };
     ]
   in
@@ -37,6 +38,7 @@ let () =
         acceptance_criteria = [];
         open_questions = [];
         functional_changes = [];
+        context_resources = [];
       }
   in
   let _orch, _effects, actions =

--- a/test/test_orchestrator_properties.ml
+++ b/test/test_orchestrator_properties.ml
@@ -39,6 +39,7 @@ let make_gameplan patches =
       acceptance_criteria = [];
       open_questions = [];
       functional_changes = [];
+      context_resources = [];
     }
 
 let tick orch ~patches =

--- a/test/test_patch_controller.ml
+++ b/test/test_patch_controller.ml
@@ -22,6 +22,7 @@ let make_patch pid branch =
       test_stubs_implemented = [];
       complexity = None;
       precedents = [];
+      required_context = [];
     }
 
 let make_gameplan patch =
@@ -39,6 +40,7 @@ let make_gameplan patch =
       acceptance_criteria = [];
       open_questions = [];
       functional_changes = [];
+      context_resources = [];
     }
 
 let make_orch patch agent =

--- a/test/test_patch_controller_state_machine.ml
+++ b/test/test_patch_controller_state_machine.ml
@@ -22,6 +22,7 @@ let make_patch pid branch =
       test_stubs_implemented = [];
       complexity = None;
       precedents = [];
+      required_context = [];
     }
 
 let make_gameplan patch =
@@ -39,6 +40,7 @@ let make_gameplan patch =
       acceptance_criteria = [];
       open_questions = [];
       functional_changes = [];
+      context_resources = [];
     }
 
 let messages_equal a b = List.equal Orchestrator.equal_patch_agent_message a b

--- a/test/test_persistence_properties.ml
+++ b/test/test_persistence_properties.ml
@@ -36,6 +36,7 @@ let gameplan_for_agent (agent : Onton_core.Patch_agent.t) =
             test_stubs_implemented = [];
             complexity = None;
             precedents = [];
+            required_context = [];
           };
         ];
       current_state_analysis = "";
@@ -43,6 +44,7 @@ let gameplan_for_agent (agent : Onton_core.Patch_agent.t) =
       acceptance_criteria = [];
       open_questions = [];
       functional_changes = [];
+      context_resources = [];
     }
 
 (** Compare two snapshots field by field. Orchestrator.t is opaque without [eq],
@@ -128,6 +130,7 @@ let () =
                 acceptance_criteria = [];
                 open_questions = [];
                 functional_changes = [];
+                context_resources = [];
               }
           in
           let orchestrator =
@@ -263,6 +266,7 @@ let () =
                 acceptance_criteria = [];
                 open_questions = [];
                 functional_changes = [];
+                context_resources = [];
               }
           in
           let main_branch = Branch.of_string "main" in
@@ -316,6 +320,7 @@ let () =
                 acceptance_criteria = [];
                 open_questions = [];
                 functional_changes = [];
+                context_resources = [];
               }
           in
           let main_branch = Branch.of_string "main" in

--- a/test/test_poll_log_properties.ml
+++ b/test/test_poll_log_properties.ml
@@ -31,6 +31,7 @@ let make_patch pid branch =
       test_stubs_implemented = [];
       complexity = None;
       precedents = [];
+      required_context = [];
     }
 
 let make_orch patch agent =

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -17,6 +17,7 @@ let make_gameplan patches =
       acceptance_criteria = [];
       open_questions = [];
       functional_changes = [];
+      context_resources = [];
     }
 
 let tick orch ~patches =
@@ -159,6 +160,7 @@ let () =
          test_stubs_implemented = [];
          complexity = None;
          precedents = [];
+         required_context = [];
        }
    in
    let a = Types.Patch_id.of_string "A" in
@@ -400,6 +402,7 @@ let () =
           test_stubs_implemented = [];
           complexity = None;
           precedents = [];
+          required_context = [];
         };
     ]
   in
@@ -461,6 +464,7 @@ let () =
         test_stubs_implemented = [];
         complexity = None;
         precedents = [];
+        required_context = [];
       }
   in
 
@@ -573,6 +577,7 @@ let () =
           test_stubs_implemented = [];
           complexity = None;
           precedents = [];
+          required_context = [];
         };
       Types.Patch.
         {
@@ -590,6 +595,7 @@ let () =
           test_stubs_implemented = [];
           complexity = None;
           precedents = [];
+          required_context = [];
         };
     ]
   in
@@ -639,6 +645,7 @@ let () =
             test_stubs_implemented = [];
             complexity = None;
             precedents = [];
+            required_context = [];
           };
       ]
     in
@@ -668,6 +675,7 @@ let () =
                 test_stubs_implemented = [];
                 complexity = None;
                 precedents = [];
+                required_context = [];
               };
           ]
         in
@@ -775,6 +783,7 @@ let () =
             test_stubs_implemented = [];
             complexity = None;
             precedents = [];
+            required_context = [];
           };
       ]
     in
@@ -841,6 +850,7 @@ let () =
                   test_stubs_implemented = [];
                   complexity = None;
                   precedents = [];
+                  required_context = [];
                 };
             ]
           in
@@ -970,6 +980,7 @@ let () =
             test_stubs_implemented = [];
             complexity = None;
             precedents = [];
+            required_context = [];
           };
       ]
     in

--- a/test/test_prune_decision_properties.ml
+++ b/test/test_prune_decision_properties.ml
@@ -19,6 +19,7 @@ let patch i =
       test_stubs_implemented = [];
       complexity = None;
       precedents = [];
+      required_context = [];
     }
 
 let agent_for_patch ?(merged = false) (p : Patch.t) =

--- a/test/test_reconciler_properties.ml
+++ b/test/test_reconciler_properties.ml
@@ -551,6 +551,7 @@ let prop_reconcile_e2e_catches_drift =
           test_stubs_implemented = [];
           complexity = None;
           precedents = [];
+          required_context = [];
         }
       in
       let graph = Graph.of_patches [ patch ] in
@@ -592,6 +593,7 @@ let prop_reconcile_dedup_rebase =
           test_stubs_implemented = [];
           complexity = None;
           precedents = [];
+          required_context = [];
         }
       in
       let graph = Graph.of_patches [ patch ] in

--- a/test/test_runtime_create.ml
+++ b/test/test_runtime_create.ml
@@ -20,6 +20,7 @@ let () =
       acceptance_criteria = [];
       open_questions = [];
       functional_changes = [];
+      context_resources = [];
     }
   in
   let snapshot =
@@ -55,6 +56,7 @@ let () =
       acceptance_criteria = [];
       open_questions = [];
       functional_changes = [];
+      context_resources = [];
     }
   in
   let snapshot =

--- a/test/test_spawn_logic.ml
+++ b/test/test_spawn_logic.ml
@@ -27,6 +27,7 @@ let make_gameplan patches =
       acceptance_criteria = [];
       open_questions = [];
       functional_changes = [];
+      context_resources = [];
     }
 
 (* ========== Helper: prepare orchestrator with PRs and queued ops ========== *)

--- a/test/test_worktree_missing_recovery.ml
+++ b/test/test_worktree_missing_recovery.ml
@@ -98,6 +98,7 @@ let () =
           test_stubs_implemented = [];
           complexity = None;
           precedents = [];
+          required_context = [];
         };
     ]
   in


### PR DESCRIPTION
## Summary
- add first-class contextResources and per-patch requiredContext parsing/validation
- inject required context into patch prompts while preserving existing precedents routing
- update write-gameplan schema, guidance, example, and regression coverage

## Verification
- dune fmt
- dune build
- dune runtest
- pre-commit hook: build + tests + format check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds first-class `contextResources` and per-patch `requiredContext` with strict two-way validation, and shows only the required resources in patch prompts. IDs are trimmed/normalized; invalid `consumedBy`, non-array `consumedBy`, or non-string `requiredContext` entries hard-error.

- **New Features**
  - Gameplan: `contextResources` and per-patch `requiredContext` with strict checks — unique normalized IDs, allowed `kind`, `consumedBy` must be an array of existing patches, `requiredContext` must be a string-array referencing existing resources, and two-way routing must match exactly.
  - Prompts: patch prompts include “Required Context Before Editing” listing only that patch’s resources, plus PR-body guidance to add a short “Spec/Evidence Mapping”.
  - Schema/docs/APIs: updated JSON schema, SKILL guidance, and example; new types (`Context_resource`) and prompt APIs (`required_context_resources`, `render_patch_layer ?context_resources`). Legacy gameplans default to empty lists.

- **Migration**
  - Add `contextResources: []` at the gameplan level and `"requiredContext": []` to each patch; allowed kinds: `existing-implementation`, `contract`, `predecessor`, `reference-doc`, `test-or-static-check`, `external-reference`.
  - Ensure routing is exact and shapes are correct: `consumedBy` must be an array of valid patch IDs; `requiredContext` must be an array of strings whose IDs exist. Any mismatch or bad shape fails parsing.
  - If you call `render_patch_layer` directly, pass the optional `?context_resources` when composing prompts.

<sup>Written for commit b45418f8447d067dcf3270195592351ebd8b5868. Summary will update on new commits. <a href="https://cubic.dev/pr/flowglad/onton/pull/288?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gameplans now include authoritative "context resources" and patches can declare required context; tooling validates routing and references.
  * Patch prompts and PR-body templates surface required context resources and a short Spec/Evidence mapping when applicable.

* **Documentation**
  * Gameplan docs and JSON schema updated with contextResources/requiredContext structure, guidance, and verification checklist.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flowglad/onton/pull/288?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->