### PR TITLE
Accept +N positional args to add ad-hoc PRs at startup

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -894,7 +894,67 @@ let run_main_loop (setup : runtime_setup) (cap : constructed_capabilities)
             :: common_fibers)
         with Fibers.Tui.Quit -> ())
 
-let run_with_config ~no_lock ~auto_merge (config : config) gameplan
+(** Add a list of GitHub PRs as ad-hoc patches to the running orchestrator.
+    Mirrors [Tui_input.Prompt_pr] in [tui_fiber.ml]: fetch PR state, skip
+    forks/missing head branches, no-op when already registered. Failures are
+    reported to stderr and the event log; the remaining PRs still proceed. *)
+let add_pr_extras_to_runtime ~(setup : runtime_setup)
+    ~(cap : constructed_capabilities) (prs : Pr_number.t list) =
+  let module Forge = (val cap.forge) in
+  List.iter
+    (fun pr_number ->
+      let n = Pr_number.to_int pr_number in
+      let patch_id = Patch_id.of_string (string_of_int n) in
+      let already_exists =
+        Runtime.read setup.runtime (fun snap ->
+            Base.Option.is_some
+              (Orchestrator.find_agent snap.Runtime.orchestrator patch_id))
+      in
+      if already_exists then
+        log_event setup.runtime ~patch_id
+          (Printf.sprintf "Ad-hoc PR #%d already registered" n)
+      else
+        match Forge.pr_state pr_number with
+        | Error err ->
+            let msg =
+              Printf.sprintf "Cannot add ad-hoc PR #%d — %s" n
+                (Forge.show_error err)
+            in
+            Printf.eprintf "onton: %s\n%!" msg;
+            log_event setup.runtime ~patch_id msg
+        | Ok pr_state when Pr_state.is_fork pr_state ->
+            let msg =
+              Printf.sprintf "Cannot add ad-hoc PR #%d — fork PRs not supported"
+                n
+            in
+            Printf.eprintf "onton: %s\n%!" msg;
+            log_event setup.runtime ~patch_id msg
+        | Ok pr_state -> (
+            match pr_state.Pr_state.head_branch with
+            | None ->
+                let msg =
+                  Printf.sprintf "Cannot add ad-hoc PR #%d — no head branch" n
+                in
+                Printf.eprintf "onton: %s\n%!" msg;
+                log_event setup.runtime ~patch_id msg
+            | Some branch ->
+                cap.register_pr_number ~patch_id ~pr_number;
+                Runtime.update_orchestrator setup.runtime (fun orch ->
+                    let base_branch =
+                      Base.Option.value pr_state.Pr_state.base_branch
+                        ~default:(Orchestrator.main_branch orch)
+                    in
+                    Orchestrator.add_agent orch ~patch_id ~branch ~base_branch
+                      ~pr_number);
+                let msg =
+                  Printf.sprintf "Ad-hoc PR #%d added (%s)" n
+                    (Branch.to_string branch)
+                in
+                Printf.eprintf "onton: %s\n%!" msg;
+                log_event setup.runtime ~patch_id msg))
+    prs
+
+let run_with_config ~no_lock ~auto_merge ~pr_extras (config : config) gameplan
     existing_snapshot =
   let resolved = Resolved_config.of_config config |> ok_or_exit in
   let {
@@ -958,6 +1018,7 @@ let run_with_config ~no_lock ~auto_merge (config : config) gameplan
     setup_runtime env ~config:resolved ~gameplan ~existing_snapshot ~auto_merge
   in
   let capabilities = construct_capabilities ~net:(Eio.Stdenv.net env) setup in
+  add_pr_extras_to_runtime ~setup ~cap:capabilities pr_extras;
   let tui_state = Tui_state.create () in
   let fiber_env = build_fiber_env setup capabilities ~tui_state in
   run_main_loop setup capabilities fiber_env ~tui_state
@@ -978,7 +1039,7 @@ let run_with_config ~no_lock ~auto_merge (config : config) gameplan
 
 let run ~project ~gameplan_path ~github_token ~backend ~model
     ~(main_branch : Branch.t option) ~poll_interval ~(repo_root : string option)
-    ~max_concurrency ~headless ~no_lock ~auto_merge =
+    ~max_concurrency ~headless ~no_lock ~auto_merge ~pr_extras =
   match
     resolve_config ~project ~gameplan_path ~github_token ~backend ~model
       ~main_branch ~poll_interval ~repo_root ~max_concurrency ~headless
@@ -987,7 +1048,8 @@ let run ~project ~gameplan_path ~github_token ~backend ~model
       Base.List.iter errs ~f:(fun e -> Printf.eprintf "Error: %s\n" e);
       Stdlib.exit 1
   | Ok (config, gameplan, existing_snapshot) ->
-      run_with_config ~no_lock ~auto_merge config gameplan existing_snapshot
+      run_with_config ~no_lock ~auto_merge ~pr_extras config gameplan
+        existing_snapshot
 
 (** {1 CLI via Cmdliner} *)
 
@@ -1000,6 +1062,44 @@ let project_arg =
         ~doc:
           "Project name to resume. If omitted, derived from --gameplan's \
            project name.")
+
+(** Trailing positional arguments after PROJECT. The only currently recognized
+    form is [+N], which adds GitHub PR #N to the session as an ad-hoc patch
+    before the fibers start — the same path the TUI uses for [Prompt_pr]. *)
+let pr_extras_arg =
+  let open Cmdliner in
+  Arg.(
+    value & pos_right 0 string []
+    & info [] ~docv:"EXTRA"
+        ~doc:
+          "Additional positional arguments. Currently only the form [+N] is \
+           accepted, where N is a PR number; each [+N] is added to the running \
+           session as an ad-hoc patch.")
+
+(** Parse trailing positional args into PR numbers. Each must be
+    [+<positive int>]. Returns [Error] on the first bad token so the user sees
+    the offender by name instead of a silent ignore. *)
+let parse_pr_extras (raw : string list) : (Pr_number.t list, string) result =
+  let parse_one s =
+    if String.length s < 2 || not (Char.equal s.[0] '+') then
+      Error
+        (Printf.sprintf
+           "unrecognized positional argument %S — expected +N (e.g. +123)" s)
+    else
+      let rest = String.sub s 1 (String.length s - 1) in
+      match int_of_string_opt rest with
+      | Some n when n > 0 -> Ok (Pr_number.of_int n)
+      | _ ->
+          Error
+            (Printf.sprintf
+               "invalid PR number in %S — expected a positive integer after +" s)
+  in
+  let rec loop acc = function
+    | [] -> Ok (List.rev acc)
+    | x :: xs -> (
+        match parse_one x with Ok n -> loop (n :: acc) xs | Error e -> Error e)
+  in
+  loop [] raw
 
 let gameplan_path_arg =
   let open Cmdliner in
@@ -1131,9 +1231,9 @@ let auto_merge_arg =
 
 let main_cmd =
   let open Cmdliner in
-  let run_cmd project gameplan_path github_token backend model main_branch
-      poll_interval repo_root max_concurrency headless upload_debug no_lock
-      prune no_refresh auto_merge =
+  let run_cmd project pr_extras_raw gameplan_path github_token backend model
+      main_branch poll_interval repo_root max_concurrency headless upload_debug
+      no_lock prune no_refresh auto_merge =
     if prune then
       Stdlib.exit
         ( Eio_main.run @@ fun env ->
@@ -1161,6 +1261,13 @@ let main_cmd =
           "Error: --auto-merge requires --gameplan. It only seeds the initial \
            state of a fresh project.\n";
         Stdlib.exit 1);
+      let pr_extras =
+        match parse_pr_extras pr_extras_raw with
+        | Ok prs -> prs
+        | Error msg ->
+            Printf.eprintf "onton: %s\n" msg;
+            Stdlib.exit 1
+      in
       let main_branch =
         Base.Option.map main_branch ~f:(fun s ->
             Branch.of_string (Base.String.strip s))
@@ -1168,14 +1275,15 @@ let main_cmd =
       run ~project ~gameplan_path ~github_token
         ~backend:(Base.String.strip backend)
         ~model:(Base.String.strip model) ~main_branch ~poll_interval ~repo_root
-        ~max_concurrency ~headless ~no_lock ~auto_merge)
+        ~max_concurrency ~headless ~no_lock ~auto_merge ~pr_extras)
   in
   let term =
     Term.(
-      const run_cmd $ project_arg $ gameplan_path_arg $ github_token_arg
-      $ backend_arg $ model_arg $ main_branch_arg $ poll_interval_arg $ repo_arg
-      $ max_concurrency_arg $ headless_arg $ upload_debug_arg $ no_lock_arg
-      $ prune_arg $ no_refresh_arg $ auto_merge_arg)
+      const run_cmd $ project_arg $ pr_extras_arg $ gameplan_path_arg
+      $ github_token_arg $ backend_arg $ model_arg $ main_branch_arg
+      $ poll_interval_arg $ repo_arg $ max_concurrency_arg $ headless_arg
+      $ upload_debug_arg $ no_lock_arg $ prune_arg $ no_refresh_arg
+      $ auto_merge_arg)
   in
   let info =
     Cmd.info "onton" ~version:Version.s
@@ -1184,7 +1292,9 @@ let main_cmd =
          Usage:\n\
         \  onton [PROJECT] --gameplan GAMEPLAN [OPTIONS]   Start a new project\n\
         \  onton PROJECT [OPTIONS]                         Resume a saved \
-         project"
+         project\n\
+        \  onton PROJECT +N [+N ...] [OPTIONS]             Resume and add PR \
+         #N as an ad-hoc patch"
   in
   Cmd.v info term
 

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -894,67 +894,103 @@ let run_main_loop (setup : runtime_setup) (cap : constructed_capabilities)
             :: common_fibers)
         with Fibers.Tui.Quit -> ())
 
-(** Add a list of GitHub PRs as ad-hoc patches to the running orchestrator.
-    Mirrors [Tui_input.Prompt_pr] in [tui_fiber.ml]: fetch PR state, skip
-    forks/missing head branches, no-op when already registered. Failures are
-    reported to stderr and the event log; the remaining PRs still proceed. *)
-let add_pr_extras_to_runtime ~(setup : runtime_setup)
-    ~(cap : constructed_capabilities) (prs : Pr_number.t list) =
-  let module Forge = (val cap.forge) in
-  List.iter
-    (fun pr_number ->
-      let n = Pr_number.to_int pr_number in
-      let patch_id = Patch_id.of_string (string_of_int n) in
-      let already_exists =
-        Runtime.read setup.runtime (fun snap ->
-            Base.Option.is_some
-              (Orchestrator.find_agent snap.Runtime.orchestrator patch_id))
-      in
-      if already_exists then
-        log_event setup.runtime ~patch_id
-          (Printf.sprintf "Ad-hoc PR #%d already registered" n)
-      else
-        match Forge.pr_state pr_number with
-        | Error err ->
-            let msg =
-              Printf.sprintf "Cannot add ad-hoc PR #%d — %s" n
-                (Forge.show_error err)
-            in
-            Printf.eprintf "onton: %s\n%!" msg;
-            log_event setup.runtime ~patch_id msg
-        | Ok pr_state when Pr_state.is_fork pr_state ->
-            let msg =
-              Printf.sprintf "Cannot add ad-hoc PR #%d — fork PRs not supported"
-                n
-            in
-            Printf.eprintf "onton: %s\n%!" msg;
-            log_event setup.runtime ~patch_id msg
-        | Ok pr_state -> (
-            match pr_state.Pr_state.head_branch with
-            | None ->
-                let msg =
-                  Printf.sprintf "Cannot add ad-hoc PR #%d — no head branch" n
-                in
-                Printf.eprintf "onton: %s\n%!" msg;
-                log_event setup.runtime ~patch_id msg
-            | Some branch ->
-                cap.register_pr_number ~patch_id ~pr_number;
-                Runtime.update_orchestrator setup.runtime (fun orch ->
-                    let base_branch =
-                      Base.Option.value pr_state.Pr_state.base_branch
-                        ~default:(Orchestrator.main_branch orch)
-                    in
-                    Orchestrator.add_agent orch ~patch_id ~branch ~base_branch
-                      ~pr_number);
-                let msg =
-                  Printf.sprintf "Ad-hoc PR #%d added (%s)" n
-                    (Branch.to_string branch)
-                in
-                Printf.eprintf "onton: %s\n%!" msg;
-                log_event setup.runtime ~patch_id msg))
-    prs
+(** Trailing-positional PR operations parsed from the command line. *)
+type pr_op = Add_pr of Pr_number.t | Remove_pr of Pr_number.t
 
-let run_with_config ~no_lock ~auto_merge ~pr_extras (config : config) gameplan
+let report setup ~patch_id msg =
+  Printf.eprintf "onton: %s\n%!" msg;
+  log_event setup.runtime ~patch_id msg
+
+(** Add a single GitHub PR as an ad-hoc patch. Mirrors [Tui_input.Prompt_pr] in
+    [tui_fiber.ml]: fetch PR state, skip forks/missing head branches, no-op when
+    already registered. *)
+let apply_add_pr ~(setup : runtime_setup) ~(cap : constructed_capabilities)
+    pr_number =
+  let module Forge = (val cap.forge) in
+  let n = Pr_number.to_int pr_number in
+  let patch_id = Patch_id.of_string (string_of_int n) in
+  let already_exists =
+    Runtime.read setup.runtime (fun snap ->
+        Base.Option.is_some
+          (Orchestrator.find_agent snap.Runtime.orchestrator patch_id))
+  in
+  if already_exists then
+    report setup ~patch_id (Printf.sprintf "Ad-hoc PR #%d already registered" n)
+  else
+    match Forge.pr_state pr_number with
+    | Error err ->
+        report setup ~patch_id
+          (Printf.sprintf "Cannot add ad-hoc PR #%d — %s" n
+             (Forge.show_error err))
+    | Ok pr_state when Pr_state.is_fork pr_state ->
+        report setup ~patch_id
+          (Printf.sprintf "Cannot add ad-hoc PR #%d — fork PRs not supported" n)
+    | Ok pr_state -> (
+        match pr_state.Pr_state.head_branch with
+        | None ->
+            report setup ~patch_id
+              (Printf.sprintf "Cannot add ad-hoc PR #%d — no head branch" n)
+        | Some branch ->
+            cap.register_pr_number ~patch_id ~pr_number;
+            Runtime.update_orchestrator setup.runtime (fun orch ->
+                let base_branch =
+                  Base.Option.value pr_state.Pr_state.base_branch
+                    ~default:(Orchestrator.main_branch orch)
+                in
+                Orchestrator.add_agent orch ~patch_id ~branch ~base_branch
+                  ~pr_number);
+            report setup ~patch_id
+              (Printf.sprintf "Ad-hoc PR #%d added (%s)" n
+                 (Branch.to_string branch)))
+
+(** Remove a single ad-hoc PR. Mirrors [Tui_input.Remove_patch] in
+    [tui_fiber.ml]: refuses to touch gameplan patches, warns on busy ones. *)
+let apply_remove_pr ~(setup : runtime_setup) ~(cap : constructed_capabilities)
+    pr_number =
+  let n = Pr_number.to_int pr_number in
+  let patch_id = Patch_id.of_string (string_of_int n) in
+  let agent_opt, in_gameplan =
+    Runtime.read setup.runtime (fun snap ->
+        let agent =
+          Orchestrator.find_agent snap.Runtime.orchestrator patch_id
+        in
+        let in_gp =
+          Base.List.exists snap.Runtime.gameplan.Gameplan.patches
+            ~f:(fun (p : Patch.t) -> Patch_id.equal p.Patch.id patch_id)
+        in
+        (agent, in_gp))
+  in
+  match agent_opt with
+  | None ->
+      report setup ~patch_id
+        (Printf.sprintf "Cannot remove PR #%d — not registered" n)
+  | Some _ when in_gameplan ->
+      report setup ~patch_id
+        (Printf.sprintf
+           "Cannot remove PR #%d — gameplan patches cannot be removed" n)
+  | Some agent ->
+      if agent.Patch_agent.busy then
+        report setup ~patch_id
+          (Printf.sprintf
+             "Warning — PR #%d is currently running, it may create a GitHub PR \
+              before stopping"
+             n);
+      Runtime.update_orchestrator setup.runtime (fun orch ->
+          Orchestrator.remove_agent orch patch_id);
+      cap.unregister_pr_number ~patch_id;
+      report setup ~patch_id (Printf.sprintf "Removed ad-hoc PR #%d" n)
+
+(** Apply trailing-positional PR ops in command-line order, so [+5 -5 +5] leaves
+    PR #5 registered. *)
+let apply_pr_ops ~(setup : runtime_setup) ~(cap : constructed_capabilities)
+    (ops : pr_op list) =
+  List.iter
+    (function
+      | Add_pr n -> apply_add_pr ~setup ~cap n
+      | Remove_pr n -> apply_remove_pr ~setup ~cap n)
+    ops
+
+let run_with_config ~no_lock ~auto_merge ~pr_ops (config : config) gameplan
     existing_snapshot =
   let resolved = Resolved_config.of_config config |> ok_or_exit in
   let {
@@ -1018,7 +1054,7 @@ let run_with_config ~no_lock ~auto_merge ~pr_extras (config : config) gameplan
     setup_runtime env ~config:resolved ~gameplan ~existing_snapshot ~auto_merge
   in
   let capabilities = construct_capabilities ~net:(Eio.Stdenv.net env) setup in
-  add_pr_extras_to_runtime ~setup ~cap:capabilities pr_extras;
+  apply_pr_ops ~setup ~cap:capabilities pr_ops;
   let tui_state = Tui_state.create () in
   let fiber_env = build_fiber_env setup capabilities ~tui_state in
   run_main_loop setup capabilities fiber_env ~tui_state
@@ -1039,7 +1075,7 @@ let run_with_config ~no_lock ~auto_merge ~pr_extras (config : config) gameplan
 
 let run ~project ~gameplan_path ~github_token ~backend ~model
     ~(main_branch : Branch.t option) ~poll_interval ~(repo_root : string option)
-    ~max_concurrency ~headless ~no_lock ~auto_merge ~pr_extras =
+    ~max_concurrency ~headless ~no_lock ~auto_merge ~pr_ops =
   match
     resolve_config ~project ~gameplan_path ~github_token ~backend ~model
       ~main_branch ~poll_interval ~repo_root ~max_concurrency ~headless
@@ -1048,7 +1084,7 @@ let run ~project ~gameplan_path ~github_token ~backend ~model
       Base.List.iter errs ~f:(fun e -> Printf.eprintf "Error: %s\n" e);
       Stdlib.exit 1
   | Ok (config, gameplan, existing_snapshot) ->
-      run_with_config ~no_lock ~auto_merge ~pr_extras config gameplan
+      run_with_config ~no_lock ~auto_merge ~pr_ops config gameplan
         existing_snapshot
 
 (** {1 CLI via Cmdliner} *)
@@ -1063,43 +1099,60 @@ let project_arg =
           "Project name to resume. If omitted, derived from --gameplan's \
            project name.")
 
-(** Trailing positional arguments after PROJECT. The only currently recognized
-    form is [+N], which adds GitHub PR #N to the session as an ad-hoc patch
-    before the fibers start — the same path the TUI uses for [Prompt_pr]. *)
-let pr_extras_arg =
-  let open Cmdliner in
-  Arg.(
-    value & pos_right 0 string []
-    & info [] ~docv:"EXTRA"
-        ~doc:
-          "Additional positional arguments. Currently only the form [+N] is \
-           accepted, where N is a PR number; each [+N] is added to the running \
-           session as an ad-hoc patch.")
+(** A token is a PR op iff it matches [^[+-][0-9]+$]. We classify before
+    cmdliner sees argv because cmdliner would otherwise reject [-N] as an
+    unknown short option. False positives are vanishingly rare: no current onton
+    flag uses [-<digits>] form, and project names of the same shape are
+    pathological. *)
+let looks_like_pr_op (s : string) : bool =
+  let len = String.length s in
+  len >= 2
+  && (Char.equal s.[0] '+' || Char.equal s.[0] '-')
+  && String.for_all
+       (function '0' .. '9' -> true | _ -> false)
+       (String.sub s 1 (len - 1))
 
-(** Parse trailing positional args into PR numbers. Each must be
-    [+<positive int>]. Returns [Error] on the first bad token so the user sees
-    the offender by name instead of a silent ignore. *)
-let parse_pr_extras (raw : string list) : (Pr_number.t list, string) result =
-  let parse_one s =
-    if String.length s < 2 || not (Char.equal s.[0] '+') then
-      Error
-        (Printf.sprintf
-           "unrecognized positional argument %S — expected +N (e.g. +123)" s)
-    else
-      let rest = String.sub s 1 (String.length s - 1) in
-      match int_of_string_opt rest with
-      | Some n when n > 0 -> Ok (Pr_number.of_int n)
-      | _ ->
-          Error
-            (Printf.sprintf
-               "invalid PR number in %S — expected a positive integer after +" s)
-  in
-  let rec loop acc = function
-    | [] -> Ok (List.rev acc)
-    | x :: xs -> (
-        match parse_one x with Ok n -> loop (n :: acc) xs | Error e -> Error e)
-  in
-  loop [] raw
+let parse_pr_op_token (s : string) : (pr_op, string) result =
+  if not (looks_like_pr_op s) then
+    Error
+      (Printf.sprintf
+         "unrecognized PR op token %S — expected +N or -N (e.g. +123, -123)" s)
+  else
+    let rest = String.sub s 1 (String.length s - 1) in
+    match int_of_string_opt rest with
+    | Some n when n > 0 ->
+        let pr = Pr_number.of_int n in
+        if Char.equal s.[0] '+' then Ok (Add_pr pr) else Ok (Remove_pr pr)
+    | _ ->
+        Error
+          (Printf.sprintf
+             "invalid PR number in %S — expected a positive integer after the \
+              sign"
+             s)
+
+(** Strip [+N]/[-N] tokens out of [argv] before cmdliner parses it. Returns the
+    list of ops in left-to-right order alongside the filtered argv. *)
+let extract_pr_ops_from_argv (argv : string array) :
+    (pr_op list * string array, string) result =
+  let n = Array.length argv in
+  let ops = ref [] in
+  let kept = ref [] in
+  let err = ref None in
+  let i = ref 0 in
+  while !i < n && Option.is_none !err do
+    let tok = argv.(!i) in
+    if !i > 0 && looks_like_pr_op tok then
+      match parse_pr_op_token tok with
+      | Ok op -> ops := op :: !ops
+      | Error msg -> err := Some msg
+    else kept := tok :: !kept;
+    incr i
+  done;
+  match !err with
+  | Some msg -> Error msg
+  | None ->
+      let kept_argv = Array.of_list (List.rev !kept) in
+      Ok (List.rev !ops, kept_argv)
 
 let gameplan_path_arg =
   let open Cmdliner in
@@ -1229,11 +1282,11 @@ let auto_merge_arg =
            per-patch toggles set via the TUI survive restarts. Individual \
            patches can still be toggled off in the TUI manage overlay.")
 
-let main_cmd =
+let main_cmd ~pr_ops =
   let open Cmdliner in
-  let run_cmd project pr_extras_raw gameplan_path github_token backend model
-      main_branch poll_interval repo_root max_concurrency headless upload_debug
-      no_lock prune no_refresh auto_merge =
+  let run_cmd project gameplan_path github_token backend model main_branch
+      poll_interval repo_root max_concurrency headless upload_debug no_lock
+      prune no_refresh auto_merge =
     if prune then
       Stdlib.exit
         ( Eio_main.run @@ fun env ->
@@ -1261,13 +1314,6 @@ let main_cmd =
           "Error: --auto-merge requires --gameplan. It only seeds the initial \
            state of a fresh project.\n";
         Stdlib.exit 1);
-      let pr_extras =
-        match parse_pr_extras pr_extras_raw with
-        | Ok prs -> prs
-        | Error msg ->
-            Printf.eprintf "onton: %s\n" msg;
-            Stdlib.exit 1
-      in
       let main_branch =
         Base.Option.map main_branch ~f:(fun s ->
             Branch.of_string (Base.String.strip s))
@@ -1275,15 +1321,14 @@ let main_cmd =
       run ~project ~gameplan_path ~github_token
         ~backend:(Base.String.strip backend)
         ~model:(Base.String.strip model) ~main_branch ~poll_interval ~repo_root
-        ~max_concurrency ~headless ~no_lock ~auto_merge ~pr_extras)
+        ~max_concurrency ~headless ~no_lock ~auto_merge ~pr_ops)
   in
   let term =
     Term.(
-      const run_cmd $ project_arg $ pr_extras_arg $ gameplan_path_arg
-      $ github_token_arg $ backend_arg $ model_arg $ main_branch_arg
-      $ poll_interval_arg $ repo_arg $ max_concurrency_arg $ headless_arg
-      $ upload_debug_arg $ no_lock_arg $ prune_arg $ no_refresh_arg
-      $ auto_merge_arg)
+      const run_cmd $ project_arg $ gameplan_path_arg $ github_token_arg
+      $ backend_arg $ model_arg $ main_branch_arg $ poll_interval_arg $ repo_arg
+      $ max_concurrency_arg $ headless_arg $ upload_debug_arg $ no_lock_arg
+      $ prune_arg $ no_refresh_arg $ auto_merge_arg)
   in
   let info =
     Cmd.info "onton" ~version:Version.s
@@ -1293,9 +1338,15 @@ let main_cmd =
         \  onton [PROJECT] --gameplan GAMEPLAN [OPTIONS]   Start a new project\n\
         \  onton PROJECT [OPTIONS]                         Resume a saved \
          project\n\
-        \  onton PROJECT +N [+N ...] [OPTIONS]             Resume and add PR \
-         #N as an ad-hoc patch"
+        \  onton PROJECT (+N|-N) ... [OPTIONS]             Resume and \
+         add/remove PR #N as an ad-hoc patch"
   in
   Cmd.v info term
 
-let () = Stdlib.exit (Cmdliner.Cmd.eval main_cmd)
+let () =
+  match extract_pr_ops_from_argv Sys.argv with
+  | Error msg ->
+      Printf.eprintf "onton: %s\n" msg;
+      Stdlib.exit 1
+  | Ok (pr_ops, argv) ->
+      Stdlib.exit (Cmdliner.Cmd.eval ~argv (main_cmd ~pr_ops))

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1161,7 +1161,7 @@ let extract_pr_ops_from_argv (argv : string array) :
     if !i = 0 then kept := tok :: !kept
     else if cli_option_takes_value tok then (
       kept := tok :: !kept;
-      if !i + 1 < n then (
+      if !i + 1 < n && not (looks_like_pr_op argv.(!i + 1)) then (
         incr i;
         kept := argv.(!i) :: !kept))
     else if is_flag_like_token tok && not (looks_like_pr_op tok) then

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1130,6 +1130,19 @@ let parse_pr_op_token (s : string) : (pr_op, string) result =
               sign"
              s)
 
+let cli_option_takes_value (s : string) : bool =
+  match String.index_opt s '=' with
+  | Some _ -> false
+  | None -> (
+      match s with
+      | "--gameplan" | "--token" | "--backend" | "--model" | "--repo"
+      | "--main-branch" | "--poll-interval" | "--max-concurrency" ->
+          true
+      | _ -> false)
+
+let is_flag_like_token (s : string) : bool =
+  String.length s > 0 && Char.equal s.[0] '-'
+
 (** Strip [+N]/[-N] tokens out of [argv] before cmdliner parses it. Returns the
     list of ops in left-to-right order alongside the filtered argv. *)
 let extract_pr_ops_from_argv (argv : string array) :
@@ -1138,14 +1151,32 @@ let extract_pr_ops_from_argv (argv : string array) :
   let ops = ref [] in
   let kept = ref [] in
   let err = ref None in
+  let saw_project = ref false in
   let i = ref 0 in
   while !i < n && Option.is_none !err do
     let tok = argv.(!i) in
-    if !i > 0 && looks_like_pr_op tok then
+    if !i = 0 then kept := tok :: !kept
+    else if cli_option_takes_value tok then (
+      kept := tok :: !kept;
+      if !i + 1 < n then (
+        incr i;
+        kept := argv.(!i) :: !kept))
+    else if is_flag_like_token tok && not (looks_like_pr_op tok) then
+      kept := tok :: !kept
+    else if looks_like_pr_op tok then
       match parse_pr_op_token tok with
       | Ok op -> ops := op :: !ops
       | Error msg -> err := Some msg
-    else kept := tok :: !kept;
+    else if not !saw_project then (
+      saw_project := true;
+      kept := tok :: !kept)
+    else
+      err :=
+        Some
+          (Printf.sprintf
+             "unrecognized positional argument %S — expected +N or -N (e.g. \
+              +123, -123)"
+             tok);
     incr i
   done;
   match !err with

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1134,6 +1134,9 @@ let cli_option_takes_value (s : string) : bool =
   match String.index_opt s '=' with
   | Some _ -> false
   | None -> (
+      (* Keep this in sync with Cmdliner [opt] arguments below:
+         --gameplan, --token, --backend, --model, --repo, --main-branch,
+         --poll-interval, and --max-concurrency. *)
       match s with
       | "--gameplan" | "--token" | "--backend" | "--model" | "--repo"
       | "--main-branch" | "--poll-interval" | "--max-concurrency" ->


### PR DESCRIPTION
## Summary
- Onton now accepts arbitrary positional arguments after `PROJECT`. The first (and currently only) supported form is `+N`, where N is a GitHub PR number.
- Each `+N` fetches the PR via the forge and registers it as an ad-hoc patch on the running orchestrator — the same path the TUI already exposes via `Prompt_pr` (fork-aware, no-op if already registered, falls back to the orchestrator's main branch when GitHub omits a base).
- Bad tokens (non-`+`, non-integer, non-positive) are rejected up front with a precise error pointing at the offender.

## Test plan
- [x] `dune build` clean
- [x] `dune runtest` green
- [x] `onton --help` shows the new `EXTRA` arg and `onton PROJECT +N` usage line
- [x] `onton bogus +foo` → `invalid PR number in "+foo" — expected a positive integer after +`
- [x] `onton bogus +0` → same shape
- [x] `onton bogus notapr` → `unrecognized positional argument "notapr" — expected +N (e.g. +123)`
- [ ] Sanity run against a real project: `onton myproj +<live-pr>` adds the PR and the runner picks it up

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/310"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781922892&installation_id=126163856&pr_number=310&repository=flowglad%2Fonton&return_to=https%3A%2F%2Fgithub.com%2Fflowglad%2Fonton%2Fpull%2F310&signature=0281b30f53f1ca59b2c0aab6976ec9d58240b3fcd8f43e328350fbdec4c696bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accept `+N` and `-N` positional args after PROJECT to preload or remove ad‑hoc GitHub PRs at startup. This mirrors the TUI add/remove flows so you can resume, queue, and clean up PRs from the CLI.

- **New Features**
  - `onton PROJECT (+N|-N) ...` tokens run left‑to‑right before fibers start; e.g. `+5 -5 +5` leaves PR #5 registered.
  - Adding: fork PRs or missing head branches are skipped with clear stderr/event logs; duplicates are no‑ops.
  - Removing: gameplan patches are protected; warns if a patch is running; unknown patches report a clear error.
  - Parsing: `+/-N` tokens are stripped from argv before `cmdliner` (so `-N` isn’t a short flag); PR tokens right after value flags are preserved and parsed as ops; only `+/-<positive int>` is accepted; invalid tokens or extra args error with clear `+N`/`-N` guidance; `--help` and usage updated.

<sup>Written for commit 3ed13b64ae6e8656a5b48dffba841cfc8d3548a9. Summary will update on new commits. <a href="https://cubic.dev/pr/flowglad/onton/pull/310?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Resume sessions with ad-hoc PR operations using trailing +N / -N tokens; operations are applied in command-line order, validated early, and help text documents the PROJECT (+N|-N) ... syntax.
  * PR ops are executed at startup before the interactive UI is created.

* **Behavior / Bug Fixes**
  * Adding a PR validates and skips unsuitable or already-registered PRs and auto-registers agents on the base branch.
  * Removing a PR refuses protected patches, warns if an agent is busy, and unregisters the PR.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flowglad/onton/pull/310?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->