### PR TITLE
[extract-bin-fibers] Patch 3: Extract prune logic to lib/prune_runner

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -296,13 +296,6 @@ module Pr_registry = struct
         Hashtbl.remove t.table patch_id)
 end
 
-(** Pluralize a count for inline rendering: [pluralize 1 "comment"] →
-    ["1 comment"], [pluralize 2 "comment"] → ["2 comments"]. Pass [~plural] when
-    the plural is irregular. *)
-let pluralize ?plural n singular =
-  let many = match plural with Some p -> p | None -> singular ^ "s" in
-  Printf.sprintf "%d %s" n (if n = 1 then singular else many)
-
 let build_branch_map (gameplan : Gameplan.t) ~default =
   let map =
     Base.List.fold gameplan.Gameplan.patches
@@ -4540,144 +4533,6 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
     Skips any project whose lock is held by a live process — pruning state out
     from under a running [onton] would invalidate its in-memory view. *)
 
-let rec remove_path path =
-  match Unix.lstat path with
-  | exception Unix.Unix_error (Unix.ENOENT, _, _) -> ()
-  | { Unix.st_kind = Unix.S_DIR; _ } -> (
-      let entries = Stdlib.Sys.readdir path in
-      Array.iter
-        (fun name -> remove_path (Stdlib.Filename.concat path name))
-        entries;
-      try Unix.rmdir path with Unix.Unix_error (Unix.ENOENT, _, _) -> ())
-  | {
-   Unix.st_kind =
-     ( Unix.S_REG | Unix.S_LNK | Unix.S_CHR | Unix.S_BLK | Unix.S_FIFO
-     | Unix.S_SOCK );
-   _;
-  } -> (
-      try Stdlib.Sys.remove path with Sys_error _ -> ())
-
-type prune_status =
-  | All_merged
-  | Not_merged
-  | No_patches
-  | No_snapshot
-  | Load_error of string
-
-let classify_project ~slug =
-  let snap_path = Project_store.snapshot_path slug in
-  if not (Stdlib.Sys.file_exists snap_path) then No_snapshot
-  else
-    match Persistence.load ~path:snap_path with
-    | Error msg -> Load_error msg
-    | Ok snap -> (
-        let agents = Orchestrator.agents_map snap.Runtime.orchestrator in
-        let patches = snap.Runtime.gameplan.Gameplan.patches in
-        match Prune_decision.classify_snapshot ~patches ~agents with
-        | Prune_decision.All_merged -> All_merged
-        | Prune_decision.Not_merged -> Not_merged
-        | Prune_decision.No_patches -> No_patches)
-
-let worktree_root_for ~project_name =
-  let home =
-    match Stdlib.Sys.getenv_opt "HOME" with Some h -> h | None -> "."
-  in
-  Stdlib.Filename.concat home (Stdlib.Filename.concat "worktrees" project_name)
-
-(** Stored config records the gameplan-provided [project_name] verbatim, which
-    is what worktrees are keyed by under [~/worktrees/]. The data dir is keyed
-    by slug, so the worktree hint requires reading the config to recover the
-    original name — falling back to the slug if config is unreadable. *)
-let recover_project_name ~slug =
-  match Project_store.load_config ~project_name:slug with
-  | Ok cfg -> cfg.Project_store.project_name
-  | Error _ -> slug
-
-let run_prune () =
-  let slugs = Project_store.list_projects () in
-  if Base.List.is_empty slugs then (
-    Printf.printf "No stored projects to consider.\n";
-    Stdlib.exit 0);
-  let removed = ref [] in
-  let kept = ref [] in
-  let errors = ref [] in
-  Base.List.iter slugs ~f:(fun slug ->
-      (* [list_projects] returns slugs (already valid path components); the
-         data dir is keyed by slug and slugifying a slug is a no-op, so passing
-         the slug back through [project_dir] is correct. The recovered
-         [project_name] is only used for reporting and the worktree hint. *)
-      let project_dir = Project_store.project_dir slug in
-      let acquired =
-        Project_lock.acquire ~project_dir ~on_stale:(fun pid ->
-            Printf.eprintf
-              "onton prune: reclaimed stale lock for %s (PID %d)\n%!" slug pid)
-      in
-      match acquired with
-      | Error (Project_lock.Held_by { pid; _ }) ->
-          let project_name = recover_project_name ~slug in
-          kept := (project_name, Printf.sprintf "in use (PID %d)" pid) :: !kept
-      | Error (Project_lock.Io_error msg) ->
-          let project_name = recover_project_name ~slug in
-          errors :=
-            (project_name, Printf.sprintf "lock error: %s" msg) :: !errors
-      | Ok lock -> (
-          let project_name = recover_project_name ~slug in
-          match
-            try
-              Ok
-                (Fun.protect
-                   ~finally:(fun () -> Project_lock.release lock)
-                   (fun () ->
-                     let status = classify_project ~slug in
-                     (match status with
-                     | All_merged -> remove_path project_dir
-                     | Not_merged | No_patches | No_snapshot | Load_error _ ->
-                         ());
-                     status))
-            with exn -> Error (Printexc.to_string exn)
-          with
-          | Error msg ->
-              errors :=
-                (project_name, Printf.sprintf "prune failed: %s" msg) :: !errors
-          | Ok All_merged -> (
-              try
-                removed :=
-                  (project_name, worktree_root_for ~project_name) :: !removed
-              with exn ->
-                errors := (project_name, Printexc.to_string exn) :: !errors)
-          | Ok Not_merged ->
-              kept := (project_name, "has unmerged patches") :: !kept
-          | Ok No_patches ->
-              kept := (project_name, "gameplan has no patches") :: !kept
-          | Ok No_snapshot ->
-              kept := (project_name, "no snapshot — never ran") :: !kept
-          | Ok (Load_error msg) ->
-              errors :=
-                (project_name, Printf.sprintf "snapshot load failed: %s" msg)
-                :: !errors));
-  Base.List.iter (List.rev !removed) ~f:(fun (n, _) ->
-      Printf.printf "removed %s\n" n);
-  Base.List.iter (List.rev !kept) ~f:(fun (n, reason) ->
-      Printf.printf "kept    %s — %s\n" n reason);
-  Base.List.iter (List.rev !errors) ~f:(fun (n, msg) ->
-      Printf.eprintf "error   %s — %s\n" n msg);
-  Printf.printf "\n%s pruned, %d kept, %s.\n"
-    (pluralize (Base.List.length !removed) "project")
-    (Base.List.length !kept)
-    (pluralize (Base.List.length !errors) "error");
-  let leftover_worktrees =
-    Base.List.filter !removed ~f:(fun (_, p) -> Stdlib.Sys.file_exists p)
-  in
-  if not (Base.List.is_empty leftover_worktrees) then (
-    Printf.printf
-      "\n\
-       Worktree directories are not pruned automatically (they may contain \
-       build outputs).\n\
-       Remove them manually once they are no longer needed:\n";
-    Base.List.iter (List.rev leftover_worktrees) ~f:(fun (_, p) ->
-        Printf.printf "  rm -rf %s\n" p));
-  if not (Base.List.is_empty !errors) then Stdlib.exit 1
-
 let run ~project ~gameplan_path ~github_token ~backend ~model
     ~(main_branch : Branch.t option) ~poll_interval ~(repo_root : string option)
     ~max_concurrency ~headless ~no_lock =
@@ -4813,7 +4668,7 @@ let main_cmd =
   let run_cmd project gameplan_path github_token backend model main_branch
       poll_interval repo_root max_concurrency headless upload_debug no_lock
       prune =
-    if prune then run_prune ()
+    if prune then Stdlib.exit (Prune_runner.run_prune ())
     else if upload_debug then (
       match project with
       | None ->

--- a/lib/prune_runner.ml
+++ b/lib/prune_runner.ml
@@ -76,17 +76,19 @@ let run_prune () =
         let acquired =
           Project_lock.acquire ~project_dir ~on_stale:(fun pid ->
               Stdlib.Printf.eprintf
-                "onton prune: reclaimed stale lock for %s (PID %d)\n%!" slug
-                pid)
+                "onton prune: reclaimed stale lock for %s (PID %d)\n%!" slug pid)
         in
         match acquired with
         | Error (Project_lock.Held_by { pid; _ }) ->
             let project_name = recover_project_name ~slug in
-            kept := (project_name, Stdlib.Printf.sprintf "in use (PID %d)" pid) :: !kept
+            kept :=
+              (project_name, Stdlib.Printf.sprintf "in use (PID %d)" pid)
+              :: !kept
         | Error (Project_lock.Io_error msg) ->
             let project_name = recover_project_name ~slug in
             errors :=
-              (project_name, Stdlib.Printf.sprintf "lock error: %s" msg) :: !errors
+              (project_name, Stdlib.Printf.sprintf "lock error: %s" msg)
+              :: !errors
         | Ok lock -> (
             let project_name = recover_project_name ~slug in
             match
@@ -121,9 +123,11 @@ let run_prune () =
                 kept := (project_name, "no snapshot — never ran") :: !kept
             | Ok (Load_error msg) ->
                 errors :=
-                  (project_name, Stdlib.Printf.sprintf "snapshot load failed: %s" msg)
+                  ( project_name,
+                    Stdlib.Printf.sprintf "snapshot load failed: %s" msg )
                   :: !errors));
-    List.iter (List.rev !removed) ~f:(fun (n, _) -> Stdlib.Printf.printf "removed %s\n" n);
+    List.iter (List.rev !removed) ~f:(fun (n, _) ->
+        Stdlib.Printf.printf "removed %s\n" n);
     List.iter (List.rev !kept) ~f:(fun (n, reason) ->
         Stdlib.Printf.printf "kept    %s — %s\n" n reason);
     List.iter (List.rev !errors) ~f:(fun (n, msg) ->

--- a/lib/prune_runner.ml
+++ b/lib/prune_runner.ml
@@ -62,7 +62,7 @@ let run_prune () =
   if List.is_empty slugs then (
     Stdlib.Printf.printf "No stored projects to consider.\n";
     0)
-  else
+  else (
     let removed = ref [] in
     let kept = ref [] in
     let errors = ref [] in
@@ -147,4 +147,4 @@ let run_prune () =
          Remove them manually once they are no longer needed:\n";
       List.iter (List.rev leftover_worktrees) ~f:(fun (_, p) ->
           Stdlib.Printf.printf "  rm -rf %s\n" p));
-    if not (List.is_empty !errors) then 1 else 0
+    if not (List.is_empty !errors) then 1 else 0)

--- a/lib/prune_runner.ml
+++ b/lib/prune_runner.ml
@@ -62,7 +62,7 @@ let run_prune () =
   if List.is_empty slugs then (
     Stdlib.Printf.printf "No stored projects to consider.\n";
     0)
-  else (
+  else
     let removed = ref [] in
     let kept = ref [] in
     let errors = ref [] in
@@ -147,4 +147,4 @@ let run_prune () =
          Remove them manually once they are no longer needed:\n";
       List.iter (List.rev leftover_worktrees) ~f:(fun (_, p) ->
           Stdlib.Printf.printf "  rm -rf %s\n" p));
-    if not (List.is_empty !errors) then 1 else 0)
+    if not (List.is_empty !errors) then 1 else 0

--- a/lib/prune_runner.ml
+++ b/lib/prune_runner.ml
@@ -1,0 +1,146 @@
+open Base
+open Types
+
+type prune_status =
+  | All_merged
+  | Not_merged
+  | No_patches
+  | No_snapshot
+  | Load_error of string
+
+let pluralize ?plural n singular =
+  let many = match plural with Some p -> p | None -> singular ^ "s" in
+  Stdlib.Printf.sprintf "%d %s" n (if n = 1 then singular else many)
+
+let rec remove_path path =
+  match Unix.lstat path with
+  | exception Unix.Unix_error (Unix.ENOENT, _, _) -> ()
+  | { Unix.st_kind = Unix.S_DIR; _ } -> (
+      let entries = Stdlib.Sys.readdir path in
+      Array.iter entries ~f:(fun name ->
+          remove_path (Stdlib.Filename.concat path name));
+      try Unix.rmdir path with Unix.Unix_error (Unix.ENOENT, _, _) -> ())
+  | {
+   Unix.st_kind =
+     ( Unix.S_REG | Unix.S_LNK | Unix.S_CHR | Unix.S_BLK | Unix.S_FIFO
+     | Unix.S_SOCK );
+   _;
+  } -> (
+      try Stdlib.Sys.remove path with Sys_error _ -> ())
+
+let classify_project ~slug =
+  let snap_path = Project_store.snapshot_path slug in
+  if not (Stdlib.Sys.file_exists snap_path) then No_snapshot
+  else
+    match Persistence.load ~path:snap_path with
+    | Error msg -> Load_error msg
+    | Ok snap -> (
+        let agents = Orchestrator.agents_map snap.Runtime.orchestrator in
+        let patches = snap.Runtime.gameplan.Gameplan.patches in
+        match Prune_decision.classify_snapshot ~patches ~agents with
+        | Prune_decision.All_merged -> All_merged
+        | Prune_decision.Not_merged -> Not_merged
+        | Prune_decision.No_patches -> No_patches)
+
+let worktree_root_for ~project_name =
+  let home =
+    match Stdlib.Sys.getenv_opt "HOME" with Some h -> h | None -> "."
+  in
+  Stdlib.Filename.concat home (Stdlib.Filename.concat "worktrees" project_name)
+
+(** Stored config records the gameplan-provided [project_name] verbatim, which
+    is what worktrees are keyed by under [~/worktrees/]. The data dir is keyed
+    by slug, so the worktree hint requires reading the config to recover the
+    original name — falling back to the slug if config is unreadable. *)
+let recover_project_name ~slug =
+  match Project_store.load_config ~project_name:slug with
+  | Ok cfg -> cfg.Project_store.project_name
+  | Error _ -> slug
+
+let run_prune () =
+  let slugs = Project_store.list_projects () in
+  if List.is_empty slugs then (
+    Stdlib.Printf.printf "No stored projects to consider.\n";
+    0)
+  else
+    let removed = ref [] in
+    let kept = ref [] in
+    let errors = ref [] in
+    List.iter slugs ~f:(fun slug ->
+        (* [list_projects] returns slugs (already valid path components); the
+           data dir is keyed by slug and slugifying a slug is a no-op, so
+           passing the slug back through [project_dir] is correct. The
+           recovered [project_name] is only used for reporting and the
+           worktree hint. *)
+        let project_dir = Project_store.project_dir slug in
+        let acquired =
+          Project_lock.acquire ~project_dir ~on_stale:(fun pid ->
+              Stdlib.Printf.eprintf
+                "onton prune: reclaimed stale lock for %s (PID %d)\n%!" slug
+                pid)
+        in
+        match acquired with
+        | Error (Project_lock.Held_by { pid; _ }) ->
+            let project_name = recover_project_name ~slug in
+            kept := (project_name, Stdlib.Printf.sprintf "in use (PID %d)" pid) :: !kept
+        | Error (Project_lock.Io_error msg) ->
+            let project_name = recover_project_name ~slug in
+            errors :=
+              (project_name, Stdlib.Printf.sprintf "lock error: %s" msg) :: !errors
+        | Ok lock -> (
+            let project_name = recover_project_name ~slug in
+            match
+              try
+                Ok
+                  (Stdlib.Fun.protect
+                     ~finally:(fun () -> Project_lock.release lock)
+                     (fun () ->
+                       let status = classify_project ~slug in
+                       (match status with
+                       | All_merged -> remove_path project_dir
+                       | Not_merged | No_patches | No_snapshot | Load_error _ ->
+                           ());
+                       status))
+              with exn -> Error (Exn.to_string exn)
+            with
+            | Error msg ->
+                errors :=
+                  (project_name, Stdlib.Printf.sprintf "prune failed: %s" msg)
+                  :: !errors
+            | Ok All_merged -> (
+                try
+                  removed :=
+                    (project_name, worktree_root_for ~project_name) :: !removed
+                with exn ->
+                  errors := (project_name, Exn.to_string exn) :: !errors)
+            | Ok Not_merged ->
+                kept := (project_name, "has unmerged patches") :: !kept
+            | Ok No_patches ->
+                kept := (project_name, "gameplan has no patches") :: !kept
+            | Ok No_snapshot ->
+                kept := (project_name, "no snapshot — never ran") :: !kept
+            | Ok (Load_error msg) ->
+                errors :=
+                  (project_name, Stdlib.Printf.sprintf "snapshot load failed: %s" msg)
+                  :: !errors));
+    List.iter (List.rev !removed) ~f:(fun (n, _) -> Stdlib.Printf.printf "removed %s\n" n);
+    List.iter (List.rev !kept) ~f:(fun (n, reason) ->
+        Stdlib.Printf.printf "kept    %s — %s\n" n reason);
+    List.iter (List.rev !errors) ~f:(fun (n, msg) ->
+        Stdlib.Printf.eprintf "error   %s — %s\n" n msg);
+    Stdlib.Printf.printf "\n%s pruned, %d kept, %s.\n"
+      (pluralize (List.length !removed) "project")
+      (List.length !kept)
+      (pluralize (List.length !errors) "error");
+    let leftover_worktrees =
+      List.filter !removed ~f:(fun (_, p) -> Stdlib.Sys.file_exists p)
+    in
+    if not (List.is_empty leftover_worktrees) then (
+      Stdlib.Printf.printf
+        "\n\
+         Worktree directories are not pruned automatically (they may contain \
+         build outputs).\n\
+         Remove them manually once they are no longer needed:\n";
+      List.iter (List.rev leftover_worktrees) ~f:(fun (_, p) ->
+          Stdlib.Printf.printf "  rm -rf %s\n" p));
+    if not (List.is_empty !errors) then 1 else 0

--- a/lib/prune_runner.mli
+++ b/lib/prune_runner.mli
@@ -1,0 +1,5 @@
+val run_prune : unit -> int
+(** Remove stored projects whose gameplan patches are all merged.
+
+    Returns [0] on success and [1] when one or more projects could not be
+    pruned due to lock or snapshot errors. *)

--- a/lib/prune_runner.mli
+++ b/lib/prune_runner.mli
@@ -1,5 +1,5 @@
 val run_prune : unit -> int
 (** Remove stored projects whose gameplan patches are all merged.
 
-    Returns [0] on success and [1] when one or more projects could not be
-    pruned due to lock or snapshot errors. *)
+    Returns [0] on success and [1] when one or more projects could not be pruned
+    due to lock or snapshot errors. *)


### PR DESCRIPTION
## Patch 3: Extract prune logic to lib/prune_runner

- Move remove_path, classify_project, worktree_root_for, recover_project_name, run_prune into lib/prune_runner.ml.
- Expose run_prune : unit -> int (or unit, matching current return) in lib/prune_runner.mli.
- Delete the lifted bindings from bin/main.ml; the prune_arg cmdliner branch becomes `if prune then Stdlib.exit (Prune_runner.run_prune ())`.

## Changes
- Move remove_path, classify_project, worktree_root_for, recover_project_name, run_prune into lib/prune_runner.ml.
- Expose run_prune : unit -> int (or unit, matching current return) in lib/prune_runner.mli.
- Delete the lifted bindings from bin/main.ml; the prune_arg cmdliner branch becomes `if prune then Stdlib.exit (Prune_runner.run_prune ())`.

## Files to Modify
- lib/prune_runner.mli (create): Expose run_prune.
- lib/prune_runner.ml (create): Port remove_path, classify_project, worktree_root_for, recover_project_name, run_prune from bin/main.ml:4543–4691; reuse Prune_decision from lib_core unchanged.
- lib/dune (modify): Register prune_runner among library modules.
- bin/main.ml (modify): Replace the lifted block (4543–4691) with a single call into Prune_runner.run_prune from the prune_arg branch.

## Gameplan Specification

```
module EXTRACT_BIN_FIBERS.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> After this gameplan, bin/main.ml contains only command-line
> parsing, config resolution, capability construction, and the
> assembly of fiber modules. Every fiber body lives behind a .mli
> in lib. Run-level capabilities flow through a shared Run_env
> signature, not as positional arguments.

Fiber.
poller => Fiber.
runner => Fiber.
tui => Fiber.
input => Fiber.
headless => Fiber.
persistence => Fiber.

in-lib? f: Fiber => Bool.
in-bin? f: Fiber => Bool.

Capability.
runtime => Capability.
clock => Capability.
fs => Capability.
project-name => Capability.
user-config => Capability.
worktree-mutex => Capability.
hook-mutex => Capability.

run-env-captures? c: Capability => Bool.

ResolvedConfig.
project-name-is-string? rc: ResolvedConfig => Bool.
assert-false-removed? => Bool.

bin-main-line-count => Nat0.
runner-fiber-line-count => Nat0.
---
> Every fiber body lives in lib, not in bin.
all f: Fiber | in-lib? f.
all f: Fiber | ~ (in-bin? f).

> Every shared run-level capability is captured by Run_env.
all c: Capability | run-env-captures? c.

> Resolved_config.t has project_name : string; the assert-false is gone.
all rc: ResolvedConfig | project-name-is-string? rc.
assert-false-removed?.

> Size invariants: the binary is small enough to read as wiring.
bin-main-line-count < 1500.
runner-fiber-line-count < 500.

where

> ══════════════════════════════════════════
> SUPPORTING EXTRACTIONS
> ══════════════════════════════════════════
> Three runner helpers, the managed-repo plumbing, the prune
> subcommand, the TUI view-model record, and the resolved-config
> type are all exposed from lib with .mli boundaries.

Helper.
managed-repo => Helper.
prune-runner => Helper.
tui-state => Helper.
long-lived-sessions => Helper.
busy-guard => Helper.
worktree-plan-executor => Helper.
resolved-config => Helper.

helper-in-lib? h: Helper => Bool.
---
all h: Helper | helper-in-lib? h.

```

## Patch Specification

```
module EXTRACT_BIN_FIBERS_PATCH_3.

> Patch 3 extracts the prune subcommand into a lib module.

PruneRunner.
run-prune? pr: PruneRunner => Bool.
---
all pr: PruneRunner | run-prune? pr.

```


## Implementation Notes

- `lib/dune` did not need a stanza change in practice: the library already uses `(modules :standard)`, so `Prune_runner` is picked up automatically. I left `lib/dune` unchanged rather than adding redundant module enumeration.
- The extracted module keeps the CLI behavior but returns an exit code instead of calling `Stdlib.exit` internally. That keeps `Prune_runner.run_prune` usable as a library boundary while preserving the exact command-line outcome via `Stdlib.exit (Prune_runner.run_prune ())` in `bin/main.ml`.
- The move into `open Base` exposed a few bin-only assumptions during extraction: `Array.iter` needed labeled Base-style application, `Printf` references needed `Stdlib.Printf`, and `Fun.protect`/`Printexc.to_string` were normalized to `Stdlib.Fun.protect` and `Exn.to_string` to satisfy the project's warning policy. No behavior changed; these were namespace/alert fixes caused by the new lib context.
- The old top-level `pluralize` helper in `bin/main.ml` became unused after the extraction and was removed. The nested `pluralize` inside `Make_fibers` remains in use and was left untouched.
- Spec/Evidence Mapping:
  - Patch spec `run-prune?`: implemented by [lib/prune_runner.mli] exposing `val run_prune : unit -> int` and [lib/prune_runner.ml] holding the full prune flow; authoritative context consulted: `bin/main.ml`, `lib_core/prune_decision.{ml,mli}`.
  - PR acceptance criterion "prune branch becomes a single call": implemented in `bin/main.ml` as `if prune then Stdlib.exit (Prune_runner.run_prune ())`; verified by `dune build`.
  - Supporting extraction "prune-runner in lib with .mli boundary": satisfied by the new `lib/prune_runner.{ml,mli}` pair; verified by `dune build` and full `dune runtest`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Prune operation enhanced with improved error handling and comprehensive reporting. Now displays detailed information about removed projects, retained projects with retention reasons, and any errors encountered.
  * Prune operation returns proper exit codes: success (0) for successful completion, failure (1) when projects cannot be pruned due to lock acquisition or snapshot loading issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flowglad/onton/pull/299?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->