### PR TITLE
Defer mark-for-review until the patch reaches a fixpoint

### DIFF
--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -835,6 +835,7 @@ let%test "reconcile_patch keeps PR draft while merge conflict is active" =
   let t = Orchestrator.fire t (Orchestrator.Start (pid, main)) in
   let t = Orchestrator.set_pr_number t pid (Pr_number.of_int 42) in
   let t = Orchestrator.set_pr_body_delivered t pid true in
+  let t = Orchestrator.set_checks_passing t pid true in
   let t = Orchestrator.complete t pid in
   let t = Orchestrator.set_has_conflict t pid in
   let _, effects =
@@ -904,6 +905,7 @@ let%test
   let t = Orchestrator.fire t (Orchestrator.Start (child_id, parent_branch)) in
   let t = Orchestrator.set_pr_number t child_id (Pr_number.of_int 42) in
   let t = Orchestrator.set_pr_body_delivered t child_id true in
+  let t = Orchestrator.set_checks_passing t child_id true in
   let t = Orchestrator.complete t child_id in
   let gp =
     Gameplan.

--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -260,14 +260,32 @@ let reconcile_patch t ~project_name:_ ~gameplan:_ ~(patch : Patch.t) =
                   ~branch_of
                   ~main:(Orchestrator.main_branch t)
               in
-              let desired_draft =
-                if Branch.equal expected_base (Orchestrator.main_branch t) then
-                  not agent.pr_body_delivered
-                else true
+              (* Mark-for-review is a one-way ratchet: we only emit
+                 [draft = false]. Re-drafting a ready PR is disruptive to
+                 reviewers, so the controller defers the transition until
+                 the patch has reached a fixpoint and then never flips back.
+
+                 The fixpoint requires the PR body to be delivered, the
+                 expected base to be [main] (all deps merged), the local
+                 branch to actually be rebased onto that base (otherwise a
+                 pending rebase could still surface a conflict), no active
+                 merge conflict, and CI green. [branch_rebased_onto] lags
+                 [expected_base] until the Rebase action lands, and
+                 [has_conflict] is set the moment a rebase or push surfaces
+                 a conflict — both must clear before we open for review. *)
+              let rebase_pending =
+                match agent.branch_rebased_onto with
+                | Some b -> not (Branch.equal b expected_base)
+                | None -> false
               in
-              if Bool.(agent.is_draft <> desired_draft) then
+              let ready_for_review =
+                Branch.equal expected_base (Orchestrator.main_branch t)
+                && agent.pr_body_delivered && (not agent.has_conflict)
+                && (not rebase_pending) && agent.checks_passing
+              in
+              if agent.is_draft && ready_for_review then
                 effects :=
-                  Set_pr_draft { patch_id; pr_number; draft = desired_draft }
+                  Set_pr_draft { patch_id; pr_number; draft = false }
                   :: !effects;
               if not (Branch.equal actual_base expected_base) then
                 effects :=
@@ -718,6 +736,7 @@ let%test "reconcile_patch requests ready-for-review after pr_body on main" =
   let t = Orchestrator.fire t (Orchestrator.Start (pid, main)) in
   let t = Orchestrator.set_pr_number t pid (Pr_number.of_int 42) in
   let t = Orchestrator.set_pr_body_delivered t pid true in
+  let t = Orchestrator.set_checks_passing t pid true in
   let t = Orchestrator.complete t pid in
   let _, effects =
     reconcile_patch t ~project_name:"proj"
@@ -743,6 +762,175 @@ let%test "reconcile_patch requests ready-for-review after pr_body on main" =
   List.exists effects ~f:(function
     | Set_pr_draft { patch_id; draft = false; _ } -> Patch_id.equal patch_id pid
     | Set_pr_draft _ | Set_pr_base _ -> false)
+
+let%test "reconcile_patch keeps PR draft while CI is not green" =
+  let patch, t = make_orchestrator ~patch_id:pid ~main_branch:main in
+  let t = Orchestrator.fire t (Orchestrator.Start (pid, main)) in
+  let t = Orchestrator.set_pr_number t pid (Pr_number.of_int 42) in
+  let t = Orchestrator.set_pr_body_delivered t pid true in
+  let t = Orchestrator.complete t pid in
+  (* checks_passing left at its default [false] — CI hasn't reported green. *)
+  let _, effects =
+    reconcile_patch t ~project_name:"proj"
+      ~gameplan:
+        Gameplan.
+          {
+            project_name = "proj";
+            repo_owner = "";
+            repo_name = "";
+            problem_statement = "";
+            solution_summary = "";
+            final_state_spec = "";
+            patches = [ patch ];
+            current_state_analysis = "";
+            explicit_opinions = "";
+            acceptance_criteria = [];
+            open_questions = [];
+            functional_changes = [];
+            context_resources = [];
+          }
+      ~patch
+  in
+  List.is_empty effects
+
+let%test "reconcile_patch never re-drafts a PR once it is ready for review" =
+  let patch, t = make_orchestrator ~patch_id:pid ~main_branch:main in
+  let t = Orchestrator.fire t (Orchestrator.Start (pid, main)) in
+  let t = Orchestrator.set_pr_number t pid (Pr_number.of_int 42) in
+  let t = Orchestrator.set_pr_body_delivered t pid true in
+  let t = Orchestrator.complete t pid in
+  (* Simulate GitHub having observed the PR as ready-for-review. *)
+  let t = Orchestrator.set_is_draft t pid false in
+  (* Now CI flaps red and a fresh conflict arrives. *)
+  let t = Orchestrator.set_checks_passing t pid false in
+  let t = Orchestrator.set_has_conflict t pid in
+  let _, effects =
+    reconcile_patch t ~project_name:"proj"
+      ~gameplan:
+        Gameplan.
+          {
+            project_name = "proj";
+            repo_owner = "";
+            repo_name = "";
+            problem_statement = "";
+            solution_summary = "";
+            final_state_spec = "";
+            patches = [ patch ];
+            current_state_analysis = "";
+            explicit_opinions = "";
+            acceptance_criteria = [];
+            open_questions = [];
+            functional_changes = [];
+            context_resources = [];
+          }
+      ~patch
+  in
+  not
+    (List.exists effects ~f:(function
+      | Set_pr_draft _ -> true
+      | Set_pr_base _ -> false))
+
+let%test "reconcile_patch keeps PR draft while merge conflict is active" =
+  let patch, t = make_orchestrator ~patch_id:pid ~main_branch:main in
+  let t = Orchestrator.fire t (Orchestrator.Start (pid, main)) in
+  let t = Orchestrator.set_pr_number t pid (Pr_number.of_int 42) in
+  let t = Orchestrator.set_pr_body_delivered t pid true in
+  let t = Orchestrator.complete t pid in
+  let t = Orchestrator.set_has_conflict t pid in
+  let _, effects =
+    reconcile_patch t ~project_name:"proj"
+      ~gameplan:
+        Gameplan.
+          {
+            project_name = "proj";
+            repo_owner = "";
+            repo_name = "";
+            problem_statement = "";
+            solution_summary = "";
+            final_state_spec = "";
+            patches = [ patch ];
+            current_state_analysis = "";
+            explicit_opinions = "";
+            acceptance_criteria = [];
+            open_questions = [];
+            functional_changes = [];
+            context_resources = [];
+          }
+      ~patch
+  in
+  not
+    (List.exists effects ~f:(function
+      | Set_pr_draft { draft = false; _ } -> true
+      | Set_pr_draft _ | Set_pr_base _ -> false))
+
+let%test
+    "reconcile_patch keeps child PR draft until rebased onto main after parent \
+     merges" =
+  let parent_id = Patch_id.of_string "parent" in
+  let child_id = Patch_id.of_string "child" in
+  let parent_branch = Branch.of_string "parent-branch" in
+  let child_branch = Branch.of_string "child-branch" in
+  let mk_patch id branch deps =
+    {
+      Patch.id;
+      title = "test";
+      description = "test";
+      branch;
+      dependencies = deps;
+      spec = "";
+      acceptance_criteria = [];
+      changes = [];
+      files = [];
+      classification = "";
+      test_stubs_introduced = [];
+      test_stubs_implemented = [];
+      complexity = None;
+      precedents = [];
+      required_context = [];
+    }
+  in
+  let parent_patch = mk_patch parent_id parent_branch [] in
+  let child_patch = mk_patch child_id child_branch [ parent_id ] in
+  let t =
+    Orchestrator.create ~patches:[ parent_patch; child_patch ] ~main_branch:main
+  in
+  let t = Orchestrator.fire t (Orchestrator.Start (parent_id, main)) in
+  let t = Orchestrator.set_pr_number t parent_id (Pr_number.of_int 41) in
+  let t = Orchestrator.complete t parent_id in
+  let t = Orchestrator.mark_merged t parent_id in
+  (* Child started on the parent's branch — branch_rebased_onto records
+     [parent_branch], NOT main. Parent has since merged, so expected_base
+     flips to main, but the local branch has not yet been rebased. *)
+  let t = Orchestrator.fire t (Orchestrator.Start (child_id, parent_branch)) in
+  let t = Orchestrator.set_pr_number t child_id (Pr_number.of_int 42) in
+  let t = Orchestrator.set_pr_body_delivered t child_id true in
+  let t = Orchestrator.complete t child_id in
+  let gp =
+    Gameplan.
+      {
+        project_name = "proj";
+        repo_owner = "";
+        repo_name = "";
+        problem_statement = "";
+        solution_summary = "";
+        final_state_spec = "";
+        patches = [ parent_patch; child_patch ];
+        current_state_analysis = "";
+        explicit_opinions = "";
+        acceptance_criteria = [];
+        open_questions = [];
+        functional_changes = [];
+        context_resources = [];
+      }
+  in
+  let _, effects =
+    reconcile_patch t ~project_name:"proj" ~gameplan:gp ~patch:child_patch
+  in
+  not
+    (List.exists effects ~f:(function
+      | Set_pr_draft { patch_id; draft = false; _ } ->
+          Patch_id.equal patch_id child_id
+      | Set_pr_draft _ | Set_pr_base _ -> false))
 
 let%test "reconcile_patch emits no effects for merged agent" =
   let patch, t = make_orchestrator ~patch_id:pid ~main_branch:main in

--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -276,7 +276,7 @@ let reconcile_patch t ~project_name:_ ~gameplan:_ ~(patch : Patch.t) =
               let rebase_pending =
                 match agent.branch_rebased_onto with
                 | Some b -> not (Branch.equal b expected_base)
-                | None -> false
+                | None -> true
               in
               let ready_for_review =
                 Branch.equal expected_base (Orchestrator.main_branch t)

--- a/test/test_patch_controller.ml
+++ b/test/test_patch_controller.ml
@@ -257,6 +257,40 @@ let () =
         end)
   in
 
+  let prop_unknown_rebase_blocks_ready_for_review =
+    Test.make
+      ~name:"patch_controller: unknown rebase target blocks ready-for-review"
+      ~count:200
+      Gen.(pair gen_patch_id gen_branch)
+      (fun (pid, branch) ->
+        let patch = make_patch pid branch in
+        let gameplan = make_gameplan patch in
+        let agent =
+          Patch_agent.restore ~patch_id:pid ~branch
+            ~pr_number:(Some (Pr_number.of_int 42))
+            ~has_session:false ~busy:false ~merged:false ~queue:[]
+            ~satisfies:false ~changed:false ~has_conflict:false
+            ~base_branch:(Some main) ~notified_base_branch:(Some main)
+            ~ci_failure_count:0 ~session_fallback:Patch_agent.Fresh_available
+            ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
+            ~merge_ready:false ~is_draft:true ~pr_body_delivered:true
+            ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
+            ~conflict_noop_count:0 ~no_commits_push_count:0
+            ~branch_rebased_onto:None ~checks_passing:true ~current_op:None
+            ~current_op_state:Patch_agent.Queued ~current_message_id:None
+            ~generation:0 ~worktree_path:None ~branch_blocked:false
+            ~llm_session_id:None ~automerge_enabled:false
+            ~automerge_deadline:None ~automerge_inflight:false
+            ~automerge_failure_count:0 ~delivered_ci_run_ids:[]
+        in
+        let orch = make_orch patch agent in
+        let _orch, effects =
+          Patch_controller.reconcile_patch orch ~project_name:"test-project"
+            ~gameplan ~patch
+        in
+        not (has_draft_effect effects))
+  in
+
   let prop_intervention_stable_after_threshold =
     Test.make
       ~name:
@@ -501,6 +535,7 @@ let () =
             ~pr_number:(Some (Pr_number.of_int 42))
             ~merged:false ~queue:[] ~base_branch:(Some main) ~is_draft:true
             ~pr_body_delivered:true ~start_attempts_without_pr:0
+          |> fun agent -> Patch_agent.set_branch_rebased_onto agent main
         in
         let orch = make_orch patch agent in
         let poll =
@@ -795,10 +830,10 @@ let () =
             ~merge_ready:false ~is_draft:true ~pr_body_delivered:false
             ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
             ~conflict_noop_count:0 ~no_commits_push_count:0
-            ~branch_rebased_onto:None ~checks_passing:false ~current_op:None
-            ~current_op_state:Patch_agent.Queued ~current_message_id:None
-            ~generation:0 ~worktree_path:None ~branch_blocked:false
-            ~llm_session_id:None ~automerge_enabled:false
+            ~branch_rebased_onto:(Some main) ~checks_passing:false
+            ~current_op:None ~current_op_state:Patch_agent.Queued
+            ~current_message_id:None ~generation:0 ~worktree_path:None
+            ~branch_blocked:false ~llm_session_id:None ~automerge_enabled:false
             ~automerge_deadline:None ~automerge_inflight:false
             ~automerge_failure_count:0 ~delivered_ci_run_ids:[]
         in
@@ -1066,6 +1101,7 @@ let () =
       prop_plan_tick_deterministic;
       prop_pr_body_queue_idempotent;
       prop_draft_reemits_until_success;
+      prop_unknown_rebase_blocks_ready_for_review;
       prop_intervention_stable_after_threshold;
       prop_reconcile_all_exposes_pr_body_as_next_action;
       prop_reconcile_all_blocks_restart_after_intervention;

--- a/test/test_patch_controller.ml
+++ b/test/test_patch_controller.ml
@@ -206,19 +206,35 @@ let () =
   in
 
   let prop_draft_reemits_until_success =
-    Test.make ~name:"patch_controller: draft effect re-emits until acknowledged"
+    Test.make
+      ~name:
+        "patch_controller: ready-for-review effect re-emits until acknowledged"
       ~count:200
-      Gen.(triple gen_patch_id gen_branch bool)
-      (fun (pid, branch, notes_delivered) ->
-        let desired_draft = not notes_delivered in
+      Gen.(pair gen_patch_id gen_branch)
+      (fun (pid, branch) ->
         let patch = make_patch pid branch in
         let gameplan = make_gameplan patch in
+        (* Agent is at the ready-for-review fixpoint except is_draft is still
+           true on GitHub; reconcile must emit Set_pr_draft{draft=false} until
+           the effect is acknowledged. One-way ratchet — the reverse
+           direction (re-draft) is not exercised by this property. *)
         let agent =
-          make_agent ~patch_id:pid ~branch
+          Patch_agent.restore ~patch_id:pid ~branch
             ~pr_number:(Some (Pr_number.of_int 42))
-            ~merged:false ~queue:[] ~base_branch:(Some main)
-            ~is_draft:(not desired_draft) ~pr_body_delivered:notes_delivered
-            ~start_attempts_without_pr:0
+            ~has_session:false ~busy:false ~merged:false ~queue:[]
+            ~satisfies:false ~changed:false ~has_conflict:false
+            ~base_branch:(Some main) ~notified_base_branch:(Some main)
+            ~ci_failure_count:0 ~session_fallback:Patch_agent.Fresh_available
+            ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
+            ~merge_ready:false ~is_draft:true ~pr_body_delivered:true
+            ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
+            ~conflict_noop_count:0 ~no_commits_push_count:0
+            ~branch_rebased_onto:(Some main) ~checks_passing:true
+            ~current_op:None ~current_op_state:Patch_agent.Queued
+            ~current_message_id:None ~generation:0 ~worktree_path:None
+            ~branch_blocked:false ~llm_session_id:None ~automerge_enabled:false
+            ~automerge_deadline:None ~automerge_inflight:false
+            ~automerge_failure_count:0 ~delivered_ci_run_ids:[]
         in
         let orch = make_orch patch agent in
         begin try
@@ -496,7 +512,7 @@ let () =
               is_draft = true;
               has_conflict = false;
               merge_ready = false;
-              checks_passing = false;
+              checks_passing = true;
               ci_checks = [];
             }
         in
@@ -801,12 +817,15 @@ let () =
           in
           if not has_pr_body_action then false
           else
-            (* Fire Pr_body action and simulate delivery *)
+            (* Fire Pr_body action and simulate delivery. CI must be
+               observed green before the controller will mark ready —
+               that's a precondition of the fixpoint. *)
             let orch1 =
               Orchestrator.fire orch1
                 (Orchestrator.Respond (pid, Operation_kind.Pr_body))
             in
             let orch1 = Orchestrator.set_pr_body_delivered orch1 pid true in
+            let orch1 = Orchestrator.set_checks_passing orch1 pid true in
             let orch1 = Orchestrator.complete orch1 pid in
             (* Cycle 2: should converge — only draft effect *)
             let _orch2, effects2, actions2 =


### PR DESCRIPTION
## Summary

- `reconcile_patch` was flipping a child PR to ready-for-review on the very tick its parent merged — before any rebase had run — so a subsequent rebase conflict left the PR briefly ready with an active merge conflict. A similar gap existed for failing CI.
- Tighten `desired_draft` to require a real fixpoint: PR body delivered, expected base is `main`, the local branch is actually rebased onto that base (`branch_rebased_onto = expected_base`), no active conflict, and CI green.
- Make the emission a one-way ratchet: `reconcile_patch` only ever emits `Set_pr_draft{draft=false}`. Re-drafting a ready PR is disruptive and the merge gate already blocks the actual merge on conflict/CI state via `is_approved` + `checks_passing`.

## Test plan

- [x] `dune runtest` — all property and inline tests pass
- [x] New inline tests in `lib/patch_controller.ml`:
  - `keeps PR draft while merge conflict is active`
  - `keeps child PR draft until rebased onto main after parent merges`
  - `keeps PR draft while CI is not green`
  - `never re-drafts a PR once it is ready for review`
- [x] Updated `prop_draft_reemits_until_success`, `prop_poll_to_controller_promotes_ready_after_pr_body`, `prop_mixed_cycle_converges_for_bootstrap_patch`, and the existing `requests ready-for-review after pr_body on main` test for the new fixpoint precondition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781980768&installation_id=126163856&pr_number=314&repository=flowglad%2Fonton&return_to=https%3A%2F%2Fgithub.com%2Fflowglad%2Fonton%2Fpull%2F314&signature=a723988159c6ecbb4c6a6c3930df876e78f39670b2f52ee56d567974b3df441d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defers marking PRs ready-for-review until the patch hits a true fixpoint to avoid brief ready states during conflicts, failing CI, or before a needed rebase. Makes the transition one-way to reduce churn for reviewers.

- **Bug Fixes**
  - Ready only when: PR body delivered, expected base is `main`, branch rebased onto that base, no conflicts, and CI green.
  - Treats unknown `branch_rebased_onto` as a pending rebase to block early ready states.
  - One-way ratchet: only emits `Set_pr_draft{draft=false}`; never re-drafts from this path.
  - Tests: added/updated inline and property tests to isolate the ready-for-review gate, including CI not green, active conflicts, child waiting for rebase after parent merge, unknown rebase target blocking, and re-emit-until-acknowledged behavior; adjusted existing tests to require CI green and recorded rebase target.

<sup>Written for commit 35787955eaddc604c258d6e5b94afb20e231133e. Summary will update on new commits. <a href="https://cubic.dev/pr/flowglad/onton/pull/314?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * PRs now only leave draft state once all readiness conditions are met (correct base, PR body delivered, no conflicts, CI passing, no pending rebase) and will not be re-drafted afterward.

* **Tests**
  * Added and updated tests covering CI-failure, merge-conflict, unknown rebase target, child-PR rebase gating, and no re-draft-after-ready scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flowglad/onton/pull/314?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->