### PR TITLE
Functorize review service client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       # `opam install` step under ~90s by serving precompiled binaries.
       - uses: ocaml/setup-ocaml@e32b06a3e831ff2fbc6f08cf35be2085e3918014 # v3.6.1
         with:
-          ocaml-compiler: '5.4.0'
+          ocaml-compiler: '5.4.1'
           dune-cache: true
 
       - name: Use opam.ocaml.org archive cache
@@ -105,11 +105,11 @@ jobs:
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
         with:
           path: _opam
-          key: opam-${{ runner.os }}-ocaml-5.4.0-${{ hashFiles('*.opam') }}
+          key: opam-${{ runner.os }}-ocaml-5.4.1-${{ hashFiles('*.opam') }}
 
       - uses: ocaml/setup-ocaml@e32b06a3e831ff2fbc6f08cf35be2085e3918014 # v3.6.1
         with:
-          ocaml-compiler: '5.4.0'
+          ocaml-compiler: '5.4.1'
 
       - name: Use opam.ocaml.org archive cache
         run: opam option 'archive-mirrors=["https://opam.ocaml.org/cache"]'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,6 +100,6 @@ Pitfalls when reading a bundle:
 - Reference specification: `../orchestrate-gameplan/spec/anton.pant`
 
 ## Stack
-- OCaml 5.4.0, dune 3.21, local opam switch
+- OCaml 5.4.1, dune 3.21, local opam switch
 - `open Base` in lib modules for Jane Street ppx compatibility
 - PPX: ppx_deriving (show/eq/ord), ppx_sexp_conv, ppx_compare, ppx_hash, ppx_expect, ppx_inline_test, ppx_assert

--- a/README.md
+++ b/README.md
@@ -84,12 +84,12 @@ x86_64).
 ### Option C: From source
 
 Only needed if you want to modify onton or are on a platform without prebuilt
-binaries. Requires OCaml 5.4.0, dune 3.21, and opam:
+binaries. Requires OCaml 5.4.1, dune 3.21, and opam:
 
 ```sh
 git clone https://github.com/flowglad/onton.git
 cd onton
-opam switch create . ocaml.5.4.0 --deps-only
+opam switch create . ocaml.5.4.1 --deps-only
 eval $(opam env)
 opam install . --deps-only
 dune build
@@ -237,7 +237,7 @@ worth knowing about:
 ### Building from source (development only)
 
 In addition to the runtime dependencies above, building from source needs the
-OCaml toolchain listed under [Option C](#option-c-from-source): OCaml 5.4.0,
+OCaml toolchain listed under [Option C](#option-c-from-source): OCaml 5.4.1,
 dune 3.21, and opam. `opam install . --deps-only` installs the rest
 (`base`, `eio`, `cmarkit`, `re`, `cmdliner`, `qcheck`, etc.).
 

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1875,17 +1875,17 @@ struct
 
   (** Poller fiber — periodically polls GitHub for PR state changes and
       reconciles. *)
-  let poll_review_backends ~net ~clock ~runtime ~patch_id ~findings_registry
-      ~review_backends ~owner ~repo ~pr_number : Review_service.finding list =
-    Base.List.concat_map review_backends ~f:(fun (b : Review_backend.t) ->
-        match
-          Review_service_client.list_findings ~net ~clock ~backend:b ~owner
-            ~repo ~pr_number ()
-        with
+  let poll_review_backends ~runtime ~patch_id ~findings_registry ~review_clients
+      ~owner ~repo ~pr_number : Review_service.finding list =
+    Base.List.concat_map review_clients
+      ~f:(fun
+          (module R : Review_service_client.S
+            with type error = Review_service_client.error)
+        ->
+        match R.list_findings ~owner ~repo ~pr_number () with
         | Error err ->
             log_event runtime ~patch_id
-              (Printf.sprintf "Poll error — %s"
-                 (Review_service_client.show_error err));
+              (Printf.sprintf "Poll error — %s" (R.show_error err));
             []
         | Ok response ->
             let parsed_count =
@@ -1896,8 +1896,7 @@ struct
                 (Printf.sprintf
                    "Review backend %s declared %d finding(s) but parsed %d — \
                     possible review-service schema drift"
-                   b.Review_backend.name response.Review_service.count
-                   parsed_count);
+                   R.name response.Review_service.count parsed_count);
             Base.List.iter response.Review_service.dropped_findings
               ~f:(fun (e : Review_service.finding_parse_error) ->
                 let json =
@@ -1909,25 +1908,23 @@ struct
                   (Printf.sprintf
                      "Review backend %s dropped finding at index %d while \
                       parsing: %s; json=%s"
-                     b.Review_backend.name e.Review_service.index
-                     e.Review_service.error json));
+                     R.name e.Review_service.index e.Review_service.error json));
             let keyed_findings =
               Base.List.map response.Review_service.findings
                 ~f:(fun (f : Review_service.finding) ->
                   let key =
-                    Findings_registry.make_key
-                      ~backend_name:b.Review_backend.name ~owner ~repo
+                    Findings_registry.make_key ~backend_name:R.name ~owner ~repo
                       ~pr_number ~finding_id:f.Review_service.id
                   in
                   (key, f))
             in
             Findings_registry.remove_stale_for_scope findings_registry
-              ~backend_name:b.Review_backend.name ~owner ~repo ~pr_number
+              ~backend_name:R.name ~owner ~repo ~pr_number
               ~keep_keys:(Base.List.map keyed_findings ~f:fst);
             Base.List.map keyed_findings ~f:(fun (key, f) ->
                 Findings_registry.register findings_registry ~key
                   {
-                    Findings_registry.backend = b;
+                    Findings_registry.backend_name = R.name;
                     owner;
                     repo;
                     pr_number;
@@ -1951,8 +1948,8 @@ struct
     | Error (Github.Json_parse_error msg) -> Poll_outcome.Json_parse_failed msg
 
   let poller_fiber (module StartupReconciler : STARTUP_RECONCILER) ~runtime
-      ~clock ~net ~process_mgr ~config ~project_name ~pr_registry ~branch_of
-      ~event_log ~review_backends ~findings_registry =
+      ~clock ~process_mgr ~config ~project_name ~pr_registry ~branch_of
+      ~event_log ~review_clients ~findings_registry =
     let main = config.main_branch in
     let skip_logged : (Patch_id.t, bool) Hashtbl.t = Hashtbl.create 16 in
     let skip_logged_mutex = Eio.Mutex.create () in
@@ -2077,11 +2074,11 @@ struct
                  Failures inside [poll_review_backends] are logged but
                  non-fatal. *)
                 let findings =
-                  if Base.List.is_empty review_backends then []
+                  if Base.List.is_empty review_clients then []
                   else
-                    poll_review_backends ~net ~clock ~runtime ~patch_id
-                      ~findings_registry ~review_backends
-                      ~owner:config.github_owner ~repo:config.github_repo
+                    poll_review_backends ~runtime ~patch_id ~findings_registry
+                      ~review_clients ~owner:config.github_owner
+                      ~repo:config.github_repo
                       ~pr_number:(Pr_number.to_int pr_number)
                 in
                 let pr_state = { pr_state with Pr_state.findings } in
@@ -2247,8 +2244,8 @@ struct
   (** Runner fiber — executes orchestrator actions by driving backend sessions
       concurrently. *)
   let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name
-      ~pr_registry ~findings_registry ~review_backends ~transcripts ~net
-      ~event_log ?status_msg () =
+      ~pr_registry ~findings_registry ~review_clients ~transcripts ~event_log
+      ?status_msg () =
     let main = config.main_branch in
     let process_mgr = Eio.Stdenv.process_mgr env in
     let clock = Eio.Stdenv.clock env in
@@ -2936,11 +2933,11 @@ struct
                       if Operation_kind.equal kind Operation_kind.Findings then
                         match pr_number with
                         | Some pr_num
-                          when not (Base.List.is_empty review_backends) ->
+                          when not (Base.List.is_empty review_clients) ->
                             log_event runtime ~patch_id
                               "Fetching fresh findings from review backends";
-                            poll_review_backends ~net ~clock ~runtime ~patch_id
-                              ~findings_registry ~review_backends
+                            poll_review_backends ~runtime ~patch_id
+                              ~findings_registry ~review_clients
                               ~owner:config.github_owner
                               ~repo:config.github_repo
                               ~pr_number:(Pr_number.to_int pr_num)
@@ -3683,7 +3680,8 @@ struct
                                                   ~project_name ~patch_id
                                               in
                                               Findings_resolver
-                                              .resolve_after_session ~net ~clock
+                                              .resolve_after_session
+                                                ~review_clients
                                                 ~log:(fun msg ->
                                                   log_event runtime ~patch_id
                                                     msg)
@@ -4597,7 +4595,10 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
         (Activity_log_sink.sink
            ~update:(Runtime.update_activity_log runtime)
            ());
-      let review_backends = repo_config.Repo_config.review_backends in
+      let review_clients =
+        Base.List.map repo_config.Repo_config.review_backends ~f:(fun backend ->
+            Review_service_client.make ~net ~clock ~backend)
+      in
       let findings_registry = Findings_registry.create () in
       let common_fibers =
         [
@@ -4605,9 +4606,8 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
           (fun () ->
             poller_fiber
               (module Reconciler : STARTUP_RECONCILER)
-              ~runtime ~clock ~net ~process_mgr ~config ~project_name
-              ~pr_registry ~branch_of ~event_log ~review_backends
-              ~findings_registry);
+              ~runtime ~clock ~process_mgr ~config ~project_name ~pr_registry
+              ~branch_of ~event_log ~review_clients ~findings_registry);
           (fun () ->
             persistence_fiber ~runtime ~clock ~project_name ~transcripts);
         ]
@@ -4617,7 +4617,7 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
           ((fun () -> headless_fiber ~runtime ~clock ~stdout)
           :: (fun () ->
             runner_fiber ~runtime ~env ~config ~pick_backend ~project_name
-              ~pr_registry ~findings_registry ~review_backends ~transcripts ~net
+              ~pr_registry ~findings_registry ~review_clients ~transcripts
               ~event_log ())
           :: common_fibers)
       else
@@ -4670,8 +4670,8 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
                     ~repo:config.github_repo ~resolve_routing)
                 :: (fun () ->
                   runner_fiber ~runtime ~env ~config ~pick_backend ~project_name
-                    ~pr_registry ~findings_registry ~review_backends
-                    ~transcripts ~net ~event_log ~status_msg ())
+                    ~pr_registry ~findings_registry ~review_clients ~transcripts
+                    ~event_log ~status_msg ())
                 :: common_fibers)
             with Quit_tui -> ())
 

--- a/lib/findings_registry.ml
+++ b/lib/findings_registry.ml
@@ -1,5 +1,5 @@
 type entry = {
-  backend : Onton_core.Review_backend.t;
+  backend_name : string;
   owner : string;
   repo : string;
   pr_number : int;
@@ -23,8 +23,7 @@ let remove_stale_for_scope t ~backend_name ~owner ~repo ~pr_number ~keep_keys =
       Hashtbl.iter
         (fun key (entry : entry) ->
           let same_scope =
-            String.equal entry.backend.Onton_core.Review_backend.name
-              backend_name
+            String.equal entry.backend_name backend_name
             && String.equal entry.owner owner
             && String.equal entry.repo repo
             && entry.pr_number = pr_number

--- a/lib/findings_registry.mli
+++ b/lib/findings_registry.mli
@@ -13,14 +13,15 @@
 type t
 
 type entry = {
-  backend : Onton_core.Review_backend.t;
+  backend_name : string;
   owner : string;
   repo : string;
   pr_number : int;
   finding_id : string;
 }
 (** The information needed to address a resolve verb back to the originating
-    backend, on the same PR coordinates Onton observed. [finding_id] is the raw
+    backend, on the same PR coordinates Onton observed. [backend_name] selects
+    the configured review-service client, and [finding_id] is the raw
     backend-local id used in the review-service API path. *)
 
 val create : unit -> t

--- a/lib/findings_resolver.ml
+++ b/lib/findings_resolver.ml
@@ -9,7 +9,14 @@ let read_artifact path =
            (fun () -> Stdlib.In_channel.input_all ic))
     with Sys_error msg -> Error msg
 
-let resolve_after_session ~net ~clock ~log ~findings_registry ~artifact_path
+let find_review_client review_clients ~backend_name =
+  List.find_opt
+    (fun (module R : Review_service_client.S
+           with type error = Review_service_client.error) ->
+      String.equal R.name backend_name)
+    review_clients
+
+let resolve_after_session ~review_clients ~log ~findings_registry ~artifact_path
     ~delivered ?actor () =
   (* Parse the wontfix artifact. Missing means "no wontfix entries"; read or
      parse failures fail closed so we do not accidentally mark findings as
@@ -72,25 +79,35 @@ let resolve_after_session ~net ~clock ~log ~findings_registry ~artifact_path
               | Some r -> (Onton_core.Review_service.Resolve_wontfix, Some r)
               | None -> (Onton_core.Review_service.Resolve_addressed, None)
             in
-            match
-              Review_service_client.mark_resolved ~net ~clock
-                ~backend:entry.Findings_registry.backend
-                ~owner:entry.Findings_registry.owner
-                ~repo:entry.Findings_registry.repo
-                ~pr_number:entry.Findings_registry.pr_number
-                ~finding_id:entry.Findings_registry.finding_id ~kind ?actor
-                ?reason ()
-            with
-            | Ok response ->
+            let backend_name = entry.Findings_registry.backend_name in
+            match find_review_client review_clients ~backend_name with
+            | None ->
                 log
-                  (Printf.sprintf "Resolved finding %s as %s (server: %s)" f.id
-                     (Onton_core.Review_service.resolve_kind_to_string kind)
-                     (Onton_core.Review_service.outcome_kind_to_string
-                        response.Onton_core.Review_service.outcome.kind));
-                Findings_registry.forget findings_registry ~key:f.id
-            | Error err ->
-                log
-                  (Printf.sprintf "Failed to resolve finding %s — %s" f.id
-                     (Review_service_client.show_error err));
-                Findings_registry.forget findings_registry ~key:f.id))
+                  (Printf.sprintf
+                     "Skipping resolve for finding %s — review backend %s is \
+                      no longer configured"
+                     f.id backend_name)
+            | Some
+                (module R : Review_service_client.S
+                  with type error = Review_service_client.error) -> (
+                match
+                  R.mark_resolved ~owner:entry.Findings_registry.owner
+                    ~repo:entry.Findings_registry.repo
+                    ~pr_number:entry.Findings_registry.pr_number
+                    ~finding_id:entry.Findings_registry.finding_id ~kind ?actor
+                    ?reason ()
+                with
+                | Ok response ->
+                    log
+                      (Printf.sprintf "Resolved finding %s as %s (server: %s)"
+                         f.id
+                         (Onton_core.Review_service.resolve_kind_to_string kind)
+                         (Onton_core.Review_service.outcome_kind_to_string
+                            response.Onton_core.Review_service.outcome.kind));
+                    Findings_registry.forget findings_registry ~key:f.id
+                | Error err ->
+                    log
+                      (Printf.sprintf "Failed to resolve finding %s — %s" f.id
+                         (R.show_error err));
+                    Findings_registry.forget findings_registry ~key:f.id)))
       delivered

--- a/lib/findings_resolver.ml
+++ b/lib/findings_resolver.ml
@@ -86,7 +86,8 @@ let resolve_after_session ~review_clients ~log ~findings_registry ~artifact_path
                   (Printf.sprintf
                      "Skipping resolve for finding %s — review backend %s is \
                       no longer configured"
-                     f.id backend_name)
+                     f.id backend_name);
+                Findings_registry.forget findings_registry ~key:f.id
             | Some
                 (module R : Review_service_client.S
                   with type error = Review_service_client.error) -> (

--- a/lib/findings_resolver.mli
+++ b/lib/findings_resolver.mli
@@ -9,8 +9,7 @@
     the rest of the session pipeline. *)
 
 val resolve_after_session :
-  net:_ Eio.Net.t ->
-  clock:_ Eio.Time.clock ->
+  review_clients:Review_service_client.client list ->
   log:(string -> unit) ->
   findings_registry:Findings_registry.t ->
   artifact_path:string ->

--- a/lib/review_service_client.ml
+++ b/lib/review_service_client.ml
@@ -185,3 +185,47 @@ let mark_resolved ~net ~clock ~backend ~owner ~repo ~pr_number ~finding_id ~kind
       match Onton_core.Review_service.parse_resolve_response_string body with
       | Ok r -> Ok r
       | Error msg -> Error (Parse_error msg))
+
+module type S = sig
+  type error
+
+  val show_error : error -> string
+  val name : string
+
+  val list_findings :
+    owner:string ->
+    repo:string ->
+    pr_number:int ->
+    unit ->
+    (Onton_core.Review_service.findings_response, error) Result.t
+
+  val mark_resolved :
+    owner:string ->
+    repo:string ->
+    pr_number:int ->
+    finding_id:string ->
+    kind:Onton_core.Review_service.resolve_kind ->
+    ?actor:string ->
+    ?reason:string ->
+    unit ->
+    (Onton_core.Review_service.resolve_response, error) Result.t
+end
+
+type client = (module S with type error = error)
+
+let make ~net ~clock ~(backend : Onton_core.Review_backend.t) : client =
+  let module M = struct
+    type nonrec error = error
+
+    let show_error = show_error
+    let name = backend.Onton_core.Review_backend.name
+
+    let list_findings ~owner ~repo ~pr_number () =
+      list_findings ~net ~clock ~backend ~owner ~repo ~pr_number ()
+
+    let mark_resolved ~owner ~repo ~pr_number ~finding_id ~kind ?actor ?reason
+        () =
+      mark_resolved ~net ~clock ~backend ~owner ~repo ~pr_number ~finding_id
+        ~kind ?actor ?reason ()
+  end in
+  (module M)

--- a/lib/review_service_client.mli
+++ b/lib/review_service_client.mli
@@ -23,6 +23,43 @@ type error =
 
 val show_error : error -> string
 
+(** Consumer-facing review-service capability. Implementations capture network,
+    clock, and backend configuration at construction time. *)
+module type S = sig
+  type error
+
+  val show_error : error -> string
+  val name : string
+
+  val list_findings :
+    owner:string ->
+    repo:string ->
+    pr_number:int ->
+    unit ->
+    (Onton_core.Review_service.findings_response, error) Stdlib.Result.t
+
+  val mark_resolved :
+    owner:string ->
+    repo:string ->
+    pr_number:int ->
+    finding_id:string ->
+    kind:Onton_core.Review_service.resolve_kind ->
+    ?actor:string ->
+    ?reason:string ->
+    unit ->
+    (Onton_core.Review_service.resolve_response, error) Stdlib.Result.t
+end
+
+type client = (module S with type error = error)
+
+val make :
+  net:_ Eio.Net.t ->
+  clock:_ Eio.Time.clock ->
+  backend:Onton_core.Review_backend.t ->
+  client
+(** [make ~net ~clock ~backend] packages a review-service backend as a
+    capability module whose calls no longer need per-call effect arguments. *)
+
 val list_findings :
   net:_ Eio.Net.t ->
   clock:_ Eio.Time.clock ->

--- a/onton.opam
+++ b/onton.opam
@@ -4,7 +4,7 @@ version: "0.6.0"
 synopsis: "OCaml orchestrator for parallel Claude Code agents"
 maintainer: ["flowglad"]
 depends: [
-  "ocaml" {= "5.4.0"}
+  "ocaml" {= "5.4.1"}
   "dune" {>= "3.21" & < "3.22"}
   "base" {>= "v0.17.0"}
   "eio" {>= "1.3"}

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -5,7 +5,7 @@
 #   - post-checkout: runs sync-skills.sh after branch switches so ~/.agents/skills
 #     always points at the current checkout
 #   - pre-commit: runs dune build / runtest / fmt against the project's local
-#     opam switch (5.4.0), not whatever the user's default switch happens to be
+#     opam switch (5.4.1), not whatever the user's default switch happens to be
 #
 # Safe to run repeatedly. Refuses to overwrite a pre-existing hook that isn't
 # onton's own (detected via a sentinel comment). Also runs sync-skills.sh once
@@ -84,7 +84,7 @@ install_hook pre-commit <<'HOOK'
 # to detect that this hook is owned by onton and may be safely overwritten.
 set -e
 
-# Activate the project's local opam switch (5.4.0) rather than whatever the
+# Activate the project's local opam switch (5.4.1) rather than whatever the
 # user's default switch happens to be. git-common-dir resolves to the main
 # repo's .git from any worktree; its parent is the project root that holds _opam.
 PROJECT_ROOT="$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")"


### PR DESCRIPTION
## Summary
- add a Review_service_client capability module that captures net, clock, and backend at construction
- route polling and findings resolution through constructed review clients instead of threading raw effect args
- upgrade the repo OCaml requirement and local switch docs from 5.4.0 to 5.4.1

## Verification
- pre-commit hook passed: dune build, dune runtest, format check
- manually verified local switch invariant: ocaml-base-compiler 5.4.1

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Functorized the review-service client into capability modules that capture `net`, `clock`, and backend config, simplifying polling and resolution. Upgraded to `ocaml` 5.4.1 across opam, CI, docs, and hooks to avoid solver conflicts.

- **Refactors**
  - Added `Review_service_client.S` and `make` to build per-backend clients; calls no longer pass `net`/`clock` each time.
  - Converted poller and runner to use a `review_clients` list instead of raw backends.
  - Switched `findings_resolver` to resolve via the matching client by `backend_name`.
  - Updated `findings_registry` entries to store `backend_name` (not the full backend record).
  - Adjusted public signatures in `findings_resolver.mli` and `review_service_client.mli`; rewired call sites in `bin/main.ml`.

- **Bug Fixes**
  - Forget findings when a review backend is no longer configured to avoid registry leaks; still logs and skips resolving.

<sup>Written for commit 67494bfddb2bb697c3d057b6d0579e937c4ded37. Summary will update on new commits. <a href="https://cubic.dev/pr/flowglad/onton/pull/289?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

