### PR TITLE
Add gameplan validator script

### DIFF
--- a/skills/write-gameplan/SKILL.md
+++ b/skills/write-gameplan/SKILL.md
@@ -351,25 +351,33 @@ Write test stubs with skip/pending markers BEFORE implementation:
 
 ## Verification
 
-After writing the gameplan JSON, verify:
+Run the validator before finalising:
 
-1. **Schema compliance** — Validate the output against the JSON Schema in `references/gameplan-schema.json`. If `ajv` or another JSON Schema validator is available, run it programmatically. Otherwise, re-read the schema and manually confirm:
-   - All `required` fields are present at every level (top-level, patch, featureFlag, etc.)
-   - `additionalProperties: false` is enforced — no extra fields anywhere
-   - Enum values match exactly (`INFRA`/`GATED`/`BEHAVIOR`, `create`/`modify`/`delete`, etc.)
-   - `oneOf` discriminants are correct (feature flag `type`, nullable `workstream`)
-   - Patch numbers are positive integers (`minimum: 1`)
-   - `projectName` matches the kebab-case `pattern`
-   - Do NOT use non-schema field names (e.g. `project` instead of `projectName`, `summary` instead of `solutionSummary`, `id` instead of `number`, `description` instead of `changes`)
-2. **Each spec MUST parse cleanly** — extract `spec`/`finalStateSpec` strings to temp files and validate them with the spec language's toolchain (see [Specification Language](#specification-language)). Fix any parse errors before finalizing. If the toolchain is not installed, flag it as a blocker — do NOT skip validation or fall back to manual review
-3. The dependency graph is a valid DAG
-4. All test stubs have corresponding implementations
-5. **Functional change ownership is total and single-valued** — every `functionalChanges[i].id` is unique; every `functionalChanges[i].ownedBy` resolves to an existing `patches[].number`; no functional change appears unowned in prose. Re-read `problemStatement`, `solutionSummary`, `acceptanceCriteria`, and `finalStateSpec` and confirm every behavioral promise has a corresponding `functionalChanges` entry pointing at a single patch. Set `mergabilityChecklist.functionalChangesOwnedByExactlyOnePatch` to `true` only when this holds.
-6. **Context routing is exact** — every `contextResources[i].id` is unique and non-empty; every `requiredContext` entry resolves to an existing resource; every `consumedBy` patch exists; and each resource's `consumedBy` list exactly matches the patches whose `requiredContext` includes that resource ID. Confirm docs/evals/reference patches name the implementation or contract they describe.
-7. **Spec/evidence mapping is complete where applicable** — for each functional change, identify the spec or acceptance criterion it satisfies, the patch that implements it, the required context resource consulted (if any), and the test/static check expected to prove it.
-8. **Operational considerations are substantive** — the schema requires every sub-field of `operationalConsiderations` to be present, but presence is not engagement. For each sub-field, confirm the response names concrete surfaces in *this* gameplan (specific runtimes, formats, code paths, stateful writes) rather than generic platitudes. A sub-field may say "not applicable" only when the gameplan genuinely does not touch that surface, and only with a brief justification grounded in the actual changes. See [Operational Considerations](#operational-considerations).
-9. **Atomicity holds** — re-read [Atomicity Constraint](#atomicity-constraint-read-this-first) and walk the patch list. Confirm that no patch is conditional on the outcome of another, no patch description or `changes` step expects a human to act between patches (flip a flag, run a script, observe a metric, decide a branch), and no patch implies an observation/soak window before the next one runs. If any of these slipped in, the work must be re-decomposed as a multi-milestone workstream via [[write-workstream]] — do not patch around it inside the gameplan. Set `mergabilityChecklist.gameplanIsAtomicAndAutonomous` to `true` only when this check passes.
-10. The mergability checklist passes
+```
+python3 scripts/validate.py <path/to/gameplan.json>
+```
+
+It exits 0 on PASS and 1 with explicit error lines on FAIL. Fix every reported error; do not ship a gameplan that has validator failures or WARNs.
+
+Soft dependencies — install both so nothing is skipped:
+- `jsonschema` (pip) — enables JSON Schema shape validation. Without it, only semantic checks run.
+- `pant` 0.22+ — enables Pantagruel spec parsing. Install: `brew tap subsetpark/pantagruel https://github.com/subsetpark/pantagruel && brew install pantagruel`.
+
+The validator covers everything mechanisable: schema shape, spec parsing, context-routing reciprocity, functional-change ID and ownership integrity, dependency-graph DAG correctness and classification consistency, testMap consistency, and repo-relative path safety. See `scripts/validate.py` for the exact set.
+
+The rest is human judgement. Walk these before setting the relevant `mergabilityChecklist` booleans to `true`:
+
+1. **Functional-change coverage** (`functionalChangesOwnedByExactlyOnePatch`) — the validator confirms each FC has a single resolving `ownedBy`. It cannot confirm the *set* of FCs covers every observable change. Re-read `problemStatement`, `solutionSummary`, `acceptanceCriteria`, and `finalStateSpec`; every behavioural promise there must map to an FC.
+
+2. **Context-resource fit** — the validator confirms routing is bidirectional and references resolve. Manually confirm that docs/evals/reference patches actually name the implementation or contract they describe — a resource attached to a patch that never reads it is dead weight.
+
+3. **Spec/evidence completeness** — for each functional change, confirm a spec or acceptance criterion expresses it, a patch implements it, the required context (if any) is attached, and a test/static check is expected to prove it.
+
+4. **Operational considerations are substantive** (`operationalConsiderationsSubstantive`) — every `operationalConsiderations` sub-field is required by the schema, but presence ≠ engagement. Confirm each sub-field names concrete surfaces in *this* gameplan (specific runtimes, formats, code paths, stateful writes) rather than platitudes. "Not applicable" only with a brief gameplan-specific justification. See [Operational Considerations](#operational-considerations).
+
+5. **Atomicity** (`gameplanIsAtomicAndAutonomous`) — re-read [Atomicity Constraint](#atomicity-constraint-read-this-first) and walk the patch list. Confirm no patch is conditional on another's outcome, no `changes` step expects a human between patches (flag flip, manual script, dashboard check, decision branch), and no patch implies an observation/soak window. If any slipped in, re-decompose as a multi-milestone workstream via [[write-workstream]].
+
+6. **Remaining checklist booleans** — once the items above hold, set every other `mergabilityChecklist` boolean honestly based on the gameplan content and the validator's PASS.
 
 ## Resolving Open Questions
 
@@ -391,7 +399,7 @@ For each open question, in order:
    - Removing the question from `openQuestions`.
 5. **Move to the next question.** Do not batch — questions are presented sequentially because later questions often depend on earlier answers, and batching prevents the programmer from reasoning about each decision in isolation.
 
-After the last question is resolved, **re-run verification** (schema validation and spec parsing) since edits made during this dialogue may have introduced regressions.
+After the last question is resolved, **re-run `scripts/validate.py`** since edits made during this dialogue may have introduced regressions.
 
 The end state is a gameplan with `openQuestions: []` and an `explicitOpinions` array that captures every decision made during the dialogue.
 
@@ -404,8 +412,8 @@ The `spec` and `finalStateSpec` fields contain source code in a formal specifica
 We use [Pantagruel](https://github.com/subsetpark/pantagruel) — a language for writing formal specifications with domains, rules, and invariants organized into progressive-disclosure chapters.
 
 - **Language reference**: `https://raw.githubusercontent.com/subsetpark/pantagruel/refs/heads/master/REFERENCE.md` — fetch this for syntax details
-- **Validation (parse + type-check)**: extract spec strings to `.pant` files and run `pant <file.pant>`. Bare `pant` type-checks; exit code 0 means the spec is well-formed. On pant 0.22, success produces no output. If `pant` is not installed, install via Homebrew: `brew tap subsetpark/pantagruel https://github.com/subsetpark/pantagruel && brew install pantagruel`
-- **SMT verification (optional)**: `pant --check <file.pant>` runs SMT-based invariant/precondition checks (requires `z3` or `cvc5`). Use this to catch contradictions, unreachable states, and violated invariants — not a replacement for the parse check. `--bound N` sets the domain-element bound (default 3); `--solver z3|cvc5` picks a solver
+- **Parse validation**: covered by `scripts/validate.py` (see [Verification](#verification)). Bare `pant <file.pant>` type-checks; exit 0 = well-formed; on 0.22, success is silent.
+- **SMT verification (optional)**: `pant --check <file.pant>` runs SMT-based invariant/precondition checks (requires `z3` or `cvc5`). Use this to catch contradictions, unreachable states, and violated invariants — not a replacement for the parse check. `--bound N` sets the domain-element bound (default 3); `--solver z3|cvc5` picks a solver. The validator does not run `--check`; invoke it manually when you want SMT coverage.
 - **Module naming**: final-state spec uses `<PROJECT_NAME>` (e.g., `EXTRACT_DECISION`); per-patch specs use `<PROJECT_NAME>_PATCH_<N>`
 - **Style**:
   - Progressive disclosure (top-down chapter structure); keep per-patch specs self-contained (redeclare referenced domains/rules rather than importing)
@@ -437,3 +445,4 @@ V2 JSON gameplans are consumed programmatically via the `patches` and `dependenc
 
 - `references/gameplan-schema.json` — Formal JSON Schema (draft 2020-12)
 - `references/example.json` — Complete real-world example (uses Pantagruel for specs)
+- `scripts/validate.py` — End-to-end validator (schema + pant + routing + DAG + testMap + paths). Run `python3 scripts/validate.py <gameplan.json>` before finalising.

--- a/skills/write-gameplan/scripts/validate.py
+++ b/skills/write-gameplan/scripts/validate.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""Validate a gameplan JSON.
+
+Runs every check enumerated in SKILL.md's Verification section that can be
+mechanised: JSON Schema shape, Pantagruel spec parsing, context-routing
+reciprocity, functional-change ownership, dependency-graph integrity, and
+testMap consistency.
+
+Usage:
+    python3 scripts/validate.py path/to/gameplan.json
+
+Exit codes:
+    0 — all checks pass
+    1 — one or more checks failed
+    2 — usage / I/O error
+
+Soft dependencies:
+    jsonschema  — enables shape validation; without it, only semantic checks run
+    pant        — enables Pantagruel spec parsing; without it, specs are skipped
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+SCHEMA_PATH = Path(__file__).resolve().parent.parent / "references" / "gameplan-schema.json"
+
+
+def _pid(x: Any) -> str:
+    """Normalise patch IDs to strings (schema permits int or str)."""
+    return str(x)
+
+
+def validate_schema(inst: dict, errors: list[str]) -> None:
+    try:
+        import jsonschema  # type: ignore
+    except ImportError:
+        print("WARN: jsonschema not installed; skipping shape validation", file=sys.stderr)
+        return
+    schema = json.loads(SCHEMA_PATH.read_text())
+    for e in jsonschema.Draft202012Validator(schema).iter_errors(inst):
+        loc = "/".join(str(p) for p in e.absolute_path) or "<root>"
+        errors.append(f"schema [{loc}]: {e.message}")
+
+
+def validate_patch_numbers(inst: dict, errors: list[str]) -> dict[str, dict]:
+    patches = inst.get("patches", [])
+    nums = [_pid(p["number"]) for p in patches]
+    seen: set[str] = set()
+    dupes: set[str] = set()
+    for n in nums:
+        if n in seen:
+            dupes.add(n)
+        seen.add(n)
+    if dupes:
+        errors.append(f"duplicate patch numbers: {sorted(dupes)}")
+    return {_pid(p["number"]): p for p in patches}
+
+
+def validate_routing(inst: dict, patches_by_id: dict[str, dict], errors: list[str]) -> None:
+    resources = {r["id"]: set(_pid(p) for p in r["consumedBy"]) for r in inst.get("contextResources", [])}
+    rids = [r["id"] for r in inst.get("contextResources", [])]
+    if len(rids) != len(set(rids)):
+        errors.append("duplicate contextResource ids")
+    patch_ctx = {_pid(p["number"]): set(p.get("requiredContext", []) or []) for p in inst.get("patches", [])}
+
+    for rid, consumers in resources.items():
+        for pid in consumers:
+            if pid not in patches_by_id:
+                errors.append(f"resource {rid!r} lists missing patch {pid} in consumedBy")
+            elif rid not in patch_ctx.get(pid, set()):
+                errors.append(
+                    f"routing mismatch: resource {rid!r}.consumedBy contains patch {pid}, "
+                    f"but patch {pid}.requiredContext does NOT contain {rid!r}"
+                )
+    for pid, ctx in patch_ctx.items():
+        for rid in ctx:
+            if rid not in resources:
+                errors.append(f"patch {pid}.requiredContext references unknown resource {rid!r}")
+            elif pid not in resources[rid]:
+                errors.append(
+                    f"routing mismatch: patch {pid}.requiredContext contains {rid!r}, "
+                    f"but resource {rid!r}.consumedBy does NOT contain patch {pid}"
+                )
+
+
+def validate_functional_changes(inst: dict, patches_by_id: dict[str, dict], errors: list[str]) -> None:
+    fcs = inst.get("functionalChanges", []) or []
+    ids = [fc["id"] for fc in fcs]
+    if len(ids) != len(set(ids)):
+        errors.append("duplicate functionalChange ids")
+    for fc in fcs:
+        owner = _pid(fc["ownedBy"])
+        if owner not in patches_by_id:
+            errors.append(f"functionalChange {fc['id']!r} ownedBy missing patch {owner}")
+    checklist = inst.get("mergabilityChecklist", {})
+    if checklist.get("functionalChangesOwnedByExactlyOnePatch") is True:
+        # Every FC having a single ownedBy is structurally enforced by the schema
+        # (a single string/int, not a list). This check confirms each owner resolves.
+        # The "covers every observable change" half is a human judgement we cannot
+        # mechanise; flag if there are no FCs at all when checklist claims true.
+        if not fcs:
+            print(
+                "INFO: functionalChanges is empty; the 'covers every observable change' "
+                "half of the checklist remains a human judgement",
+                file=sys.stderr,
+            )
+
+
+def validate_dependency_graph(inst: dict, patches_by_id: dict[str, dict], errors: list[str]) -> None:
+    dg = inst.get("dependencyGraph", []) or []
+    dg_ids = [_pid(d["patch"]) for d in dg]
+    if len(dg_ids) != len(set(dg_ids)):
+        errors.append("duplicate dependencyGraph entries")
+    missing = set(patches_by_id) - set(dg_ids)
+    extra = set(dg_ids) - set(patches_by_id)
+    if missing:
+        errors.append(f"dependencyGraph missing patches: {sorted(missing, key=lambda s: (len(s), s))}")
+    if extra:
+        errors.append(f"dependencyGraph references unknown patches: {sorted(extra)}")
+
+    # classification consistency: dependencyGraph[i].classification == patches[i].classification
+    for d in dg:
+        pid = _pid(d["patch"])
+        if pid in patches_by_id:
+            patch_class = patches_by_id[pid].get("classification")
+            if patch_class != d.get("classification"):
+                errors.append(
+                    f"dependencyGraph patch {pid} classification {d.get('classification')!r} "
+                    f"does not match patch.classification {patch_class!r}"
+                )
+
+    deps = {_pid(d["patch"]): [_pid(x) for x in d.get("dependsOn", [])] for d in dg}
+    for p, ds in deps.items():
+        for dep in ds:
+            if dep not in patches_by_id:
+                errors.append(f"patch {p} depends on unknown patch {dep}")
+
+    # DFS cycle detection
+    UNVISITED, VISITING, DONE = 0, 1, 2
+    color: dict[str, int] = {n: UNVISITED for n in deps}
+    cycle_found = [False]
+
+    def dfs(node: str, stack: list[str]) -> None:
+        if cycle_found[0]:
+            return
+        color[node] = VISITING
+        for nxt in deps.get(node, []):
+            if nxt not in color:
+                continue
+            if color[nxt] == VISITING:
+                idx = stack.index(nxt) if nxt in stack else 0
+                cycle = stack[idx:] + [nxt]
+                errors.append(f"dependency cycle: {' -> '.join(cycle)}")
+                cycle_found[0] = True
+                return
+            if color[nxt] == UNVISITED:
+                dfs(nxt, stack + [nxt])
+                if cycle_found[0]:
+                    return
+        color[node] = DONE
+
+    for n in list(deps):
+        if color.get(n) == UNVISITED:
+            dfs(n, [n])
+            if cycle_found[0]:
+                break
+
+
+def validate_test_map(inst: dict, patches_by_id: dict[str, dict], errors: list[str]) -> None:
+    test_map = inst.get("testMap", []) or []
+    test_names: dict[str, dict] = {}
+    for tm in test_map:
+        if tm["testName"] in test_names:
+            errors.append(f"duplicate testMap entry {tm['testName']!r}")
+        test_names[tm["testName"]] = tm
+        for key in ("stubPatch", "implPatch"):
+            pid = _pid(tm[key])
+            if pid not in patches_by_id:
+                errors.append(f"testMap {tm['testName']!r}.{key} references unknown patch {pid}")
+
+    for p in inst.get("patches", []):
+        pid = _pid(p["number"])
+        for tn in p.get("testStubsIntroduced") or []:
+            tm = test_names.get(tn)
+            if tm is None:
+                errors.append(f"patch {pid}.testStubsIntroduced has {tn!r} not in testMap")
+            elif _pid(tm["stubPatch"]) != pid:
+                errors.append(
+                    f"patch {pid}.testStubsIntroduced lists {tn!r}, "
+                    f"but testMap.stubPatch = {tm['stubPatch']}"
+                )
+        for tn in p.get("testStubsImplemented") or []:
+            tm = test_names.get(tn)
+            if tm is None:
+                errors.append(f"patch {pid}.testStubsImplemented has {tn!r} not in testMap")
+            elif _pid(tm["implPatch"]) != pid:
+                errors.append(
+                    f"patch {pid}.testStubsImplemented lists {tn!r}, "
+                    f"but testMap.implPatch = {tm['implPatch']}"
+                )
+
+
+def validate_specs(inst: dict, errors: list[str]) -> None:
+    pant = shutil.which("pant")
+    if not pant:
+        print("WARN: pant not installed; skipping spec parse validation", file=sys.stderr)
+        return
+    with tempfile.TemporaryDirectory(prefix="gameplan-specs-") as td:
+        tdp = Path(td)
+        for p in inst.get("patches", []):
+            spec = p.get("spec", "")
+            if not spec.strip():
+                errors.append(f"patch {p['number']}.spec is empty")
+                continue
+            f = tdp / f"patch_{p['number']}.pant"
+            f.write_text(spec)
+            r = subprocess.run([pant, str(f)], capture_output=True, text=True)
+            if r.returncode != 0:
+                msg = (r.stderr or r.stdout).strip()
+                errors.append(f"patch {p['number']}.spec failed pant:\n  {msg}")
+        final = inst.get("finalStateSpec", "")
+        if not final.strip():
+            errors.append("finalStateSpec is empty")
+        else:
+            f = tdp / "final.pant"
+            f.write_text(final)
+            r = subprocess.run([pant, str(f)], capture_output=True, text=True)
+            if r.returncode != 0:
+                msg = (r.stderr or r.stdout).strip()
+                errors.append(f"finalStateSpec failed pant:\n  {msg}")
+
+
+def validate_path_safety(inst: dict, errors: list[str]) -> None:
+    """Repo-relative paths only (no .. escapes, no absolute paths)."""
+    def check(path: str, where: str) -> None:
+        if not path:
+            return
+        if path.startswith("/"):
+            errors.append(f"{where}: absolute path {path!r} not allowed")
+        # split on / and check no '..' segment
+        if any(seg == ".." for seg in path.split("/")):
+            errors.append(f"{where}: path {path!r} escapes the repo root with '..'")
+
+    for rc in inst.get("requiredChanges", []) or []:
+        check(rc.get("file", ""), f"requiredChanges[file={rc.get('file')!r}]")
+    for p in inst.get("patches", []) or []:
+        for fobj in p.get("files", []) or []:
+            check(fobj.get("path", ""), f"patch {p.get('number')}.files[path={fobj.get('path')!r}]")
+    for r in inst.get("contextResources", []) or []:
+        for path in r.get("paths", []) or []:
+            # External URLs are permitted for external-reference / reference-doc / paper / etc.
+            if path.startswith(("http://", "https://")):
+                continue
+            check(path, f"contextResources[id={r.get('id')!r}].paths")
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(f"usage: {Path(argv[0]).name} <gameplan.json>", file=sys.stderr)
+        return 2
+    gp_path = Path(argv[1])
+    if not gp_path.exists():
+        print(f"file not found: {gp_path}", file=sys.stderr)
+        return 2
+    try:
+        inst = json.loads(gp_path.read_text())
+    except json.JSONDecodeError as e:
+        print(f"invalid JSON: {e}", file=sys.stderr)
+        return 2
+
+    errors: list[str] = []
+    validate_schema(inst, errors)
+    patches_by_id = validate_patch_numbers(inst, errors)
+    validate_routing(inst, patches_by_id, errors)
+    validate_functional_changes(inst, patches_by_id, errors)
+    validate_dependency_graph(inst, patches_by_id, errors)
+    validate_test_map(inst, patches_by_id, errors)
+    validate_path_safety(inst, errors)
+    validate_specs(inst, errors)
+
+    if errors:
+        for e in errors:
+            print(f"ERROR: {e}")
+        print(f"\nFAIL: {len(errors)} error(s) in {gp_path}", file=sys.stderr)
+        return 1
+    print(f"PASS: {gp_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/skills/write-gameplan/scripts/validate.py
+++ b/skills/write-gameplan/scripts/validate.py
@@ -141,35 +141,35 @@ def validate_dependency_graph(inst: dict, patches_by_id: dict[str, dict], errors
             if dep not in patches_by_id:
                 errors.append(f"patch {p} depends on unknown patch {dep}")
 
-    # DFS cycle detection
+    # DFS cycle detection: cover every node referenced by an edge (not just
+    # dg keys) and report every distinct cycle.
     UNVISITED, VISITING, DONE = 0, 1, 2
-    color: dict[str, int] = {n: UNVISITED for n in deps}
-    cycle_found = [False]
+    all_nodes = set(deps) | {d for ds in deps.values() for d in ds}
+    color: dict[str, int] = {n: UNVISITED for n in all_nodes}
+    seen_cycles: set[tuple[str, ...]] = set()
+
+    def canon(cycle: list[str]) -> tuple[str, ...]:
+        k = min(range(len(cycle)), key=lambda i: cycle[i:] + cycle[:i])
+        return tuple(cycle[k:] + cycle[:k])
 
     def dfs(node: str, stack: list[str]) -> None:
-        if cycle_found[0]:
-            return
         color[node] = VISITING
         for nxt in deps.get(node, []):
-            if nxt not in color:
-                continue
             if color[nxt] == VISITING:
-                idx = stack.index(nxt) if nxt in stack else 0
-                cycle = stack[idx:] + [nxt]
-                errors.append(f"dependency cycle: {' -> '.join(cycle)}")
-                cycle_found[0] = True
-                return
-            if color[nxt] == UNVISITED:
+                # VISITING is only set by an active dfs frame, so nxt is on stack.
+                idx = stack.index(nxt)
+                cycle_nodes = stack[idx:]
+                key = canon(cycle_nodes)
+                if key not in seen_cycles:
+                    seen_cycles.add(key)
+                    errors.append(f"dependency cycle: {' -> '.join(cycle_nodes + [nxt])}")
+            elif color[nxt] == UNVISITED:
                 dfs(nxt, stack + [nxt])
-                if cycle_found[0]:
-                    return
         color[node] = DONE
 
-    for n in list(deps):
-        if color.get(n) == UNVISITED:
+    for n in sorted(all_nodes):
+        if color[n] == UNVISITED:
             dfs(n, [n])
-            if cycle_found[0]:
-                break
 
 
 def validate_test_map(inst: dict, patches_by_id: dict[str, dict], errors: list[str]) -> None:


### PR DESCRIPTION
## Summary

- Adds `skills/write-gameplan/scripts/validate.py` — a single command that mechanises every check SKILL.md's Verification section had previously enumerated in prose: JSON Schema shape, Pantagruel spec parsing, context-routing reciprocity, functional-change ID/ownership integrity, dependency-graph DAG correctness and classification consistency, testMap consistency, and repo-relative path safety.
- Rewrites the Verification section in `skills/write-gameplan/SKILL.md` to lead with the validator invocation and list only the human-judgement items (each named with the `mergabilityChecklist` boolean it gates), removing duplication between SKILL prose and what the script enforces.

## Why

A recent gameplan shipped with a `consumedBy` list that did not match the corresponding patches' `requiredContext` entries. onton caught it at load time; the existing JSON Schema did not, because cross-reference integrity is not expressible in JSON Schema Draft 2020-12. The validator closes that gap: it walks `contextResources[].consumedBy` against `patches[].requiredContext` in both directions and reports any mismatch with the exact resource/patch pair involved.

## Soft dependencies

- `jsonschema` (pip) — enables JSON Schema shape validation.
- `pant` 0.22+ — enables Pantagruel spec parsing. Install: `brew tap subsetpark/pantagruel https://github.com/subsetpark/pantagruel && brew install pantagruel`.

When either is missing, the corresponding phase prints a `WARN` and is skipped — install both for full coverage.

## Test plan

- [x] Validator PASSes against `skills/write-gameplan/references/example.json`.
- [x] Validator FAILs with the expected routing error when `consumedBy` is deliberately broken.
- [x] `dune build`, `dune runtest`, and format check pass (pre-commit hook ran the full suite).
- [ ] Reviewer runs `python3 skills/write-gameplan/scripts/validate.py skills/write-gameplan/references/example.json` and confirms `PASS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/303"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781895370&installation_id=126163856&pr_number=303&repository=flowglad%2Fonton&return_to=https%3A%2F%2Fgithub.com%2Fflowglad%2Fonton%2Fpull%2F303&signature=5bf8beb89f0ce3e142fae03b846efa63e3d0fb65d90a1a7857d4c67561646bd1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a one-step gameplan validator CLI that automates schema, spec, and cross-reference checks to prevent routing mismatches and hidden dependency cycles. Updates SKILL.md to lead with the tool and keep only human checks tied to the mergability checklist.

- New Features
  - Added `skills/write-gameplan/scripts/validate.py` to validate schema, Pantagruel parse, context-routing reciprocity, functional-change ownership, dependency DAG and classification, testMap consistency, and repo‑relative path safety. Dependency cycle detection now reports every independent cycle and also covers nodes referenced only by edges.

- Migration
  - Run: python3 skills/write-gameplan/scripts/validate.py <gameplan.json> (0 = PASS, 1 = FAIL).
  - Install for full coverage: `jsonschema` (pip) and `pant` 0.22+. Missing tools emit WARNs and skip those phases.

<sup>Written for commit b63c8a886e6af935cc5a502bd80d195354b0b73a. Summary will update on new commits. <a href="https://cubic.dev/pr/flowglad/onton/pull/303?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

