### PR TITLE
[extract-bin-fibers] Patch 10: Extract headless_fiber and persistence_fiber

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -196,6 +196,20 @@ struct
 
   module Poller = Poller_fiber.Make (Forge) (W) (Env_poller)
 
+  module Headless_Env : Headless_fiber.Headless_env.S = struct
+    let runtime = Env.runtime
+    let clock = Env.clock
+  end
+
+  module Persistence_Env : Persistence_fiber.Persistence_env.S = struct
+    let runtime = Env.runtime
+    let clock = Env.clock
+    let project_name = Env.project_name
+  end
+
+  module Headless = Headless_fiber.Make (Headless_Env)
+  module Persistence_fiber_runner = Persistence_fiber.Make (Persistence_Env)
+
   (** Execute declarative GitHub effects and record successful observations back
       into durable state. *)
   let execute_github_effects ~runtime effects =
@@ -1495,63 +1509,17 @@ struct
     in
     loop ()
 
-  (** Format a Unix timestamp as HH:MM:SS for headless log lines. *)
-  let format_time ts =
-    let t = Unix.localtime ts in
-    Printf.sprintf "%02d:%02d:%02d" t.Unix.tm_hour t.Unix.tm_min t.Unix.tm_sec
+  (** Per-agent poll intent, collected inside [read] and executed outside. *)
+  type poll_intent =
+    | Skip_no_pr of Patch_id.t
+    | Poll of {
+        patch_id : Patch_id.t;
+        pr_number : Pr_number.t;
+        was_merged : bool;
+      }
 
-  let format_event (e : Activity_log.Event.t) =
-    let pid_str =
-      match e.Activity_log.Event.patch_id with
-      | Some pid -> Printf.sprintf "[%s] " (Patch_id.to_string pid)
-      | None -> ""
-    in
-    pid_str ^ e.Activity_log.Event.message
-
-  let format_transition (t : Activity_log.Transition_entry.t) =
-    Printf.sprintf "[%s] %s -> %s"
-      (Patch_id.to_string t.Activity_log.Transition_entry.patch_id)
-      (Tui.label t.Activity_log.Transition_entry.from_status)
-      (Tui.label t.Activity_log.Transition_entry.to_status)
-
-  (** Headless logging fiber — prints events and transitions to stdout as plain
-      text, without TUI escape codes. Uses a count-based cursor to avoid losing
-      entries with identical timestamps. *)
-  let headless_fiber ~runtime ~clock ~stdout =
-    (* Track seen entries by set of (timestamp, message) to handle entries that
-     sort before previously-displayed ones (e.g. an event logged just before
-     a stream entry but displayed in the next poll cycle). *)
-    let seen = Hashtbl.create 256 in
-    let rec loop () =
-      let entries =
-        Runtime.read runtime (fun snap ->
-            merged_log_entries ~log:snap.Runtime.activity_log ~limit:500
-              ~compare:(fun (t1, _) (t2, _) -> Base.Float.ascending t1 t2)
-              ~map_event:format_event ~map_transition:format_transition
-              ~map_stream:(fun (s : Activity_log.Stream_entry.t) ->
-                Printf.sprintf "[%s] %s"
-                  (Patch_id.to_string s.Activity_log.Stream_entry.patch_id)
-                  (format_stream_kind s.Activity_log.Stream_entry.kind)))
-      in
-      Base.List.iter entries ~f:(fun (ts, msg) ->
-          let key = (ts, msg) in
-          if not (Hashtbl.mem seen key) then (
-            Hashtbl.replace seen key true;
-            Eio.Flow.copy_string
-              (Printf.sprintf "%s %s\n" (format_time ts) msg)
-              stdout));
-      (* Bound the seen set: rebuild from current entries so it never grows
-       beyond the merged_log_entries window (~1500 entries max). *)
-      if Hashtbl.length seen > 2000 then (
-        let current = Hashtbl.create 256 in
-        Base.List.iter entries ~f:(fun key -> Hashtbl.replace current key true);
-        Hashtbl.reset seen;
-        Hashtbl.iter (fun k v -> Hashtbl.replace seen k v) current);
-      Eio.Time.sleep clock 1.0;
-      loop ()
-    in
-    loop ()
-
+  (** Poller fiber — periodically polls GitHub for PR state changes and
+      reconciles. *)
   let poll_review_backends ~runtime ~patch_id ~findings_registry ~review_clients
       ~owner ~repo ~pr_number : Review_service.finding list =
     Base.List.concat_map review_clients
@@ -3331,30 +3299,6 @@ struct
         amloop ());
     loop sw
 
-  (** {1 Persistence fiber} *)
-
-  (** Periodic persistence fiber — saves runtime snapshot every 5 seconds. *)
-  let persistence_fiber ~runtime ~clock ~project_name ~transcripts =
-    let path = Project_store.snapshot_path project_name in
-    Project_store.ensure_dir (Stdlib.Filename.dirname path);
-    let rec loop () =
-      Eio.Time.sleep clock 5.0;
-      (* Sync transcripts into the snapshot before saving *)
-      Runtime.update runtime (fun snap ->
-          let t = snap.Runtime.transcripts in
-          Base.Hashtbl.clear t;
-          Hashtbl.iter
-            (fun k v -> Base.Hashtbl.set t ~key:k ~data:v)
-            transcripts;
-          snap);
-      let snap = Runtime.snapshot_unsync runtime in
-      (match Persistence.save ~path snap with
-      | Ok () -> ()
-      | Error msg ->
-          log_event runtime (Printf.sprintf "Persistence save failed — %s" msg));
-      loop ()
-    in
-    loop ()
 end
 
 (** {1 Main entry point} *)
@@ -3993,13 +3937,12 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
         [
           reconciliation_fiber;
           (fun () -> poller_fiber (module Reconciler : STARTUP_RECONCILER));
-          (fun () ->
-            persistence_fiber ~runtime ~clock ~project_name ~transcripts);
+          (Persistence_fiber_runner.run ~transcripts);
         ]
       in
       if config.headless then
         Eio.Fiber.all
-          ((fun () -> headless_fiber ~runtime ~clock ~stdout)
+          ((Headless.run ~stdout)
           :: (fun () -> runner_fiber ())
           :: common_fibers)
       else

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -3298,7 +3298,6 @@ struct
         in
         amloop ());
     loop sw
-
 end
 
 (** {1 Main entry point} *)
@@ -3937,14 +3936,12 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
         [
           reconciliation_fiber;
           (fun () -> poller_fiber (module Reconciler : STARTUP_RECONCILER));
-          (Persistence_fiber_runner.run ~transcripts);
+          Persistence_fiber_runner.run ~transcripts;
         ]
       in
       if config.headless then
         Eio.Fiber.all
-          ((Headless.run ~stdout)
-          :: (fun () -> runner_fiber ())
-          :: common_fibers)
+          (Headless.run ~stdout :: (fun () -> runner_fiber ()) :: common_fibers)
       else
         let tui_state = Tui_state.create () in
         let raw_state = Term.Raw.enter () in

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -3936,7 +3936,7 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
         [
           reconciliation_fiber;
           (fun () -> poller_fiber (module Reconciler : STARTUP_RECONCILER));
-          Persistence_fiber_runner.run ~transcripts;
+          (fun () -> Persistence_fiber_runner.run ~transcripts ());
         ]
       in
       if config.headless then

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1509,15 +1509,6 @@ struct
     in
     loop ()
 
-  (** Per-agent poll intent, collected inside [read] and executed outside. *)
-  type poll_intent =
-    | Skip_no_pr of Patch_id.t
-    | Poll of {
-        patch_id : Patch_id.t;
-        pr_number : Pr_number.t;
-        was_merged : bool;
-      }
-
   (** Poller fiber — periodically polls GitHub for PR state changes and
       reconciles. *)
   let poll_review_backends ~runtime ~patch_id ~findings_registry ~review_clients

--- a/lib/headless_fiber.ml
+++ b/lib/headless_fiber.ml
@@ -77,7 +77,8 @@ module Make (Env : Headless_env.S) = struct
               stdout));
       if Stdlib.Hashtbl.length seen > 2000 then (
         let current = Stdlib.Hashtbl.create 256 in
-        List.iter entries ~f:(fun key -> Stdlib.Hashtbl.replace current key true);
+        List.iter entries ~f:(fun key ->
+            Stdlib.Hashtbl.replace current key true);
         Stdlib.Hashtbl.reset seen;
         Stdlib.Hashtbl.iter (fun k v -> Stdlib.Hashtbl.replace seen k v) current);
       Eio.Time.sleep Env.clock 1.0;

--- a/lib/headless_fiber.ml
+++ b/lib/headless_fiber.ml
@@ -1,0 +1,87 @@
+open Base
+
+module Headless_env = struct
+  module type S = sig
+    val runtime : Runtime.t
+    val clock : float Eio.Time.clock_ty Eio.Time.clock
+  end
+end
+
+module Make (Env : Headless_env.S) = struct
+  let merged_log_entries ~(log : Activity_log.t) ~limit ~compare
+      ~(map_event : Activity_log.Event.t -> 'a)
+      ~(map_transition : Activity_log.Transition_entry.t -> 'a)
+      ~(map_stream : Activity_log.Stream_entry.t -> 'a) =
+    let events =
+      List.map (Activity_log.recent_events log ~limit) ~f:(fun e ->
+          (e.Activity_log.Event.timestamp, map_event e))
+    in
+    let transitions =
+      List.map (Activity_log.recent_transitions log ~limit) ~f:(fun t ->
+          (t.Activity_log.Transition_entry.timestamp, map_transition t))
+    in
+    let stream =
+      List.map (Activity_log.recent_stream_entries log ~limit) ~f:(fun s ->
+          (s.Activity_log.Stream_entry.timestamp, map_stream s))
+    in
+    List.sort (events @ transitions @ stream) ~compare
+
+  let format_stream_kind (kind : Activity_log.Stream_entry.kind) =
+    match kind with
+    | Activity_log.Stream_entry.Tool_use (name, input) ->
+        if String.length input > 0 then Printf.sprintf "Tool %s — %s" name input
+        else Printf.sprintf "Tool %s" name
+    | Activity_log.Stream_entry.Text_chunk text -> text
+    | Activity_log.Stream_entry.Finished reason ->
+        Printf.sprintf "Finished — %s" reason
+    | Activity_log.Stream_entry.Stream_error msg ->
+        Printf.sprintf "Stream error — %s" msg
+
+  let format_time ts =
+    let t = Unix.localtime ts in
+    Printf.sprintf "%02d:%02d:%02d" t.Unix.tm_hour t.Unix.tm_min t.Unix.tm_sec
+
+  let format_event (e : Activity_log.Event.t) =
+    let pid_str =
+      match e.Activity_log.Event.patch_id with
+      | Some pid -> Printf.sprintf "[%s] " (Types.Patch_id.to_string pid)
+      | None -> ""
+    in
+    pid_str ^ e.Activity_log.Event.message
+
+  let format_transition (t : Activity_log.Transition_entry.t) =
+    Printf.sprintf "[%s] %s -> %s"
+      (Types.Patch_id.to_string t.Activity_log.Transition_entry.patch_id)
+      (Tui.label t.Activity_log.Transition_entry.from_status)
+      (Tui.label t.Activity_log.Transition_entry.to_status)
+
+  let run ~stdout () =
+    let seen = Stdlib.Hashtbl.create 256 in
+    let rec loop () =
+      let entries =
+        Runtime.read Env.runtime (fun snap ->
+            merged_log_entries ~log:snap.Runtime.activity_log ~limit:500
+              ~compare:(fun (t1, _) (t2, _) -> Float.ascending t1 t2)
+              ~map_event:format_event ~map_transition:format_transition
+              ~map_stream:(fun (s : Activity_log.Stream_entry.t) ->
+                Printf.sprintf "[%s] %s"
+                  (Types.Patch_id.to_string s.Activity_log.Stream_entry.patch_id)
+                  (format_stream_kind s.Activity_log.Stream_entry.kind)))
+      in
+      List.iter entries ~f:(fun (ts, msg) ->
+          let key = (ts, msg) in
+          if not (Stdlib.Hashtbl.mem seen key) then (
+            Stdlib.Hashtbl.replace seen key true;
+            Eio.Flow.copy_string
+              (Printf.sprintf "%s %s\n" (format_time ts) msg)
+              stdout));
+      if Stdlib.Hashtbl.length seen > 2000 then (
+        let current = Stdlib.Hashtbl.create 256 in
+        List.iter entries ~f:(fun key -> Stdlib.Hashtbl.replace current key true);
+        Stdlib.Hashtbl.reset seen;
+        Stdlib.Hashtbl.iter (fun k v -> Stdlib.Hashtbl.replace seen k v) current);
+      Eio.Time.sleep Env.clock 1.0;
+      loop ()
+    in
+    loop ()
+end

--- a/lib/headless_fiber.ml
+++ b/lib/headless_fiber.ml
@@ -8,6 +8,8 @@ module Headless_env = struct
 end
 
 module Make (Env : Headless_env.S) = struct
+  (* Duplicated from [bin/main.ml] for Patch 10 extraction scope. Consolidate
+     with the TUI-side helper in a later patch if we want one shared home. *)
   let merged_log_entries ~(log : Activity_log.t) ~limit ~compare
       ~(map_event : Activity_log.Event.t -> 'a)
       ~(map_transition : Activity_log.Transition_entry.t -> 'a)
@@ -26,6 +28,8 @@ module Make (Env : Headless_env.S) = struct
     in
     List.sort (events @ transitions @ stream) ~compare
 
+  (* Duplicated from [bin/main.ml] for Patch 10 extraction scope. Consolidate
+     with the TUI-side helper in a later patch if we want one shared home. *)
   let format_stream_kind (kind : Activity_log.Stream_entry.kind) =
     match kind with
     | Activity_log.Stream_entry.Tool_use (name, input) ->

--- a/lib/headless_fiber.mli
+++ b/lib/headless_fiber.mli
@@ -1,0 +1,10 @@
+module Headless_env : sig
+  module type S = sig
+    val runtime : Runtime.t
+    val clock : float Eio.Time.clock_ty Eio.Time.clock
+  end
+end
+
+module Make (_ : Headless_env.S) : sig
+  val run : stdout:_ Eio.Flow.sink -> unit -> unit
+end

--- a/lib/persistence_fiber.ml
+++ b/lib/persistence_fiber.ml
@@ -1,0 +1,35 @@
+open Base
+
+module Persistence_env = struct
+  module type S = sig
+    val runtime : Runtime.t
+    val clock : float Eio.Time.clock_ty Eio.Time.clock
+    val project_name : string
+  end
+end
+
+module Make (Env : Persistence_env.S) = struct
+  let log_event = Runtime_logging.log_event
+
+  let run ~transcripts () =
+    let path = Project_store.snapshot_path Env.project_name in
+    Project_store.ensure_dir (Stdlib.Filename.dirname path);
+    let rec loop () =
+      Eio.Time.sleep Env.clock 5.0;
+      Runtime.update Env.runtime (fun snap ->
+          let t = snap.Runtime.transcripts in
+          Hashtbl.clear t;
+          Stdlib.Hashtbl.iter
+            (fun k v -> Hashtbl.set t ~key:k ~data:v)
+            transcripts;
+          snap);
+      let snap = Runtime.snapshot_unsync Env.runtime in
+      (match Persistence.save ~path snap with
+      | Ok () -> ()
+      | Error msg ->
+          log_event Env.runtime
+            (Printf.sprintf "Persistence save failed — %s" msg));
+      loop ()
+    in
+    loop ()
+end

--- a/lib/persistence_fiber.ml
+++ b/lib/persistence_fiber.ml
@@ -18,9 +18,9 @@ module Make (Env : Persistence_env.S) = struct
       Eio.Time.sleep Env.clock 5.0;
       Runtime.update Env.runtime (fun snap ->
           let t = snap.Runtime.transcripts in
-          Hashtbl.clear t;
+          Base.Hashtbl.clear t;
           Stdlib.Hashtbl.iter
-            (fun k v -> Hashtbl.set t ~key:k ~data:v)
+            (fun k v -> Base.Hashtbl.set t ~key:k ~data:v)
             transcripts;
           snap);
       let snap = Runtime.snapshot_unsync Env.runtime in

--- a/lib/persistence_fiber.mli
+++ b/lib/persistence_fiber.mli
@@ -1,0 +1,11 @@
+module Persistence_env : sig
+  module type S = sig
+    val runtime : Runtime.t
+    val clock : float Eio.Time.clock_ty Eio.Time.clock
+    val project_name : string
+  end
+end
+
+module Make (_ : Persistence_env.S) : sig
+  val run : transcripts:(Types.Patch_id.t, string) Stdlib.Hashtbl.t -> unit -> unit
+end

--- a/lib/persistence_fiber.mli
+++ b/lib/persistence_fiber.mli
@@ -7,5 +7,6 @@ module Persistence_env : sig
 end
 
 module Make (_ : Persistence_env.S) : sig
-  val run : transcripts:(Types.Patch_id.t, string) Stdlib.Hashtbl.t -> unit -> unit
+  val run :
+    transcripts:(Types.Patch_id.t, string) Stdlib.Hashtbl.t -> unit -> unit
 end


### PR DESCRIPTION
## Patch 10: Extract headless_fiber and persistence_fiber

- Define Headless_env.S — the minimal subset of FIBER_ENV (runtime, clock, project_name, transcripts, event_log, etc. — verify).
- Define Persistence_env.S — runtime, clock, project_name, and any other Eio handles persistence_fiber reads.
- Lift both bodies, replace closure-captured deps with Env accesses, instantiate in Make_fibers, update call sites.
- Confirm dune build + dune runtest pass.

## Changes
- Define Headless_env.S — the minimal subset of FIBER_ENV (runtime, clock, project_name, transcripts, event_log, etc. — verify).
- Define Persistence_env.S — runtime, clock, project_name, and any other Eio handles persistence_fiber reads.
- Lift both bodies, replace closure-captured deps with Env accesses, instantiate in Make_fibers, update call sites.
- Confirm dune build + dune runtest pass.

## Files to Modify
- lib/headless_fiber.mli (create): module Headless_env : module type S and module Make(Env : Headless_env.S) producing val run : stdout:_ Eio.Flow.sink -> unit -> unit.
- lib/headless_fiber.ml (create): Move the body of headless_fiber (bin/main.ml:1676–1793) into the new module.
- lib/persistence_fiber.mli (create): module Persistence_env : module type S and module Make(Env : Persistence_env.S) producing val run : transcripts:(Patch_id.t, string) Hashtbl.t -> unit -> unit.
- lib/persistence_fiber.ml (create): Move the body of persistence_fiber (bin/main.ml:3814–3839) into the new module.
- lib/dune (modify): Register headless_fiber and persistence_fiber among library modules.
- bin/main.ml (modify): Inside Make_fibers, instantiate both modules and replace the in-line fiber bindings; call sites at lines 4469 and 4474 become `Headless.run ~stdout ()` and `Persistence.run ~transcripts ()`.

## Gameplan Specification

```
module EXTRACT_BIN_FIBERS.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> After this gameplan, bin/main.ml contains only command-line
> parsing, config resolution, capability construction, and the
> assembly of fiber modules. Every fiber body lives behind a .mli
> in lib. Run-level capabilities flow through a shared Run_env
> signature, not as positional arguments.

Fiber.
poller => Fiber.
runner => Fiber.
tui => Fiber.
input => Fiber.
headless => Fiber.
persistence => Fiber.

in-lib? f: Fiber => Bool.
in-bin? f: Fiber => Bool.

Capability.
runtime => Capability.
clock => Capability.
fs => Capability.
project-name => Capability.
user-config => Capability.
worktree-mutex => Capability.
hook-mutex => Capability.

run-env-captures? c: Capability => Bool.

ResolvedConfig.
project-name-is-string? rc: ResolvedConfig => Bool.
assert-false-removed? => Bool.

bin-main-line-count => Nat0.
runner-fiber-line-count => Nat0.
---
> Every fiber body lives in lib, not in bin.
all f: Fiber | in-lib? f.
all f: Fiber | ~ (in-bin? f).

> Every shared run-level capability is captured by Run_env.
all c: Capability | run-env-captures? c.

> Resolved_config.t has project_name : string; the assert-false is gone.
all rc: ResolvedConfig | project-name-is-string? rc.
assert-false-removed?.

> Size invariants: the binary is small enough to read as wiring.
bin-main-line-count < 1500.
runner-fiber-line-count < 500.

where

> ══════════════════════════════════════════
> SUPPORTING EXTRACTIONS
> ══════════════════════════════════════════
> Three runner helpers, the managed-repo plumbing, the prune
> subcommand, the TUI view-model record, and the resolved-config
> type are all exposed from lib with .mli boundaries.

Helper.
managed-repo => Helper.
prune-runner => Helper.
tui-state => Helper.
long-lived-sessions => Helper.
busy-guard => Helper.
worktree-plan-executor => Helper.
resolved-config => Helper.

helper-in-lib? h: Helper => Bool.
---
all h: Helper | helper-in-lib? h.

```

## Patch Specification

```
module EXTRACT_BIN_FIBERS_PATCH_10.

> Patch 10 moves headless_fiber and persistence_fiber to lib.

Fiber.
headless => Fiber.
persistence => Fiber.
in-lib? f: Fiber => Bool.
---
in-lib? headless.
in-lib? persistence.

```


## Implementation Notes

- `Headless_env.S` ended up smaller than the patch prose suggested: the extracted headless fiber only needs `runtime` and `clock`. It does not read `project_name`, `transcripts`, or `event_log`; keeping those out matches the gameplan's “minimal per-fiber Env” rule rather than copying the old `FIBER_ENV` shape.
- `Persistence_env.S` captures only `runtime`, `clock`, and `project_name`. `transcripts` stays as a call-time argument because it is mutable session state threaded from startup, not a fixed run capability; that split keeps the functor env aligned with the existing `Run_env`/`Session_driver` pattern.
- The headless extraction duplicates the small log-formatting helpers it actually needs (`merged_log_entries`, stream/event/transition formatting, timestamp formatting) instead of moving shared helpers out of `bin/main.ml`. That keeps Patch 10 scoped to the two fiber bodies and avoids mixing in unrelated refactors to TUI/shared helper placement.
- Deviation from the PR checklist: `lib/dune` did not need a code change. The library already uses `(modules :standard)`, so the new `lib/*.ml` files are picked up automatically; `dune build` was the static check confirming registration.
- One wiring detail worth noticing: the new persistence functor instance is named `Persistence_fiber_runner` in `bin/main.ml` to avoid shadowing the existing top-level `Persistence` module used for snapshot `load/save`.

- Spec/Evidence Mapping:
  - `in-lib? headless` / `in-lib? persistence`: implemented by [`lib/headless_fiber.ml`](/Users/zax/worktrees/extract-bin-fibers/patch-10/lib/headless_fiber.ml) and [`lib/persistence_fiber.ml`](/Users/zax/worktrees/extract-bin-fibers/patch-10/lib/persistence_fiber.ml); extracted from `current-bin-main`; proven by `dune build`.
  - “replace closure-captured deps with Env accesses, instantiate in Make_fibers, update call sites”: implemented in [`bin/main.ml`](/Users/zax/worktrees/extract-bin-fibers/patch-10/bin/main.ml) via `Headless_Env`, `Persistence_Env`, `Headless`, and `Persistence_fiber_runner`; required context checked against `existing-env-functors`; proven by `dune build` and `dune runtest`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted the headless logging and persistence fibers into `lib` as functorized modules with `run` entrypoints. Behavior is unchanged and a stale poller-local type was removed after rebase.

- **Refactors**
  - Added `lib/headless_fiber.{ml,mli}` with `Headless_env.S` (runtime, clock) and `Make(Env).run ~stdout ()`; includes local copies of small formatting helpers.
  - Added `lib/persistence_fiber.{ml,mli}` with `Persistence_env.S` (runtime, clock, project_name) and `Make(Env).run ~transcripts ()`.
  - Updated public types per review: use `Types.Patch_id.t` and `Stdlib.Hashtbl.t` in the `.mli`.
  - Wired them in `bin/main.ml` via `Headless.run ~stdout` and `Persistence_fiber_runner.run ~transcripts`; headless logs every 1s, snapshots persist every 5s via `Eio`.

<sup>Written for commit f4f21c328c36a9669c2760b39adfcb02aedcf96b. Summary will update on new commits. <a href="https://cubic.dev/pr/flowglad/onton/pull/300?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

