### PR TITLE
Reconcile PR state with the forge during --prune

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1103,9 +1103,9 @@ let no_refresh_arg =
     value & flag
     & info [ "no-refresh" ]
         ~doc:
-          "When pruning, skip the forge reconciliation step and rely solely \
-           on the [merged] flag stored in each project's snapshot. Useful \
-           offline or when forge tokens have been rotated.")
+          "When pruning, skip the forge reconciliation step and rely solely on \
+           the [merged] flag stored in each project's snapshot. Useful offline \
+           or when forge tokens have been rotated.")
 
 let main_cmd =
   let open Cmdliner in
@@ -1114,11 +1114,9 @@ let main_cmd =
       prune no_refresh =
     if prune then
       Stdlib.exit
-        (Eio_main.run @@ fun env ->
-         Prune_runner.run_prune
-           ~net:(Eio.Stdenv.net env)
-           ~clock:(Eio.Stdenv.clock env)
-           ~refresh:(not no_refresh) ())
+        ( Eio_main.run @@ fun env ->
+          Prune_runner.run_prune ~net:(Eio.Stdenv.net env)
+            ~clock:(Eio.Stdenv.clock env) ~refresh:(not no_refresh) () )
     else if upload_debug then (
       match project with
       | None ->

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1092,15 +1092,33 @@ let prune_arg =
     & info [ "prune" ]
         ~doc:
           "Remove every stored project whose gameplan patches are all merged. \
-           Skips projects whose lock is held by a live onton process. Does not \
-           require any other arguments.")
+           Skips projects whose lock is held by a live onton process. By \
+           default, each project's non-terminal patches are reconciled with \
+           the forge first (one PR-state query per patch) so out-of-band \
+           merges are detected; pass --no-refresh to skip the network step.")
+
+let no_refresh_arg =
+  let open Cmdliner in
+  Arg.(
+    value & flag
+    & info [ "no-refresh" ]
+        ~doc:
+          "When pruning, skip the forge reconciliation step and rely solely \
+           on the [merged] flag stored in each project's snapshot. Useful \
+           offline or when forge tokens have been rotated.")
 
 let main_cmd =
   let open Cmdliner in
   let run_cmd project gameplan_path github_token backend model main_branch
       poll_interval repo_root max_concurrency headless upload_debug no_lock
-      prune =
-    if prune then Stdlib.exit (Prune_runner.run_prune ())
+      prune no_refresh =
+    if prune then
+      Stdlib.exit
+        (Eio_main.run @@ fun env ->
+         Prune_runner.run_prune
+           ~net:(Eio.Stdenv.net env)
+           ~clock:(Eio.Stdenv.clock env)
+           ~refresh:(not no_refresh) ())
     else if upload_debug then (
       match project with
       | None ->
@@ -1132,7 +1150,7 @@ let main_cmd =
       const run_cmd $ project_arg $ gameplan_path_arg $ github_token_arg
       $ backend_arg $ model_arg $ main_branch_arg $ poll_interval_arg $ repo_arg
       $ max_concurrency_arg $ headless_arg $ upload_debug_arg $ no_lock_arg
-      $ prune_arg)
+      $ prune_arg $ no_refresh_arg)
   in
   let info =
     Cmd.info "onton" ~version:Version.s

--- a/lib/prune_runner.ml
+++ b/lib/prune_runner.ml
@@ -237,7 +237,9 @@ let run_prune ~net ~clock ~refresh () =
                        | Not_merged | No_patches | No_snapshot | Load_error _ ->
                            ());
                        (status, refresh_summary)))
-              with exn -> Error (Exn.to_string exn)
+              with
+              | Eio.Cancel.Cancelled _ as exn -> raise exn
+              | exn -> Error (Exn.to_string exn)
             with
             | Error msg ->
                 errors :=

--- a/lib/prune_runner.ml
+++ b/lib/prune_runner.ml
@@ -79,7 +79,11 @@ let refresh_agents_from_forge ~net ~clock ~(cfg : Project_store.stored_config)
       let results =
         Eio.Fiber.List.map ~max_fibers:16
           (fun (patch_id, pr_number) ->
-            (patch_id, pr_number, Forge.pr_state pr_number))
+            let result =
+              try Result.map_error (Forge.pr_state pr_number) ~f:(fun _ -> ())
+              with _ -> Error ()
+            in
+            (patch_id, pr_number, result))
           candidates
       in
       let attempted = List.length results in
@@ -236,10 +240,14 @@ let run_prune ~net ~clock ~refresh () =
                 errors :=
                   (project_name, Stdlib.Printf.sprintf "prune failed: %s" msg)
                   :: !errors
-            | Ok (All_merged, _) -> (
+            | Ok (All_merged, refresh_summary) -> (
                 try
+                  let refresh_note =
+                    Option.bind refresh_summary ~f:format_refresh_summary
+                  in
                   removed :=
-                    (project_name, worktree_root_for ~project_name) :: !removed
+                    (project_name, worktree_root_for ~project_name, refresh_note)
+                    :: !removed
                 with exn ->
                   errors := (project_name, Exn.to_string exn) :: !errors)
             | Ok (Not_merged, refresh_summary) ->
@@ -256,8 +264,10 @@ let run_prune ~net ~clock ~refresh () =
                   ( project_name,
                     Stdlib.Printf.sprintf "snapshot load failed: %s" msg )
                   :: !errors));
-    List.iter (List.rev !removed) ~f:(fun (n, _) ->
-        Stdlib.Printf.printf "removed %s\n" n);
+    List.iter (List.rev !removed) ~f:(fun (n, _, refresh_note) ->
+        match refresh_note with
+        | None -> Stdlib.Printf.printf "removed %s\n" n
+        | Some note -> Stdlib.Printf.printf "removed %s — %s\n" n note);
     List.iter (List.rev !kept) ~f:(fun (n, reason) ->
         Stdlib.Printf.printf "kept    %s — %s\n" n reason);
     List.iter (List.rev !errors) ~f:(fun (n, msg) ->
@@ -267,7 +277,7 @@ let run_prune ~net ~clock ~refresh () =
       (List.length !kept)
       (pluralize (List.length !errors) "error");
     let leftover_worktrees =
-      List.filter !removed ~f:(fun (_, p) -> Stdlib.Sys.file_exists p)
+      List.filter !removed ~f:(fun (_, p, _) -> Stdlib.Sys.file_exists p)
     in
     if not (List.is_empty leftover_worktrees) then (
       Stdlib.Printf.printf
@@ -275,6 +285,6 @@ let run_prune ~net ~clock ~refresh () =
          Worktree directories are not pruned automatically (they may contain \
          build outputs).\n\
          Remove them manually once they are no longer needed:\n";
-      List.iter (List.rev leftover_worktrees) ~f:(fun (_, p) ->
+      List.iter (List.rev leftover_worktrees) ~f:(fun (_, p, _) ->
           Stdlib.Printf.printf "  rm -rf %s\n" p));
     if not (List.is_empty !errors) then 1 else 0

--- a/lib/prune_runner.ml
+++ b/lib/prune_runner.ml
@@ -8,18 +8,18 @@ type prune_status =
   | No_snapshot
   | Load_error of string
 
-(** Per-project refresh summary, captured during classification and stitched
-    into the human-readable [kept] reason. None when refresh was disabled or
-    the project had nothing eligible to refresh. *)
 type refresh_summary = {
   attempted : int;
   newly_merged : int;
   errors : int;
   skipped_reason : string option;
       (** When the project was eligible for refresh but it was skipped (e.g.
-          missing token), explain why so the user understands the kept
-          reason. *)
+          missing token), explain why so the user understands the kept reason.
+      *)
 }
+(** Per-project refresh summary, captured during classification and stitched
+    into the human-readable [kept] reason. None when refresh was disabled or the
+    project had nothing eligible to refresh. *)
 
 let pluralize ?plural n singular =
   let many = match plural with Some p -> p | None -> singular ^ "s" in
@@ -98,8 +98,7 @@ let refresh_agents_from_forge ~net ~clock ~(cfg : Project_store.stored_config)
                   (agents, merged_count + 1, errs)
                 else (agents, merged_count, errs))
       in
-      ( agents,
-        { attempted; newly_merged; errors; skipped_reason = None } )
+      (agents, { attempted; newly_merged; errors; skipped_reason = None })
 
 let format_refresh_summary (s : refresh_summary) =
   let pr_word n = if n = 1 then "PR" else "PRs" in
@@ -114,14 +113,14 @@ let format_refresh_summary (s : refresh_summary) =
               (pr_word s.attempted);
           ]
           @ (if s.newly_merged > 0 then
-               [
-                 Stdlib.Printf.sprintf "%d newly merged" s.newly_merged;
-               ]
+               [ Stdlib.Printf.sprintf "%d newly merged" s.newly_merged ]
              else [])
           @
           if s.errors > 0 then
-            [ Stdlib.Printf.sprintf "%d forge error%s" s.errors
-                (if s.errors = 1 then "" else "s") ]
+            [
+              Stdlib.Printf.sprintf "%d forge error%s" s.errors
+                (if s.errors = 1 then "" else "s");
+            ]
           else []
         in
         Some (String.concat ~sep:", " parts)

--- a/lib/prune_runner.ml
+++ b/lib/prune_runner.ml
@@ -8,6 +8,19 @@ type prune_status =
   | No_snapshot
   | Load_error of string
 
+(** Per-project refresh summary, captured during classification and stitched
+    into the human-readable [kept] reason. None when refresh was disabled or
+    the project had nothing eligible to refresh. *)
+type refresh_summary = {
+  attempted : int;
+  newly_merged : int;
+  errors : int;
+  skipped_reason : string option;
+      (** When the project was eligible for refresh but it was skipped (e.g.
+          missing token), explain why so the user understands the kept
+          reason. *)
+}
+
 let pluralize ?plural n singular =
   let many = match plural with Some p -> p | None -> singular ^ "s" in
   Stdlib.Printf.sprintf "%d %s" n (if n = 1 then singular else many)
@@ -28,19 +41,126 @@ let rec remove_path path =
   } -> (
       try Stdlib.Sys.remove path with Sys_error _ -> ())
 
-let classify_project ~slug =
+(** Build the list of (patch_id, pr_number) pairs that can be reconciled with
+    the forge: agent stored as not-merged AND has a PR number on file. *)
+let refresh_candidates (agents : Patch_agent.t Map.M(Patch_id).t) =
+  Map.fold agents ~init:[] ~f:(fun ~key:patch_id ~data:agent acc ->
+      if agent.Patch_agent.merged then acc
+      else
+        match agent.Patch_agent.pr_number with
+        | None -> acc
+        | Some pr_number -> (patch_id, pr_number) :: acc)
+
+(** Refresh [agents] by querying the forge for every non-terminal patch with a
+    recorded PR number. Returns the (possibly updated) agents map and a
+    [refresh_summary]. Forge errors are tolerated — the corresponding agent is
+    left untouched, classification proceeds with its stored [merged] flag. *)
+let refresh_agents_from_forge ~net ~clock ~(cfg : Project_store.stored_config)
+    ~(agents : Patch_agent.t Map.M(Patch_id).t) =
+  let candidates = refresh_candidates agents in
+  if List.is_empty candidates then
+    ( agents,
+      { attempted = 0; newly_merged = 0; errors = 0; skipped_reason = None } )
+  else
+    let token = String.strip cfg.Project_store.github_token in
+    if String.is_empty token then
+      ( agents,
+        {
+          attempted = 0;
+          newly_merged = 0;
+          errors = 0;
+          skipped_reason = Some "no GitHub token in stored config";
+        } )
+    else
+      let module Forge =
+        (val Github.make ~net ~clock ~token ~owner:cfg.github_owner
+               ~repo:cfg.github_repo)
+      in
+      let results =
+        Eio.Fiber.List.map ~max_fibers:16
+          (fun (patch_id, pr_number) ->
+            (patch_id, pr_number, Forge.pr_state pr_number))
+          candidates
+      in
+      let attempted = List.length results in
+      let agents, newly_merged, errors =
+        List.fold results ~init:(agents, 0, 0)
+          ~f:(fun (agents, merged_count, errs) (patch_id, _pr_number, result) ->
+            match result with
+            | Error _ -> (agents, merged_count, errs + 1)
+            | Ok pr_state ->
+                if Pr_state.merged pr_state then
+                  let agents =
+                    Map.change agents patch_id ~f:(function
+                      | None -> None
+                      | Some agent -> Some (Patch_agent.mark_merged agent))
+                  in
+                  (agents, merged_count + 1, errs)
+                else (agents, merged_count, errs))
+      in
+      ( agents,
+        { attempted; newly_merged; errors; skipped_reason = None } )
+
+let format_refresh_summary (s : refresh_summary) =
+  let pr_word n = if n = 1 then "PR" else "PRs" in
+  match s.skipped_reason with
+  | Some reason -> Some (Stdlib.Printf.sprintf "refresh skipped — %s" reason)
+  | None ->
+      if s.attempted = 0 then None
+      else
+        let parts =
+          [
+            Stdlib.Printf.sprintf "refreshed %d %s" s.attempted
+              (pr_word s.attempted);
+          ]
+          @ (if s.newly_merged > 0 then
+               [
+                 Stdlib.Printf.sprintf "%d newly merged" s.newly_merged;
+               ]
+             else [])
+          @
+          if s.errors > 0 then
+            [ Stdlib.Printf.sprintf "%d forge error%s" s.errors
+                (if s.errors = 1 then "" else "s") ]
+          else []
+        in
+        Some (String.concat ~sep:", " parts)
+
+let classify_project ~net ~clock ~refresh ~slug =
   let snap_path = Project_store.snapshot_path slug in
-  if not (Stdlib.Sys.file_exists snap_path) then No_snapshot
+  if not (Stdlib.Sys.file_exists snap_path) then (No_snapshot, None)
   else
     match Persistence.load ~path:snap_path with
-    | Error msg -> Load_error msg
-    | Ok snap -> (
+    | Error msg -> (Load_error msg, None)
+    | Ok snap ->
         let agents = Orchestrator.agents_map snap.Runtime.orchestrator in
         let patches = snap.Runtime.gameplan.Gameplan.patches in
-        match Prune_decision.classify_snapshot ~patches ~agents with
-        | Prune_decision.All_merged -> All_merged
-        | Prune_decision.Not_merged -> Not_merged
-        | Prune_decision.No_patches -> No_patches)
+        let agents, refresh_summary =
+          if not refresh then (agents, None)
+          else
+            match Project_store.load_config ~project_name:slug with
+            | Error _ ->
+                ( agents,
+                  Some
+                    {
+                      attempted = 0;
+                      newly_merged = 0;
+                      errors = 0;
+                      skipped_reason = Some "stored config unreadable";
+                    } )
+            | Ok cfg ->
+                let agents, summary =
+                  refresh_agents_from_forge ~net ~clock ~cfg ~agents
+                in
+                (agents, Some summary)
+        in
+        let status =
+          match Prune_decision.classify_snapshot ~patches ~agents with
+          | Prune_decision.All_merged -> All_merged
+          | Prune_decision.Not_merged -> Not_merged
+          | Prune_decision.No_patches -> No_patches
+        in
+        (status, refresh_summary)
 
 let worktree_root_for ~project_name =
   let home =
@@ -57,7 +177,13 @@ let recover_project_name ~slug =
   | Ok cfg -> cfg.Project_store.project_name
   | Error _ -> slug
 
-let run_prune () =
+(** Compose a "kept" reason, appending refresh details when they apply. *)
+let kept_reason ~base ~refresh_summary =
+  match Option.bind refresh_summary ~f:format_refresh_summary with
+  | None -> base
+  | Some note -> Stdlib.Printf.sprintf "%s (%s)" base note
+
+let run_prune ~net ~clock ~refresh () =
   let slugs = Project_store.list_projects () in
   if List.is_empty slugs then (
     Stdlib.Printf.printf "No stored projects to consider.\n";
@@ -97,31 +223,36 @@ let run_prune () =
                   (Stdlib.Fun.protect
                      ~finally:(fun () -> Project_lock.release lock)
                      (fun () ->
-                       let status = classify_project ~slug in
+                       let status, refresh_summary =
+                         classify_project ~net ~clock ~refresh ~slug
+                       in
                        (match status with
                        | All_merged -> remove_path project_dir
                        | Not_merged | No_patches | No_snapshot | Load_error _ ->
                            ());
-                       status))
+                       (status, refresh_summary)))
               with exn -> Error (Exn.to_string exn)
             with
             | Error msg ->
                 errors :=
                   (project_name, Stdlib.Printf.sprintf "prune failed: %s" msg)
                   :: !errors
-            | Ok All_merged -> (
+            | Ok (All_merged, _) -> (
                 try
                   removed :=
                     (project_name, worktree_root_for ~project_name) :: !removed
                 with exn ->
                   errors := (project_name, Exn.to_string exn) :: !errors)
-            | Ok Not_merged ->
-                kept := (project_name, "has unmerged patches") :: !kept
-            | Ok No_patches ->
+            | Ok (Not_merged, refresh_summary) ->
+                kept :=
+                  ( project_name,
+                    kept_reason ~base:"has unmerged patches" ~refresh_summary )
+                  :: !kept
+            | Ok (No_patches, _) ->
                 kept := (project_name, "gameplan has no patches") :: !kept
-            | Ok No_snapshot ->
+            | Ok (No_snapshot, _) ->
                 kept := (project_name, "no snapshot — never ran") :: !kept
-            | Ok (Load_error msg) ->
+            | Ok (Load_error msg, _) ->
                 errors :=
                   ( project_name,
                     Stdlib.Printf.sprintf "snapshot load failed: %s" msg )

--- a/lib/prune_runner.ml
+++ b/lib/prune_runner.ml
@@ -80,8 +80,11 @@ let refresh_agents_from_forge ~net ~clock ~(cfg : Project_store.stored_config)
         Eio.Fiber.List.map ~max_fibers:16
           (fun (patch_id, pr_number) ->
             let result =
-              try Result.map_error (Forge.pr_state pr_number) ~f:(fun _ -> ())
-              with _ -> Error ()
+              try
+                Result.map_error (Forge.pr_state pr_number) ~f:(fun _ -> ())
+              with
+              | Eio.Cancel.Cancelled _ as exn -> raise exn
+              | _ -> Error ()
             in
             (patch_id, pr_number, result))
           candidates

--- a/lib/prune_runner.mli
+++ b/lib/prune_runner.mli
@@ -11,6 +11,7 @@ val run_prune :
     leaves the stored [merged] flag untouched so the project is kept, not
     accidentally deleted.
 
-    Returns [0] on success and [1] when one or more projects could not be pruned
-    due to lock or snapshot errors. Forge-refresh failures alone do not set the
-    exit code; they are surfaced as informational notes on the kept project. *)
+    Returns [0] on success and [1] when one or more projects report prune errors
+    (for example lock, snapshot-load, or prune-time filesystem errors).
+    Forge-refresh failures alone do not set the exit code; they are surfaced as
+    informational notes on the kept project. *)

--- a/lib/prune_runner.mli
+++ b/lib/prune_runner.mli
@@ -1,21 +1,16 @@
 val run_prune :
-  net:_ Eio.Net.t ->
-  clock:_ Eio.Time.clock ->
-  refresh:bool ->
-  unit ->
-  int
+  net:_ Eio.Net.t -> clock:_ Eio.Time.clock -> refresh:bool -> unit -> int
 (** Remove stored projects whose gameplan patches are all merged.
 
     When [refresh] is [true], every project with at least one non-terminal patch
     (i.e. an agent with [merged = false] and a recorded PR number) is reconciled
     with the forge first: per-patch [Forge.pr_state] queries update the
-    in-memory agents map before the all-merged classification runs. This
-    catches projects where merges happened out-of-band (e.g. via the GitHub UI)
-    after the supervisor stopped polling. Refresh is conservative — any forge
-    error leaves the stored [merged] flag untouched so the project is kept, not
+    in-memory agents map before the all-merged classification runs. This catches
+    projects where merges happened out-of-band (e.g. via the GitHub UI) after
+    the supervisor stopped polling. Refresh is conservative — any forge error
+    leaves the stored [merged] flag untouched so the project is kept, not
     accidentally deleted.
 
-    Returns [0] on success and [1] when one or more projects could not be
-    pruned due to lock or snapshot errors. Forge-refresh failures alone do not
-    set the exit code; they are surfaced as informational notes on the kept
-    project. *)
+    Returns [0] on success and [1] when one or more projects could not be pruned
+    due to lock or snapshot errors. Forge-refresh failures alone do not set the
+    exit code; they are surfaced as informational notes on the kept project. *)

--- a/lib/prune_runner.mli
+++ b/lib/prune_runner.mli
@@ -1,5 +1,21 @@
-val run_prune : unit -> int
+val run_prune :
+  net:_ Eio.Net.t ->
+  clock:_ Eio.Time.clock ->
+  refresh:bool ->
+  unit ->
+  int
 (** Remove stored projects whose gameplan patches are all merged.
 
-    Returns [0] on success and [1] when one or more projects could not be pruned
-    due to lock or snapshot errors. *)
+    When [refresh] is [true], every project with at least one non-terminal patch
+    (i.e. an agent with [merged = false] and a recorded PR number) is reconciled
+    with the forge first: per-patch [Forge.pr_state] queries update the
+    in-memory agents map before the all-merged classification runs. This
+    catches projects where merges happened out-of-band (e.g. via the GitHub UI)
+    after the supervisor stopped polling. Refresh is conservative — any forge
+    error leaves the stored [merged] flag untouched so the project is kept, not
+    accidentally deleted.
+
+    Returns [0] on success and [1] when one or more projects could not be
+    pruned due to lock or snapshot errors. Forge-refresh failures alone do not
+    set the exit code; they are surfaced as informational notes on the kept
+    project. *)


### PR DESCRIPTION
## Summary
- `--prune` now refreshes every non-terminal patch (`merged=false` with a recorded PR number) against the forge before classifying a project as all-merged, so projects whose PRs were merged out-of-band (e.g. via the GitHub UI after the supervisor stopped polling) are detected and removed.
- Refresh is parallel per project (`Eio.Fiber.List.map ~max_fibers:16`) and uses the per-project token already in `Project_store.stored_config`. Forge errors leave the stored `merged` flag untouched — prune stays conservative and never deletes on uncertainty.
- New `--no-refresh` flag preserves the old local-only behavior for offline use or rotated tokens.

## Test plan
- [x] `dune build` clean
- [x] `dune runtest` passes (existing `Prune_decision` property tests unchanged — pure logic is unaffected)
- [x] `--prune` and `--prune --no-refresh` smoke-tested with an empty data dir
- [ ] Manually try `--prune` on a real project with at least one PR merged via the GitHub UI after the project stopped, confirm it is reported as removed (with `refreshed N PRs, 1 newly merged` in the trace) and the data dir is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/309"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781904761&installation_id=126163856&pr_number=309&repository=flowglad%2Fonton&return_to=https%3A%2F%2Fgithub.com%2Fflowglad%2Fonton%2Fpull%2F309&signature=bedf1e48ebdd34b29c907e0737e5dea40518c1250696f5c3cfa9728906fc85cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`--prune` now refreshes each non-terminal patch against the forge before deciding, so projects with PRs merged in the UI are detected and cleaned up. Added `--no-refresh` to keep the old offline behavior; refresh failures never change the exit code.

- **New Features**
  - Parallel per project (max 16) using the stored token; when config/token is missing or unreadable, refresh is skipped with a clear reason.
  - Output appends a short note to kept/removed lines (e.g., “refreshed N PRs, X newly merged[, Y forge errors]” or “refresh skipped — no GitHub token”).
  - Safe by default: forge errors keep stored state and don’t affect the exit code (only lock/snapshot/fs errors return non‑zero); CLI wires `Eio` net/clock and documents default reconciliation and `--no-refresh`.

- **Bug Fixes**
  - Preserve cancellation during refresh and propagate it through the outer prune handler by re-raising `Eio.Cancel.Cancelled`, so Ctrl‑C/timeouts stop prune promptly.

<sup>Written for commit 57af6c627cf8dbc7ef952e764062650640f80f78. Summary will update on new commits. <a href="https://cubic.dev/pr/flowglad/onton/pull/309?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--no-refresh` CLI flag to skip forge reconciliation during pruning (refresh is on by default).
  * Prune can refresh per-project PR merge state with the forge to detect out‑of‑band merges; refresh appends concise notes to kept/removed output.
  * Refresh runs with bounded concurrency, tolerates forge lookup failures (keeps projects when uncertain), and is skipped when per-project config/token is missing.

* **Documentation**
  * Updated `--prune` help text to describe default reconciliation behavior and reference `--no-refresh`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flowglad/onton/pull/309?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->