### PR TITLE
Add backend/model defaults to per-repo config

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,6 +479,40 @@ overridden. Stored configs written by older onton versions (where `backend`
 was `claude-opus` or `claude-sonnet`) are migrated to the decomposed shape
 automatically on load.
 
+### Per-repo defaults (`config.json`)
+
+To avoid re-typing `--backend` / `--model` for every fresh run in a repo,
+write a per-repo config at
+`~/.config/onton/<owner>/<repo>/config.json`:
+
+```jsonc
+{
+  "default": {
+    "backend": "codex",
+    "model":   "auto"
+  },
+  "routing": {
+    "1": { "backend": "claude", "model": "haiku"   },
+    "3": { "backend": "codex",  "model": "gpt-5.5" }
+  }
+}
+```
+
+Resolution order, evaluated per field independently:
+
+1. CLI flag (`--backend` / `--model`)
+2. Previously stored value from the project store (resume only)
+3. `default.backend` / `default.model` from `config.json`
+4. Built-in (`claude`; model unset)
+
+`model: "auto"` from any source — the CLI flag or `default.model` —
+activates the `routing` map: each patch's complexity (1/2/3) picks its
+own `(backend, model)`, falling back to the effective backend's hardcoded
+ladder for tiers with no entry. Both subfields of `default` are
+optional; pin just `backend`, just `model`, or both. Run
+`onton-check-repo-config <owner> <repo>` to verify how a `config.json`
+parses.
+
 ### Supported models
 
 Onton passes `--model` through to the backend CLI verbatim, so any model the

--- a/bin/check_repo_config.ml
+++ b/bin/check_repo_config.ml
@@ -16,6 +16,9 @@ let () =
           Printf.printf "PARSE ERROR: %s\n" msg;
           exit 1
       | Ok c ->
+          let show_opt = function Some s -> s | None -> "(unset)" in
+          Printf.printf "default.backend   : %s\n" (show_opt c.default_backend);
+          Printf.printf "default.model     : %s\n" (show_opt c.default_model);
           Printf.printf "complexity_routes : %d entries\n"
             (List.length c.complexity_routes);
           Printf.printf "review_backends   : %d entries\n"

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -14,17 +14,58 @@ let default_backend = "claude"
 let known_backends =
   [ "claude"; "codex"; "opencode"; "pi"; "gemini"; "patch-agent" ]
 
-(** Resolve a CLI [--backend]/[--model] pair (or stored equivalents) into the
-    canonical [(backend, model)] tuple used internally. Empty [backend] falls
-    back to [default_backend]. An empty [model] is preserved — the backend
-    dispatch then omits [--model] from the underlying CLI call so each
-    provider's own default applies. *)
-let resolve_backend_model ~backend ~model =
-  let backend =
-    if Base.String.is_empty (Base.String.strip backend) then default_backend
-    else Base.String.strip backend
-  in
-  (backend, Base.String.strip model)
+type repo_coords = {
+  github_token : string;
+  github_owner : string;
+  github_repo : string;
+  repo_root : string;
+}
+(** Coordinates that locate the GitHub repo and its local checkout. Resolved
+    independently per path (fresh: from --repo + git remote; gameplan: from the
+    parsed gameplan + onton-managed checkout; resume: stored + inferred). *)
+
+type run_knobs = {
+  poll_interval : float;
+  max_concurrency : int;
+  headless : bool;
+  patch_agent_provider : string option;
+  patch_agent_effort : string option;
+}
+(** Run-time knobs that don't vary inside a single invocation. Built once at the
+    top of [resolve_config] from CLI flags and env vars, then shared by all
+    three paths. *)
+
+type backend_inputs = {
+  cli_backend : string;
+  cli_model : string;
+  stored_backend : string;
+  stored_model : string;
+}
+(** The four sources that feed [Backend_routing.resolve_pair]. Fresh and
+    gameplan paths leave [stored_*] as [""] (no prior run); the resume path
+    populates them from [Project_store]. *)
+
+(** Load the per-repo [config.json] for the given GitHub coordinates, or exit on
+    error. [config.json] is allowed to be absent ([empty] returned) but a
+    malformed file is a hard failure — the run cannot continue with a config the
+    user thought they were applying. *)
+let load_repo_config_or_exit ~github_owner ~github_repo =
+  let config_dir = User_config.config_dir ~github_owner ~github_repo in
+  match Repo_config.load ~config_dir ~known_backends () with
+  | Ok t -> t
+  | Error msg ->
+      Printf.eprintf "Error: %s\n" msg;
+      Stdlib.exit 1
+
+(** Resolve the effective [(backend, model)] pair from the four layered sources:
+    CLI flag, [Project_store] stored value, [Repo_config.default_*], and the
+    hard-coded built-in default. Per-field precedence is
+    [CLI > stored > config > built-in]. [stored_backend] / [stored_model] are
+    [""] for fresh and gameplan paths (no stored value to consult). *)
+let resolve_backend_model ~cli_backend ~cli_model ~stored_backend ~stored_model
+    ~repo_config =
+  Backend_routing.resolve_pair ~cli_backend ~cli_model ~stored_backend
+    ~stored_model ~repo_config ~built_in_backend:default_backend
 
 (** {1 PR number registry}
 
@@ -233,6 +274,55 @@ let with_snapshot_load ~project_name config gameplan =
             project_name msg;
         ]
 
+(** Finalize a run: load the per-repo config, layer-merge the effective
+    [(backend, model)] from CLI / stored / config / built-in, persist the
+    resolved config to disk, and attach the on-disk snapshot. Centralizes the
+    body shared by the fresh, gameplan, and resume paths. *)
+let finalize_run ~project_name ~repo_coords ~run_knobs ~backend_inputs
+    ~main_branch ~gameplan =
+  let { github_token; github_owner; github_repo; repo_root } = repo_coords in
+  let {
+    poll_interval;
+    max_concurrency;
+    headless;
+    patch_agent_provider;
+    patch_agent_effort;
+  } =
+    run_knobs
+  in
+  let { cli_backend; cli_model; stored_backend; stored_model } =
+    backend_inputs
+  in
+  let repo_config = load_repo_config_or_exit ~github_owner ~github_repo in
+  let backend, model =
+    resolve_backend_model ~cli_backend ~cli_model ~stored_backend ~stored_model
+      ~repo_config
+  in
+  Project_store.save_config ~project_name ~github_token ~github_owner
+    ~github_repo ~backend ~model
+    ~main_branch:(Branch.to_string main_branch)
+    ~poll_interval ~repo_root ~max_concurrency;
+  let config =
+    {
+      Resolved_config.project = Some project_name;
+      backend;
+      model;
+      github_token;
+      github_owner;
+      github_repo;
+      main_branch;
+      poll_interval;
+      repo_root;
+      max_concurrency;
+      headless;
+      patch_agent_provider;
+      patch_agent_effort;
+      user_config = User_config.load ~github_owner ~github_repo;
+      repo_config;
+    }
+  in
+  with_snapshot_load ~project_name config gameplan
+
 (** Resolve CLI args into a config ready to run.
     - [--gameplan] provided: parse it, persist config + gameplan source, derive
       project name.
@@ -254,6 +344,18 @@ let resolve_config ~project ~gameplan_path ~github_token ~backend ~model
         let s = Base.String.strip s in
         if Base.String.is_empty s then None else Some s
     | None -> None
+  in
+  let run_knobs =
+    {
+      poll_interval;
+      max_concurrency;
+      headless;
+      patch_agent_provider;
+      patch_agent_effort;
+    }
+  in
+  let cli_backend_inputs ?(stored_backend = "") ?(stored_model = "") () =
+    { cli_backend = backend; cli_model = model; stored_backend; stored_model }
   in
   let repo_root_for_fresh =
     Repo_root.normalize (Base.Option.value repo_root ~default:".")
@@ -292,32 +394,17 @@ let resolve_config ~project ~gameplan_path ~github_token ~backend ~model
           context_resources = [];
         }
       in
-      let backend, model = resolve_backend_model ~backend ~model in
       let main_branch = resolve_branch ~repo_root main_branch in
-      Project_store.save_config ~project_name ~github_token:token
-        ~github_owner:owner ~github_repo:repo ~backend ~model
-        ~main_branch:(Branch.to_string main_branch)
-        ~poll_interval ~repo_root ~max_concurrency;
-      let config =
-        Resolved_config.
-          {
-            project = Some project_name;
-            backend;
-            model;
-            github_token = token;
-            github_owner = owner;
-            github_repo = repo;
-            main_branch;
-            poll_interval;
-            repo_root;
-            max_concurrency;
-            headless;
-            patch_agent_provider;
-            patch_agent_effort;
-            user_config = User_config.load ~github_owner:owner ~github_repo:repo;
-          }
+      let repo_coords =
+        {
+          github_token = token;
+          github_owner = owner;
+          github_repo = repo;
+          repo_root;
+        }
       in
-      with_snapshot_load ~project_name config gameplan
+      finalize_run ~project_name ~repo_coords ~run_knobs
+        ~backend_inputs:(cli_backend_inputs ()) ~main_branch ~gameplan
   | _, Some gp_path -> (
       match Gameplan_parser.parse_file gp_path with
       | Error msg -> Error [ Printf.sprintf "Error parsing gameplan: %s" msg ]
@@ -380,35 +467,20 @@ let resolve_config ~project ~gameplan_path ~github_token ~backend ~model
                         owner repo msg;
                     ]
               | Ok repo_root ->
-                  let backend, model = resolve_backend_model ~backend ~model in
                   let main_branch = resolve_branch ~repo_root main_branch in
-                  Project_store.save_config ~project_name ~github_token:token
-                    ~github_owner:owner ~github_repo:repo ~backend ~model
-                    ~main_branch:(Branch.to_string main_branch)
-                    ~poll_interval ~repo_root ~max_concurrency;
                   Project_store.save_gameplan_source ~project_name
                     ~source_path:gp_path;
-                  let config =
-                    Resolved_config.
-                      {
-                        project = Some project_name;
-                        backend;
-                        model;
-                        github_token = token;
-                        github_owner = owner;
-                        github_repo = repo;
-                        main_branch;
-                        poll_interval;
-                        repo_root;
-                        max_concurrency;
-                        headless;
-                        patch_agent_provider;
-                        patch_agent_effort;
-                        user_config =
-                          User_config.load ~github_owner:owner ~github_repo:repo;
-                      }
+                  let repo_coords =
+                    {
+                      github_token = token;
+                      github_owner = owner;
+                      github_repo = repo;
+                      repo_root;
+                    }
                   in
-                  with_snapshot_load ~project_name config gameplan)))
+                  finalize_run ~project_name ~repo_coords ~run_knobs
+                    ~backend_inputs:(cli_backend_inputs ()) ~main_branch
+                    ~gameplan)))
   | Some proj, None -> (
       if not (Project_store.project_exists proj) then
         Error
@@ -437,16 +509,6 @@ let resolve_config ~project ~gameplan_path ~github_token ~backend ~model
                   let merge_cli_stored cli stored_val =
                     let c = Base.String.strip cli in
                     if Base.String.is_empty c then stored_val else c
-                  in
-                  let resolved_backend_str =
-                    merge_cli_stored backend stored.Project_store.backend
-                  in
-                  let resolved_model_str =
-                    merge_cli_stored model stored.Project_store.model
-                  in
-                  let backend, model =
-                    resolve_backend_model ~backend:resolved_backend_str
-                      ~model:resolved_model_str
                   in
                   let token_from_stored =
                     merge_cli_stored github_token
@@ -517,34 +579,31 @@ let resolve_config ~project ~gameplan_path ~github_token ~backend ~model
                     | Some b -> b
                     | None -> Branch.of_string stored.Project_store.main_branch
                   in
-                  (* Persist the resolved config so the next launch without
-                     CLI overrides picks up the current values. *)
-                  Project_store.save_config ~project_name:proj
-                    ~github_token:token ~github_owner:owner ~github_repo:repo
-                    ~backend ~model ~main_branch:(Branch.to_string branch)
-                    ~poll_interval:stored.Project_store.poll_interval ~repo_root
-                    ~max_concurrency:stored.Project_store.max_concurrency;
-                  let config =
-                    Resolved_config.
-                      {
-                        project = Some proj;
-                        backend;
-                        model;
-                        github_token = token;
-                        github_owner = owner;
-                        github_repo = repo;
-                        main_branch = branch;
-                        poll_interval = stored.Project_store.poll_interval;
-                        repo_root;
-                        max_concurrency = stored.Project_store.max_concurrency;
-                        headless;
-                        patch_agent_provider;
-                        patch_agent_effort;
-                        user_config =
-                          User_config.load ~github_owner:owner ~github_repo:repo;
-                      }
+                  let repo_coords =
+                    {
+                      github_token = token;
+                      github_owner = owner;
+                      github_repo = repo;
+                      repo_root;
+                    }
                   in
-                  with_snapshot_load ~project_name:proj config gameplan))
+                  (* Resume reuses the stored [poll_interval] and
+                     [max_concurrency] rather than today's CLI defaults so a
+                     project's settled values survive without explicit flags. *)
+                  let run_knobs =
+                    {
+                      run_knobs with
+                      poll_interval = stored.Project_store.poll_interval;
+                      max_concurrency = stored.Project_store.max_concurrency;
+                    }
+                  in
+                  let backend_inputs =
+                    cli_backend_inputs
+                      ~stored_backend:stored.Project_store.backend
+                      ~stored_model:stored.Project_store.model ()
+                  in
+                  finalize_run ~project_name:proj ~repo_coords ~run_knobs
+                    ~backend_inputs ~main_branch:branch ~gameplan))
 
 let ok_or_exit = function
   | Ok x -> x
@@ -678,18 +737,13 @@ let construct_capabilities ~net (setup : runtime_setup) =
         None
     | None -> None
   in
-  let cli_model_opt = if Base.String.is_empty model then None else Some model in
-  let repo_config =
-    let config_dir = User_config.config_dir ~github_owner ~github_repo in
-    match Repo_config.load ~config_dir ~known_backends () with
-    | Ok t -> t
-    | Error msg ->
-        Printf.eprintf "Error: %s\n" msg;
-        Stdlib.exit 1
+  let effective_model_opt =
+    if Base.String.is_empty model then None else Some model
   in
+  let repo_config = config.Resolved_config.repo_config in
   (match
      Backend_preflight.validate ~default_backend:backend
-       ~cli_model:cli_model_opt ~repo_config ()
+       ~effective_model:effective_model_opt ~repo_config ()
    with
   | Ok () -> ()
   | Error errs ->
@@ -702,7 +756,7 @@ let construct_capabilities ~net (setup : runtime_setup) =
   let pick_backend ~complexity =
     let ({ Backend_routing.backend; model } as decision) =
       Backend_routing.decide ~repo_config ~default_backend:backend
-        ~cli_model:cli_model_opt ~complexity
+        ~effective_model:effective_model_opt ~complexity
     in
     (Backend_registry.get registry ~backend ~model, decision)
   in
@@ -713,7 +767,7 @@ let construct_capabilities ~net (setup : runtime_setup) =
   let resolve_routing ~complexity : Backend_routing.decision =
     let dec : Backend_routing.decision =
       Backend_routing.decide ~repo_config ~default_backend:backend
-        ~cli_model:cli_model_opt ~complexity
+        ~effective_model:effective_model_opt ~complexity
     in
     {
       dec with
@@ -1024,8 +1078,10 @@ let model_arg =
            [auto] picks a model per patch from the gameplan's [complexity] \
            field (1/2/3 → cheap/standard/strongest tier of the selected \
            backend). The per-backend ladder can be overridden by writing \
-           [~/.config/onton/<owner>/<repo>/config.json] with a [routing] map — \
-           see lib/repo_config.mli for the schema. When omitted, onton does \
+           [~/.config/onton/<owner>/<repo>/config.json] with a [routing] map; \
+           the same file's [default.{backend,model}] block sets per-repo \
+           defaults below CLI flags and stored values — see \
+           lib_core/repo_config.mli for the schema. When omitted, onton does \
            not pass --model to the underlying CLI, so the backend's own \
            default applies.")
 

--- a/lib/backend_preflight.ml
+++ b/lib/backend_preflight.ml
@@ -54,14 +54,14 @@ let check_backend ?getenv_opt ?is_executable backend =
                 PATH, or choose another backend with --backend."
                backend command))
 
-let selected_backends ~default_backend ~cli_model ~(repo_config : Repo_config.t)
-    =
+let selected_backends ~default_backend ~effective_model
+    ~(repo_config : Repo_config.t) =
   let add acc backend =
     if List.mem acc backend ~equal:String.equal then acc else backend :: acc
   in
   let acc = add [] default_backend in
   let uses_routes =
-    match cli_model with
+    match effective_model with
     | Some model -> Backend_routing.is_auto_model (Some model)
     | None -> false
   in
@@ -73,9 +73,11 @@ let selected_backends ~default_backend ~cli_model ~(repo_config : Repo_config.t)
   in
   List.rev acc
 
-let validate ?getenv_opt ?is_executable ~default_backend ~cli_model ~repo_config
-    () =
-  let backends = selected_backends ~default_backend ~cli_model ~repo_config in
+let validate ?getenv_opt ?is_executable ~default_backend ~effective_model
+    ~repo_config () =
+  let backends =
+    selected_backends ~default_backend ~effective_model ~repo_config
+  in
   let errors =
     List.filter_map backends ~f:(fun backend ->
         match check_backend ?getenv_opt ?is_executable backend with
@@ -84,31 +86,31 @@ let validate ?getenv_opt ?is_executable ~default_backend ~cli_model ~repo_config
   in
   match errors with [] -> Ok () | _ :: _ -> Error errors
 
-let%test "selected_backends ignores routes unless cli model is auto" =
+let%test "selected_backends ignores routes unless effective model is auto" =
   let repo_config =
     {
-      Repo_config.complexity_routes =
-        [ (1, { backend = "codex"; model = None }) ];
-      review_backends = [];
+      Repo_config.empty with
+      complexity_routes = [ (1, { backend = "codex"; model = None }) ];
     }
   in
   List.equal String.equal
-    (selected_backends ~default_backend:"claude" ~cli_model:None ~repo_config)
+    (selected_backends ~default_backend:"claude" ~effective_model:None
+       ~repo_config)
     [ "claude" ]
 
-let%test "selected_backends includes routes for auto model" =
+let%test "selected_backends includes routes for auto effective model" =
   let repo_config =
     {
-      Repo_config.complexity_routes =
+      Repo_config.empty with
+      complexity_routes =
         [
           (1, { backend = "codex"; model = None });
           (2, { backend = "claude"; model = Some "sonnet" });
         ];
-      review_backends = [];
     }
   in
   List.equal String.equal
-    (selected_backends ~default_backend:"claude" ~cli_model:(Some "auto")
+    (selected_backends ~default_backend:"claude" ~effective_model:(Some "auto")
        ~repo_config)
     [ "claude"; "codex" ]
 
@@ -118,7 +120,7 @@ let%test "validate reports missing backend executable" =
     validate
       ~getenv_opt:(fun _ -> Some "/bin")
       ~is_executable:(fun _ -> false)
-      ~default_backend:"codex" ~cli_model:None ~repo_config ()
+      ~default_backend:"codex" ~effective_model:None ~repo_config ()
   with
   | Error [ msg ] ->
       String.is_substring msg ~substring:"codex"

--- a/lib/resolved_config.ml
+++ b/lib/resolved_config.ml
@@ -15,6 +15,7 @@ type config = {
   patch_agent_provider : string option;
   patch_agent_effort : string option;
   user_config : User_config.t;
+  repo_config : Repo_config.t;
 }
 
 type t = {
@@ -32,6 +33,7 @@ type t = {
   patch_agent_provider : string option;
   patch_agent_effort : string option;
   user_config : User_config.t;
+  repo_config : Repo_config.t;
 }
 
 let known_backends =
@@ -117,4 +119,5 @@ let of_config (config : config) =
           patch_agent_provider = config.patch_agent_provider;
           patch_agent_effort = config.patch_agent_effort;
           user_config = config.user_config;
+          repo_config = config.repo_config;
         }

--- a/lib/resolved_config.mli
+++ b/lib/resolved_config.mli
@@ -15,6 +15,11 @@ type config = {
   patch_agent_provider : string option;
   patch_agent_effort : string option;
   user_config : User_config.t;
+  repo_config : Repo_config.t;
+      (** Per-repo [config.json], loaded once during config resolution. Already
+          consulted as part of the [(backend, model)] merge before this record
+          is constructed; carried through so [routing] and [reviewBackends] are
+          available to the runtime without re-reading the file. *)
 }
 
 type t = {
@@ -32,6 +37,7 @@ type t = {
   patch_agent_provider : string option;
   patch_agent_effort : string option;
   user_config : User_config.t;
+  repo_config : Repo_config.t;
 }
 
 val of_config : config -> (t, string list) result

--- a/lib_core/backend_routing.ml
+++ b/lib_core/backend_routing.ml
@@ -6,10 +6,33 @@ let is_auto_model = function
   | Some s -> String.equal (String.lowercase s) "auto"
   | None -> false
 
-let decide ~(repo_config : Repo_config.t) ~default_backend ~cli_model
+let first_nonempty (xs : string list) ~default =
+  match List.find xs ~f:(fun s -> not (String.is_empty (String.strip s))) with
+  | Some s -> String.strip s
+  | None -> default
+
+let resolve_pair ~cli_backend ~cli_model ~stored_backend ~stored_model
+    ~(repo_config : Repo_config.t) ~built_in_backend =
+  let cfg_backend =
+    Option.value repo_config.Repo_config.default_backend ~default:""
+  in
+  let cfg_model =
+    Option.value repo_config.Repo_config.default_model ~default:""
+  in
+  let backend =
+    first_nonempty
+      [ cli_backend; stored_backend; cfg_backend ]
+      ~default:built_in_backend
+  in
+  let model =
+    first_nonempty [ cli_model; stored_model; cfg_model ] ~default:""
+  in
+  (backend, model)
+
+let decide ~(repo_config : Repo_config.t) ~default_backend ~effective_model
     ~complexity : decision =
-  if not (is_auto_model cli_model) then
-    { backend = default_backend; model = cli_model }
+  if not (is_auto_model effective_model) then
+    { backend = default_backend; model = effective_model }
   else
     match Repo_config.route_for_complexity repo_config ~complexity with
     | Some { Repo_config.backend; model } -> { backend; model }
@@ -48,3 +71,85 @@ let%test "resolve_auto: leaves None unchanged" =
   let dec = { backend = "claude"; model = None } in
   let out = resolve_auto dec ~auto_model ~complexity:(Some 2) in
   Option.is_none out.model
+
+(* [resolve_pair] tests. *)
+
+let empty_config = Repo_config.empty
+
+let config_with ?(default_backend = None) ?(default_model = None) () =
+  { Repo_config.empty with default_backend; default_model }
+
+let%test "resolve_pair: CLI wins over everything" =
+  let b, m =
+    resolve_pair ~cli_backend:"codex" ~cli_model:"gpt-5"
+      ~stored_backend:"claude" ~stored_model:"sonnet"
+      ~repo_config:
+        (config_with ~default_backend:(Some "gemini")
+           ~default_model:(Some "gemini-2.5-pro") ())
+      ~built_in_backend:"claude"
+  in
+  String.equal b "codex" && String.equal m "gpt-5"
+
+let%test "resolve_pair: stored wins over config when CLI empty" =
+  let b, m =
+    resolve_pair ~cli_backend:"" ~cli_model:"" ~stored_backend:"claude"
+      ~stored_model:"sonnet"
+      ~repo_config:
+        (config_with ~default_backend:(Some "codex")
+           ~default_model:(Some "gpt-5") ())
+      ~built_in_backend:"claude"
+  in
+  String.equal b "claude" && String.equal m "sonnet"
+
+let%test "resolve_pair: config wins when CLI and stored both empty" =
+  let b, m =
+    resolve_pair ~cli_backend:"" ~cli_model:"" ~stored_backend:""
+      ~stored_model:""
+      ~repo_config:
+        (config_with ~default_backend:(Some "codex")
+           ~default_model:(Some "auto") ())
+      ~built_in_backend:"claude"
+  in
+  String.equal b "codex" && String.equal m "auto"
+
+let%test "resolve_pair: built-in backend wins as last resort" =
+  let b, m =
+    resolve_pair ~cli_backend:"" ~cli_model:"" ~stored_backend:""
+      ~stored_model:"" ~repo_config:empty_config ~built_in_backend:"claude"
+  in
+  String.equal b "claude" && String.equal m ""
+
+let%test "resolve_pair: per-field independence (CLI backend, config model)" =
+  let b, m =
+    resolve_pair ~cli_backend:"codex" ~cli_model:"" ~stored_backend:""
+      ~stored_model:""
+      ~repo_config:(config_with ~default_model:(Some "auto") ())
+      ~built_in_backend:"claude"
+  in
+  String.equal b "codex" && String.equal m "auto"
+
+let%test "resolve_pair: per-field independence (CLI model, stored backend)" =
+  let b, m =
+    resolve_pair ~cli_backend:"" ~cli_model:"sonnet" ~stored_backend:"claude"
+      ~stored_model:"" ~repo_config:empty_config ~built_in_backend:"codex"
+  in
+  String.equal b "claude" && String.equal m "sonnet"
+
+let%test "resolve_pair: whitespace-only treated as empty" =
+  let b, m =
+    resolve_pair ~cli_backend:"   " ~cli_model:"\t" ~stored_backend:"\n "
+      ~stored_model:""
+      ~repo_config:
+        (config_with ~default_backend:(Some "gemini")
+           ~default_model:(Some "gemini-2.5-pro") ())
+      ~built_in_backend:"claude"
+  in
+  String.equal b "gemini" && String.equal m "gemini-2.5-pro"
+
+let%test "resolve_pair: strips surrounding whitespace from chosen value" =
+  let b, m =
+    resolve_pair ~cli_backend:"  codex  " ~cli_model:"  gpt-5  "
+      ~stored_backend:"" ~stored_model:"" ~repo_config:empty_config
+      ~built_in_backend:"claude"
+  in
+  String.equal b "codex" && String.equal m "gpt-5"

--- a/lib_core/backend_routing.mli
+++ b/lib_core/backend_routing.mli
@@ -17,26 +17,50 @@ type decision = {
 val decide :
   repo_config:Repo_config.t ->
   default_backend:string ->
-  cli_model:string option ->
+  effective_model:string option ->
   complexity:int option ->
   decision
-(** Precedence rules:
+(** Precedence rules. [default_backend] and [effective_model] are the values
+    that come out of {!resolve_pair} — i.e. the post-merge effective backend and
+    model, not the raw CLI flags.
 
-    + If [cli_model] is not the literal ["auto"] (case-insensitive), the CLI
-      wins for the whole run: result is
-      [{ backend = default_backend; model = cli_model }]. The repo config is
-      ignored. This preserves the "explicit override" escape hatch.
-    + If [cli_model] is ["auto"] (case-insensitive) AND [Repo_config] has a
-      route for this complexity: the route wins —
+    + If [effective_model] is not the literal ["auto"] (case-insensitive), the
+      effective pair wins for the whole run: result is
+      [{ backend = default_backend; model = effective_model }]. The routing map
+      is ignored. This preserves the "explicit override" escape hatch.
+    + If [effective_model] is ["auto"] (case-insensitive) AND [Repo_config] has
+      a route for this complexity: the route wins —
       [{ backend = route.backend; model = route.model }]. This is the only case
       where the routing map takes effect.
-    + Otherwise ([cli_model] is ["auto"] but no route applies — typically
+    + Otherwise ([effective_model] is ["auto"] but no route applies — typically
       because [complexity = None], or the route map has no entry for this
-      complexity): result is [{ backend = default_backend; model = cli_model }].
-      The downstream backend will see [Some "auto"] and apply its own hardcoded
-      ladder via [Llm_backend.resolve_auto_model].
+      complexity): result is
+      [{ backend = default_backend; model = effective_model }]. The downstream
+      backend will see [Some "auto"] and apply its own hardcoded ladder via
+      [Llm_backend.resolve_auto_model].
 
     The function never raises and is total over all inputs. *)
+
+val resolve_pair :
+  cli_backend:string ->
+  cli_model:string ->
+  stored_backend:string ->
+  stored_model:string ->
+  repo_config:Repo_config.t ->
+  built_in_backend:string ->
+  string * string
+(** Merge the four sources of backend/model — CLI flag, [Project_store] (stored
+    value from a previous run), [Repo_config.default_*], and the hard-coded
+    built-in default — into the effective [(backend, model)] string pair.
+
+    Each field is resolved independently. Precedence within a field is
+    [CLI > stored > config > built-in]; the first non-empty (after
+    [String.strip]) value wins. [model] may come back as [""], meaning "no model
+    was configured anywhere" — the caller then omits [--model] from the
+    underlying CLI call so the provider's own default applies. [backend] always
+    falls back to [built_in_backend] and so is never empty.
+
+    Pure: no IO, no global state. *)
 
 val is_auto_model : string option -> bool
 (** [is_auto_model m] returns [true] iff [m] is [Some s] where [s]

--- a/lib_core/repo_config.ml
+++ b/lib_core/repo_config.ml
@@ -3,11 +3,20 @@ open Base
 type route = { backend : string; model : string option }
 
 type t = {
+  default_backend : string option;
+  default_model : string option;
   complexity_routes : (int * route) list;
   review_backends : Review_backend.t list;
 }
 
-let empty = { complexity_routes = []; review_backends = [] }
+let empty =
+  {
+    default_backend = None;
+    default_model = None;
+    complexity_routes = [];
+    review_backends = [];
+  }
+
 let config_path ~config_dir = Stdlib.Filename.concat config_dir "config.json"
 
 let parse_route ~known_backends ~complexity (json : Yojson.Safe.t) :
@@ -90,6 +99,40 @@ let parse_routing ~known_backends (json : Yojson.Safe.t) :
 
 let default_known_review_kinds = [ "review-service" ]
 
+let parse_default ~known_backends (json : Yojson.Safe.t) :
+    (string option * string option, string) Result.t =
+  let open Yojson.Safe.Util in
+  match json with
+  | `Null -> Ok (None, None)
+  | `Assoc _ ->
+      let backend_result =
+        match member "backend" json with
+        | `Null -> Ok None
+        | `String s when String.is_empty (String.strip s) -> Ok None
+        | `String s ->
+            let name = String.strip s in
+            if List.mem known_backends name ~equal:String.equal then
+              Ok (Some name)
+            else
+              Error
+                (Printf.sprintf
+                   "default.backend = %S is not a known backend (expected one \
+                    of: %s)"
+                   name
+                   (String.concat ~sep:", " known_backends))
+        | _ -> Error "default.backend must be a string"
+      in
+      let model_result =
+        match member "model" json with
+        | `Null -> Ok None
+        | `String s when String.is_empty (String.strip s) -> Ok None
+        | `String s -> Ok (Some (String.strip s))
+        | _ -> Error "default.model must be a string when present"
+      in
+      Result.bind backend_result ~f:(fun b ->
+          Result.map model_result ~f:(fun m -> (b, m)))
+  | _ -> Error "default must be an object {backend, model}"
+
 let parse_string ~known_backends
     ?(known_review_kinds = default_known_review_kinds) (raw : string) :
     (t, string) Result.t =
@@ -102,13 +145,22 @@ let parse_string ~known_backends
       let open Yojson.Safe.Util in
       match json with
       | `Assoc _ ->
+          let default_json = member "default" json in
           let routing = member "routing" json in
           let review_backends_json = member "reviewBackends" json in
-          Result.bind (parse_routing ~known_backends routing) ~f:(fun routes ->
-              Result.map
-                (Review_backend.parse_array ~known_kinds:known_review_kinds
-                   review_backends_json) ~f:(fun review_backends ->
-                  { complexity_routes = routes; review_backends }))
+          Result.bind (parse_default ~known_backends default_json)
+            ~f:(fun (default_backend, default_model) ->
+              Result.bind (parse_routing ~known_backends routing)
+                ~f:(fun routes ->
+                  Result.map
+                    (Review_backend.parse_array ~known_kinds:known_review_kinds
+                       review_backends_json) ~f:(fun review_backends ->
+                      {
+                        default_backend;
+                        default_model;
+                        complexity_routes = routes;
+                        review_backends;
+                      })))
       | _ -> Error "config.json: top-level value must be an object")
 
 let load ~config_dir ~known_backends ?known_review_kinds () =
@@ -274,4 +326,85 @@ let%test "parse_string: invalid reviewBackends propagates as Error" =
   let raw = {|{"reviewBackends":[{"name":"a","kind":"unknown"}]}|} in
   match parse_string ~known_backends:[ "claude" ] raw with
   | Error msg -> String.is_substring msg ~substring:"unknown"
+  | Ok _ -> false
+
+let%test "parse_string: default absent -> both None" =
+  match parse_string ~known_backends:[ "claude" ] "{}" with
+  | Ok t -> Option.is_none t.default_backend && Option.is_none t.default_model
+  | Error _ -> false
+
+let%test "parse_string: default with backend only" =
+  let raw = {|{"default":{"backend":"codex"}}|} in
+  match parse_string ~known_backends:[ "claude"; "codex" ] raw with
+  | Ok t ->
+      Option.equal String.equal t.default_backend (Some "codex")
+      && Option.is_none t.default_model
+  | Error _ -> false
+
+let%test "parse_string: default with model only" =
+  let raw = {|{"default":{"model":"sonnet"}}|} in
+  match parse_string ~known_backends:[ "claude" ] raw with
+  | Ok t ->
+      Option.is_none t.default_backend
+      && Option.equal String.equal t.default_model (Some "sonnet")
+  | Error _ -> false
+
+let%test "parse_string: default with both fields" =
+  let raw = {|{"default":{"backend":"codex","model":"gpt-5.5"}}|} in
+  match parse_string ~known_backends:[ "claude"; "codex" ] raw with
+  | Ok t ->
+      Option.equal String.equal t.default_backend (Some "codex")
+      && Option.equal String.equal t.default_model (Some "gpt-5.5")
+  | Error _ -> false
+
+let%test "parse_string: default.backend unknown rejected" =
+  let raw = {|{"default":{"backend":"made-up"}}|} in
+  match parse_string ~known_backends:[ "claude" ] raw with
+  | Error msg ->
+      String.is_substring msg ~substring:"made-up"
+      && String.is_substring msg ~substring:"default.backend"
+  | Ok _ -> false
+
+let%test "parse_string: default.model = 'auto' preserved verbatim" =
+  let raw = {|{"default":{"backend":"claude","model":"auto"}}|} in
+  match parse_string ~known_backends:[ "claude" ] raw with
+  | Ok t -> Option.equal String.equal t.default_model (Some "auto")
+  | Error _ -> false
+
+let%test "parse_string: default.backend empty string treated as None" =
+  let raw = {|{"default":{"backend":"  ","model":"sonnet"}}|} in
+  match parse_string ~known_backends:[ "claude" ] raw with
+  | Ok t ->
+      Option.is_none t.default_backend
+      && Option.equal String.equal t.default_model (Some "sonnet")
+  | Error _ -> false
+
+let%test "parse_string: default coexists with routing" =
+  let raw =
+    {|{
+       "default":{"backend":"codex","model":"auto"},
+       "routing":{"1":{"backend":"claude","model":"haiku"}}
+     }|}
+  in
+  match parse_string ~known_backends:[ "claude"; "codex" ] raw with
+  | Ok t -> (
+      Option.equal String.equal t.default_backend (Some "codex")
+      && Option.equal String.equal t.default_model (Some "auto")
+      &&
+      match t.complexity_routes with
+      | [ (1, { backend = "claude"; model = Some "haiku" }) ] -> true
+      | _ -> false)
+  | Error _ -> false
+
+let%test "parse_string: non-string default.backend rejected" =
+  let raw = {|{"default":{"backend":123}}|} in
+  match parse_string ~known_backends:[ "claude" ] raw with
+  | Error msg ->
+      String.is_substring msg ~substring:"default.backend must be a string"
+  | Ok _ -> false
+
+let%test "parse_string: default not an object rejected" =
+  let raw = {|{"default":"claude"}|} in
+  match parse_string ~known_backends:[ "claude" ] raw with
+  | Error msg -> String.is_substring msg ~substring:"default must be an object"
   | Ok _ -> false

--- a/lib_core/repo_config.mli
+++ b/lib_core/repo_config.mli
@@ -2,10 +2,16 @@
     [~/.config/onton/<owner>/<repo>/config.json] (the same directory layout the
     [User_config] hook lives in — see [User_config.config_dir]).
 
-    Currently only carries the [routing] map — a per-patch override that binds
-    each complexity tier (1/2/3) to a [(backend, model)] tuple. The map only
-    takes effect when [onton --model auto] is in use; explicit [--model <name>]
-    still wins for the whole run.
+    Carries three sections:
+    - [default] — a per-repo default [(backend, model)] pair that mirrors the
+      [--backend] / [--model] CLI flags. Either field may be omitted. Slots into
+      the resolution chain below [Project_store] (stored values from previous
+      runs) but above the hard-coded built-in default.
+    - [routing] — a per-patch override that binds each complexity tier (1/2/3)
+      to a [(backend, model)] tuple. Fires when the effective model (CLI or
+      [default.model]) is the literal ["auto"] (case-insensitive). Otherwise the
+      effective pair drives the whole run.
+    - [reviewBackends] — additional review sources to poll alongside the forge.
 
     Unknown top-level keys are ignored so the file can grow with new sections
     (e.g. timeouts, hook overrides) without breaking older binaries. *)
@@ -19,10 +25,19 @@ type route = {
 }
 
 type t = {
+  default_backend : string option;
+      (** Top-level [default.backend] from the config file. [Some name] (where
+          [name] is in the caller's [known_backends]) acts as the per-repo
+          default backend when neither [--backend] nor a previously stored
+          backend is set. [None] means "not configured — fall through". *)
+  default_model : string option;
+      (** Top-level [default.model] from the config file. [Some "auto"] (case-
+          insensitive) activates [routing] in the same way as [--model auto].
+          [Some other] pins a specific model. [None] means "not configured". *)
   complexity_routes : (int * route) list;
       (** Sparse map indexed by complexity (1/2/3). Stored as an alist because
           the set is tiny and the lookup is per-patch — fast enough. Missing
-          keys mean "no override", and the caller falls back to its default
+          keys mean "no override", and the caller falls back to the effective
           backend / built-in [auto_model] ladder. *)
   review_backends : Review_backend.t list;
       (** Additional review sources to poll alongside the forge. Empty (the
@@ -52,6 +67,10 @@ val load :
     The schema is:
     {[
       {
+        "default": {
+          "backend": "codex",
+          "model":   "auto"
+        },
         "routing": {
           "1": { "backend": "claude", "model": "haiku" },
           "2": { "backend": "codex",  "model": "gpt-5.4" },
@@ -59,8 +78,9 @@ val load :
         }
       }
     ]}
-    [model] is optional. Top-level extra keys are ignored so the file can grow
-    without breaking older binaries. *)
+    Inside [routing.<n>], [backend] is required and [model] is optional. Inside
+    [default], both [backend] and [model] are optional. Top-level extra keys are
+    ignored so the file can grow without breaking older binaries. *)
 
 val route_for_complexity : t -> complexity:int option -> route option
 (** Look up the override for a given patch complexity. [None] when the patch has

--- a/test/test_backend_routing.ml
+++ b/test/test_backend_routing.ml
@@ -76,7 +76,7 @@ let gen_repo_config : Repo_config.t QCheck2.Gen.t =
   in
   let* routes = list_size (return (List.length keys)) gen_route in
   let complexity_routes = List.zip_exn keys routes in
-  return { Repo_config.complexity_routes; review_backends = [] }
+  return { Repo_config.empty with complexity_routes }
 
 let pp_decision (d : Backend_routing.decision) =
   Printf.sprintf "{ backend = %s; model = %s }" d.backend
@@ -93,8 +93,8 @@ let () =
          gen_complexity)
       (fun (repo_config, default_backend, cli_model, complexity) ->
         let d =
-          Backend_routing.decide ~repo_config ~default_backend ~cli_model
-            ~complexity
+          Backend_routing.decide ~repo_config ~default_backend
+            ~effective_model:cli_model ~complexity
         in
         String.equal d.backend default_backend
         && Option.equal String.equal d.model cli_model)
@@ -107,12 +107,12 @@ let () =
          gen_complexity)
       (fun (repo_config, default_backend, cli_model, complexity) ->
         let with_cfg =
-          Backend_routing.decide ~repo_config ~default_backend ~cli_model
-            ~complexity
+          Backend_routing.decide ~repo_config ~default_backend
+            ~effective_model:cli_model ~complexity
         in
         let without_cfg =
           Backend_routing.decide ~repo_config:Repo_config.empty ~default_backend
-            ~cli_model ~complexity
+            ~effective_model:cli_model ~complexity
         in
         String.equal with_cfg.backend without_cfg.backend
         && Option.equal String.equal with_cfg.model without_cfg.model)
@@ -128,7 +128,7 @@ let () =
         | Some route ->
             let d =
               Backend_routing.decide ~repo_config ~default_backend
-                ~cli_model:(Some auto) ~complexity
+                ~effective_model:(Some auto) ~complexity
             in
             String.equal d.backend route.backend
             && Option.equal String.equal d.model route.model)
@@ -146,7 +146,7 @@ let () =
         | None ->
             let d =
               Backend_routing.decide ~repo_config ~default_backend
-                ~cli_model:(Some auto) ~complexity
+                ~effective_model:(Some auto) ~complexity
             in
             (* The fallback canonicalises to lowercase "auto" regardless of
                how the user typed [--model], so registry deduplication works. *)
@@ -162,7 +162,7 @@ let () =
       (fun (repo_config, default_backend, auto) ->
         let d =
           Backend_routing.decide ~repo_config ~default_backend
-            ~cli_model:(Some auto) ~complexity:None
+            ~effective_model:(Some auto) ~complexity:None
         in
         String.equal d.backend default_backend
         && Option.equal String.equal d.model (Some "auto"))
@@ -177,7 +177,7 @@ let () =
         let decisions =
           List.map variants ~f:(fun v ->
               Backend_routing.decide ~repo_config ~default_backend
-                ~cli_model:(Some v) ~complexity)
+                ~effective_model:(Some v) ~complexity)
         in
         match decisions with
         | [] -> true
@@ -211,8 +211,8 @@ let () =
       (fun (repo_config, default_backend, cli_model, complexity) ->
         try
           let d =
-            Backend_routing.decide ~repo_config ~default_backend ~cli_model
-              ~complexity
+            Backend_routing.decide ~repo_config ~default_backend
+              ~effective_model:cli_model ~complexity
           in
           not (String.is_empty d.backend)
         with _ -> false)


### PR DESCRIPTION
## Summary

- `config.json` (`~/.config/onton/<owner>/<repo>/config.json`) gains a top-level `default` block with optional `backend` and `model` subfields, mirroring the `--backend` / `--model` CLI flags. Either subfield may be omitted; pin one or both.
- Resolution order becomes **CLI > stored (resume only) > config > built-in**, evaluated per field. `model: "auto"` from any source — CLI flag or `default.model` — activates the existing `routing` map.
- All three modes (auto-routing across complexity tiers, auto-model with a fixed backend, fully fixed pair) can now be expressed by CLI flags _or_ by per-repo config, without re-typing on every invocation.
- Internal refactor: collapse the fresh/gameplan/resume boilerplate in `bin/main.ml` behind a shared `finalize_run` helper, and group its arguments into three records (`repo_coords` / `run_knobs` / `backend_inputs`).

## Schema

```jsonc
{
  "default": {
    "backend": "codex",
    "model":   "auto"
  },
  "routing": {
    "1": { "backend": "claude", "model": "haiku"   },
    "3": { "backend": "codex",  "model": "gpt-5.5" }
  }
}
```

Unknown top-level keys are still ignored for forward compatibility.

## Test plan

- [x] `dune build` clean
- [x] `dune runtest` passes (added 9 `repo_config` parser tests, 8 `Backend_routing.resolve_pair` merge tests, and updated `Backend_preflight` + `test_backend_routing` for the `effective_model` rename)
- [ ] Manual smoke against a checkout with `config.json`:
  - [ ] `default.backend = "codex"` only, no CLI flags → codex selected
  - [ ] `default.model = "auto"` only → routing map fires
  - [ ] `--backend claude` overrides `default.backend = "codex"`
  - [ ] Resume with stored `backend = "claude"` while config has `default.backend = "codex"` → stored wins (resolution order leaves stored above config)
- [ ] `onton-check-repo-config <owner> <repo>` prints the new `default.{backend,model}` lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/312"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781967551&installation_id=126163856&pr_number=312&repository=flowglad%2Fonton&return_to=https%3A%2F%2Fgithub.com%2Fflowglad%2Fonton%2Fpull%2F312&signature=7b696b053bffde13687051762d755af8dbd7ab716c9d0acc776c63b6f59a5f4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add per-repo defaults for `backend` and `model` in `~/.config/onton/<owner>/<repo>/config.json`, with precedence CLI > stored > config > built-in. `model: "auto"` from any source triggers routing so teams can avoid re-typing flags.

- **New Features**
  - Support `default.{backend,model}` in per-repo `config.json`; either field can be omitted.
  - Per-field resolution: CLI > stored > config > built-in; backend always falls back to built-in.
  - `auto` from CLI or `default.model` activates the `routing` map; all three modes (auto-routing, auto-model + fixed backend, fully fixed) work via flags or config.
  - `onton-check-repo-config <owner> <repo>` now prints `default.backend` and `default.model`.
  - README and `--model` help updated with the schema and precedence.

- **Refactors**
  - Centralized backend/model resolution and persistence via `finalize_run` with `repo_coords`, `run_knobs`, and `backend_inputs`.
  - Added `Backend_routing.resolve_pair` to merge CLI, stored, config, and built-in values.
  - Switched call sites from `cli_model` to `effective_model` to reflect post-merge semantics.
  - Load repo config once during setup and carry it in `Resolved_config` for routing and review backends.
  - Expanded tests for repo config parsing, pair resolution, and routing behavior.

<sup>Written for commit c099e05f87b29df021d2c792310b4590eaf83b20. Summary will update on new commits. <a href="https://cubic.dev/pr/flowglad/onton/pull/312?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for per-repository backend and model defaults through configuration files
  * Implemented intelligent routing that automatically selects backends based on patch complexity when model is set to auto mode

* **Documentation**
  * Added comprehensive documentation on per-repository configuration, including JSON structure, configuration precedence rules, and automatic routing behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flowglad/onton/pull/312?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->