### PR TITLE
[dependency-injection-functors] Patch 1: Functorize Worktree_setup environment

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -307,7 +307,6 @@ module Make_fibers
     (Forge : Onton.Forge.S with type error = Github.error)
     (W : Worktree.S) =
 struct
-  module Worktree_setup = Worktree_setup.Make (W)
   module Session_driver = Session_driver.Make (W)
 
   (** Execute declarative GitHub effects and record successful observations back
@@ -697,59 +696,18 @@ struct
             ~reason:Orchestrator.Unexpected_exception ~agent_before:before
             ~agent_after:after)
 
-  let resolve_worktree_path = Worktree_setup.resolve_worktree_path
-  let ensure_worktree = Worktree_setup.ensure_worktree
-
-  (** Execute a [Worktree_plan.t] against the live filesystem. The plan is built
-      purely (see [Worktree_plan.for_rebase] / [for_merge_conflict]); this
-      function is the single place that turns its ops into git invocations.
-
-      Short-circuits on the first failing op:
-      - [Ensure_worktree] failure →
-        [Worktree.Error "<label> failed: worktree missing"]
-      - [Fetch_origin] error →
-        [Worktree.Error "fetch before rebase failed: ..."] (this exact prefix
-        matches the historical log/event format)
-      - [Rebase_onto] returns its result verbatim; only [Worktree.Ok] continues.
-
-      Returns the final result paired with the worktree path so callers can use
-      it for follow-on effects like [Worktree.force_push_with_lease]. *)
-  let execute_worktree_plan ~runtime ~clock ~fs ~project_name ~patch_id
-      ~(agent : Patch_agent.t) ~user_config ~worktree_mutex ~hook_mutex
-      ~fetch_lock ~fail_label ~ancestor_ids (plan : Worktree_plan.t) =
-    let default_path = Worktree.worktree_dir ~project_name ~patch_id in
-    let rec loop ~path = function
-      | [] -> (Worktree.Ok, path)
-      | Worktree_plan.Ensure_worktree :: rest -> (
-          match
-            ensure_worktree ~runtime ~clock ~fs ~project_name ~patch_id ~agent
-              ~user_config ~worktree_mutex ~hook_mutex ()
-          with
-          | Some p -> loop ~path:p rest
-          | None ->
-              log_event runtime ~patch_id
-                (Printf.sprintf
-                   "Cannot %s — worktree missing and could not be created"
-                   fail_label);
-              ( Worktree.Error
-                  (Printf.sprintf "%s failed: worktree missing" fail_label),
-                path ))
-      | Worktree_plan.Fetch_origin :: rest -> (
-          match W.fetch_origin ~fetch_lock ~path with
-          | Result.Ok () -> loop ~path rest
-          | Result.Error msg ->
-              log_event runtime ~patch_id
-                (Printf.sprintf "Fetch failed before %s — %s" fail_label msg);
-              ( Worktree.Error
-                  (Printf.sprintf "fetch before rebase failed: %s" msg),
-                path ))
-      | Worktree_plan.Rebase_onto target :: rest -> (
-          match W.rebase_onto ~path ~target ~project_name ~ancestor_ids with
-          | Worktree.Ok -> loop ~path rest
-          | (Worktree.Noop | Worktree.Conflict _ | Worktree.Error _) as r ->
-              (r, path))
-    in
-    loop ~path:default_path plan
+  let resolve_worktree_path ~project_name ~patch_id
+      ~(agent : Patch_agent.t) ?branch () =
+    match (branch, agent.Patch_agent.worktree_path) with
+    | None, Some p -> p
+    | _ ->
+        let search_branch =
+          match branch with Some b -> b | None -> agent.Patch_agent.branch
+        in
+        let found = W.find_for_branch search_branch in
+        (match found with
+        | Some p -> p
+        | None -> Worktree.worktree_dir ~project_name ~patch_id)
 
   (** {1 Fibers} *)
 
@@ -2115,6 +2073,49 @@ struct
      of short-lived children. Running 10 hooks in parallel is how issue
      #209 blew through the system FD table. *)
     let hook_mutex = Eio.Mutex.create () in
+    let module Env = struct
+      let runtime = runtime
+      let (clock : float Eio.Time.clock_ty Eio.Time.clock) = clock
+      let fs = fs
+      let project_name = project_name
+      let user_config = config.user_config
+      let worktree_mutex = worktree_mutex
+      let hook_mutex = hook_mutex
+    end in
+    let module WS = Worktree_setup.Make (W) (Env) in
+    let execute_worktree_plan ~patch_id ~(agent : Patch_agent.t) ~fetch_lock
+        ~fail_label ~ancestor_ids (plan : Worktree_plan.t) =
+      let default_path = Worktree.worktree_dir ~project_name ~patch_id in
+      let rec loop ~path = function
+        | [] -> (Worktree.Ok, path)
+        | Worktree_plan.Ensure_worktree :: rest -> (
+            match WS.ensure_worktree ~patch_id ~agent () with
+            | Some p -> loop ~path:p rest
+            | None ->
+                log_event runtime ~patch_id
+                  (Printf.sprintf
+                     "Cannot %s — worktree missing and could not be created"
+                     fail_label);
+                ( Worktree.Error
+                    (Printf.sprintf "%s failed: worktree missing" fail_label),
+                  path ))
+        | Worktree_plan.Fetch_origin :: rest -> (
+            match W.fetch_origin ~fetch_lock ~path with
+            | Result.Ok () -> loop ~path rest
+            | Result.Error msg ->
+                log_event runtime ~patch_id
+                  (Printf.sprintf "Fetch failed before %s — %s" fail_label msg);
+                ( Worktree.Error
+                    (Printf.sprintf "fetch before rebase failed: %s" msg),
+                  path ))
+        | Worktree_plan.Rebase_onto target :: rest -> (
+            match W.rebase_onto ~path ~target ~project_name ~ancestor_ids with
+            | Worktree.Ok -> loop ~path rest
+            | (Worktree.Noop | Worktree.Conflict _ | Worktree.Error _) as r ->
+                (r, path))
+      in
+      loop ~path:default_path plan
+    in
     let long_lived_sessions :
         (Patch_id.t, Session_driver.long_lived_session) Stdlib.Hashtbl.t =
       Stdlib.Hashtbl.create 16
@@ -2389,10 +2390,7 @@ struct
                                       (fun orch ->
                                         Orchestrator.mark_running orch patch_id);
                                     match
-                                      ensure_worktree ~runtime ~clock ~fs
-                                        ~project_name ~patch_id ~agent
-                                        ~user_config:config.user_config
-                                        ~worktree_mutex ~hook_mutex
+                                      WS.ensure_worktree ~patch_id ~agent
                                         ~branch:patch.Patch.branch
                                         ~base_ref:(Branch.to_string base_branch)
                                         ()
@@ -2628,10 +2626,8 @@ struct
                                 patch_id)
                         in
                         let rebase_result, wt_path =
-                          execute_worktree_plan ~runtime ~clock ~fs
-                            ~project_name ~patch_id ~agent
-                            ~user_config:config.user_config ~worktree_mutex
-                            ~hook_mutex ~fetch_lock:fetch_mutex
+                          execute_worktree_plan ~patch_id ~agent
+                            ~fetch_lock:fetch_mutex
                             ~fail_label:"rebase" ~ancestor_ids
                             (Worktree_plan.for_rebase ~new_base)
                         in
@@ -2900,10 +2896,7 @@ struct
                                         render_base_changed_prefix base_change
                                       in
                                       let wt_path_opt =
-                                        ensure_worktree ~runtime ~clock ~fs
-                                          ~project_name ~patch_id ~agent
-                                          ~user_config:config.user_config
-                                          ~worktree_mutex ~hook_mutex ()
+                                        WS.ensure_worktree ~patch_id ~agent ()
                                       in
                                       let wt_path =
                                         match wt_path_opt with
@@ -3038,10 +3031,7 @@ struct
                                      against fresh refs, not the stale
                                      local tracking ref. *)
                                         let rebase_result, _wt_path =
-                                          execute_worktree_plan ~runtime ~clock
-                                            ~fs ~project_name ~patch_id ~agent
-                                            ~user_config:config.user_config
-                                            ~worktree_mutex ~hook_mutex
+                                          execute_worktree_plan ~patch_id ~agent
                                             ~fetch_lock:fetch_mutex
                                             ~fail_label:"merge-conflict rebase"
                                             ~ancestor_ids

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -2033,7 +2033,8 @@ struct
       concurrently. *)
   let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name
       ~pr_registry ~findings_registry ~review_clients ~transcripts ~event_log
-      ~worktree_mutex ~hook_mutex ?status_msg () =
+      ~worktree_mutex ~hook_mutex ~ws ?status_msg () =
+    let module WS = (val ws : Worktree_setup.S) in
     let main = config.main_branch in
     let clock = Eio.Stdenv.clock env in
     let fs = Eio.Stdenv.fs env in
@@ -2050,16 +2051,6 @@ struct
     (* Serializes [git fetch origin] across worktrees to avoid ref-lock races on
      the shared [refs/remotes/origin/*] store. See [Worktree.fetch_origin]. *)
     let fetch_mutex = Eio.Mutex.create () in
-    let module Env = struct
-      let runtime = runtime
-      let (clock : float Eio.Time.clock_ty Eio.Time.clock) = clock
-      let fs = fs
-      let project_name = project_name
-      let user_config = config.user_config
-      let worktree_mutex = worktree_mutex
-      let hook_mutex = hook_mutex
-    end in
-    let module WS = Worktree_setup.Make (W) (Env) in
     let execute_worktree_plan ~patch_id ~(agent : Patch_agent.t) ~fetch_lock
         ~fail_label ~ancestor_ids (plan : Worktree_plan.t) =
       let default_path = Worktree.worktree_dir ~project_name ~patch_id in
@@ -4426,7 +4417,9 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
           :: (fun () ->
             runner_fiber ~runtime ~env ~config ~pick_backend ~project_name
               ~pr_registry ~findings_registry ~review_clients ~transcripts
-              ~event_log ~worktree_mutex ~hook_mutex ())
+              ~event_log ~worktree_mutex ~hook_mutex
+              ~ws:(module WS : Worktree_setup.S)
+              ())
           :: common_fibers)
       else
         let list_selected = ref 0 in
@@ -4479,7 +4472,9 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
                 :: (fun () ->
                   runner_fiber ~runtime ~env ~config ~pick_backend ~project_name
                     ~pr_registry ~findings_registry ~review_clients ~transcripts
-                    ~event_log ~worktree_mutex ~hook_mutex ~status_msg ())
+                    ~event_log ~worktree_mutex ~hook_mutex
+                    ~ws:(module WS : Worktree_setup.S)
+                    ~status_msg ())
                 :: common_fibers)
             with Quit_tui -> ())
 

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1744,7 +1744,8 @@ struct
 
   let poller_fiber (module StartupReconciler : STARTUP_RECONCILER) ~runtime
       ~clock ~process_mgr ~config ~project_name ~pr_registry ~branch_of
-      ~event_log ~review_clients ~findings_registry ~resolve_worktree_path =
+      ~event_log ~review_clients ~findings_registry ~ws =
+    let module WS = (val ws : Worktree_setup.S) in
     let main = config.main_branch in
     let skip_logged : (Patch_id.t, bool) Hashtbl.t = Hashtbl.create 16 in
     let skip_logged_mutex = Eio.Mutex.create () in
@@ -1902,7 +1903,9 @@ struct
                       if Option.is_some agent.Patch_agent.worktree_path then
                         None
                       else
-                        let path = resolve_worktree_path ~patch_id ~agent () in
+                        let path =
+                          WS.resolve_worktree_path ~patch_id ~agent ()
+                        in
                         let default =
                           Worktree.worktree_dir ~project_name ~patch_id
                         in
@@ -4405,8 +4408,7 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
               (module Reconciler : STARTUP_RECONCILER)
               ~runtime ~clock ~process_mgr ~config ~project_name ~pr_registry
               ~branch_of ~event_log ~review_clients ~findings_registry
-              ~resolve_worktree_path:(fun ~patch_id ~agent () ->
-                WS.resolve_worktree_path ~patch_id ~agent ()));
+              ~ws:(module WS : Worktree_setup.S));
           (fun () ->
             persistence_fiber ~runtime ~clock ~project_name ~transcripts);
         ]

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1902,9 +1902,7 @@ struct
                       if Option.is_some agent.Patch_agent.worktree_path then
                         None
                       else
-                        let path =
-                          resolve_worktree_path ~patch_id ~agent ()
-                        in
+                        let path = resolve_worktree_path ~patch_id ~agent () in
                         let default =
                           Worktree.worktree_dir ~project_name ~patch_id
                         in
@@ -2606,8 +2604,8 @@ struct
                         in
                         let rebase_result, wt_path =
                           execute_worktree_plan ~patch_id ~agent
-                            ~fetch_lock:fetch_mutex
-                            ~fail_label:"rebase" ~ancestor_ids
+                            ~fetch_lock:fetch_mutex ~fail_label:"rebase"
+                            ~ancestor_ids
                             (Worktree_plan.for_rebase ~new_base)
                         in
                         (match rebase_result with

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -696,19 +696,6 @@ struct
             ~reason:Orchestrator.Unexpected_exception ~agent_before:before
             ~agent_after:after)
 
-  let resolve_worktree_path ~project_name ~patch_id
-      ~(agent : Patch_agent.t) ?branch () =
-    match (branch, agent.Patch_agent.worktree_path) with
-    | None, Some p -> p
-    | _ ->
-        let search_branch =
-          match branch with Some b -> b | None -> agent.Patch_agent.branch
-        in
-        let found = W.find_for_branch search_branch in
-        (match found with
-        | Some p -> p
-        | None -> Worktree.worktree_dir ~project_name ~patch_id)
-
   (** {1 Fibers} *)
 
   exception Quit_tui
@@ -1757,7 +1744,7 @@ struct
 
   let poller_fiber (module StartupReconciler : STARTUP_RECONCILER) ~runtime
       ~clock ~process_mgr ~config ~project_name ~pr_registry ~branch_of
-      ~event_log ~review_clients ~findings_registry =
+      ~event_log ~review_clients ~findings_registry ~resolve_worktree_path =
     let main = config.main_branch in
     let skip_logged : (Patch_id.t, bool) Hashtbl.t = Hashtbl.create 16 in
     let skip_logged_mutex = Eio.Mutex.create () in
@@ -1916,8 +1903,7 @@ struct
                         None
                       else
                         let path =
-                          resolve_worktree_path ~project_name ~patch_id ~agent
-                            ()
+                          resolve_worktree_path ~patch_id ~agent ()
                         in
                         let default =
                           Worktree.worktree_dir ~project_name ~patch_id
@@ -2049,7 +2035,7 @@ struct
       concurrently. *)
   let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name
       ~pr_registry ~findings_registry ~review_clients ~transcripts ~event_log
-      ?status_msg () =
+      ~worktree_mutex ~hook_mutex ?status_msg () =
     let main = config.main_branch in
     let clock = Eio.Stdenv.clock env in
     let fs = Eio.Stdenv.fs env in
@@ -2063,16 +2049,9 @@ struct
       Eio.Semaphore.acquire semaphore;
       Fun.protect ~finally:(fun () -> Eio.Semaphore.release semaphore) f
     in
-    let worktree_mutex = Eio.Mutex.create () in
     (* Serializes [git fetch origin] across worktrees to avoid ref-lock races on
      the shared [refs/remotes/origin/*] store. See [Worktree.fetch_origin]. *)
     let fetch_mutex = Eio.Mutex.create () in
-    (* Serializes [on_worktree_create] invocations across patch fibers. The
-     hook runs user build commands ([npm install], [dune build], …) which
-     aren't parallelism-safe across shared caches AND fan out into dozens
-     of short-lived children. Running 10 hooks in parallel is how issue
-     #209 blew through the system FD table. *)
-    let hook_mutex = Eio.Mutex.create () in
     let module Env = struct
       let runtime = runtime
       let (clock : float Eio.Time.clock_ty Eio.Time.clock) = clock
@@ -3202,8 +3181,8 @@ struct
                                           ~f:Branch.to_string
                                       in
                                       let wt_path =
-                                        resolve_worktree_path ~project_name
-                                          ~patch_id ~agent ()
+                                        WS.resolve_worktree_path ~patch_id
+                                          ~agent ()
                                       in
                                       let agents_md =
                                         read_optional_file
@@ -4417,6 +4396,18 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
             Review_service_client.make ~net ~clock ~backend)
       in
       let findings_registry = Findings_registry.create () in
+      let worktree_mutex = Eio.Mutex.create () in
+      let hook_mutex = Eio.Mutex.create () in
+      let module Wt_env = struct
+        let runtime = runtime
+        let (clock : float Eio.Time.clock_ty Eio.Time.clock) = clock
+        let fs = Eio.Stdenv.fs env
+        let project_name = project_name
+        let user_config = config.user_config
+        let worktree_mutex = worktree_mutex
+        let hook_mutex = hook_mutex
+      end in
+      let module WS = Worktree_setup.Make (WorktreeClient) (Wt_env) in
       let common_fibers =
         [
           reconciliation_fiber;
@@ -4424,7 +4415,9 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
             poller_fiber
               (module Reconciler : STARTUP_RECONCILER)
               ~runtime ~clock ~process_mgr ~config ~project_name ~pr_registry
-              ~branch_of ~event_log ~review_clients ~findings_registry);
+              ~branch_of ~event_log ~review_clients ~findings_registry
+              ~resolve_worktree_path:(fun ~patch_id ~agent () ->
+                WS.resolve_worktree_path ~patch_id ~agent ()));
           (fun () ->
             persistence_fiber ~runtime ~clock ~project_name ~transcripts);
         ]
@@ -4435,7 +4428,7 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
           :: (fun () ->
             runner_fiber ~runtime ~env ~config ~pick_backend ~project_name
               ~pr_registry ~findings_registry ~review_clients ~transcripts
-              ~event_log ())
+              ~event_log ~worktree_mutex ~hook_mutex ())
           :: common_fibers)
       else
         let list_selected = ref 0 in
@@ -4488,7 +4481,7 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
                 :: (fun () ->
                   runner_fiber ~runtime ~env ~config ~pick_backend ~project_name
                     ~pr_registry ~findings_registry ~review_clients ~transcripts
-                    ~event_log ~status_msg ())
+                    ~event_log ~worktree_mutex ~hook_mutex ~status_msg ())
                 :: common_fibers)
             with Quit_tui -> ())
 

--- a/lib/session_driver.ml
+++ b/lib/session_driver.ml
@@ -126,8 +126,6 @@ let%test_module "extract_pr_number_from_text" =
   end)
 
 module Make (W : Worktree.S) = struct
-  module Worktree_setup = Worktree_setup.Make (W)
-
   let session_mode = session_mode
   let extract_pr_number_from_text = extract_pr_number_from_text
 
@@ -153,10 +151,17 @@ module Make (W : Worktree.S) = struct
           | `Resume id -> (Some id, false)
           | `Fresh -> (None, true)
         in
-        match
-          Worktree_setup.ensure_worktree ~runtime ~clock ~fs ~project_name
-            ~patch_id ~agent ~user_config ~worktree_mutex ~hook_mutex ()
-        with
+        let module Env = struct
+          let runtime = runtime
+          let (clock : float Eio.Time.clock_ty Eio.Time.clock) = clock
+          let fs = fs
+          let project_name = project_name
+          let user_config = user_config
+          let worktree_mutex = worktree_mutex
+          let hook_mutex = hook_mutex
+        end in
+        let module WS = Worktree_setup.Make (W) (Env) in
+        match WS.ensure_worktree ~patch_id ~agent () with
         | None ->
             Runtime.update_orchestrator runtime (fun orch ->
                 Orchestrator.apply_session_result orch patch_id

--- a/lib/session_driver.mli
+++ b/lib/session_driver.mli
@@ -14,7 +14,7 @@ module Make (_ : Worktree.S) : sig
   val run :
     kind:Types.Operation_kind.t option ->
     runtime:Runtime.t ->
-    clock:_ Eio.Time.clock ->
+    clock:float Eio.Time.clock_ty Eio.Time.clock ->
     fs:Eio.Fs.dir_ty Eio.Path.t ->
     project_name:string ->
     patch_id:Types.Patch_id.t ->
@@ -60,7 +60,7 @@ module Make (_ : Worktree.S) : sig
     sw:Eio.Switch.t ->
     kind:Types.Operation_kind.t option ->
     runtime:Runtime.t ->
-    clock:_ Eio.Time.clock ->
+    clock:float Eio.Time.clock_ty Eio.Time.clock ->
     fs:Eio.Fs.dir_ty Eio.Path.t ->
     project_name:string ->
     patch_id:Types.Patch_id.t ->

--- a/lib/worktree_setup.ml
+++ b/lib/worktree_setup.ml
@@ -11,8 +11,7 @@ module type ENV = sig
 end
 
 module Make (W : Worktree.S) (Env : ENV) = struct
-  let resolve_worktree_path ~project_name ~patch_id ~(agent : Patch_agent.t)
-      ?branch () =
+  let resolve_worktree_path ~patch_id ~(agent : Patch_agent.t) ?branch () =
     (* When the caller passes [?branch], they're asking for that branch's
      worktree specifically — the agent's stored [worktree_path] may be from
      a previous branch and would be stale. Only short-circuit on the stored
@@ -27,7 +26,8 @@ module Make (W : Worktree.S) (Env : ENV) = struct
         let path =
           match found with
           | Some p -> p
-          | None -> Worktree.worktree_dir ~project_name ~patch_id
+          | None ->
+              Worktree.worktree_dir ~project_name:Env.project_name ~patch_id
         in
         path
 
@@ -40,9 +40,7 @@ module Make (W : Worktree.S) (Env : ENV) = struct
     let worktree_mutex = Env.worktree_mutex in
     let hook_mutex = Env.hook_mutex in
     let log_event = Runtime_logging.log_event in
-    let path =
-      resolve_worktree_path ~project_name ~patch_id ~agent ?branch ()
-    in
+    let path = resolve_worktree_path ~patch_id ~agent ?branch () in
     if Stdlib.Sys.file_exists path then (
       Runtime.update_orchestrator runtime (fun orch ->
           Orchestrator.set_worktree_path orch patch_id path);

--- a/lib/worktree_setup.ml
+++ b/lib/worktree_setup.ml
@@ -1,6 +1,16 @@
 open Base
 
-module Make (W : Worktree.S) = struct
+module type ENV = sig
+  val runtime : Runtime.t
+  val clock : float Eio.Time.clock_ty Eio.Time.clock
+  val fs : Eio.Fs.dir_ty Eio.Path.t
+  val project_name : string
+  val user_config : User_config.t
+  val worktree_mutex : Eio.Mutex.t
+  val hook_mutex : Eio.Mutex.t
+end
+
+module Make (W : Worktree.S) (Env : ENV) = struct
   let resolve_worktree_path ~project_name ~patch_id ~(agent : Patch_agent.t)
       ?branch () =
     (* When the caller passes [?branch], they're asking for that branch's
@@ -21,9 +31,14 @@ module Make (W : Worktree.S) = struct
         in
         path
 
-  let ensure_worktree ~runtime ~clock ~fs ~project_name ~patch_id
-      ~(agent : Patch_agent.t) ~(user_config : User_config.t) ~worktree_mutex
-      ~hook_mutex ?branch ?base_ref () =
+  let ensure_worktree ~patch_id ~(agent : Patch_agent.t) ?branch ?base_ref () =
+    let runtime = Env.runtime in
+    let clock = Env.clock in
+    let fs = Env.fs in
+    let project_name = Env.project_name in
+    let user_config = Env.user_config in
+    let worktree_mutex = Env.worktree_mutex in
+    let hook_mutex = Env.hook_mutex in
     let log_event = Runtime_logging.log_event in
     let path =
       resolve_worktree_path ~project_name ~patch_id ~agent ?branch ()

--- a/lib/worktree_setup.ml
+++ b/lib/worktree_setup.ml
@@ -10,7 +10,24 @@ module type ENV = sig
   val hook_mutex : Eio.Mutex.t
 end
 
-module Make (W : Worktree.S) (Env : ENV) = struct
+module type S = sig
+  val resolve_worktree_path :
+    patch_id:Types.Patch_id.t ->
+    agent:Patch_agent.t ->
+    ?branch:Types.Branch.t ->
+    unit ->
+    string
+
+  val ensure_worktree :
+    patch_id:Types.Patch_id.t ->
+    agent:Patch_agent.t ->
+    ?branch:Types.Branch.t ->
+    ?base_ref:string ->
+    unit ->
+    string option
+end
+
+module Make (W : Worktree.S) (Env : ENV) : S = struct
   let resolve_worktree_path ~patch_id ~(agent : Patch_agent.t) ?branch () =
     (* When the caller passes [?branch], they're asking for that branch's
      worktree specifically — the agent's stored [worktree_path] may be from

--- a/lib/worktree_setup.mli
+++ b/lib/worktree_setup.mli
@@ -17,7 +17,7 @@ module type ENV = sig
   val hook_mutex : Eio.Mutex.t
 end
 
-module Make (_ : Worktree.S) (_ : ENV) : sig
+module type S = sig
   val resolve_worktree_path :
     patch_id:Types.Patch_id.t ->
     agent:Patch_agent.t ->
@@ -42,3 +42,5 @@ module Make (_ : Worktree.S) (_ : ENV) : sig
       serialised through [Env.hook_mutex] and persists the path on the agent
       record. All log lines go through [Runtime_logging.log_event]. *)
 end
+
+module Make (_ : Worktree.S) (_ : ENV) : S

--- a/lib/worktree_setup.mli
+++ b/lib/worktree_setup.mli
@@ -5,7 +5,19 @@
     owns that logic so both callers go through the same code path — same
     persistence, same hook invocation, same logging. *)
 
-module Make (_ : Worktree.S) : sig
+module type ENV = sig
+  val runtime : Runtime.t
+  val clock : float Eio.Time.clock_ty Eio.Time.clock
+  val fs : Eio.Fs.dir_ty Eio.Path.t
+  val project_name : string
+  val user_config : User_config.t
+  val worktree_mutex : Eio.Mutex.t
+  val hook_mutex : Eio.Mutex.t
+end
+(** Construction-time environment for worktree provisioning. Values here are
+    fixed for the lifetime of the module instance and never vary per call. *)
+
+module Make (_ : Worktree.S) (_ : ENV) : sig
   val resolve_worktree_path :
     project_name:string ->
     patch_id:Types.Patch_id.t ->
@@ -19,15 +31,8 @@ module Make (_ : Worktree.S) : sig
       persisted path on the agent record is consulted but not written. *)
 
   val ensure_worktree :
-    runtime:Runtime.t ->
-    clock:_ Eio.Time.clock ->
-    fs:Eio.Fs.dir_ty Eio.Path.t ->
-    project_name:string ->
     patch_id:Types.Patch_id.t ->
     agent:Patch_agent.t ->
-    user_config:User_config.t ->
-    worktree_mutex:Eio.Mutex.t ->
-    hook_mutex:Eio.Mutex.t ->
     ?branch:Types.Branch.t ->
     ?base_ref:string ->
     unit ->
@@ -35,6 +40,6 @@ module Make (_ : Worktree.S) : sig
   (** Ensure a worktree exists for the patch. Returns [Some path] on success or
       [None] when the branch's worktree cannot be created (e.g. it's checked out
       in the main tree). On creation, runs the user's [on_worktree_create] hook
-      serialised through [hook_mutex] and persists the path on the agent record.
-      All log lines go through [Runtime_logging.log_event]. *)
+      serialised through [Env.hook_mutex] and persists the path on the agent
+      record. All log lines go through [Runtime_logging.log_event]. *)
 end

--- a/lib/worktree_setup.mli
+++ b/lib/worktree_setup.mli
@@ -19,7 +19,6 @@ end
 
 module Make (_ : Worktree.S) (_ : ENV) : sig
   val resolve_worktree_path :
-    project_name:string ->
     patch_id:Types.Patch_id.t ->
     agent:Patch_agent.t ->
     ?branch:Types.Branch.t ->

--- a/lib/worktree_setup.mli
+++ b/lib/worktree_setup.mli
@@ -5,6 +5,8 @@
     owns that logic so both callers go through the same code path — same
     persistence, same hook invocation, same logging. *)
 
+(** Construction-time environment for worktree provisioning. Values here are
+    fixed for the lifetime of the module instance and never vary per call. *)
 module type ENV = sig
   val runtime : Runtime.t
   val clock : float Eio.Time.clock_ty Eio.Time.clock
@@ -14,8 +16,6 @@ module type ENV = sig
   val worktree_mutex : Eio.Mutex.t
   val hook_mutex : Eio.Mutex.t
 end
-(** Construction-time environment for worktree provisioning. Values here are
-    fixed for the lifetime of the module instance and never vary per call. *)
 
 module Make (_ : Worktree.S) (_ : ENV) : sig
   val resolve_worktree_path :

--- a/test/dune
+++ b/test/dune
@@ -306,3 +306,8 @@
  (name test_debug_upload)
  (modules test_debug_upload)
  (libraries onton onton_core unix))
+
+(test
+ (name test_dependency_injection_functors)
+ (modules test_dependency_injection_functors)
+ (libraries onton onton_core eio eio_main eio.unix))

--- a/test/dune
+++ b/test/dune
@@ -310,4 +310,4 @@
 (test
  (name test_dependency_injection_functors)
  (modules test_dependency_injection_functors)
- (libraries onton onton_core eio eio_main eio.unix))
+ (libraries onton onton_core eio))

--- a/test/test_dependency_injection_functors.ml
+++ b/test/test_dependency_injection_functors.ml
@@ -14,17 +14,13 @@ module Fake_worktree : Worktree.S = struct
   let resolve_main_root () = assert false
   let is_checked_out_in_repo_root _ = assert false
   let remote_branch_exists _ = assert false
-
   let create ~project_name:_ ~patch_id:_ ~branch:_ ~base_ref:_ = assert false
-
   let remove _ = assert false
   let detect_branch ~path:_ = assert false
   let list_with_branches () = assert false
   let find_for_branch _ = assert false
   let prune_admin () = assert false
-
   let run_hook ~clock:_ ~script:_ ~cwd:_ ~env:_ () = assert false
-
   let fetch_origin ~fetch_lock:_ ~path:_ = assert false
   let git_status ~path:_ = assert false
   let conflict_diff ~path:_ = assert false
@@ -66,4 +62,5 @@ let _check_narrowed :
 
 let () =
   print_endline
-    "Patch 1: Worktree_setup.Make(W)(Env).ensure_worktree narrowed signature: OK"
+    "Patch 1: Worktree_setup.Make(W)(Env).ensure_worktree narrowed signature: \
+     OK"

--- a/test/test_dependency_injection_functors.ml
+++ b/test/test_dependency_injection_functors.ml
@@ -1,0 +1,93 @@
+open Onton
+open Onton_core
+open Onton_core.Types
+
+(** Patch 1 compile-time signature check.
+
+    Verifies that [Worktree_setup.Make(W)(Env)] exposes [ensure_worktree] with
+    only patch-specific inputs after the stable provisioning environment is
+    captured as a functor argument. The type annotation on [check_narrowed]
+    below is the authoritative assertion: if the functor adds or retains stable
+    parameters on [ensure_worktree], this file will not compile. *)
+
+module Fake_worktree : Worktree.S = struct
+  let resolve_main_root () = assert false
+  let is_checked_out_in_repo_root _ = assert false
+  let remote_branch_exists _ = assert false
+
+  let create ~project_name:_ ~patch_id:_ ~branch:_ ~base_ref:_ = assert false
+
+  let remove _ = assert false
+  let detect_branch ~path:_ = assert false
+  let list_with_branches () = assert false
+  let find_for_branch _ = assert false
+  let prune_admin () = assert false
+
+  let run_hook ~clock:_ ~script:_ ~cwd:_ ~env:_ () = assert false
+
+  let fetch_origin ~fetch_lock:_ ~path:_ = assert false
+  let git_status ~path:_ = assert false
+  let conflict_diff ~path:_ = assert false
+
+  let rebase_onto ~path:_ ~target:_ ~project_name:_ ~ancestor_ids:_ =
+    assert false
+
+  let read_in_progress_conflict_info ~path:_ ~target:_ ~project_name:_
+      ~ancestor_ids:_ =
+    assert false
+
+  let force_push_with_lease ~path:_ ~branch:_ ~base:_ = assert false
+  let rebase_in_progress ~path:_ = assert false
+end
+
+let () =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  let fs = Eio.Stdenv.fs env in
+  let gameplan =
+    {
+      Gameplan.project_name = "test";
+      repo_owner = "";
+      repo_name = "";
+      problem_statement = "";
+      solution_summary = "";
+      final_state_spec = "";
+      patches = [];
+      current_state_analysis = "";
+      explicit_opinions = "";
+      acceptance_criteria = [];
+      open_questions = [];
+      functional_changes = [];
+      context_resources = [];
+    }
+  in
+  let runtime =
+    Runtime.create ~gameplan
+      ~main_branch:(Branch.of_string "main")
+      ()
+  in
+  let module Env : Worktree_setup.ENV = struct
+    let runtime = runtime
+    let (clock : float Eio.Time.clock_ty Eio.Time.clock) = clock
+    let fs = fs
+    let project_name = "test"
+    let user_config = { User_config.on_worktree_create = None }
+    let worktree_mutex = Eio.Mutex.create ()
+    let hook_mutex = Eio.Mutex.create ()
+  end in
+  let module WS = Worktree_setup.Make (Fake_worktree) (Env) in
+  (* Compile-time assertion: ensure_worktree accepts only patch-specific inputs.
+     Runtime, clock, fs, project_name, user_config, and mutexes are gone from
+     the call surface — they live in Env now. *)
+  let check_narrowed :
+      patch_id:Patch_id.t ->
+      agent:Patch_agent.t ->
+      ?branch:Branch.t ->
+      ?base_ref:string ->
+      unit ->
+      string option =
+    WS.ensure_worktree
+  in
+  ignore check_narrowed;
+  print_endline
+    "Patch 1: Worktree_setup.Make(W)(Env).ensure_worktree narrowed signature: OK"

--- a/test/test_dependency_injection_functors.ml
+++ b/test/test_dependency_injection_functors.ml
@@ -37,6 +37,8 @@ module Fake_worktree : Worktree.S = struct
 end
 
 module Fake_env : Worktree_setup.ENV = struct
+  (* Runtime.create is Eio-free: test_runtime_create.ml verifies it can be
+     called outside Eio_main.run without raising an Unhandled effect. *)
   let runtime =
     Runtime.create
       ~gameplan:
@@ -57,8 +59,8 @@ module Fake_env : Worktree_setup.ENV = struct
         }
       ~main_branch:(Branch.of_string "main") ()
 
-  (* Eio resources cannot be created outside Eio_main.run; they are never
-     dereferenced because Worktree_setup.Make defines functions only. *)
+  (* Eio resources require the scheduler; they are never dereferenced here
+     because Worktree_setup.Make defines functions only. *)
   let clock : float Eio.Time.clock_ty Eio.Time.clock = Obj.magic ()
   let fs : Eio.Fs.dir_ty Eio.Path.t = Obj.magic ()
   let worktree_mutex : Eio.Mutex.t = Obj.magic ()

--- a/test/test_dependency_injection_functors.ml
+++ b/test/test_dependency_injection_functors.ml
@@ -6,7 +6,7 @@ open Onton_core.Types
 
     Verifies that [Worktree_setup.Make(W)(Env)] exposes [ensure_worktree] with
     only patch-specific inputs after the stable provisioning environment is
-    captured as a functor argument. The type annotation on [check_narrowed]
+    captured as a functor argument. The type annotation on [_check_narrowed]
     below is the authoritative assertion: if the functor adds or retains stable
     parameters on [ensure_worktree], this file will not compile. *)
 
@@ -40,54 +40,30 @@ module Fake_worktree : Worktree.S = struct
   let rebase_in_progress ~path:_ = assert false
 end
 
+module Fake_env : Worktree_setup.ENV = struct
+  let runtime : Runtime.t = Obj.magic ()
+  let clock : float Eio.Time.clock_ty Eio.Time.clock = Obj.magic ()
+  let fs : Eio.Fs.dir_ty Eio.Path.t = Obj.magic ()
+  let project_name : string = Obj.magic ()
+  let user_config : User_config.t = Obj.magic ()
+  let worktree_mutex : Eio.Mutex.t = Obj.magic ()
+  let hook_mutex : Eio.Mutex.t = Obj.magic ()
+end
+
+module WS = Worktree_setup.Make (Fake_worktree) (Fake_env)
+
+(* Compile-time assertion: ensure_worktree accepts only patch-specific inputs.
+   Runtime, clock, fs, project_name, user_config, and mutexes are gone from
+   the call surface — they live in Env now. *)
+let _check_narrowed :
+    patch_id:Patch_id.t ->
+    agent:Patch_agent.t ->
+    ?branch:Branch.t ->
+    ?base_ref:string ->
+    unit ->
+    string option =
+  WS.ensure_worktree
+
 let () =
-  Eio_main.run @@ fun env ->
-  let clock = Eio.Stdenv.clock env in
-  let fs = Eio.Stdenv.fs env in
-  let gameplan =
-    {
-      Gameplan.project_name = "test";
-      repo_owner = "";
-      repo_name = "";
-      problem_statement = "";
-      solution_summary = "";
-      final_state_spec = "";
-      patches = [];
-      current_state_analysis = "";
-      explicit_opinions = "";
-      acceptance_criteria = [];
-      open_questions = [];
-      functional_changes = [];
-      context_resources = [];
-    }
-  in
-  let runtime =
-    Runtime.create ~gameplan
-      ~main_branch:(Branch.of_string "main")
-      ()
-  in
-  let module Env : Worktree_setup.ENV = struct
-    let runtime = runtime
-    let (clock : float Eio.Time.clock_ty Eio.Time.clock) = clock
-    let fs = fs
-    let project_name = "test"
-    let user_config = { User_config.on_worktree_create = None }
-    let worktree_mutex = Eio.Mutex.create ()
-    let hook_mutex = Eio.Mutex.create ()
-  end in
-  let module WS = Worktree_setup.Make (Fake_worktree) (Env) in
-  (* Compile-time assertion: ensure_worktree accepts only patch-specific inputs.
-     Runtime, clock, fs, project_name, user_config, and mutexes are gone from
-     the call surface — they live in Env now. *)
-  let check_narrowed :
-      patch_id:Patch_id.t ->
-      agent:Patch_agent.t ->
-      ?branch:Branch.t ->
-      ?base_ref:string ->
-      unit ->
-      string option =
-    WS.ensure_worktree
-  in
-  ignore check_narrowed;
   print_endline
     "Patch 1: Worktree_setup.Make(W)(Env).ensure_worktree narrowed signature: OK"

--- a/test/test_dependency_injection_functors.ml
+++ b/test/test_dependency_injection_functors.ml
@@ -37,13 +37,34 @@ module Fake_worktree : Worktree.S = struct
 end
 
 module Fake_env : Worktree_setup.ENV = struct
-  let runtime : Runtime.t = Obj.magic ()
+  let runtime =
+    Runtime.create
+      ~gameplan:
+        {
+          Gameplan.project_name = "";
+          repo_owner = "";
+          repo_name = "";
+          problem_statement = "";
+          solution_summary = "";
+          final_state_spec = "";
+          patches = [];
+          current_state_analysis = "";
+          explicit_opinions = "";
+          acceptance_criteria = [];
+          open_questions = [];
+          functional_changes = [];
+          context_resources = [];
+        }
+      ~main_branch:(Branch.of_string "main") ()
+
+  (* Eio resources cannot be created outside Eio_main.run; they are never
+     dereferenced because Worktree_setup.Make defines functions only. *)
   let clock : float Eio.Time.clock_ty Eio.Time.clock = Obj.magic ()
   let fs : Eio.Fs.dir_ty Eio.Path.t = Obj.magic ()
-  let project_name : string = Obj.magic ()
-  let user_config : User_config.t = Obj.magic ()
   let worktree_mutex : Eio.Mutex.t = Obj.magic ()
   let hook_mutex : Eio.Mutex.t = Obj.magic ()
+  let project_name = ""
+  let user_config = { User_config.on_worktree_create = None }
 end
 
 module WS = Worktree_setup.Make (Fake_worktree) (Fake_env)
@@ -59,8 +80,3 @@ let _check_narrowed :
     unit ->
     string option =
   WS.ensure_worktree
-
-let () =
-  print_endline
-    "Patch 1: Worktree_setup.Make(W)(Env).ensure_worktree narrowed signature: \
-     OK"


### PR DESCRIPTION
## Patch 1: Functorize Worktree_setup environment

- Define Worktree_setup.ENV in the mli with runtime, clock, fs, project_name, user_config, worktree_mutex, and hook_mutex values.
- Change module Make from `Make (_ : Worktree.S)` to `Make (W : Worktree.S) (Env : ENV)`.
- Remove runtime, clock, fs, project_name, user_config, worktree_mutex, and hook_mutex from `ensure_worktree`'s public signature.
- Inside Worktree_setup, replace parameter references with Env references while preserving all logging, hook execution, mutex use, and return values.
- Update the worktree-plan executor in bin/main.ml to instantiate Worktree_setup with a local Env module and call `ensure_worktree ~patch_id ~agent ?branch ?base_ref ()`.
- Add a compile-time test scaffold or expect-style test module that instantiates Worktree_setup.Make with fake modules and documents Patch 1's narrowed signature expectation.

## Changes
- Define Worktree_setup.ENV in the mli with runtime, clock, fs, project_name, user_config, worktree_mutex, and hook_mutex values.
- Change module Make from `Make (_ : Worktree.S)` to `Make (W : Worktree.S) (Env : ENV)`.
- Remove runtime, clock, fs, project_name, user_config, worktree_mutex, and hook_mutex from `ensure_worktree`'s public signature.
- Inside Worktree_setup, replace parameter references with Env references while preserving all logging, hook execution, mutex use, and return values.
- Update the worktree-plan executor in bin/main.ml to instantiate Worktree_setup with a local Env module and call `ensure_worktree ~patch_id ~agent ?branch ?base_ref ()`.
- Add a compile-time test scaffold or expect-style test module that instantiates Worktree_setup.Make with fake modules and documents Patch 1's narrowed signature expectation.

## Files to Modify
- lib/worktree_setup.mli (modify): Add an ENV module type and change Make to take both Worktree.S and ENV.
- lib/worktree_setup.ml (modify): Move stable provisioning dependencies from ensure_worktree parameters into Env.
- bin/main.ml (modify): Update execute_worktree_plan scaffolding to call the narrowed Worktree_setup API through a local environment module.
- test/test_dependency_injection_functors.ml (create): Add pending/static signature coverage for Worktree_setup.Make(W)(Env).
- test/dune (modify): Register the new test executable if the repo uses explicit test stanzas.

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[pattern] ML module functor dependency injection** — This patch should follow the existing local pattern in Github.make, Worktree.make, and Startup_reconciler.Make: capture effect capabilities at module construction and expose narrower per-call operations.

## Gameplan Specification

```
module DEPENDENCY_INJECTION_FUNCTORS.

> Final state: high- and medium-priority dependency clusters are
> represented as construction-time functor environments. Public and
> local call surfaces expose per-call values only, while preserving
> existing synchronization and behavior.

CapabilityCluster.
worktree-setup-cluster => CapabilityCluster.
session-driver-cluster => CapabilityCluster.
fiber-run-cluster => CapabilityCluster.

cluster-captured-by-functor? c: CapabilityCluster => Bool.
call-surface-narrowed? c: CapabilityCluster => Bool.
behavior-preserved? c: CapabilityCluster => Bool.
shared-synchronization-preserved? => Bool.
no-new-external-contract? => Bool.
---
cluster-captured-by-functor? worktree-setup-cluster.
cluster-captured-by-functor? session-driver-cluster.
cluster-captured-by-functor? fiber-run-cluster.
call-surface-narrowed? worktree-setup-cluster.
call-surface-narrowed? session-driver-cluster.
call-surface-narrowed? fiber-run-cluster.
behavior-preserved? worktree-setup-cluster.
behavior-preserved? session-driver-cluster.
behavior-preserved? fiber-run-cluster.
shared-synchronization-preserved?.
no-new-external-contract?.

```

## Patch Specification

```
module DEPENDENCY_INJECTION_FUNCTORS_PATCH_1.

> Patch 1 establishes that worktree provisioning dependencies are
> construction-time dependencies, not per-call dependencies.

Dependency.
worktree-runtime => Dependency.
worktree-clock => Dependency.
worktree-fs => Dependency.
worktree-project => Dependency.
worktree-user-config => Dependency.
worktree-locks => Dependency.

worktree-env-functor? => Bool.
worktree-call-surface-narrowed? => Bool.
shared-locks-preserved? => Bool.
---
worktree-env-functor?.
worktree-call-surface-narrowed?.
shared-locks-preserved?.

```


## Implementation Notes

**Clock type narrowing.** `Worktree_setup.ENV.clock` uses the closed type `float Eio.Time.clock_ty Eio.Time.clock` rather than the wildcard `_ Eio.Time.clock`. This was necessary because OCaml's module type checker cannot satisfy a `val clock : [> ...]` constraint from a closed-type value (the two are incompatible in module inclusion checks, unlike ordinary type unification). As a consequence, `Session_driver.Make.run` and `run_long_lived` had their `clock` parameter narrowed from `_ Eio.Time.clock` to `float Eio.Time.clock_ty Eio.Time.clock` in the mli. All callers in `bin/main.ml` supply `Eio.Stdenv.clock env`, which unifies to the closed type at the call site, so no functional change results.

**Session_driver bridges Patch 1 and Patch 2.** Because `Session_driver.Make` still threads `runtime`, `clock`, `fs`, etc. through `run`/`run_long_lived` parameters (Patch 2 will lift these to a construction-time ENV), the `run_with_backend` function creates a local `Env` module inline from the per-call parameters and applies `Worktree_setup.Make(W)(Env)` at the single call site. This is intentionally a transitional pattern — Patch 2 will eliminate the local inline module by moving the Env to Session_driver's own functor boundary.

**Spec/Evidence Mapping.**
- `worktree-env-functor?` — `lib/worktree_setup.mli`: `module type ENV` + `Make (_ : Worktree.S) (_ : ENV)`
- `worktree-call-surface-narrowed?` — `lib/worktree_setup.mli`: `ensure_worktree` signature retains only `~patch_id`, `~agent`, `?branch`, `?base_ref`; compile-time assertion in `test/test_dependency_injection_functors.ml` via type annotation on `check_narrowed`
- `shared-locks-preserved?` — `lib/worktree_setup.ml`: `Env.worktree_mutex` and `Env.hook_mutex` are used in the same `Eio.Mutex.use_ro` call sites as before; no change to locking protocol

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Functorized Worktree_setup by moving stable deps into a construction-time ENV and narrowing ensure_worktree to patch-only args. Introduced a concrete S interface and a single WS instance shared by poller and runner.

- **Refactors**
  - Added `Worktree_setup.ENV` and `S`; `Make (W) (Env) : S`.
  - Removed `project_name` from `WS.resolve_worktree_path`; uses `Env.project_name`.
  - bin/main: build shared `worktree_mutex`/`hook_mutex` and one `WS`; pass `~ws` to both poller and runner; rebase executor now local to runner and calls `WS.ensure_worktree`.
  - Deleted inline `resolve_worktree_path`/`ensure_worktree` from fibers; all calls go through the shared `WS`.
  - session_driver: build a local `Env` per call and use `WS.ensure_worktree`; mli clock type narrowed to `float Eio.Time.clock_ty Eio.Time.clock`.
  - Tests: compile-time DI check with `Fake_env`; documents `Runtime.create` is Eio-free.

- **Migration**
  - Instantiate `Worktree_setup.Make(W)(Env)` once and pass `~ws` to fibers.
  - Replace `resolve_worktree_path ~project_name ...` with `WS.resolve_worktree_path ~patch_id ~agent ?branch ()`.
  - Call `WS.ensure_worktree ~patch_id ~agent ?branch ?base_ref ()`; update clock annotations to `float Eio.Time.clock_ty Eio.Time.clock`.

<sup>Written for commit e0a47fa7f380844fb814c0b7c3f58d7c02c8ece1. Summary will update on new commits. <a href="https://cubic.dev/pr/flowglad/onton/pull/294?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal worktree setup and session execution architecture to simplify parameter passing and improve code organization.
  * Enhanced type safety for clock parameter specifications.

* **Tests**
  * Added new test suite to validate internal dependency injection patterns and module signatures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flowglad/onton/pull/294?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->