### PR TITLE
Route GitHub preflight through forge client

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -4381,15 +4381,6 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
         (Project_store.snapshot_path project_name);
       let net = Eio.Stdenv.net env in
       let clock = Eio.Stdenv.clock env in
-      (match
-         Github.check_repo_access ~net ~clock ~token:config.github_token
-           ~owner:config.github_owner ~repo:config.github_repo ()
-       with
-      | Ok () -> ()
-      | Error err ->
-          Printf.eprintf "Error: cannot access GitHub repo %s/%s: %s\n"
-            config.github_owner config.github_repo (Github.show_error err);
-          Stdlib.exit 1);
       let forge =
         Github.make ~net ~clock ~token:config.github_token
           ~owner:config.github_owner ~repo:config.github_repo
@@ -4400,6 +4391,12 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
         Worktree.make ~process_mgr ~repo_root:config.repo_root
       in
       let module WorktreeClient = (val worktree_client) in
+      (match Forge.check_repo_access () with
+      | Ok () -> ()
+      | Error err ->
+          Printf.eprintf "Error: cannot access GitHub repo %s/%s: %s\n"
+            config.github_owner config.github_repo (Github.show_error err);
+          Stdlib.exit 1);
       let module Reconciler = Startup_reconciler.Make (Forge) (WorktreeClient)
       in
       let module Fibers = Make_fibers (Forge) (WorktreeClient) in

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -125,7 +125,6 @@ let show_error = function
 type t = { token : string; owner : string; repo : string }
 
 let create ~token ~owner ~repo = { token; owner; repo }
-let with_client ~token ~owner ~repo ~f = f (create ~token ~owner ~repo)
 
 let graphql_query =
   {|query($owner: String!, $repo: String!, $number: Int!) {
@@ -538,10 +537,6 @@ let check_repo_access_internal ~net ~clock ?timeout t =
   match request ~net ~clock ?timeout t ~meth:`GET ~path () with
   | Ok _ -> Ok ()
   | Error _ as e -> e
-
-let check_repo_access ~net ~clock ?timeout ~token ~owner ~repo () =
-  with_client ~token ~owner ~repo ~f:(fun client ->
-      check_repo_access_internal ~net ~clock ?timeout client)
 
 let pr_state ~net ~clock ?timeout t pr =
   let body = build_request_body t pr in

--- a/lib/github.mli
+++ b/lib/github.mli
@@ -32,20 +32,6 @@ val default_timeout : float
     stuck in [SYN_SENT] (e.g. dropped packets, dead route) can block the calling
     fiber indefinitely. *)
 
-val check_repo_access :
-  net:_ Eio.Net.t ->
-  clock:_ Eio.Time.clock ->
-  ?timeout:float ->
-  token:string ->
-  owner:string ->
-  repo:string ->
-  unit ->
-  (unit, error) Result.t
-(** [check_repo_access ~net ~clock ~token ~owner ~repo] verifies that the
-    configured token can access [owner/repo] via [GET /repos/:owner/:repo]. This
-    is a startup preflight so missing tokens, expired credentials, SSO gaps, and
-    wrong repository names fail before long-running orchestration starts. *)
-
 val parse_response_json :
   owner:string -> Yojson.Safe.t -> (Pr_state.t, error) Result.t
 (** Parse a GitHub GraphQL response JSON value into a [Pr_state.t]. Pure


### PR DESCRIPTION
## Summary
- construct the GitHub forge before startup repo access validation
- call Forge.check_repo_access() instead of the raw Github.check_repo_access helper
- remove the now-unexported top-level GitHub preflight wrapper and its private client wrapper

## Verification
- dune fmt
- dune build
- dune runtest
- pre-commit hook: dune build, dune runtest, format check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/292"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781885369&installation_id=126163856&pr_number=292&repository=flowglad%2Fonton&return_to=https%3A%2F%2Fgithub.com%2Fflowglad%2Fonton%2Fpull%2F292&signature=4f62847a94bdc799d4cf7a1db34ba9b71fe5c027814f72a7b0e584eb1cae24c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route the GitHub repo-access preflight through the forge client so startup validation uses the same interface as runtime operations. This removes duplicate helpers and simplifies initialization.

- **Refactors**
  - Build the GitHub forge before startup validation and call Forge.check_repo_access().
  - Remove `Github.with_client` and the exported `Github.check_repo_access` (deleted from `github.mli`).

<sup>Written for commit b521185d0dca612d1d1890e4ac61929b00c7f7c4. Summary will update on new commits. <a href="https://cubic.dev/pr/flowglad/onton/pull/292?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

