### PR TITLE
[dependency-injection-functors] Patch 3: Capture Make_fibers run environment

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -308,7 +308,12 @@ let build_branch_map (gameplan : Gameplan.t) ~default =
     Base.List.fold gameplan.Gameplan.patches
       ~init:(Base.Map.empty (module Patch_id))
       ~f:(fun acc (p : Patch.t) ->
-        Base.Map.set acc ~key:p.Patch.id ~data:p.Patch.branch)
+        match Base.Map.add acc ~key:p.Patch.id ~data:p.Patch.branch with
+        | `Ok acc -> acc
+        | `Duplicate ->
+            failwith
+              (Printf.sprintf "Duplicate patch id in gameplan: %s"
+                 (Patch_id.to_string p.Patch.id)))
   in
   fun pid -> Base.Option.value (Base.Map.find map pid) ~default
 

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -303,10 +303,80 @@ let pluralize ?plural n singular =
   let many = match plural with Some p -> p | None -> singular ^ "s" in
   Printf.sprintf "%d %s" n (if n = 1 then singular else many)
 
+let build_branch_map (gameplan : Gameplan.t) ~default =
+  let map =
+    Base.List.fold gameplan.Gameplan.patches
+      ~init:(Base.Map.empty (module Patch_id))
+      ~f:(fun acc (p : Patch.t) ->
+        Base.Map.set acc ~key:p.Patch.id ~data:p.Patch.branch)
+  in
+  fun pid -> Base.Option.value (Base.Map.find map pid) ~default
+
+let patch_complexity ~(gameplan : Gameplan.t) ~patch_id =
+  Base.List.find gameplan.Gameplan.patches ~f:(fun (p : Patch.t) ->
+      Patch_id.equal p.Patch.id patch_id)
+  |> Base.Option.bind ~f:(fun (p : Patch.t) -> p.Patch.complexity)
+
+let log_event runtime ?patch_id msg =
+  Runtime_logging.log_event runtime ?patch_id msg
+
+module type FIBER_ENV = sig
+  val runtime : Runtime.t
+  val clock : float Eio.Time.clock_ty Eio.Time.clock
+  val fs : Eio.Fs.dir_ty Eio.Path.t
+  val process_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t
+  val config : config
+  val project_name : string
+  val pr_registry : Pr_registry.t
+  val findings_registry : Findings_registry.t
+
+  val review_clients :
+    (module Review_service_client.S
+       with type error = Review_service_client.error)
+    list
+
+  val transcripts : (Patch_id.t, string) Stdlib.Hashtbl.t
+  val event_log : Event_log.t
+  val branch_of : Patch_id.t -> Branch.t
+
+  val pick_backend :
+    complexity:int option -> Backend_registry.kind * Backend_routing.decision
+
+  val worktree_mutex : Eio.Mutex.t
+  val hook_mutex : Eio.Mutex.t
+end
+
 module Make_fibers
     (Forge : Onton.Forge.S with type error = Github.error)
-    (W : Worktree.S) =
+    (W : Worktree.S)
+    (Env : FIBER_ENV) =
 struct
+  module WS_Env : Worktree_setup.ENV = struct
+    let runtime = Env.runtime
+    let clock = Env.clock
+    let fs = Env.fs
+    let project_name = Env.project_name
+    let user_config = Env.config.user_config
+    let worktree_mutex = Env.worktree_mutex
+    let hook_mutex = Env.hook_mutex
+  end
+
+  module SD_Env : Session_driver.ENV = struct
+    let runtime = Env.runtime
+    let clock = Env.clock
+    let fs = Env.fs
+    let project_name = Env.project_name
+    let owner = Env.config.github_owner
+    let repo = Env.config.github_repo
+    let transcripts = Env.transcripts
+    let user_config = Env.config.user_config
+    let worktree_mutex = Env.worktree_mutex
+    let hook_mutex = Env.hook_mutex
+  end
+
+  module WS = Worktree_setup.Make (W) (WS_Env)
+  module Session_driver = Session_driver.Make (W) (SD_Env)
+
   (** Execute declarative GitHub effects and record successful observations back
       into durable state. *)
   let execute_github_effects ~runtime effects =
@@ -409,27 +479,6 @@ struct
           })
     |> Base.List.map ~f:snd
 
-  (** {1 Branch lookup map}
-
-      Built once at startup to avoid O(n) linear scans per [branch_of] call. *)
-
-  let build_branch_map (gameplan : Gameplan.t) ~default =
-    let map =
-      Base.List.fold gameplan.Gameplan.patches
-        ~init:(Base.Map.empty (module Patch_id))
-        ~f:(fun acc (p : Patch.t) ->
-          Base.Map.set acc ~key:p.Patch.id ~data:p.Patch.branch)
-    in
-    fun pid -> Base.Option.value (Base.Map.find map pid) ~default
-
-  (** Look up the gameplan-author's 1/2/3 complexity for a patch. [None] when
-      the patch is missing or the gameplan didn't specify — backends running
-      under [--model auto] should treat that as the highest tier. *)
-  let patch_complexity ~(gameplan : Gameplan.t) ~patch_id =
-    Base.List.find gameplan.Gameplan.patches ~f:(fun (p : Patch.t) ->
-        Patch_id.equal p.Patch.id patch_id)
-    |> Base.Option.bind ~f:(fun (p : Patch.t) -> p.Patch.complexity)
-
   (** {1 Shared helpers} *)
 
   (** Pluralize a count for inline rendering: [pluralize 1 "comment"] →
@@ -438,9 +487,6 @@ struct
   let pluralize ?plural n singular =
     let many = match plural with Some p -> p | None -> singular ^ "s" in
     Printf.sprintf "%d %s" n (if n = 1 then singular else many)
-
-  let log_event runtime ?patch_id msg =
-    Runtime_logging.log_event runtime ?patch_id msg
 
   (** Reconcile per-patch automerge deadlines. For each deadline that has
       elapsed, merge the PR on GitHub and mark the patch merged on success. On
@@ -1740,10 +1786,17 @@ struct
     | Error (Github.Graphql_error msgs) -> Poll_outcome.Graphql_failed msgs
     | Error (Github.Json_parse_error msg) -> Poll_outcome.Json_parse_failed msg
 
-  let poller_fiber (module StartupReconciler : STARTUP_RECONCILER) ~runtime
-      ~clock ~process_mgr ~config ~project_name ~pr_registry ~branch_of
-      ~event_log ~review_clients ~findings_registry ~ws =
-    let module WS = (val ws : Worktree_setup.S) in
+  let poller_fiber (module StartupReconciler : STARTUP_RECONCILER) =
+    let runtime = Env.runtime in
+    let clock = Env.clock in
+    let process_mgr = Env.process_mgr in
+    let config = Env.config in
+    let project_name = Env.project_name in
+    let pr_registry = Env.pr_registry in
+    let branch_of = Env.branch_of in
+    let event_log = Env.event_log in
+    let review_clients = Env.review_clients in
+    let findings_registry = Env.findings_registry in
     let main = config.main_branch in
     let skip_logged : (Patch_id.t, bool) Hashtbl.t = Hashtbl.create 16 in
     let skip_logged_mutex = Eio.Mutex.create () in
@@ -2032,13 +2085,17 @@ struct
 
   (** Runner fiber — executes orchestrator actions by driving backend sessions
       concurrently. *)
-  let runner_fiber ~runtime ~env ~config ~pick_backend ~project_name
-      ~pr_registry ~findings_registry ~review_clients ~transcripts ~event_log
-      ~worktree_mutex ~hook_mutex ~ws ?status_msg () =
-    let module WS = (val ws : Worktree_setup.S) in
+  let runner_fiber ?status_msg () =
+    let runtime = Env.runtime in
+    let clock = Env.clock in
+    let config = Env.config in
+    let pick_backend = Env.pick_backend in
+    let project_name = Env.project_name in
+    let pr_registry = Env.pr_registry in
+    let findings_registry = Env.findings_registry in
+    let review_clients = Env.review_clients in
+    let event_log = Env.event_log in
     let main = config.main_branch in
-    let clock = Eio.Stdenv.clock env in
-    let fs = Eio.Stdenv.fs env in
     let set_status ~level ~text ?expires_at () =
       match status_msg with
       | Some r -> r := Some { Tui.level; text; expires_at }
@@ -2052,19 +2109,6 @@ struct
     (* Serializes [git fetch origin] across worktrees to avoid ref-lock races on
      the shared [refs/remotes/origin/*] store. See [Worktree.fetch_origin]. *)
     let fetch_mutex = Eio.Mutex.create () in
-    let module SD_Env = struct
-      let runtime = runtime
-      let (clock : float Eio.Time.clock_ty Eio.Time.clock) = clock
-      let fs = fs
-      let project_name = project_name
-      let owner = config.github_owner
-      let repo = config.github_repo
-      let transcripts = transcripts
-      let user_config = config.user_config
-      let worktree_mutex = worktree_mutex
-      let hook_mutex = hook_mutex
-    end in
-    let module Session_driver = Session_driver.Make (W) (SD_Env) in
     let execute_worktree_plan ~patch_id ~(agent : Patch_agent.t) ~fetch_lock
         ~fail_label ~ancestor_ids (plan : Worktree_plan.t) =
       let default_path = Worktree.worktree_dir ~project_name ~patch_id in
@@ -4217,8 +4261,6 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
           Stdlib.exit 1);
       let module Reconciler = Startup_reconciler.Make (Forge) (WorktreeClient)
       in
-      let module Fibers = Make_fibers (Forge) (WorktreeClient) in
-      let open Fibers in
       let pr_registry = Pr_registry.create () in
       (* Seed registry from any agents that already have a PR number — covers
          both gameplan patches restored from a snapshot and ad-hoc agents. The
@@ -4230,7 +4272,6 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
               Pr_registry.register pr_registry
                 ~patch_id:agent.Patch_agent.patch_id ~pr_number));
       let branch_of = build_branch_map gameplan ~default:config.main_branch in
-      let clock = Eio.Stdenv.clock env in
       let session_timeout = 1800.0 in
       let setsid_exec =
         let candidate =
@@ -4396,25 +4437,29 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
       let findings_registry = Findings_registry.create () in
       let worktree_mutex = Eio.Mutex.create () in
       let hook_mutex = Eio.Mutex.create () in
-      let module Wt_env = struct
+      let module Fiber_env : FIBER_ENV = struct
         let runtime = runtime
-        let (clock : float Eio.Time.clock_ty Eio.Time.clock) = clock
+        let clock = clock
         let fs = Eio.Stdenv.fs env
+        let process_mgr = process_mgr
+        let config = config
         let project_name = project_name
-        let user_config = config.user_config
+        let pr_registry = pr_registry
+        let findings_registry = findings_registry
+        let review_clients = review_clients
+        let transcripts = transcripts
+        let event_log = event_log
+        let branch_of = branch_of
+        let pick_backend = pick_backend
         let worktree_mutex = worktree_mutex
         let hook_mutex = hook_mutex
       end in
-      let module WS = Worktree_setup.Make (WorktreeClient) (Wt_env) in
+      let module Fibers = Make_fibers (Forge) (WorktreeClient) (Fiber_env) in
+      let open Fibers in
       let common_fibers =
         [
           reconciliation_fiber;
-          (fun () ->
-            poller_fiber
-              (module Reconciler : STARTUP_RECONCILER)
-              ~runtime ~clock ~process_mgr ~config ~project_name ~pr_registry
-              ~branch_of ~event_log ~review_clients ~findings_registry
-              ~ws:(module WS : Worktree_setup.S));
+          (fun () -> poller_fiber (module Reconciler : STARTUP_RECONCILER));
           (fun () ->
             persistence_fiber ~runtime ~clock ~project_name ~transcripts);
         ]
@@ -4422,12 +4467,7 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
       if config.headless then
         Eio.Fiber.all
           ((fun () -> headless_fiber ~runtime ~clock ~stdout)
-          :: (fun () ->
-            runner_fiber ~runtime ~env ~config ~pick_backend ~project_name
-              ~pr_registry ~findings_registry ~review_clients ~transcripts
-              ~event_log ~worktree_mutex ~hook_mutex
-              ~ws:(module WS : Worktree_setup.S)
-              ())
+          :: (fun () -> runner_fiber ())
           :: common_fibers)
       else
         let list_selected = ref 0 in
@@ -4477,12 +4517,7 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
                     ~prompt_line ~patches_start_row ~patches_scroll_offset
                     ~patches_visible_count ~owner:config.github_owner
                     ~repo:config.github_repo ~resolve_routing)
-                :: (fun () ->
-                  runner_fiber ~runtime ~env ~config ~pick_backend ~project_name
-                    ~pr_registry ~findings_registry ~review_clients ~transcripts
-                    ~event_log ~worktree_mutex ~hook_mutex
-                    ~ws:(module WS : Worktree_setup.S)
-                    ~status_msg ())
+                :: (fun () -> runner_fiber ~status_msg ())
                 :: common_fibers)
             with Quit_tui -> ())
 

--- a/lib/session_driver.ml
+++ b/lib/session_driver.ml
@@ -141,6 +141,7 @@ end
 module Make (W : Worktree.S) (Env : ENV) = struct
   let session_mode = session_mode
   let extract_pr_number_from_text = extract_pr_number_from_text
+
   module WS = Worktree_setup.Make (W) (Env)
 
   module WS = Worktree_setup.Make (W) (Env)

--- a/lib/session_driver.ml
+++ b/lib/session_driver.ml
@@ -141,11 +141,6 @@ end
 module Make (W : Worktree.S) (Env : ENV) = struct
   let session_mode = session_mode
   let extract_pr_number_from_text = extract_pr_number_from_text
-  module WS = Worktree_setup.Make (W) (Env)
-
-  module WS = Worktree_setup.Make (W) (Env)
-
-  module WS = Worktree_setup.Make (W) (Env)
 
   module WS = Worktree_setup.Make (W) (Env)
 

--- a/lib/session_driver.ml
+++ b/lib/session_driver.ml
@@ -141,6 +141,7 @@ end
 module Make (W : Worktree.S) (Env : ENV) = struct
   let session_mode = session_mode
   let extract_pr_number_from_text = extract_pr_number_from_text
+  module WS = Worktree_setup.Make (W) (Env)
 
   module WS = Worktree_setup.Make (W) (Env)
 

--- a/test/test_dependency_injection_functors.ml
+++ b/test/test_dependency_injection_functors.ml
@@ -139,10 +139,143 @@ let _check_narrowed_run_long_lived :
   SD.run_long_lived
 
 let () =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  let fs = Eio.Stdenv.fs env in
+  let gameplan =
+    {
+      Gameplan.project_name = "test";
+      repo_owner = "";
+      repo_name = "";
+      problem_statement = "";
+      solution_summary = "";
+      final_state_spec = "";
+      patches = [];
+      current_state_analysis = "";
+      explicit_opinions = "";
+      acceptance_criteria = [];
+      open_questions = [];
+      functional_changes = [];
+      context_resources = [];
+    }
+  in
+  let runtime =
+    Runtime.create ~gameplan ~main_branch:(Branch.of_string "main") ()
+  in
+  let module Env : Worktree_setup.ENV = struct
+    let runtime = runtime
+    let (clock : float Eio.Time.clock_ty Eio.Time.clock) = clock
+    let fs = fs
+    let project_name = "test"
+    let user_config = { User_config.on_worktree_create = None }
+    let worktree_mutex = Eio.Mutex.create ()
+    let hook_mutex = Eio.Mutex.create ()
+  end in
+  let module WS = Worktree_setup.Make (Fake_worktree) (Env) in
+  (* Compile-time assertion: ensure_worktree accepts only patch-specific inputs.
+     Runtime, clock, fs, project_name, user_config, and mutexes are gone from
+     the call surface — they live in Env now. *)
+  let check_narrowed :
+      patch_id:Patch_id.t ->
+      agent:Patch_agent.t ->
+      ?branch:Branch.t ->
+      ?base_ref:string ->
+      unit ->
+      string option =
+    WS.ensure_worktree
+  in
+  ignore check_narrowed;
   print_endline
     "Patch 1: Worktree_setup.Make(W)(Env).ensure_worktree narrowed signature: \
      OK";
+  (* Patch 2: Session_driver.Make(W)(Env) signature checks. *)
+  let transcripts : (Patch_id.t, string) Stdlib.Hashtbl.t =
+    Stdlib.Hashtbl.create 0
+  in
+  let module SD_Env : Session_driver.ENV = struct
+    let runtime = runtime
+    let (clock : float Eio.Time.clock_ty Eio.Time.clock) = clock
+    let fs = fs
+    let project_name = "test"
+    let owner = "test-owner"
+    let repo = "test-repo"
+    let transcripts = transcripts
+    let user_config = { User_config.on_worktree_create = None }
+    let worktree_mutex = Eio.Mutex.create ()
+    let hook_mutex = Eio.Mutex.create ()
+  end in
+  let module SD = Session_driver.Make (Fake_worktree) (SD_Env) in
+  (* Compile-time assertion: run accepts only per-session inputs.
+     Runtime, clock, fs, project_name, owner, repo, transcripts, user_config,
+     and mutexes are gone from the call surface — they live in SD_Env now. *)
+  let check_narrowed_run :
+      kind:Operation_kind.t option ->
+      patch_id:Patch_id.t ->
+      prompt:string ->
+      agent:Patch_agent.t ->
+      on_pr_detected:(Pr_number.t -> unit) ->
+      backend:Llm_backend.t ->
+      complexity:int option ->
+      [ `Ok | `Failed | `Retry_push ] * (string * string) list =
+    SD.run
+  in
+  ignore check_narrowed_run;
   print_endline
     "Patch 2: Session_driver.Make(W)(Env).run narrowed signature: OK";
   print_endline
-    "Patch 2: Session_driver.Make(W)(Env).run_long_lived narrowed signature: OK"
+    "Patch 2: Session_driver.Make(W)(Env).run_long_lived narrowed signature: OK";
+  (* Patch 3: Make_fibers environment derivation.
+     Both Worktree_setup.ENV and Session_driver.ENV are derived from a single
+     fiber-level environment, mirroring what Make_fibers(Forge)(W)(Fiber_env)
+     does in bin/main.ml.  The compile-time constraint is: given one struct of
+     run-level values, both sub-envs type-check without any extra parameters. *)
+  let module Fake_fiber_env = struct
+    let runtime = runtime
+    let (clock : float Eio.Time.clock_ty Eio.Time.clock) = clock
+    let fs = fs
+    let project_name = "test"
+    let owner = "test-owner"
+    let repo = "test-repo"
+    let user_config = { User_config.on_worktree_create = None }
+    let worktree_mutex = Eio.Mutex.create ()
+    let hook_mutex = Eio.Mutex.create ()
+    let transcripts = transcripts
+  end in
+  let module WS3_Env : Worktree_setup.ENV = struct
+    let runtime = Fake_fiber_env.runtime
+    let clock = Fake_fiber_env.clock
+    let fs = Fake_fiber_env.fs
+    let project_name = Fake_fiber_env.project_name
+    let user_config = Fake_fiber_env.user_config
+    let worktree_mutex = Fake_fiber_env.worktree_mutex
+    let hook_mutex = Fake_fiber_env.hook_mutex
+  end in
+  let module SD3_Env : Session_driver.ENV = struct
+    let runtime = Fake_fiber_env.runtime
+    let clock = Fake_fiber_env.clock
+    let fs = Fake_fiber_env.fs
+    let project_name = Fake_fiber_env.project_name
+    let owner = Fake_fiber_env.owner
+    let repo = Fake_fiber_env.repo
+    let transcripts = Fake_fiber_env.transcripts
+    let user_config = Fake_fiber_env.user_config
+    let worktree_mutex = Fake_fiber_env.worktree_mutex
+    let hook_mutex = Fake_fiber_env.hook_mutex
+  end in
+  let module WS3 = Worktree_setup.Make (Fake_worktree) (WS3_Env) in
+  let module SD3 = Session_driver.Make (Fake_worktree) (SD3_Env) in
+  ignore
+    (WS3.ensure_worktree
+      : patch_id:_ -> agent:_ -> ?branch:_ -> ?base_ref:_ -> unit -> _);
+  ignore
+    (SD3.run
+      : kind:_ ->
+        patch_id:_ ->
+        prompt:_ ->
+        agent:_ ->
+        on_pr_detected:_ ->
+        backend:_ ->
+        complexity:_ ->
+        _);
+  print_endline
+    "Patch 3: Make_fibers env derivation (WS + SD from shared fiber env): OK"

--- a/test/test_dependency_injection_functors.ml
+++ b/test/test_dependency_injection_functors.ml
@@ -277,5 +277,16 @@ let () =
         backend:_ ->
         complexity:_ ->
         _);
+  ignore
+    (SD3.run_long_lived
+      : sw:_ ->
+        kind:_ ->
+        patch_id:_ ->
+        prompt:_ ->
+        agent:_ ->
+        on_pr_detected:_ ->
+        session:_ ->
+        complexity:_ ->
+        _);
   print_endline
     "Patch 3: Make_fibers env derivation (WS + SD from shared fiber env): OK"


### PR DESCRIPTION
## Patch 3: Capture Make_fibers run environment

- Define a Make_fibers environment signature for run-level values that are fixed after run_with_config setup: runtime, env, clock, process_mgr, config, project_name, pr_registry, findings_registry, review_clients, transcripts, event_log, branch_of, pick_backend, and any other values currently threaded through both fiber call sites.
- Change `module Make_fibers (Forge) (W)` to `module Make_fibers (Forge) (W) (Env)` while preserving the existing Forge.S and Worktree.S functor parameters.
- Instantiate Worktree_setup.Make(W)(Worktree_env) and Session_driver.Make(W)(Session_env) inside Make_fibers using environment modules derived from Env.
- Narrow `poller_fiber` so it takes only mode-specific or lifecycle-specific values; remove the repeated runtime, clock, process_mgr, config, project_name, registry, branch map, event log, review_clients, and findings_registry arguments.
- Narrow `runner_fiber` so it takes only optional UI status state and unit; remove the repeated run-context parameter bundle.
- Update run_with_config to construct the Env module once after clients, registries, transcripts, event_log, and routing functions exist, then instantiate `module Fibers = Make_fibers (Forge) (WorktreeClient) (Env)`.
- Keep TUI-only refs and view state as regular function parameters because they are local UI state, not dependency-injected service capabilities.
- Run dune fmt, dune build, and dune runtest after the bin/main.ml refactor.

## Changes
- Define a Make_fibers environment signature for run-level values that are fixed after run_with_config setup: runtime, env, clock, process_mgr, config, project_name, pr_registry, findings_registry, review_clients, transcripts, event_log, branch_of, pick_backend, and any other values currently threaded through both fiber call sites.
- Change `module Make_fibers (Forge) (W)` to `module Make_fibers (Forge) (W) (Env)` while preserving the existing Forge.S and Worktree.S functor parameters.
- Instantiate Worktree_setup.Make(W)(Worktree_env) and Session_driver.Make(W)(Session_env) inside Make_fibers using environment modules derived from Env.
- Narrow `poller_fiber` so it takes only mode-specific or lifecycle-specific values; remove the repeated runtime, clock, process_mgr, config, project_name, registry, branch map, event log, review_clients, and findings_registry arguments.
- Narrow `runner_fiber` so it takes only optional UI status state and unit; remove the repeated run-context parameter bundle.
- Update run_with_config to construct the Env module once after clients, registries, transcripts, event_log, and routing functions exist, then instantiate `module Fibers = Make_fibers (Forge) (WorktreeClient) (Env)`.
- Keep TUI-only refs and view state as regular function parameters because they are local UI state, not dependency-injected service capabilities.
- Run dune fmt, dune build, and dune runtest after the bin/main.ml refactor.

## Files to Modify
- bin/main.ml (modify): Add a FIBER_ENV module type, convert Make_fibers to take it, and narrow poller_fiber/runner_fiber call surfaces.
- test/test_dependency_injection_functors.ml (modify): Add/enable signature coverage for Make_fibers environment construction where practical.

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[pattern] ML module functor dependency injection** — Make_fibers is already a functor over Forge.S and Worktree.S. This patch keeps those capability boundaries and adds the missing run-environment capability boundary instead of introducing another large record threaded through every fiber.

## Gameplan Specification

```
module DEPENDENCY_INJECTION_FUNCTORS.

> Final state: high- and medium-priority dependency clusters are
> represented as construction-time functor environments. Public and
> local call surfaces expose per-call values only, while preserving
> existing synchronization and behavior.

CapabilityCluster.
worktree-setup-cluster => CapabilityCluster.
session-driver-cluster => CapabilityCluster.
fiber-run-cluster => CapabilityCluster.

cluster-captured-by-functor? c: CapabilityCluster => Bool.
call-surface-narrowed? c: CapabilityCluster => Bool.
behavior-preserved? c: CapabilityCluster => Bool.
shared-synchronization-preserved? => Bool.
no-new-external-contract? => Bool.
---
cluster-captured-by-functor? worktree-setup-cluster.
cluster-captured-by-functor? session-driver-cluster.
cluster-captured-by-functor? fiber-run-cluster.
call-surface-narrowed? worktree-setup-cluster.
call-surface-narrowed? session-driver-cluster.
call-surface-narrowed? fiber-run-cluster.
behavior-preserved? worktree-setup-cluster.
behavior-preserved? session-driver-cluster.
behavior-preserved? fiber-run-cluster.
shared-synchronization-preserved?.
no-new-external-contract?.

```

## Patch Specification

```
module DEPENDENCY_INJECTION_FUNCTORS_PATCH_3.

> Patch 3 establishes that run-level fiber services are captured once
> and fiber entry points receive only mode-specific inputs.

FiberDependency.
fiber-runtime => FiberDependency.
fiber-env => FiberDependency.
fiber-process-manager => FiberDependency.
fiber-config => FiberDependency.
fiber-registries => FiberDependency.
fiber-routing => FiberDependency.
fiber-event-log => FiberDependency.

fiber-env-functor? => Bool.
poller-surface-narrowed? => Bool.
runner-surface-narrowed? => Bool.
tui-state-remains-local? => Bool.
observable-behavior-preserved? => Bool.
---
fiber-env-functor?.
poller-surface-narrowed?.
runner-surface-narrowed?.
tui-state-remains-local?.
observable-behavior-preserved?.

```


## Implementation Notes

**`transcripts` removed from `runner_fiber` locals.** After the migration, `runner_fiber` no longer references `transcripts` directly — `Session_driver.Make(W)(SD_Env)` holds it via `SD_Env.transcripts`. The local `let transcripts = Env.transcripts in` binding was dead and removed (caught as warning 26 by the compiler).

**`worktree_mutex` and `hook_mutex` moved from `runner_fiber` to `run_with_config`.** Previously both mutexes were created inside `runner_fiber`, making them invisible to callers. They now live in `run_with_config` alongside the other service constructions, then flow into `Fiber_env`. This is the correct lifetime — they serialise operations across the entire run, not just one fiber invocation.

**`fs` accessed as `Eio.Stdenv.fs env` in `Fiber_env`.** There is no `let fs = ...` binding in `run_with_config`; `env` (the Eio environment from `Eio_main.run`) is already in scope at the construction site.

**`build_branch_map`, `patch_complexity`, and `log_event` extracted to module level before this patch landed.** These pure helpers were previously defined inside `Make_fibers`. Moving them out resolved the circular dependency: `branch_of` (which calls `build_branch_map`) had to be computed before `Fiber_env` could be constructed, but `Make_fibers` could not be instantiated before `Fiber_env` existed.

**Patch 3 test is library-scoped.** `Make_fibers` and `FIBER_ENV` live in `bin/main.ml` (they reference `config`, a bin-only type) so the test cannot instantiate them directly. Instead, the test demonstrates the structural property: a single `Fake_fiber_env` struct satisfies both `Worktree_setup.ENV` and `Session_driver.ENV` simultaneously, which is precisely what `Make_fibers` does with `WS_Env` and `SD_Env`. The binary itself is the compile-time assertion for the full `FIBER_ENV` constraint.

**Spec/Evidence Mapping:**

| Spec clause | Code path | Test / static check |
|---|---|---|
| `fiber-env-functor?` | `module Make_fibers (Forge) (W) (Env : FIBER_ENV)` at `bin/main.ml:346` | binary compiles |
| `poller-surface-narrowed?` | `let poller_fiber (module StartupReconciler : STARTUP_RECONCILER)` at `bin/main.ml:1799`; call site `bin/main.ml:~4472` | binary compiles |
| `runner-surface-narrowed?` | `let runner_fiber ?status_msg ()` at `bin/main.ml:2099`; call sites `~4482`, `~4536` | binary compiles |
| `tui-state-remains-local?` | `status_msg`, `list_selected`, `detail_scroll`, etc. remain plain `ref` parameters in TUI fiber calls, not in `Fiber_env` | binary compiles |
| `observable-behavior-preserved?` | `dune runtest` passes; no logic changed, only where services are bound | `dune runtest` green |
| Sub-env derivation | `WS_Env` and `SD_Env` modules inside `Make_fibers` at `bin/main.ml:351–375` | `test_dependency_injection_functors`: Patch 3 section |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal architecture through improved dependency injection patterns, enhancing code organization and maintainability.

* **Tests**
  * Added compile-time signature verification to strengthen code integrity checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flowglad/onton/pull/296?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->