### PR TITLE
Add 'b' bump command to patch management mode

### DIFF
--- a/lib/tui.ml
+++ b/lib/tui.ml
@@ -1037,7 +1037,8 @@ let render_help_overlay ~width ~height =
   let pad_line line = if width <= 0 then "" else Term.fit_width width line in
   List.map visible ~f:pad_line
 
-let render_manage_overlay ~width ~height ~automerge_enabled =
+let render_manage_overlay ~width ~height ~automerge_enabled ~needs_intervention
+    =
   let dismiss = Term.styled [ Term.Sgr.dim ] "(esc to cancel)" in
   let title =
     Term.styled
@@ -1055,11 +1056,19 @@ let render_manage_overlay ~width ~height ~automerge_enabled =
       Term.styled [ Term.Sgr.bold; Term.Sgr.fg_green ] automerge_label
     else Term.styled [ Term.Sgr.dim ] automerge_label
   in
+  let bump_item =
+    if needs_intervention then
+      Some
+        (Term.styled [ Term.Sgr.dim ]
+           "    b   Bump (clear intervention, continue patch loop)")
+    else None
+  in
   let items =
     [
       Term.styled [ Term.Sgr.dim ] "    m   Force mark as merged (break glass)";
       automerge_item;
     ]
+    @ Option.to_list bump_item
   in
   let content = title :: "" :: items in
   let overlay_h = Int.max 0 (Int.min (List.length content) (height - 1)) in
@@ -1154,17 +1163,25 @@ let render_frame ~width ~height ~selected ~scroll_offset ~view_mode
     let overlay = render_help_overlay ~width ~height in
     { no_patches with lines = overlay }
   else if show_manage then
-    let automerge_enabled =
+    let target_pv =
       match view_mode with
       | Detail_view patch_id ->
           List.find views ~f:(fun pv -> Patch_id.equal pv.patch_id patch_id)
-          |> Option.value_map ~default:false ~f:(fun pv -> pv.automerge_enabled)
-      | List_view ->
-          List.nth views selected
-          |> Option.value_map ~default:false ~f:(fun pv -> pv.automerge_enabled)
-      | Timeline_view -> false
+      | List_view -> List.nth views selected
+      | Timeline_view -> None
     in
-    let overlay = render_manage_overlay ~width ~height ~automerge_enabled in
+    let automerge_enabled =
+      Option.value_map target_pv ~default:false ~f:(fun pv ->
+          pv.automerge_enabled)
+    in
+    let needs_intervention =
+      Option.value_map target_pv ~default:false ~f:(fun pv ->
+          pv.needs_intervention)
+    in
+    let overlay =
+      render_manage_overlay ~width ~height ~automerge_enabled
+        ~needs_intervention
+    in
     { no_patches with lines = overlay; detail_scroll_offset = scroll_offset }
   else
     let header = render_header ~project_name ~backend_name ~width in

--- a/lib/tui.ml
+++ b/lib/tui.ml
@@ -1167,7 +1167,12 @@ let render_frame ~width ~height ~selected ~scroll_offset ~view_mode
       match view_mode with
       | Detail_view patch_id ->
           List.find views ~f:(fun pv -> Patch_id.equal pv.patch_id patch_id)
-      | List_view -> List.nth views selected
+      | List_view ->
+          let count = List.length views in
+          if count = 0 then None
+          else
+            let idx = Int.max 0 (Int.min selected (count - 1)) in
+            List.nth views idx
       | Timeline_view -> None
     in
     let automerge_enabled =

--- a/lib/tui.mli
+++ b/lib/tui.mli
@@ -156,7 +156,11 @@ val views_of_orchestrator :
 val render_help_overlay : width:int -> height:int -> string list
 
 val render_manage_overlay :
-  width:int -> height:int -> automerge_enabled:bool -> string list
+  width:int ->
+  height:int ->
+  automerge_enabled:bool ->
+  needs_intervention:bool ->
+  string list
 
 type prompt_info = { prompt_text : string; cursor_col : int }
 

--- a/lib/tui_fiber.ml
+++ b/lib/tui_fiber.ml
@@ -351,24 +351,25 @@ struct
                   | Tui.Timeline_view -> None
                 in
                 match target_patch_id with
-                | Some patch_id ->
-                    let needs_intervention =
-                      Runtime.read Env.runtime (fun snap ->
-                          match
-                            Orchestrator.find_agent snap.Runtime.orchestrator
-                              patch_id
-                          with
-                          | None -> false
-                          | Some agent -> Patch_agent.needs_intervention agent)
-                    in
-                    if not needs_intervention then
-                      log_event Env.runtime ~patch_id
-                        "Cannot bump — patch is not in needs-intervention"
-                    else (
-                      Runtime.update_orchestrator Env.runtime (fun orch ->
-                          Orchestrator.reset_intervention_state orch patch_id);
-                      log_event Env.runtime ~patch_id
-                        "Bumped — cleared intervention state")
+                | Some patch_id -> (
+                    match
+                      Runtime.update_orchestrator_returning Env.runtime
+                        (fun orch ->
+                          match Orchestrator.find_agent orch patch_id with
+                          | None -> (orch, false)
+                          | Some agent ->
+                              if Patch_agent.needs_intervention agent then
+                                ( Orchestrator.reset_intervention_state orch
+                                    patch_id,
+                                  true )
+                              else (orch, false))
+                    with
+                    | true ->
+                        log_event Env.runtime ~patch_id
+                          "Bumped — cleared intervention state"
+                    | false ->
+                        log_event Env.runtime ~patch_id
+                          "Cannot bump — patch is not in needs-intervention")
                 | None -> ())
             | Term.Key.Char _ | Term.Key.Enter | Term.Key.Tab | Term.Key.Paste _
             | Term.Key.Backspace | Term.Key.Up | Term.Key.Down | Term.Key.Left

--- a/lib/tui_fiber.ml
+++ b/lib/tui_fiber.ml
@@ -342,6 +342,34 @@ struct
                         log_event Env.runtime ~patch_id "Automerge disabled"
                     | None -> ())
                 | None -> ())
+            | Term.Key.Char 'b' -> (
+                input_mode := Tui_input.Normal;
+                let target_patch_id =
+                  match !view_mode with
+                  | Tui.Detail_view patch_id -> Some patch_id
+                  | Tui.List_view -> selected_pid ()
+                  | Tui.Timeline_view -> None
+                in
+                match target_patch_id with
+                | Some patch_id ->
+                    let needs_intervention =
+                      Runtime.read Env.runtime (fun snap ->
+                          match
+                            Orchestrator.find_agent snap.Runtime.orchestrator
+                              patch_id
+                          with
+                          | None -> false
+                          | Some agent -> Patch_agent.needs_intervention agent)
+                    in
+                    if not needs_intervention then
+                      log_event Env.runtime ~patch_id
+                        "Cannot bump — patch is not in needs-intervention"
+                    else (
+                      Runtime.update_orchestrator Env.runtime (fun orch ->
+                          Orchestrator.reset_intervention_state orch patch_id);
+                      log_event Env.runtime ~patch_id
+                        "Bumped — cleared intervention state")
+                | None -> ())
             | Term.Key.Char _ | Term.Key.Enter | Term.Key.Tab | Term.Key.Paste _
             | Term.Key.Backspace | Term.Key.Up | Term.Key.Down | Term.Key.Left
             | Term.Key.Right | Term.Key.Home | Term.Key.End | Term.Key.Page_up


### PR DESCRIPTION
## Summary
- New `b` action in the Manage Patch overlay, shown only when the selected patch is in `needs-intervention`.
- Clears the patch's failure counters and resets `session_fallback` to `Fresh_available` via the existing `Orchestrator.reset_intervention_state` (which also refreshes the base branch). No human message is required; the poller picks the patch back up on its next cycle and re-enqueues the appropriate op (Ci, Merge_conflict, etc.) naturally.
- Refuses with a log line if the patch isn't actually in needs-intervention (e.g. raced against a state change).

## Test plan
- [ ] Drive a patch into needs-intervention (e.g. force repeated CI failures), open the Manage Patch overlay, hit `b`, confirm the overlay closes, the activity log shows "Bumped — cleared intervention state", and the patch resumes work on the next poll tick.
- [ ] Open the overlay on a healthy patch; confirm the `b` row is absent and that pressing `b` logs "Cannot bump — patch is not in needs-intervention".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/317"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782231684&installation_id=126163856&pr_number=317&repository=flowglad%2Fonton&return_to=https%3A%2F%2Fgithub.com%2Fflowglad%2Fonton%2Fpull%2F317&signature=3ad31ea07cb04e05535988ec13a9a92fb0a62e90052ff8afdf64a37cd616f821"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a new 'b' bump command in the Manage Patch overlay to clear a patch’s intervention state and resume automated processing without a human message. The option only shows for patches in needs-intervention.

- **New Features**
  - Manage overlay shows "b   Bump (clear intervention, continue patch loop)" only when the selected patch is in needs-intervention.
  - On 'b', calls Orchestrator.reset_intervention_state to clear failure counters, reset session fallback, and refresh the base branch.
  - Logs "Bumped — cleared intervention state" on success, or "Cannot bump — patch is not in needs-intervention" otherwise.

- **Bug Fixes**
  - Guard bump with a real-time check of the agent’s needs-intervention state to prevent race conditions.
  - Clamp manage overlay selection to a valid index so the overlay and bump target the correct patch.

<sup>Written for commit c4fdfac7bc397ccf847c1f6f196a3bc1618d62e9. Summary will update on new commits. <a href="https://cubic.dev/pr/flowglad/onton/pull/317?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "bump" menu entry to manage overlay for patches requiring intervention.
  * Added keyboard shortcut ('b') to bump selected patches and reset intervention state.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flowglad/onton/pull/317?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->