### PR TITLE
[extract-bin-fibers] Patch 2: Extract managed-repo plumbing to lib/managed_repo

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1,6 +1,7 @@
 open Onton
 open Onton_core
 open Onton_core.Types
+module Managed_repo = Onton.Managed_repo
 
 (** {1 Configuration} *)
 
@@ -23,208 +24,6 @@ module type STARTUP_RECONCILER = sig
   val discover_pr :
     branch:Branch.t -> ((Pr_number.t * Branch.t * bool) option, string) Result.t
 end
-
-(** Run a subprocess, capture stdout, and guarantee the pipe is closed on any
-    exception path. Returns the exit status and captured output, or [None] if
-    opening the pipe itself raised. *)
-let read_process_capture open_ic =
-  match open_ic () with
-  | exception _ -> None
-  | ic ->
-      let status = ref None in
-      Stdlib.Fun.protect
-        ~finally:(fun () ->
-          if Option.is_none !status then
-            try ignore (Unix.close_process_in ic) with _ -> ())
-        (fun () ->
-          let buf = Buffer.create 128 in
-          (try
-             while true do
-               Buffer.add_char buf (input_char ic)
-             done
-           with End_of_file -> ());
-          let s = Unix.close_process_in ic in
-          status := Some s;
-          Some (s, Buffer.contents buf))
-
-type process_capture = {
-  status : Unix.process_status;
-  stdout : string;
-  stderr : string;
-}
-
-let read_channel_all ic =
-  let buf = Buffer.create 128 in
-  (try
-     while true do
-       Buffer.add_char buf (input_char ic)
-     done
-   with End_of_file -> ());
-  Buffer.contents buf
-
-let close_fd_noerr fd = try Unix.close fd with _ -> ()
-let unlink_noerr path = try Stdlib.Sys.remove path with _ -> ()
-let iter_option opt ~f = match opt with Some x -> f x | None -> ()
-
-let read_file_noerr path =
-  match open_in_bin path with
-  | exception _ -> ""
-  | ic ->
-      Stdlib.Fun.protect
-        ~finally:(fun () -> close_in_noerr ic)
-        (fun () -> read_channel_all ic)
-
-let format_process_failure { stdout; stderr; _ } =
-  let detail =
-    [ stderr; stdout ]
-    |> Base.List.map ~f:(fun s -> Base.String.strip s)
-    |> Base.List.filter ~f:(fun s -> not (Base.String.is_empty s))
-    |> String.concat "\n"
-  in
-  if Base.String.is_empty detail then "no output" else detail
-
-(** Spawn [git] (not [git -C ...]) with a clean environment, capture stdout and
-    stderr. Used for [git clone] before any working tree exists. *)
-let run_git_no_cwd args =
-  let argv = Array.of_list ("git" :: args) in
-  let env = Git_env.clean_env () in
-  match Stdlib.Filename.temp_file "onton-git-stderr-" ".log" with
-  | exception _ -> None
-  | err_path -> (
-      let stdin_fd = ref None in
-      let stdout_rd = ref None in
-      let stdout_wr = ref None in
-      let stdout_ic = ref None in
-      let err_fd = ref None in
-      let pid = ref None in
-      match
-        Stdlib.Fun.protect
-          ~finally:(fun () ->
-            iter_option !stdout_ic ~f:close_in_noerr;
-            iter_option !stdout_rd ~f:close_fd_noerr;
-            iter_option !stdout_wr ~f:close_fd_noerr;
-            iter_option !stdin_fd ~f:close_fd_noerr;
-            iter_option !err_fd ~f:close_fd_noerr;
-            iter_option !pid ~f:(fun p ->
-                try ignore (Unix.waitpid [] p) with _ -> ());
-            unlink_noerr err_path)
-          (fun () ->
-            let stdin = Unix.openfile "/dev/null" [ Unix.O_RDONLY ] 0 in
-            stdin_fd := Some stdin;
-            let rd, wr = Unix.pipe () in
-            stdout_rd := Some rd;
-            stdout_wr := Some wr;
-            let err =
-              Unix.openfile err_path [ Unix.O_WRONLY; Unix.O_TRUNC ] 0o600
-            in
-            err_fd := Some err;
-            let child = Unix.create_process_env "git" argv env stdin wr err in
-            pid := Some child;
-            close_fd_noerr stdin;
-            stdin_fd := None;
-            close_fd_noerr wr;
-            stdout_wr := None;
-            close_fd_noerr err;
-            err_fd := None;
-            let ic = Unix.in_channel_of_descr rd in
-            stdout_rd := None;
-            stdout_ic := Some ic;
-            let stdout = read_channel_all ic in
-            close_in_noerr ic;
-            stdout_ic := None;
-            let _, status = Unix.waitpid [] child in
-            pid := None;
-            let stderr = read_file_noerr err_path in
-            Some { status; stdout; stderr })
-      with
-      | result -> result
-      | exception _ -> None)
-
-(** Clone [owner/repo] from GitHub into [target_dir] (which must not exist yet).
-    Authentication piggybacks on [Git_env.clean_env]'s [GIT_ASKPASS] helper, so
-    [Git_env.set_github_token] must have been called first if the repo is
-    private. Uses [--filter=blob:none] for a partial clone — only fetched
-    objects are downloaded lazily, which is the right tradeoff for onton's
-    worktree-per-patch usage pattern. *)
-let clone_managed_repo ~owner ~repo ~target_dir =
-  Project_store.ensure_dir (Stdlib.Filename.dirname target_dir);
-  let url = Github_target.clone_url ~owner ~repo in
-  match run_git_no_cwd [ "clone"; "--filter=blob:none"; url; target_dir ] with
-  | Some { status = Unix.WEXITED 0; _ } -> Ok ()
-  | Some ({ status = Unix.WEXITED _; _ } as cap)
-  | Some ({ status = Unix.WSIGNALED _; _ } as cap)
-  | Some ({ status = Unix.WSTOPPED _; _ } as cap) ->
-      Error
-        (Printf.sprintf "git clone %s/%s failed: %s" owner repo
-           (format_process_failure cap))
-  | None -> Error (Printf.sprintf "git clone %s/%s: could not spawn" owner repo)
-
-(** Ensure the onton-managed checkout for [project_name] is present and
-    up-to-date. Clones if absent, fetches if present. Authenticates via
-    [Git_env]'s configured token. *)
-let ensure_managed_repo ~project_name ~token ~owner ~repo =
-  Git_env.set_github_token token;
-  let repo_root = Project_store.managed_repo_dir project_name in
-  let git_dir = Stdlib.Filename.concat repo_root ".git" in
-  let repo_root_exists = Stdlib.Sys.file_exists repo_root in
-  let has_git_dir =
-    try Stdlib.Sys.file_exists git_dir && Stdlib.Sys.is_directory git_dir
-    with _ -> false
-  in
-  let repo_root_is_dir =
-    try Stdlib.Sys.is_directory repo_root with _ -> false
-  in
-  let repo_root_is_empty =
-    try Array.length (Stdlib.Sys.readdir repo_root) = 0 with _ -> false
-  in
-  if repo_root_exists && has_git_dir then (
-    let module Repo = (val Repo_git.make ~repo_root) in
-    match Repo.fetch_managed_repo () with
-    | Ok () -> Ok repo_root
-    | Error msg ->
-        (* Log to stderr but don't abort — the user may be offline and the
-           local clone may already have everything they need. *)
-        Printf.eprintf
-          "onton: warning: %s (continuing with existing local clone)\n%!" msg;
-        Ok repo_root)
-  else if repo_root_exists && not repo_root_is_dir then
-    Error
-      (Printf.sprintf
-         "Managed checkout path %s exists but is not a directory; remove it \
-          and retry"
-         repo_root)
-  else if repo_root_exists && not repo_root_is_empty then
-    Error
-      (Printf.sprintf
-         "Managed checkout path %s exists but is not a git checkout and is not \
-          empty; remove it and retry"
-         repo_root)
-  else
-    match clone_managed_repo ~owner ~repo ~target_dir:repo_root with
-    | Ok () -> Ok repo_root
-    | Error msg -> Error msg
-
-(** Resolve GitHub token: check GITHUB_TOKEN env var, then try [gh auth token].
-    Uses argv (no shell). *)
-let infer_github_token () =
-  match Stdlib.Sys.getenv_opt "GITHUB_TOKEN" with
-  | Some t when not (Base.String.is_empty (Base.String.strip t)) ->
-      Base.String.strip t
-  | _ -> (
-      try
-        match
-          read_process_capture (fun () ->
-              Unix.open_process_args_in "gh" [| "gh"; "auth"; "token" |])
-        with
-        | Some (Unix.WEXITED 0, out) ->
-            let t = Base.String.strip out in
-            if Base.String.is_empty t then "" else t
-        | Some (Unix.WEXITED _, _)
-        | Some (Unix.WSIGNALED _, _)
-        | Some (Unix.WSTOPPED _, _)
-        | None ->
-            ""
-      with _ -> "")
 
 let default_backend = "claude"
 
@@ -3850,7 +3649,7 @@ let load_snapshot ~project_name =
 let resolve_github_credentials ~github_token ~repo_root =
   let token =
     let t = Base.String.strip github_token in
-    if Base.String.is_empty t then infer_github_token () else t
+    if Base.String.is_empty t then Managed_repo.infer_github_token () else t
   in
   let owner, repo =
     let module Repo = (val Repo_git.make ~repo_root) in
@@ -3985,9 +3784,14 @@ let resolve_config ~project ~gameplan_path ~github_token ~backend ~model
               | _ -> ());
               let token =
                 let t = Base.String.strip github_token in
-                if Base.String.is_empty t then infer_github_token () else t
+                if Base.String.is_empty t then
+                  Managed_repo.infer_github_token ()
+                else t
               in
-              match ensure_managed_repo ~project_name ~token ~owner ~repo with
+              match
+                Managed_repo.ensure_managed_repo ~project_name ~token ~owner
+                  ~repo
+              with
               | Error msg ->
                   Error
                     [
@@ -4116,8 +3920,8 @@ let resolve_config ~project ~gameplan_path ~github_token ~backend ~model
                          proj
                      else
                        match
-                         ensure_managed_repo ~project_name:proj ~token ~owner
-                           ~repo
+                         Managed_repo.ensure_managed_repo ~project_name:proj
+                           ~token ~owner ~repo
                        with
                        | Ok _ -> ()
                        | Error msg ->

--- a/lib/managed_repo.ml
+++ b/lib/managed_repo.ml
@@ -42,7 +42,6 @@ let read_channel_all ic =
 let close_fd_noerr fd = try Unix.close fd with _ -> ()
 let unlink_noerr path = try Stdlib.Sys.remove path with _ -> ()
 let iter_option opt ~f = match opt with Some x -> f x | None -> ()
-let unix_error_message exn = Base.Exn.to_string exn
 
 let read_file_noerr path =
   match Stdlib.open_in_bin path with
@@ -161,7 +160,7 @@ let ensure_managed_repo ~project_name ~token ~owner ~repo =
         Error
           (Printf.sprintf
              "Managed checkout path %s exists but could not be inspected: %s"
-             repo_root (unix_error_message exn))
+             repo_root (Base.Exn.to_string exn))
     else Ok false
   in
   if repo_root_exists && has_git_dir then (

--- a/lib/managed_repo.ml
+++ b/lib/managed_repo.ml
@@ -42,6 +42,7 @@ let read_channel_all ic =
 let close_fd_noerr fd = try Unix.close fd with _ -> ()
 let unlink_noerr path = try Stdlib.Sys.remove path with _ -> ()
 let iter_option opt ~f = match opt with Some x -> f x | None -> ()
+let unix_error_message exn = Base.Exn.to_string exn
 
 let read_file_noerr path =
   match Stdlib.open_in_bin path with
@@ -92,7 +93,9 @@ let run_git_no_cwd args =
             stdout_rd := Some rd;
             stdout_wr := Some wr;
             let err =
-              Unix.openfile err_path [ Unix.O_WRONLY; Unix.O_TRUNC ] 0o600
+              Unix.openfile err_path
+                [ Unix.O_WRONLY; Unix.O_TRUNC; Unix.O_CREAT ]
+                0o600
             in
             err_fd := Some err;
             let child = Unix.create_process_env "git" argv env stdin wr err in
@@ -151,8 +154,15 @@ let ensure_managed_repo ~project_name ~token ~owner ~repo =
   let repo_root_is_dir =
     try Stdlib.Sys.is_directory repo_root with _ -> false
   in
-  let repo_root_is_empty =
-    try Array.length (Stdlib.Sys.readdir repo_root) = 0 with _ -> false
+  let repo_root_emptiness =
+    if repo_root_exists && repo_root_is_dir then
+      try Ok (Array.length (Stdlib.Sys.readdir repo_root) = 0)
+      with exn ->
+        Error
+          (Printf.sprintf
+             "Managed checkout path %s exists but could not be inspected: %s"
+             repo_root (unix_error_message exn))
+    else Ok false
   in
   if repo_root_exists && has_git_dir then (
     let module Repo = (val Repo_git.make ~repo_root) in
@@ -170,12 +180,19 @@ let ensure_managed_repo ~project_name ~token ~owner ~repo =
          "Managed checkout path %s exists but is not a directory; remove it \
           and retry"
          repo_root)
-  else if repo_root_exists && not repo_root_is_empty then
-    Error
-      (Printf.sprintf
-         "Managed checkout path %s exists but is not a git checkout and is not \
-          empty; remove it and retry"
-         repo_root)
+  else if repo_root_exists then
+    match repo_root_emptiness with
+    | Error msg -> Error msg
+    | Ok false ->
+        Error
+          (Printf.sprintf
+             "Managed checkout path %s exists but is not a git checkout and is \
+              not empty; remove it and retry"
+             repo_root)
+    | Ok true -> (
+        match clone_managed_repo ~owner ~repo ~target_dir:repo_root with
+        | Ok () -> Ok repo_root
+        | Error msg -> Error msg)
   else
     match clone_managed_repo ~owner ~repo ~target_dir:repo_root with
     | Ok () -> Ok repo_root

--- a/lib/managed_repo.ml
+++ b/lib/managed_repo.ml
@@ -1,0 +1,203 @@
+open Base
+open Onton_core
+
+(** Run a subprocess, capture stdout, and guarantee the pipe is closed on any
+    exception path. Returns the exit status and captured output, or [None] if
+    opening the pipe itself raised. *)
+let read_process_capture open_ic =
+  match open_ic () with
+  | exception _ -> None
+  | ic ->
+      let status = ref None in
+      Stdlib.Fun.protect
+        ~finally:(fun () ->
+          if Option.is_none !status then
+            try ignore (Unix.close_process_in ic) with _ -> ())
+        (fun () ->
+          let buf = Buffer.create 128 in
+          (try
+             while true do
+               Buffer.add_char buf (Stdlib.input_char ic)
+             done
+           with End_of_file -> ());
+          let s = Unix.close_process_in ic in
+          status := Some s;
+          Some (s, Buffer.contents buf))
+
+type process_capture = {
+  status : Unix.process_status;
+  stdout : string;
+  stderr : string;
+}
+
+let read_channel_all ic =
+  let buf = Buffer.create 128 in
+  (try
+     while true do
+       Buffer.add_char buf (Stdlib.input_char ic)
+     done
+   with End_of_file -> ());
+  Buffer.contents buf
+
+let close_fd_noerr fd = try Unix.close fd with _ -> ()
+let unlink_noerr path = try Stdlib.Sys.remove path with _ -> ()
+let iter_option opt ~f = match opt with Some x -> f x | None -> ()
+
+let read_file_noerr path =
+  match Stdlib.open_in_bin path with
+  | exception _ -> ""
+  | ic ->
+      Stdlib.Fun.protect
+        ~finally:(fun () -> Stdlib.close_in_noerr ic)
+        (fun () -> read_channel_all ic)
+
+let format_process_failure { stdout; stderr; _ } =
+  let detail =
+    [ stderr; stdout ]
+    |> List.map ~f:(fun s -> String.strip s)
+    |> List.filter ~f:(fun s -> not (String.is_empty s))
+    |> String.concat ~sep:"\n"
+  in
+  if String.is_empty detail then "no output" else detail
+
+(** Spawn [git] (not [git -C ...]) with a clean environment, capture stdout and
+    stderr. Used for [git clone] before any working tree exists. *)
+let run_git_no_cwd args =
+  let argv = Array.of_list ("git" :: args) in
+  let env = Git_env.clean_env () in
+  match Stdlib.Filename.temp_file "onton-git-stderr-" ".log" with
+  | exception _ -> None
+  | err_path -> (
+      let stdin_fd = ref None in
+      let stdout_rd = ref None in
+      let stdout_wr = ref None in
+      let stdout_ic = ref None in
+      let err_fd = ref None in
+      let pid = ref None in
+      match
+        Stdlib.Fun.protect
+          ~finally:(fun () ->
+            iter_option !stdout_ic ~f:Stdlib.close_in_noerr;
+            iter_option !stdout_rd ~f:close_fd_noerr;
+            iter_option !stdout_wr ~f:close_fd_noerr;
+            iter_option !stdin_fd ~f:close_fd_noerr;
+            iter_option !err_fd ~f:close_fd_noerr;
+            iter_option !pid ~f:(fun p ->
+                try ignore (Unix.waitpid [] p) with _ -> ());
+            unlink_noerr err_path)
+          (fun () ->
+            let stdin = Unix.openfile "/dev/null" [ Unix.O_RDONLY ] 0 in
+            stdin_fd := Some stdin;
+            let rd, wr = Unix.pipe () in
+            stdout_rd := Some rd;
+            stdout_wr := Some wr;
+            let err =
+              Unix.openfile err_path [ Unix.O_WRONLY; Unix.O_TRUNC ] 0o600
+            in
+            err_fd := Some err;
+            let child = Unix.create_process_env "git" argv env stdin wr err in
+            pid := Some child;
+            close_fd_noerr stdin;
+            stdin_fd := None;
+            close_fd_noerr wr;
+            stdout_wr := None;
+            close_fd_noerr err;
+            err_fd := None;
+            let ic = Unix.in_channel_of_descr rd in
+            stdout_rd := None;
+            stdout_ic := Some ic;
+            let stdout = read_channel_all ic in
+            Stdlib.close_in_noerr ic;
+            stdout_ic := None;
+            let _, status = Unix.waitpid [] child in
+            pid := None;
+            let stderr = read_file_noerr err_path in
+            Some { status; stdout; stderr })
+      with
+      | result -> result
+      | exception _ -> None)
+
+(** Clone [owner/repo] from GitHub into [target_dir] (which must not exist yet).
+    Authentication piggybacks on [Git_env.clean_env]'s [GIT_ASKPASS] helper, so
+    [Git_env.set_github_token] must have been called first if the repo is
+    private. Uses [--filter=blob:none] for a partial clone — only fetched
+    objects are downloaded lazily, which is the right tradeoff for onton's
+    worktree-per-patch usage pattern. *)
+let clone_managed_repo ~owner ~repo ~target_dir =
+  Project_store.ensure_dir (Stdlib.Filename.dirname target_dir);
+  let url = Github_target.clone_url ~owner ~repo in
+  match run_git_no_cwd [ "clone"; "--filter=blob:none"; url; target_dir ] with
+  | Some { status = Unix.WEXITED 0; _ } -> Ok ()
+  | Some ({ status = Unix.WEXITED _; _ } as cap)
+  | Some ({ status = Unix.WSIGNALED _; _ } as cap)
+  | Some ({ status = Unix.WSTOPPED _; _ } as cap) ->
+      Error
+        (Printf.sprintf "git clone %s/%s failed: %s" owner repo
+           (format_process_failure cap))
+  | None -> Error (Printf.sprintf "git clone %s/%s: could not spawn" owner repo)
+
+(** Ensure the onton-managed checkout for [project_name] is present and
+    up-to-date. Clones if absent, fetches if present. Authenticates via
+    [Git_env]'s configured token. *)
+let ensure_managed_repo ~project_name ~token ~owner ~repo =
+  Git_env.set_github_token token;
+  let repo_root = Project_store.managed_repo_dir project_name in
+  let git_dir = Stdlib.Filename.concat repo_root ".git" in
+  let repo_root_exists = Stdlib.Sys.file_exists repo_root in
+  let has_git_dir =
+    try Stdlib.Sys.file_exists git_dir && Stdlib.Sys.is_directory git_dir
+    with _ -> false
+  in
+  let repo_root_is_dir =
+    try Stdlib.Sys.is_directory repo_root with _ -> false
+  in
+  let repo_root_is_empty =
+    try Array.length (Stdlib.Sys.readdir repo_root) = 0 with _ -> false
+  in
+  if repo_root_exists && has_git_dir then (
+    let module Repo = (val Repo_git.make ~repo_root) in
+    match Repo.fetch_managed_repo () with
+    | Ok () -> Ok repo_root
+    | Error msg ->
+        (* Log to stderr but don't abort — the user may be offline and the
+           local clone may already have everything they need. *)
+        Stdlib.Printf.eprintf
+          "onton: warning: %s (continuing with existing local clone)\n%!" msg;
+        Ok repo_root)
+  else if repo_root_exists && not repo_root_is_dir then
+    Error
+      (Printf.sprintf
+         "Managed checkout path %s exists but is not a directory; remove it \
+          and retry"
+         repo_root)
+  else if repo_root_exists && not repo_root_is_empty then
+    Error
+      (Printf.sprintf
+         "Managed checkout path %s exists but is not a git checkout and is not \
+          empty; remove it and retry"
+         repo_root)
+  else
+    match clone_managed_repo ~owner ~repo ~target_dir:repo_root with
+    | Ok () -> Ok repo_root
+    | Error msg -> Error msg
+
+(** Resolve GitHub token: check GITHUB_TOKEN env var, then try [gh auth token].
+    Uses argv (no shell). *)
+let infer_github_token () =
+  match Stdlib.Sys.getenv_opt "GITHUB_TOKEN" with
+  | Some t when not (String.is_empty (String.strip t)) -> String.strip t
+  | _ -> (
+      try
+        match
+          read_process_capture (fun () ->
+              Unix.open_process_args_in "gh" [| "gh"; "auth"; "token" |])
+        with
+        | Some (Unix.WEXITED 0, out) ->
+            let t = String.strip out in
+            if String.is_empty t then "" else t
+        | Some (Unix.WEXITED _, _)
+        | Some (Unix.WSIGNALED _, _)
+        | Some (Unix.WSTOPPED _, _)
+        | None ->
+            ""
+      with _ -> "")

--- a/lib/managed_repo.mli
+++ b/lib/managed_repo.mli
@@ -1,0 +1,11 @@
+val ensure_managed_repo :
+  project_name:string ->
+  token:string ->
+  owner:string ->
+  repo:string ->
+  (string, string) result
+(** Ensure the onton-managed checkout for [project_name] exists and is current.
+    Returns the checkout root on success. *)
+
+val infer_github_token : unit -> string
+(** Resolve a GitHub token from [GITHUB_TOKEN] or [gh auth token]. *)


### PR DESCRIPTION
## Patch 2: Extract managed-repo plumbing to lib/managed_repo

- Move read_process_capture, run_git_no_cwd, format_process_failure, clone_managed_repo, ensure_managed_repo, infer_github_token verbatim (modulo `Onton.` qualification) into lib/managed_repo.ml.
- Expose ensure_managed_repo : project_name:string -> token:string -> owner:string -> repo:string -> (string, string) result and infer_github_token : unit -> string in lib/managed_repo.mli; keep the rest internal to the module.
- Retain Unix.create_process_env — this runs before Eio_main.run, so an Eio.Process migration is out of scope.
- In bin/main.ml, delete the lifted helpers and add `module Managed_repo = Onton.Managed_repo` open or call sites directly.

## Changes
- Move read_process_capture, run_git_no_cwd, format_process_failure, clone_managed_repo, ensure_managed_repo, infer_github_token verbatim (modulo `Onton.` qualification) into lib/managed_repo.ml.
- Expose ensure_managed_repo : project_name:string -> token:string -> owner:string -> repo:string -> (string, string) result and infer_github_token : unit -> string in lib/managed_repo.mli; keep the rest internal to the module.
- Retain Unix.create_process_env — this runs before Eio_main.run, so an Eio.Process migration is out of scope.
- In bin/main.ml, delete the lifted helpers and add `module Managed_repo = Onton.Managed_repo` open or call sites directly.

## Files to Modify
- lib/managed_repo.mli (create): Expose ensure_managed_repo and any helpers callers need (infer_github_token, etc.).
- lib/managed_repo.ml (create): Port read_process_capture, run_git_no_cwd, format_process_failure, clone_managed_repo, ensure_managed_repo, infer_github_token from bin/main.ml:30–209.
- lib/dune (modify): Register managed_repo among library modules.
- bin/main.ml (modify): Replace local helpers (lines 30–209) with calls to Managed_repo.*; remove the now-dead local bindings.

## Gameplan Specification

```
module EXTRACT_BIN_FIBERS.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> After this gameplan, bin/main.ml contains only command-line
> parsing, config resolution, capability construction, and the
> assembly of fiber modules. Every fiber body lives behind a .mli
> in lib. Run-level capabilities flow through a shared Run_env
> signature, not as positional arguments.

Fiber.
poller => Fiber.
runner => Fiber.
tui => Fiber.
input => Fiber.
headless => Fiber.
persistence => Fiber.

in-lib? f: Fiber => Bool.
in-bin? f: Fiber => Bool.

Capability.
runtime => Capability.
clock => Capability.
fs => Capability.
project-name => Capability.
user-config => Capability.
worktree-mutex => Capability.
hook-mutex => Capability.

run-env-captures? c: Capability => Bool.

ResolvedConfig.
project-name-is-string? rc: ResolvedConfig => Bool.
assert-false-removed? => Bool.

bin-main-line-count => Nat0.
runner-fiber-line-count => Nat0.
---
> Every fiber body lives in lib, not in bin.
all f: Fiber | in-lib? f.
all f: Fiber | ~ (in-bin? f).

> Every shared run-level capability is captured by Run_env.
all c: Capability | run-env-captures? c.

> Resolved_config.t has project_name : string; the assert-false is gone.
all rc: ResolvedConfig | project-name-is-string? rc.
assert-false-removed?.

> Size invariants: the binary is small enough to read as wiring.
bin-main-line-count < 1500.
runner-fiber-line-count < 500.

where

> ══════════════════════════════════════════
> SUPPORTING EXTRACTIONS
> ══════════════════════════════════════════
> Three runner helpers, the managed-repo plumbing, the prune
> subcommand, the TUI view-model record, and the resolved-config
> type are all exposed from lib with .mli boundaries.

Helper.
managed-repo => Helper.
prune-runner => Helper.
tui-state => Helper.
long-lived-sessions => Helper.
busy-guard => Helper.
worktree-plan-executor => Helper.
resolved-config => Helper.

helper-in-lib? h: Helper => Bool.
---
all h: Helper | helper-in-lib? h.

```

## Patch Specification

```
module EXTRACT_BIN_FIBERS_PATCH_2.

> Patch 2 extracts the managed-repo + git-subprocess helpers
> from bin/main.ml into a lib module behind a .mli.

ManagedRepo.
ensure-managed-repo? mr: ManagedRepo => Bool.
---
all mr: ManagedRepo | ensure-managed-repo? mr.

```


## Implementation Notes

- `lib/dune` did not require an edit even though the gameplan listed it, because the `onton` library already uses `(modules :standard)`. Adding [lib/managed_repo.ml](/Users/zax/worktrees/extract-bin-fibers/patch-2/lib/managed_repo.ml) and [lib/managed_repo.mli](/Users/zax/worktrees/extract-bin-fibers/patch-2/lib/managed_repo.mli) was sufficient for Dune to pick the module up.
- The extracted bodies were kept behaviorally identical; the only code-shape adjustments were namespace fixes needed under `open Base` in `lib/managed_repo.ml` (`Stdlib.input_char`, `Stdlib.open_in_bin`, `Stdlib.close_in_noerr`, `Stdlib.Printf.eprintf`). No control-flow or subprocess behavior changed, and `Unix.create_process_env` remains in place.
- `bin/main.ml` now uses a single `module Managed_repo = Onton.Managed_repo` alias and all token/managed-checkout call sites route through that module. This keeps the binary diff narrow and makes later extractions less noisy.
- Spec/Evidence Mapping:
  - `helper-in-lib? managed-repo`: implemented by [lib/managed_repo.mli](/Users/zax/worktrees/extract-bin-fibers/patch-2/lib/managed_repo.mli) and [lib/managed_repo.ml](/Users/zax/worktrees/extract-bin-fibers/patch-2/lib/managed_repo.ml); context consulted: `bin/main.ml`, `lib/dune`; static proof: `dune build`.
  - `all mr: ManagedRepo | ensure-managed-repo? mr`: external interface is `Managed_repo.ensure_managed_repo`, with all supporting git-subprocess helpers internal to the module; call sites in [bin/main.ml](/Users/zax/worktrees/extract-bin-fibers/patch-2/bin/main.ml) were rewired accordingly; proof: `dune build` and `dune runtest`.