### PR TITLE
Functorize worktree access

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -453,8 +453,13 @@ let pluralize ?plural n singular =
   let many = match plural with Some p -> p | None -> singular ^ "s" in
   Printf.sprintf "%d %s" n (if n = 1 then singular else many)
 
-module Make_fibers (Forge : Onton.Forge.S with type error = Github.error) =
+module Make_fibers
+    (Forge : Onton.Forge.S with type error = Github.error)
+    (W : Worktree.S) =
 struct
+  module Worktree_setup = Worktree_setup.Make (W)
+  module Session_driver = Session_driver.Make (W)
+
   (** Execute declarative GitHub effects and record successful observations back
       into durable state. *)
   let execute_github_effects ~runtime effects =
@@ -859,18 +864,16 @@ struct
 
       Returns the final result paired with the worktree path so callers can use
       it for follow-on effects like [Worktree.force_push_with_lease]. *)
-  let execute_worktree_plan ~runtime ~process_mgr ~clock ~fs ~repo_root
-      ~project_name ~patch_id ~(agent : Patch_agent.t) ~user_config
-      ~worktree_mutex ~hook_mutex ~fetch_lock ~fail_label ~ancestor_ids
-      (plan : Worktree_plan.t) =
+  let execute_worktree_plan ~runtime ~clock ~fs ~project_name ~patch_id
+      ~(agent : Patch_agent.t) ~user_config ~worktree_mutex ~hook_mutex
+      ~fetch_lock ~fail_label ~ancestor_ids (plan : Worktree_plan.t) =
     let default_path = Worktree.worktree_dir ~project_name ~patch_id in
     let rec loop ~path = function
       | [] -> (Worktree.Ok, path)
       | Worktree_plan.Ensure_worktree :: rest -> (
           match
-            ensure_worktree ~runtime ~process_mgr ~clock ~fs ~repo_root
-              ~project_name ~patch_id ~agent ~user_config ~worktree_mutex
-              ~hook_mutex ()
+            ensure_worktree ~runtime ~clock ~fs ~project_name ~patch_id ~agent
+              ~user_config ~worktree_mutex ~hook_mutex ()
           with
           | Some p -> loop ~path:p rest
           | None ->
@@ -882,7 +885,7 @@ struct
                   (Printf.sprintf "%s failed: worktree missing" fail_label),
                 path ))
       | Worktree_plan.Fetch_origin :: rest -> (
-          match Worktree.fetch_origin ~fetch_lock ~process_mgr ~path with
+          match W.fetch_origin ~fetch_lock ~path with
           | Result.Ok () -> loop ~path rest
           | Result.Error msg ->
               log_event runtime ~patch_id
@@ -891,10 +894,7 @@ struct
                   (Printf.sprintf "fetch before rebase failed: %s" msg),
                 path ))
       | Worktree_plan.Rebase_onto target :: rest -> (
-          match
-            Worktree.rebase_onto ~process_mgr ~path ~target ~project_name
-              ~ancestor_ids
-          with
+          match W.rebase_onto ~path ~target ~project_name ~ancestor_ids with
           | Worktree.Ok -> loop ~path rest
           | (Worktree.Noop | Worktree.Conflict _ | Worktree.Error _) as r ->
               (r, path))
@@ -2111,9 +2111,8 @@ struct
                         None
                       else
                         let path =
-                          resolve_worktree_path ~process_mgr
-                            ~repo_root:config.repo_root ~project_name ~patch_id
-                            ~agent ()
+                          resolve_worktree_path ~project_name ~patch_id ~agent
+                            ()
                         in
                         let default =
                           Worktree.worktree_dir ~project_name ~patch_id
@@ -2223,10 +2222,7 @@ struct
                    | Some a -> Branch.to_string a.Patch_agent.branch
                    | None -> "unknown")
              in
-             let main_root =
-               Worktree.resolve_main_root ~process_mgr
-                 ~repo_root:config.repo_root
-             in
+             let main_root = W.resolve_main_root () in
              log_event runtime ~patch_id
                (Printf.sprintf
                   "Cannot work on patch — branch %s is checked out in the main \
@@ -2549,8 +2545,7 @@ struct
                                       (fun orch ->
                                         Orchestrator.mark_running orch patch_id);
                                     match
-                                      ensure_worktree ~runtime ~process_mgr
-                                        ~clock ~fs ~repo_root:config.repo_root
+                                      ensure_worktree ~runtime ~clock ~fs
                                         ~project_name ~patch_id ~agent
                                         ~user_config:config.user_config
                                         ~worktree_mutex ~hook_mutex
@@ -2789,10 +2784,10 @@ struct
                                 patch_id)
                         in
                         let rebase_result, wt_path =
-                          execute_worktree_plan ~runtime ~process_mgr ~clock ~fs
-                            ~repo_root:config.repo_root ~project_name ~patch_id
-                            ~agent ~user_config:config.user_config
-                            ~worktree_mutex ~hook_mutex ~fetch_lock:fetch_mutex
+                          execute_worktree_plan ~runtime ~clock ~fs
+                            ~project_name ~patch_id ~agent
+                            ~user_config:config.user_config ~worktree_mutex
+                            ~hook_mutex ~fetch_lock:fetch_mutex
                             ~fail_label:"rebase" ~ancestor_ids
                             (Worktree_plan.for_rebase ~new_base)
                         in
@@ -2830,8 +2825,8 @@ struct
                             ~f:(fun Orchestrator.Push_branch ->
                               let branch = agent.Patch_agent.branch in
                               let result =
-                                Worktree.force_push_with_lease ~process_mgr
-                                  ~path:wt_path ~branch ~base:new_base
+                                W.force_push_with_lease ~path:wt_path ~branch
+                                  ~base:new_base
                               in
                               (match result with
                               | Worktree.Push_ok ->
@@ -3061,8 +3056,7 @@ struct
                                         render_base_changed_prefix base_change
                                       in
                                       let wt_path_opt =
-                                        ensure_worktree ~runtime ~process_mgr
-                                          ~clock ~fs ~repo_root:config.repo_root
+                                        ensure_worktree ~runtime ~clock ~fs
                                           ~project_name ~patch_id ~agent
                                           ~user_config:config.user_config
                                           ~worktree_mutex ~hook_mutex ()
@@ -3081,16 +3075,13 @@ struct
                                           agent.Patch_agent.pr_number
                                         in
                                         let rebase_still_in_progress =
-                                          Worktree.rebase_in_progress
-                                            ~process_mgr ~path:wt_path
+                                          W.rebase_in_progress ~path:wt_path
                                         in
                                         let git_status =
-                                          Worktree.git_status ~process_mgr
-                                            ~path:wt_path
+                                          W.git_status ~path:wt_path
                                         in
                                         let git_diff =
-                                          Worktree.conflict_diff ~process_mgr
-                                            ~path:wt_path
+                                          W.conflict_diff ~path:wt_path
                                         in
                                         Event_log.log_conflict_delivery
                                           event_log ~patch_id ~path:wt_path
@@ -3177,10 +3168,7 @@ struct
                                                  snap.Runtime.orchestrator)
                                               patch_id)
                                       in
-                                      if
-                                        Worktree.rebase_in_progress ~process_mgr
-                                          ~path:wt_path
-                                      then (
+                                      if W.rebase_in_progress ~path:wt_path then (
                                         log_event runtime ~patch_id
                                           "Delivering merge-conflict — rebase \
                                            already in progress";
@@ -3189,9 +3177,8 @@ struct
                                          (possibly stale) local tracking ref.
                                          See Worktree_plan.for_merge_conflict. *)
                                         let conflict_info =
-                                          Worktree
-                                          .read_in_progress_conflict_info
-                                            ~process_mgr ~path:wt_path
+                                          W.read_in_progress_conflict_info
+                                            ~path:wt_path
                                             ~target:
                                               (Types.Branch.of_string
                                                  ("origin/" ^ base))
@@ -3207,10 +3194,8 @@ struct
                                      against fresh refs, not the stale
                                      local tracking ref. *)
                                         let rebase_result, _wt_path =
-                                          execute_worktree_plan ~runtime
-                                            ~process_mgr ~clock ~fs
-                                            ~repo_root:config.repo_root
-                                            ~project_name ~patch_id ~agent
+                                          execute_worktree_plan ~runtime ~clock
+                                            ~fs ~project_name ~patch_id ~agent
                                             ~user_config:config.user_config
                                             ~worktree_mutex ~hook_mutex
                                             ~fetch_lock:fetch_mutex
@@ -3281,9 +3266,8 @@ struct
                                                 agent.Patch_agent.branch
                                               in
                                               let result =
-                                                Worktree.force_push_with_lease
-                                                  ~process_mgr ~path:wt_path
-                                                  ~branch
+                                                W.force_push_with_lease
+                                                  ~path:wt_path ~branch
                                                   ~base:
                                                     (Types.Branch.of_string base)
                                               in
@@ -3384,9 +3368,8 @@ struct
                                           ~f:Branch.to_string
                                       in
                                       let wt_path =
-                                        resolve_worktree_path ~process_mgr
-                                          ~repo_root:config.repo_root
-                                          ~project_name ~patch_id ~agent ()
+                                        resolve_worktree_path ~project_name
+                                          ~patch_id ~agent ()
                                       in
                                       let agents_md =
                                         read_optional_file
@@ -4416,8 +4399,14 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
           ~owner:config.github_owner ~repo:config.github_repo
       in
       let module Forge = (val forge) in
-      let module Reconciler = Startup_reconciler.Make (Forge) in
-      let module Fibers = Make_fibers (Forge) in
+      let process_mgr = Eio.Stdenv.process_mgr env in
+      let worktree_client =
+        Worktree.make ~process_mgr ~repo_root:config.repo_root
+      in
+      let module WorktreeClient = (val worktree_client) in
+      let module Reconciler = Startup_reconciler.Make (Forge) (WorktreeClient)
+      in
+      let module Fibers = Make_fibers (Forge) (WorktreeClient) in
       let open Fibers in
       let pr_registry = Pr_registry.create () in
       (* Seed registry from any agents that already have a PR number — covers
@@ -4430,7 +4419,6 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
               Pr_registry.register pr_registry
                 ~patch_id:agent.Patch_agent.patch_id ~pr_number));
       let branch_of = build_branch_map gameplan ~default:config.main_branch in
-      let process_mgr = Eio.Stdenv.process_mgr env in
       let clock = Eio.Stdenv.clock env in
       let session_timeout = 1800.0 in
       let setsid_exec =
@@ -4521,14 +4509,12 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
             Orchestrator.all_agents snap.Runtime.orchestrator)
       in
       let pre_worktrees, pre_wt_error =
-        Startup_reconciler.recover_worktrees ~process_mgr
-          ~repo_root:config.repo_root ~patches:gameplan.Gameplan.patches
+        Reconciler.recover_worktrees ~patches:gameplan.Gameplan.patches
       in
       let reconciliation_fiber () =
         let startup =
           Reconciler.reconcile ~patches:gameplan.Gameplan.patches
-            ~repo_root:config.repo_root ~process_mgr ~agents:pre_agents
-            ~pre_recovered_worktrees:pre_worktrees ()
+            ~agents:pre_agents ~pre_recovered_worktrees:pre_worktrees ()
         in
         let errored_ids =
           Base.List.map startup.Startup_reconciler.errors

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -2246,7 +2246,6 @@ struct
       ~pr_registry ~findings_registry ~review_backends ~transcripts ~net
       ~event_log ?status_msg () =
     let main = config.main_branch in
-    let process_mgr = Eio.Stdenv.process_mgr env in
     let clock = Eio.Stdenv.clock env in
     let fs = Eio.Stdenv.fs env in
     let set_status ~level ~text ?expires_at () =
@@ -2289,11 +2288,10 @@ struct
         ~prompt ~agent ~on_pr_detected ~complexity =
       match pick_backend ~complexity with
       | Backend_registry.Ephemeral backend, _decision ->
-          Session_driver.run ~kind ~runtime ~process_mgr ~clock ~fs
-            ~project_name ~patch_id ~repo_root:config.repo_root ~prompt ~agent
-            ~owner:config.github_owner ~repo:config.github_repo ~on_pr_detected
-            ~transcripts ~user_config:config.user_config ~worktree_mutex
-            ~hook_mutex ~backend ~complexity
+          Session_driver.run ~kind ~runtime ~clock ~fs ~project_name ~patch_id
+            ~prompt ~agent ~owner:config.github_owner ~repo:config.github_repo
+            ~on_pr_detected ~transcripts ~user_config:config.user_config
+            ~worktree_mutex ~hook_mutex ~backend ~complexity
       | Backend_registry.Long_lived backend, decision -> (
           let patch_agent_model_result =
             match
@@ -2329,12 +2327,11 @@ struct
                     Stdlib.Hashtbl.replace long_lived_sessions patch_id session;
                     session
               in
-              Session_driver.run_long_lived ~sw ~kind ~runtime ~process_mgr
-                ~clock ~fs ~project_name ~patch_id ~repo_root:config.repo_root
-                ~prompt ~agent ~owner:config.github_owner
-                ~repo:config.github_repo ~on_pr_detected ~transcripts
-                ~user_config:config.user_config ~worktree_mutex ~hook_mutex
-                ~session ~complexity)
+              Session_driver.run_long_lived ~sw ~kind ~runtime ~clock ~fs
+                ~project_name ~patch_id ~prompt ~agent
+                ~owner:config.github_owner ~repo:config.github_repo
+                ~on_pr_detected ~transcripts ~user_config:config.user_config
+                ~worktree_mutex ~hook_mutex ~session ~complexity)
     in
     let shutdown_finished_long_lived_sessions ~sw () =
       let finished =

--- a/lib/session_driver.ml
+++ b/lib/session_driver.ml
@@ -133,9 +133,9 @@ module Make (W : Worktree.S) = struct
 
   let run_with_backend ~session_mode_for_agent
       ~(kind : Types.Operation_kind.t option) ~runtime ~clock ~fs ~project_name
-      ~patch_id ~repo_root:_ ~prompt ~(agent : Patch_agent.t) ~owner ~repo
-      ~on_pr_detected ~transcripts ~user_config ~worktree_mutex ~hook_mutex
-      ~backend_name ~run_backend ~complexity =
+      ~patch_id ~prompt ~(agent : Patch_agent.t) ~owner ~repo ~on_pr_detected
+      ~transcripts ~user_config ~worktree_mutex ~hook_mutex ~backend_name
+      ~run_backend ~complexity =
     let log_event = Runtime_logging.log_event in
     let log_stream_entry = Runtime_logging.log_stream_entry in
     match session_mode_for_agent agent with
@@ -784,14 +784,13 @@ module Make (W : Worktree.S) = struct
                 apply_result_and_emit_complete final_session_result;
                 (final_user_result, List.rev !tool_failures)))
 
-  let run ~(kind : Types.Operation_kind.t option) ~runtime ~process_mgr:_ ~clock
-      ~fs ~project_name ~patch_id ~repo_root ~prompt ~(agent : Patch_agent.t)
-      ~owner ~repo ~on_pr_detected ~transcripts ~user_config ~worktree_mutex
-      ~hook_mutex ~backend ~complexity =
-    run_with_backend ~kind ~runtime ~clock ~fs ~project_name ~patch_id
-      ~repo_root ~prompt ~agent ~owner ~repo ~on_pr_detected ~transcripts
-      ~user_config ~worktree_mutex ~hook_mutex
-      ~session_mode_for_agent:session_mode
+  let run ~(kind : Types.Operation_kind.t option) ~runtime ~clock ~fs
+      ~project_name ~patch_id ~prompt ~(agent : Patch_agent.t) ~owner ~repo
+      ~on_pr_detected ~transcripts ~user_config ~worktree_mutex ~hook_mutex
+      ~backend ~complexity =
+    run_with_backend ~kind ~runtime ~clock ~fs ~project_name ~patch_id ~prompt
+      ~agent ~owner ~repo ~on_pr_detected ~transcripts ~user_config
+      ~worktree_mutex ~hook_mutex ~session_mode_for_agent:session_mode
       ~backend_name:backend.Llm_backend.name
       ~run_backend:backend.Llm_backend.run_streaming ~complexity
 
@@ -874,10 +873,10 @@ module Make (W : Worktree.S) = struct
         | Some handle -> session.shutdown handle);
         match handle with None -> () | Some handle -> session.shutdown handle)
 
-  let run_long_lived ~sw ~(kind : Types.Operation_kind.t option) ~runtime
-      ~process_mgr:_ ~clock ~fs ~project_name ~patch_id ~repo_root ~prompt
-      ~(agent : Patch_agent.t) ~owner ~repo ~on_pr_detected ~transcripts
-      ~user_config ~worktree_mutex ~hook_mutex ~session ~complexity =
+  let run_long_lived ~sw ~(kind : Types.Operation_kind.t option) ~runtime ~clock
+      ~fs ~project_name ~patch_id ~prompt ~(agent : Patch_agent.t) ~owner ~repo
+      ~on_pr_detected ~transcripts ~user_config ~worktree_mutex ~hook_mutex
+      ~session ~complexity =
     let (Long_lived_session session) = session in
     let run_backend ~project_name ~cwd ~patch_id ~prompt ~resume_session:_
         ~session_uuid:_ ~complexity:_ ~on_event =
@@ -965,9 +964,9 @@ module Make (W : Worktree.S) = struct
                 session.failure_reason <- Some message;
                 failed_result message)
     in
-    run_with_backend ~kind ~runtime ~clock ~fs ~project_name ~patch_id
-      ~repo_root ~prompt ~agent ~owner ~repo ~on_pr_detected ~transcripts
-      ~user_config ~worktree_mutex ~hook_mutex
+    run_with_backend ~kind ~runtime ~clock ~fs ~project_name ~patch_id ~prompt
+      ~agent ~owner ~repo ~on_pr_detected ~transcripts ~user_config
+      ~worktree_mutex ~hook_mutex
       ~session_mode_for_agent:(fun _ -> `Fresh)
       ~backend_name:session.name ~run_backend ~complexity
 end

--- a/lib/session_driver.ml
+++ b/lib/session_driver.ml
@@ -125,179 +125,186 @@ let%test_module "extract_pr_number_from_text" =
         (pr 12)
   end)
 
-let run_with_backend ~session_mode_for_agent
-    ~(kind : Types.Operation_kind.t option) ~runtime ~process_mgr ~clock ~fs
-    ~project_name ~patch_id ~repo_root ~prompt ~(agent : Patch_agent.t) ~owner
-    ~repo ~on_pr_detected ~transcripts ~user_config ~worktree_mutex ~hook_mutex
-    ~backend_name ~run_backend ~complexity =
-  let log_event = Runtime_logging.log_event in
-  let log_stream_entry = Runtime_logging.log_stream_entry in
-  match session_mode_for_agent agent with
-  | `Give_up ->
-      log_event runtime ~patch_id
-        "Session fallback exhausted — continue and fresh both failed, needs \
-         intervention";
-      Runtime.update_orchestrator runtime (fun orch ->
-          Orchestrator.apply_session_result orch patch_id
-            Orchestrator.Session_give_up);
-      (`Failed, [])
-  | (`Resume _ | `Fresh) as mode -> (
-      let resume_session, is_fresh =
-        match mode with `Resume id -> (Some id, false) | `Fresh -> (None, true)
-      in
-      match
-        Worktree_setup.ensure_worktree ~runtime ~process_mgr ~clock ~fs
-          ~repo_root ~project_name ~patch_id ~agent ~user_config ~worktree_mutex
-          ~hook_mutex ()
-      with
-      | None ->
-          Runtime.update_orchestrator runtime (fun orch ->
-              Orchestrator.apply_session_result orch patch_id
-                Orchestrator.Session_worktree_missing);
-          (`Failed, [])
-      | Some worktree_path ->
-          let cwd = Eio.Path.(fs / worktree_path) in
-          (* Read once at session start so the per-event callback below can
+module Make (W : Worktree.S) = struct
+  module Worktree_setup = Worktree_setup.Make (W)
+
+  let session_mode = session_mode
+  let extract_pr_number_from_text = extract_pr_number_from_text
+
+  let run_with_backend ~session_mode_for_agent
+      ~(kind : Types.Operation_kind.t option) ~runtime ~clock ~fs ~project_name
+      ~patch_id ~repo_root:_ ~prompt ~(agent : Patch_agent.t) ~owner ~repo
+      ~on_pr_detected ~transcripts ~user_config ~worktree_mutex ~hook_mutex
+      ~backend_name ~run_backend ~complexity =
+    let log_event = Runtime_logging.log_event in
+    let log_stream_entry = Runtime_logging.log_stream_entry in
+    match session_mode_for_agent agent with
+    | `Give_up ->
+        log_event runtime ~patch_id
+          "Session fallback exhausted — continue and fresh both failed, needs \
+           intervention";
+        Runtime.update_orchestrator runtime (fun orch ->
+            Orchestrator.apply_session_result orch patch_id
+              Orchestrator.Session_give_up);
+        (`Failed, [])
+    | (`Resume _ | `Fresh) as mode -> (
+        let resume_session, is_fresh =
+          match mode with
+          | `Resume id -> (Some id, false)
+          | `Fresh -> (None, true)
+        in
+        match
+          Worktree_setup.ensure_worktree ~runtime ~clock ~fs ~project_name
+            ~patch_id ~agent ~user_config ~worktree_mutex ~hook_mutex ()
+        with
+        | None ->
+            Runtime.update_orchestrator runtime (fun orch ->
+                Orchestrator.apply_session_result orch patch_id
+                  Orchestrator.Session_worktree_missing);
+            (`Failed, [])
+        | Some worktree_path ->
+            let cwd = Eio.Path.(fs / worktree_path) in
+            (* Read once at session start so the per-event callback below can
              persist the session id to the crash-recovery sidecar without
              repeated env lookups.  When unset, the sidecar write is a no-op:
              nothing to recover from on restart anyway. *)
-          let snapshot_path_opt =
-            match Stdlib.Sys.getenv_opt "ONTON_SNAPSHOT_PATH" with
-            | Some p when not (String.is_empty (String.strip p)) -> Some p
-            | _ -> None
-          in
-          let text_buf =
-            let buf = Buffer.create 4096 in
-            (match Stdlib.Hashtbl.find_opt transcripts patch_id with
-            | Some prev when String.length prev > 0 ->
-                Buffer.add_string buf prev;
-                Buffer.add_char buf '\n'
-            | Some _ | None -> ());
-            (* Write the prompt being delivered so it appears in the transcript *)
-            let now = Unix.gettimeofday () in
-            let tm = Unix.localtime now in
-            Buffer.add_string buf
-              (Printf.sprintf
-                 "\n---\n**[%02d:%02d:%02d] Delivered to %s%s:**\n\n"
-                 tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec backend_name
-                 (match resume_session with
-                 | Some id ->
-                     Printf.sprintf " (--resume %s)"
-                       (String.sub id ~pos:0 ~len:(min 8 (String.length id)))
-                 | None -> ""));
-            Buffer.add_string buf prompt;
-            Buffer.add_string buf
-              (Printf.sprintf "\n\n---\n**%s response:**\n\n" backend_name);
-            Stdlib.Hashtbl.replace transcripts patch_id (Buffer.contents buf);
-            buf
-          in
-          let error_buf = Buffer.create 256 in
-          let session_started_at = Unix.gettimeofday () in
-          let session_uuid = Session_id.mint () in
-          let session_sink =
-            Session_artifacts.create ~project_name ~patch_id ~session_uuid
-          in
-          Telemetry_dispatch.register_sink session_sink;
-          Exn.protect
-            ~finally:(fun () ->
-              Telemetry_dispatch.unregister_sink
-                ~name:(Session_artifacts.sink_name ~session_uuid))
-            ~f:(fun () ->
-              let tool_count = ref 0 in
-              (* Accumulates (tool_name, status) for Tool_use events that report a
+            let snapshot_path_opt =
+              match Stdlib.Sys.getenv_opt "ONTON_SNAPSHOT_PATH" with
+              | Some p when not (String.is_empty (String.strip p)) -> Some p
+              | _ -> None
+            in
+            let text_buf =
+              let buf = Buffer.create 4096 in
+              (match Stdlib.Hashtbl.find_opt transcripts patch_id with
+              | Some prev when String.length prev > 0 ->
+                  Buffer.add_string buf prev;
+                  Buffer.add_char buf '\n'
+              | Some _ | None -> ());
+              (* Write the prompt being delivered so it appears in the transcript *)
+              let now = Unix.gettimeofday () in
+              let tm = Unix.localtime now in
+              Buffer.add_string buf
+                (Printf.sprintf
+                   "\n---\n**[%02d:%02d:%02d] Delivered to %s%s:**\n\n"
+                   tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec backend_name
+                   (match resume_session with
+                   | Some id ->
+                       Printf.sprintf " (--resume %s)"
+                         (String.sub id ~pos:0 ~len:(min 8 (String.length id)))
+                   | None -> ""));
+              Buffer.add_string buf prompt;
+              Buffer.add_string buf
+                (Printf.sprintf "\n\n---\n**%s response:**\n\n" backend_name);
+              Stdlib.Hashtbl.replace transcripts patch_id (Buffer.contents buf);
+              buf
+            in
+            let error_buf = Buffer.create 256 in
+            let session_started_at = Unix.gettimeofday () in
+            let session_uuid = Session_id.mint () in
+            let session_sink =
+              Session_artifacts.create ~project_name ~patch_id ~session_uuid
+            in
+            Telemetry_dispatch.register_sink session_sink;
+            Exn.protect
+              ~finally:(fun () ->
+                Telemetry_dispatch.unregister_sink
+                  ~name:(Session_artifacts.sink_name ~session_uuid))
+              ~f:(fun () ->
+                let tool_count = ref 0 in
+                (* Accumulates (tool_name, status) for Tool_use events that report a
              non-"completed" status (OpenCode surfaces [pending]/[running] or
              error states; other backends do not populate [status] and so never
              contribute here). Propagated to the caller so artifact-backed
              phases like Pr_body can tell "agent chose not to write" apart
              from "a tool call was announced but never executed". *)
-              let tool_failures = ref [] in
-              let pr_found = ref false in
-              let needle_len =
-                String.length
-                  (Printf.sprintf "github.com/%s/%s/pull/" owner repo)
-              in
-              (* Lookback window for the per-chunk tail scan. We need to re-scan
+                let tool_failures = ref [] in
+                let pr_found = ref false in
+                let needle_len =
+                  String.length
+                    (Printf.sprintf "github.com/%s/%s/pull/" owner repo)
+                in
+                (* Lookback window for the per-chunk tail scan. We need to re-scan
              far enough back to include both the URL prefix and the digit run
              that may have started in a previous chunk; 32 digits covers any
              realistic PR number even if split across many tiny chunks. *)
-              let pr_url_lookback = needle_len + 32 in
-              let try_extract_pr ?(at_end_of_stream = false) text =
-                if !pr_found then ()
-                else
-                  match
-                    extract_pr_number_from_text ~at_end_of_stream ~owner ~repo
-                      text
-                  with
-                  | Some pr_number ->
-                      pr_found := true;
-                      log_stream_entry runtime ~patch_id
-                        (Activity_log.Stream_entry.Text_chunk
-                           (Printf.sprintf "PR #%d detected"
-                              (Types.Pr_number.to_int pr_number)));
-                      on_pr_detected pr_number
-                  | None -> ()
-              in
-              let last_sync = ref (Unix.gettimeofday ()) in
-              let sync_transcript () =
-                Stdlib.Hashtbl.replace transcripts patch_id
-                  (Buffer.contents text_buf)
-              in
-              let maybe_sync_transcript () =
-                let now = Unix.gettimeofday () in
-                if Float.( >= ) (now -. !last_sync) 0.2 then (
-                  last_sync := now;
-                  sync_transcript ())
-              in
-              let captured_session_id = ref None in
-              let captured_init = ref Failure_subkind.default_init in
-              let content_gate = ref (Content_gate.create ()) in
-              let maybe_persist_session_id () =
-                match (snapshot_path_opt, !captured_session_id) with
-                | Some snapshot_path, Some session_id -> (
+                let pr_url_lookback = needle_len + 32 in
+                let try_extract_pr ?(at_end_of_stream = false) text =
+                  if !pr_found then ()
+                  else
                     match
-                      Persistence.record_session_id ~snapshot_path ~patch_id
-                        ~session_id
+                      extract_pr_number_from_text ~at_end_of_stream ~owner ~repo
+                        text
                     with
-                    | Ok () -> ()
-                    | Error msg ->
-                        log_event runtime ~patch_id
-                          (Printf.sprintf
-                             "Failed to record session_id sidecar for %s — %s"
-                             session_id msg))
-                | None, _ | _, None -> ()
-              in
-              let backend_accepted_turn = ref false in
-              let mark_backend_accepted_turn () =
-                if not !backend_accepted_turn then (
-                  backend_accepted_turn := true;
-                  match kind with
-                  | Some Types.Operation_kind.Human ->
-                      Runtime.update_orchestrator runtime (fun orch ->
-                          Orchestrator.mark_inflight_human_messages_delivered
-                            orch patch_id)
-                  | Some Types.Operation_kind.Ci
-                  | Some Types.Operation_kind.Review_comments
-                  | Some Types.Operation_kind.Findings
-                  | Some Types.Operation_kind.Pr_body
-                  | Some Types.Operation_kind.Merge_conflict
-                  | Some Types.Operation_kind.Rebase
-                  | None ->
-                      ())
-              in
-              let on_event (event : Types.Stream_event.t) =
-                let () =
-                  match event with
-                  (* Turn_started is the preferred signal; the arms below are
+                    | Some pr_number ->
+                        pr_found := true;
+                        log_stream_entry runtime ~patch_id
+                          (Activity_log.Stream_entry.Text_chunk
+                             (Printf.sprintf "PR #%d detected"
+                                (Types.Pr_number.to_int pr_number)));
+                        on_pr_detected pr_number
+                    | None -> ()
+                in
+                let last_sync = ref (Unix.gettimeofday ()) in
+                let sync_transcript () =
+                  Stdlib.Hashtbl.replace transcripts patch_id
+                    (Buffer.contents text_buf)
+                in
+                let maybe_sync_transcript () =
+                  let now = Unix.gettimeofday () in
+                  if Float.( >= ) (now -. !last_sync) 0.2 then (
+                    last_sync := now;
+                    sync_transcript ())
+                in
+                let captured_session_id = ref None in
+                let captured_init = ref Failure_subkind.default_init in
+                let content_gate = ref (Content_gate.create ()) in
+                let maybe_persist_session_id () =
+                  match (snapshot_path_opt, !captured_session_id) with
+                  | Some snapshot_path, Some session_id -> (
+                      match
+                        Persistence.record_session_id ~snapshot_path ~patch_id
+                          ~session_id
+                      with
+                      | Ok () -> ()
+                      | Error msg ->
+                          log_event runtime ~patch_id
+                            (Printf.sprintf
+                               "Failed to record session_id sidecar for %s — %s"
+                               session_id msg))
+                  | None, _ | _, None -> ()
+                in
+                let backend_accepted_turn = ref false in
+                let mark_backend_accepted_turn () =
+                  if not !backend_accepted_turn then (
+                    backend_accepted_turn := true;
+                    match kind with
+                    | Some Types.Operation_kind.Human ->
+                        Runtime.update_orchestrator runtime (fun orch ->
+                            Orchestrator.mark_inflight_human_messages_delivered
+                              orch patch_id)
+                    | Some Types.Operation_kind.Ci
+                    | Some Types.Operation_kind.Review_comments
+                    | Some Types.Operation_kind.Findings
+                    | Some Types.Operation_kind.Pr_body
+                    | Some Types.Operation_kind.Merge_conflict
+                    | Some Types.Operation_kind.Rebase
+                    | None ->
+                        ())
+                in
+                let on_event (event : Types.Stream_event.t) =
+                  let () =
+                    match event with
+                    (* Turn_started is the preferred signal; the arms below are
                  fallbacks for backends that do not emit it. *)
-                  | Types.Stream_event.Turn_started ->
-                      mark_backend_accepted_turn ()
-                  | Types.Stream_event.Text_delta text ->
-                      mark_backend_accepted_turn ();
-                      let prev_len = Buffer.length text_buf in
-                      Buffer.add_string text_buf text;
-                      maybe_sync_transcript ();
-                      if not !pr_found then
-                        (* Anchor the tail window to [prev_len], NOT [new_len].
+                    | Types.Stream_event.Turn_started ->
+                        mark_backend_accepted_turn ()
+                    | Types.Stream_event.Text_delta text ->
+                        mark_backend_accepted_turn ();
+                        let prev_len = Buffer.length text_buf in
+                        Buffer.add_string text_buf text;
+                        maybe_sync_transcript ();
+                        if not !pr_found then
+                          (* Anchor the tail window to [prev_len], NOT [new_len].
                        We want the window to always cover the ENTIRE new chunk
                        plus up to [pr_url_lookback] bytes back into the prior
                        content (to catch a URL/digit run that spanned the
@@ -306,79 +313,80 @@ let run_with_backend ~session_mode_for_agent
                        [new_len] would shrink the window to the last
                        [pr_url_lookback] bytes and miss URLs in the early part
                        of long chunks. *)
-                        let offset = max 0 (prev_len - pr_url_lookback) in
-                        let tail =
-                          Buffer.To_string.sub text_buf ~pos:offset
-                            ~len:(Buffer.length text_buf - offset)
-                        in
-                        try_extract_pr tail
-                  | Types.Stream_event.Tool_use { name; input; status } ->
-                      mark_backend_accepted_turn ();
-                      tool_count := !tool_count + 1;
-                      (* OpenCode emits pending → running → completed for a single
+                          let offset = max 0 (prev_len - pr_url_lookback) in
+                          let tail =
+                            Buffer.To_string.sub text_buf ~pos:offset
+                              ~len:(Buffer.length text_buf - offset)
+                          in
+                          try_extract_pr tail
+                    | Types.Stream_event.Tool_use { name; input; status } ->
+                        mark_backend_accepted_turn ();
+                        tool_count := !tool_count + 1;
+                        (* OpenCode emits pending → running → completed for a single
                      tool call. Track only the latest unresolved status per tool
                      name: clear on completed, replace on any other status.
                      Otherwise a normal pending → completed lifecycle would
                      leave a stale (name, "pending") entry that
                      [classify_pr_body_respond] would misread as a blocked
                      Write. *)
-                      (match status with
-                      | Some s when String.equal s "completed" ->
-                          tool_failures :=
-                            List.filter !tool_failures ~f:(fun (n, _) ->
-                                not (String.equal n name))
-                      | Some s ->
-                          let without =
-                            List.filter !tool_failures ~f:(fun (n, _) ->
-                                not (String.equal n name))
-                          in
-                          tool_failures := (name, s) :: without
-                      | None -> ());
-                      let summary =
-                        try
-                          let json = Yojson.Safe.from_string input in
-                          let field key =
-                            Yojson.Safe.Util.(
-                              member key json |> to_string_option)
-                          in
-                          let s =
-                            match name with
-                            | "Bash" -> field "command"
-                            | "Read" | "Write" -> field "file_path"
-                            | "Edit" -> field "file_path"
-                            | "Glob" -> field "pattern"
-                            | "Grep" -> field "pattern"
-                            | _ -> None
-                          in
-                          match s with Some v -> truncate v 80 | None -> ""
-                        with _ -> ""
-                      in
-                      let detail =
-                        if not (String.is_empty summary) then
-                          Printf.sprintf " %s" summary
-                        else ""
-                      in
-                      let sep =
-                        let len = Buffer.length text_buf in
-                        if len = 0 then ""
-                        else if
-                          len >= 2
-                          && Char.equal (Buffer.nth text_buf (len - 1)) '\n'
-                          && Char.equal (Buffer.nth text_buf (len - 2)) '\n'
-                        then ""
-                        else if Char.equal (Buffer.nth text_buf (len - 1)) '\n'
-                        then "\n"
-                        else "\n\n"
-                      in
-                      Buffer.add_string text_buf
-                        (Printf.sprintf "%s[tool: %s]%s\n" sep name detail);
-                      sync_transcript ();
-                      log_stream_entry runtime ~patch_id
-                        (Activity_log.Stream_entry.Tool_use (name, summary))
-                  | Types.Stream_event.Final_result { stop_reason; _ } ->
-                      mark_backend_accepted_turn ();
-                      sync_transcript ();
-                      (* Final pass with end-of-stream semantics — catches PR URLs
+                        (match status with
+                        | Some s when String.equal s "completed" ->
+                            tool_failures :=
+                              List.filter !tool_failures ~f:(fun (n, _) ->
+                                  not (String.equal n name))
+                        | Some s ->
+                            let without =
+                              List.filter !tool_failures ~f:(fun (n, _) ->
+                                  not (String.equal n name))
+                            in
+                            tool_failures := (name, s) :: without
+                        | None -> ());
+                        let summary =
+                          try
+                            let json = Yojson.Safe.from_string input in
+                            let field key =
+                              Yojson.Safe.Util.(
+                                member key json |> to_string_option)
+                            in
+                            let s =
+                              match name with
+                              | "Bash" -> field "command"
+                              | "Read" | "Write" -> field "file_path"
+                              | "Edit" -> field "file_path"
+                              | "Glob" -> field "pattern"
+                              | "Grep" -> field "pattern"
+                              | _ -> None
+                            in
+                            match s with Some v -> truncate v 80 | None -> ""
+                          with _ -> ""
+                        in
+                        let detail =
+                          if not (String.is_empty summary) then
+                            Printf.sprintf " %s" summary
+                          else ""
+                        in
+                        let sep =
+                          let len = Buffer.length text_buf in
+                          if len = 0 then ""
+                          else if
+                            len >= 2
+                            && Char.equal (Buffer.nth text_buf (len - 1)) '\n'
+                            && Char.equal (Buffer.nth text_buf (len - 2)) '\n'
+                          then ""
+                          else if
+                            Char.equal (Buffer.nth text_buf (len - 1)) '\n'
+                          then "\n"
+                          else "\n\n"
+                        in
+                        Buffer.add_string text_buf
+                          (Printf.sprintf "%s[tool: %s]%s\n" sep name detail);
+                        sync_transcript ();
+                        log_stream_entry runtime ~patch_id
+                          (Activity_log.Stream_entry.Tool_use (name, summary))
+                    | Types.Stream_event.Final_result { stop_reason; _ } ->
+                        mark_backend_accepted_turn ();
+                        sync_transcript ();
+                        (* Final pass with end-of-stream semantics — catches PR URLs
                      whose digit run terminates exactly at the buffer end (no
                      trailing newline / next chunk to provide a non-digit
                      terminator).
@@ -392,40 +400,40 @@ let run_with_backend ~session_mode_for_agent
                      the same buffer. The per-chunk path already saw any URL
                      that had a non-digit terminator during streaming, so the
                      final pass only needs to cover what the tail window does. *)
-                      (if not !pr_found then
-                         let full = Buffer.contents text_buf in
-                         let len = String.length full in
-                         let offset = max 0 (len - pr_url_lookback) in
-                         let tail =
-                           String.sub full ~pos:offset ~len:(len - offset)
-                         in
-                         try_extract_pr ~at_end_of_stream:true tail);
-                      let reason = Types.Stop_reason.to_display stop_reason in
-                      log_stream_entry runtime ~patch_id
-                        (Activity_log.Stream_entry.Finished reason)
-                  | Types.Stream_event.Error msg ->
-                      if Buffer.length error_buf > 0 then
-                        Buffer.add_char error_buf '\n';
-                      Buffer.add_string error_buf msg;
-                      log_stream_entry runtime ~patch_id
-                        (Activity_log.Stream_entry.Stream_error msg)
-                  | Types.Stream_event.Session_init
-                      {
-                        session_id;
-                        api_key_source;
-                        model;
-                        claude_code_version;
-                        permission_mode = _;
-                      } ->
-                      captured_session_id := Some session_id;
-                      captured_init :=
+                        (if not !pr_found then
+                           let full = Buffer.contents text_buf in
+                           let len = String.length full in
+                           let offset = max 0 (len - pr_url_lookback) in
+                           let tail =
+                             String.sub full ~pos:offset ~len:(len - offset)
+                           in
+                           try_extract_pr ~at_end_of_stream:true tail);
+                        let reason = Types.Stop_reason.to_display stop_reason in
+                        log_stream_entry runtime ~patch_id
+                          (Activity_log.Stream_entry.Finished reason)
+                    | Types.Stream_event.Error msg ->
+                        if Buffer.length error_buf > 0 then
+                          Buffer.add_char error_buf '\n';
+                        Buffer.add_string error_buf msg;
+                        log_stream_entry runtime ~patch_id
+                          (Activity_log.Stream_entry.Stream_error msg)
+                    | Types.Stream_event.Session_init
                         {
-                          Failure_subkind.api_key_source;
+                          session_id;
+                          api_key_source;
                           model;
                           claude_code_version;
-                        }
-                in
-                (* Persist the crash-recovery sidecar lazily: only after claude
+                          permission_mode = _;
+                        } ->
+                        captured_session_id := Some session_id;
+                        captured_init :=
+                          {
+                            Failure_subkind.api_key_source;
+                            model;
+                            claude_code_version;
+                          }
+                  in
+                  (* Persist the crash-recovery sidecar lazily: only after claude
                has *committed* a conversation turn to its .jsonl (first
                Final_result event).  Streamed chunks (Text_delta, Tool_use)
                can fire before the turn lands on disk — if the API errors
@@ -433,286 +441,289 @@ let run_with_backend ~session_mode_for_agent
                sidecar pointing at it would poison every later --resume.
                Run this after the event dispatch so a same-batch Session_init
                has already updated [captured_session_id]. *)
-                let next_gate, persist =
-                  Content_gate.should_persist !content_gate event
+                  let next_gate, persist =
+                    Content_gate.should_persist !content_gate event
+                  in
+                  content_gate := next_gate;
+                  if persist then maybe_persist_session_id ()
                 in
-                content_gate := next_gate;
-                if persist then maybe_persist_session_id ()
-              in
-              let cancelled = ref None in
-              let result =
-                try
-                  Ok
-                    (run_backend ~project_name ~cwd ~patch_id ~prompt
-                       ~resume_session ~session_uuid ~complexity ~on_event)
-                with
-                | Eio.Cancel.Cancelled _ as exn ->
-                    cancelled := Some exn;
-                    Error (Stdlib.Printexc.to_string exn)
-                | exn -> Error (Stdlib.Printexc.to_string exn)
-              in
-              let open Run_classification in
-              let outcome =
-                Result.map
-                  ~f:(fun (r : Llm_backend.result) ->
-                    {
-                      exit_code = r.Llm_backend.exit_code;
-                      got_events = r.Llm_backend.got_events;
-                      saw_final_result = r.Llm_backend.saw_final_result;
-                      stderr = r.Llm_backend.stderr;
-                      stream_errors = String.strip (Buffer.contents error_buf);
-                      timed_out = r.Llm_backend.timed_out;
-                    })
-                  result
-              in
-              (* classify routes Error outcomes to Process_error, so the
+                let cancelled = ref None in
+                let result =
+                  try
+                    Ok
+                      (run_backend ~project_name ~cwd ~patch_id ~prompt
+                         ~resume_session ~session_uuid ~complexity ~on_event)
+                  with
+                  | Eio.Cancel.Cancelled _ as exn ->
+                      cancelled := Some exn;
+                      Error (Stdlib.Printexc.to_string exn)
+                  | exn -> Error (Stdlib.Printexc.to_string exn)
+                in
+                let open Run_classification in
+                let outcome =
+                  Result.map
+                    ~f:(fun (r : Llm_backend.result) ->
+                      {
+                        exit_code = r.Llm_backend.exit_code;
+                        got_events = r.Llm_backend.got_events;
+                        saw_final_result = r.Llm_backend.saw_final_result;
+                        stderr = r.Llm_backend.stderr;
+                        stream_errors = String.strip (Buffer.contents error_buf);
+                        timed_out = r.Llm_backend.timed_out;
+                      })
+                    result
+                in
+                (* classify routes Error outcomes to Process_error, so the
              empty-events arms below only ever see Ok. *)
-              let log_empty_resume ~tail =
-                match result with
-                | Error _ -> ()
-                | Ok r ->
-                    let render label s =
-                      let s = String.strip s in
-                      if String.is_empty s then label ^ "=empty"
-                      else
-                        Printf.sprintf "%s=%d chars: %s" label (String.length s)
-                          (truncate s 500)
-                    in
-                    log_event runtime ~patch_id
-                      (Printf.sprintf
-                         "Resume exited %d (%s) with no parsed stream events%s \
-                          — %s %s"
-                         r.Llm_backend.exit_code backend_name tail
-                         (render "stdout" r.Llm_backend.stdout)
-                         (render "stderr" r.Llm_backend.stderr))
-              in
-              let classification =
-                classify ~is_resume:(Option.is_some resume_session) outcome
-              in
-              let session_result, user_result =
-                match classification with
-                | Process_error msg ->
-                    let detail =
-                      Printf.sprintf "Process error from %s — %s" backend_name
-                        msg
-                    in
-                    log_event runtime ~patch_id detail;
-                    ( Orchestrator.Session_process_error
-                        { is_fresh; detail = Some detail },
-                      `Failed )
-                | No_session_to_resume ->
-                    log_empty_resume
-                      ~tail:" — no session to resume, retrying fresh";
-                    (* Remove the stub .jsonl that claude refused to resume.
+                let log_empty_resume ~tail =
+                  match result with
+                  | Error _ -> ()
+                  | Ok r ->
+                      let render label s =
+                        let s = String.strip s in
+                        if String.is_empty s then label ^ "=empty"
+                        else
+                          Printf.sprintf "%s=%d chars: %s" label
+                            (String.length s) (truncate s 500)
+                      in
+                      log_event runtime ~patch_id
+                        (Printf.sprintf
+                           "Resume exited %d (%s) with no parsed stream \
+                            events%s — %s %s"
+                           r.Llm_backend.exit_code backend_name tail
+                           (render "stdout" r.Llm_backend.stdout)
+                           (render "stderr" r.Llm_backend.stderr))
+                in
+                let classification =
+                  classify ~is_resume:(Option.is_some resume_session) outcome
+                in
+                let session_result, user_result =
+                  match classification with
+                  | Process_error msg ->
+                      let detail =
+                        Printf.sprintf "Process error from %s — %s" backend_name
+                          msg
+                      in
+                      log_event runtime ~patch_id detail;
+                      ( Orchestrator.Session_process_error
+                          { is_fresh; detail = Some detail },
+                        `Failed )
+                  | No_session_to_resume ->
+                      log_empty_resume
+                        ~tail:" — no session to resume, retrying fresh";
+                      (* Remove the stub .jsonl that claude refused to resume.
                    Otherwise it sits in the per-patch projects dir forever and
                    trips any future attempt that happens to target the same
                    session id.  Best-effort: a missing file or a transient
                    filesystem error must not interrupt the retry path. *)
-                    (match resume_session with
-                    | None -> ()
-                    | Some session_id when safe_session_id session_id -> (
-                        try
-                          let path =
-                            Spawn_env.claude_session_jsonl_path ~project_name
-                              ~patch_id ~worktree_path ~session_id
-                          in
-                          Unix.unlink path
-                        with _ -> ())
-                    | Some session_id ->
+                      (match resume_session with
+                      | None -> ()
+                      | Some session_id when safe_session_id session_id -> (
+                          try
+                            let path =
+                              Spawn_env.claude_session_jsonl_path ~project_name
+                                ~patch_id ~worktree_path ~session_id
+                            in
+                            Unix.unlink path
+                          with _ -> ())
+                      | Some session_id ->
+                          log_event runtime ~patch_id
+                            (Printf.sprintf
+                               "Skipping cleanup for unsafe Claude session id \
+                                %S"
+                               session_id));
+                      (Orchestrator.Session_no_resume, `Failed)
+                  | Timed_out ->
+                      let detail =
+                        Printf.sprintf "Session timed out (%s) — marking failed"
+                          backend_name
+                      in
+                      log_event runtime ~patch_id detail;
+                      ( Orchestrator.Session_failed
+                          { is_fresh; detail = Some detail },
+                        `Failed )
+                  | Success { stream_errors } ->
+                      (match (resume_session, result) with
+                      | Some _, Ok r when not r.Llm_backend.got_events ->
+                          log_empty_resume ~tail:""
+                      | Some _, (Ok _ | Error _) | None, _ -> ());
+                      if String.length stream_errors > 0 then
                         log_event runtime ~patch_id
                           (Printf.sprintf
-                             "Skipping cleanup for unsafe Claude session id %S"
-                             session_id));
-                    (Orchestrator.Session_no_resume, `Failed)
-                | Timed_out ->
-                    let detail =
-                      Printf.sprintf "Session timed out (%s) — marking failed"
-                        backend_name
-                    in
-                    log_event runtime ~patch_id detail;
-                    ( Orchestrator.Session_failed
-                        { is_fresh; detail = Some detail },
-                      `Failed )
-                | Success { stream_errors } ->
-                    (match (resume_session, result) with
-                    | Some _, Ok r when not r.Llm_backend.got_events ->
-                        log_empty_resume ~tail:""
-                    | Some _, (Ok _ | Error _) | None, _ -> ());
-                    if String.length stream_errors > 0 then
-                      log_event runtime ~patch_id
-                        (Printf.sprintf
-                           "Session exited 0 (%s) with stream errors — %s"
-                           backend_name
-                           (truncate stream_errors 500));
-                    let text_len = Buffer.length text_buf in
-                    let tools = !tool_count in
-                    if tools = 0 && text_len < 200 then
-                      log_event runtime ~patch_id
-                        (Printf.sprintf
-                           "Session exited 0 (%s) with no tool use and %s of \
-                            text — %s"
-                           backend_name
-                           (pluralize text_len "char")
-                           (truncate
-                              (String.strip (Buffer.contents text_buf))
-                              200));
-                    (Orchestrator.Session_ok, `Ok)
-                | Session_failed { exit_code; detail } ->
-                    let formatted =
-                      Printf.sprintf "Session failed (%s) — exit %d: %s"
-                        backend_name exit_code detail
-                    in
-                    log_event runtime ~patch_id formatted;
-                    ( Orchestrator.Session_failed
-                        { is_fresh; detail = Some formatted },
-                      `Failed )
-              in
-              let tail s =
-                let len = String.length s in
-                let pos = max 0 (len - 4096) in
-                String.sub s ~pos ~len:(len - pos)
-              in
-              let text_tail = tail (Buffer.contents text_buf) in
-              let stderr_tail =
-                match result with
-                | Ok r -> tail r.Llm_backend.stderr
-                | Error msg -> tail msg
-              in
-              let subkind =
-                Failure_subkind.classify ~classification ~init:!captured_init
-                  ~text_tail ~stderr_tail
-              in
-              let meta =
-                let init = !captured_init in
-                let exit_code =
-                  match result with
-                  | Ok r -> r.Llm_backend.exit_code
-                  | Error _ -> 1
+                             "Session exited 0 (%s) with stream errors — %s"
+                             backend_name
+                             (truncate stream_errors 500));
+                      let text_len = Buffer.length text_buf in
+                      let tools = !tool_count in
+                      if tools = 0 && text_len < 200 then
+                        log_event runtime ~patch_id
+                          (Printf.sprintf
+                             "Session exited 0 (%s) with no tool use and %s of \
+                              text — %s"
+                             backend_name
+                             (pluralize text_len "char")
+                             (truncate
+                                (String.strip (Buffer.contents text_buf))
+                                200));
+                      (Orchestrator.Session_ok, `Ok)
+                  | Session_failed { exit_code; detail } ->
+                      let formatted =
+                        Printf.sprintf "Session failed (%s) — exit %d: %s"
+                          backend_name exit_code detail
+                      in
+                      log_event runtime ~patch_id formatted;
+                      ( Orchestrator.Session_failed
+                          { is_fresh; detail = Some formatted },
+                        `Failed )
                 in
-                Session_meta.create ~onton_session_uuid:session_uuid
-                  ?claude_session_id:!captured_session_id
-                  ~patch_id:(Types.Patch_id.to_string patch_id)
-                  ~started_at:session_started_at
-                  ~ended_at:(Unix.gettimeofday ()) ~exit_code ~subkind
-                  ?api_key_source:init.api_key_source ?model:init.model
-                  ?claude_code_version:init.claude_code_version ()
-              in
-              Telemetry_dispatch.emit
-                (Telemetry.Event.Spawn_finalized
-                   {
-                     patch_id;
-                     session_uuid;
-                     meta = Session_meta.yojson_of_t meta;
-                   });
-              (* Observability: if any tool_use events reported a non-"completed"
+                let tail s =
+                  let len = String.length s in
+                  let pos = max 0 (len - 4096) in
+                  String.sub s ~pos ~len:(len - pos)
+                in
+                let text_tail = tail (Buffer.contents text_buf) in
+                let stderr_tail =
+                  match result with
+                  | Ok r -> tail r.Llm_backend.stderr
+                  | Error msg -> tail msg
+                in
+                let subkind =
+                  Failure_subkind.classify ~classification ~init:!captured_init
+                    ~text_tail ~stderr_tail
+                in
+                let meta =
+                  let init = !captured_init in
+                  let exit_code =
+                    match result with
+                    | Ok r -> r.Llm_backend.exit_code
+                    | Error _ -> 1
+                  in
+                  Session_meta.create ~onton_session_uuid:session_uuid
+                    ?claude_session_id:!captured_session_id
+                    ~patch_id:(Types.Patch_id.to_string patch_id)
+                    ~started_at:session_started_at
+                    ~ended_at:(Unix.gettimeofday ()) ~exit_code ~subkind
+                    ?api_key_source:init.api_key_source ?model:init.model
+                    ?claude_code_version:init.claude_code_version ()
+                in
+                Telemetry_dispatch.emit
+                  (Telemetry.Event.Spawn_finalized
+                     {
+                       patch_id;
+                       session_uuid;
+                       meta = Session_meta.yojson_of_t meta;
+                     });
+                (* Observability: if any tool_use events reported a non-"completed"
              status (OpenCode's sandbox/rejection/pending states), summarize
              them so the disconnect is visible in the activity log even when
              the session otherwise looks healthy. *)
-              (match !tool_failures with
-              | [] -> ()
-              | failures ->
-                  let rendered =
-                    List.rev failures
-                    |> List.map ~f:(fun (n, s) -> Printf.sprintf "%s[%s]" n s)
-                    |> String.concat ~sep:", "
-                  in
-                  log_event runtime ~patch_id
-                    (Printf.sprintf
-                       "Session ended with %d non-completed tool call(s) (%s): \
-                        %s"
-                       (List.length failures) backend_name rendered));
-              let apply_result_and_emit_complete final_session_result =
-                let agent_before, agent_after =
-                  Runtime.update_orchestrator_returning runtime (fun orch ->
-                      let agent_before = Orchestrator.agent orch patch_id in
-                      (* Store the captured session_id BEFORE applying the session
+                (match !tool_failures with
+                | [] -> ()
+                | failures ->
+                    let rendered =
+                      List.rev failures
+                      |> List.map ~f:(fun (n, s) -> Printf.sprintf "%s[%s]" n s)
+                      |> String.concat ~sep:", "
+                    in
+                    log_event runtime ~patch_id
+                      (Printf.sprintf
+                         "Session ended with %d non-completed tool call(s) \
+                          (%s): %s"
+                         (List.length failures) backend_name rendered));
+                let apply_result_and_emit_complete final_session_result =
+                  let agent_before, agent_after =
+                    Runtime.update_orchestrator_returning runtime (fun orch ->
+                        let agent_before = Orchestrator.agent orch patch_id in
+                        (* Store the captured session_id BEFORE applying the session
                      result. [apply_session_result] clears [llm_session_id] on
                      start-path fresh failure (via [on_session_failure]) and on
                      [Session_no_resume] / [Session_give_up]; doing the set
                      afterwards would overwrite that reset and break the
                      clean-retry path. *)
-                      let orch =
-                        match !captured_session_id with
-                        | Some _ ->
-                            Orchestrator.set_llm_session_id orch patch_id
-                              !captured_session_id
-                        | None -> orch
-                      in
-                      let orch =
-                        Orchestrator.apply_session_result orch patch_id
-                          final_session_result
-                      in
-                      let agent_after = Orchestrator.agent orch patch_id in
-                      (orch, (agent_before, agent_after)))
+                        let orch =
+                          match !captured_session_id with
+                          | Some _ ->
+                              Orchestrator.set_llm_session_id orch patch_id
+                                !captured_session_id
+                          | None -> orch
+                        in
+                        let orch =
+                          Orchestrator.apply_session_result orch patch_id
+                            final_session_result
+                        in
+                        let agent_after = Orchestrator.agent orch patch_id in
+                        (orch, (agent_before, agent_after)))
+                  in
+                  Telemetry_dispatch.emit
+                    (Telemetry.Event.Complete
+                       {
+                         patch_id;
+                         session_uuid = Some session_uuid;
+                         subkind;
+                         payload =
+                           `Assoc
+                             [
+                               ( "result",
+                                 `String
+                                   (Orchestrator.show_session_result
+                                      final_session_result) );
+                               ( "agent_before",
+                                 Persistence.patch_agent_to_yojson agent_before
+                               );
+                               ( "agent_after",
+                                 Persistence.patch_agent_to_yojson agent_after
+                               );
+                             ];
+                       })
                 in
-                Telemetry_dispatch.emit
-                  (Telemetry.Event.Complete
-                     {
-                       patch_id;
-                       session_uuid = Some session_uuid;
-                       subkind;
-                       payload =
-                         `Assoc
-                           [
-                             ( "result",
-                               `String
-                                 (Orchestrator.show_session_result
-                                    final_session_result) );
-                             ( "agent_before",
-                               Persistence.patch_agent_to_yojson agent_before );
-                             ( "agent_after",
-                               Persistence.patch_agent_to_yojson agent_after );
-                           ];
-                     })
-              in
-              (match !cancelled with
-              | None -> ()
-              | Some exn ->
-                  apply_result_and_emit_complete session_result;
-                  raise exn);
-              (* Supervisor-owned push: agent commits locally; we push every
+                (match !cancelled with
+                | None -> ()
+                | Some exn ->
+                    apply_result_and_emit_complete session_result;
+                    raise exn);
+                (* Supervisor-owned push: agent commits locally; we push every
              local commit to the remote at session end. force_push_with_lease
              is idempotent (Push_up_to_date when nothing new), and lease-safe
              against concurrent remote updates. Runs regardless of the LLM's
              session result so commits made before a partial failure still
              reach the remote. *)
-              let branch = agent.Patch_agent.branch in
-              let base =
-                match agent.Patch_agent.base_branch with
-                | Some b -> b
-                | None ->
-                    (* Invariant: a running session always has a base_branch set
+                let branch = agent.Patch_agent.branch in
+                let base =
+                  match agent.Patch_agent.base_branch with
+                  | Some b -> b
+                  | None ->
+                      (* Invariant: a running session always has a base_branch set
                    by start/respond/rebase. Fall back to main just in case. *)
-                    Runtime.read runtime (fun snap ->
-                        Orchestrator.main_branch snap.Runtime.orchestrator)
-              in
-              let push_outcome =
-                Worktree.force_push_with_lease ~process_mgr ~path:worktree_path
-                  ~branch ~base
-              in
-              (match push_outcome with
-              | Worktree.Push_ok ->
-                  log_event runtime ~patch_id "runner: pushed after session"
-              | Worktree.Push_up_to_date ->
-                  log_event runtime ~patch_id
-                    "runner: push up-to-date after session (no new commits)"
-              | Worktree.Push_no_commits ->
-                  log_event runtime ~patch_id
-                    "runner: session ended with no commits on branch — push \
-                     skipped, PR creation deferred"
-              | Worktree.Push_rejected ->
-                  log_event runtime ~patch_id
-                    "runner: push rejected after session (lease)"
-              | Worktree.Push_worktree_missing ->
-                  log_event runtime ~patch_id
-                    (Printf.sprintf
-                       "runner: worktree disappeared mid-session (%s) — local \
-                        commits are lost; will reconstruct on next attempt"
-                       worktree_path)
-              | Worktree.Push_error msg ->
-                  log_event runtime ~patch_id
-                    (Printf.sprintf "runner: push error after session: %s" msg));
-              (* Combine LLM session outcome with push outcome into a single
+                      Runtime.read runtime (fun snap ->
+                          Orchestrator.main_branch snap.Runtime.orchestrator)
+                in
+                let push_outcome =
+                  W.force_push_with_lease ~path:worktree_path ~branch ~base
+                in
+                (match push_outcome with
+                | Worktree.Push_ok ->
+                    log_event runtime ~patch_id "runner: pushed after session"
+                | Worktree.Push_up_to_date ->
+                    log_event runtime ~patch_id
+                      "runner: push up-to-date after session (no new commits)"
+                | Worktree.Push_no_commits ->
+                    log_event runtime ~patch_id
+                      "runner: session ended with no commits on branch — push \
+                       skipped, PR creation deferred"
+                | Worktree.Push_rejected ->
+                    log_event runtime ~patch_id
+                      "runner: push rejected after session (lease)"
+                | Worktree.Push_worktree_missing ->
+                    log_event runtime ~patch_id
+                      (Printf.sprintf
+                         "runner: worktree disappeared mid-session (%s) — \
+                          local commits are lost; will reconstruct on next \
+                          attempt"
+                         worktree_path)
+                | Worktree.Push_error msg ->
+                    log_event runtime ~patch_id
+                      (Printf.sprintf "runner: push error after session: %s" msg));
+                (* Combine LLM session outcome with push outcome into a single
              session_result via the pure decision in
              [Orchestrator.combine_session_and_push]. user_result mirrors:
              same Ok/Failed disposition unless the combination promoted us
@@ -724,234 +735,239 @@ let run_with_backend ~session_mode_for_agent
              not a failure — override Session_no_commits to Session_ok so
              the no_commits_push_count counter does not march toward
              needs_intervention and the operation completes cleanly. *)
-              let no_commits_is_ok =
-                match kind with
-                | Some Types.Operation_kind.Human -> true
-                | Some Types.Operation_kind.Findings -> true
-                | Some Types.Operation_kind.Ci
-                | Some Types.Operation_kind.Review_comments
-                | Some Types.Operation_kind.Pr_body
-                | Some Types.Operation_kind.Merge_conflict
-                | Some Types.Operation_kind.Rebase
-                | None ->
-                    false
-              in
-              let final_session_result =
-                let combined =
-                  Orchestrator.combine_session_and_push ~session:session_result
-                    ~push:push_outcome
+                let no_commits_is_ok =
+                  match kind with
+                  | Some Types.Operation_kind.Human -> true
+                  | Some Types.Operation_kind.Findings -> true
+                  | Some Types.Operation_kind.Ci
+                  | Some Types.Operation_kind.Review_comments
+                  | Some Types.Operation_kind.Pr_body
+                  | Some Types.Operation_kind.Merge_conflict
+                  | Some Types.Operation_kind.Rebase
+                  | None ->
+                      false
                 in
-                match combined with
-                | Orchestrator.Session_no_commits when no_commits_is_ok ->
-                    Orchestrator.Session_ok
-                | Orchestrator.Session_ok | Orchestrator.Session_no_commits
-                | Orchestrator.Session_process_error _
-                | Orchestrator.Session_no_resume | Orchestrator.Session_failed _
-                | Orchestrator.Session_give_up
-                | Orchestrator.Session_worktree_missing
-                | Orchestrator.Session_push_failed ->
-                    combined
-              in
-              let final_user_result =
-                match final_session_result with
-                | Orchestrator.Session_ok -> user_result
-                | Orchestrator.Session_push_failed
-                | Orchestrator.Session_no_commits ->
-                    (* LLM session ran fine but commits didn't ship (push failed
+                let final_session_result =
+                  let combined =
+                    Orchestrator.combine_session_and_push
+                      ~session:session_result ~push:push_outcome
+                  in
+                  match combined with
+                  | Orchestrator.Session_no_commits when no_commits_is_ok ->
+                      Orchestrator.Session_ok
+                  | Orchestrator.Session_ok | Orchestrator.Session_no_commits
+                  | Orchestrator.Session_process_error _
+                  | Orchestrator.Session_no_resume
+                  | Orchestrator.Session_failed _ | Orchestrator.Session_give_up
+                  | Orchestrator.Session_worktree_missing
+                  | Orchestrator.Session_push_failed ->
+                      combined
+                in
+                let final_user_result =
+                  match final_session_result with
+                  | Orchestrator.Session_ok -> user_result
+                  | Orchestrator.Session_push_failed
+                  | Orchestrator.Session_no_commits ->
+                      (* LLM session ran fine but commits didn't ship (push failed
                    or the agent made no commits) — signal retry so the
                    Respond path uses Respond_retry_push (clean complete) and
                    the reconciler re-enqueues the operation naturally. After
                    2 consecutive no-commit sessions, needs_intervention fires
                    and the scheduler stops re-enqueueing. *)
-                    `Retry_push
-                | Orchestrator.Session_process_error _
-                | Orchestrator.Session_no_resume | Orchestrator.Session_failed _
-                | Orchestrator.Session_give_up
-                | Orchestrator.Session_worktree_missing ->
-                    `Failed
-              in
-              apply_result_and_emit_complete final_session_result;
-              (final_user_result, List.rev !tool_failures)))
+                      `Retry_push
+                  | Orchestrator.Session_process_error _
+                  | Orchestrator.Session_no_resume
+                  | Orchestrator.Session_failed _ | Orchestrator.Session_give_up
+                  | Orchestrator.Session_worktree_missing ->
+                      `Failed
+                in
+                apply_result_and_emit_complete final_session_result;
+                (final_user_result, List.rev !tool_failures)))
 
-let run ~(kind : Types.Operation_kind.t option) ~runtime ~process_mgr ~clock ~fs
-    ~project_name ~patch_id ~repo_root ~prompt ~(agent : Patch_agent.t) ~owner
-    ~repo ~on_pr_detected ~transcripts ~user_config ~worktree_mutex ~hook_mutex
-    ~backend ~complexity =
-  run_with_backend ~kind ~runtime ~process_mgr ~clock ~fs ~project_name
-    ~patch_id ~repo_root ~prompt ~agent ~owner ~repo ~on_pr_detected
-    ~transcripts ~user_config ~worktree_mutex ~hook_mutex
-    ~session_mode_for_agent:session_mode ~backend_name:backend.Llm_backend.name
-    ~run_backend:backend.Llm_backend.run_streaming ~complexity
+  let run ~(kind : Types.Operation_kind.t option) ~runtime ~process_mgr:_ ~clock
+      ~fs ~project_name ~patch_id ~repo_root ~prompt ~(agent : Patch_agent.t)
+      ~owner ~repo ~on_pr_detected ~transcripts ~user_config ~worktree_mutex
+      ~hook_mutex ~backend ~complexity =
+    run_with_backend ~kind ~runtime ~clock ~fs ~project_name ~patch_id
+      ~repo_root ~prompt ~agent ~owner ~repo ~on_pr_detected ~transcripts
+      ~user_config ~worktree_mutex ~hook_mutex
+      ~session_mode_for_agent:session_mode
+      ~backend_name:backend.Llm_backend.name
+      ~run_backend:backend.Llm_backend.run_streaming ~complexity
 
-type long_lived_session =
-  | Long_lived_session : {
-      name : string;
-      start : sw:Eio.Switch.t -> Llm_backend_long_lived.start_config -> 'handle;
-      prompt_backend :
-        'handle ->
-        prompt:string ->
-        timeout:float ->
-        on_event:(Types.Stream_event.t -> unit) ->
-        Llm_backend_long_lived.result;
-      shutdown : 'handle -> unit;
-      mutable handle : 'handle option;
-      mutable pending_shutdown_handle : 'handle option;
-      mutable failed : bool;
-      mutable failure_reason : string option;
-      provider : string;
-      model : string;
-      effort : string;
-      mutable gameplan_prompt : string;
-      mutable patch_prompt : string;
-      timeout : float;
-    }
-      -> long_lived_session
-
-let create_long_lived_session ~(backend : Llm_backend_long_lived.t) ~provider
-    ~model ~effort ~gameplan_prompt ~patch_prompt =
-  let (Llm_backend_long_lived.T
-         { name; timeout; start; prompt = prompt_backend; shutdown; _ }) =
-    backend
-  in
-  Long_lived_session
-    {
-      name;
-      start;
-      prompt_backend;
-      shutdown;
-      handle = None;
-      pending_shutdown_handle = None;
-      failed = false;
-      failure_reason = None;
-      provider;
-      model;
-      effort;
-      gameplan_prompt;
-      patch_prompt;
-      timeout;
-    }
-
-let update_long_lived_session_prompts session ~gameplan_prompt ~patch_prompt =
-  let (Long_lived_session session) = session in
-  let changed =
-    (not (String.equal session.gameplan_prompt gameplan_prompt))
-    || not (String.equal session.patch_prompt patch_prompt)
-  in
-  if changed && Option.is_some session.handle then (
-    let handle = session.handle in
-    session.handle <- None;
-    session.pending_shutdown_handle <- handle;
-    session.failed <- true;
-    session.failure_reason <-
-      Some "long-lived backend prompt prefix changed after session start");
-  session.gameplan_prompt <- gameplan_prompt;
-  session.patch_prompt <- patch_prompt
-
-let long_lived_session_failed = function
-  | Long_lived_session session -> session.failed
-
-let shutdown_long_lived_session = function
-  | Long_lived_session session -> (
-      let pending_shutdown_handle = session.pending_shutdown_handle in
-      let handle = session.handle in
-      session.pending_shutdown_handle <- None;
-      session.handle <- None;
-      (match pending_shutdown_handle with
-      | None -> ()
-      | Some handle -> session.shutdown handle);
-      match handle with None -> () | Some handle -> session.shutdown handle)
-
-let run_long_lived ~sw ~(kind : Types.Operation_kind.t option) ~runtime
-    ~process_mgr ~clock ~fs ~project_name ~patch_id ~repo_root ~prompt
-    ~(agent : Patch_agent.t) ~owner ~repo ~on_pr_detected ~transcripts
-    ~user_config ~worktree_mutex ~hook_mutex ~session ~complexity =
-  let (Long_lived_session session) = session in
-  let run_backend ~project_name ~cwd ~patch_id ~prompt ~resume_session:_
-      ~session_uuid:_ ~complexity:_ ~on_event =
-    let failed_result message =
-      on_event (Types.Stream_event.Error message);
-      {
-        Llm_backend.exit_code = 1;
-        stdout = "";
-        stderr = message;
-        got_events = true;
-        saw_final_result = false;
-        timed_out = false;
+  type long_lived_session =
+    | Long_lived_session : {
+        name : string;
+        start :
+          sw:Eio.Switch.t -> Llm_backend_long_lived.start_config -> 'handle;
+        prompt_backend :
+          'handle ->
+          prompt:string ->
+          timeout:float ->
+          on_event:(Types.Stream_event.t -> unit) ->
+          Llm_backend_long_lived.result;
+        shutdown : 'handle -> unit;
+        mutable handle : 'handle option;
+        mutable pending_shutdown_handle : 'handle option;
+        mutable failed : bool;
+        mutable failure_reason : string option;
+        provider : string;
+        model : string;
+        effort : string;
+        mutable gameplan_prompt : string;
+        mutable patch_prompt : string;
+        timeout : float;
       }
+        -> long_lived_session
+
+  let create_long_lived_session ~(backend : Llm_backend_long_lived.t) ~provider
+      ~model ~effort ~gameplan_prompt ~patch_prompt =
+    let (Llm_backend_long_lived.T
+           { name; timeout; start; prompt = prompt_backend; shutdown; _ }) =
+      backend
     in
-    if session.failed then
-      failed_result
-        (Option.value session.failure_reason
-           ~default:
-             "long-lived backend session already failed; waiting for teardown")
-    else
-      match
-        match session.handle with
-        | Some handle -> Ok handle
-        | None -> (
+    Long_lived_session
+      {
+        name;
+        start;
+        prompt_backend;
+        shutdown;
+        handle = None;
+        pending_shutdown_handle = None;
+        failed = false;
+        failure_reason = None;
+        provider;
+        model;
+        effort;
+        gameplan_prompt;
+        patch_prompt;
+        timeout;
+      }
+
+  let update_long_lived_session_prompts session ~gameplan_prompt ~patch_prompt =
+    let (Long_lived_session session) = session in
+    let changed =
+      (not (String.equal session.gameplan_prompt gameplan_prompt))
+      || not (String.equal session.patch_prompt patch_prompt)
+    in
+    if changed && Option.is_some session.handle then (
+      let handle = session.handle in
+      session.handle <- None;
+      session.pending_shutdown_handle <- handle;
+      session.failed <- true;
+      session.failure_reason <-
+        Some "long-lived backend prompt prefix changed after session start");
+    session.gameplan_prompt <- gameplan_prompt;
+    session.patch_prompt <- patch_prompt
+
+  let long_lived_session_failed = function
+    | Long_lived_session session -> session.failed
+
+  let shutdown_long_lived_session = function
+    | Long_lived_session session -> (
+        let pending_shutdown_handle = session.pending_shutdown_handle in
+        let handle = session.handle in
+        session.pending_shutdown_handle <- None;
+        session.handle <- None;
+        (match pending_shutdown_handle with
+        | None -> ()
+        | Some handle -> session.shutdown handle);
+        match handle with None -> () | Some handle -> session.shutdown handle)
+
+  let run_long_lived ~sw ~(kind : Types.Operation_kind.t option) ~runtime
+      ~process_mgr:_ ~clock ~fs ~project_name ~patch_id ~repo_root ~prompt
+      ~(agent : Patch_agent.t) ~owner ~repo ~on_pr_detected ~transcripts
+      ~user_config ~worktree_mutex ~hook_mutex ~session ~complexity =
+    let (Long_lived_session session) = session in
+    let run_backend ~project_name ~cwd ~patch_id ~prompt ~resume_session:_
+        ~session_uuid:_ ~complexity:_ ~on_event =
+      let failed_result message =
+        on_event (Types.Stream_event.Error message);
+        {
+          Llm_backend.exit_code = 1;
+          stdout = "";
+          stderr = message;
+          got_events = true;
+          saw_final_result = false;
+          timed_out = false;
+        }
+      in
+      if session.failed then
+        failed_result
+          (Option.value session.failure_reason
+             ~default:
+               "long-lived backend session already failed; waiting for teardown")
+      else
+        match
+          match session.handle with
+          | Some handle -> Ok handle
+          | None -> (
+              try
+                let handle =
+                  session.start ~sw
+                    {
+                      project_name;
+                      worktree = cwd;
+                      patch_id;
+                      provider = session.provider;
+                      model = session.model;
+                      effort = session.effort;
+                      gameplan_prompt = session.gameplan_prompt;
+                      patch_prompt = session.patch_prompt;
+                    }
+                in
+                session.handle <- Some handle;
+                Ok handle
+              with
+              | Eio.Cancel.Cancelled _ as exn -> raise exn
+              | exn ->
+                  session.failed <- true;
+                  let message =
+                    Printf.sprintf "long-lived backend start raised: %s"
+                      (Stdlib.Printexc.to_string exn)
+                  in
+                  session.failure_reason <- Some message;
+                  Error message)
+        with
+        | Error message -> failed_result message
+        | Ok handle -> (
             try
-              let handle =
-                session.start ~sw
-                  {
-                    project_name;
-                    worktree = cwd;
-                    patch_id;
-                    provider = session.provider;
-                    model = session.model;
-                    effort = session.effort;
-                    gameplan_prompt = session.gameplan_prompt;
-                    patch_prompt = session.patch_prompt;
-                  }
+              let result =
+                session.prompt_backend handle ~prompt ~timeout:session.timeout
+                  ~on_event
               in
-              session.handle <- Some handle;
-              Ok handle
+              if
+                result.Llm_backend.exit_code <> 0
+                || result.Llm_backend.timed_out
+              then (
+                session.handle <- None;
+                session.failed <- true;
+                session.failure_reason <-
+                  Some "long-lived backend prompt failed or timed out";
+                try session.shutdown handle with _ -> ());
+              result
             with
-            | Eio.Cancel.Cancelled _ as exn -> raise exn
+            | Eio.Cancel.Cancelled _ as exn ->
+                session.handle <- None;
+                session.failed <- true;
+                session.failure_reason <-
+                  Some "long-lived backend prompt cancelled";
+                (try session.shutdown handle with _ -> ());
+                raise exn
             | exn ->
+                session.handle <- None;
+                session.pending_shutdown_handle <- Some handle;
                 session.failed <- true;
                 let message =
-                  Printf.sprintf "long-lived backend start raised: %s"
+                  Printf.sprintf "long-lived backend prompt raised: %s"
                     (Stdlib.Printexc.to_string exn)
                 in
                 session.failure_reason <- Some message;
-                Error message)
-      with
-      | Error message -> failed_result message
-      | Ok handle -> (
-          try
-            let result =
-              session.prompt_backend handle ~prompt ~timeout:session.timeout
-                ~on_event
-            in
-            if result.Llm_backend.exit_code <> 0 || result.Llm_backend.timed_out
-            then (
-              session.handle <- None;
-              session.failed <- true;
-              session.failure_reason <-
-                Some "long-lived backend prompt failed or timed out";
-              try session.shutdown handle with _ -> ());
-            result
-          with
-          | Eio.Cancel.Cancelled _ as exn ->
-              session.handle <- None;
-              session.failed <- true;
-              session.failure_reason <-
-                Some "long-lived backend prompt cancelled";
-              (try session.shutdown handle with _ -> ());
-              raise exn
-          | exn ->
-              session.handle <- None;
-              session.pending_shutdown_handle <- Some handle;
-              session.failed <- true;
-              let message =
-                Printf.sprintf "long-lived backend prompt raised: %s"
-                  (Stdlib.Printexc.to_string exn)
-              in
-              session.failure_reason <- Some message;
-              failed_result message)
-  in
-  run_with_backend ~kind ~runtime ~process_mgr ~clock ~fs ~project_name
-    ~patch_id ~repo_root ~prompt ~agent ~owner ~repo ~on_pr_detected
-    ~transcripts ~user_config ~worktree_mutex ~hook_mutex
-    ~session_mode_for_agent:(fun _ -> `Fresh)
-    ~backend_name:session.name ~run_backend ~complexity
+                failed_result message)
+    in
+    run_with_backend ~kind ~runtime ~clock ~fs ~project_name ~patch_id
+      ~repo_root ~prompt ~agent ~owner ~repo ~on_pr_detected ~transcripts
+      ~user_config ~worktree_mutex ~hook_mutex
+      ~session_mode_for_agent:(fun _ -> `Fresh)
+      ~backend_name:session.name ~run_backend ~complexity
+end

--- a/lib/session_driver.mli
+++ b/lib/session_driver.mli
@@ -10,95 +10,97 @@
     several modules. The backend below is already abstracted; this is the single
     place where "run a session for this patch" lives. *)
 
-val run :
-  kind:Types.Operation_kind.t option ->
-  runtime:Runtime.t ->
-  process_mgr:_ Eio.Process.mgr ->
-  clock:_ Eio.Time.clock ->
-  fs:Eio.Fs.dir_ty Eio.Path.t ->
-  project_name:string ->
-  patch_id:Types.Patch_id.t ->
-  repo_root:string ->
-  prompt:string ->
-  agent:Patch_agent.t ->
-  owner:string ->
-  repo:string ->
-  on_pr_detected:(Types.Pr_number.t -> unit) ->
-  transcripts:(Types.Patch_id.t, string) Stdlib.Hashtbl.t ->
-  user_config:User_config.t ->
-  worktree_mutex:Eio.Mutex.t ->
-  hook_mutex:Eio.Mutex.t ->
-  backend:Llm_backend.t ->
-  complexity:int option ->
-  [ `Ok | `Failed | `Retry_push ] * (string * string) list
-(** Returns the supervisor disposition and the list of [(tool_name, status)]
-    pairs for any tool calls that did not reach a [completed] state (used by the
-    Pr_body classifier to disambiguate "agent chose not to write" from "Write
-    was blocked"). Callers may also produce a [`Stale] variant from pre-flight
-    checks before invoking this function — the polymorphic-variant union widens
-    at the call site. *)
+module Make (_ : Worktree.S) : sig
+  val run :
+    kind:Types.Operation_kind.t option ->
+    runtime:Runtime.t ->
+    process_mgr:_ Eio.Process.mgr ->
+    clock:_ Eio.Time.clock ->
+    fs:Eio.Fs.dir_ty Eio.Path.t ->
+    project_name:string ->
+    patch_id:Types.Patch_id.t ->
+    repo_root:string ->
+    prompt:string ->
+    agent:Patch_agent.t ->
+    owner:string ->
+    repo:string ->
+    on_pr_detected:(Types.Pr_number.t -> unit) ->
+    transcripts:(Types.Patch_id.t, string) Stdlib.Hashtbl.t ->
+    user_config:User_config.t ->
+    worktree_mutex:Eio.Mutex.t ->
+    hook_mutex:Eio.Mutex.t ->
+    backend:Llm_backend.t ->
+    complexity:int option ->
+    [ `Ok | `Failed | `Retry_push ] * (string * string) list
+  (** Returns the supervisor disposition and the list of [(tool_name, status)]
+      pairs for any tool calls that did not reach a [completed] state (used by
+      the Pr_body classifier to disambiguate "agent chose not to write" from
+      "Write was blocked"). Callers may also produce a [`Stale] variant from
+      pre-flight checks before invoking this function — the polymorphic-variant
+      union widens at the call site. *)
 
-type long_lived_session
-(** Mutable per-patch long-lived backend session state. The backend's
-    existential handle type remains tied to the backend that created it. *)
+  type long_lived_session
+  (** Mutable per-patch long-lived backend session state. The backend's
+      existential handle type remains tied to the backend that created it. *)
 
-val create_long_lived_session :
-  backend:Llm_backend_long_lived.t ->
-  provider:string ->
-  model:string ->
-  effort:string ->
-  gameplan_prompt:string ->
-  patch_prompt:string ->
-  long_lived_session
+  val create_long_lived_session :
+    backend:Llm_backend_long_lived.t ->
+    provider:string ->
+    model:string ->
+    effort:string ->
+    gameplan_prompt:string ->
+    patch_prompt:string ->
+    long_lived_session
 
-val update_long_lived_session_prompts :
-  long_lived_session -> gameplan_prompt:string -> patch_prompt:string -> unit
+  val update_long_lived_session_prompts :
+    long_lived_session -> gameplan_prompt:string -> patch_prompt:string -> unit
 
-val long_lived_session_failed : long_lived_session -> bool
-val shutdown_long_lived_session : long_lived_session -> unit
+  val long_lived_session_failed : long_lived_session -> bool
+  val shutdown_long_lived_session : long_lived_session -> unit
 
-val run_long_lived :
-  sw:Eio.Switch.t ->
-  kind:Types.Operation_kind.t option ->
-  runtime:Runtime.t ->
-  process_mgr:_ Eio.Process.mgr ->
-  clock:_ Eio.Time.clock ->
-  fs:Eio.Fs.dir_ty Eio.Path.t ->
-  project_name:string ->
-  patch_id:Types.Patch_id.t ->
-  repo_root:string ->
-  prompt:string ->
-  agent:Patch_agent.t ->
-  owner:string ->
-  repo:string ->
-  on_pr_detected:(Types.Pr_number.t -> unit) ->
-  transcripts:(Types.Patch_id.t, string) Stdlib.Hashtbl.t ->
-  user_config:User_config.t ->
-  worktree_mutex:Eio.Mutex.t ->
-  hook_mutex:Eio.Mutex.t ->
-  session:long_lived_session ->
-  complexity:int option ->
-  [ `Ok | `Failed | `Retry_push ] * (string * string) list
-(** Long-lived backend counterpart to {!run}. It shares the same supervisor
-    bookkeeping and delivers the rendered turn over [backend.prompt] instead of
-    spawning a fresh backend process. *)
+  val run_long_lived :
+    sw:Eio.Switch.t ->
+    kind:Types.Operation_kind.t option ->
+    runtime:Runtime.t ->
+    process_mgr:_ Eio.Process.mgr ->
+    clock:_ Eio.Time.clock ->
+    fs:Eio.Fs.dir_ty Eio.Path.t ->
+    project_name:string ->
+    patch_id:Types.Patch_id.t ->
+    repo_root:string ->
+    prompt:string ->
+    agent:Patch_agent.t ->
+    owner:string ->
+    repo:string ->
+    on_pr_detected:(Types.Pr_number.t -> unit) ->
+    transcripts:(Types.Patch_id.t, string) Stdlib.Hashtbl.t ->
+    user_config:User_config.t ->
+    worktree_mutex:Eio.Mutex.t ->
+    hook_mutex:Eio.Mutex.t ->
+    session:long_lived_session ->
+    complexity:int option ->
+    [ `Ok | `Failed | `Retry_push ] * (string * string) list
+  (** Long-lived backend counterpart to {!run}. It shares the same supervisor
+      bookkeeping and delivers the rendered turn over [backend.prompt] instead
+      of spawning a fresh backend process. *)
 
-val session_mode : Patch_agent.t -> [ `Resume of string | `Fresh | `Give_up ]
-(** Inspect the agent's session-fallback state to decide whether the next
-    invocation should resume an existing session, start fresh, or give up. *)
+  val session_mode : Patch_agent.t -> [ `Resume of string | `Fresh | `Give_up ]
+  (** Inspect the agent's session-fallback state to decide whether the next
+      invocation should resume an existing session, start fresh, or give up. *)
 
-val extract_pr_number_from_text :
-  ?at_end_of_stream:bool ->
-  owner:string ->
-  repo:string ->
-  string ->
-  Types.Pr_number.t option
-(** Scan [text] for a [github.com/<owner>/<repo>/pull/N] URL and return the
-    first [N] found. Used to sniff PR creation from the agent's stdout stream.
+  val extract_pr_number_from_text :
+    ?at_end_of_stream:bool ->
+    owner:string ->
+    repo:string ->
+    string ->
+    Types.Pr_number.t option
+  (** Scan [text] for a [github.com/<owner>/<repo>/pull/N] URL and return the
+      first [N] found. Used to sniff PR creation from the agent's stdout stream.
 
-    A digit run terminating at the end of [text] is treated as
-    potentially-incomplete by default, so this function will return [None] for
-    [".../pull/12"] when the next stream chunk could turn it into
-    [.../pull/1234]. Pass [~at_end_of_stream:true] when calling on a complete
-    buffer (e.g. on [Final_result]) to treat end-of-buffer as a valid
-    terminator. *)
+      A digit run terminating at the end of [text] is treated as
+      potentially-incomplete by default, so this function will return [None] for
+      [".../pull/12"] when the next stream chunk could turn it into
+      [.../pull/1234]. Pass [~at_end_of_stream:true] when calling on a complete
+      buffer (e.g. on [Final_result]) to treat end-of-buffer as a valid
+      terminator. *)
+end

--- a/lib/session_driver.mli
+++ b/lib/session_driver.mli
@@ -14,12 +14,10 @@ module Make (_ : Worktree.S) : sig
   val run :
     kind:Types.Operation_kind.t option ->
     runtime:Runtime.t ->
-    process_mgr:_ Eio.Process.mgr ->
     clock:_ Eio.Time.clock ->
     fs:Eio.Fs.dir_ty Eio.Path.t ->
     project_name:string ->
     patch_id:Types.Patch_id.t ->
-    repo_root:string ->
     prompt:string ->
     agent:Patch_agent.t ->
     owner:string ->
@@ -62,12 +60,10 @@ module Make (_ : Worktree.S) : sig
     sw:Eio.Switch.t ->
     kind:Types.Operation_kind.t option ->
     runtime:Runtime.t ->
-    process_mgr:_ Eio.Process.mgr ->
     clock:_ Eio.Time.clock ->
     fs:Eio.Fs.dir_ty Eio.Path.t ->
     project_name:string ->
     patch_id:Types.Patch_id.t ->
-    repo_root:string ->
     prompt:string ->
     agent:Patch_agent.t ->
     owner:string ->

--- a/lib/startup_reconciler.ml
+++ b/lib/startup_reconciler.ml
@@ -26,9 +26,9 @@ type t = {
 
 (** Discover existing worktrees and match them to patches by branch name.
     Returns matched worktrees and an optional error string if listing failed. *)
-let recover_worktrees ~process_mgr ~repo_root ~patches =
+let recover_worktrees_with (module W : Worktree.S) ~patches =
   let worktrees, list_error =
-    try (Worktree.list_with_branches ~process_mgr ~repo_root, None) with
+    try (W.list_with_branches (), None) with
     | Eio.Exn.Io _ as exn ->
         ( [],
           Some
@@ -57,7 +57,7 @@ let find_stale_busy ~agents =
   List.filter_map agents ~f:(fun (agent : Patch_agent.t) ->
       if agent.busy then Some agent.patch_id else None)
 
-module Make (F : Forge.S) = struct
+module Make (F : Forge.S) (W : Worktree.S) = struct
   (** Query GitHub REST API for a branch, returning discovery info for the first
       non-CLOSED PR. *)
   let discover_pr ~branch =
@@ -67,8 +67,9 @@ module Make (F : Forge.S) = struct
         Ok (Some (pr_number, base_branch, merged))
     | Error err -> Error (F.show_error err)
 
-  let reconcile ~patches ?(repo_root = ".") ?process_mgr ?(agents = [])
-      ?pre_recovered_worktrees () =
+  let recover_worktrees ~patches = recover_worktrees_with (module W) ~patches
+
+  let reconcile ~patches ?(agents = []) ?pre_recovered_worktrees () =
     let results =
       Eio.Fiber.List.map ~max_fibers:8
         (fun (patch : Patch.t) ->
@@ -88,11 +89,9 @@ module Make (F : Forge.S) = struct
           | Error err -> (discovered, (patch.Patch.id, err) :: errors))
     in
     let recovered_worktrees, worktree_error =
-      match (pre_recovered_worktrees, process_mgr) with
-      | Some wts, _ -> (wts, None)
-      | None, Some pm -> recover_worktrees ~process_mgr:pm ~repo_root ~patches
-      | None, None ->
-          ([], Some "worktree recovery skipped: no process_mgr provided")
+      match pre_recovered_worktrees with
+      | Some wts -> (wts, None)
+      | None -> recover_worktrees ~patches
     in
     let reset_pending = find_stale_busy ~agents in
     {

--- a/lib/startup_reconciler.mli
+++ b/lib/startup_reconciler.mli
@@ -46,34 +46,28 @@ type t = {
     contains per-patch PR discovery failures. [worktree_errors] contains global
     worktree listing failures (not per-patch). *)
 
-val recover_worktrees :
-  process_mgr:_ Eio.Process.mgr ->
-  repo_root:string ->
-  patches:Patch.t list ->
-  worktree_recovery list * string option
-(** Discover existing worktrees and match them to patches by branch name.
-    Returns matched worktrees and an optional error string if listing failed.
-    Can be called before [reconcile] to capture worktree state early. *)
-
-module Make (_ : Forge.S) : sig
+module Make (_ : Forge.S) (_ : Worktree.S) : sig
   val discover_pr :
     branch:Branch.t -> ((Pr_number.t * Branch.t * bool) option, string) Result.t
   (** Query the GitHub REST API for a branch, returning the first non-CLOSED PR
       as [(pr_number, base_branch, merged)] or [None]. *)
 
+  val recover_worktrees :
+    patches:Patch.t list -> worktree_recovery list * string option
+  (** Discover existing worktrees and match them to patches by branch name.
+      Returns matched worktrees and an optional error string if listing failed.
+      Can be called before [reconcile] to capture worktree state early. *)
+
   val reconcile :
     patches:Patch.t list ->
-    ?repo_root:string ->
-    ?process_mgr:_ Eio.Process.mgr ->
     ?agents:Patch_agent.t list ->
     ?pre_recovered_worktrees:worktree_recovery list ->
     unit ->
     t
-  (** [reconcile ~patches ?repo_root ?process_mgr ?agents
-       ?pre_recovered_worktrees ()] queries GitHub REST API for each patch's
-      branch to find existing PRs and identifies stale busy agents from [agents]
-      (default [[]]). When [pre_recovered_worktrees] is provided, uses it
-      directly instead of scanning the filesystem (avoids racing with concurrent
-      worktree creation). Otherwise discovers worktrees under [repo_root]
-      (default ["."]) using [process_mgr]. *)
+  (** [reconcile ~patches ?agents ?pre_recovered_worktrees ()] queries GitHub
+      REST API for each patch's branch to find existing PRs and identifies stale
+      busy agents from [agents] (default [[]]). When [pre_recovered_worktrees]
+      is provided, uses it directly instead of scanning the filesystem (avoids
+      racing with concurrent worktree creation). Otherwise discovers worktrees
+      through the injected [Worktree.S]. *)
 end

--- a/lib/worktree.ml
+++ b/lib/worktree.ml
@@ -659,3 +659,99 @@ let exists t = Stdlib.Sys.file_exists t.path
 let path t = t.path
 let patch_id t = t.patch_id
 let branch t = t.branch
+
+module type S = sig
+  val resolve_main_root : unit -> string
+  val is_checked_out_in_repo_root : Types.Branch.t -> bool
+  val remote_branch_exists : string -> bool
+
+  val create :
+    project_name:string ->
+    patch_id:Types.Patch_id.t ->
+    branch:Types.Branch.t ->
+    base_ref:string ->
+    t
+
+  val remove : t -> unit
+  val detect_branch : path:string -> Types.Branch.t
+  val list_with_branches : unit -> (string * Types.Branch.t) list
+  val find_for_branch : Types.Branch.t -> string option
+  val prune_admin : unit -> unit
+
+  val run_hook :
+    clock:_ Eio.Time.clock ->
+    script:string ->
+    cwd:Eio.Fs.dir_ty Eio.Path.t ->
+    env:(string * string) list ->
+    unit ->
+    (unit, string) Result.t
+
+  val fetch_origin :
+    fetch_lock:Eio.Mutex.t -> path:string -> (unit, string) Result.t
+
+  val git_status : path:string -> string
+  val conflict_diff : path:string -> string
+
+  val rebase_onto :
+    path:string ->
+    target:Types.Branch.t ->
+    project_name:string ->
+    ancestor_ids:Types.Patch_id.t list ->
+    rebase_result
+
+  val read_in_progress_conflict_info :
+    path:string ->
+    target:Types.Branch.t ->
+    project_name:string ->
+    ancestor_ids:Types.Patch_id.t list ->
+    conflict_info option
+
+  val force_push_with_lease :
+    path:string -> branch:Types.Branch.t -> base:Types.Branch.t -> push_result
+
+  val rebase_in_progress : path:string -> bool
+end
+
+type client = (module S)
+
+let make ~process_mgr ~repo_root =
+  (module struct
+    let resolve_main_root () = resolve_main_root ~process_mgr ~repo_root
+
+    let is_checked_out_in_repo_root branch =
+      is_checked_out_in_repo_root ~process_mgr ~repo_root branch
+
+    let remote_branch_exists branch_str =
+      remote_branch_exists ~process_mgr ~repo_root branch_str
+
+    let create ~project_name ~patch_id ~branch ~base_ref =
+      create ~process_mgr ~repo_root ~project_name ~patch_id ~branch ~base_ref
+
+    let remove t = remove ~process_mgr ~repo_root t
+    let detect_branch ~path = detect_branch ~process_mgr ~path
+    let list_with_branches () = list_with_branches ~process_mgr ~repo_root
+    let find_for_branch branch = find_for_branch ~process_mgr ~repo_root branch
+    let prune_admin () = prune_admin ~process_mgr ~repo_root
+
+    let run_hook ~clock ~script ~cwd ~env () =
+      User_config.run_hook ~process_mgr ~clock ~script ~cwd ~env ()
+
+    let fetch_origin ~fetch_lock ~path =
+      fetch_origin ~fetch_lock ~process_mgr ~path
+
+    let git_status ~path = git_status ~process_mgr ~path
+    let conflict_diff ~path = conflict_diff ~process_mgr ~path
+
+    let rebase_onto ~path ~target ~project_name ~ancestor_ids =
+      rebase_onto ~process_mgr ~path ~target ~project_name ~ancestor_ids
+
+    let read_in_progress_conflict_info ~path ~target ~project_name ~ancestor_ids
+        =
+      read_in_progress_conflict_info ~process_mgr ~path ~target ~project_name
+        ~ancestor_ids
+
+    let force_push_with_lease ~path ~branch ~base =
+      force_push_with_lease ~process_mgr ~path ~branch ~base
+
+    let rebase_in_progress ~path = rebase_in_progress ~process_mgr ~path
+  end : S)

--- a/lib/worktree.mli
+++ b/lib/worktree.mli
@@ -270,6 +270,62 @@ val rebase_in_progress : process_mgr:_ Eio.Process.mgr -> path:string -> bool
 (** Returns [true] if there is a rebase currently in progress in the worktree at
     [path] (checks for [rebase-merge] or [rebase-apply] in the gitdir). *)
 
+module type S = sig
+  val resolve_main_root : unit -> string
+  val is_checked_out_in_repo_root : Types.Branch.t -> bool
+  val remote_branch_exists : string -> bool
+
+  val create :
+    project_name:string ->
+    patch_id:Types.Patch_id.t ->
+    branch:Types.Branch.t ->
+    base_ref:string ->
+    t
+
+  val remove : t -> unit
+  val detect_branch : path:string -> Types.Branch.t
+  val list_with_branches : unit -> (string * Types.Branch.t) list
+  val find_for_branch : Types.Branch.t -> string option
+  val prune_admin : unit -> unit
+
+  val run_hook :
+    clock:_ Eio.Time.clock ->
+    script:string ->
+    cwd:Eio.Fs.dir_ty Eio.Path.t ->
+    env:(string * string) list ->
+    unit ->
+    (unit, string) Result.t
+
+  val fetch_origin :
+    fetch_lock:Eio.Mutex.t -> path:string -> (unit, string) Result.t
+
+  val git_status : path:string -> string
+  val conflict_diff : path:string -> string
+
+  val rebase_onto :
+    path:string ->
+    target:Types.Branch.t ->
+    project_name:string ->
+    ancestor_ids:Types.Patch_id.t list ->
+    rebase_result
+
+  val read_in_progress_conflict_info :
+    path:string ->
+    target:Types.Branch.t ->
+    project_name:string ->
+    ancestor_ids:Types.Patch_id.t list ->
+    conflict_info option
+
+  val force_push_with_lease :
+    path:string -> branch:Types.Branch.t -> base:Types.Branch.t -> push_result
+
+  val rebase_in_progress : path:string -> bool
+end
+
+type client = (module S)
+
+val make : process_mgr:_ Eio.Process.mgr -> repo_root:string -> client
+
 val find_for_branch :
   process_mgr:_ Eio.Process.mgr ->
   repo_root:string ->

--- a/lib/worktree_setup.ml
+++ b/lib/worktree_setup.ml
@@ -1,146 +1,145 @@
 open Base
 
-let resolve_worktree_path ~process_mgr ~repo_root ~project_name ~patch_id
-    ~(agent : Patch_agent.t) ?branch () =
-  (* When the caller passes [?branch], they're asking for that branch's
+module Make (W : Worktree.S) = struct
+  let resolve_worktree_path ~project_name ~patch_id ~(agent : Patch_agent.t)
+      ?branch () =
+    (* When the caller passes [?branch], they're asking for that branch's
      worktree specifically — the agent's stored [worktree_path] may be from
      a previous branch and would be stale. Only short-circuit on the stored
      path when no [branch] is supplied. *)
-  match (branch, agent.Patch_agent.worktree_path) with
-  | None, Some p -> p
-  | _ ->
-      let search_branch =
+    match (branch, agent.Patch_agent.worktree_path) with
+    | None, Some p -> p
+    | _ ->
+        let search_branch =
+          match branch with Some b -> b | None -> agent.Patch_agent.branch
+        in
+        let found = W.find_for_branch search_branch in
+        let path =
+          match found with
+          | Some p -> p
+          | None -> Worktree.worktree_dir ~project_name ~patch_id
+        in
+        path
+
+  let ensure_worktree ~runtime ~clock ~fs ~project_name ~patch_id
+      ~(agent : Patch_agent.t) ~(user_config : User_config.t) ~worktree_mutex
+      ~hook_mutex ?branch ?base_ref () =
+    let log_event = Runtime_logging.log_event in
+    let path =
+      resolve_worktree_path ~project_name ~patch_id ~agent ?branch ()
+    in
+    if Stdlib.Sys.file_exists path then (
+      Runtime.update_orchestrator runtime (fun orch ->
+          Orchestrator.set_worktree_path orch patch_id path);
+      Some path)
+    else
+      let br =
         match branch with Some b -> b | None -> agent.Patch_agent.branch
       in
-      let found =
-        Worktree.find_for_branch ~process_mgr ~repo_root search_branch
-      in
-      let path =
-        match found with
-        | Some p -> p
-        | None -> Worktree.worktree_dir ~project_name ~patch_id
-      in
-      path
-
-let ensure_worktree ~runtime ~process_mgr ~clock ~fs ~repo_root ~project_name
-    ~patch_id ~(agent : Patch_agent.t) ~(user_config : User_config.t)
-    ~worktree_mutex ~hook_mutex ?branch ?base_ref () =
-  let log_event = Runtime_logging.log_event in
-  let path =
-    resolve_worktree_path ~process_mgr ~repo_root ~project_name ~patch_id ~agent
-      ?branch ()
-  in
-  if Stdlib.Sys.file_exists path then (
-    Runtime.update_orchestrator runtime (fun orch ->
-        Orchestrator.set_worktree_path orch patch_id path);
-    Some path)
-  else
-    let br =
-      match branch with Some b -> b | None -> agent.Patch_agent.branch
-    in
-    (* The previous worktree directory is gone — prune git's registry first so
+      (* The previous worktree directory is gone — prune git's registry first so
        a stale entry (deleted dir but still listed by [git worktree list])
        does not steer [find_for_branch] back to the same dead path and
        prevent [Worktree.create] from re-registering it. *)
-    Worktree.prune_admin ~process_mgr ~repo_root;
-    let found = Worktree.find_for_branch ~process_mgr ~repo_root br in
-    (* Treat a hit whose directory is gone as a miss — defends against races
+      W.prune_admin ();
+      let found = W.find_for_branch br in
+      (* Treat a hit whose directory is gone as a miss — defends against races
        (another process re-registering between our prune and our list) or
        git versions that leave half-pruned state. We log the discard so the
        user can see why we are recreating despite git's bookkeeping. *)
-    let live_existing =
-      match found with
-      | Some p when Stdlib.Sys.file_exists p -> Some p
-      | Some stale ->
+      let live_existing =
+        match found with
+        | Some p when Stdlib.Sys.file_exists p -> Some p
+        | Some stale ->
+            log_event runtime ~patch_id
+              (Printf.sprintf
+                 "Ignoring stale worktree registration (git lists %s but \
+                  directory is gone) — will recreate"
+                 stale);
+            None
+        | None -> None
+      in
+      match live_existing with
+      | Some existing ->
           log_event runtime ~patch_id
-            (Printf.sprintf
-               "Ignoring stale worktree registration (git lists %s but \
-                directory is gone) — will recreate"
-               stale);
-          None
-      | None -> None
-    in
-    match live_existing with
-    | Some existing ->
-        log_event runtime ~patch_id
-          (Printf.sprintf "Found existing worktree for branch at %s" existing);
-        Runtime.update_orchestrator runtime (fun orch ->
-            Orchestrator.set_worktree_path orch patch_id existing);
-        Some existing
-    | None -> (
-        if Worktree.is_checked_out_in_repo_root ~process_mgr ~repo_root br then (
-          let main_root = Worktree.resolve_main_root ~process_mgr ~repo_root in
-          log_event runtime ~patch_id
-            (Printf.sprintf
-               "Cannot create worktree — branch %s is checked out in the main \
-                working tree (%s). Switch the main tree to another branch \
-                (e.g. `git -C %s checkout <default-branch>`) and try again."
-               (Types.Branch.to_string br)
-               main_root main_root);
-          None)
-        else
-          let base =
-            match base_ref with
-            | Some b -> b
-            | None -> (
-                match agent.Patch_agent.base_branch with
-                | Some b -> Types.Branch.to_string b
-                | None -> "HEAD")
-          in
-          log_event runtime ~patch_id
-            (Printf.sprintf "Creating worktree at %s" path);
-          let created =
-            match
-              Eio.Mutex.use_ro worktree_mutex (fun () ->
-                  ignore
-                    (Worktree.create ~process_mgr ~repo_root ~project_name
-                       ~patch_id ~branch:br ~base_ref:base))
-            with
-            | () -> true
-            | exception (Eio.Cancel.Cancelled _ as exn) -> raise exn
-            | exception exn ->
-                log_event runtime ~patch_id
-                  (Printf.sprintf "Worktree creation failed — %s"
-                     (Stdlib.Printexc.to_string exn));
-                false
-          in
-          match (created, Stdlib.Sys.file_exists path) with
-          | true, true ->
-              Runtime.update_orchestrator runtime (fun orch ->
-                  Orchestrator.set_worktree_path orch patch_id path);
-              (match user_config.User_config.on_worktree_create with
-              | Some script -> (
-                  let env =
-                    [
-                      ("ONTON_WORKTREE_PATH", path);
-                      ("ONTON_PATCH_ID", Types.Patch_id.to_string patch_id);
-                      ("ONTON_BRANCH", Types.Branch.to_string br);
-                    ]
-                  in
-                  let cwd = Eio.Path.(fs / path) in
-                  (* [hook_mutex] serializes hook invocations across patch
+            (Printf.sprintf "Found existing worktree for branch at %s" existing);
+          Runtime.update_orchestrator runtime (fun orch ->
+              Orchestrator.set_worktree_path orch patch_id existing);
+          Some existing
+      | None -> (
+          if W.is_checked_out_in_repo_root br then (
+            let main_root = W.resolve_main_root () in
+            log_event runtime ~patch_id
+              (Printf.sprintf
+                 "Cannot create worktree — branch %s is checked out in the \
+                  main working tree (%s). Switch the main tree to another \
+                  branch (e.g. `git -C %s checkout <default-branch>`) and try \
+                  again."
+                 (Types.Branch.to_string br)
+                 main_root main_root);
+            None)
+          else
+            let base =
+              match base_ref with
+              | Some b -> b
+              | None -> (
+                  match agent.Patch_agent.base_branch with
+                  | Some b -> Types.Branch.to_string b
+                  | None -> "HEAD")
+            in
+            log_event runtime ~patch_id
+              (Printf.sprintf "Creating worktree at %s" path);
+            let created =
+              match
+                Eio.Mutex.use_ro worktree_mutex (fun () ->
+                    ignore
+                      (W.create ~project_name ~patch_id ~branch:br
+                         ~base_ref:base))
+              with
+              | () -> true
+              | exception (Eio.Cancel.Cancelled _ as exn) -> raise exn
+              | exception exn ->
+                  log_event runtime ~patch_id
+                    (Printf.sprintf "Worktree creation failed — %s"
+                       (Stdlib.Printexc.to_string exn));
+                  false
+            in
+            match (created, Stdlib.Sys.file_exists path) with
+            | true, true ->
+                Runtime.update_orchestrator runtime (fun orch ->
+                    Orchestrator.set_worktree_path orch patch_id path);
+                (match user_config.User_config.on_worktree_create with
+                | Some script -> (
+                    let env =
+                      [
+                        ("ONTON_WORKTREE_PATH", path);
+                        ("ONTON_PATCH_ID", Types.Patch_id.to_string patch_id);
+                        ("ONTON_BRANCH", Types.Branch.to_string br);
+                      ]
+                    in
+                    let cwd = Eio.Path.(fs / path) in
+                    (* [hook_mutex] serializes hook invocations across patch
                      fibers — npm/dune/bun aren't parallelism-safe across
                      shared caches, and per-hook fan-out is the dominant
                      subprocess multiplier (see issue #209). *)
-                  match
-                    Eio.Mutex.use_ro hook_mutex (fun () ->
-                        User_config.run_hook ~process_mgr ~clock ~script ~cwd
-                          ~env ())
-                  with
-                  | Ok () ->
-                      log_event runtime ~patch_id "Ran on_worktree_create hook"
-                  | Error msg ->
-                      log_event runtime ~patch_id
-                        (Printf.sprintf "Hook on_worktree_create failed — %s"
-                           msg))
-              | None -> ());
-              Some path
-          | true, false ->
-              log_event runtime ~patch_id
-                (Printf.sprintf "Worktree still missing at %s" path);
-              None
-          | false, _ -> (
-              (* [Worktree.create] raised. A concurrent fiber may have already
+                    match
+                      Eio.Mutex.use_ro hook_mutex (fun () ->
+                          W.run_hook ~clock ~script ~cwd ~env ())
+                    with
+                    | Ok () ->
+                        log_event runtime ~patch_id
+                          "Ran on_worktree_create hook"
+                    | Error msg ->
+                        log_event runtime ~patch_id
+                          (Printf.sprintf "Hook on_worktree_create failed — %s"
+                             msg))
+                | None -> ());
+                Some path
+            | true, false ->
+                log_event runtime ~patch_id
+                  (Printf.sprintf "Worktree still missing at %s" path);
+                None
+            | false, _ -> (
+                (* [Worktree.create] raised. A concurrent fiber may have already
                  added a real worktree for [br] before our attempt collided.
                  [find_for_branch] queries [git worktree list], which only
                  reports atomically-registered worktrees — so a hit here is a
@@ -149,12 +148,13 @@ let ensure_worktree ~runtime ~process_mgr ~clock ~fs ~repo_root ~project_name
                  branch: the winning creator is already responsible for it,
                  mirroring the existing "Found existing worktree for branch"
                  path above. *)
-              match Worktree.find_for_branch ~process_mgr ~repo_root br with
-              | Some existing ->
-                  log_event runtime ~patch_id
-                    (Printf.sprintf
-                       "Adopting concurrently-created worktree at %s" existing);
-                  Runtime.update_orchestrator runtime (fun orch ->
-                      Orchestrator.set_worktree_path orch patch_id existing);
-                  Some existing
-              | None -> None))
+                match W.find_for_branch br with
+                | Some existing ->
+                    log_event runtime ~patch_id
+                      (Printf.sprintf
+                         "Adopting concurrently-created worktree at %s" existing);
+                    Runtime.update_orchestrator runtime (fun orch ->
+                        Orchestrator.set_worktree_path orch patch_id existing);
+                    Some existing
+                | None -> None))
+end

--- a/lib/worktree_setup.mli
+++ b/lib/worktree_setup.mli
@@ -5,38 +5,36 @@
     owns that logic so both callers go through the same code path — same
     persistence, same hook invocation, same logging. *)
 
-val resolve_worktree_path :
-  process_mgr:_ Eio.Process.mgr ->
-  repo_root:string ->
-  project_name:string ->
-  patch_id:Types.Patch_id.t ->
-  agent:Patch_agent.t ->
-  ?branch:Types.Branch.t ->
-  unit ->
-  string
-(** Resolve the worktree path for a patch. Checks the stored path first, then
-    searches git worktrees by branch, then falls back to the canonical
-    [Worktree.worktree_dir] path. Pure-ish — no side effects on disk; the
-    persisted path on the agent record is consulted but not written. *)
+module Make (_ : Worktree.S) : sig
+  val resolve_worktree_path :
+    project_name:string ->
+    patch_id:Types.Patch_id.t ->
+    agent:Patch_agent.t ->
+    ?branch:Types.Branch.t ->
+    unit ->
+    string
+  (** Resolve the worktree path for a patch. Checks the stored path first, then
+      searches git worktrees by branch, then falls back to the canonical
+      [Worktree.worktree_dir] path. Pure-ish — no side effects on disk; the
+      persisted path on the agent record is consulted but not written. *)
 
-val ensure_worktree :
-  runtime:Runtime.t ->
-  process_mgr:_ Eio.Process.mgr ->
-  clock:_ Eio.Time.clock ->
-  fs:Eio.Fs.dir_ty Eio.Path.t ->
-  repo_root:string ->
-  project_name:string ->
-  patch_id:Types.Patch_id.t ->
-  agent:Patch_agent.t ->
-  user_config:User_config.t ->
-  worktree_mutex:Eio.Mutex.t ->
-  hook_mutex:Eio.Mutex.t ->
-  ?branch:Types.Branch.t ->
-  ?base_ref:string ->
-  unit ->
-  string option
-(** Ensure a worktree exists for the patch. Returns [Some path] on success or
-    [None] when the branch's worktree cannot be created (e.g. it's checked out
-    in the main tree). On creation, runs the user's [on_worktree_create] hook
-    serialised through [hook_mutex] and persists the path on the agent record.
-    All log lines go through [Runtime_logging.log_event]. *)
+  val ensure_worktree :
+    runtime:Runtime.t ->
+    clock:_ Eio.Time.clock ->
+    fs:Eio.Fs.dir_ty Eio.Path.t ->
+    project_name:string ->
+    patch_id:Types.Patch_id.t ->
+    agent:Patch_agent.t ->
+    user_config:User_config.t ->
+    worktree_mutex:Eio.Mutex.t ->
+    hook_mutex:Eio.Mutex.t ->
+    ?branch:Types.Branch.t ->
+    ?base_ref:string ->
+    unit ->
+    string option
+  (** Ensure a worktree exists for the patch. Returns [Some path] on success or
+      [None] when the branch's worktree cannot be created (e.g. it's checked out
+      in the main tree). On creation, runs the user's [on_worktree_create] hook
+      serialised through [hook_mutex] and persists the path on the agent record.
+      All log lines go through [Runtime_logging.log_event]. *)
+end


### PR DESCRIPTION
## Summary
- add a Worktree.S capability and Worktree.make client for repo-scoped git/worktree effects
- functorize Worktree_setup, Startup_reconciler, and Session_driver over the worktree client
- wire a single WorktreeClient through bin/main.ml and remove app-path process_mgr/repo_root threading for worktree effects

## Tests
- dune build
- dune fmt
- env HOME=/private/tmp/onton-empty-home XDG_CONFIG_HOME=/private/tmp/onton-empty-xdg GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 dune runtest
- pre-commit hook: dune build, dune runtest, format check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/290"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Functorized all worktree operations behind a `Worktree.S` interface and wired a single client through the app, dropping `process_mgr`/`repo_root` plumbing across session APIs. This simplifies session flow and makes repo-scoped git actions easier to test and mock.

- **Refactors**
  - Added `Worktree.S` and moved worktree operations behind it (create/remove, list/find, hooks, fetch, status).
  - Functorized `Worktree_setup`, `Startup_reconciler`, and `Session_driver` over `Worktree.S`.
  - Removed `process_mgr`/`repo_root` from `Session_driver.Make` (`run`, `run_long_lived`) and updated `runner_fiber` call sites.
  - Updated `bin/main.ml` to construct and pass one worktree client; removed ad-hoc threading of `process_mgr` and `repo_root`.

- **Migration**
  - Provide a `Worktree.S` implementation and pass it to `Worktree_setup.Make`, `Startup_reconciler.Make`, and `Session_driver.Make`.
  - Update calls to `Session_driver.run`/`run_long_lived` to remove `process_mgr`/`repo_root`.
  - Use `Startup_reconciler.Make(...).recover_worktrees`; the top-level `recover_worktrees` was removed.

<sup>Written for commit ca186341ca08e1c50419111f3f12385ffff2fe5d. Summary will update on new commits. <a href="https://cubic.dev/pr/flowglad/onton/pull/290?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal architectural patterns to improve dependency injection and module composition across session management, worktree operations, and startup reconciliation components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flowglad/onton/pull/290?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->