### PR TITLE
Adapt TUI layout for short terminal heights

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1521,7 +1521,7 @@ struct
                           | None -> 24
                         in
                         (* Keep in sync with render_frame Timeline_view reserved *)
-                        let reserved = 11 in
+                        let reserved = 9 in
                         let max_rows = Base.Int.max 0 (height - reserved) in
                         let max_offset = Base.Int.max 0 (total - max_rows) in
                         timeline_scroll :=

--- a/lib/tui.ml
+++ b/lib/tui.ml
@@ -461,14 +461,36 @@ type frame = {
 }
 [@@warning "-69"]
 
-let render_header ~project_name ~width =
-  let title =
-    Term.styled
-      [ Term.Sgr.bold; Term.Sgr.fg_cyan ]
-      (Printf.sprintf " %s " project_name)
+(** Build the header row: project name on the left, backend on the right.
+
+    Both segments are truncated when [width] is constrained. The backend segment
+    is sacrificed first (collapsed to empty) so the project name is always
+    visible — a saturated TUI still tells the user which session they are
+    looking at. *)
+let render_header ~project_name ~backend_name ~width =
+  let title_raw = Printf.sprintf " %s " project_name in
+  let backend_raw =
+    if String.is_empty backend_name then ""
+    else Printf.sprintf " %s " backend_name
+  in
+  let title_w = Term.visible_length title_raw in
+  let backend_w = Term.visible_length backend_raw in
+  let style_title s = Term.styled [ Term.Sgr.bold; Term.Sgr.fg_cyan ] s in
+  let style_backend s = Term.styled [ Term.Sgr.dim ] s in
+  let header_line =
+    if width <= 0 then ""
+    else if title_w + backend_w + 1 <= width then
+      let pad = width - title_w - backend_w in
+      style_title title_raw ^ String.make pad ' ' ^ style_backend backend_raw
+    else if title_w <= width then
+      (* Backend doesn't fit — keep the project name and pad to width. *)
+      style_title title_raw ^ String.make (width - title_w) ' '
+    else
+      (* Project name itself overflows — truncate it. *)
+      style_title (Term.fit_width width title_raw)
   in
   let rule = Term.hrule width in
-  [ title; rule ]
+  [ header_line; rule ]
 
 let short_op_name = function
   | Operation_kind.Ci -> "ci"
@@ -591,34 +613,6 @@ let render_patches ~width ~selected ~max_visible ~now (views : patch_view list)
       header_lines,
       offset,
       vis_count )
-
-let render_summary ~backend_name (views : patch_view list) =
-  let count status =
-    List.count views ~f:(fun v -> equal_display_status v.status status)
-  in
-  let total = List.length views in
-  let merged = count Merged in
-  let busy_views = List.filter views ~f:(fun v -> is_running_status v.status) in
-  let queued =
-    List.count busy_views ~f:(fun v ->
-        Patch_agent.equal_op_state v.current_op_state Patch_agent.Queued)
-  in
-  let running = List.length busy_views - queued in
-  let needs_help = count Needs_help in
-  let parts =
-    [
-      backend_name;
-      Printf.sprintf "%d/%d merged" merged total;
-      (if running > 0 then Printf.sprintf "%d running" running else "");
-      (if queued > 0 then Printf.sprintf "%d queued" queued else "");
-      (if needs_help > 0 then
-         Term.styled [ Term.Sgr.fg_red ]
-           (Printf.sprintf "%d need help" needs_help)
-       else "");
-    ]
-    |> List.filter ~f:(fun s -> not (String.is_empty s))
-  in
-  Term.styled [ Term.Sgr.dim ] (" " ^ String.concat ~sep:" │ " parts)
 
 let format_activity_ts ts =
   match try Some (Unix.localtime ts) with _ -> None with
@@ -1173,8 +1167,7 @@ let render_frame ~width ~height ~selected ~scroll_offset ~view_mode
     let overlay = render_manage_overlay ~width ~height ~automerge_enabled in
     { no_patches with lines = overlay; detail_scroll_offset = scroll_offset }
   else
-    let header = render_header ~project_name ~width in
-    let summary = [ render_summary ~backend_name views ] in
+    let header = render_header ~project_name ~backend_name ~width in
     let footer = render_footer ~width ~view_mode ?prompt_line () in
     let status_line =
       let rendered = render_status_msg ~width status_msg in
@@ -1187,11 +1180,10 @@ let render_frame ~width ~height ~selected ~scroll_offset ~view_mode
         with
         | Some pv ->
             let info_h = detail_info_height pv in
-            (* Chrome: header(2) + blank + summary(1) + blank + info + blank
-               before footer + footer *)
+            (* Chrome: header(2) + blank + info + blank before footer + status +
+               footer *)
             let fixed =
-              2 + 1 + 1 + 1 + info_h + 1 + List.length status_line
-              + List.length footer
+              2 + 1 + info_h + 1 + List.length status_line + List.length footer
             in
             let max_section = Int.max 0 (height - fixed) in
             let scroll =
@@ -1201,8 +1193,8 @@ let render_frame ~width ~height ~selected ~scroll_offset ~view_mode
               render_detail pv ~width ~scroll ~now ~transcript ()
             in
             let lines =
-              header @ [ "" ] @ summary @ [ "" ] @ info @ transcript_section
-              @ [ "" ] @ status_line @ footer
+              header @ [ "" ] @ info @ transcript_section @ [ "" ] @ status_line
+              @ footer
             in
             {
               no_patches with
@@ -1212,16 +1204,15 @@ let render_frame ~width ~height ~selected ~scroll_offset ~view_mode
             }
         | None ->
             let lines =
-              header @ [ "" ] @ summary @ [ "" ] @ [ " (patch not found)" ]
-              @ [ "" ] @ status_line @ footer
+              header @ [ "" ] @ [ " (patch not found)" ] @ [ "" ] @ status_line
+              @ footer
             in
             { no_patches with lines })
     | Timeline_view ->
-        (* Budget: header(2) + blank + summary(1) + blank + "Timeline" header(1)
-         + scroll indicators(2) + blank before footer + footer *)
+        (* Budget: header(2) + blank + "Timeline" header(1) + scroll
+           indicators(2) + blank before footer + status + footer *)
         let reserved =
-          2 + 1 + 1 + 1 + 1 + 2 + 1 + List.length status_line
-          + List.length footer
+          2 + 1 + 1 + 2 + 1 + List.length status_line + List.length footer
         in
         let max_rows = Int.max 0 (height - reserved) in
         let scroll =
@@ -1229,30 +1220,46 @@ let render_frame ~width ~height ~selected ~scroll_offset ~view_mode
         in
         let timeline = render_timeline ~width ~scroll activity in
         let lines =
-          header @ [ "" ] @ summary @ [ "" ] @ timeline @ [ "" ] @ status_line
-          @ footer
+          header @ [ "" ] @ timeline @ [ "" ] @ status_line @ footer
         in
         { no_patches with lines }
     | List_view ->
-        let activity_lines = render_activity activity in
-        let activity_height =
-          if List.is_empty activity_lines then 0
-          else 1 + List.length activity_lines
+        (* Patches get priority. Reserve only the non-patch, non-activity
+           chrome: header(2) + blank after header + up to 2 scroll indicators
+           + blank before footer + status + footer. Activity is rendered into
+           whatever space is left after the patch block, and collapses
+           entirely when there is no room. *)
+        let chrome_reserved =
+          2 + 1 + 2 + 1 + List.length status_line + List.length footer
         in
-        (* Budget: header(2) + blank + summary(1) + blank + "Patches" header(1)
-         + scroll indicators(2) + blank before footer + footer +
-         activity block *)
-        let reserved =
-          2 + 1 + 1 + 1 + 1 + 2 + 1 + List.length status_line
-          + List.length footer + activity_height
+        let max_patch_rows =
+          Int.max 0 (height - chrome_reserved - 1 (* "Patches" header *))
         in
-        let max_patch_rows = Int.max 0 (height - reserved) in
         let patches, patch_header_lines, scroll_off, visible_rows =
           render_patches ~width ~selected ~max_visible:max_patch_rows ~now views
         in
-        let patches_start_row = 5 + patch_header_lines + 1 in
+        let patches_start_row = 3 + patch_header_lines + 1 in
+        let lines_before_activity =
+          2 (* header *) + 1 (* blank *) + List.length patches
+        in
+        let lines_after_activity =
+          1 (* blank before footer *) + List.length status_line
+          + List.length footer
+        in
+        let activity_budget =
+          (* Need at least 2 lines (Activity header + 1 entry) plus a blank
+             separator, so check against 3 total. *)
+          height - lines_before_activity - lines_after_activity - 1
+        in
+        let activity_lines =
+          if List.is_empty activity || activity_budget < 2 then []
+          else
+            let raw = render_activity activity in
+            if List.length raw <= activity_budget then raw
+            else List.take raw activity_budget
+        in
         let lines =
-          header @ [ "" ] @ summary @ [ "" ] @ patches
+          header @ [ "" ] @ patches
           @ (if List.is_empty activity_lines then [] else "" :: activity_lines)
           @ [ "" ] @ status_line @ footer
         in

--- a/lib/tui.ml
+++ b/lib/tui.ml
@@ -1225,15 +1225,19 @@ let render_frame ~width ~height ~selected ~scroll_offset ~view_mode
         { no_patches with lines }
     | List_view ->
         (* Patches get priority. Reserve only the non-patch, non-activity
-           chrome: header(2) + blank after header + up to 2 scroll indicators
-           + blank before footer + status + footer. Activity is rendered into
-           whatever space is left after the patch block, and collapses
-           entirely when there is no room. *)
+           chrome: header(2) + blank after header + blank before footer +
+           status + footer. Scroll indicators are reserved only when patches
+           actually overflow, so the rows they would have taken go to
+           activity when the list fits. *)
         let chrome_reserved =
-          2 + 1 + 2 + 1 + List.length status_line + List.length footer
+          2 + 1 + 1 + List.length status_line + List.length footer
         in
+        let patches_section_max = Int.max 0 (height - chrome_reserved) in
+        let total_views = List.length views in
         let max_patch_rows =
-          Int.max 0 (height - chrome_reserved - 1 (* "Patches" header *))
+          let without_indicators = Int.max 0 (patches_section_max - 1) in
+          if total_views <= without_indicators then without_indicators
+          else Int.max 0 (patches_section_max - 3)
         in
         let patches, patch_header_lines, scroll_off, visible_rows =
           render_patches ~width ~selected ~max_visible:max_patch_rows ~now views
@@ -1246,17 +1250,18 @@ let render_frame ~width ~height ~selected ~scroll_offset ~view_mode
           1 (* blank before footer *) + List.length status_line
           + List.length footer
         in
+        (* Space available for the activity section, which includes its own
+           blank separator from the patch block. Need at least 3 lines
+           (separator + "Activity" header + 1 entry) to be worth rendering. *)
         let activity_budget =
-          (* Need at least 2 lines (Activity header + 1 entry) plus a blank
-             separator, so check against 3 total. *)
-          height - lines_before_activity - lines_after_activity - 1
+          height - lines_before_activity - lines_after_activity
         in
         let activity_lines =
-          if List.is_empty activity || activity_budget < 2 then []
+          if List.is_empty activity || activity_budget < 3 then []
           else
             let raw = render_activity activity in
-            if List.length raw <= activity_budget then raw
-            else List.take raw activity_budget
+            let take = Int.min (List.length raw) (activity_budget - 1) in
+            List.take raw take
         in
         let lines =
           header @ [ "" ] @ patches

--- a/lib/tui.ml
+++ b/lib/tui.ml
@@ -1250,9 +1250,14 @@ let render_frame ~width ~height ~selected ~scroll_offset ~view_mode
           1 (* blank before footer *) + List.length status_line
           + List.length footer
         in
-        (* Space available for the activity section, which includes its own
-           blank separator from the patch block. Need at least 3 lines
-           (separator + "Activity" header + 1 entry) to be worth rendering. *)
+        (* [activity_budget] is the total space available for the activity
+           block, which when rendered is: 1 blank separator + render_activity
+           output ("Activity" header + one line per entry). Need ≥ 3 to fit
+           separator + header + 1 entry. The separator is folded into
+           [activity_lines] itself so the budget accounting is local: the
+           sole invariant is [List.length activity_lines ≤ activity_budget],
+           and there is no separate prepend at the concat site that could
+           drift from the budget. *)
         let activity_budget =
           height - lines_before_activity - lines_after_activity
         in
@@ -1260,13 +1265,12 @@ let render_frame ~width ~height ~selected ~scroll_offset ~view_mode
           if List.is_empty activity || activity_budget < 3 then []
           else
             let raw = render_activity activity in
-            let take = Int.min (List.length raw) (activity_budget - 1) in
-            List.take raw take
+            let max_raw = activity_budget - 1 (* reserve 1 for separator *) in
+            "" :: List.take raw (Int.min (List.length raw) max_raw)
         in
         let lines =
-          header @ [ "" ] @ patches
-          @ (if List.is_empty activity_lines then [] else "" :: activity_lines)
-          @ [ "" ] @ status_line @ footer
+          header @ [ "" ] @ patches @ activity_lines @ [ "" ] @ status_line
+          @ footer
         in
         {
           no_patches with

--- a/lib/tui.ml
+++ b/lib/tui.ml
@@ -1265,7 +1265,7 @@ let render_frame ~width ~height ~selected ~scroll_offset ~view_mode
           if List.is_empty activity || activity_budget < 3 then []
           else
             let raw = render_activity activity in
-            let max_raw = activity_budget - 1 (* reserve 1 for separator *) in
+            let max_raw = activity_budget - 1 in
             "" :: List.take raw (Int.min (List.length raw) max_raw)
         in
         let lines =

--- a/test/dune
+++ b/test/dune
@@ -107,6 +107,11 @@
  (libraries onton_core))
 
 (test
+ (name test_tui_render_frame)
+ (modules test_tui_render_frame)
+ (libraries onton onton_core base))
+
+(test
  (name test_stream_parser)
  (modules test_stream_parser)
  (libraries onton onton_core qcheck-core))

--- a/test/test_tui_render_frame.ml
+++ b/test/test_tui_render_frame.ml
@@ -1,0 +1,200 @@
+(** Rendering tests for [Tui.render_frame], focused on the short-terminal
+    behavior described in flowglad/onton#267.
+
+    These exercise the actual frame layout — they do not paint to a real
+    terminal. The frame is rendered, ANSI is stripped, and the resulting
+    plain-text lines are inspected. *)
+
+open Base
+open Onton
+open Onton_core.Types
+
+let make_view ~id ~title =
+  {
+    Tui.patch_id = Patch_id.of_string id;
+    title;
+    branch = Branch.of_string (Printf.sprintf "branch-%s" id);
+    status = Tui.Pending;
+    queue_len = 0;
+    current_op = None;
+    current_op_state = Onton_core.Patch_agent.Queued;
+    ci_failures = 0;
+    dep_ids = [];
+    has_pr = false;
+    has_conflict = false;
+    needs_intervention = false;
+    human_messages = 0;
+    ci_checks = [];
+    recent_stream = [];
+    pr_number = None;
+    base_branch = None;
+    worktree_path = None;
+    intervention_reason = None;
+    automerge_enabled = false;
+    automerge_deadline = None;
+    automerge_failure_count = 0;
+    complexity = None;
+    backend = "claude";
+    model = None;
+  }
+
+let plain_lines frame =
+  Tui.frame_to_string frame |> String.split ~on:'\n'
+  |> List.map ~f:Onton.Term.strip_ansi
+
+let render ?(width = 80) ?(height = 24) ?(view_mode = Tui.List_view)
+    ?(activity = []) ?(project_name = "demo") ?(backend_name = "claude") views =
+  Tui.render_frame ~width ~height ~selected:0 ~scroll_offset:0 ~view_mode
+    ~activity ~project_name ~backend_name ~show_help:false ~show_manage:false
+    ~now:0.0 views
+
+let one_view = [ make_view ~id:"1" ~title:"first patch" ]
+
+let many_views =
+  List.init 8 ~f:(fun i ->
+      make_view
+        ~id:(Int.to_string (i + 1))
+        ~title:(Printf.sprintf "patch %d" (i + 1)))
+
+let one_activity_entry =
+  [
+    Tui.Event
+      { patch_id = Some "1"; message = "something happened"; timestamp = 0.0 };
+  ]
+
+let four_activity_entries =
+  List.init 4 ~f:(fun i ->
+      Tui.Event
+        {
+          patch_id = Some "1";
+          message = Printf.sprintf "event %d" i;
+          timestamp = Float.of_int i;
+        })
+
+(* --- helpers --------------------------------------------------------------- *)
+
+let line_contains lines needle =
+  List.exists lines ~f:(fun line -> String.is_substring line ~substring:needle)
+
+let find_index lines ~f =
+  List.findi lines ~f:(fun _ line -> f line) |> Option.map ~f:fst
+
+(* --- tests ----------------------------------------------------------------- *)
+
+let test_header_has_project_and_backend () =
+  let frame = render one_view in
+  let lines = plain_lines frame in
+  let first = List.hd_exn lines in
+  assert (String.is_substring first ~substring:"demo");
+  assert (String.is_substring first ~substring:"claude");
+  (* Backend should appear on the right half *)
+  let demo_at = String.substr_index_exn first ~pattern:"demo" in
+  let backend_at = String.substr_index_exn first ~pattern:"claude" in
+  assert (backend_at > demo_at)
+
+let test_header_truncates_when_too_narrow () =
+  (* Width too small for both project name and backend — project name wins. *)
+  let frame = render ~width:10 one_view in
+  let lines = plain_lines frame in
+  let first = List.hd_exn lines in
+  assert (String.is_substring first ~substring:"demo");
+  (* Visible width of the header line should not exceed the terminal width. *)
+  assert (Onton.Term.visible_length first <= 10)
+
+let test_no_summary_row () =
+  (* The dedicated " backend | X/Y merged | …" summary line is gone. *)
+  let frame = render one_view in
+  let lines = plain_lines frame in
+  assert (not (line_contains lines "merged │"));
+  assert (not (line_contains lines "1/1 merged"))
+
+let test_list_view_shows_activity_when_room () =
+  let frame = render ~height:24 ~activity:four_activity_entries one_view in
+  let lines = plain_lines frame in
+  assert (line_contains lines "Activity");
+  assert (line_contains lines "event 0");
+  assert (line_contains lines "event 3")
+
+let test_list_view_collapses_activity_when_tight () =
+  (* Height that fits header + some patch rows + footer but not the full
+     activity block. Activity must collapse, patches must remain. *)
+  let frame = render ~height:12 ~activity:four_activity_entries many_views in
+  let lines = plain_lines frame in
+  assert (line_contains lines "Patches");
+  assert (Tui.patch_count frame >= 1);
+  (* No activity rows shown — patches won the budget. *)
+  assert (not (line_contains lines "event 0"));
+  assert (not (line_contains lines "event 3"))
+
+let test_list_view_patches_survive_activity_at_short_height () =
+  (* The patch block must keep at least one row at a typical short tmux
+     pane height; activity must be the first thing to disappear. *)
+  let frame = render ~height:14 ~activity:four_activity_entries many_views in
+  assert (Tui.patch_count frame >= 1);
+  let lines = plain_lines frame in
+  assert (not (line_contains lines "event 0"))
+
+let test_list_view_activity_squeezed_partial () =
+  (* At a height where activity barely fits, it should be truncated rather
+     than steal from patches. *)
+  let frame = render ~height:18 ~activity:four_activity_entries many_views in
+  assert (Tui.patch_count frame >= 1);
+  let lines = plain_lines frame in
+  (* Not all four entries should show — there isn't room for them all *)
+  let visible_events =
+    List.count
+      [ "event 0"; "event 1"; "event 2"; "event 3" ]
+      ~f:(line_contains lines)
+  in
+  assert (visible_events < 4)
+
+let test_frame_anchored_at_top () =
+  (* The header must be on the first emitted line — paint_frame moves the
+     cursor to row 1 and then writes [lines.[0]] first. *)
+  let frame = render one_view in
+  let lines = plain_lines frame in
+  let header = List.hd_exn lines in
+  assert (String.is_substring header ~substring:"demo")
+
+let test_detail_view_no_summary () =
+  let pv = make_view ~id:"1" ~title:"focus me" in
+  let frame = render ~view_mode:(Tui.Detail_view pv.Tui.patch_id) [ pv ] in
+  let lines = plain_lines frame in
+  assert (line_contains lines "focus me");
+  (* Detail view used to repeat the summary line; that line is gone. *)
+  assert (not (line_contains lines "1/1 merged"))
+
+let test_timeline_view_no_summary () =
+  let frame =
+    render ~view_mode:Tui.Timeline_view ~activity:one_activity_entry one_view
+  in
+  let lines = plain_lines frame in
+  assert (not (line_contains lines "1/1 merged"));
+  assert (line_contains lines "something happened")
+
+let test_patches_render_above_activity () =
+  let frame = render ~activity:one_activity_entry many_views in
+  let lines = plain_lines frame in
+  let patches_idx =
+    find_index lines ~f:(String.is_substring ~substring:"Patches")
+  in
+  let activity_idx =
+    find_index lines ~f:(String.is_substring ~substring:"Activity")
+  in
+  match (patches_idx, activity_idx) with
+  | Some p, Some a -> assert (p < a)
+  | _ -> assert false
+
+let () =
+  test_header_has_project_and_backend ();
+  test_header_truncates_when_too_narrow ();
+  test_no_summary_row ();
+  test_list_view_shows_activity_when_room ();
+  test_list_view_collapses_activity_when_tight ();
+  test_list_view_patches_survive_activity_at_short_height ();
+  test_list_view_activity_squeezed_partial ();
+  test_frame_anchored_at_top ();
+  test_detail_view_no_summary ();
+  test_timeline_view_no_summary ();
+  test_patches_render_above_activity ();
+  Stdlib.print_endline "PASS: tui render_frame short-height tests"

--- a/test/test_tui_render_frame.ml
+++ b/test/test_tui_render_frame.ml
@@ -140,12 +140,15 @@ let test_list_view_activity_squeezed_partial () =
   let frame = render ~height:18 ~activity:four_activity_entries many_views in
   assert (Tui.patch_count frame >= 1);
   let lines = plain_lines frame in
-  (* Not all four entries should show — there isn't room for them all *)
+  (* Activity is partially visible: at least one entry shown but not all
+     four. Asserting both ends prevents the test from passing vacuously if
+     activity collapsed entirely. *)
   let visible_events =
     List.count
       [ "event 0"; "event 1"; "event 2"; "event 3" ]
       ~f:(line_contains lines)
   in
+  assert (visible_events >= 1);
   assert (visible_events < 4)
 
 let test_frame_anchored_at_top () =


### PR DESCRIPTION
## Summary
- Header now puts the project name on the left and the dimmed backend on the right (truncates gracefully — backend collapses first, then project name).
- Drops the dedicated `backend │ X/Y merged │ N running` summary row from list/detail/timeline chrome.
- List view rewritten to give the patch list priority over the activity feed: activity now uses whatever space is left after patches, and disappears entirely when the terminal is too short.

## Test plan
- [x] `dune build` and `dune runtest` clean.
- [x] New `test_tui_render_frame` covers: header layout + truncation, summary row absence in all three views, activity rendered when tall, activity collapsed when short, patches surviving short heights, activity squeezed when budget is tight, patches rendered above activity.
- [ ] Eyeball the TUI inside a tmux pane sized to ~12 rows.

Closes #267.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/293"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781888269&installation_id=126163856&pr_number=293&repository=flowglad%2Fonton&return_to=https%3A%2F%2Fgithub.com%2Fflowglad%2Fonton%2Fpull%2F293&signature=00f1a6c1558b5c010782088dd1251b522cdc750834c79b79b56d0ef345ada4ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimized the TUI for short terminal heights by prioritizing patches and moving status into a compact header. Activity now uses leftover space, truncates or hides first, and timeline/list views reserve fewer fixed rows.

- **New Features**
  - Header: project on the left, dim backend on the right; backend drops first, both truncate gracefully.
  - Removed the “backend │ X/Y merged │ N running” summary row from list/detail/timeline.
  - List view: patch-first; activity uses leftover rows, truncates, and hides first when tight.
  - Reserves patch scroll-indicator rows only when patches overflow; separator merged into the activity block for accurate budgeting.
  - Timeline reserved rows reduced 11 → 9.
  - Added `test_tui_render_frame` covering header truncation, summary removal, patch-first layout, activity collapse/partial squeeze, and patches-above-activity ordering.

- **Refactors**
  - Removed a redundant inline comment to satisfy `ocamlformat`.

<sup>Written for commit 85110d6c6d76cdb2ac01784e8f381042baca69f4. Summary will update on new commits. <a href="https://cubic.dev/pr/flowglad/onton/pull/293?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Backend name now displays in the header (right-aligned) instead of a separate row, streamlining the interface layout.

* **Improvements**
  * Timeline view now provides more scrollable area for content.
  * Activity visibility in list views better handled under space constraints.

* **Tests**
  * Added comprehensive rendering tests for UI layout behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flowglad/onton/pull/293?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->