### PR TITLE
Add --auto-merge flag for fresh gameplan projects

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -588,7 +588,7 @@ type constructed_capabilities = {
 
 type built_fiber_env = (module FIBER_ENV)
 
-let setup_runtime env ~config ~gameplan ~existing_snapshot =
+let setup_runtime env ~config ~gameplan ~existing_snapshot ~auto_merge =
   let { Resolved_config.headless; project_name; main_branch; _ } = config in
   if headless then
     Sys.set_signal Sys.sigint
@@ -606,6 +606,14 @@ let setup_runtime env ~config ~gameplan ~existing_snapshot =
         Printf.eprintf "Starting new project %S.\n%!" project_name;
         Runtime.create ~gameplan ~main_branch ()
   in
+  (* [--auto-merge] only seeds the initial state of a fresh project. On resume,
+     each patch's persisted [automerge_enabled] wins so per-patch user toggles
+     are not silently re-enabled across restarts. *)
+  if auto_merge && Base.Option.is_none existing_snapshot then
+    Runtime.update_orchestrator runtime (fun orch ->
+        Base.Map.fold (Orchestrator.agents_map orch) ~init:orch
+          ~f:(fun ~key:pid ~data:_ acc ->
+            Orchestrator.set_automerge_enabled acc pid true));
   Unix.putenv "ONTON_SNAPSHOT_PATH" (Project_store.snapshot_path project_name);
   {
     config;
@@ -886,7 +894,8 @@ let run_main_loop (setup : runtime_setup) (cap : constructed_capabilities)
             :: common_fibers)
         with Fibers.Tui.Quit -> ())
 
-let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
+let run_with_config ~no_lock ~auto_merge (config : config) gameplan
+    existing_snapshot =
   let resolved = Resolved_config.of_config config |> ok_or_exit in
   let {
     Resolved_config.github_token;
@@ -945,7 +954,9 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
       Base.Option.iter lock ~f:Project_lock.release)
   @@ fun () ->
   Eio_main.run @@ fun env ->
-  let setup = setup_runtime env ~config:resolved ~gameplan ~existing_snapshot in
+  let setup =
+    setup_runtime env ~config:resolved ~gameplan ~existing_snapshot ~auto_merge
+  in
   let capabilities = construct_capabilities ~net:(Eio.Stdenv.net env) setup in
   let tui_state = Tui_state.create () in
   let fiber_env = build_fiber_env setup capabilities ~tui_state in
@@ -967,7 +978,7 @@ let run_with_config ~no_lock (config : config) gameplan existing_snapshot =
 
 let run ~project ~gameplan_path ~github_token ~backend ~model
     ~(main_branch : Branch.t option) ~poll_interval ~(repo_root : string option)
-    ~max_concurrency ~headless ~no_lock =
+    ~max_concurrency ~headless ~no_lock ~auto_merge =
   match
     resolve_config ~project ~gameplan_path ~github_token ~backend ~model
       ~main_branch ~poll_interval ~repo_root ~max_concurrency ~headless
@@ -976,7 +987,7 @@ let run ~project ~gameplan_path ~github_token ~backend ~model
       Base.List.iter errs ~f:(fun e -> Printf.eprintf "Error: %s\n" e);
       Stdlib.exit 1
   | Ok (config, gameplan, existing_snapshot) ->
-      run_with_config ~no_lock config gameplan existing_snapshot
+      run_with_config ~no_lock ~auto_merge config gameplan existing_snapshot
 
 (** {1 CLI via Cmdliner} *)
 
@@ -1107,11 +1118,27 @@ let no_refresh_arg =
            the [merged] flag stored in each project's snapshot. Useful offline \
            or when forge tokens have been rotated.")
 
+let auto_merge_arg =
+  let open Cmdliner in
+  Arg.(
+    value & flag
+    & info [ "auto-merge" ]
+        ~doc:
+          "Enable automerge for every patch in the gameplan at project start. \
+           Only valid when paired with --gameplan; ignored on resume so \
+           per-patch toggles set via the TUI survive restarts. Individual \
+           patches can still be toggled off in the TUI manage overlay.")
+
 let main_cmd =
   let open Cmdliner in
   let run_cmd project gameplan_path github_token backend model main_branch
       poll_interval repo_root max_concurrency headless upload_debug no_lock
-      prune no_refresh =
+      prune no_refresh auto_merge =
+    if auto_merge && Base.Option.is_none gameplan_path then (
+      Printf.eprintf
+        "Error: --auto-merge requires --gameplan. It only seeds the initial \
+         state of a fresh project.\n";
+      Stdlib.exit 1);
     if prune then
       Stdlib.exit
         ( Eio_main.run @@ fun env ->
@@ -1141,14 +1168,14 @@ let main_cmd =
       run ~project ~gameplan_path ~github_token
         ~backend:(Base.String.strip backend)
         ~model:(Base.String.strip model) ~main_branch ~poll_interval ~repo_root
-        ~max_concurrency ~headless ~no_lock
+        ~max_concurrency ~headless ~no_lock ~auto_merge
   in
   let term =
     Term.(
       const run_cmd $ project_arg $ gameplan_path_arg $ github_token_arg
       $ backend_arg $ model_arg $ main_branch_arg $ poll_interval_arg $ repo_arg
       $ max_concurrency_arg $ headless_arg $ upload_debug_arg $ no_lock_arg
-      $ prune_arg $ no_refresh_arg)
+      $ prune_arg $ no_refresh_arg $ auto_merge_arg)
   in
   let info =
     Cmd.info "onton" ~version:Version.s

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1134,11 +1134,6 @@ let main_cmd =
   let run_cmd project gameplan_path github_token backend model main_branch
       poll_interval repo_root max_concurrency headless upload_debug no_lock
       prune no_refresh auto_merge =
-    if auto_merge && Base.Option.is_none gameplan_path then (
-      Printf.eprintf
-        "Error: --auto-merge requires --gameplan. It only seeds the initial \
-         state of a fresh project.\n";
-      Stdlib.exit 1);
     if prune then
       Stdlib.exit
         ( Eio_main.run @@ fun env ->
@@ -1160,7 +1155,12 @@ let main_cmd =
           Eio_main.run @@ fun env ->
           Debug_upload.run ~net:(Eio.Stdenv.net env) ~project_name
             ~version:Version.s)
-    else
+    else (
+      if auto_merge && Base.Option.is_none gameplan_path then (
+        Printf.eprintf
+          "Error: --auto-merge requires --gameplan. It only seeds the initial \
+           state of a fresh project.\n";
+        Stdlib.exit 1);
       let main_branch =
         Base.Option.map main_branch ~f:(fun s ->
             Branch.of_string (Base.String.strip s))
@@ -1168,7 +1168,7 @@ let main_cmd =
       run ~project ~gameplan_path ~github_token
         ~backend:(Base.String.strip backend)
         ~model:(Base.String.strip model) ~main_branch ~poll_interval ~repo_root
-        ~max_concurrency ~headless ~no_lock ~auto_merge
+        ~max_concurrency ~headless ~no_lock ~auto_merge)
   in
   let term =
     Term.(


### PR DESCRIPTION
## Summary
- New `--auto-merge` flag seeds `automerge_enabled = true` on every patch when starting a fresh project from a gameplan.
- Validated to require `--gameplan` — applying it on resume would silently undo per-patch TUI toggles the user already set.
- Snapshot resume path is unchanged: persisted per-patch state wins, so users can still disable automerge for individual patches via the TUI manage overlay and have it stick across restarts.

## Test plan
- [x] `dune build` clean
- [x] `dune runtest` green
- [x] `dune exec onton -- --help=plain` lists the flag
- [x] `dune exec onton -- --auto-merge` (no gameplan) errors with a clear message
- [ ] Smoke test on a real gameplan: confirm all patches show automerge enabled in the TUI on first start, disabling one persists across `onton PROJECT` resume

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/311"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781964858&installation_id=126163856&pr_number=311&repository=flowglad%2Fonton&return_to=https%3A%2F%2Fgithub.com%2Fflowglad%2Fonton%2Fpull%2F311&signature=8db9264a61ba53fc07e951511f79378f251c854bf044a0bdfe2831817562dca7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `--auto-merge` flag that pre-enables automerge for all patches when starting a fresh project with `--gameplan`. It errors if used without `--gameplan`, is ignored on resume so per‑patch toggles persist, and its validation no longer runs for utility commands (`--prune`, `--upload-debug`).

<sup>Written for commit f8c7c70f36e8f7ac7131b32a9c833b4fd90fc278. Summary will update on new commits. <a href="https://cubic.dev/pr/flowglad/onton/pull/311?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new --auto-merge CLI flag to enable automatic automerge for all patch agents when starting a fresh project.
  * Flag validation requires using --auto-merge together with --gameplan; the flag is ignored when resuming existing projects.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flowglad/onton/pull/311?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->