### PR TITLE
Summarize GitHub HTTP error bodies before logging them

### DIFF
--- a/lib/github.mli
+++ b/lib/github.mli
@@ -27,6 +27,13 @@ val response_error_message_contains : string -> substring:string -> bool
     distinct 422 cases (e.g. "pull request already exists" vs "no commits
     between"). Pure; safe on malformed input. *)
 
+val extract_github_message : string -> string
+(** Summarize an HTTP error response body for activity-log display. When the
+    body is a GitHub JSON error, returns the [message] field (and any
+    [errors[].message] details). When the body is not JSON — e.g. the multi-KB
+    HTML page GitHub serves on 5xx — truncates to ~200 characters so it does not
+    flood the activity stream. *)
+
 val default_timeout : float
 (** Per-request timeout default, in seconds. Without a timeout, a TCP connect
     stuck in [SYN_SENT] (e.g. dropped packets, dead route) can block the calling

--- a/lib/poller_fiber.ml
+++ b/lib/poller_fiber.ml
@@ -126,7 +126,8 @@ struct
     | Error (Github.Transport_error { msg; _ }) ->
         Poll_outcome.Transport_failed { msg }
     | Error (Github.Http_error { status; body; _ }) ->
-        Poll_outcome.Http_failed { status; msg = body }
+        Poll_outcome.Http_failed
+          { status; msg = Github.extract_github_message body }
     | Error (Github.Graphql_error msgs) -> Poll_outcome.Graphql_failed msgs
     | Error (Github.Json_parse_error msg) -> Poll_outcome.Json_parse_failed msg
 


### PR DESCRIPTION
## Summary
- GitHub's 5xx responses are multi-KB HTML pages (`<!DOCTYPE html>…Hello future GitHubber!…`). We were stuffing the raw body verbatim into `Poll_outcome.Http_failed.msg`, which `Poll_cycle.classify` then formatted into a `"Poll error — HTTP 502: …"` activity entry. Two ~60 KB entries in one project's snapshot were enough to make the TUI unusable.
- `Github.extract_github_message` already does the right thing: returns the JSON `message` field for proper GitHub errors and truncates non-JSON bodies (including HTML) at ~200 chars. It just wasn't exposed or used at the polling boundary.
- Exposes `extract_github_message` in `github.mli` and calls it in `poller_fiber.ml` when translating `Github.Http_error` into `Poll_outcome.Http_failed`, so the raw body never reaches the activity log.

## Test plan
- [x] `dune build` clean
- [x] `dune runtest` passes (pre-commit hook ran the suite)
- [ ] Manually verify a fresh GitHub 5xx logs a short summary instead of the HTML dump

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/313"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781968372&installation_id=126163856&pr_number=313&repository=flowglad%2Fonton&return_to=https%3A%2F%2Fgithub.com%2Fflowglad%2Fonton%2Fpull%2F313&signature=c255e3ccb3c4bf3895d8da32dad28bda8c0c7ad70104c4bb37607801610d01a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Summarizes GitHub HTTP error bodies before logging to prevent multi‑KB HTML from flooding the activity log and hurting the TUI. Exposes extract_github_message and uses it at the poll boundary so JSON errors show their message and non‑JSON bodies are truncated (~200 chars).

<sup>Written for commit 14cb15bf7703cf4ec607874c760460575df0f8ff. Summary will update on new commits. <a href="https://cubic.dev/pr/flowglad/onton/pull/313?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitHub error messages displayed in activity logs by extracting structured error details from JSON responses and truncating verbose HTML error pages to maintain clean, readable logs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flowglad/onton/pull/313?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->