### PR TITLE
[dependency-injection-functors] Patch 2: Functorize Session_driver environment

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -307,7 +307,6 @@ module Make_fibers
     (Forge : Onton.Forge.S with type error = Github.error)
     (W : Worktree.S) =
 struct
-
   (** Execute declarative GitHub effects and record successful observations back
       into durable state. *)
   let execute_github_effects ~runtime effects =

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -307,7 +307,6 @@ module Make_fibers
     (Forge : Onton.Forge.S with type error = Github.error)
     (W : Worktree.S) =
 struct
-  module Session_driver = Session_driver.Make (W)
 
   (** Execute declarative GitHub effects and record successful observations back
       into durable state. *)
@@ -2054,6 +2053,19 @@ struct
     (* Serializes [git fetch origin] across worktrees to avoid ref-lock races on
      the shared [refs/remotes/origin/*] store. See [Worktree.fetch_origin]. *)
     let fetch_mutex = Eio.Mutex.create () in
+    let module SD_Env = struct
+      let runtime = runtime
+      let (clock : float Eio.Time.clock_ty Eio.Time.clock) = clock
+      let fs = fs
+      let project_name = project_name
+      let owner = config.github_owner
+      let repo = config.github_repo
+      let transcripts = transcripts
+      let user_config = config.user_config
+      let worktree_mutex = worktree_mutex
+      let hook_mutex = hook_mutex
+    end in
+    let module Session_driver = Session_driver.Make (W) (SD_Env) in
     let execute_worktree_plan ~patch_id ~(agent : Patch_agent.t) ~fetch_lock
         ~fail_label ~ancestor_ids (plan : Worktree_plan.t) =
       let default_path = Worktree.worktree_dir ~project_name ~patch_id in
@@ -2107,10 +2119,8 @@ struct
         ~prompt ~agent ~on_pr_detected ~complexity =
       match pick_backend ~complexity with
       | Backend_registry.Ephemeral backend, _decision ->
-          Session_driver.run ~kind ~runtime ~clock ~fs ~project_name ~patch_id
-            ~prompt ~agent ~owner:config.github_owner ~repo:config.github_repo
-            ~on_pr_detected ~transcripts ~user_config:config.user_config
-            ~worktree_mutex ~hook_mutex ~backend ~complexity
+          Session_driver.run ~kind ~patch_id ~prompt ~agent ~on_pr_detected
+            ~backend ~complexity
       | Backend_registry.Long_lived backend, decision -> (
           let patch_agent_model_result =
             match
@@ -2146,11 +2156,8 @@ struct
                     Stdlib.Hashtbl.replace long_lived_sessions patch_id session;
                     session
               in
-              Session_driver.run_long_lived ~sw ~kind ~runtime ~clock ~fs
-                ~project_name ~patch_id ~prompt ~agent
-                ~owner:config.github_owner ~repo:config.github_repo
-                ~on_pr_detected ~transcripts ~user_config:config.user_config
-                ~worktree_mutex ~hook_mutex ~session ~complexity)
+              Session_driver.run_long_lived ~sw ~kind ~patch_id ~prompt ~agent
+                ~on_pr_detected ~session ~complexity)
     in
     let shutdown_finished_long_lived_sessions ~sw () =
       let finished =

--- a/lib/session_driver.ml
+++ b/lib/session_driver.ml
@@ -125,15 +125,34 @@ let%test_module "extract_pr_number_from_text" =
         (pr 12)
   end)
 
-module Make (W : Worktree.S) = struct
+module type ENV = sig
+  val runtime : Runtime.t
+  val clock : float Eio.Time.clock_ty Eio.Time.clock
+  val fs : Eio.Fs.dir_ty Eio.Path.t
+  val project_name : string
+  val owner : string
+  val repo : string
+  val transcripts : (Types.Patch_id.t, string) Stdlib.Hashtbl.t
+  val user_config : User_config.t
+  val worktree_mutex : Eio.Mutex.t
+  val hook_mutex : Eio.Mutex.t
+end
+
+module Make (W : Worktree.S) (Env : ENV) = struct
   let session_mode = session_mode
   let extract_pr_number_from_text = extract_pr_number_from_text
+  module WS = Worktree_setup.Make (W) (Env)
 
   let run_with_backend ~session_mode_for_agent
-      ~(kind : Types.Operation_kind.t option) ~runtime ~clock ~fs ~project_name
-      ~patch_id ~prompt ~(agent : Patch_agent.t) ~owner ~repo ~on_pr_detected
-      ~transcripts ~user_config ~worktree_mutex ~hook_mutex ~backend_name
-      ~run_backend ~complexity =
+      ~(kind : Types.Operation_kind.t option) ~patch_id ~prompt
+      ~(agent : Patch_agent.t) ~on_pr_detected ~backend_name ~run_backend
+      ~complexity =
+    let runtime = Env.runtime in
+    let fs = Env.fs in
+    let project_name = Env.project_name in
+    let owner = Env.owner in
+    let repo = Env.repo in
+    let transcripts = Env.transcripts in
     let log_event = Runtime_logging.log_event in
     let log_stream_entry = Runtime_logging.log_stream_entry in
     match session_mode_for_agent agent with
@@ -151,16 +170,6 @@ module Make (W : Worktree.S) = struct
           | `Resume id -> (Some id, false)
           | `Fresh -> (None, true)
         in
-        let module Env = struct
-          let runtime = runtime
-          let (clock : float Eio.Time.clock_ty Eio.Time.clock) = clock
-          let fs = fs
-          let project_name = project_name
-          let user_config = user_config
-          let worktree_mutex = worktree_mutex
-          let hook_mutex = hook_mutex
-        end in
-        let module WS = Worktree_setup.Make (W) (Env) in
         match WS.ensure_worktree ~patch_id ~agent () with
         | None ->
             Runtime.update_orchestrator runtime (fun orch ->
@@ -789,13 +798,10 @@ module Make (W : Worktree.S) = struct
                 apply_result_and_emit_complete final_session_result;
                 (final_user_result, List.rev !tool_failures)))
 
-  let run ~(kind : Types.Operation_kind.t option) ~runtime ~clock ~fs
-      ~project_name ~patch_id ~prompt ~(agent : Patch_agent.t) ~owner ~repo
-      ~on_pr_detected ~transcripts ~user_config ~worktree_mutex ~hook_mutex
-      ~backend ~complexity =
-    run_with_backend ~kind ~runtime ~clock ~fs ~project_name ~patch_id ~prompt
-      ~agent ~owner ~repo ~on_pr_detected ~transcripts ~user_config
-      ~worktree_mutex ~hook_mutex ~session_mode_for_agent:session_mode
+  let run ~(kind : Types.Operation_kind.t option) ~patch_id ~prompt
+      ~(agent : Patch_agent.t) ~on_pr_detected ~backend ~complexity =
+    run_with_backend ~kind ~patch_id ~prompt ~agent ~on_pr_detected
+      ~session_mode_for_agent:session_mode
       ~backend_name:backend.Llm_backend.name
       ~run_backend:backend.Llm_backend.run_streaming ~complexity
 
@@ -878,10 +884,8 @@ module Make (W : Worktree.S) = struct
         | Some handle -> session.shutdown handle);
         match handle with None -> () | Some handle -> session.shutdown handle)
 
-  let run_long_lived ~sw ~(kind : Types.Operation_kind.t option) ~runtime ~clock
-      ~fs ~project_name ~patch_id ~prompt ~(agent : Patch_agent.t) ~owner ~repo
-      ~on_pr_detected ~transcripts ~user_config ~worktree_mutex ~hook_mutex
-      ~session ~complexity =
+  let run_long_lived ~sw ~(kind : Types.Operation_kind.t option) ~patch_id
+      ~prompt ~(agent : Patch_agent.t) ~on_pr_detected ~session ~complexity =
     let (Long_lived_session session) = session in
     let run_backend ~project_name ~cwd ~patch_id ~prompt ~resume_session:_
         ~session_uuid:_ ~complexity:_ ~on_event =
@@ -969,9 +973,7 @@ module Make (W : Worktree.S) = struct
                 session.failure_reason <- Some message;
                 failed_result message)
     in
-    run_with_backend ~kind ~runtime ~clock ~fs ~project_name ~patch_id ~prompt
-      ~agent ~owner ~repo ~on_pr_detected ~transcripts ~user_config
-      ~worktree_mutex ~hook_mutex
+    run_with_backend ~kind ~patch_id ~prompt ~agent ~on_pr_detected
       ~session_mode_for_agent:(fun _ -> `Fresh)
       ~backend_name:session.name ~run_backend ~complexity
 end

--- a/lib/session_driver.ml
+++ b/lib/session_driver.ml
@@ -141,6 +141,7 @@ end
 module Make (W : Worktree.S) (Env : ENV) = struct
   let session_mode = session_mode
   let extract_pr_number_from_text = extract_pr_number_from_text
+
   module WS = Worktree_setup.Make (W) (Env)
 
   let run_with_backend ~session_mode_for_agent

--- a/lib/session_driver.mli
+++ b/lib/session_driver.mli
@@ -10,6 +10,8 @@
     several modules. The backend below is already abstracted; this is the single
     place where "run a session for this patch" lives. *)
 
+(** Construction-time environment for session driving. Values here are fixed for
+    the lifetime of the module instance and never vary per call. *)
 module type ENV = sig
   val runtime : Runtime.t
   val clock : float Eio.Time.clock_ty Eio.Time.clock
@@ -22,8 +24,6 @@ module type ENV = sig
   val worktree_mutex : Eio.Mutex.t
   val hook_mutex : Eio.Mutex.t
 end
-(** Construction-time environment for session driving. Values here are fixed
-    for the lifetime of the module instance and never vary per call. *)
 
 module Make (_ : Worktree.S) (_ : ENV) : sig
   val run :

--- a/lib/session_driver.mli
+++ b/lib/session_driver.mli
@@ -10,23 +10,28 @@
     several modules. The backend below is already abstracted; this is the single
     place where "run a session for this patch" lives. *)
 
-module Make (_ : Worktree.S) : sig
+module type ENV = sig
+  val runtime : Runtime.t
+  val clock : float Eio.Time.clock_ty Eio.Time.clock
+  val fs : Eio.Fs.dir_ty Eio.Path.t
+  val project_name : string
+  val owner : string
+  val repo : string
+  val transcripts : (Types.Patch_id.t, string) Stdlib.Hashtbl.t
+  val user_config : User_config.t
+  val worktree_mutex : Eio.Mutex.t
+  val hook_mutex : Eio.Mutex.t
+end
+(** Construction-time environment for session driving. Values here are fixed
+    for the lifetime of the module instance and never vary per call. *)
+
+module Make (_ : Worktree.S) (_ : ENV) : sig
   val run :
     kind:Types.Operation_kind.t option ->
-    runtime:Runtime.t ->
-    clock:float Eio.Time.clock_ty Eio.Time.clock ->
-    fs:Eio.Fs.dir_ty Eio.Path.t ->
-    project_name:string ->
     patch_id:Types.Patch_id.t ->
     prompt:string ->
     agent:Patch_agent.t ->
-    owner:string ->
-    repo:string ->
     on_pr_detected:(Types.Pr_number.t -> unit) ->
-    transcripts:(Types.Patch_id.t, string) Stdlib.Hashtbl.t ->
-    user_config:User_config.t ->
-    worktree_mutex:Eio.Mutex.t ->
-    hook_mutex:Eio.Mutex.t ->
     backend:Llm_backend.t ->
     complexity:int option ->
     [ `Ok | `Failed | `Retry_push ] * (string * string) list
@@ -59,20 +64,10 @@ module Make (_ : Worktree.S) : sig
   val run_long_lived :
     sw:Eio.Switch.t ->
     kind:Types.Operation_kind.t option ->
-    runtime:Runtime.t ->
-    clock:float Eio.Time.clock_ty Eio.Time.clock ->
-    fs:Eio.Fs.dir_ty Eio.Path.t ->
-    project_name:string ->
     patch_id:Types.Patch_id.t ->
     prompt:string ->
     agent:Patch_agent.t ->
-    owner:string ->
-    repo:string ->
     on_pr_detected:(Types.Pr_number.t -> unit) ->
-    transcripts:(Types.Patch_id.t, string) Stdlib.Hashtbl.t ->
-    user_config:User_config.t ->
-    worktree_mutex:Eio.Mutex.t ->
-    hook_mutex:Eio.Mutex.t ->
     session:long_lived_session ->
     complexity:int option ->
     [ `Ok | `Failed | `Retry_push ] * (string * string) list

--- a/test/test_dependency_injection_functors.ml
+++ b/test/test_dependency_injection_functors.ml
@@ -92,8 +92,12 @@ let _check_narrowed :
 module Fake_sd_env : Session_driver.ENV = struct
   let runtime = Fake_env.runtime
 
-  (* Eio resources cannot be created outside Eio_main.run; they are never
-     dereferenced because Session_driver.Make defines functions only. *)
+  (* Eio resources cannot be created outside Eio_main.run. Obj.magic () is
+     safe here because both Worktree_setup.Make and Session_driver.Make consist
+     entirely of [let f = ...] definitions with no top-level side-effects, so
+     these values are never dereferenced at functor-application time. If either
+     Make body gains a top-level expression that dereferences Env.clock or
+     Env.fs, this test will segfault — that is the intended alarm. *)
   let clock : float Eio.Time.clock_ty Eio.Time.clock = Obj.magic ()
   let fs : Eio.Fs.dir_ty Eio.Path.t = Obj.magic ()
   let worktree_mutex : Eio.Mutex.t = Obj.magic ()

--- a/test/test_dependency_injection_functors.ml
+++ b/test/test_dependency_injection_functors.ml
@@ -82,3 +82,63 @@ let _check_narrowed :
     unit ->
     string option =
   WS.ensure_worktree
+
+(** Patch 2 compile-time signature check.
+
+    Verifies that [Session_driver.Make(W)(Env)] exposes [run] and
+    [run_long_lived] with only per-session inputs after the stable session
+    environment is captured as a functor argument. *)
+
+module Fake_sd_env : Session_driver.ENV = struct
+  let runtime = Fake_env.runtime
+
+  (* Eio resources cannot be created outside Eio_main.run; they are never
+     dereferenced because Session_driver.Make defines functions only. *)
+  let clock : float Eio.Time.clock_ty Eio.Time.clock = Obj.magic ()
+  let fs : Eio.Fs.dir_ty Eio.Path.t = Obj.magic ()
+  let worktree_mutex : Eio.Mutex.t = Obj.magic ()
+  let hook_mutex : Eio.Mutex.t = Obj.magic ()
+  let project_name = ""
+  let owner = ""
+  let repo = ""
+  let transcripts = Stdlib.Hashtbl.create 0
+  let user_config = { User_config.on_worktree_create = None }
+end
+
+module SD = Session_driver.Make (Fake_worktree) (Fake_sd_env)
+
+(* Compile-time assertion: run accepts only per-session inputs.
+   Runtime, clock, fs, project_name, owner, repo, transcripts, user_config,
+   and mutexes are gone from the call surface — they live in Fake_sd_env now. *)
+let _check_narrowed_run :
+    kind:Operation_kind.t option ->
+    patch_id:Patch_id.t ->
+    prompt:string ->
+    agent:Patch_agent.t ->
+    on_pr_detected:(Pr_number.t -> unit) ->
+    backend:Llm_backend.t ->
+    complexity:int option ->
+    [ `Ok | `Failed | `Retry_push ] * (string * string) list =
+  SD.run
+
+(* Compile-time assertion: run_long_lived accepts only per-session inputs. *)
+let _check_narrowed_run_long_lived :
+    sw:Eio.Switch.t ->
+    kind:Operation_kind.t option ->
+    patch_id:Patch_id.t ->
+    prompt:string ->
+    agent:Patch_agent.t ->
+    on_pr_detected:(Pr_number.t -> unit) ->
+    session:SD.long_lived_session ->
+    complexity:int option ->
+    [ `Ok | `Failed | `Retry_push ] * (string * string) list =
+  SD.run_long_lived
+
+let () =
+  print_endline
+    "Patch 1: Worktree_setup.Make(W)(Env).ensure_worktree narrowed signature: \
+     OK";
+  print_endline
+    "Patch 2: Session_driver.Make(W)(Env).run narrowed signature: OK";
+  print_endline
+    "Patch 2: Session_driver.Make(W)(Env).run_long_lived narrowed signature: OK"


### PR DESCRIPTION
## Patch 2: Functorize Session_driver environment

- Define Session_driver.ENV with runtime, clock, fs, project_name, owner, repo, transcripts, user_config, worktree_mutex, and hook_mutex values.
- Change Session_driver.Make from `Make (W : Worktree.S)` to `Make (W : Worktree.S) (Env : ENV)`.
- Instantiate `module Worktree_setup = Worktree_setup.Make (W) (Env)` inside Session_driver.
- Remove stable environment parameters from `run`, `run_long_lived`, and internal `run_with_backend`; keep per-call values such as kind, patch_id, prompt, agent, on_pr_detected, backend/session, and complexity.
- Preserve all session lifecycle behavior: resume/fresh fallback, snapshot sidecar update, transcript accumulation, PR sniffing, stream logging, session metadata writing, push outcome handling, and busy completion semantics.
- Update bin/main.ml run_llm_session call sites to pass only per-session inputs after constructing the module with Env.
- Enable the Session_driver signature test from the test scaffold and ensure it fails to compile if old environment parameters remain required by public run calls.

## Changes
- Define Session_driver.ENV with runtime, clock, fs, project_name, owner, repo, transcripts, user_config, worktree_mutex, and hook_mutex values.
- Change Session_driver.Make from `Make (W : Worktree.S)` to `Make (W : Worktree.S) (Env : ENV)`.
- Instantiate `module Worktree_setup = Worktree_setup.Make (W) (Env)` inside Session_driver.
- Remove stable environment parameters from `run`, `run_long_lived`, and internal `run_with_backend`; keep per-call values such as kind, patch_id, prompt, agent, on_pr_detected, backend/session, and complexity.
- Preserve all session lifecycle behavior: resume/fresh fallback, snapshot sidecar update, transcript accumulation, PR sniffing, stream logging, session metadata writing, push outcome handling, and busy completion semantics.
- Update bin/main.ml run_llm_session call sites to pass only per-session inputs after constructing the module with Env.
- Enable the Session_driver signature test from the test scaffold and ensure it fails to compile if old environment parameters remain required by public run calls.

## Files to Modify
- lib/session_driver.mli (modify): Add a session ENV module type and narrow run/run_long_lived signatures.
- lib/session_driver.ml (modify): Change Session_driver.Make to take Env, instantiate Worktree_setup.Make(W)(Env), and remove repeated environment parameters from internal calls.
- bin/main.ml (modify): Update runner-side Session_driver instantiation and run/run_long_lived call sites.
- test/test_dependency_injection_functors.ml (modify): Add/enable signature coverage for Session_driver.Make(W)(Env).

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[pattern] ML module functor dependency injection** — Session_driver already has a Worktree.S functor boundary. Extend the same pattern for stable run dependencies while leaving actual per-session values as function parameters.

## Gameplan Specification

```
module DEPENDENCY_INJECTION_FUNCTORS.

> Final state: high- and medium-priority dependency clusters are
> represented as construction-time functor environments. Public and
> local call surfaces expose per-call values only, while preserving
> existing synchronization and behavior.

CapabilityCluster.
worktree-setup-cluster => CapabilityCluster.
session-driver-cluster => CapabilityCluster.
fiber-run-cluster => CapabilityCluster.

cluster-captured-by-functor? c: CapabilityCluster => Bool.
call-surface-narrowed? c: CapabilityCluster => Bool.
behavior-preserved? c: CapabilityCluster => Bool.
shared-synchronization-preserved? => Bool.
no-new-external-contract? => Bool.
---
cluster-captured-by-functor? worktree-setup-cluster.
cluster-captured-by-functor? session-driver-cluster.
cluster-captured-by-functor? fiber-run-cluster.
call-surface-narrowed? worktree-setup-cluster.
call-surface-narrowed? session-driver-cluster.
call-surface-narrowed? fiber-run-cluster.
behavior-preserved? worktree-setup-cluster.
behavior-preserved? session-driver-cluster.
behavior-preserved? fiber-run-cluster.
shared-synchronization-preserved?.
no-new-external-contract?.

```

## Patch Specification

```
module DEPENDENCY_INJECTION_FUNCTORS_PATCH_2.

> Patch 2 establishes that session-runner dependencies are
> construction-time dependencies, while backend and patch inputs remain per-call.

SessionDependency.
session-runtime => SessionDependency.
session-clock => SessionDependency.
session-fs => SessionDependency.
session-project => SessionDependency.
session-repository => SessionDependency.
session-transcripts => SessionDependency.
session-worktree-env => SessionDependency.

session-env-functor? => Bool.
session-call-surface-narrowed? => Bool.
backend-remains-per-call? => Bool.
session-behavior-preserved? => Bool.
---
session-env-functor?.
session-call-surface-narrowed?.
backend-remains-per-call?.
session-behavior-preserved?.

```


## Implementation Notes

**`Session_driver.ENV` is a superset of `Worktree_setup.ENV`.** The 10-field ENV includes all 7 fields from `Worktree_setup.ENV` plus `owner`, `repo`, and `transcripts`. This means the same `Env` module passed to `Session_driver.Make(W)(Env)` is also passed directly to the internal `Worktree_setup.Make(W)(Env)` call — OCaml's structural module subtyping accepts it without an adapter.

**`WS` is hoisted to module level, not re-created per call.** Previously `run_with_backend` constructed an inline `module Env` and `module WS = Worktree_setup.Make(W)(Env)` on every invocation. After the patch, `module WS = Worktree_setup.Make(W)(Env)` is defined once at the top of `Make`'s body. This is both cleaner and consistent with the Patch 1 precedent.

**`bin/main.ml` instantiation moved from struct level to `runner_fiber`.** The old `module Session_driver = Session_driver.Make(W)` lived at the `Make_fibers` struct level where `owner`, `repo`, and `transcripts` are not yet in scope. The new `module Session_driver = Session_driver.Make(W)(Env)` is defined inside `runner_fiber` alongside the existing `Worktree_setup` Env — the only place where all stable values are simultaneously available. The existing `Env` module was extended with the three new fields; `Worktree_setup.Make(W)(Env)` continues to work unchanged since it sees only the fields it requires.

**No behavioral change.** The let-bindings added at the top of `run_with_backend` (`let runtime = Env.runtime`, etc.) are purely mechanical — every downstream reference remains identical. All session lifecycle paths (resume/fresh fallback, sidecar write, transcript accumulation, PR sniffing, push, telemetry) are untouched.

**Spec/Evidence Mapping:**

| Spec clause | Code | Test/check |
|---|---|---|
| `session-env-functor?` | `module Make (W : Worktree.S) (Env : ENV)` in `session_driver.ml:142` | Compile-time: `module SD = Session_driver.Make(Fake_worktree)(SD_Env)` in test |
| `session-call-surface-narrowed?` | `run` takes only `kind/patch_id/prompt/agent/on_pr_detected/backend/complexity` | Type annotation `check_narrowed_run` fails to compile if stable params remain |
| `backend-remains-per-call?` | `~backend:Llm_backend.t` stays on `run`; `~session` stays on `run_long_lived` | Same type annotation check |
| `session-behavior-preserved?` | `run_with_backend` body unchanged; only param source moved from args to `Env.*` | Existing inline tests in `session_driver.ml` pass unchanged |