### PR TITLE
[extract-bin-fibers] Patch 1: Introduce shared Run_env signature

### DIFF
--- a/lib/run_env.ml
+++ b/lib/run_env.ml
@@ -1,0 +1,9 @@
+module type S = sig
+  val runtime : Runtime.t
+  val clock : float Eio.Time.clock_ty Eio.Time.clock
+  val fs : Eio.Fs.dir_ty Eio.Path.t
+  val project_name : string
+  val user_config : User_config.t
+  val worktree_mutex : Eio.Mutex.t
+  val hook_mutex : Eio.Mutex.t
+end

--- a/lib/run_env.mli
+++ b/lib/run_env.mli
@@ -1,0 +1,10 @@
+(** Shared run-level capabilities captured at functor instantiation time. *)
+module type S = sig
+  val runtime : Runtime.t
+  val clock : float Eio.Time.clock_ty Eio.Time.clock
+  val fs : Eio.Fs.dir_ty Eio.Path.t
+  val project_name : string
+  val user_config : User_config.t
+  val worktree_mutex : Eio.Mutex.t
+  val hook_mutex : Eio.Mutex.t
+end

--- a/lib/session_driver.ml
+++ b/lib/session_driver.ml
@@ -126,16 +126,10 @@ let%test_module "extract_pr_number_from_text" =
   end)
 
 module type ENV = sig
-  val runtime : Runtime.t
-  val clock : float Eio.Time.clock_ty Eio.Time.clock
-  val fs : Eio.Fs.dir_ty Eio.Path.t
-  val project_name : string
+  include Run_env.S
   val owner : string
   val repo : string
   val transcripts : (Types.Patch_id.t, string) Stdlib.Hashtbl.t
-  val user_config : User_config.t
-  val worktree_mutex : Eio.Mutex.t
-  val hook_mutex : Eio.Mutex.t
 end
 
 module Make (W : Worktree.S) (Env : ENV) = struct

--- a/lib/session_driver.ml
+++ b/lib/session_driver.ml
@@ -127,6 +127,7 @@ let%test_module "extract_pr_number_from_text" =
 
 module type ENV = sig
   include Run_env.S
+
   val owner : string
   val repo : string
   val transcripts : (Types.Patch_id.t, string) Stdlib.Hashtbl.t

--- a/lib/session_driver.mli
+++ b/lib/session_driver.mli
@@ -13,16 +13,10 @@
 (** Construction-time environment for session driving. Values here are fixed for
     the lifetime of the module instance and never vary per call. *)
 module type ENV = sig
-  val runtime : Runtime.t
-  val clock : float Eio.Time.clock_ty Eio.Time.clock
-  val fs : Eio.Fs.dir_ty Eio.Path.t
-  val project_name : string
+  include Run_env.S
   val owner : string
   val repo : string
   val transcripts : (Types.Patch_id.t, string) Stdlib.Hashtbl.t
-  val user_config : User_config.t
-  val worktree_mutex : Eio.Mutex.t
-  val hook_mutex : Eio.Mutex.t
 end
 
 module Make (_ : Worktree.S) (_ : ENV) : sig

--- a/lib/session_driver.mli
+++ b/lib/session_driver.mli
@@ -14,6 +14,7 @@
     the lifetime of the module instance and never vary per call. *)
 module type ENV = sig
   include Run_env.S
+
   val owner : string
   val repo : string
   val transcripts : (Types.Patch_id.t, string) Stdlib.Hashtbl.t

--- a/lib/worktree_setup.ml
+++ b/lib/worktree_setup.ml
@@ -1,14 +1,6 @@
 open Base
 
-module type ENV = sig
-  val runtime : Runtime.t
-  val clock : float Eio.Time.clock_ty Eio.Time.clock
-  val fs : Eio.Fs.dir_ty Eio.Path.t
-  val project_name : string
-  val user_config : User_config.t
-  val worktree_mutex : Eio.Mutex.t
-  val hook_mutex : Eio.Mutex.t
-end
+module type ENV = Run_env.S
 
 module type S = sig
   val resolve_worktree_path :

--- a/lib/worktree_setup.mli
+++ b/lib/worktree_setup.mli
@@ -5,9 +5,9 @@
     owns that logic so both callers go through the same code path — same
     persistence, same hook invocation, same logging. *)
 
-module type ENV = Run_env.S
 (** Construction-time environment for worktree provisioning. Values here are
     fixed for the lifetime of the module instance and never vary per call. *)
+module type ENV = Run_env.S
 
 module type S = sig
   val resolve_worktree_path :

--- a/lib/worktree_setup.mli
+++ b/lib/worktree_setup.mli
@@ -5,9 +5,9 @@
     owns that logic so both callers go through the same code path — same
     persistence, same hook invocation, same logging. *)
 
+module type ENV = Run_env.S
 (** Construction-time environment for worktree provisioning. Values here are
     fixed for the lifetime of the module instance and never vary per call. *)
-module type ENV = Run_env.S
 
 module type S = sig
   val resolve_worktree_path :

--- a/lib/worktree_setup.mli
+++ b/lib/worktree_setup.mli
@@ -7,15 +7,7 @@
 
 (** Construction-time environment for worktree provisioning. Values here are
     fixed for the lifetime of the module instance and never vary per call. *)
-module type ENV = sig
-  val runtime : Runtime.t
-  val clock : float Eio.Time.clock_ty Eio.Time.clock
-  val fs : Eio.Fs.dir_ty Eio.Path.t
-  val project_name : string
-  val user_config : User_config.t
-  val worktree_mutex : Eio.Mutex.t
-  val hook_mutex : Eio.Mutex.t
-end
+module type ENV = Run_env.S
 
 module type S = sig
   val resolve_worktree_path :


### PR DESCRIPTION
## Patch 1: Introduce shared Run_env signature

- Create lib/run_env.mli and lib/run_env.ml exposing `module type S = sig val runtime : Runtime.t val clock : float Eio.Time.clock_ty Eio.Time.clock val fs : Eio.Fs.dir_ty Eio.Path.t val project_name : string val user_config : User_config.t val worktree_mutex : Eio.Mutex.t val hook_mutex : Eio.Mutex.t end`.
- Register `run_env` in lib/dune's modules list.
- Rewrite Worktree_setup.ENV as `module type ENV = Run_env.S` (signature equivalence — Worktree_setup.Make(W)(Env : ENV) callers do not change).
- Rewrite Session_driver.ENV as `module type ENV = sig include Run_env.S val owner : string val repo : string val transcripts : (Types.Patch_id.t, string) Stdlib.Hashtbl.t end`.
- Build with dune and run dune runtest to confirm no regression — both downstream Make functors compile against the new ENV.

## Changes
- Create lib/run_env.mli and lib/run_env.ml exposing `module type S = sig val runtime : Runtime.t val clock : float Eio.Time.clock_ty Eio.Time.clock val fs : Eio.Fs.dir_ty Eio.Path.t val project_name : string val user_config : User_config.t val worktree_mutex : Eio.Mutex.t val hook_mutex : Eio.Mutex.t end`.
- Register `run_env` in lib/dune's modules list.
- Rewrite Worktree_setup.ENV as `module type ENV = Run_env.S` (signature equivalence — Worktree_setup.Make(W)(Env : ENV) callers do not change).
- Rewrite Session_driver.ENV as `module type ENV = sig include Run_env.S val owner : string val repo : string val transcripts : (Types.Patch_id.t, string) Stdlib.Hashtbl.t end`.
- Build with dune and run dune runtest to confirm no regression — both downstream Make functors compile against the new ENV.

## Files to Modify
- lib/run_env.mli (create): Define module type S with the seven shared run-level capabilities.
- lib/run_env.ml (create): Module type-only file: contains `module type S = sig ... end`.
- lib/dune (modify): Register run_env among library modules.
- lib/worktree_setup.mli (modify): Replace inline ENV with `module type ENV = Run_env.S`.
- lib/worktree_setup.ml (modify): Update ENV reference in Make functor to use Run_env.S.
- lib/session_driver.mli (modify): ENV becomes `sig include Run_env.S val owner : string val repo : string val transcripts : ... end`.
- lib/session_driver.ml (modify): Update ENV reference in Make functor to use the include form.

## Gameplan Specification

```
module EXTRACT_BIN_FIBERS.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> After this gameplan, bin/main.ml contains only command-line
> parsing, config resolution, capability construction, and the
> assembly of fiber modules. Every fiber body lives behind a .mli
> in lib. Run-level capabilities flow through a shared Run_env
> signature, not as positional arguments.

Fiber.
poller => Fiber.
runner => Fiber.
tui => Fiber.
input => Fiber.
headless => Fiber.
persistence => Fiber.

in-lib? f: Fiber => Bool.
in-bin? f: Fiber => Bool.

Capability.
runtime => Capability.
clock => Capability.
fs => Capability.
project-name => Capability.
user-config => Capability.
worktree-mutex => Capability.
hook-mutex => Capability.

run-env-captures? c: Capability => Bool.

ResolvedConfig.
project-name-is-string? rc: ResolvedConfig => Bool.
assert-false-removed? => Bool.

bin-main-line-count => Nat0.
runner-fiber-line-count => Nat0.
---
> Every fiber body lives in lib, not in bin.
all f: Fiber | in-lib? f.
all f: Fiber | ~ (in-bin? f).

> Every shared run-level capability is captured by Run_env.
all c: Capability | run-env-captures? c.

> Resolved_config.t has project_name : string; the assert-false is gone.
all rc: ResolvedConfig | project-name-is-string? rc.
assert-false-removed?.

> Size invariants: the binary is small enough to read as wiring.
bin-main-line-count < 1500.
runner-fiber-line-count < 500.

where

> ══════════════════════════════════════════
> SUPPORTING EXTRACTIONS
> ══════════════════════════════════════════
> Three runner helpers, the managed-repo plumbing, the prune
> subcommand, the TUI view-model record, and the resolved-config
> type are all exposed from lib with .mli boundaries.

Helper.
managed-repo => Helper.
prune-runner => Helper.
tui-state => Helper.
long-lived-sessions => Helper.
busy-guard => Helper.
worktree-plan-executor => Helper.
resolved-config => Helper.

helper-in-lib? h: Helper => Bool.
---
all h: Helper | helper-in-lib? h.

```

## Patch Specification

```
module EXTRACT_BIN_FIBERS_PATCH_1.

> Patch 1 introduces the shared Run_env capability signature.
> Worktree_setup.ENV and Session_driver.ENV reuse it via include.

Capability.
runtime => Capability.
clock => Capability.
fs => Capability.
project-name => Capability.
user-config => Capability.
worktree-mutex => Capability.
hook-mutex => Capability.

shared? c: Capability => Bool.
run-env-captures? c: Capability => Bool.
---
> Every shared capability is captured by Run_env.
all c: Capability, shared? c | run-env-captures? c.

```


## Implementation Notes

- `lib/dune` did not need an explicit edit beyond adding the new files: the library already uses `(modules :standard)`, so `Run_env` is picked up automatically. I left the stanza semantically unchanged rather than hard-coding a module list just to satisfy the patch text.
- `Worktree_setup.ENV` is now a direct alias to `Run_env.S`, while `Session_driver.ENV` uses `include Run_env.S` plus its three extra fields. That keeps `Worktree_setup` strictly signature-equivalent and lets `Session_driver` state the shared bundle once without changing any call sites.
- No downstream instantiations needed edits. The existing functor applications already supplied the shared seven values, so this patch stays structural and keeps the public surface stable.
- Spec/Evidence Mapping:
  - Shared capability bundle captured by `Run_env`: [`lib/run_env.mli`](/Users/zax/worktrees/extract-bin-fibers/patch-1/lib/run_env.mli:2) and [`lib/run_env.ml`](/Users/zax/worktrees/extract-bin-fibers/patch-1/lib/run_env.ml:1). Context consulted: `lib/worktree_setup.mli`, `lib/session_driver.mli`, `lib/dune`.
  - `Worktree_setup.ENV` reuses the shared signature: [`lib/worktree_setup.mli`](/Users/zax/worktrees/extract-bin-fibers/patch-1/lib/worktree_setup.mli:9), [`lib/worktree_setup.ml`](/Users/zax/worktrees/extract-bin-fibers/patch-1/lib/worktree_setup.ml:3). Proof: `dune build` and the existing narrowing test output in `dune runtest` (`Worktree_setup.Make(W)(Env).ensure_worktree narrowed signature: OK`).
  - `Session_driver.ENV` reuses the shared signature plus local extras: [`lib/session_driver.mli`](/Users/zax/worktrees/extract-bin-fibers/patch-1/lib/session_driver.mli:15), [`lib/session_driver.ml`](/Users/zax/worktrees/extract-bin-fibers/patch-1/lib/session_driver.ml:128). Proof: `dune build` and the existing narrowing test output in `dune runtest` (`Session_driver.Make(W)(Env).run narrowed signature: OK`, `run_long_lived narrowed signature: OK`).