### PR TITLE
[extract-bin-fibers] Patch 7: Extract poller_fiber to lib/poller_fiber

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -20,10 +20,7 @@ type config = {
   user_config : User_config.t;
 }
 
-module type STARTUP_RECONCILER = sig
-  val discover_pr :
-    branch:Branch.t -> ((Pr_number.t * Branch.t * bool) option, string) Result.t
-end
+module type STARTUP_RECONCILER = Poller_fiber.STARTUP_RECONCILER
 
 let default_backend = "claude"
 
@@ -173,6 +170,31 @@ struct
 
   module WS = Worktree_setup.Make (W) (WS_Env)
   module Session_driver = Session_driver.Make (W) (SD_Env)
+
+  module Env_poller : Poller_fiber.Poller_env.S = struct
+    let runtime = Env.runtime
+    let clock = Env.clock
+    let fs = Env.fs
+    let project_name = Env.project_name
+    let user_config = Env.config.user_config
+    let worktree_mutex = Env.worktree_mutex
+    let hook_mutex = Env.hook_mutex
+    let process_mgr = Env.process_mgr
+    let github_owner = Env.config.github_owner
+    let github_repo = Env.config.github_repo
+    let main_branch = Env.config.main_branch
+    let poll_interval = Env.config.poll_interval
+    let repo_root = Env.config.repo_root
+    let find_pr_number = Pr_registry.find Env.pr_registry
+    let register_pr_number = Pr_registry.register Env.pr_registry
+    let unregister_pr_number = Pr_registry.unregister Env.pr_registry
+    let findings_registry = Env.findings_registry
+    let review_clients = Env.review_clients
+    let event_log = Env.event_log
+    let branch_of = Env.branch_of
+  end
+
+  module Poller = Poller_fiber.Make (Forge) (W) (Env_poller)
 
   (** Execute declarative GitHub effects and record successful observations back
       into durable state. *)
@@ -1500,17 +1522,6 @@ struct
     in
     loop ()
 
-  (** Per-agent poll intent, collected inside [read] and executed outside. *)
-  type poll_intent =
-    | Skip_no_pr of Patch_id.t
-    | Poll of {
-        patch_id : Patch_id.t;
-        pr_number : Pr_number.t;
-        was_merged : bool;
-      }
-
-  (** Poller fiber — periodically polls GitHub for PR state changes and
-      reconciles. *)
   let poll_review_backends ~runtime ~patch_id ~findings_registry ~review_clients
       ~owner ~repo ~pr_number : Review_service.finding list =
     Base.List.concat_map review_clients
@@ -1568,317 +1579,7 @@ struct
                   };
                 { f with Review_service.id = key }))
 
-  (** Translate a [Github] result into a [Poll_outcome.t]. Pure-modulo-show; the
-      boundary lets [Poll_cycle.classify] reason about timeouts the same way it
-      reasons about other failures, which is the invariant the interleaving
-      property tests exercise. *)
-  let poll_outcome_of_github_result = function
-    | Ok pr_state -> Poll_outcome.Ok_pr_state pr_state
-    | Error (Github.Timeout { seconds; _ }) ->
-        Poll_outcome.Timed_out { seconds }
-    | Error (Github.Transport_error { msg; _ }) ->
-        Poll_outcome.Transport_failed { msg }
-    | Error (Github.Http_error { status; body; _ }) ->
-        Poll_outcome.Http_failed { status; msg = body }
-    | Error (Github.Graphql_error msgs) -> Poll_outcome.Graphql_failed msgs
-    | Error (Github.Json_parse_error msg) -> Poll_outcome.Json_parse_failed msg
-
-  let poller_fiber (module StartupReconciler : STARTUP_RECONCILER) =
-    let runtime = Env.runtime in
-    let clock = Env.clock in
-    let process_mgr = Env.process_mgr in
-    let config = Env.config in
-    let project_name = Env.project_name in
-    let pr_registry = Env.pr_registry in
-    let branch_of = Env.branch_of in
-    let event_log = Env.event_log in
-    let review_clients = Env.review_clients in
-    let findings_registry = Env.findings_registry in
-    let main = config.main_branch in
-    let skip_logged : (Patch_id.t, bool) Hashtbl.t = Hashtbl.create 16 in
-    let skip_logged_mutex = Eio.Mutex.create () in
-    let mark_skip_logged patch_id =
-      Eio.Mutex.use_rw ~protect:true skip_logged_mutex (fun () ->
-          if Hashtbl.mem skip_logged patch_id then false
-          else (
-            Hashtbl.replace skip_logged patch_id true;
-            true))
-    in
-    let rec loop () =
-      let intents =
-        Runtime.read runtime (fun snap ->
-            let agents = Orchestrator.all_agents snap.Runtime.orchestrator in
-            Base.List.filter_map agents ~f:(fun (agent : Patch_agent.t) ->
-                if Patch_agent.has_pr agent && not agent.Patch_agent.merged then
-                  match
-                    Pr_registry.find pr_registry
-                      ~patch_id:agent.Patch_agent.patch_id
-                  with
-                  | None -> Some (Skip_no_pr agent.Patch_agent.patch_id)
-                  | Some pr_number ->
-                      Some
-                        (Poll
-                           {
-                             patch_id = agent.Patch_agent.patch_id;
-                             pr_number;
-                             was_merged = agent.Patch_agent.merged;
-                           })
-                else None))
-      in
-      (* Handle Skip_no_pr intents up front — they need no network I/O. *)
-      let poll_intents =
-        Base.List.filter_map intents ~f:(function
-          | Skip_no_pr patch_id ->
-              if mark_skip_logged patch_id then
-                log_event runtime ~patch_id
-                  "Skipping poll — no PR number registered";
-              None
-          | Poll { patch_id; pr_number; was_merged } ->
-              Some (patch_id, pr_number, was_merged))
-      in
-      (* Phase 1a: parallel per-patch PR state fetch.
-
-       This is the head-of-line-blocking fix: when one patch's TCP connect
-       is wedged in [SYN_SENT], the forge returns [Timeout] after the default
-       GitHub request timeout — and every other patch's fiber proceeds
-       independently. *)
-      let outcomes =
-        Eio.Fiber.List.map ~max_fibers:16
-          (fun (patch_id, pr_number, was_merged) ->
-            let outcome =
-              poll_outcome_of_github_result (Forge.pr_state pr_number)
-            in
-            (patch_id, pr_number, was_merged, outcome))
-          poll_intents
-      in
-      (* Phase 1b: pure classification. *)
-      let plans =
-        Base.List.map outcomes
-          ~f:(fun (patch_id, pr_number, was_merged, outcome) ->
-            let cls =
-              Poll_cycle.classify { patch_id; pr_number; was_merged; outcome }
-            in
-            (patch_id, pr_number, cls))
-      in
-      (* Phase 1c: per-patch effectful tail. Builds observations from
-       [Apply_pr_state] plans, handles [Rediscover_pr] / [Skip_fork] /
-       [Log_error]. *)
-      let observations =
-        Base.List.filter_map plans ~f:(fun (patch_id, pr_number, cls) ->
-            match cls with
-            | Poll_cycle.Log_error { message } ->
-                log_event runtime ~patch_id message;
-                None
-            | Poll_cycle.Skip_fork _ ->
-                if mark_skip_logged patch_id then
-                  log_event runtime ~patch_id
-                    (Printf.sprintf
-                       "Skipping PR #%d — fork PRs are not supported"
-                       (Pr_number.to_int pr_number));
-                None
-            | Poll_cycle.Rediscover_pr { head_branch } ->
-                log_event runtime ~patch_id
-                  (Printf.sprintf "PR #%d closed — looking for replacement"
-                     (Pr_number.to_int pr_number));
-                let branch =
-                  match head_branch with
-                  | Some b -> b
-                  | None ->
-                      Runtime.read runtime (fun snap ->
-                          match
-                            Orchestrator.find_agent snap.Runtime.orchestrator
-                              patch_id
-                          with
-                          | Some agent -> agent.Patch_agent.branch
-                          | None -> branch_of patch_id)
-                in
-                (match StartupReconciler.discover_pr ~branch with
-                | Ok (Some (new_pr, base_branch, merged)) ->
-                    log_event runtime ~patch_id
-                      (Printf.sprintf "Switched to PR #%d"
-                         (Pr_number.to_int new_pr));
-                    Pr_registry.register pr_registry ~patch_id ~pr_number:new_pr;
-                    Runtime.update_orchestrator runtime (fun orch ->
-                        Patch_controller.apply_replacement_pr orch patch_id
-                          ~pr_number:new_pr ~base_branch ~merged)
-                | Ok None ->
-                    log_event runtime ~patch_id
-                      "No open PR found — cleared stale PR state, will create \
-                       on next session";
-                    Pr_registry.unregister pr_registry ~patch_id;
-                    Runtime.update_orchestrator runtime (fun orch ->
-                        Orchestrator.clear_pr orch patch_id)
-                | Error msg ->
-                    log_event runtime ~patch_id
-                      (Printf.sprintf "PR re-discovery failed — %s" msg));
-                None
-            | Poll_cycle.Apply_pr_state
-                { pr_state; poll_result; ci_checks_truncated } ->
-                (* Augment with findings from every configured review backend.
-                 Failures inside [poll_review_backends] are logged but
-                 non-fatal. *)
-                let findings =
-                  if Base.List.is_empty review_clients then []
-                  else
-                    poll_review_backends ~runtime ~patch_id ~findings_registry
-                      ~review_clients ~owner:config.github_owner
-                      ~repo:config.github_repo
-                      ~pr_number:(Pr_number.to_int pr_number)
-                in
-                let pr_state = { pr_state with Pr_state.findings } in
-                let branch_in_root =
-                  match pr_state.Pr_state.head_branch with
-                  | Some b ->
-                      Worktree.is_checked_out_in_repo_root ~process_mgr
-                        ~repo_root:config.repo_root b
-                  | None -> false
-                in
-                let failed_ci =
-                  Base.List.filter poll_result.Poller.ci_checks
-                    ~f:(fun (c : Ci_check.t) ->
-                      Base.List.mem Patch_decision.failure_conclusions
-                        c.Ci_check.conclusion ~equal:Base.String.equal)
-                in
-                let worktree_candidate =
-                  let agent =
-                    Runtime.read runtime (fun snap ->
-                        Orchestrator.find_agent snap.Runtime.orchestrator
-                          patch_id)
-                  in
-                  match agent with
-                  | None -> None
-                  | Some agent ->
-                      if Option.is_some agent.Patch_agent.worktree_path then
-                        None
-                      else
-                        let path =
-                          WS.resolve_worktree_path ~patch_id ~agent ()
-                        in
-                        let default =
-                          Worktree.worktree_dir ~project_name ~patch_id
-                        in
-                        if not (String.equal path default) then Some path
-                        else None
-                in
-                let observation =
-                  Patch_controller.
-                    {
-                      poll_result;
-                      base_branch = pr_state.Pr_state.base_branch;
-                      branch_in_root;
-                      worktree_path = worktree_candidate;
-                    }
-                in
-                Some (patch_id, observation, failed_ci, ci_checks_truncated))
-      in
-      (* Phase 2: Single atomic update — apply all poll results + reconcile.
-       This prevents the runner from seeing an intermediate state where
-       poll results are applied but the reconciler hasn't run yet. *)
-      let per_patch_sides, reconcile_logs =
-        Runtime.update_orchestrator_returning runtime (fun orch ->
-            (* Apply all poll results *)
-            let orch, sides =
-              Base.List.fold observations ~init:(orch, [])
-                ~f:(fun
-                    (orch, sides) (patch_id, obs, failed_ci, ci_truncated) ->
-                  match Orchestrator.find_agent orch patch_id with
-                  | None -> (orch, sides)
-                  | Some agent_before ->
-                      let orch, log_entries, newly_blocked =
-                        Patch_controller.apply_poll_result orch patch_id obs
-                      in
-                      let agent_after = Orchestrator.agent orch patch_id in
-                      Event_log.log_poll event_log ~patch_id
-                        ~poll_result:obs.Patch_controller.poll_result
-                        ~agent_before ~agent_after
-                        ~logs:
-                          (Base.List.map log_entries
-                             ~f:(fun (e : Patch_controller.poll_log_entry) ->
-                               e.Patch_controller.message));
-                      ( orch,
-                        ( patch_id,
-                          log_entries,
-                          newly_blocked,
-                          failed_ci,
-                          ci_truncated )
-                        :: sides ))
-            in
-            (* Reconcile — detect merges and enqueue rebases *)
-            let agents = Orchestrator.all_agents orch in
-            let patch_views =
-              Base.List.map agents ~f:(fun (a : Patch_agent.t) ->
-                  Reconciler.
-                    {
-                      id = a.Patch_agent.patch_id;
-                      has_pr = Patch_agent.has_pr a;
-                      merged = a.Patch_agent.merged;
-                      busy = a.Patch_agent.busy;
-                      needs_intervention = Patch_agent.needs_intervention a;
-                      branch_blocked = a.Patch_agent.branch_blocked;
-                      queue = a.Patch_agent.queue;
-                      base_branch =
-                        Base.Option.value a.Patch_agent.base_branch
-                          ~default:main;
-                      branch_rebased_onto = a.Patch_agent.branch_rebased_onto;
-                    })
-            in
-            let merged_patches =
-              Base.List.filter_map agents ~f:(fun (a : Patch_agent.t) ->
-                  if a.Patch_agent.merged then Some a.Patch_agent.patch_id
-                  else None)
-            in
-            let actions =
-              Reconciler.reconcile ~graph:(Orchestrator.graph orch) ~main
-                ~merged_pr_patches:merged_patches ~branch_of patch_views
-            in
-            let rec_logs = ref [] in
-            let orch =
-              Base.List.fold actions ~init:orch ~f:(fun orch action ->
-                  match action with
-                  | Reconciler.Mark_merged pid ->
-                      Orchestrator.mark_merged orch pid
-                  | Reconciler.Enqueue_rebase pid ->
-                      rec_logs :=
-                        ("rebase enqueued by reconciler", pid) :: !rec_logs;
-                      Orchestrator.enqueue orch pid Operation_kind.Rebase
-                  | Reconciler.Start_operation _ -> orch)
-            in
-            (orch, (Base.List.rev sides, Base.List.rev !rec_logs)))
-      in
-      (* Phase 3: Side effects — outside the lock *)
-      Base.List.iter per_patch_sides
-        ~f:(fun
-            (patch_id, log_entries, newly_blocked, _failed_ci, ci_truncated) ->
-          Base.List.iter log_entries
-            ~f:(fun (entry : Patch_controller.poll_log_entry) ->
-              log_event runtime ~patch_id:entry.Patch_controller.patch_id
-                entry.Patch_controller.message);
-          (if newly_blocked then
-             let b =
-               Runtime.read runtime (fun snap ->
-                   match
-                     Orchestrator.find_agent snap.Runtime.orchestrator patch_id
-                   with
-                   | Some a -> Branch.to_string a.Patch_agent.branch
-                   | None -> "unknown")
-             in
-             let main_root = W.resolve_main_root () in
-             log_event runtime ~patch_id
-               (Printf.sprintf
-                  "Cannot work on patch — branch %s is checked out in the main \
-                   working tree (%s); release it (e.g. `git -C %s checkout \
-                   <default-branch>`) before continuing"
-                  b main_root main_root));
-          if ci_truncated then
-            log_event runtime ~patch_id
-              "Warning — CI check list was truncated (>100 checks); some \
-               failures may not appear in the prompt");
-      Base.List.iter reconcile_logs ~f:(fun (msg, pid) ->
-          log_event runtime ~patch_id:pid msg);
-      Eio.Time.sleep clock config.poll_interval;
-      loop ()
-    in
-    loop ()
+  let poller_fiber startup_reconciler = Poller.run startup_reconciler
 
   (** Runner fiber — executes orchestrator actions by driving backend sessions
       concurrently. *)

--- a/lib/poller_fiber.ml
+++ b/lib/poller_fiber.ml
@@ -1,0 +1,421 @@
+open Base
+open Types
+
+module Poller_env = struct
+  module type S = sig
+    include Run_env.S
+
+    val process_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t
+    val github_owner : string
+    val github_repo : string
+    val main_branch : Branch.t
+    val poll_interval : float
+    val repo_root : string
+    val find_pr_number : patch_id:Patch_id.t -> Pr_number.t option
+
+    val register_pr_number :
+      patch_id:Patch_id.t -> pr_number:Pr_number.t -> unit
+
+    val unregister_pr_number : patch_id:Patch_id.t -> unit
+    val findings_registry : Findings_registry.t
+
+    val review_clients :
+      (module Review_service_client.S
+         with type error = Review_service_client.error)
+      list
+
+    val event_log : Event_log.t
+    val branch_of : Patch_id.t -> Branch.t
+  end
+end
+
+module type STARTUP_RECONCILER = sig
+  val discover_pr :
+    branch:Branch.t -> ((Pr_number.t * Branch.t * bool) option, string) Result.t
+end
+
+module Make
+    (Forge : Forge.S with type error = Github.error)
+    (W : Worktree.S)
+    (Env : Poller_env.S) =
+struct
+  module WS = Worktree_setup.Make (W) (Env)
+
+  (** Per-agent poll intent, collected inside [read] and executed outside. *)
+  type poll_intent =
+    | Skip_no_pr of Patch_id.t
+    | Poll of {
+        patch_id : Patch_id.t;
+        pr_number : Pr_number.t;
+        was_merged : bool;
+      }
+
+  let poll_review_backends ~runtime ~patch_id ~findings_registry ~review_clients
+      ~owner ~repo ~pr_number : Review_service.finding list =
+    List.concat_map review_clients
+      ~f:(fun
+          (module R : Review_service_client.S
+            with type error = Review_service_client.error)
+        ->
+        match R.list_findings ~owner ~repo ~pr_number () with
+        | Error err ->
+            Runtime_logging.log_event runtime ~patch_id
+              (Printf.sprintf "Poll error — %s" (R.show_error err));
+            []
+        | Ok response ->
+            let parsed_count = List.length response.Review_service.findings in
+            if not (Int.equal parsed_count response.Review_service.count) then
+              Runtime_logging.log_event runtime ~patch_id
+                (Printf.sprintf
+                   "Review backend %s declared %d finding(s) but parsed %d — \
+                    possible review-service schema drift"
+                   R.name response.Review_service.count parsed_count);
+            List.iter response.Review_service.dropped_findings
+              ~f:(fun (e : Review_service.finding_parse_error) ->
+                let json =
+                  if String.length e.Review_service.json <= 500 then
+                    e.Review_service.json
+                  else String.sub e.Review_service.json ~pos:0 ~len:497 ^ "..."
+                in
+                Runtime_logging.log_event runtime ~patch_id
+                  (Printf.sprintf
+                     "Review backend %s dropped finding at index %d while \
+                      parsing: %s; json=%s"
+                     R.name e.Review_service.index e.Review_service.error json));
+            let keyed_findings =
+              List.map response.Review_service.findings
+                ~f:(fun (f : Review_service.finding) ->
+                  let key =
+                    Findings_registry.make_key ~backend_name:R.name ~owner ~repo
+                      ~pr_number ~finding_id:f.Review_service.id
+                  in
+                  (key, f))
+            in
+            Findings_registry.remove_stale_for_scope findings_registry
+              ~backend_name:R.name ~owner ~repo ~pr_number
+              ~keep_keys:(List.map keyed_findings ~f:fst);
+            List.map keyed_findings ~f:(fun (key, f) ->
+                Findings_registry.register findings_registry ~key
+                  {
+                    Findings_registry.backend_name = R.name;
+                    owner;
+                    repo;
+                    pr_number;
+                    finding_id = f.Review_service.id;
+                  };
+                { f with Review_service.id = key }))
+
+  (** Translate a [Github] result into a [Poll_outcome.t]. Pure-modulo-show; the
+      boundary lets [Poll_cycle.classify] reason about timeouts the same way it
+      reasons about other failures, which is the invariant the interleaving
+      property tests exercise. *)
+  let poll_outcome_of_github_result = function
+    | Ok pr_state -> Poll_outcome.Ok_pr_state pr_state
+    | Error (Github.Timeout { seconds; _ }) ->
+        Poll_outcome.Timed_out { seconds }
+    | Error (Github.Transport_error { msg; _ }) ->
+        Poll_outcome.Transport_failed { msg }
+    | Error (Github.Http_error { status; body; _ }) ->
+        Poll_outcome.Http_failed { status; msg = body }
+    | Error (Github.Graphql_error msgs) -> Poll_outcome.Graphql_failed msgs
+    | Error (Github.Json_parse_error msg) -> Poll_outcome.Json_parse_failed msg
+
+  let run (module StartupReconciler : STARTUP_RECONCILER) =
+    let runtime = Env.runtime in
+    let clock = Env.clock in
+    let process_mgr = Env.process_mgr in
+    let project_name = Env.project_name in
+    let github_owner = Env.github_owner in
+    let github_repo = Env.github_repo in
+    let main = Env.main_branch in
+    let poll_interval = Env.poll_interval in
+    let repo_root = Env.repo_root in
+    let find_pr_number = Env.find_pr_number in
+    let register_pr_number = Env.register_pr_number in
+    let unregister_pr_number = Env.unregister_pr_number in
+    let branch_of = Env.branch_of in
+    let event_log = Env.event_log in
+    let review_clients = Env.review_clients in
+    let findings_registry = Env.findings_registry in
+    let skip_logged : (Patch_id.t, bool) Stdlib.Hashtbl.t =
+      Stdlib.Hashtbl.create 16
+    in
+    let skip_logged_mutex = Eio.Mutex.create () in
+    let mark_skip_logged patch_id =
+      Eio.Mutex.use_rw ~protect:true skip_logged_mutex (fun () ->
+          if Stdlib.Hashtbl.mem skip_logged patch_id then false
+          else (
+            Stdlib.Hashtbl.replace skip_logged patch_id true;
+            true))
+    in
+    let rec loop () =
+      let intents =
+        Runtime.read runtime (fun snap ->
+            let agents = Orchestrator.all_agents snap.Runtime.orchestrator in
+            List.filter_map agents ~f:(fun (agent : Patch_agent.t) ->
+                if Patch_agent.has_pr agent && not agent.Patch_agent.merged then
+                  match find_pr_number ~patch_id:agent.Patch_agent.patch_id with
+                  | None -> Some (Skip_no_pr agent.Patch_agent.patch_id)
+                  | Some pr_number ->
+                      Some
+                        (Poll
+                           {
+                             patch_id = agent.Patch_agent.patch_id;
+                             pr_number;
+                             was_merged = agent.Patch_agent.merged;
+                           })
+                else None))
+      in
+      (* Handle Skip_no_pr intents up front — they need no network I/O. *)
+      let poll_intents =
+        List.filter_map intents ~f:(function
+          | Skip_no_pr patch_id ->
+              if mark_skip_logged patch_id then
+                Runtime_logging.log_event runtime ~patch_id
+                  "Skipping poll — no PR number registered";
+              None
+          | Poll { patch_id; pr_number; was_merged } ->
+              Some (patch_id, pr_number, was_merged))
+      in
+      (* Phase 1a: parallel per-patch PR state fetch.
+
+       This is the head-of-line-blocking fix: when one patch's TCP connect
+       is wedged in [SYN_SENT], the forge returns [Timeout] after the default
+       GitHub request timeout — and every other patch's fiber proceeds
+       independently. *)
+      let outcomes =
+        Eio.Fiber.List.map ~max_fibers:16
+          (fun (patch_id, pr_number, was_merged) ->
+            let outcome =
+              poll_outcome_of_github_result (Forge.pr_state pr_number)
+            in
+            (patch_id, pr_number, was_merged, outcome))
+          poll_intents
+      in
+      (* Phase 1b: pure classification. *)
+      let plans =
+        List.map outcomes ~f:(fun (patch_id, pr_number, was_merged, outcome) ->
+            let cls =
+              Poll_cycle.classify { patch_id; pr_number; was_merged; outcome }
+            in
+            (patch_id, pr_number, cls))
+      in
+      (* Phase 1c: per-patch effectful tail. Builds observations from
+       [Apply_pr_state] plans, handles [Rediscover_pr] / [Skip_fork] /
+       [Log_error]. *)
+      let observations =
+        List.filter_map plans ~f:(fun (patch_id, pr_number, cls) ->
+            match cls with
+            | Poll_cycle.Log_error { message } ->
+                Runtime_logging.log_event runtime ~patch_id message;
+                None
+            | Poll_cycle.Skip_fork _ ->
+                if mark_skip_logged patch_id then
+                  Runtime_logging.log_event runtime ~patch_id
+                    (Printf.sprintf
+                       "Skipping PR #%d — fork PRs are not supported"
+                       (Pr_number.to_int pr_number));
+                None
+            | Poll_cycle.Rediscover_pr { head_branch } ->
+                Runtime_logging.log_event runtime ~patch_id
+                  (Printf.sprintf "PR #%d closed — looking for replacement"
+                     (Pr_number.to_int pr_number));
+                let branch =
+                  match head_branch with
+                  | Some b -> b
+                  | None ->
+                      Runtime.read runtime (fun snap ->
+                          match
+                            Orchestrator.find_agent snap.Runtime.orchestrator
+                              patch_id
+                          with
+                          | Some agent -> agent.Patch_agent.branch
+                          | None -> branch_of patch_id)
+                in
+                (match StartupReconciler.discover_pr ~branch with
+                | Ok (Some (new_pr, base_branch, merged)) ->
+                    Runtime_logging.log_event runtime ~patch_id
+                      (Printf.sprintf "Switched to PR #%d"
+                         (Pr_number.to_int new_pr));
+                    register_pr_number ~patch_id ~pr_number:new_pr;
+                    Runtime.update_orchestrator runtime (fun orch ->
+                        Patch_controller.apply_replacement_pr orch patch_id
+                          ~pr_number:new_pr ~base_branch ~merged)
+                | Ok None ->
+                    Runtime_logging.log_event runtime ~patch_id
+                      "No open PR found — cleared stale PR state, will create \
+                       on next session";
+                    unregister_pr_number ~patch_id;
+                    Runtime.update_orchestrator runtime (fun orch ->
+                        Orchestrator.clear_pr orch patch_id)
+                | Error msg ->
+                    Runtime_logging.log_event runtime ~patch_id
+                      (Printf.sprintf "PR re-discovery failed — %s" msg));
+                None
+            | Poll_cycle.Apply_pr_state
+                { pr_state; poll_result; ci_checks_truncated } ->
+                (* Augment with findings from every configured review backend.
+                 Failures inside [poll_review_backends] are logged but
+                 non-fatal. *)
+                let findings =
+                  if List.is_empty review_clients then []
+                  else
+                    poll_review_backends ~runtime ~patch_id ~findings_registry
+                      ~review_clients ~owner:github_owner ~repo:github_repo
+                      ~pr_number:(Pr_number.to_int pr_number)
+                in
+                let pr_state = { pr_state with Pr_state.findings } in
+                let branch_in_root =
+                  match pr_state.Pr_state.head_branch with
+                  | Some b ->
+                      Worktree.is_checked_out_in_repo_root ~process_mgr
+                        ~repo_root b
+                  | None -> false
+                in
+                let failed_ci =
+                  List.filter poll_result.Poller.ci_checks
+                    ~f:(fun (c : Ci_check.t) ->
+                      List.mem Patch_decision.failure_conclusions
+                        c.Ci_check.conclusion ~equal:String.equal)
+                in
+                let worktree_candidate =
+                  let agent =
+                    Runtime.read runtime (fun snap ->
+                        Orchestrator.find_agent snap.Runtime.orchestrator
+                          patch_id)
+                  in
+                  match agent with
+                  | None -> None
+                  | Some agent ->
+                      if Option.is_some agent.Patch_agent.worktree_path then
+                        None
+                      else
+                        let path =
+                          WS.resolve_worktree_path ~patch_id ~agent ()
+                        in
+                        let default =
+                          Worktree.worktree_dir ~project_name ~patch_id
+                        in
+                        if not (String.equal path default) then Some path
+                        else None
+                in
+                let observation =
+                  Patch_controller.
+                    {
+                      poll_result;
+                      base_branch = pr_state.Pr_state.base_branch;
+                      branch_in_root;
+                      worktree_path = worktree_candidate;
+                    }
+                in
+                Some (patch_id, observation, failed_ci, ci_checks_truncated))
+      in
+      (* Phase 2: Single atomic update — apply all poll results + reconcile.
+       This prevents the runner from seeing an intermediate state where
+       poll results are applied but the reconciler hasn't run yet. *)
+      let per_patch_sides, reconcile_logs =
+        Runtime.update_orchestrator_returning runtime (fun orch ->
+            (* Apply all poll results *)
+            let orch, sides =
+              List.fold observations ~init:(orch, [])
+                ~f:(fun
+                    (orch, sides) (patch_id, obs, failed_ci, ci_truncated) ->
+                  match Orchestrator.find_agent orch patch_id with
+                  | None -> (orch, sides)
+                  | Some agent_before ->
+                      let orch, log_entries, newly_blocked =
+                        Patch_controller.apply_poll_result orch patch_id obs
+                      in
+                      let agent_after = Orchestrator.agent orch patch_id in
+                      Event_log.log_poll event_log ~patch_id
+                        ~poll_result:obs.Patch_controller.poll_result
+                        ~agent_before ~agent_after
+                        ~logs:
+                          (List.map log_entries
+                             ~f:(fun (e : Patch_controller.poll_log_entry) ->
+                               e.Patch_controller.message));
+                      ( orch,
+                        ( patch_id,
+                          log_entries,
+                          newly_blocked,
+                          failed_ci,
+                          ci_truncated )
+                        :: sides ))
+            in
+            (* Reconcile — detect merges and enqueue rebases *)
+            let agents = Orchestrator.all_agents orch in
+            let patch_views =
+              List.map agents ~f:(fun (a : Patch_agent.t) ->
+                  Reconciler.
+                    {
+                      id = a.Patch_agent.patch_id;
+                      has_pr = Patch_agent.has_pr a;
+                      merged = a.Patch_agent.merged;
+                      busy = a.Patch_agent.busy;
+                      needs_intervention = Patch_agent.needs_intervention a;
+                      branch_blocked = a.Patch_agent.branch_blocked;
+                      queue = a.Patch_agent.queue;
+                      base_branch =
+                        Option.value a.Patch_agent.base_branch ~default:main;
+                      branch_rebased_onto = a.Patch_agent.branch_rebased_onto;
+                    })
+            in
+            let merged_patches =
+              List.filter_map agents ~f:(fun (a : Patch_agent.t) ->
+                  if a.Patch_agent.merged then Some a.Patch_agent.patch_id
+                  else None)
+            in
+            let actions =
+              Reconciler.reconcile ~graph:(Orchestrator.graph orch) ~main
+                ~merged_pr_patches:merged_patches ~branch_of patch_views
+            in
+            let rec_logs = ref [] in
+            let orch =
+              List.fold actions ~init:orch ~f:(fun orch action ->
+                  match action with
+                  | Reconciler.Mark_merged pid ->
+                      Orchestrator.mark_merged orch pid
+                  | Reconciler.Enqueue_rebase pid ->
+                      rec_logs :=
+                        ("rebase enqueued by reconciler", pid) :: !rec_logs;
+                      Orchestrator.enqueue orch pid Operation_kind.Rebase
+                  | Reconciler.Start_operation _ -> orch)
+            in
+            (orch, (List.rev sides, List.rev !rec_logs)))
+      in
+      (* Phase 3: Side effects — outside the lock *)
+      List.iter per_patch_sides
+        ~f:(fun
+            (patch_id, log_entries, newly_blocked, _failed_ci, ci_truncated) ->
+          List.iter log_entries
+            ~f:(fun (entry : Patch_controller.poll_log_entry) ->
+              Runtime_logging.log_event runtime
+                ~patch_id:entry.Patch_controller.patch_id
+                entry.Patch_controller.message);
+          (if newly_blocked then
+             let b =
+               Runtime.read runtime (fun snap ->
+                   match
+                     Orchestrator.find_agent snap.Runtime.orchestrator patch_id
+                   with
+                   | Some a -> Branch.to_string a.Patch_agent.branch
+                   | None -> "unknown")
+             in
+             let main_root = W.resolve_main_root () in
+             Runtime_logging.log_event runtime ~patch_id
+               (Printf.sprintf
+                  "Cannot work on patch — branch %s is checked out in the main \
+                   working tree (%s); release it (e.g. `git -C %s checkout \
+                   <default-branch>`) before continuing"
+                  b main_root main_root));
+          if ci_truncated then
+            Runtime_logging.log_event runtime ~patch_id
+              "Warning — CI check list was truncated (>100 checks); some \
+               failures may not appear in the prompt");
+      List.iter reconcile_logs ~f:(fun (msg, pid) ->
+          Runtime_logging.log_event runtime ~patch_id:pid msg);
+      Eio.Time.sleep clock poll_interval;
+      loop ()
+    in
+    loop ()
+end

--- a/lib/poller_fiber.ml
+++ b/lib/poller_fiber.ml
@@ -39,7 +39,17 @@ module Make
     (W : Worktree.S)
     (Env : Poller_env.S) =
 struct
-  module WS = Worktree_setup.Make (W) (Env)
+  module WS_Env : Worktree_setup.ENV = struct
+    let runtime = Env.runtime
+    let clock = Env.clock
+    let fs = Env.fs
+    let project_name = Env.project_name
+    let user_config = Env.user_config
+    let worktree_mutex = Env.worktree_mutex
+    let hook_mutex = Env.hook_mutex
+  end
+
+  module WS = Worktree_setup.Make (W) (WS_Env)
 
   (** Per-agent poll intent, collected inside [read] and executed outside. *)
   type poll_intent =

--- a/lib/poller_fiber.mli
+++ b/lib/poller_fiber.mli
@@ -1,0 +1,42 @@
+open Types
+
+(** Minimal construction-time environment for the poller fiber. *)
+module Poller_env : sig
+  module type S = sig
+    include Run_env.S
+
+    val process_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t
+    val github_owner : string
+    val github_repo : string
+    val main_branch : Branch.t
+    val poll_interval : float
+    val repo_root : string
+    val find_pr_number : patch_id:Patch_id.t -> Pr_number.t option
+
+    val register_pr_number :
+      patch_id:Patch_id.t -> pr_number:Pr_number.t -> unit
+
+    val unregister_pr_number : patch_id:Patch_id.t -> unit
+    val findings_registry : Findings_registry.t
+
+    val review_clients :
+      (module Review_service_client.S
+         with type error = Review_service_client.error)
+      list
+
+    val event_log : Event_log.t
+    val branch_of : Patch_id.t -> Branch.t
+  end
+end
+
+module type STARTUP_RECONCILER = sig
+  val discover_pr :
+    branch:Branch.t -> ((Pr_number.t * Branch.t * bool) option, string) Result.t
+end
+
+module Make
+    (_ : Forge.S with type error = Github.error)
+    (_ : Worktree.S)
+    (_ : Poller_env.S) : sig
+  val run : (module STARTUP_RECONCILER) -> unit
+end


### PR DESCRIPTION
## Patch 7: Extract poller_fiber to lib/poller_fiber

- Define Poller_env.S in lib/poller_fiber.mli — the minimal subset of FIBER_ENV the poller actually reads (likely runtime, clock, project_name, owner, repo, pr_registry, findings_registry, event_log, review_clients, transcripts, branch_of plus the seven Run_env capabilities — verify by reading bin/main.ml:1794–2092).
- Lift the poller_fiber body verbatim into lib/poller_fiber.ml's Make functor; replace closure-captured deps with Env accesses.
- In bin/main.ml's Make_fibers, instantiate `module Poller = Onton.Poller_fiber.Make (Forge) (W) (Env_poller)` and replace the in-line `poller_fiber` definition with a binding that delegates to `Poller.run`.
- Confirm dune build + dune runtest still pass.

## Changes
- Define Poller_env.S in lib/poller_fiber.mli — the minimal subset of FIBER_ENV the poller actually reads (likely runtime, clock, project_name, owner, repo, pr_registry, findings_registry, event_log, review_clients, transcripts, branch_of plus the seven Run_env capabilities — verify by reading bin/main.ml:1794–2092).
- Lift the poller_fiber body verbatim into lib/poller_fiber.ml's Make functor; replace closure-captured deps with Env accesses.
- In bin/main.ml's Make_fibers, instantiate `module Poller = Onton.Poller_fiber.Make (Forge) (W) (Env_poller)` and replace the in-line `poller_fiber` definition with a binding that delegates to `Poller.run`.
- Confirm dune build + dune runtest still pass.

## Files to Modify
- lib/poller_fiber.mli (create): module Poller_env : module type S and module Make(Forge)(W)(Env : Poller_env.S) producing val run : (module Startup_reconciler.S) -> unit.
- lib/poller_fiber.ml (create): Move poller_fiber body from bin/main.ml:1794–2092; reads pr_registry, findings_registry, event_log, review_clients, transcripts, branch_of, and the seven shared capabilities through Env.
- lib/dune (modify): Register poller_fiber among library modules.
- bin/main.ml (modify): Inside Make_fibers, replace the poller_fiber body with `module Poller = Onton.Poller_fiber.Make (Forge) (W) (Env_poller)` where Env_poller projects from FIBER_ENV. Call site at line 4467 becomes `Poller.run (module Reconciler)`.

## Gameplan Specification

```
module EXTRACT_BIN_FIBERS.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> After this gameplan, bin/main.ml contains only command-line
> parsing, config resolution, capability construction, and the
> assembly of fiber modules. Every fiber body lives behind a .mli
> in lib. Run-level capabilities flow through a shared Run_env
> signature, not as positional arguments.

Fiber.
poller => Fiber.
runner => Fiber.
tui => Fiber.
input => Fiber.
headless => Fiber.
persistence => Fiber.

in-lib? f: Fiber => Bool.
in-bin? f: Fiber => Bool.

Capability.
runtime => Capability.
clock => Capability.
fs => Capability.
project-name => Capability.
user-config => Capability.
worktree-mutex => Capability.
hook-mutex => Capability.

run-env-captures? c: Capability => Bool.

ResolvedConfig.
project-name-is-string? rc: ResolvedConfig => Bool.
assert-false-removed? => Bool.

bin-main-line-count => Nat0.
runner-fiber-line-count => Nat0.
---
> Every fiber body lives in lib, not in bin.
all f: Fiber | in-lib? f.
all f: Fiber | ~ (in-bin? f).

> Every shared run-level capability is captured by Run_env.
all c: Capability | run-env-captures? c.

> Resolved_config.t has project_name : string; the assert-false is gone.
all rc: ResolvedConfig | project-name-is-string? rc.
assert-false-removed?.

> Size invariants: the binary is small enough to read as wiring.
bin-main-line-count < 1500.
runner-fiber-line-count < 500.

where

> ══════════════════════════════════════════
> SUPPORTING EXTRACTIONS
> ══════════════════════════════════════════
> Three runner helpers, the managed-repo plumbing, the prune
> subcommand, the TUI view-model record, and the resolved-config
> type are all exposed from lib with .mli boundaries.

Helper.
managed-repo => Helper.
prune-runner => Helper.
tui-state => Helper.
long-lived-sessions => Helper.
busy-guard => Helper.
worktree-plan-executor => Helper.
resolved-config => Helper.

helper-in-lib? h: Helper => Bool.
---
all h: Helper | helper-in-lib? h.

```

## Patch Specification

```
module EXTRACT_BIN_FIBERS_PATCH_7.

> Patch 7 moves poller_fiber from bin/main.ml to lib/poller_fiber.ml
> as a Make(Forge)(W)(Env) functor over Poller_env.S.

Fiber.
poller => Fiber.
in-lib? f: Fiber => Bool.
---
in-lib? poller.

```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/304"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781895492&installation_id=126163856&pr_number=304&repository=flowglad%2Fonton&return_to=https%3A%2F%2Fgithub.com%2Fflowglad%2Fonton%2Fpull%2F304&signature=5c1e55b50824b96f966cbc105c78663b783d3c2c0ad075bece892510a0c5f53d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted the poller fiber from `bin/main.ml` into `lib/poller_fiber` as a functor with a minimal env interface. Moved worktree-setup wiring into the poller; no behavior changes.

- **Refactors**
  - Added `lib/poller_fiber.mli` defining `Poller_env.S` and `STARTUP_RECONCILER`, exposing `Make(...).run`.
  - Implemented `lib/poller_fiber.ml`: moved the poller logic; dependencies now read via `Env`; built `WS_Env` and `Worktree_setup.Make` to resolve worktree paths inside the poller; parallel GitHub polling, classification, reconciliation, and review-backend findings preserved.
  - Updated `bin/main.ml`: added `Env_poller` (projects runtime, clock, fs, user config, mutexes, process manager, owner/repo, main branch, poll interval, repo root, PR-registry ops, findings registry, event log, review clients, `branch_of`), instantiated `Poller_fiber.Make (Forge) (W) (Env_poller)`, delegated to `Poller.run`; `STARTUP_RECONCILER` now aliases `Poller_fiber.STARTUP_RECONCILER`.

<sup>Written for commit d21f15674fee6e601a7acc2946e546591e8cfa6c. Summary will update on new commits. <a href="https://cubic.dev/pr/flowglad/onton/pull/304?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

