### PR TITLE
Harden worktree start point + push safety against PR #315-class wipes

### DIFF
--- a/lib/runner_fiber_impl.ml
+++ b/lib/runner_fiber_impl.ml
@@ -664,7 +664,7 @@ struct
                                         ~base_ref:(Branch.to_string base_branch)
                                         ()
                                     with
-                                    | None ->
+                                    | Worktree_setup.Missing ->
                                         Runtime.update_orchestrator runtime
                                           (fun orch ->
                                             Orchestrator.apply_session_result
@@ -672,7 +672,8 @@ struct
                                               Orchestrator
                                               .Session_worktree_missing);
                                         `Failed
-                                    | Some _wt_path ->
+                                    | Worktree_setup.Refused -> `Failed
+                                    | Worktree_setup.Path _wt_path ->
                                         (* Capture the initial anchor for this
                                            Start: resolve origin/<base_branch>'s
                                            current tip so the first rebase has
@@ -1204,8 +1205,9 @@ struct
                                       in
                                       let wt_path =
                                         match wt_path_opt with
-                                        | Some p -> p
-                                        | None ->
+                                        | Worktree_setup.Path p -> p
+                                        | Worktree_setup.Missing
+                                        | Worktree_setup.Refused ->
                                             Worktree.worktree_dir ~project_name
                                               ~patch_id
                                       in

--- a/lib/session_driver.ml
+++ b/lib/session_driver.ml
@@ -167,12 +167,13 @@ module Make (W : Worktree.S) (Env : ENV) = struct
           | `Fresh -> (None, true)
         in
         match WS.ensure_worktree ~patch_id ~agent () with
-        | None ->
+        | Worktree_setup.Missing ->
             Runtime.update_orchestrator runtime (fun orch ->
                 Orchestrator.apply_session_result orch patch_id
                   Orchestrator.Session_worktree_missing);
             (`Failed, [])
-        | Some worktree_path ->
+        | Worktree_setup.Refused -> (`Failed, [])
+        | Worktree_setup.Path worktree_path ->
             let cwd = Eio.Path.(fs / worktree_path) in
             (* Read once at session start so the per-event callback below can
              persist the session id to the crash-recovery sidecar without

--- a/lib/worktree.ml
+++ b/lib/worktree.ml
@@ -661,31 +661,122 @@ type push_gate = Worktree_parser.push_gate = Proceed | Skip_no_commits
 let push_gate_from_count = Worktree_parser.push_gate_from_count
 let classify_push_result = Worktree_parser.classify_push_result
 
-(** Effectful: run [git rev-list --count base..HEAD] in the worktree. *)
-let commits_ahead_of_base ~process_mgr ~path ~base =
-  let base_str = Types.Branch.to_string base in
-  let code, stdout, _ =
-    run_git_exit_code ~process_mgr
-      [ "git"; "-C"; path; "rev-list"; "--count"; base_str ^ "..HEAD" ]
+(* [commits_ahead_of_base] previously ran [git rev-list --count base..HEAD]
+   in the worktree; that's the function that produced PR #315's HEAD-vs-branch
+   gate mismatch. [gather_push_plan_inputs] below now measures ahead-of-base
+   on the named branch (refs/heads/<branch>), not HEAD, so an agent that
+   [git switch]ed mid-session cannot trip the gate with commits the push
+   command would never upload. *)
+
+(* Gather the inputs [Push_plan.plan] needs. Returns a tuple so the caller
+   can pattern-match the planner output without re-reading git twice. *)
+let gather_push_plan_inputs ~process_mgr ~path ~branch_str ~base_str =
+  let worktree_path_exists = Stdlib.Sys.file_exists path in
+  let worktree_head_branch =
+    if not worktree_path_exists then None
+    else
+      let code, stdout, _ =
+        run_git_exit_code ~process_mgr
+          [ "git"; "-C"; path; "rev-parse"; "--abbrev-ref"; "HEAD" ]
+      in
+      if code = 0 then
+        let s = String.strip stdout in
+        if String.is_empty s || String.equal s "HEAD" then None else Some s
+      else None
   in
-  parse_commit_count ~code ~stdout
+  let read_sha ref_name =
+    if not worktree_path_exists then None
+    else
+      let code, stdout, _ =
+        run_git_exit_code ~process_mgr
+          [ "git"; "-C"; path; "rev-parse"; "--verify"; ref_name ]
+      in
+      if code = 0 then
+        let s = String.strip stdout in
+        if String.is_empty s then None else Some s
+      else None
+  in
+  let branch_ref_sha = read_sha ("refs/heads/" ^ branch_str) in
+  let remote_tracking_sha = read_sha ("refs/remotes/origin/" ^ branch_str) in
+  let ancestry : Push_plan.ancestry =
+    if not worktree_path_exists then Push_plan.Unknown
+    else
+      match (branch_ref_sha, remote_tracking_sha) with
+      | _, None -> Push_plan.No_remote_yet
+      | None, Some _ -> Push_plan.Unknown
+      | Some local, Some remote -> (
+          let code, _, _ =
+            run_git_exit_code ~process_mgr
+              [
+                "git"; "-C"; path; "merge-base"; "--is-ancestor"; remote; local;
+              ]
+          in
+          (* exit 0 = remote is ancestor of local (local includes remote);
+             exit 1 = it isn't (push would wipe commits);
+             anything else = unknown (treat conservatively at the planner). *)
+          match code with
+          | 0 -> Push_plan.Local_includes_remote
+          | 1 -> Push_plan.Local_missing_remote
+          | _ -> Push_plan.Unknown)
+  in
+  let commits_ahead_of_base =
+    if not worktree_path_exists then None
+    else
+      (* Measure ahead-of-base on the NAMED BRANCH, not worktree HEAD —
+         otherwise an agent that [git switch]ed mid-session could trip the
+         gate with commits the push command would never upload. *)
+      let code, stdout, _ =
+        run_git_exit_code ~process_mgr
+          [
+            "git";
+            "-C";
+            path;
+            "rev-list";
+            "--count";
+            base_str ^ "..refs/heads/" ^ branch_str;
+          ]
+      in
+      Worktree_parser.parse_commit_count ~code ~stdout
+  in
+  ( worktree_path_exists,
+    worktree_head_branch,
+    branch_ref_sha,
+    remote_tracking_sha,
+    ancestry,
+    commits_ahead_of_base )
 
 let force_push_with_lease ~process_mgr ~path ~branch ~base =
-  (* If the worktree directory is gone (deleted out from under us mid-session),
-     short-circuit before spawning git so the caller can route to the
-     worktree-missing cleanup path. Without this, every git invocation below
-     fails with "fatal: cannot change to '<path>': No such file or directory"
-     and surfaces as a generic [Push_error] that triggers retry-push instead
-     of reconstruction. *)
-  if not (Stdlib.Sys.file_exists path) then Push_worktree_missing
-  else
-    let count = commits_ahead_of_base ~process_mgr ~path ~base in
-    match push_gate_from_count count with
-    | Skip_no_commits -> Push_no_commits
-    | Proceed ->
-        let branch_str = Types.Branch.to_string branch in
-        let code, stdout, stderr =
-          run_git_exit_code ~process_mgr
+  let branch_str = Types.Branch.to_string branch in
+  let base_str = Types.Branch.to_string base in
+  let ( worktree_path_exists,
+        worktree_head_branch,
+        branch_ref_sha,
+        remote_tracking_sha,
+        ancestry,
+        commits_ahead_of_base ) =
+    gather_push_plan_inputs ~process_mgr ~path ~branch_str ~base_str
+  in
+  let decision =
+    Push_plan.plan ~expected_branch:branch_str ~worktree_path_exists
+      ~worktree_head_branch ~branch_ref_sha ~remote_tracking_sha ~ancestry
+      ~commits_ahead_of_base
+  in
+  match decision with
+  | Refuse Push_plan.Worktree_missing -> Push_worktree_missing
+  | Refuse Push_plan.No_commits_ahead_of_base -> Push_no_commits
+  | Refuse
+      (( Push_plan.Branch_ref_missing _ | Push_plan.Branch_switched _
+       | Push_plan.Local_missing_remote_commits _ ) as r) -> (
+      match Push_plan.to_push_reject_classify_rejection r with
+      | Some rej -> Push_rejected rej
+      | None ->
+          (* These three refusals all map to Some _ per
+             [to_push_reject_classify_rejection]; fall back conservatively. *)
+          Push_error (Push_plan.short_label (Push_plan.Refuse r)))
+  | Push action ->
+      let args =
+        match action with
+        | Push_plan.Force_push_if_includes ->
             [
               "git";
               "-C";
@@ -705,8 +796,20 @@ let force_push_with_lease ~process_mgr ~path ~branch ~base =
               "origin";
               branch_str;
             ]
-        in
-        classify_push_result ~code ~stdout ~stderr
+        | Push_plan.Initial_push ->
+            [
+              "git";
+              "-C";
+              path;
+              "push";
+              "--porcelain";
+              "-u";
+              "origin";
+              branch_str;
+            ]
+      in
+      let code, stdout, stderr = run_git_exit_code ~process_mgr args in
+      classify_push_result ~code ~stdout ~stderr
 
 let rebase_in_progress ~process_mgr ~path =
   let code, stdout, _ =

--- a/lib/worktree.ml
+++ b/lib/worktree.ml
@@ -563,6 +563,15 @@ let force_push_with_lease ~process_mgr ~path ~branch ~base =
               "push";
               "--porcelain";
               "--force-with-lease";
+              (* --force-if-includes refuses to overwrite the remote when our
+                 local branch does not contain the remote tip's reflog entry.
+                 --force-with-lease alone only checks "is remote where I last
+                 saw it?" — once a background fetch updates the local tracking
+                 ref to match actual remote, the lease passes even when local
+                 is strictly behind, silently wiping remote commits. See
+                 incident notes for PR #315 (auto-closed by a force-push of an
+                 empty branch). Requires git ≥ 2.30. *)
+              "--force-if-includes";
               "origin";
               branch_str;
             ]

--- a/lib/worktree.ml
+++ b/lib/worktree.ml
@@ -104,6 +104,89 @@ let run_git ~process_mgr args =
       let cmd = String.concat ~sep:" " args in
       failwith (Printf.sprintf "git command failed: %s\nstderr: %s" cmd stderr)
 
+(* Run a git command and capture (exit_code, stdout, stderr) without raising.
+   Defined here, ahead of its first use in [read_repo_ref_sha] and
+   [compute_ancestry], so the worktree-creation planner inputs can be gathered
+   before the type re-exports and the heavier rebase/push functions below. *)
+let run_git_exit_code ~process_mgr args =
+  Eio.Switch.run @@ fun sw ->
+  let stdout_buf = Buffer.create 0 in
+  let stderr_buf = Buffer.create 64 in
+  let env = Stdlib.Lazy.force clean_git_env in
+  let child =
+    Eio.Process.spawn ~sw process_mgr ~env
+      ~stdout:(Eio.Flow.buffer_sink stdout_buf)
+      ~stderr:(Eio.Flow.buffer_sink stderr_buf)
+      args
+  in
+  let code =
+    match Eio.Process.await child with `Exited c -> c | `Signaled s -> 128 + s
+  in
+  (code, Buffer.contents stdout_buf, Buffer.contents stderr_buf)
+
+(* Read a ref's SHA from the main repo (NOT a worktree). Returns [None] if the
+   ref does not exist or git fails. Used by [Worktree.create] to feed inputs to
+   [Start_point_plan.plan]. *)
+let read_repo_ref_sha ~process_mgr ~repo_root ~ref_name =
+  let code, stdout, _ =
+    run_git_exit_code ~process_mgr
+      [ "git"; "-C"; repo_root; "rev-parse"; "--verify"; ref_name ]
+  in
+  if code = 0 then
+    let s = String.strip stdout in
+    if String.is_empty s then None else Some s
+  else None
+
+(* Compute the ancestor relationship between [local] and [remote] using two
+   [git merge-base --is-ancestor] probes. Returns [Unknown] if either probe
+   fails. Pure inputs are SHAs already known to exist at the time of call —
+   caller is expected to gather them via [read_repo_ref_sha] first. *)
+let compute_repo_ancestry ~process_mgr ~repo_root ~local ~remote :
+    Start_point_plan.ancestry =
+  let is_ancestor a b =
+    let code, _, _ =
+      run_git_exit_code ~process_mgr
+        [ "git"; "-C"; repo_root; "merge-base"; "--is-ancestor"; a; b ]
+    in
+    match code with 0 -> Some true | 1 -> Some false | _ -> None
+  in
+  match (is_ancestor local remote, is_ancestor remote local) with
+  | Some true, Some true -> Start_point_plan.Equal
+  | Some true, Some false -> Start_point_plan.Remote_ahead
+  | Some false, Some true -> Start_point_plan.Local_ahead
+  | Some false, Some false -> Start_point_plan.Diverged
+  | _ -> Start_point_plan.Unknown
+
+(* Fetch a single branch from origin into the corresponding remote-tracking
+   ref. Best-effort: missing remote branch / network failure returns Error.
+   Caller is expected to log Error and proceed — the planner correctly handles
+   [remote_ref = None] for the "brand new branch" case.
+
+   Operates on [repo_root]; worktrees share the ref store with the main repo,
+   so this updates [refs/remotes/origin/<branch>] for all workers. The
+   [fetch_lock] mutex must be the same one shared with [fetch_origin] above. *)
+let fetch_origin_branch ~fetch_lock ~process_mgr ~repo_root ~branch_str =
+  Eio.Mutex.use_ro fetch_lock (fun () ->
+      try
+        let code, _stdout, stderr =
+          run_git_exit_code ~process_mgr
+            [
+              "git";
+              "-C";
+              repo_root;
+              "fetch";
+              "origin";
+              branch_str ^ ":refs/remotes/origin/" ^ branch_str;
+            ]
+        in
+        Worktree_parser.classify_fetch_result ~code ~stderr
+      with
+      | exn when has_cancellation exn -> raise exn
+      | exn ->
+          Result.Error
+            (Printf.sprintf "git fetch origin %s crashed: %s" branch_str
+               (Exn.to_string exn)))
+
 let add_worktree_for_existing_branch ~process_mgr ~repo_root ~path ~branch_str =
   run_git ~process_mgr
     [ "git"; "-C"; repo_root; "worktree"; "add"; path; branch_str ]
@@ -147,42 +230,101 @@ let check_case_insensitive_ref_collision ~process_mgr ~repo_root branch_str =
            branch_str colliding colliding)
   | None -> ()
 
-let create ~process_mgr ~repo_root ~project_name ~patch_id ~branch ~base_ref =
+(* Execute the [action] half of a [Start_point_plan.decision] against the
+   worktree at [path]. Raises only on truly exceptional git failures; the
+   "branch was concurrently created" race is handled inline by falling back to
+   the [Use_local_branch_unchanged] command shape. *)
+let execute_start_point_action ~process_mgr ~repo_root ~path ~branch_str
+    (action : Start_point_plan.action) =
+  match action with
+  | Use_local_branch_unchanged _ ->
+      add_worktree_for_existing_branch ~process_mgr ~repo_root ~path ~branch_str
+  | Reset_and_use_remote_tracking _ ->
+      (* [-B] resets / recreates the local branch at the remote tracking ref
+         before checking it out into the new worktree. Defeats the PR #315
+         failure mode: if [refs/heads/<branch>] was stale, [-B] points it at
+         [origin/<branch>] now. *)
+      run_git ~process_mgr
+        [
+          "git";
+          "-C";
+          repo_root;
+          "worktree";
+          "add";
+          "-B";
+          branch_str;
+          path;
+          "origin/" ^ branch_str;
+        ]
+  | Create_new_branch_from_base { base_branch } -> (
+      match
+        run_git ~process_mgr
+          [
+            "git";
+            "-C";
+            repo_root;
+            "worktree";
+            "add";
+            "-b";
+            branch_str;
+            path;
+            base_branch;
+          ]
+      with
+      | () -> ()
+      | exception e when has_cancellation e -> raise e
+      | exception _ when branch_exists ~process_mgr ~repo_root branch_str ->
+          (* Branch was created (e.g. by a concurrent attempt) but worktree
+             setup failed — retry without -b. *)
+          add_worktree_for_existing_branch ~process_mgr ~repo_root ~path
+            ~branch_str)
+
+(* [Worktree.create] consults [Start_point_plan] before executing any git
+   command, ensuring the worktree starts at the right commit regardless of
+   whether the user's local clone has a stale branch ref. See the [.mli] doc
+   on [create] and [start_point_plan.mli] for the rules.
+
+   Returns [Error _] when the planner refuses (local diverged from remote,
+   branch checked out in main, etc.); the caller in [Worktree_setup] surfaces
+   refusals through the orchestrator's [needs_intervention] path. *)
+let create ~process_mgr ~repo_root ~project_name ~patch_id ~branch ~base_ref :
+    (t, Start_point_plan.refusal) Result.t =
   let path = worktree_dir ~project_name ~patch_id in
   let branch_str = Types.Branch.to_string branch in
-  if Stdlib.Sys.file_exists path then { patch_id; branch; path }
-  else if branch_exists ~process_mgr ~repo_root branch_str then (
-    add_worktree_for_existing_branch ~process_mgr ~repo_root ~path ~branch_str;
-    { patch_id; branch; path })
-  else
-    let start_point =
-      if remote_branch_exists ~process_mgr ~repo_root branch_str then
-        "origin/" ^ branch_str
-      else base_ref
-    in
+  if Stdlib.Sys.file_exists path then Result.Ok { patch_id; branch; path }
+  else (
     check_case_insensitive_ref_collision ~process_mgr ~repo_root branch_str;
-    (match
-       run_git ~process_mgr
-         [
-           "git";
-           "-C";
-           repo_root;
-           "worktree";
-           "add";
-           "-b";
-           branch_str;
-           path;
-           start_point;
-         ]
-     with
-    | () -> ()
-    | exception e when has_cancellation e -> raise e
-    | exception _ when branch_exists ~process_mgr ~repo_root branch_str ->
-        (* Branch was created (e.g. by a concurrent attempt) but worktree
-           setup failed — retry without -b *)
-        add_worktree_for_existing_branch ~process_mgr ~repo_root ~path
-          ~branch_str);
-    { patch_id; branch; path }
+    let local_ref =
+      read_repo_ref_sha ~process_mgr ~repo_root
+        ~ref_name:("refs/heads/" ^ branch_str)
+    in
+    let remote_ref =
+      read_repo_ref_sha ~process_mgr ~repo_root
+        ~ref_name:("refs/remotes/origin/" ^ branch_str)
+    in
+    let ancestry =
+      match (local_ref, remote_ref) with
+      | Some l, Some r ->
+          compute_repo_ancestry ~process_mgr ~repo_root ~local:l ~remote:r
+      | _ -> Start_point_plan.Unknown
+    in
+    (* [branch_checked_out_in_main_root] and [existing_worktree_path] are
+       checked by [Worktree_setup.ensure_worktree] before this point — we
+       pass [false]/[None] so the planner's totality contract is preserved
+       without redoing the work. If [Worktree.create] is ever called from
+       a caller that does not pre-check, those inputs should be supplied
+       there. *)
+    let decision =
+      Start_point_plan.plan ~local_ref ~remote_ref ~ancestry
+        ~base_branch:base_ref ~branch_checked_out_in_main_root:false
+        ~existing_worktree_path:None
+    in
+    match decision with
+    | Refuse refusal -> Result.Error refusal
+    | Plan action ->
+        execute_start_point_action ~process_mgr ~repo_root ~path ~branch_str
+          action;
+        Result.Ok { patch_id; branch; path })
 
 let remove ~process_mgr ~repo_root t =
   Eio.Process.run process_mgr
@@ -268,21 +410,9 @@ type rebase_result = Worktree_parser.rebase_result =
   | Error of string
 [@@deriving show, eq, sexp_of, compare]
 
-let run_git_exit_code ~process_mgr args =
-  Eio.Switch.run @@ fun sw ->
-  let stdout_buf = Buffer.create 0 in
-  let stderr_buf = Buffer.create 64 in
-  let env = Stdlib.Lazy.force clean_git_env in
-  let child =
-    Eio.Process.spawn ~sw process_mgr ~env
-      ~stdout:(Eio.Flow.buffer_sink stdout_buf)
-      ~stderr:(Eio.Flow.buffer_sink stderr_buf)
-      args
-  in
-  let code =
-    match Eio.Process.await child with `Exited c -> c | `Signaled s -> 128 + s
-  in
-  (code, Buffer.contents stdout_buf, Buffer.contents stderr_buf)
+(* [run_git_exit_code] is defined earlier in the file, just after [run_git],
+   so the start-point planner helpers above ([read_repo_ref_sha],
+   [compute_repo_ancestry], [fetch_origin_branch]) can call it. *)
 
 (** Pure: does [subject] match the conventional "[<project>] Patch <N>:"
     commit-subject format for some [N] in [ancestor_ids]? The patch-id segment
@@ -714,7 +844,14 @@ module type S = sig
     patch_id:Types.Patch_id.t ->
     branch:Types.Branch.t ->
     base_ref:string ->
-    t
+    (t, Start_point_plan.refusal) Result.t
+
+  val fetch_origin_branch :
+    fetch_lock:Eio.Mutex.t -> branch:string -> (unit, string) Result.t
+  (** Fetch a single branch from origin into the corresponding remote-tracking
+      ref. Best-effort: missing remote branch / network failure returns [Error].
+      Caller in [Worktree_setup.ensure_worktree] runs this before [create] so
+      the planner sees a fresh view of [origin/<branch>]. *)
 
   val remove : t -> unit
   val detect_branch : path:string -> Types.Branch.t
@@ -790,6 +927,9 @@ let make ~process_mgr ~repo_root =
 
     let fetch_origin ~fetch_lock ~path =
       fetch_origin ~fetch_lock ~process_mgr ~path
+
+    let fetch_origin_branch ~fetch_lock ~branch =
+      fetch_origin_branch ~fetch_lock ~process_mgr ~repo_root ~branch_str:branch
 
     let git_status ~path = git_status ~process_mgr ~path
     let conflict_diff ~path = conflict_diff ~process_mgr ~path

--- a/lib/worktree.ml
+++ b/lib/worktree.ml
@@ -712,11 +712,27 @@ let gather_push_plan_inputs ~process_mgr ~path ~branch_str ~base_str =
               ]
           in
           (* exit 0 = remote is ancestor of local (local includes remote);
-             exit 1 = it isn't (push would wipe commits);
-             anything else = unknown (treat conservatively at the planner). *)
+             exit 1 only means remote is not an ancestor of local. Probe the
+             inverse to distinguish local-behind from true divergence. *)
           match code with
           | 0 -> Push_plan.Local_includes_remote
-          | 1 -> Push_plan.Local_missing_remote
+          | 1 -> (
+              let inverse_code, _, _ =
+                run_git_exit_code ~process_mgr
+                  [
+                    "git";
+                    "-C";
+                    path;
+                    "merge-base";
+                    "--is-ancestor";
+                    local;
+                    remote;
+                  ]
+              in
+              match inverse_code with
+              | 0 -> Push_plan.Local_missing_remote
+              | 1 -> Push_plan.Local_diverged_from_remote
+              | _ -> Push_plan.Unknown)
           | _ -> Push_plan.Unknown)
   in
   let commits_ahead_of_base =
@@ -766,7 +782,8 @@ let force_push_with_lease ~process_mgr ~path ~branch ~base =
   | Refuse Push_plan.No_commits_ahead_of_base -> Push_no_commits
   | Refuse
       (( Push_plan.Branch_ref_missing _ | Push_plan.Branch_switched _
-       | Push_plan.Local_missing_remote_commits _ ) as r) -> (
+       | Push_plan.Local_missing_remote_commits _
+       | Push_plan.Local_diverged_from_remote_commits _ ) as r) -> (
       match Push_plan.to_push_reject_classify_rejection r with
       | Some rej -> Push_rejected rej
       | None ->

--- a/lib/worktree.mli
+++ b/lib/worktree.mli
@@ -32,7 +32,35 @@ val create :
   patch_id:Types.Patch_id.t ->
   branch:Types.Branch.t ->
   base_ref:string ->
-  t
+  (t, Start_point_plan.refusal) Result.t
+(** Create a git worktree for [branch] under [project_name]/[patch_id].
+
+    Consults {!Start_point_plan.plan} before invoking git: reads the local
+    [refs/heads/<branch>] and remote-tracking [refs/remotes/origin/<branch>]
+    SHAs from [repo_root], computes their two-way ancestry, and executes the
+    action the planner returns. The supervisor is responsible for running
+    [fetch_origin_branch] beforehand so [refs/remotes/origin/<branch>] is fresh;
+    without that step the planner would see a stale remote ref.
+
+    Returns [Error refusal] when the planner refuses (local diverged from
+    remote, branch already checked out elsewhere, etc.). The caller surfaces
+    refusals through the orchestrator's intervention path.
+
+    Pre-empted inputs [branch_checked_out_in_main_root] and
+    [existing_worktree_path] are checked by the caller
+    ({!Worktree_setup.ensure_worktree}) before this function runs; this function
+    passes [false] / [None] to the planner. *)
+
+val fetch_origin_branch :
+  fetch_lock:Eio.Mutex.t ->
+  process_mgr:_ Eio.Process.mgr ->
+  repo_root:string ->
+  branch_str:string ->
+  (unit, string) Result.t
+(** Run [git -C <repo_root> fetch origin <branch>:refs/remotes/origin/<branch>]
+    under the shared [fetch_lock]. Best-effort: missing remote branch / network
+    failure returns [Error]; caller logs and proceeds (the planner correctly
+    handles [remote_ref = None] for the brand-new-branch case). *)
 
 val remove : process_mgr:_ Eio.Process.mgr -> repo_root:string -> t -> unit
 
@@ -289,7 +317,10 @@ module type S = sig
     patch_id:Types.Patch_id.t ->
     branch:Types.Branch.t ->
     base_ref:string ->
-    t
+    (t, Start_point_plan.refusal) Result.t
+
+  val fetch_origin_branch :
+    fetch_lock:Eio.Mutex.t -> branch:string -> (unit, string) Result.t
 
   val remove : t -> unit
   val detect_branch : path:string -> Types.Branch.t

--- a/lib/worktree.mli
+++ b/lib/worktree.mli
@@ -257,10 +257,11 @@ val push_gate_from_count : int option -> push_gate
 
 val classify_push_result :
   code:int -> stdout:string -> stderr:string -> push_result
-(** Pure: classify a [git push --porcelain --force-with-lease] invocation into a
-    [push_result]. [Push_no_commits] is never returned by this function — that
-    variant is only produced by the gate (the push is skipped entirely when the
-    branch has no commits ahead of base). *)
+(** Pure: classify a
+    [git push --porcelain --force-with-lease --force-if-includes] invocation
+    into a [push_result]. [Push_no_commits] is never returned by this function —
+    that variant is only produced by the gate (the push is skipped entirely when
+    the branch has no commits ahead of base). *)
 
 val force_push_with_lease :
   process_mgr:_ Eio.Process.mgr ->

--- a/lib/worktree_plan_executor.ml
+++ b/lib/worktree_plan_executor.ml
@@ -33,8 +33,16 @@ module Make (W : Worktree.S) (Env : Run_env.S) : S = struct
       | [] -> (last_rebase, path, Base.List.rev events)
       | Worktree_plan.Ensure_worktree :: rest -> (
           match WS.ensure_worktree ~patch_id ~agent () with
-          | Some p -> loop ~path:p ~last_rebase ~events rest
-          | None ->
+          | Worktree_setup.Path p -> loop ~path:p ~last_rebase ~events rest
+          | Worktree_setup.Refused ->
+              Runtime_logging.log_event Env.runtime ~patch_id
+                (Printf.sprintf "Cannot %s — worktree start point was refused"
+                   fail_label);
+              ( Worktree.Error
+                  (Printf.sprintf "%s failed: worktree refused" fail_label),
+                path,
+                Base.List.rev events )
+          | Worktree_setup.Missing ->
               Runtime_logging.log_event Env.runtime ~patch_id
                 (Printf.sprintf
                    "Cannot %s — worktree missing and could not be created"

--- a/lib/worktree_setup.ml
+++ b/lib/worktree_setup.ml
@@ -49,6 +49,12 @@ module Make (W : Worktree.S) (Env : ENV) : S = struct
     let worktree_mutex = Env.worktree_mutex in
     let hook_mutex = Env.hook_mutex in
     let log_event = Runtime_logging.log_event in
+    let start_point_refusal_rejection refusal =
+      let reason =
+        Start_point_plan.short_label (Start_point_plan.Refuse refusal)
+      in
+      Push_reject_classify.Local_state_unsafe { reason }
+    in
     let path = resolve_worktree_path ~patch_id ~agent ?branch () in
     if Stdlib.Sys.file_exists path then (
       Runtime.update_orchestrator runtime (fun orch ->
@@ -145,12 +151,18 @@ module Make (W : Worktree.S) (Env : ENV) : S = struct
                   log_decision "ok";
                   true
               | `Refused refusal ->
-                  log_decision
-                    (Start_point_plan.short_label
-                       (Start_point_plan.Refuse refusal));
+                  let label =
+                    Start_point_plan.short_label
+                      (Start_point_plan.Refuse refusal)
+                  in
+                  log_decision label;
                   log_event runtime ~patch_id
                     (Printf.sprintf "Worktree creation refused — %s"
                        (Start_point_plan.show_refusal refusal));
+                  Runtime.update_orchestrator runtime (fun orch ->
+                      Orchestrator.apply_session_result orch patch_id
+                        (Orchestrator.Session_push_failed
+                           (Some (start_point_refusal_rejection refusal))));
                   false
               | `Raised exn ->
                   log_event runtime ~patch_id
@@ -194,7 +206,11 @@ module Make (W : Worktree.S) (Env : ENV) : S = struct
                   (Printf.sprintf "Worktree still missing at %s" path);
                 None
             | false, _ -> (
-                (* [Worktree.create] raised. A concurrent fiber may have already
+                match create_outcome with
+                | `Refused _ -> None
+                | `Created -> None
+                | `Raised _ -> (
+                    (* [Worktree.create] raised. A concurrent fiber may have already
                  added a real worktree for [br] before our attempt collided.
                  [find_for_branch] queries [git worktree list], which only
                  reports atomically-registered worktrees — so a hit here is a
@@ -203,13 +219,15 @@ module Make (W : Worktree.S) (Env : ENV) : S = struct
                  branch: the winning creator is already responsible for it,
                  mirroring the existing "Found existing worktree for branch"
                  path above. *)
-                match W.find_for_branch br with
-                | Some existing ->
-                    log_event runtime ~patch_id
-                      (Printf.sprintf
-                         "Adopting concurrently-created worktree at %s" existing);
-                    Runtime.update_orchestrator runtime (fun orch ->
-                        Orchestrator.set_worktree_path orch patch_id existing);
-                    Some existing
-                | None -> None))
+                    match W.find_for_branch br with
+                    | Some existing ->
+                        log_event runtime ~patch_id
+                          (Printf.sprintf
+                             "Adopting concurrently-created worktree at %s"
+                             existing);
+                        Runtime.update_orchestrator runtime (fun orch ->
+                            Orchestrator.set_worktree_path orch patch_id
+                              existing);
+                        Some existing
+                    | None -> None)))
 end

--- a/lib/worktree_setup.ml
+++ b/lib/worktree_setup.ml
@@ -98,6 +98,7 @@ module Make (W : Worktree.S) (Env : ENV) : S = struct
       | None -> (
           if W.is_checked_out_in_repo_root br then (
             let main_root = W.resolve_main_root () in
+            let refusal = Start_point_plan.Branch_checked_out_in_main_root in
             log_event runtime ~patch_id
               (Printf.sprintf
                  "Cannot create worktree — branch %s is checked out in the \
@@ -106,7 +107,11 @@ module Make (W : Worktree.S) (Env : ENV) : S = struct
                   again."
                  (Types.Branch.to_string br)
                  main_root main_root);
-            Missing)
+            Runtime.update_orchestrator runtime (fun orch ->
+                Orchestrator.apply_session_result orch patch_id
+                  (Orchestrator.Session_push_failed
+                     (Some (start_point_refusal_rejection refusal))));
+            Refused)
           else
             let base =
               match base_ref with

--- a/lib/worktree_setup.ml
+++ b/lib/worktree_setup.ml
@@ -2,6 +2,8 @@ open Base
 
 module type ENV = Run_env.S
 
+type ensure_result = Path of string | Missing | Refused
+
 module type S = sig
   val resolve_worktree_path :
     patch_id:Types.Patch_id.t ->
@@ -16,7 +18,7 @@ module type S = sig
     ?branch:Types.Branch.t ->
     ?base_ref:string ->
     unit ->
-    string option
+    ensure_result
 end
 
 module Make (W : Worktree.S) (Env : ENV) : S = struct
@@ -59,7 +61,7 @@ module Make (W : Worktree.S) (Env : ENV) : S = struct
     if Stdlib.Sys.file_exists path then (
       Runtime.update_orchestrator runtime (fun orch ->
           Orchestrator.set_worktree_path orch patch_id path);
-      Some path)
+      Path path)
     else
       let br =
         match branch with Some b -> b | None -> agent.Patch_agent.branch
@@ -92,7 +94,7 @@ module Make (W : Worktree.S) (Env : ENV) : S = struct
             (Printf.sprintf "Found existing worktree for branch at %s" existing);
           Runtime.update_orchestrator runtime (fun orch ->
               Orchestrator.set_worktree_path orch patch_id existing);
-          Some existing
+          Path existing
       | None -> (
           if W.is_checked_out_in_repo_root br then (
             let main_root = W.resolve_main_root () in
@@ -104,7 +106,7 @@ module Make (W : Worktree.S) (Env : ENV) : S = struct
                   again."
                  (Types.Branch.to_string br)
                  main_root main_root);
-            None)
+            Missing)
           else
             let base =
               match base_ref with
@@ -200,15 +202,15 @@ module Make (W : Worktree.S) (Env : ENV) : S = struct
                           (Printf.sprintf "Hook on_worktree_create failed — %s"
                              msg))
                 | None -> ());
-                Some path
+                Path path
             | true, false ->
                 log_event runtime ~patch_id
                   (Printf.sprintf "Worktree still missing at %s" path);
-                None
+                Missing
             | false, _ -> (
                 match create_outcome with
-                | `Refused _ -> None
-                | `Created -> None
+                | `Refused _ -> Refused
+                | `Created -> Missing
                 | `Raised _ -> (
                     (* [Worktree.create] raised. A concurrent fiber may have already
                  added a real worktree for [br] before our attempt collided.
@@ -228,6 +230,6 @@ module Make (W : Worktree.S) (Env : ENV) : S = struct
                         Runtime.update_orchestrator runtime (fun orch ->
                             Orchestrator.set_worktree_path orch patch_id
                               existing);
-                        Some existing
-                    | None -> None)))
+                        Path existing
+                    | None -> Missing)))
 end

--- a/lib/worktree_setup.ml
+++ b/lib/worktree_setup.ml
@@ -108,18 +108,51 @@ module Make (W : Worktree.S) (Env : ENV) : S = struct
                   | Some b -> Types.Branch.to_string b
                   | None -> "HEAD")
             in
+            (* Refresh [refs/remotes/origin/<branch>] before we feed it to the
+               start-point planner — without this the planner would observe a
+               stale local view of remote, which is the failure mode that
+               wiped PR #315. Best-effort: the planner correctly handles
+               [remote_ref = None] (brand-new branch) so a missing-remote
+               fetch error is just logged and we continue. *)
+            let fetch_lock = Env.fetch_mutex in
+            (match
+               W.fetch_origin_branch ~fetch_lock
+                 ~branch:(Types.Branch.to_string br)
+             with
+            | Ok () -> ()
+            | Error msg ->
+                log_event runtime ~patch_id
+                  (Printf.sprintf "Pre-create fetch failed (continuing): %s" msg));
             log_event runtime ~patch_id
               (Printf.sprintf "Creating worktree at %s" path);
-            let created =
+            let create_outcome =
               match
                 Eio.Mutex.use_ro worktree_mutex (fun () ->
-                    ignore
-                      (W.create ~project_name ~patch_id ~branch:br
-                         ~base_ref:base))
+                    W.create ~project_name ~patch_id ~branch:br ~base_ref:base)
               with
-              | () -> true
+              | Ok _ -> `Created
+              | Error refusal -> `Refused refusal
               | exception (Eio.Cancel.Cancelled _ as exn) -> raise exn
-              | exception exn ->
+              | exception exn -> `Raised exn
+            in
+            let log_decision label =
+              log_event runtime ~patch_id
+                (Printf.sprintf "Worktree start-point: %s" label)
+            in
+            let created =
+              match create_outcome with
+              | `Created ->
+                  log_decision "ok";
+                  true
+              | `Refused refusal ->
+                  log_decision
+                    (Start_point_plan.short_label
+                       (Start_point_plan.Refuse refusal));
+                  log_event runtime ~patch_id
+                    (Printf.sprintf "Worktree creation refused — %s"
+                       (Start_point_plan.show_refusal refusal));
+                  false
+              | `Raised exn ->
                   log_event runtime ~patch_id
                     (Printf.sprintf "Worktree creation failed — %s"
                        (Stdlib.Printexc.to_string exn));

--- a/lib/worktree_setup.mli
+++ b/lib/worktree_setup.mli
@@ -9,6 +9,8 @@ module type ENV = Run_env.S
 (** Construction-time environment for worktree provisioning. Values here are
     fixed for the lifetime of the module instance and never vary per call. *)
 
+type ensure_result = Path of string | Missing | Refused
+
 module type S = sig
   val resolve_worktree_path :
     patch_id:Types.Patch_id.t ->
@@ -27,12 +29,15 @@ module type S = sig
     ?branch:Types.Branch.t ->
     ?base_ref:string ->
     unit ->
-    string option
-  (** Ensure a worktree exists for the patch. Returns [Some path] on success or
-      [None] when the branch's worktree cannot be created (e.g. it's checked out
-      in the main tree). On creation, runs the user's [on_worktree_create] hook
-      serialised through [Env.hook_mutex] and persists the path on the agent
-      record. All log lines go through [Runtime_logging.log_event]. *)
+    ensure_result
+  (** Ensure a worktree exists for the patch. Returns [Path path] on success,
+      [Refused] when the start-point planner found a permanent unsafe local
+      state and has already routed it through [Session_push_failed], or
+      [Missing] when the branch's worktree cannot be created for a
+      reconstructable reason (e.g. it's checked out in the main tree). On
+      creation, runs the user's [on_worktree_create] hook serialised through
+      [Env.hook_mutex] and persists the path on the agent record. All log lines
+      go through [Runtime_logging.log_event]. *)
 end
 
 module Make (_ : Worktree.S) (_ : ENV) : S

--- a/lib_core/push_plan.ml
+++ b/lib_core/push_plan.ml
@@ -5,6 +5,7 @@ type sha = string [@@deriving show, eq, sexp_of, compare]
 type ancestry =
   | Local_includes_remote
   | Local_missing_remote
+  | Local_diverged_from_remote
   | No_remote_yet
   | Unknown
 [@@deriving show, eq, sexp_of, compare]
@@ -18,6 +19,7 @@ type refusal =
   | Branch_ref_missing of { branch : string }
   | Branch_switched of { expected : string; got : string option }
   | Local_missing_remote_commits of { local_sha : sha; remote_sha : sha }
+  | Local_diverged_from_remote_commits of { local_sha : sha; remote_sha : sha }
 [@@deriving show, eq, sexp_of, compare]
 
 type decision = Push of action | Refuse of refusal
@@ -47,8 +49,12 @@ let plan ~expected_branch ~worktree_path_exists ~worktree_head_branch
               | Local_missing_remote, Some remote_sha ->
                   Refuse
                     (Local_missing_remote_commits { local_sha; remote_sha })
-              | ( ( Local_missing_remote | Local_includes_remote | No_remote_yet
-                  | Unknown ),
+              | Local_diverged_from_remote, Some remote_sha ->
+                  Refuse
+                    (Local_diverged_from_remote_commits
+                       { local_sha; remote_sha })
+              | ( ( Local_missing_remote | Local_diverged_from_remote
+                  | Local_includes_remote | No_remote_yet | Unknown ),
                   None ) ->
                   Push Initial_push
               | (Local_includes_remote | No_remote_yet | Unknown), Some _ ->
@@ -62,6 +68,7 @@ let short_label = function
   | Refuse (Branch_ref_missing _) -> "refuse_ref_missing"
   | Refuse (Branch_switched _) -> "refuse_branch_switched"
   | Refuse (Local_missing_remote_commits _) -> "refuse_local_behind"
+  | Refuse (Local_diverged_from_remote_commits _) -> "refuse_local_diverged"
 
 let to_push_reject_classify_rejection (r : refusal) :
     Push_reject_classify.rejection option =
@@ -79,3 +86,7 @@ let to_push_reject_classify_rejection (r : refusal) :
       Some
         (Push_reject_classify.Local_state_unsafe
            { reason = "refuse_local_behind" })
+  | Local_diverged_from_remote_commits _ ->
+      Some
+        (Push_reject_classify.Local_state_unsafe
+           { reason = "refuse_local_diverged" })

--- a/lib_core/push_plan.ml
+++ b/lib_core/push_plan.ml
@@ -1,0 +1,81 @@
+open Base
+
+type sha = string [@@deriving show, eq, sexp_of, compare]
+
+type ancestry =
+  | Local_includes_remote
+  | Local_missing_remote
+  | No_remote_yet
+  | Unknown
+[@@deriving show, eq, sexp_of, compare]
+
+type action = Force_push_if_includes | Initial_push
+[@@deriving show, eq, sexp_of, compare]
+
+type refusal =
+  | No_commits_ahead_of_base
+  | Worktree_missing
+  | Branch_ref_missing of { branch : string }
+  | Branch_switched of { expected : string; got : string option }
+  | Local_missing_remote_commits of { local_sha : sha; remote_sha : sha }
+[@@deriving show, eq, sexp_of, compare]
+
+type decision = Push of action | Refuse of refusal
+[@@deriving show, eq, sexp_of, compare]
+
+let plan ~expected_branch ~worktree_path_exists ~worktree_head_branch
+    ~branch_ref_sha ~remote_tracking_sha ~ancestry ~commits_ahead_of_base =
+  if not worktree_path_exists then Refuse Worktree_missing
+  else
+    let head_matches =
+      match worktree_head_branch with
+      | Some b -> String.equal b expected_branch
+      | None -> false
+    in
+    if not head_matches then
+      Refuse
+        (Branch_switched
+           { expected = expected_branch; got = worktree_head_branch })
+    else
+      match branch_ref_sha with
+      | None -> Refuse (Branch_ref_missing { branch = expected_branch })
+      | Some local_sha -> (
+          match commits_ahead_of_base with
+          | Some 0 -> Refuse No_commits_ahead_of_base
+          | None | Some _ -> (
+              match (ancestry, remote_tracking_sha) with
+              | Local_missing_remote, Some remote_sha ->
+                  Refuse
+                    (Local_missing_remote_commits { local_sha; remote_sha })
+              | ( ( Local_missing_remote | Local_includes_remote | No_remote_yet
+                  | Unknown ),
+                  None ) ->
+                  Push Initial_push
+              | (Local_includes_remote | No_remote_yet | Unknown), Some _ ->
+                  Push Force_push_if_includes))
+
+let short_label = function
+  | Push Force_push_if_includes -> "force_push"
+  | Push Initial_push -> "initial_push"
+  | Refuse No_commits_ahead_of_base -> "refuse_no_commits"
+  | Refuse Worktree_missing -> "refuse_wt_missing"
+  | Refuse (Branch_ref_missing _) -> "refuse_ref_missing"
+  | Refuse (Branch_switched _) -> "refuse_branch_switched"
+  | Refuse (Local_missing_remote_commits _) -> "refuse_local_behind"
+
+let to_push_reject_classify_rejection (r : refusal) :
+    Push_reject_classify.rejection option =
+  match r with
+  | No_commits_ahead_of_base | Worktree_missing -> None
+  | Branch_ref_missing _ ->
+      Some
+        (Push_reject_classify.Local_state_unsafe
+           { reason = "refuse_ref_missing" })
+  | Branch_switched _ ->
+      Some
+        (Push_reject_classify.Local_state_unsafe
+           { reason = "refuse_branch_switched" })
+  | Local_missing_remote_commits _ ->
+      Some
+        (Push_reject_classify.Local_state_unsafe
+           { reason = "refuse_local_behind" })

--- a/lib_core/push_plan.mli
+++ b/lib_core/push_plan.mli
@@ -26,10 +26,10 @@
     reason to the orchestrator).
 
     Refusals that map to a planner-only state ([Branch_switched],
-    [Local_missing_remote_commits]) are translated to
-    {!Push_reject_classify.Local_state_unsafe} so the existing [is_permanent] →
-    [needs_intervention] escalation path applies without new orchestrator state.
-*)
+    [Local_missing_remote_commits], [Local_diverged_from_remote_commits]) are
+    translated to {!Push_reject_classify.Local_state_unsafe} so the existing
+    [is_permanent] → [needs_intervention] escalation path applies without new
+    orchestrator state. *)
 
 type sha = string [@@deriving show, eq, sexp_of, compare]
 
@@ -41,6 +41,8 @@ type ancestry =
   | Local_missing_remote
       (** Remote has commits the local branch does not reach — a force-push
           would lose them. *)
+  | Local_diverged_from_remote
+      (** Local and remote each have commits the other does not reach. *)
   | No_remote_yet  (** The branch has never been pushed. *)
   | Unknown  (** Ancestry could not be determined; treat conservatively. *)
 [@@deriving show, eq, sexp_of, compare]
@@ -71,6 +73,9 @@ type refusal =
       (** [ancestry = Local_missing_remote] — pushing now would force-push a
           local that is strictly behind remote on real content, wiping commits.
       *)
+  | Local_diverged_from_remote_commits of { local_sha : sha; remote_sha : sha }
+      (** [ancestry = Local_diverged_from_remote] — pushing now would force-push
+          a divergent local branch over remote-only commits. *)
 [@@deriving show, eq, sexp_of, compare]
 
 type decision = Push of action | Refuse of refusal
@@ -94,6 +99,8 @@ val plan :
     + [commits_ahead_of_base = Some 0] → [Refuse No_commits_ahead_of_base]
     + [ancestry = Local_missing_remote] (and both refs present) →
       [Refuse (Local_missing_remote_commits _)]
+    + [ancestry = Local_diverged_from_remote] (and both refs present) →
+      [Refuse (Local_diverged_from_remote_commits _)]
     + [remote_tracking_sha = None] → [Push Initial_push]
     + otherwise → [Push Force_push_if_includes] *)
 
@@ -102,15 +109,16 @@ val short_label : decision -> string
     suitable for the activity log. Always non-empty and ≤ 32 characters.
     Examples: ["force_push"], ["initial_push"], ["refuse_no_commits"],
     ["refuse_wt_missing"], ["refuse_ref_missing"], ["refuse_branch_switched"],
-    ["refuse_local_behind"]. *)
+    ["refuse_local_behind"], ["refuse_local_diverged"]. *)
 
 val to_push_reject_classify_rejection :
   refusal -> Push_reject_classify.rejection option
 (** Map planner refusals onto the rejection variant used by the orchestrator's
     permanent-rejection escalation:
 
-    - [Branch_switched] / [Local_missing_remote_commits] / [Branch_ref_missing]
-      → [Some (Local_state_unsafe { reason = short_label_of_refusal })] — route
+    - [Branch_switched] / [Local_missing_remote_commits] /
+      [Local_diverged_from_remote_commits] / [Branch_ref_missing] →
+      [Some (Local_state_unsafe { reason = short_label_of_refusal })] — route
       through [needs_intervention].
     - [No_commits_ahead_of_base] / [Worktree_missing] → [None] — the
       orchestrator already has dedicated non-rejection handlers

--- a/lib_core/push_plan.mli
+++ b/lib_core/push_plan.mli
@@ -1,0 +1,117 @@
+(** Pure decision: should a [git push] proceed, given the observed state of the
+    worktree, the named branch, and the remote-tracking ref?
+
+    [Worktree.force_push_with_lease] used to gate on
+    [git rev-list --count <base>..HEAD] (worktree HEAD) but push the named
+    branch — so an agent that [git switch]ed to a different local branch
+    mid-session could trip the gate with commits the push command would never
+    upload. Combined with [--force-with-lease]'s blind spot for local commit
+    loss, that pair of mismatches put PR #315 in the position where a push of a
+    stale branch wiped its remote.
+
+    This module makes both pre-conditions explicit. The effectful caller in
+    [Worktree.force_push_with_lease] reads:
+
+    - whether the worktree directory still exists,
+    - the worktree's current HEAD-branch name (via
+      [git rev-parse --abbrev-ref HEAD]),
+    - the SHA of [refs/heads/<expected_branch>],
+    - the SHA of [refs/remotes/origin/<expected_branch>] (if any),
+    - the two-way ancestry between those two SHAs,
+    - [git rev-list --count <base>..refs/heads/<expected_branch>] (commits ahead
+      of base, measured on the named branch — NOT HEAD),
+
+    and passes them to [plan]. The decision is either [Push action] (proceed
+    with the named git command) or [Refuse reason] (skip the push and route the
+    reason to the orchestrator).
+
+    Refusals that map to a planner-only state ([Branch_switched],
+    [Local_missing_remote_commits]) are translated to
+    {!Push_reject_classify.Local_state_unsafe} so the existing [is_permanent] →
+    [needs_intervention] escalation path applies without new orchestrator state.
+*)
+
+type sha = string [@@deriving show, eq, sexp_of, compare]
+
+(** Two-way ancestor relationship between [refs/heads/<branch>] and
+    [refs/remotes/origin/<branch>], as observed by the caller. *)
+type ancestry =
+  | Local_includes_remote
+      (** Local is at or ahead of remote — safe to force-push. *)
+  | Local_missing_remote
+      (** Remote has commits the local branch does not reach — a force-push
+          would lose them. *)
+  | No_remote_yet  (** The branch has never been pushed. *)
+  | Unknown  (** Ancestry could not be determined; treat conservatively. *)
+[@@deriving show, eq, sexp_of, compare]
+
+type action =
+  | Force_push_if_includes
+      (** [git push --porcelain --force-with-lease --force-if-includes origin
+           <branch>] — the normal supervisor push. *)
+  | Initial_push
+      (** [git push --porcelain -u origin <branch>] — first push of a brand-new
+          branch; no lease/include checks apply because remote ref is absent. *)
+[@@deriving show, eq, sexp_of, compare]
+
+type refusal =
+  | No_commits_ahead_of_base
+      (** The named branch has no commits beyond [base]. GitHub would reject the
+          push with "everything up-to-date" or accept a no-op; skip it. *)
+  | Worktree_missing
+      (** The worktree directory was deleted out from under the supervisor;
+          there is no local state to push from. *)
+  | Branch_ref_missing of { branch : string }
+      (** [refs/heads/<branch>] does not exist locally — we cannot push it. *)
+  | Branch_switched of { expected : string; got : string option }
+      (** The worktree's current HEAD does not match [expected_branch]. An agent
+          switched to a different branch mid-session, so the gate's commit count
+          does not represent what the push command would upload. *)
+  | Local_missing_remote_commits of { local_sha : sha; remote_sha : sha }
+      (** [ancestry = Local_missing_remote] — pushing now would force-push a
+          local that is strictly behind remote on real content, wiping commits.
+      *)
+[@@deriving show, eq, sexp_of, compare]
+
+type decision = Push of action | Refuse of refusal
+[@@deriving show, eq, sexp_of, compare]
+
+val plan :
+  expected_branch:string ->
+  worktree_path_exists:bool ->
+  worktree_head_branch:string option ->
+  branch_ref_sha:sha option ->
+  remote_tracking_sha:sha option ->
+  ancestry:ancestry ->
+  commits_ahead_of_base:int option ->
+  decision
+(** [plan] is total and deterministic. Pre-emption order, applied top-down:
+
+    + [worktree_path_exists = false] → [Refuse Worktree_missing]
+    + [worktree_head_branch <> Some expected_branch] →
+      [Refuse (Branch_switched { expected; got })]
+    + [branch_ref_sha = None] → [Refuse (Branch_ref_missing { branch })]
+    + [commits_ahead_of_base = Some 0] → [Refuse No_commits_ahead_of_base]
+    + [ancestry = Local_missing_remote] (and both refs present) →
+      [Refuse (Local_missing_remote_commits _)]
+    + [remote_tracking_sha = None] → [Push Initial_push]
+    + otherwise → [Push Force_push_if_includes] *)
+
+val short_label : decision -> string
+(** A short, lowercase, snake_case identifier for the planner arm that fired,
+    suitable for the activity log. Always non-empty and ≤ 32 characters.
+    Examples: ["force_push"], ["initial_push"], ["refuse_no_commits"],
+    ["refuse_wt_missing"], ["refuse_ref_missing"], ["refuse_branch_switched"],
+    ["refuse_local_behind"]. *)
+
+val to_push_reject_classify_rejection :
+  refusal -> Push_reject_classify.rejection option
+(** Map planner refusals onto the rejection variant used by the orchestrator's
+    permanent-rejection escalation:
+
+    - [Branch_switched] / [Local_missing_remote_commits] / [Branch_ref_missing]
+      → [Some (Local_state_unsafe { reason = short_label_of_refusal })] — route
+      through [needs_intervention].
+    - [No_commits_ahead_of_base] / [Worktree_missing] → [None] — the
+      orchestrator already has dedicated non-rejection handlers
+      ([Push_no_commits], [Push_worktree_missing]). *)

--- a/lib_core/push_plan.mli
+++ b/lib_core/push_plan.mli
@@ -25,11 +25,12 @@
     with the named git command) or [Refuse reason] (skip the push and route the
     reason to the orchestrator).
 
-    Refusals that map to a planner-only state ([Branch_switched],
-    [Local_missing_remote_commits], [Local_diverged_from_remote_commits]) are
-    translated to {!Push_reject_classify.Local_state_unsafe} so the existing
-    [is_permanent] → [needs_intervention] escalation path applies without new
-    orchestrator state. *)
+    Refusals that map to a planner-only state ([Branch_ref_missing],
+    [Branch_switched], [Local_missing_remote_commits],
+    [Local_diverged_from_remote_commits]) are translated to
+    {!Push_reject_classify.Local_state_unsafe} so the existing [is_permanent] →
+    [needs_intervention] escalation path applies without new orchestrator state.
+*)
 
 type sha = string [@@deriving show, eq, sexp_of, compare]
 

--- a/lib_core/push_reject_classify.ml
+++ b/lib_core/push_reject_classify.ml
@@ -108,7 +108,8 @@ let detail_excerpt = function
   | Hook_failure s | Unknown s ->
       if String.is_empty (String.strip s) then None else Some s
   | Local_state_unsafe { reason } ->
-      if String.is_empty (String.strip reason) then None else Some reason
+      let reason = truncate_200 (String.strip reason) in
+      if String.is_empty reason then None else Some reason
 
 let is_permanent = function
   | Workflow_scope_missing | Branch_protection | Push_pattern_block

--- a/lib_core/push_reject_classify.ml
+++ b/lib_core/push_reject_classify.ml
@@ -7,6 +7,7 @@ type rejection =
   | Lease_violation
   | Hook_failure of string
   | Unknown of string
+  | Local_state_unsafe of { reason : string }
 [@@deriving show, eq, sexp_of, compare]
 
 (* GitHub's remote-rejected stderr is a mix of [remote: ...] lines and a
@@ -98,6 +99,7 @@ let short_label = function
   | Lease_violation -> "lease_violation"
   | Hook_failure _ -> "hook_failure"
   | Unknown _ -> "unknown_rejection"
+  | Local_state_unsafe _ -> "local_state_unsafe"
 
 let detail_excerpt = function
   | Workflow_scope_missing | Branch_protection | Push_pattern_block
@@ -105,9 +107,11 @@ let detail_excerpt = function
       None
   | Hook_failure s | Unknown s ->
       if String.is_empty (String.strip s) then None else Some s
+  | Local_state_unsafe { reason } ->
+      if String.is_empty (String.strip reason) then None else Some reason
 
 let is_permanent = function
   | Workflow_scope_missing | Branch_protection | Push_pattern_block
-  | Hook_failure _ ->
+  | Hook_failure _ | Local_state_unsafe _ ->
       true
   | Lease_violation | Unknown _ -> false

--- a/lib_core/push_reject_classify.mli
+++ b/lib_core/push_reject_classify.mli
@@ -36,6 +36,12 @@ type rejection =
   | Unknown of string
       (** Nothing recognizable in stderr; the excerpt is preserved (truncated to
           200 chars) so the user has a starting point for diagnosis. *)
+  | Local_state_unsafe of { reason : string }
+      (** Pre-flight refusal produced by [Push_plan.plan] — the local worktree
+          state would make the push unsafe (wrong branch checked out, local
+          missing remote commits, etc.). Permanent: a retry without human action
+          cannot fix it. [reason] is a short human-readable label drawn from
+          [Push_plan.short_label]. *)
 [@@deriving show, eq, sexp_of, compare]
 
 val classify : stderr:string -> stdout:string -> rejection

--- a/lib_core/start_point_plan.ml
+++ b/lib_core/start_point_plan.ml
@@ -1,0 +1,54 @@
+open Base
+
+type sha = string [@@deriving show, eq, sexp_of, compare]
+
+type ancestry = Local_ahead | Remote_ahead | Equal | Diverged | Unknown
+[@@deriving show, eq, sexp_of, compare]
+
+type action =
+  | Reset_and_use_remote_tracking of { remote_sha : sha }
+  | Use_local_branch_unchanged of { local_sha : sha }
+  | Create_new_branch_from_base of { base_branch : string }
+[@@deriving show, eq, sexp_of, compare]
+
+type refusal =
+  | Local_diverged_from_remote of { local_sha : sha; remote_sha : sha }
+  | Local_has_unpushed_commits of { local_sha : sha; remote_sha : sha }
+  | Branch_checked_out_in_main_root
+  | Worktree_already_registered of { existing_path : string }
+[@@deriving show, eq, sexp_of, compare]
+
+type decision = Plan of action | Refuse of refusal
+[@@deriving show, eq, sexp_of, compare]
+
+let plan ~local_ref ~remote_ref ~ancestry ~base_branch
+    ~branch_checked_out_in_main_root ~existing_worktree_path =
+  if branch_checked_out_in_main_root then Refuse Branch_checked_out_in_main_root
+  else
+    match existing_worktree_path with
+    | Some existing_path ->
+        Refuse (Worktree_already_registered { existing_path })
+    | None -> (
+        match (local_ref, remote_ref) with
+        | None, None -> Plan (Create_new_branch_from_base { base_branch })
+        | None, Some remote_sha ->
+            Plan (Reset_and_use_remote_tracking { remote_sha })
+        | Some local_sha, None ->
+            Plan (Use_local_branch_unchanged { local_sha })
+        | Some local_sha, Some remote_sha -> (
+            match ancestry with
+            | Equal | Remote_ahead ->
+                Plan (Reset_and_use_remote_tracking { remote_sha })
+            | Local_ahead ->
+                Refuse (Local_has_unpushed_commits { local_sha; remote_sha })
+            | Diverged | Unknown ->
+                Refuse (Local_diverged_from_remote { local_sha; remote_sha })))
+
+let short_label = function
+  | Plan (Reset_and_use_remote_tracking _) -> "reset_to_remote"
+  | Plan (Use_local_branch_unchanged _) -> "use_local_unchanged"
+  | Plan (Create_new_branch_from_base _) -> "create_from_base"
+  | Refuse (Local_diverged_from_remote _) -> "refuse_local_diverged"
+  | Refuse (Local_has_unpushed_commits _) -> "refuse_local_ahead"
+  | Refuse Branch_checked_out_in_main_root -> "refuse_main_checkout"
+  | Refuse (Worktree_already_registered _) -> "refuse_wt_registered"

--- a/lib_core/start_point_plan.mli
+++ b/lib_core/start_point_plan.mli
@@ -1,0 +1,111 @@
+(** Pure decision: what start point should a worktree's branch be created from,
+    given the observed state of local and remote refs?
+
+    Onton's failure mode of record (PR #315) was [Worktree.create] silently
+    reusing a stale local branch ref — the user's working clone had
+    [refs/heads/<branch>] left at the PR's base, so the new worktree started
+    missing every PR commit. The agent's session pushed an empty branch over the
+    real PR, and GitHub auto-closed it.
+
+    This module exists so that decision lives in one inspectable, testable
+    place. The effectful caller in [Worktree] reads the inputs from git (after a
+    [fetch_origin <branch>] performed by [Worktree_setup]), passes them in, and
+    executes the [action] this returns — or reports the [refusal] upward so the
+    orchestrator can route to {!Patch_agent.needs_intervention}.
+
+    {1 Authority}
+
+    For an onton-managed branch, the {e remote} is authoritative whenever a
+    remote ref exists. A local ref that matches the remote or is strictly behind
+    it ([Equal] / [Remote_ahead]) is safe to reset to the remote; a local ref
+    that has commits the remote doesn't ([Local_ahead] / [Diverged]) is treated
+    as suspect — a human pushed something the supervisor doesn't know about, and
+    silently overwriting it would lose work. *)
+
+type sha = string [@@deriving show, eq, sexp_of, compare]
+
+(** Pre-computed two-way ancestor relationship between a local ref and a remote
+    tracking ref. The effectful caller fills this in with the result of two
+    [git merge-base --is-ancestor] probes, or [Unknown] if either probe failed.
+*)
+type ancestry =
+  | Local_ahead  (** local has commits not reachable from remote *)
+  | Remote_ahead
+      (** remote has commits not reachable from local — local is stale *)
+  | Equal  (** local and remote point at the same commit *)
+  | Diverged  (** each side has unique commits the other lacks *)
+  | Unknown  (** ancestry could not be determined (e.g. probe failed) *)
+[@@deriving show, eq, sexp_of, compare]
+
+(** The action a successful plan instructs the caller to take. *)
+type action =
+  | Reset_and_use_remote_tracking of { remote_sha : sha }
+      (** [git worktree add -B <branch> <path> origin/<branch>] — recreate the
+          local branch at the remote tip. Used whenever a remote ref exists and
+          the local ref is absent, equal, or strictly behind. *)
+  | Use_local_branch_unchanged of { local_sha : sha }
+      (** [git worktree add <path> <branch>] — the remote ref is unknown (never
+          been pushed yet), so the local ref is the only source of truth. *)
+  | Create_new_branch_from_base of { base_branch : string }
+      (** [git worktree add -b <branch> <path> origin/<base>] — neither local
+          nor remote ref exists; the worktree starts a brand-new branch at the
+          tip of the configured base. *)
+[@@deriving show, eq, sexp_of, compare]
+
+(** The refusal an unsuccessful plan reports — every variant is permanent in the
+    sense that retrying without a human resolving the underlying state will hit
+    the same refusal. The effectful caller logs the refusal and surfaces it
+    through the orchestrator's intervention path. *)
+type refusal =
+  | Local_diverged_from_remote of { local_sha : sha; remote_sha : sha }
+      (** Ancestry is [Diverged] (or [Unknown]) and both refs are present — a
+          human's local commits would be lost by [-B] reset. *)
+  | Local_has_unpushed_commits of { local_sha : sha; remote_sha : sha }
+      (** Ancestry is [Local_ahead] and both refs are present — the local ref is
+          strictly ahead of remote. On a create path this is suspicious: onton
+          is normally the sole writer for these branches. *)
+  | Branch_checked_out_in_main_root
+      (** The named branch is currently HEAD of the user's main working tree;
+          git would refuse to register a second worktree for it. *)
+  | Worktree_already_registered of { existing_path : string }
+      (** Git already lists a worktree for this branch elsewhere; recreating
+          would race. *)
+[@@deriving show, eq, sexp_of, compare]
+
+(** A plan is either an action to execute or a refusal to report. *)
+type decision = Plan of action | Refuse of refusal
+[@@deriving show, eq, sexp_of, compare]
+
+val plan :
+  local_ref:sha option ->
+  remote_ref:sha option ->
+  ancestry:ancestry ->
+  base_branch:string ->
+  branch_checked_out_in_main_root:bool ->
+  existing_worktree_path:string option ->
+  decision
+(** [plan] is total and deterministic. Pre-emption order, applied top-down:
+
+    + [branch_checked_out_in_main_root = true] →
+      [Refuse Branch_checked_out_in_main_root]
+    + [existing_worktree_path = Some p] →
+      [Refuse (Worktree_already_registered { existing_path = p })]
+    + [(local_ref, remote_ref) = (None, None)] →
+      [Plan (Create_new_branch_from_base { base_branch })]
+    + [(None, Some r)] →
+      [Plan (Reset_and_use_remote_tracking { remote_sha = r })]
+    + [(Some l, None)] → [Plan (Use_local_branch_unchanged { local_sha = l })]
+    + [(Some l, Some r)] with [ancestry = Equal | Remote_ahead] →
+      [Plan (Reset_and_use_remote_tracking { remote_sha = r })]
+    + [(Some l, Some r)] with [ancestry = Local_ahead] →
+      [Refuse (Local_has_unpushed_commits ...)]
+    + [(Some l, Some r)] with [ancestry = Diverged | Unknown] →
+      [Refuse (Local_diverged_from_remote ...)] (conservative — refuse rather
+      than risk silent commit loss). *)
+
+val short_label : decision -> string
+(** A short, lowercase, snake_case identifier for the planner arm that fired,
+    suitable for the activity log. Always non-empty and ≤ 32 characters.
+    Examples: ["reset_to_remote"], ["use_local_unchanged"],
+    ["create_from_base"], ["refuse_local_diverged"], ["refuse_local_ahead"],
+    ["refuse_main_checkout"], ["refuse_wt_registered"]. *)

--- a/lib_core/worktree_parser.ml
+++ b/lib_core/worktree_parser.ml
@@ -253,8 +253,8 @@ let push_gate_from_count = function
   | Some 0 -> Skip_no_commits
   | None | Some _ -> Proceed
 
-(** Classify a [git push --porcelain --force-with-lease] invocation from its
-    exit code + stdout + stderr. *)
+(** Classify a [git push --porcelain --force-with-lease --force-if-includes]
+    invocation from its exit code + stdout + stderr. *)
 let classify_push_result ~code ~stdout ~stderr =
   if code = 0 then
     match parse_push_porcelain stdout with

--- a/test/dune
+++ b/test/dune
@@ -55,6 +55,13 @@
  (ocamlc_flags (:standard -w -40-42)))
 
 (test
+ (name test_start_point_plan_properties)
+ (modules test_start_point_plan_properties)
+ (libraries onton_core re qcheck-core qcheck-core.runner)
+ (ocamlopt_flags (:standard -w -40-42))
+ (ocamlc_flags (:standard -w -40-42)))
+
+(test
  (name test_rebase_decision_properties)
  (modules test_rebase_decision_properties)
  (libraries onton_core qcheck-core qcheck-core.runner)
@@ -211,6 +218,13 @@
 (test
  (name test_worktree_missing_recovery)
  (modules test_worktree_missing_recovery)
+ (libraries onton onton_core eio eio_main eio.unix unix)
+ (ocamlopt_flags (:standard -w -40-42))
+ (ocamlc_flags (:standard -w -40-42)))
+
+(test
+ (name test_worktree_start_point_integration)
+ (modules test_worktree_start_point_integration)
  (libraries onton onton_core eio eio_main eio.unix unix)
  (ocamlopt_flags (:standard -w -40-42))
  (ocamlc_flags (:standard -w -40-42)))

--- a/test/dune
+++ b/test/dune
@@ -62,6 +62,13 @@
  (ocamlc_flags (:standard -w -40-42)))
 
 (test
+ (name test_push_plan_properties)
+ (modules test_push_plan_properties)
+ (libraries onton_core re qcheck-core qcheck-core.runner)
+ (ocamlopt_flags (:standard -w -40-42))
+ (ocamlc_flags (:standard -w -40-42)))
+
+(test
  (name test_rebase_decision_properties)
  (modules test_rebase_decision_properties)
  (libraries onton_core qcheck-core qcheck-core.runner)
@@ -225,6 +232,13 @@
 (test
  (name test_worktree_start_point_integration)
  (modules test_worktree_start_point_integration)
+ (libraries onton onton_core eio eio_main eio.unix unix)
+ (ocamlopt_flags (:standard -w -40-42))
+ (ocamlc_flags (:standard -w -40-42)))
+
+(test
+ (name test_push_plan_integration)
+ (modules test_push_plan_integration)
  (libraries onton onton_core eio eio_main eio.unix unix)
  (ocamlopt_flags (:standard -w -40-42))
  (ocamlc_flags (:standard -w -40-42)))

--- a/test/test_dependency_injection_functors.ml
+++ b/test/test_dependency_injection_functors.ml
@@ -86,7 +86,7 @@ let _check_narrowed :
     ?branch:Branch.t ->
     ?base_ref:string ->
     unit ->
-    string option =
+    Worktree_setup.ensure_result =
   WS.ensure_worktree
 
 (** Patch 2 compile-time signature check.
@@ -189,7 +189,7 @@ let () =
       ?branch:Branch.t ->
       ?base_ref:string ->
       unit ->
-      string option =
+      Worktree_setup.ensure_result =
     WS.ensure_worktree
   in
   ignore check_narrowed;

--- a/test/test_dependency_injection_functors.ml
+++ b/test/test_dependency_injection_functors.ml
@@ -22,6 +22,7 @@ module Fake_worktree : Worktree.S = struct
   let prune_admin () = assert false
   let run_hook ~clock:_ ~script:_ ~cwd:_ ~env:_ () = assert false
   let fetch_origin ~fetch_lock:_ ~path:_ = assert false
+  let fetch_origin_branch ~fetch_lock:_ ~branch:_ = assert false
   let git_status ~path:_ = assert false
   let conflict_diff ~path:_ = assert false
 

--- a/test/test_push_plan_integration.ml
+++ b/test/test_push_plan_integration.ml
@@ -145,27 +145,29 @@ let scenario_local_missing_remote env =
   setup_origin ~origin_dir;
   setup_seed_clone ~origin_dir ~managed_dir;
   sh ~dir:managed_dir "git checkout -q -b feat";
-  sh ~dir:managed_dir "echo work > work.txt";
+  sh ~dir:managed_dir "echo shared > work.txt";
   sh ~dir:managed_dir "git add work.txt";
+  sh ~dir:managed_dir "git commit -q -m 'shared work'";
+  let shared_feat_sha = git_capture ~dir:managed_dir [ "rev-parse"; "HEAD" ] in
+  sh ~dir:managed_dir "git push -q -u origin feat";
+  sh ~dir:managed_dir "echo remote > remote.txt";
+  sh ~dir:managed_dir "git add remote.txt";
   sh ~dir:managed_dir "git commit -q -m 'remote work'";
   sh ~dir:managed_dir "git push -q -u origin feat";
   let remote_feat_sha = git_capture ~dir:managed_dir [ "rev-parse"; "HEAD" ] in
-  (* Reset local feat to the base (simulating the stale-local state PR #315
-     hit), but DO NOT update the local tracking ref — that's exactly the
-     pre-conditions of the wipe. *)
+  (* Reset local feat to an older commit that is still ahead of base. This
+     makes local a strict ancestor of origin/feat while keeping
+     commits_ahead_of_base > 0, so the ancestry refusal is not pre-empted by
+     No_commits_ahead_of_base. *)
   sh ~dir:managed_dir "git checkout -q main";
-  let main_sha = git_capture ~dir:managed_dir [ "rev-parse"; "main" ] in
   sh ~dir:managed_dir
-    (Printf.sprintf "git branch -f feat %s" (Stdlib.Filename.quote main_sha));
+    (Printf.sprintf "git branch -f feat %s"
+       (Stdlib.Filename.quote shared_feat_sha));
   sh ~dir:managed_dir "git checkout -q feat";
   (* Sanity: local feat != remote feat. *)
   let local_feat = git_capture ~dir:managed_dir [ "rev-parse"; "feat" ] in
   if String.equal local_feat remote_feat_sha then
     failwith "precondition: local feat was supposed to be stale";
-  (* Add a commit so commits_ahead_of_base > 0; the refusal must still fire. *)
-  sh ~dir:managed_dir "echo trivial > trivial.txt";
-  sh ~dir:managed_dir "git add trivial.txt";
-  sh ~dir:managed_dir "git commit -q -m 'trivial'";
   let outcome =
     Worktree.force_push_with_lease ~process_mgr ~path:managed_dir
       ~branch:(Types.Branch.of_string "feat")
@@ -174,13 +176,12 @@ let scenario_local_missing_remote env =
   (match outcome with
   | Worktree.Push_rejected (Push_reject_classify.Local_state_unsafe { reason })
     ->
-      if String.equal reason "refuse_local_diverged" then
+      if String.equal reason "refuse_local_behind" then
         Stdlib.print_endline "  local_missing_remote: OK (refused)"
       else
         failwith
           (Printf.sprintf
-             "local_missing_remote: expected reason refuse_local_diverged, got \
-              %s"
+             "local_missing_remote: expected reason refuse_local_behind, got %s"
              reason)
   | Worktree.Push_rejected
       ( Push_reject_classify.Workflow_scope_missing

--- a/test/test_push_plan_integration.ml
+++ b/test/test_push_plan_integration.ml
@@ -1,0 +1,244 @@
+open Base
+open Onton
+open Onton_core
+
+(** Integration test: drive [Worktree.force_push_with_lease] against real git
+    fixtures to cover the {!Push_plan} refusal arms that the unit/property tests
+    can only assert structurally.
+
+    Scenarios:
+
+    - "branch_switched" — worktree HEAD is on a recovery branch, not the named
+      branch the push command would target. Mirrors the codex workaround that
+      put PR #315 in danger.
+    - "local_missing_remote" — local branch is at an older commit than remote
+      (force-push would wipe commits the local clone doesn't have).
+    - "happy_path_force_push" — local includes remote, commits ahead of base.
+      Push proceeds; the actual remote receives the local branch.
+
+    Every git command runs against the real binary; no mocks. *)
+
+let with_temp_dir f =
+  let dir =
+    Stdlib.Filename.concat
+      (Stdlib.Filename.get_temp_dir_name ())
+      (Printf.sprintf "onton-push-plan-%d-%d" (Unix.getpid ()) (Random.bits ()))
+  in
+  Unix.mkdir dir 0o755;
+  Stdlib.at_exit (fun () ->
+      try
+        let _ =
+          Stdlib.Sys.command
+            (Printf.sprintf "rm -rf %s" (Stdlib.Filename.quote dir))
+        in
+        ()
+      with _ -> ());
+  f dir
+
+let sh ?(dir = ".") cmd =
+  let full = Printf.sprintf "cd %s && %s" (Stdlib.Filename.quote dir) cmd in
+  let code = Stdlib.Sys.command full in
+  if code <> 0 then
+    failwith (Printf.sprintf "command failed (exit %d): %s" code full)
+
+let git_capture ?(dir = ".") args =
+  let argstr =
+    String.concat ~sep:" " (List.map ~f:Stdlib.Filename.quote args)
+  in
+  let cmd =
+    Printf.sprintf "cd %s && git %s" (Stdlib.Filename.quote dir) argstr
+  in
+  let ic = Unix.open_process_in cmd in
+  let buf = Buffer.create 128 in
+  (try
+     while true do
+       Stdlib.Buffer.add_channel buf ic 4096
+     done
+   with End_of_file -> ());
+  let _ = Unix.close_process_in ic in
+  String.strip (Buffer.contents buf)
+
+let setup_origin ~origin_dir =
+  Unix.mkdir origin_dir 0o755;
+  sh ~dir:origin_dir "git init -q --bare --initial-branch=main"
+
+let setup_seed_clone ~origin_dir ~managed_dir =
+  sh
+    (Printf.sprintf "git clone -q %s %s"
+       (Stdlib.Filename.quote origin_dir)
+       (Stdlib.Filename.quote managed_dir));
+  sh ~dir:managed_dir "git config user.email 'test@example.com'";
+  sh ~dir:managed_dir "git config user.name 'Test'";
+  sh ~dir:managed_dir "echo seed > seed.txt";
+  sh ~dir:managed_dir "git add seed.txt";
+  sh ~dir:managed_dir "git commit -q -m 'seed'";
+  sh ~dir:managed_dir "git push -q -u origin main"
+
+let scenario_branch_switched env =
+  let process_mgr = Eio.Stdenv.process_mgr env in
+  with_temp_dir @@ fun root ->
+  let origin_dir = Stdlib.Filename.concat root "origin.git" in
+  let managed_dir = Stdlib.Filename.concat root "managed" in
+  setup_origin ~origin_dir;
+  setup_seed_clone ~origin_dir ~managed_dir;
+  (* Create the agent's branch with a real commit, then switch HEAD away to
+     simulate a codex "git switch pr-X-review" mid-session. *)
+  sh ~dir:managed_dir "git checkout -q -b feat";
+  sh ~dir:managed_dir "echo work > work.txt";
+  sh ~dir:managed_dir "git add work.txt";
+  sh ~dir:managed_dir "git commit -q -m 'feat work'";
+  sh ~dir:managed_dir "git checkout -q -b recovery";
+  let outcome =
+    Worktree.force_push_with_lease ~process_mgr ~path:managed_dir
+      ~branch:(Types.Branch.of_string "feat")
+      ~base:(Types.Branch.of_string "main")
+  in
+  (match outcome with
+  | Worktree.Push_rejected (Push_reject_classify.Local_state_unsafe { reason })
+    ->
+      if String.equal reason "refuse_branch_switched" then
+        Stdlib.print_endline "  branch_switched: OK (refused)"
+      else
+        failwith
+          (Printf.sprintf
+             "branch_switched: expected reason refuse_branch_switched, got %s"
+             reason)
+  | Worktree.Push_rejected
+      ( Push_reject_classify.Workflow_scope_missing
+      | Push_reject_classify.Branch_protection
+      | Push_reject_classify.Push_pattern_block
+      | Push_reject_classify.Lease_violation
+      | Push_reject_classify.Hook_failure _ | Push_reject_classify.Unknown _ )
+  | Worktree.Push_ok | Worktree.Push_up_to_date | Worktree.Push_no_commits
+  | Worktree.Push_worktree_missing | Worktree.Push_error _ ->
+      failwith
+        (Printf.sprintf
+           "branch_switched: expected Push_rejected Local_state_unsafe, got %s"
+           (Worktree.show_push_result outcome)));
+  (* Verify nothing was pushed to remote. *)
+  let remote_has_feat =
+    Stdlib.Sys.command
+      (Printf.sprintf
+         "cd %s && git ls-remote --exit-code origin feat >/dev/null 2>&1"
+         (Stdlib.Filename.quote managed_dir))
+  in
+  if remote_has_feat = 0 then
+    failwith "branch_switched: remote received feat — push was not refused"
+
+let scenario_local_missing_remote env =
+  let process_mgr = Eio.Stdenv.process_mgr env in
+  with_temp_dir @@ fun root ->
+  let origin_dir = Stdlib.Filename.concat root "origin.git" in
+  let managed_dir = Stdlib.Filename.concat root "managed" in
+  setup_origin ~origin_dir;
+  setup_seed_clone ~origin_dir ~managed_dir;
+  sh ~dir:managed_dir "git checkout -q -b feat";
+  sh ~dir:managed_dir "echo work > work.txt";
+  sh ~dir:managed_dir "git add work.txt";
+  sh ~dir:managed_dir "git commit -q -m 'remote work'";
+  sh ~dir:managed_dir "git push -q -u origin feat";
+  let remote_feat_sha = git_capture ~dir:managed_dir [ "rev-parse"; "HEAD" ] in
+  (* Reset local feat to the base (simulating the stale-local state PR #315
+     hit), but DO NOT update the local tracking ref — that's exactly the
+     pre-conditions of the wipe. *)
+  sh ~dir:managed_dir "git checkout -q main";
+  let main_sha = git_capture ~dir:managed_dir [ "rev-parse"; "main" ] in
+  sh ~dir:managed_dir
+    (Printf.sprintf "git branch -f feat %s" (Stdlib.Filename.quote main_sha));
+  sh ~dir:managed_dir "git checkout -q feat";
+  (* Sanity: local feat != remote feat. *)
+  let local_feat = git_capture ~dir:managed_dir [ "rev-parse"; "feat" ] in
+  if String.equal local_feat remote_feat_sha then
+    failwith "precondition: local feat was supposed to be stale";
+  (* Add a commit so commits_ahead_of_base > 0; the refusal must still fire. *)
+  sh ~dir:managed_dir "echo trivial > trivial.txt";
+  sh ~dir:managed_dir "git add trivial.txt";
+  sh ~dir:managed_dir "git commit -q -m 'trivial'";
+  let outcome =
+    Worktree.force_push_with_lease ~process_mgr ~path:managed_dir
+      ~branch:(Types.Branch.of_string "feat")
+      ~base:(Types.Branch.of_string "main")
+  in
+  (match outcome with
+  | Worktree.Push_rejected (Push_reject_classify.Local_state_unsafe { reason })
+    ->
+      if String.equal reason "refuse_local_behind" then
+        Stdlib.print_endline "  local_missing_remote: OK (refused)"
+      else
+        failwith
+          (Printf.sprintf
+             "local_missing_remote: expected reason refuse_local_behind, got %s"
+             reason)
+  | Worktree.Push_rejected
+      ( Push_reject_classify.Workflow_scope_missing
+      | Push_reject_classify.Branch_protection
+      | Push_reject_classify.Push_pattern_block
+      | Push_reject_classify.Lease_violation
+      | Push_reject_classify.Hook_failure _ | Push_reject_classify.Unknown _ )
+  | Worktree.Push_ok | Worktree.Push_up_to_date | Worktree.Push_no_commits
+  | Worktree.Push_worktree_missing | Worktree.Push_error _ ->
+      failwith
+        (Printf.sprintf
+           "local_missing_remote: expected Push_rejected Local_state_unsafe, \
+            got %s"
+           (Worktree.show_push_result outcome)));
+  (* Verify remote still at the real (un-wiped) commit. *)
+  let post_remote_sha =
+    git_capture ~dir:managed_dir [ "ls-remote"; "origin"; "refs/heads/feat" ]
+  in
+  if not (String.is_prefix post_remote_sha ~prefix:remote_feat_sha) then
+    failwith
+      (Printf.sprintf
+         "local_missing_remote: remote feat changed from %s to %s — push was \
+          not refused"
+         remote_feat_sha post_remote_sha)
+
+let scenario_happy_path env =
+  let process_mgr = Eio.Stdenv.process_mgr env in
+  with_temp_dir @@ fun root ->
+  let origin_dir = Stdlib.Filename.concat root "origin.git" in
+  let managed_dir = Stdlib.Filename.concat root "managed" in
+  setup_origin ~origin_dir;
+  setup_seed_clone ~origin_dir ~managed_dir;
+  sh ~dir:managed_dir "git checkout -q -b feat";
+  sh ~dir:managed_dir "echo work > work.txt";
+  sh ~dir:managed_dir "git add work.txt";
+  sh ~dir:managed_dir "git commit -q -m 'feat work'";
+  let local_sha = git_capture ~dir:managed_dir [ "rev-parse"; "HEAD" ] in
+  let outcome =
+    Worktree.force_push_with_lease ~process_mgr ~path:managed_dir
+      ~branch:(Types.Branch.of_string "feat")
+      ~base:(Types.Branch.of_string "main")
+  in
+  (match outcome with
+  | Worktree.Push_ok -> Stdlib.print_endline "  happy_path: OK"
+  | Worktree.Push_up_to_date | Worktree.Push_no_commits
+  | Worktree.Push_rejected
+      ( Push_reject_classify.Workflow_scope_missing
+      | Push_reject_classify.Branch_protection
+      | Push_reject_classify.Push_pattern_block
+      | Push_reject_classify.Lease_violation
+      | Push_reject_classify.Hook_failure _ | Push_reject_classify.Unknown _
+      | Push_reject_classify.Local_state_unsafe _ )
+  | Worktree.Push_worktree_missing | Worktree.Push_error _ ->
+      failwith
+        (Printf.sprintf "happy_path: expected Push_ok, got %s"
+           (Worktree.show_push_result outcome)));
+  let remote_sha =
+    let raw =
+      git_capture ~dir:managed_dir [ "ls-remote"; "origin"; "refs/heads/feat" ]
+    in
+    String.prefix raw 40
+  in
+  if not (String.equal remote_sha local_sha) then
+    failwith
+      (Printf.sprintf "happy_path: remote feat=%s expected %s" remote_sha
+         local_sha)
+
+let () =
+  Eio_main.run @@ fun env ->
+  Stdlib.print_endline "Worktree.force_push_with_lease + Push_plan integration:";
+  scenario_branch_switched env;
+  scenario_local_missing_remote env;
+  scenario_happy_path env;
+  Stdlib.print_endline "All push-plan integration scenarios passed."

--- a/test/test_push_plan_integration.ml
+++ b/test/test_push_plan_integration.ml
@@ -55,8 +55,20 @@ let git_capture ?(dir = ".") args =
        Stdlib.Buffer.add_channel buf ic 4096
      done
    with End_of_file -> ());
-  let _ = Unix.close_process_in ic in
-  String.strip (Buffer.contents buf)
+  let contents = Buffer.contents buf in
+  match Unix.close_process_in ic with
+  | Unix.WEXITED 0 -> String.strip contents
+  | Unix.WEXITED code ->
+      failwith
+        (Printf.sprintf "git command failed (exit %d): %s\n%s" code cmd contents)
+  | Unix.WSIGNALED signal ->
+      failwith
+        (Printf.sprintf "git command killed by signal %d: %s\n%s" signal cmd
+           contents)
+  | Unix.WSTOPPED signal ->
+      failwith
+        (Printf.sprintf "git command stopped by signal %d: %s\n%s" signal cmd
+           contents)
 
 let setup_origin ~origin_dir =
   Unix.mkdir origin_dir 0o755;
@@ -162,12 +174,13 @@ let scenario_local_missing_remote env =
   (match outcome with
   | Worktree.Push_rejected (Push_reject_classify.Local_state_unsafe { reason })
     ->
-      if String.equal reason "refuse_local_behind" then
+      if String.equal reason "refuse_local_diverged" then
         Stdlib.print_endline "  local_missing_remote: OK (refused)"
       else
         failwith
           (Printf.sprintf
-             "local_missing_remote: expected reason refuse_local_behind, got %s"
+             "local_missing_remote: expected reason refuse_local_diverged, got \
+              %s"
              reason)
   | Worktree.Push_rejected
       ( Push_reject_classify.Workflow_scope_missing

--- a/test/test_push_plan_properties.ml
+++ b/test/test_push_plan_properties.ml
@@ -1,0 +1,355 @@
+open Base
+open Onton_core
+
+(** Property tests for {!Push_plan}.
+
+    Properties cover:
+
+    - {b PPP-1 Totality}: [plan] never raises on any combination of inputs.
+    - {b PPP-2 Branch-switch refused}: when
+      [worktree_head_branch <> Some expected_branch], decision is
+      [Refuse (Branch_switched _)] (after [Worktree_missing] pre-emption).
+    - {b PPP-3 Local-missing-remote refused}: when
+      [ancestry = Local_missing_remote] and both refs are present, decision is
+      [Refuse (Local_missing_remote_commits _)].
+    - {b PPP-4 Zero commits → skip}: [commits_ahead_of_base = Some 0] yields
+      [Refuse No_commits_ahead_of_base] (after worktree-missing, branch-switch,
+      branch-ref-missing pre-emptions).
+    - {b PPP-5 Initial push when no remote}: [remote_tracking_sha = None] + no
+      refusals → [Push Initial_push].
+    - {b PPP-6 Happy path}: all preconditions met + remote present →
+      [Push Force_push_if_includes].
+    - {b PPP-7 Worktree-missing pre-empts}: [worktree_path_exists = false]
+      always yields [Refuse Worktree_missing].
+    - {b PPP-8 Determinism}: same inputs → same output.
+    - {b PPP-9 Variant reachability}: each [decision] constructor is reachable.
+    - {b PPP-10 Refusal-to-rejection permanence}: every refusal that maps to
+      [Some rej] yields a [rej] for which
+      [Push_reject_classify.is_permanent = true].
+    - {b PPP-11 Label bounds}: [short_label] non-empty, ≤ 32 chars, snake_case.
+*)
+
+module Gen = QCheck2.Gen
+module Test = QCheck2.Test
+module PP = Push_plan
+
+(* ---------- Helpers ---------- *)
+
+let is_push_force = function
+  | PP.Push PP.Force_push_if_includes -> true
+  | PP.Push PP.Initial_push | PP.Refuse _ -> false
+
+let is_push_initial = function
+  | PP.Push PP.Initial_push -> true
+  | PP.Push PP.Force_push_if_includes | PP.Refuse _ -> false
+
+let is_refuse_no_commits = function
+  | PP.Refuse PP.No_commits_ahead_of_base -> true
+  | PP.Refuse
+      ( PP.Worktree_missing | PP.Branch_ref_missing _ | PP.Branch_switched _
+      | PP.Local_missing_remote_commits _ )
+  | PP.Push _ ->
+      false
+
+let is_refuse_wt_missing = function
+  | PP.Refuse PP.Worktree_missing -> true
+  | PP.Refuse
+      ( PP.No_commits_ahead_of_base | PP.Branch_ref_missing _
+      | PP.Branch_switched _ | PP.Local_missing_remote_commits _ )
+  | PP.Push _ ->
+      false
+
+let is_refuse_ref_missing = function
+  | PP.Refuse (PP.Branch_ref_missing _) -> true
+  | PP.Refuse
+      ( PP.No_commits_ahead_of_base | PP.Worktree_missing | PP.Branch_switched _
+      | PP.Local_missing_remote_commits _ )
+  | PP.Push _ ->
+      false
+
+let is_refuse_branch_switched = function
+  | PP.Refuse (PP.Branch_switched _) -> true
+  | PP.Refuse
+      ( PP.No_commits_ahead_of_base | PP.Worktree_missing
+      | PP.Branch_ref_missing _ | PP.Local_missing_remote_commits _ )
+  | PP.Push _ ->
+      false
+
+let is_refuse_local_behind = function
+  | PP.Refuse (PP.Local_missing_remote_commits _) -> true
+  | PP.Refuse
+      ( PP.No_commits_ahead_of_base | PP.Worktree_missing
+      | PP.Branch_ref_missing _ | PP.Branch_switched _ )
+  | PP.Push _ ->
+      false
+
+(* ---------- Generators ---------- *)
+
+let gen_sha = Gen.string_size ~gen:Gen.printable (Gen.int_range 0 40)
+let gen_branch_name = Gen.string_size ~gen:Gen.printable (Gen.int_range 1 30)
+
+let gen_ancestry =
+  Gen.oneof_array
+    [|
+      PP.Local_includes_remote;
+      PP.Local_missing_remote;
+      PP.No_remote_yet;
+      PP.Unknown;
+    |]
+
+let gen_int_option =
+  Gen.oneof [ Gen.return None; Gen.map (fun n -> Some n) (Gen.int_range 0 100) ]
+
+type plan_inputs = {
+  expected_branch : string;
+  worktree_path_exists : bool;
+  worktree_head_branch : string option;
+  branch_ref_sha : string option;
+  remote_tracking_sha : string option;
+  ancestry : PP.ancestry;
+  commits_ahead_of_base : int option;
+}
+
+let gen_inputs : plan_inputs Gen.t =
+  let open Gen in
+  let* expected_branch = gen_branch_name in
+  let* worktree_path_exists = bool in
+  let* worktree_head_branch = option gen_branch_name in
+  let* branch_ref_sha = option gen_sha in
+  let* remote_tracking_sha = option gen_sha in
+  let* ancestry = gen_ancestry in
+  let* commits_ahead_of_base = gen_int_option in
+  return
+    {
+      expected_branch;
+      worktree_path_exists;
+      worktree_head_branch;
+      branch_ref_sha;
+      remote_tracking_sha;
+      ancestry;
+      commits_ahead_of_base;
+    }
+
+let call i =
+  PP.plan ~expected_branch:i.expected_branch
+    ~worktree_path_exists:i.worktree_path_exists
+    ~worktree_head_branch:i.worktree_head_branch
+    ~branch_ref_sha:i.branch_ref_sha ~remote_tracking_sha:i.remote_tracking_sha
+    ~ancestry:i.ancestry ~commits_ahead_of_base:i.commits_ahead_of_base
+
+(* ---------- Properties ---------- *)
+
+let prop_totality =
+  Test.make ~count:500 ~name:"PPP-1: plan is total" gen_inputs (fun i ->
+      try
+        let _ : PP.decision = call i in
+        true
+      with _ -> false)
+
+let prop_branch_switch_refused =
+  Test.make ~count:500
+    ~name:"PPP-2: head_branch != expected (path exists) → Branch_switched"
+    Gen.(
+      let* i = gen_inputs in
+      let* mismatched =
+        oneof
+          [
+            return None;
+            map
+              (fun s -> Some (i.expected_branch ^ s ^ "-x"))
+              (string_size ~gen:printable (int_range 0 5));
+          ]
+      in
+      return
+        {
+          i with
+          worktree_path_exists = true;
+          worktree_head_branch = mismatched;
+        })
+    (fun i -> is_refuse_branch_switched (call i))
+
+let prop_local_missing_remote_refused =
+  Test.make ~count:500
+    ~name:
+      "PPP-3: ancestry=Local_missing_remote + both refs present → \
+       Local_missing_remote_commits"
+    Gen.(
+      let* local_sha = gen_sha in
+      let* remote_sha = gen_sha in
+      let* branch = gen_branch_name in
+      return (local_sha, remote_sha, branch))
+    (fun (local_sha, remote_sha, branch) ->
+      let d =
+        PP.plan ~expected_branch:branch ~worktree_path_exists:true
+          ~worktree_head_branch:(Some branch) ~branch_ref_sha:(Some local_sha)
+          ~remote_tracking_sha:(Some remote_sha)
+          ~ancestry:PP.Local_missing_remote ~commits_ahead_of_base:(Some 3)
+      in
+      is_refuse_local_behind d)
+
+let prop_zero_commits_skip =
+  Test.make ~count:500
+    ~name:"PPP-4: commits_ahead_of_base=Some 0 → No_commits_ahead_of_base"
+    Gen.(
+      let* branch = gen_branch_name in
+      let* local_sha = gen_sha in
+      let* remote = option gen_sha in
+      let* anc = gen_ancestry in
+      return (branch, local_sha, remote, anc))
+    (fun (branch, local_sha, remote, anc) ->
+      let d =
+        PP.plan ~expected_branch:branch ~worktree_path_exists:true
+          ~worktree_head_branch:(Some branch) ~branch_ref_sha:(Some local_sha)
+          ~remote_tracking_sha:remote ~ancestry:anc
+          ~commits_ahead_of_base:(Some 0)
+      in
+      is_refuse_no_commits d)
+
+let prop_initial_push =
+  Test.make ~count:500
+    ~name:"PPP-5: no remote, no other refusal → Push Initial_push"
+    Gen.(
+      let* branch = gen_branch_name in
+      let* local_sha = gen_sha in
+      let* commits =
+        oneof [ return None; map (fun n -> Some n) (int_range 1 50) ]
+      in
+      let* anc = oneof_array [| PP.No_remote_yet; PP.Unknown |] in
+      return (branch, local_sha, commits, anc))
+    (fun (branch, local_sha, commits, anc) ->
+      let d =
+        PP.plan ~expected_branch:branch ~worktree_path_exists:true
+          ~worktree_head_branch:(Some branch) ~branch_ref_sha:(Some local_sha)
+          ~remote_tracking_sha:None ~ancestry:anc ~commits_ahead_of_base:commits
+      in
+      is_push_initial d)
+
+let prop_happy_path =
+  Test.make ~count:500 ~name:"PPP-6: happy path → Push Force_push_if_includes"
+    Gen.(
+      let* branch = gen_branch_name in
+      let* local_sha = gen_sha in
+      let* remote_sha = gen_sha in
+      let* anc =
+        oneof_array [| PP.Local_includes_remote; PP.No_remote_yet; PP.Unknown |]
+      in
+      let* commits = int_range 1 50 in
+      return (branch, local_sha, remote_sha, anc, commits))
+    (fun (branch, local_sha, remote_sha, anc, commits) ->
+      let d =
+        PP.plan ~expected_branch:branch ~worktree_path_exists:true
+          ~worktree_head_branch:(Some branch) ~branch_ref_sha:(Some local_sha)
+          ~remote_tracking_sha:(Some remote_sha) ~ancestry:anc
+          ~commits_ahead_of_base:(Some commits)
+      in
+      is_push_force d)
+
+let prop_worktree_missing_preempts =
+  Test.make ~count:500
+    ~name:"PPP-7: worktree_path_exists=false pre-empts everything" gen_inputs
+    (fun i ->
+      let d = call { i with worktree_path_exists = false } in
+      is_refuse_wt_missing d)
+
+let prop_determinism =
+  Test.make ~count:500 ~name:"PPP-8: same inputs → same output" gen_inputs
+    (fun i -> PP.equal_decision (call i) (call i))
+
+let prop_variants_reachable =
+  Test.make ~count:1 ~name:"PPP-9: every decision variant is reachable"
+    (Gen.return ()) (fun () ->
+      let force =
+        PP.plan ~expected_branch:"b" ~worktree_path_exists:true
+          ~worktree_head_branch:(Some "b") ~branch_ref_sha:(Some "l")
+          ~remote_tracking_sha:(Some "r") ~ancestry:PP.Local_includes_remote
+          ~commits_ahead_of_base:(Some 1)
+      in
+      let initial =
+        PP.plan ~expected_branch:"b" ~worktree_path_exists:true
+          ~worktree_head_branch:(Some "b") ~branch_ref_sha:(Some "l")
+          ~remote_tracking_sha:None ~ancestry:PP.No_remote_yet
+          ~commits_ahead_of_base:(Some 1)
+      in
+      let no_commits =
+        PP.plan ~expected_branch:"b" ~worktree_path_exists:true
+          ~worktree_head_branch:(Some "b") ~branch_ref_sha:(Some "l")
+          ~remote_tracking_sha:(Some "r") ~ancestry:PP.Local_includes_remote
+          ~commits_ahead_of_base:(Some 0)
+      in
+      let wt_missing =
+        PP.plan ~expected_branch:"b" ~worktree_path_exists:false
+          ~worktree_head_branch:(Some "b") ~branch_ref_sha:(Some "l")
+          ~remote_tracking_sha:(Some "r") ~ancestry:PP.Local_includes_remote
+          ~commits_ahead_of_base:(Some 1)
+      in
+      let ref_missing =
+        PP.plan ~expected_branch:"b" ~worktree_path_exists:true
+          ~worktree_head_branch:(Some "b") ~branch_ref_sha:None
+          ~remote_tracking_sha:(Some "r") ~ancestry:PP.Unknown
+          ~commits_ahead_of_base:(Some 1)
+      in
+      let branch_switched =
+        PP.plan ~expected_branch:"b" ~worktree_path_exists:true
+          ~worktree_head_branch:(Some "other") ~branch_ref_sha:(Some "l")
+          ~remote_tracking_sha:(Some "r") ~ancestry:PP.Local_includes_remote
+          ~commits_ahead_of_base:(Some 1)
+      in
+      let local_behind =
+        PP.plan ~expected_branch:"b" ~worktree_path_exists:true
+          ~worktree_head_branch:(Some "b") ~branch_ref_sha:(Some "l")
+          ~remote_tracking_sha:(Some "r") ~ancestry:PP.Local_missing_remote
+          ~commits_ahead_of_base:(Some 1)
+      in
+      is_push_force force && is_push_initial initial
+      && is_refuse_no_commits no_commits
+      && is_refuse_wt_missing wt_missing
+      && is_refuse_ref_missing ref_missing
+      && is_refuse_branch_switched branch_switched
+      && is_refuse_local_behind local_behind)
+
+let prop_refusal_to_rejection_permanent =
+  Test.make ~count:1
+    ~name:
+      "PPP-10: every refusal that maps to Some rej yields a permanent \
+       Push_reject_classify rejection" (Gen.return ()) (fun () ->
+      let refusals =
+        [
+          PP.No_commits_ahead_of_base;
+          PP.Worktree_missing;
+          PP.Branch_ref_missing { branch = "b" };
+          PP.Branch_switched { expected = "b"; got = Some "other" };
+          PP.Local_missing_remote_commits { local_sha = "l"; remote_sha = "r" };
+        ]
+      in
+      List.for_all refusals ~f:(fun r ->
+          match PP.to_push_reject_classify_rejection r with
+          | None -> true
+          | Some rej -> Push_reject_classify.is_permanent rej))
+
+let label_re = Re.Pcre.re {|^[a-z][a-z0-9_]*$|} |> Re.compile
+
+let prop_label_bounds =
+  Test.make ~count:500 ~name:"PPP-11: short_label non-empty, ≤32, snake_case"
+    gen_inputs (fun i ->
+      let lbl = PP.short_label (call i) in
+      (not (String.is_empty lbl))
+      && String.length lbl <= 32
+      && Re.execp label_re lbl)
+
+let () =
+  let runner = QCheck_base_runner.run_tests_main in
+  ignore
+    (runner
+       [
+         prop_totality;
+         prop_branch_switch_refused;
+         prop_local_missing_remote_refused;
+         prop_zero_commits_skip;
+         prop_initial_push;
+         prop_happy_path;
+         prop_worktree_missing_preempts;
+         prop_determinism;
+         prop_variants_reachable;
+         prop_refusal_to_rejection_permanent;
+         prop_label_bounds;
+       ])

--- a/test/test_push_plan_properties.ml
+++ b/test/test_push_plan_properties.ml
@@ -9,9 +9,15 @@ open Onton_core
     - {b PPP-2 Branch-switch refused}: when
       [worktree_head_branch <> Some expected_branch], decision is
       [Refuse (Branch_switched _)] (after [Worktree_missing] pre-emption).
+    - {b PPP-2b Matching head branch not branch-switched}: when no earlier
+      pre-emption fires and [worktree_head_branch = Some expected_branch], the
+      decision is not [Refuse (Branch_switched _)].
     - {b PPP-3 Local-missing-remote refused}: when
       [ancestry = Local_missing_remote] and both refs are present, decision is
       [Refuse (Local_missing_remote_commits _)].
+    - {b PPP-3b Local-diverged-from-remote refused}: when
+      [ancestry = Local_diverged_from_remote] and both refs are present,
+      decision is [Refuse (Local_diverged_from_remote_commits _)].
     - {b PPP-4 Zero commits → skip}: [commits_ahead_of_base = Some 0] yields
       [Refuse No_commits_ahead_of_base] (after worktree-missing, branch-switch,
       branch-ref-missing pre-emptions).
@@ -47,7 +53,8 @@ let is_refuse_no_commits = function
   | PP.Refuse PP.No_commits_ahead_of_base -> true
   | PP.Refuse
       ( PP.Worktree_missing | PP.Branch_ref_missing _ | PP.Branch_switched _
-      | PP.Local_missing_remote_commits _ )
+      | PP.Local_missing_remote_commits _
+      | PP.Local_diverged_from_remote_commits _ )
   | PP.Push _ ->
       false
 
@@ -55,7 +62,8 @@ let is_refuse_wt_missing = function
   | PP.Refuse PP.Worktree_missing -> true
   | PP.Refuse
       ( PP.No_commits_ahead_of_base | PP.Branch_ref_missing _
-      | PP.Branch_switched _ | PP.Local_missing_remote_commits _ )
+      | PP.Branch_switched _ | PP.Local_missing_remote_commits _
+      | PP.Local_diverged_from_remote_commits _ )
   | PP.Push _ ->
       false
 
@@ -63,7 +71,8 @@ let is_refuse_ref_missing = function
   | PP.Refuse (PP.Branch_ref_missing _) -> true
   | PP.Refuse
       ( PP.No_commits_ahead_of_base | PP.Worktree_missing | PP.Branch_switched _
-      | PP.Local_missing_remote_commits _ )
+      | PP.Local_missing_remote_commits _
+      | PP.Local_diverged_from_remote_commits _ )
   | PP.Push _ ->
       false
 
@@ -71,7 +80,8 @@ let is_refuse_branch_switched = function
   | PP.Refuse (PP.Branch_switched _) -> true
   | PP.Refuse
       ( PP.No_commits_ahead_of_base | PP.Worktree_missing
-      | PP.Branch_ref_missing _ | PP.Local_missing_remote_commits _ )
+      | PP.Branch_ref_missing _ | PP.Local_missing_remote_commits _
+      | PP.Local_diverged_from_remote_commits _ )
   | PP.Push _ ->
       false
 
@@ -79,7 +89,17 @@ let is_refuse_local_behind = function
   | PP.Refuse (PP.Local_missing_remote_commits _) -> true
   | PP.Refuse
       ( PP.No_commits_ahead_of_base | PP.Worktree_missing
-      | PP.Branch_ref_missing _ | PP.Branch_switched _ )
+      | PP.Branch_ref_missing _ | PP.Branch_switched _
+      | PP.Local_diverged_from_remote_commits _ )
+  | PP.Push _ ->
+      false
+
+let is_refuse_local_diverged = function
+  | PP.Refuse (PP.Local_diverged_from_remote_commits _) -> true
+  | PP.Refuse
+      ( PP.No_commits_ahead_of_base | PP.Worktree_missing
+      | PP.Branch_ref_missing _ | PP.Branch_switched _
+      | PP.Local_missing_remote_commits _ )
   | PP.Push _ ->
       false
 
@@ -93,6 +113,7 @@ let gen_ancestry =
     [|
       PP.Local_includes_remote;
       PP.Local_missing_remote;
+      PP.Local_diverged_from_remote;
       PP.No_remote_yet;
       PP.Unknown;
     |]
@@ -168,6 +189,27 @@ let prop_branch_switch_refused =
         })
     (fun i -> is_refuse_branch_switched (call i))
 
+let prop_matching_head_branch_not_switched =
+  Test.make ~count:500
+    ~name:"PPP-2b: head_branch = expected → not Branch_switched"
+    Gen.(
+      let* branch = gen_branch_name in
+      let* local_sha = gen_sha in
+      let* remote_sha = option gen_sha in
+      let* anc = gen_ancestry in
+      let* commits = gen_int_option in
+      return
+        {
+          expected_branch = branch;
+          worktree_path_exists = true;
+          worktree_head_branch = Some branch;
+          branch_ref_sha = Some local_sha;
+          remote_tracking_sha = remote_sha;
+          ancestry = anc;
+          commits_ahead_of_base = commits;
+        })
+    (fun i -> not (is_refuse_branch_switched (call i)))
+
 let prop_local_missing_remote_refused =
   Test.make ~count:500
     ~name:
@@ -186,6 +228,26 @@ let prop_local_missing_remote_refused =
           ~ancestry:PP.Local_missing_remote ~commits_ahead_of_base:(Some 3)
       in
       is_refuse_local_behind d)
+
+let prop_local_diverged_from_remote_refused =
+  Test.make ~count:500
+    ~name:
+      "PPP-3b: ancestry=Local_diverged_from_remote + both refs present → \
+       Local_diverged_from_remote_commits"
+    Gen.(
+      let* local_sha = gen_sha in
+      let* remote_sha = gen_sha in
+      let* branch = gen_branch_name in
+      return (local_sha, remote_sha, branch))
+    (fun (local_sha, remote_sha, branch) ->
+      let d =
+        PP.plan ~expected_branch:branch ~worktree_path_exists:true
+          ~worktree_head_branch:(Some branch) ~branch_ref_sha:(Some local_sha)
+          ~remote_tracking_sha:(Some remote_sha)
+          ~ancestry:PP.Local_diverged_from_remote
+          ~commits_ahead_of_base:(Some 3)
+      in
+      is_refuse_local_diverged d)
 
 let prop_zero_commits_skip =
   Test.make ~count:500
@@ -300,12 +362,20 @@ let prop_variants_reachable =
           ~remote_tracking_sha:(Some "r") ~ancestry:PP.Local_missing_remote
           ~commits_ahead_of_base:(Some 1)
       in
+      let local_diverged =
+        PP.plan ~expected_branch:"b" ~worktree_path_exists:true
+          ~worktree_head_branch:(Some "b") ~branch_ref_sha:(Some "l")
+          ~remote_tracking_sha:(Some "r")
+          ~ancestry:PP.Local_diverged_from_remote
+          ~commits_ahead_of_base:(Some 1)
+      in
       is_push_force force && is_push_initial initial
       && is_refuse_no_commits no_commits
       && is_refuse_wt_missing wt_missing
       && is_refuse_ref_missing ref_missing
       && is_refuse_branch_switched branch_switched
-      && is_refuse_local_behind local_behind)
+      && is_refuse_local_behind local_behind
+      && is_refuse_local_diverged local_diverged)
 
 let prop_refusal_to_rejection_permanent =
   Test.make ~count:1
@@ -319,6 +389,8 @@ let prop_refusal_to_rejection_permanent =
           PP.Branch_ref_missing { branch = "b" };
           PP.Branch_switched { expected = "b"; got = Some "other" };
           PP.Local_missing_remote_commits { local_sha = "l"; remote_sha = "r" };
+          PP.Local_diverged_from_remote_commits
+            { local_sha = "l"; remote_sha = "r" };
         ]
       in
       List.for_all refusals ~f:(fun r ->
@@ -343,7 +415,9 @@ let () =
        [
          prop_totality;
          prop_branch_switch_refused;
+         prop_matching_head_branch_not_switched;
          prop_local_missing_remote_refused;
+         prop_local_diverged_from_remote_refused;
          prop_zero_commits_skip;
          prop_initial_push;
          prop_happy_path;

--- a/test/test_push_reject_classify_properties.ml
+++ b/test/test_push_reject_classify_properties.ml
@@ -118,7 +118,8 @@ let prop_generic_hook =
       | Push_reject_classify.Workflow_scope_missing
       | Push_reject_classify.Branch_protection
       | Push_reject_classify.Push_pattern_block
-      | Push_reject_classify.Lease_violation | Push_reject_classify.Unknown _ ->
+      | Push_reject_classify.Lease_violation | Push_reject_classify.Unknown _
+      | Push_reject_classify.Local_state_unsafe _ ->
           false)
 
 let prop_empty_stderr =
@@ -130,7 +131,8 @@ let prop_empty_stderr =
       | Push_reject_classify.Branch_protection
       | Push_reject_classify.Push_pattern_block
       | Push_reject_classify.Lease_violation
-      | Push_reject_classify.Hook_failure _ ->
+      | Push_reject_classify.Hook_failure _
+      | Push_reject_classify.Local_state_unsafe _ ->
           false)
 
 let prop_short_label_bounded =
@@ -174,7 +176,8 @@ let prop_permanence_matches_variant =
         | Push_reject_classify.Workflow_scope_missing
         | Push_reject_classify.Branch_protection
         | Push_reject_classify.Push_pattern_block
-        | Push_reject_classify.Hook_failure _ ->
+        | Push_reject_classify.Hook_failure _
+        | Push_reject_classify.Local_state_unsafe _ ->
             true
         | Push_reject_classify.Lease_violation | Push_reject_classify.Unknown _
           ->
@@ -200,6 +203,19 @@ let prop_recognizer_priority =
         (Push_reject_classify.classify ~stderr:workflow_scope_stderr ~stdout:"")
         Push_reject_classify.Workflow_scope_missing)
 
+let prop_local_state_unsafe =
+  Test.make ~count:1
+    ~name:
+      "PRC-15: Local_state_unsafe is permanent, has short_label and \
+       detail_excerpt" (Gen.return ()) (fun () ->
+      let r = Push_reject_classify.Local_state_unsafe { reason = "x" } in
+      Push_reject_classify.is_permanent r
+      && String.equal (Push_reject_classify.short_label r) "local_state_unsafe"
+      &&
+      match Push_reject_classify.detail_excerpt r with
+      | Some s -> String.equal s "x"
+      | None -> false)
+
 let prop_unknown_truncation =
   Test.make ~count:300 ~name:"PRC-14: Unknown payload is <= 200 chars"
     (Gen.string_size ~gen:Gen.char (Gen.int_range 0 1000))
@@ -216,9 +232,11 @@ let prop_unknown_truncation =
       | Push_reject_classify.Workflow_scope_missing
       | Push_reject_classify.Branch_protection
       | Push_reject_classify.Push_pattern_block
-      | Push_reject_classify.Lease_violation ->
+      | Push_reject_classify.Lease_violation
+      | Push_reject_classify.Local_state_unsafe _ ->
           (* sanitization stripped all letters, so the named-fingerprint arms
-             are unreachable here — but the type system can't know that. *)
+             and the planner-only Local_state_unsafe arm are unreachable here
+             — but the type system can't know that. *)
           true)
 
 let () =
@@ -238,6 +256,7 @@ let () =
       prop_permanence_matches_variant;
       prop_classify_is_deterministic;
       prop_recognizer_priority;
+      prop_local_state_unsafe;
       prop_unknown_truncation;
     ];
   Stdlib.print_endline "Push_reject_classify: all properties passed"

--- a/test/test_push_reject_classify_properties.ml
+++ b/test/test_push_reject_classify_properties.ml
@@ -208,12 +208,15 @@ let prop_local_state_unsafe =
     ~name:
       "PRC-15: Local_state_unsafe is permanent, has short_label and \
        detail_excerpt" (Gen.return ()) (fun () ->
-      let r = Push_reject_classify.Local_state_unsafe { reason = "x" } in
+      let r =
+        Push_reject_classify.Local_state_unsafe
+          { reason = "  " ^ String.make 300 'x' }
+      in
       Push_reject_classify.is_permanent r
       && String.equal (Push_reject_classify.short_label r) "local_state_unsafe"
       &&
       match Push_reject_classify.detail_excerpt r with
-      | Some s -> String.equal s "x"
+      | Some s -> String.length s = 200 && String.for_all s ~f:(Char.equal 'x')
       | None -> false)
 
 let prop_unknown_truncation =

--- a/test/test_start_point_plan_properties.ml
+++ b/test/test_start_point_plan_properties.ml
@@ -1,0 +1,315 @@
+open Base
+open Onton_core
+
+(** Property tests for {!Start_point_plan}.
+
+    Properties cover:
+
+    - {b SPP-1 Totality}: [plan] never raises on any combination of inputs.
+    - {b SPP-2 No silent clobber}: if both refs are present and ancestry is
+      [Local_ahead], [Diverged], or [Unknown], the decision is [Refuse _] — we
+      never silently overwrite local commits the supervisor doesn't know about.
+    - {b SPP-3 Remote authoritative}: when both refs are present and ancestry is
+      [Equal] or [Remote_ahead], the action is [Reset_and_use_remote_tracking].
+    - {b SPP-4 Missing both → create from base}: both refs absent ⇒
+      [Create_new_branch_from_base].
+    - {b SPP-5 Determinism}: same inputs yield identical output.
+    - {b SPP-6 Pre-emption}: [branch_checked_out_in_main_root = true] always
+      yields [Refuse Branch_checked_out_in_main_root] regardless of every other
+      input; [existing_worktree_path = Some _] yields
+      [Refuse Worktree_already_registered _] regardless of refs/ancestry.
+    - {b SPP-7 Label bounds}: [short_label] is non-empty, ≤ 32 chars, lowercase
+      \+ snake_case (matches [^[a-z][a-z0-9_]*$]).
+    - {b SPP-8 Variant reachability}: for each [decision] constructor, exhibit
+      an input that produces it.
+    - {b SPP-9 Remote authority over local}: when [remote_ref = Some _] and
+      ancestry is non-divergent, the action is never
+      [Use_local_branch_unchanged] (remote always wins). *)
+
+module Gen = QCheck2.Gen
+module Test = QCheck2.Test
+module SP = Start_point_plan
+
+(* ---------- Helpers (exhaustive predicates over action / refusal) ---------- *)
+
+let is_reset_to (remote : string) = function
+  | SP.Plan (SP.Reset_and_use_remote_tracking { remote_sha }) ->
+      String.equal remote_sha remote
+  | SP.Plan (SP.Use_local_branch_unchanged _)
+  | SP.Plan (SP.Create_new_branch_from_base _)
+  | SP.Refuse _ ->
+      false
+
+let is_use_local = function
+  | SP.Plan (SP.Use_local_branch_unchanged _) -> true
+  | SP.Plan (SP.Reset_and_use_remote_tracking _)
+  | SP.Plan (SP.Create_new_branch_from_base _)
+  | SP.Refuse _ ->
+      false
+
+let is_create_from_base (b : string) = function
+  | SP.Plan (SP.Create_new_branch_from_base { base_branch }) ->
+      String.equal base_branch b
+  | SP.Plan (SP.Reset_and_use_remote_tracking _)
+  | SP.Plan (SP.Use_local_branch_unchanged _)
+  | SP.Refuse _ ->
+      false
+
+let is_refuse = function SP.Refuse _ -> true | SP.Plan _ -> false
+
+let is_refuse_diverged = function
+  | SP.Refuse (SP.Local_diverged_from_remote _) -> true
+  | SP.Refuse
+      ( SP.Local_has_unpushed_commits _ | SP.Branch_checked_out_in_main_root
+      | SP.Worktree_already_registered _ )
+  | SP.Plan _ ->
+      false
+
+let is_refuse_local_ahead = function
+  | SP.Refuse (SP.Local_has_unpushed_commits _) -> true
+  | SP.Refuse
+      ( SP.Local_diverged_from_remote _ | SP.Branch_checked_out_in_main_root
+      | SP.Worktree_already_registered _ )
+  | SP.Plan _ ->
+      false
+
+let is_refuse_checked_out = function
+  | SP.Refuse SP.Branch_checked_out_in_main_root -> true
+  | SP.Refuse
+      ( SP.Local_diverged_from_remote _ | SP.Local_has_unpushed_commits _
+      | SP.Worktree_already_registered _ )
+  | SP.Plan _ ->
+      false
+
+let is_refuse_registered = function
+  | SP.Refuse (SP.Worktree_already_registered _) -> true
+  | SP.Refuse
+      ( SP.Local_diverged_from_remote _ | SP.Local_has_unpushed_commits _
+      | SP.Branch_checked_out_in_main_root ) ->
+      false
+  | SP.Plan _ -> false
+
+(* ---------- Generators ---------- *)
+
+let gen_sha = Gen.string_size ~gen:Gen.printable (Gen.int_range 0 40)
+let gen_branch_name = Gen.string_size ~gen:Gen.printable (Gen.int_range 0 30)
+
+let gen_ancestry =
+  Gen.oneof_array
+    [| SP.Local_ahead; SP.Remote_ahead; SP.Equal; SP.Diverged; SP.Unknown |]
+
+let gen_sha_option = Gen.option gen_sha
+let gen_path_option = Gen.option gen_branch_name
+
+(* Random inputs to [plan]; tuple-packed so generators stay small. *)
+type plan_inputs = {
+  local_ref : SP.sha option;
+  remote_ref : SP.sha option;
+  ancestry : SP.ancestry;
+  base_branch : string;
+  branch_checked_out_in_main_root : bool;
+  existing_worktree_path : string option;
+}
+
+let gen_inputs : plan_inputs Gen.t =
+  let open Gen in
+  let* local_ref = gen_sha_option in
+  let* remote_ref = gen_sha_option in
+  let* ancestry = gen_ancestry in
+  let* base_branch = gen_branch_name in
+  let* branch_checked_out_in_main_root = bool in
+  let* existing_worktree_path = gen_path_option in
+  return
+    {
+      local_ref;
+      remote_ref;
+      ancestry;
+      base_branch;
+      branch_checked_out_in_main_root;
+      existing_worktree_path;
+    }
+
+let call i =
+  SP.plan ~local_ref:i.local_ref ~remote_ref:i.remote_ref ~ancestry:i.ancestry
+    ~base_branch:i.base_branch
+    ~branch_checked_out_in_main_root:i.branch_checked_out_in_main_root
+    ~existing_worktree_path:i.existing_worktree_path
+
+(* ---------- Properties ---------- *)
+
+let prop_totality =
+  Test.make ~count:500 ~name:"SPP-1: plan is total" gen_inputs (fun i ->
+      try
+        let _ : SP.decision = call i in
+        true
+      with _ -> false)
+
+let prop_no_silent_clobber =
+  Test.make ~count:500
+    ~name:"SPP-2: both refs present + non-Remote-ahead/Equal ancestry → Refuse"
+    Gen.(
+      let* local = gen_sha in
+      let* remote = gen_sha in
+      let* anc = oneof_array [| SP.Local_ahead; SP.Diverged; SP.Unknown |] in
+      let* base_branch = gen_branch_name in
+      return (local, remote, anc, base_branch))
+    (fun (local, remote, anc, base_branch) ->
+      let d =
+        SP.plan ~local_ref:(Some local) ~remote_ref:(Some remote) ~ancestry:anc
+          ~base_branch ~branch_checked_out_in_main_root:false
+          ~existing_worktree_path:None
+      in
+      is_refuse d)
+
+let prop_remote_authoritative =
+  Test.make ~count:500
+    ~name:
+      "SPP-3: both refs + Equal/Remote_ahead → Reset_and_use_remote_tracking"
+    Gen.(
+      let* local = gen_sha in
+      let* remote = gen_sha in
+      let* anc = oneof_array [| SP.Equal; SP.Remote_ahead |] in
+      let* base_branch = gen_branch_name in
+      return (local, remote, anc, base_branch))
+    (fun (local, remote, anc, base_branch) ->
+      let d =
+        SP.plan ~local_ref:(Some local) ~remote_ref:(Some remote) ~ancestry:anc
+          ~base_branch ~branch_checked_out_in_main_root:false
+          ~existing_worktree_path:None
+      in
+      is_reset_to remote d)
+
+let prop_missing_both =
+  Test.make ~count:200
+    ~name:"SPP-4: local=None, remote=None → Create_new_branch_from_base"
+    Gen.(
+      let* base_branch = gen_branch_name in
+      let* anc = gen_ancestry in
+      return (base_branch, anc))
+    (fun (base_branch, anc) ->
+      let d =
+        SP.plan ~local_ref:None ~remote_ref:None ~ancestry:anc ~base_branch
+          ~branch_checked_out_in_main_root:false ~existing_worktree_path:None
+      in
+      is_create_from_base base_branch d)
+
+let prop_determinism =
+  Test.make ~count:500 ~name:"SPP-5: same inputs → same output" gen_inputs
+    (fun i -> SP.equal_decision (call i) (call i))
+
+let prop_preempt_checked_out =
+  Test.make ~count:500
+    ~name:"SPP-6a: branch_checked_out_in_main_root pre-empts everything"
+    gen_inputs (fun i ->
+      let d = call { i with branch_checked_out_in_main_root = true } in
+      SP.equal_decision d (SP.Refuse SP.Branch_checked_out_in_main_root))
+
+let prop_preempt_worktree =
+  Test.make ~count:500
+    ~name:"SPP-6b: existing_worktree_path pre-empts refs/ancestry"
+    Gen.(
+      let* i = gen_inputs in
+      let* p = gen_branch_name in
+      return (i, p))
+    (fun (i, p) ->
+      let d =
+        call
+          {
+            i with
+            branch_checked_out_in_main_root = false;
+            existing_worktree_path = Some p;
+          }
+      in
+      SP.equal_decision d
+        (SP.Refuse (SP.Worktree_already_registered { existing_path = p })))
+
+let label_re = Re.Pcre.re {|^[a-z][a-z0-9_]*$|} |> Re.compile
+
+let prop_label_bounds =
+  Test.make ~count:500 ~name:"SPP-7: short_label non-empty, ≤32, snake_case"
+    gen_inputs (fun i ->
+      let lbl = SP.short_label (call i) in
+      (not (String.is_empty lbl))
+      && String.length lbl <= 32
+      && Re.execp label_re lbl)
+
+let prop_variants_reachable =
+  Test.make ~count:1 ~name:"SPP-8: every decision variant is reachable"
+    (Gen.return ()) (fun () ->
+      let reset =
+        SP.plan ~local_ref:None ~remote_ref:(Some "r") ~ancestry:SP.Unknown
+          ~base_branch:"main" ~branch_checked_out_in_main_root:false
+          ~existing_worktree_path:None
+      in
+      let use_local =
+        SP.plan ~local_ref:(Some "l") ~remote_ref:None ~ancestry:SP.Unknown
+          ~base_branch:"main" ~branch_checked_out_in_main_root:false
+          ~existing_worktree_path:None
+      in
+      let create =
+        SP.plan ~local_ref:None ~remote_ref:None ~ancestry:SP.Unknown
+          ~base_branch:"main" ~branch_checked_out_in_main_root:false
+          ~existing_worktree_path:None
+      in
+      let refuse_diverged =
+        SP.plan ~local_ref:(Some "l") ~remote_ref:(Some "r")
+          ~ancestry:SP.Diverged ~base_branch:"main"
+          ~branch_checked_out_in_main_root:false ~existing_worktree_path:None
+      in
+      let refuse_ahead =
+        SP.plan ~local_ref:(Some "l") ~remote_ref:(Some "r")
+          ~ancestry:SP.Local_ahead ~base_branch:"main"
+          ~branch_checked_out_in_main_root:false ~existing_worktree_path:None
+      in
+      let refuse_checked_out =
+        SP.plan ~local_ref:None ~remote_ref:None ~ancestry:SP.Unknown
+          ~base_branch:"main" ~branch_checked_out_in_main_root:true
+          ~existing_worktree_path:None
+      in
+      let refuse_registered =
+        SP.plan ~local_ref:None ~remote_ref:None ~ancestry:SP.Unknown
+          ~base_branch:"main" ~branch_checked_out_in_main_root:false
+          ~existing_worktree_path:(Some "/tmp/wt")
+      in
+      is_reset_to "r" reset && is_use_local use_local
+      && is_create_from_base "main" create
+      && is_refuse_diverged refuse_diverged
+      && is_refuse_local_ahead refuse_ahead
+      && is_refuse_checked_out refuse_checked_out
+      && is_refuse_registered refuse_registered)
+
+let prop_remote_wins_over_local =
+  Test.make ~count:500
+    ~name:
+      "SPP-9: remote present + non-divergent ancestry → never \
+       Use_local_branch_unchanged"
+    Gen.(
+      let* local = gen_sha in
+      let* remote = gen_sha in
+      let* anc = oneof_array [| SP.Equal; SP.Remote_ahead |] in
+      let* base_branch = gen_branch_name in
+      return (local, remote, anc, base_branch))
+    (fun (local, remote, anc, base_branch) ->
+      let d =
+        SP.plan ~local_ref:(Some local) ~remote_ref:(Some remote) ~ancestry:anc
+          ~base_branch ~branch_checked_out_in_main_root:false
+          ~existing_worktree_path:None
+      in
+      not (is_use_local d))
+
+let () =
+  let runner = QCheck_base_runner.run_tests_main in
+  ignore
+    (runner
+       [
+         prop_totality;
+         prop_no_silent_clobber;
+         prop_remote_authoritative;
+         prop_missing_both;
+         prop_determinism;
+         prop_preempt_checked_out;
+         prop_preempt_worktree;
+         prop_label_bounds;
+         prop_variants_reachable;
+         prop_remote_wins_over_local;
+       ])

--- a/test/test_worktree_start_point_integration.ml
+++ b/test/test_worktree_start_point_integration.ml
@@ -1,0 +1,310 @@
+open Base
+open Onton
+open Onton_core
+
+(** Integration test: drive [Worktree.create] against real git fixtures to cover
+    every {!Start_point_plan} arm.
+
+    Builds two scratch repositories per scenario — an "origin" bare repo and a
+    "managed" clone — populated to produce the precise local/remote-ref state
+    the test scenario needs:
+
+    - "brand new" — neither [refs/heads/<branch>] nor
+      [refs/remotes/origin/<branch>] exists in the managed clone. Expected
+      action: [Create_new_branch_from_base].
+    - "remote ahead of stale local" — local ref exists at the base (the PR #315
+      scenario: stale local left behind on a working clone); remote ref has
+      commits the local one doesn't. Expected action:
+      [Reset_and_use_remote_tracking]; worktree HEAD must equal remote.
+    - "local only" — local branch exists, no remote ref. Expected action:
+      [Use_local_branch_unchanged].
+    - "local diverged" — local has commits remote doesn't, and remote also has
+      commits local doesn't. Expected refusal: [Local_diverged_from_remote].
+    - "local strictly ahead" — local has commits not on remote (no diverge).
+      Expected refusal: [Local_has_unpushed_commits].
+
+    Every git command runs against the real binary; no mocks. *)
+
+let with_temp_dir f =
+  let dir =
+    Stdlib.Filename.concat
+      (Stdlib.Filename.get_temp_dir_name ())
+      (Printf.sprintf "onton-start-point-%d-%d" (Unix.getpid ())
+         (Random.bits ()))
+  in
+  Unix.mkdir dir 0o755;
+  (* Worktree paths derive from $HOME (see [Worktree.worktree_dir]); redirect
+     HOME into the temp dir so the worktree lives inside our sandbox and is
+     wiped by at_exit. Without this, [~/worktrees/<project>/patch-<id>]
+     persists across scenarios and the [Sys.file_exists path] short-circuit
+     in [Worktree.create] returns a stale Ok from a previous run. *)
+  let prior_home = Stdlib.Sys.getenv_opt "HOME" in
+  Unix.putenv "HOME" dir;
+  Stdlib.at_exit (fun () ->
+      (match prior_home with Some h -> Unix.putenv "HOME" h | None -> ());
+      try
+        let _ =
+          Stdlib.Sys.command
+            (Printf.sprintf "rm -rf %s" (Stdlib.Filename.quote dir))
+        in
+        ()
+      with _ -> ());
+  f dir
+
+let sh ?(dir = ".") cmd =
+  let full = Printf.sprintf "cd %s && %s" (Stdlib.Filename.quote dir) cmd in
+  let code = Stdlib.Sys.command full in
+  if code <> 0 then
+    failwith (Printf.sprintf "command failed (exit %d): %s" code full)
+
+let git_capture ?(dir = ".") args =
+  let argstr =
+    String.concat ~sep:" " (List.map ~f:Stdlib.Filename.quote args)
+  in
+  let cmd =
+    Printf.sprintf "cd %s && git %s" (Stdlib.Filename.quote dir) argstr
+  in
+  let ic = Unix.open_process_in cmd in
+  let buf = Buffer.create 128 in
+  (try
+     while true do
+       Stdlib.Buffer.add_channel buf ic 4096
+     done
+   with End_of_file -> ());
+  let _ = Unix.close_process_in ic in
+  String.strip (Buffer.contents buf)
+
+let setup_origin_with_main ~origin_dir =
+  Unix.mkdir origin_dir 0o755;
+  sh ~dir:origin_dir "git init -q --initial-branch=main";
+  sh ~dir:origin_dir "git config user.email 'test@example.com'";
+  sh ~dir:origin_dir "git config user.name 'Test'";
+  sh ~dir:origin_dir "echo base > README.md";
+  sh ~dir:origin_dir "git add README.md";
+  sh ~dir:origin_dir "git commit -q -m 'base'"
+
+let clone_into ~origin_dir ~managed_dir =
+  sh
+    (Printf.sprintf "git clone -q %s %s"
+       (Stdlib.Filename.quote origin_dir)
+       (Stdlib.Filename.quote managed_dir));
+  sh ~dir:managed_dir "git config user.email 'test@example.com'";
+  sh ~dir:managed_dir "git config user.name 'Test'"
+
+let read_worktree_head ~managed_dir =
+  git_capture ~dir:managed_dir [ "rev-parse"; "HEAD" ]
+
+let assert_string label want got =
+  if not (String.equal want got) then
+    failwith (Printf.sprintf "%s: expected %S got %S" label want got)
+
+let assert_true label cond =
+  if not cond then failwith (Printf.sprintf "%s: assertion failed" label)
+
+let scenario_brand_new env =
+  let process_mgr = Eio.Stdenv.process_mgr env in
+  with_temp_dir @@ fun root ->
+  let origin_dir = Stdlib.Filename.concat root "origin" in
+  let managed_dir = Stdlib.Filename.concat root "managed" in
+  setup_origin_with_main ~origin_dir;
+  clone_into ~origin_dir ~managed_dir;
+  (* No "feat" branch anywhere. *)
+  let res =
+    Worktree.create ~process_mgr ~repo_root:managed_dir
+      ~project_name:"brand-new"
+      ~patch_id:(Types.Patch_id.of_string "1")
+      ~branch:(Types.Branch.of_string "feat")
+      ~base_ref:"origin/main"
+  in
+  match res with
+  | Result.Ok wt ->
+      let head = read_worktree_head ~managed_dir:wt.path in
+      let main = git_capture ~dir:managed_dir [ "rev-parse"; "origin/main" ] in
+      assert_string "brand_new: worktree HEAD == origin/main" main head;
+      Stdlib.print_endline "  brand_new: OK"
+  | Result.Error r ->
+      failwith
+        (Printf.sprintf "brand_new: expected Ok, got Error %s"
+           (Start_point_plan.show_refusal r))
+
+let scenario_remote_ahead_of_stale_local env =
+  let process_mgr = Eio.Stdenv.process_mgr env in
+  with_temp_dir @@ fun root ->
+  let origin_dir = Stdlib.Filename.concat root "origin" in
+  let managed_dir = Stdlib.Filename.concat root "managed" in
+  setup_origin_with_main ~origin_dir;
+  (* Origin has the feat branch with extra commits. *)
+  sh ~dir:origin_dir "git checkout -q -b feat";
+  sh ~dir:origin_dir "echo work > work.txt";
+  sh ~dir:origin_dir "git add work.txt";
+  sh ~dir:origin_dir "git commit -q -m 'work'";
+  let remote_feat_sha = git_capture ~dir:origin_dir [ "rev-parse"; "HEAD" ] in
+  sh ~dir:origin_dir "git checkout -q main";
+  clone_into ~origin_dir ~managed_dir;
+  (* Set up the stale local branch — points at main (the PR base), missing
+     the work commit. This mirrors the #315 state. *)
+  let main_sha = git_capture ~dir:managed_dir [ "rev-parse"; "origin/main" ] in
+  sh ~dir:managed_dir
+    (Printf.sprintf "git branch feat %s" (Stdlib.Filename.quote main_sha));
+  (* Verify the precondition: local feat == origin/main, NOT origin/feat. *)
+  let local_feat_pre = git_capture ~dir:managed_dir [ "rev-parse"; "feat" ] in
+  assert_string "precondition: local feat is stale" main_sha local_feat_pre;
+  let res =
+    Worktree.create ~process_mgr ~repo_root:managed_dir
+      ~project_name:"stale-local"
+      ~patch_id:(Types.Patch_id.of_string "2")
+      ~branch:(Types.Branch.of_string "feat")
+      ~base_ref:"origin/main"
+  in
+  match res with
+  | Result.Ok wt ->
+      let head = read_worktree_head ~managed_dir:wt.path in
+      assert_string "stale_local: worktree HEAD == remote feat" remote_feat_sha
+        head;
+      let local_feat_post =
+        git_capture ~dir:managed_dir [ "rev-parse"; "feat" ]
+      in
+      assert_string "stale_local: refs/heads/feat reset to remote"
+        remote_feat_sha local_feat_post;
+      Stdlib.print_endline "  remote_ahead_of_stale_local: OK"
+  | Result.Error r ->
+      failwith
+        (Printf.sprintf "stale_local: expected Ok, got Error %s"
+           (Start_point_plan.show_refusal r))
+
+let scenario_local_only env =
+  let process_mgr = Eio.Stdenv.process_mgr env in
+  with_temp_dir @@ fun root ->
+  let origin_dir = Stdlib.Filename.concat root "origin" in
+  let managed_dir = Stdlib.Filename.concat root "managed" in
+  setup_origin_with_main ~origin_dir;
+  clone_into ~origin_dir ~managed_dir;
+  (* Local branch only — no origin/feat. *)
+  sh ~dir:managed_dir "git checkout -q -b feat origin/main";
+  sh ~dir:managed_dir "echo local > local.txt";
+  sh ~dir:managed_dir "git add local.txt";
+  sh ~dir:managed_dir "git commit -q -m 'local'";
+  let local_feat = git_capture ~dir:managed_dir [ "rev-parse"; "feat" ] in
+  sh ~dir:managed_dir "git checkout -q main";
+  let res =
+    Worktree.create ~process_mgr ~repo_root:managed_dir
+      ~project_name:"local-only"
+      ~patch_id:(Types.Patch_id.of_string "3")
+      ~branch:(Types.Branch.of_string "feat")
+      ~base_ref:"origin/main"
+  in
+  match res with
+  | Result.Ok wt ->
+      let head = read_worktree_head ~managed_dir:wt.path in
+      assert_string "local_only: worktree HEAD == local feat" local_feat head;
+      Stdlib.print_endline "  local_only: OK"
+  | Result.Error r ->
+      failwith
+        (Printf.sprintf "local_only: expected Ok, got Error %s"
+           (Start_point_plan.show_refusal r))
+
+let scenario_diverged env =
+  let process_mgr = Eio.Stdenv.process_mgr env in
+  with_temp_dir @@ fun root ->
+  let origin_dir = Stdlib.Filename.concat root "origin" in
+  let managed_dir = Stdlib.Filename.concat root "managed" in
+  setup_origin_with_main ~origin_dir;
+  sh ~dir:origin_dir "git checkout -q -b feat";
+  sh ~dir:origin_dir "echo r > r.txt";
+  sh ~dir:origin_dir "git add r.txt";
+  sh ~dir:origin_dir "git commit -q -m 'remote commit'";
+  sh ~dir:origin_dir "git checkout -q main";
+  clone_into ~origin_dir ~managed_dir;
+  (* Build a diverged local: branch off main, commit something different. *)
+  sh ~dir:managed_dir "git checkout -q -b feat origin/main";
+  sh ~dir:managed_dir "echo l > l.txt";
+  sh ~dir:managed_dir "git add l.txt";
+  sh ~dir:managed_dir "git commit -q -m 'local commit'";
+  sh ~dir:managed_dir "git checkout -q main";
+  let res =
+    Worktree.create ~process_mgr ~repo_root:managed_dir ~project_name:"diverged"
+      ~patch_id:(Types.Patch_id.of_string "4")
+      ~branch:(Types.Branch.of_string "feat")
+      ~base_ref:"origin/main"
+  in
+  match res with
+  | Result.Ok _ -> failwith "diverged: expected Error refusal, got Ok"
+  | Result.Error r -> (
+      match r with
+      | Start_point_plan.Local_diverged_from_remote _ ->
+          Stdlib.print_endline "  diverged: OK (refused)"
+      | Start_point_plan.Local_has_unpushed_commits _
+      | Start_point_plan.Branch_checked_out_in_main_root
+      | Start_point_plan.Worktree_already_registered _ ->
+          failwith
+            (Printf.sprintf
+               "diverged: expected Local_diverged_from_remote, got %s"
+               (Start_point_plan.show_refusal r)))
+
+let scenario_local_strictly_ahead env =
+  let process_mgr = Eio.Stdenv.process_mgr env in
+  with_temp_dir @@ fun root ->
+  let origin_dir = Stdlib.Filename.concat root "origin" in
+  let managed_dir = Stdlib.Filename.concat root "managed" in
+  setup_origin_with_main ~origin_dir;
+  sh ~dir:origin_dir "git checkout -q -b feat";
+  sh ~dir:origin_dir "echo r > r.txt";
+  sh ~dir:origin_dir "git add r.txt";
+  sh ~dir:origin_dir "git commit -q -m 'shared commit'";
+  let shared_sha = git_capture ~dir:origin_dir [ "rev-parse"; "HEAD" ] in
+  sh ~dir:origin_dir "git checkout -q main";
+  clone_into ~origin_dir ~managed_dir;
+  (* Build a local that strictly contains origin/feat plus extra commits. *)
+  sh ~dir:managed_dir
+    (Printf.sprintf "git checkout -q -b feat %s"
+       (Stdlib.Filename.quote shared_sha));
+  sh ~dir:managed_dir "echo extra > extra.txt";
+  sh ~dir:managed_dir "git add extra.txt";
+  sh ~dir:managed_dir "git commit -q -m 'local extra'";
+  sh ~dir:managed_dir "git checkout -q main";
+  (* Sanity-check the precondition: local-ahead, not diverged. *)
+  let local = git_capture ~dir:managed_dir [ "rev-parse"; "feat" ] in
+  let remote = git_capture ~dir:managed_dir [ "rev-parse"; "origin/feat" ] in
+  let is_remote_ancestor_of_local =
+    let cmd =
+      Printf.sprintf "cd %s && git merge-base --is-ancestor %s %s"
+        (Stdlib.Filename.quote managed_dir)
+        (Stdlib.Filename.quote remote)
+        (Stdlib.Filename.quote local)
+    in
+    Stdlib.Sys.command cmd = 0
+  in
+  assert_true "precondition: remote is ancestor of local"
+    is_remote_ancestor_of_local;
+  let res =
+    Worktree.create ~process_mgr ~repo_root:managed_dir
+      ~project_name:"local-ahead"
+      ~patch_id:(Types.Patch_id.of_string "5")
+      ~branch:(Types.Branch.of_string "feat")
+      ~base_ref:"origin/main"
+  in
+  match res with
+  | Result.Ok _ ->
+      failwith "local_strictly_ahead: expected Error refusal, got Ok"
+  | Result.Error r -> (
+      match r with
+      | Start_point_plan.Local_has_unpushed_commits _ ->
+          Stdlib.print_endline "  local_strictly_ahead: OK (refused)"
+      | Start_point_plan.Local_diverged_from_remote _
+      | Start_point_plan.Branch_checked_out_in_main_root
+      | Start_point_plan.Worktree_already_registered _ ->
+          failwith
+            (Printf.sprintf
+               "local_strictly_ahead: expected Local_has_unpushed_commits, got \
+                %s"
+               (Start_point_plan.show_refusal r)))
+
+let () =
+  Eio_main.run @@ fun env ->
+  Stdlib.print_endline "Worktree.create + Start_point_plan integration:";
+  scenario_brand_new env;
+  scenario_remote_ahead_of_stale_local env;
+  scenario_local_only env;
+  scenario_diverged env;
+  scenario_local_strictly_ahead env;
+  Stdlib.print_endline "All start-point integration scenarios passed."


### PR DESCRIPTION
## Summary

Three-patch fix for the bug class that caused PR #315 to be force-pushed empty and auto-closed by GitHub. Each commit is independently shippable and adds its own pure decision module + property tests.

- **`Add --force-if-includes to session-end force-push`** (one-line) — the smallest possible safety lever. `--force-with-lease` alone passes whenever the local tracking ref matches actual remote, even when local is strictly behind on real content; `--force-if-includes` additionally requires the remote tip in the local branch's reflog, refusing pushes that would silently wipe commits the local clone never observed.
- **`Plan worktree start point against fresh remote refs`** — new `lib_core/start_point_plan.ml` (pure) plus `Worktree_setup.ensure_worktree` fetch-before-create. `Worktree.create` no longer trusts the user's local `refs/heads/<branch>` when it's stale; the planner returns `Reset_and_use_remote_tracking` / `Use_local_branch_unchanged` / `Create_new_branch_from_base` or one of four refusal variants. Signature changes to `(t, refusal) Result.t`. Property tests SPP-1..9 (totality, no-silent-clobber, remote-authority, pre-emption order, determinism, label bounds, exhaustive variant reachability) plus a real-git integration test reproducing the exact #315 stale-local state.
- **`Plan pushes against worktree state, not just lease`** — new `lib_core/push_plan.ml` (pure) plus an extension to `Push_reject_classify.rejection` (new `Local_state_unsafe` variant, permanent). The planner takes worktree-HEAD-branch, branch-ref SHA, remote tracking SHA, two-way ancestry, and `base..refs/heads/<branch>` commits-ahead (the *named branch*, not HEAD) and returns either a push action or one of five refusal variants. `Worktree.force_push_with_lease` now consults it before invoking git; refusals route through the existing `is_permanent` → `needs_intervention` path. Property tests PPP-1..11 plus a real-git integration test covering branch-switched, local-missing-remote, and happy-path scenarios.

The architecture mirrors the existing `Push_reject_classify` / `Rebase_decision` / `Patch_decision` convention: pure decision logic in `lib_core/`, effectful handlers in `lib/`, one property-test file per pure module.

## Test plan

- [ ] `dune build` clean
- [ ] `dune runtest` passes (full suite, including the new SPP-* and PPP-* property tests and two new real-git integration tests)
- [ ] `dune fmt` produces no diff
- [ ] Manual repro: in a scratch clone, set `refs/heads/<branch>` to the PR base (stale local), then start onton against that PR — confirm the activity log shows the fetch-then-reset path and the worktree HEAD matches the PR head, not the stale local ref
- [ ] Manual repro: hand-corrupt a worktree so a session-end push would force-overwrite remote, confirm `Push_refused` with `refuse_local_behind` / `refuse_branch_switched` rather than a `git push` reaching the remote

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/318"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782232401&installation_id=126163856&pr_number=318&repository=flowglad%2Fonton&return_to=https%3A%2F%2Fgithub.com%2Fflowglad%2Fonton%2Fpull%2F318&signature=c0e969c0219c6ebaf6ec6ea924af212eccec9e512667efb7f501704c2213acb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened worktree creation and push safety to prevent silent branch wipes like PR #315. Adds pure planners for start-point and push, uses `--force-if-includes`, and permanently refuses unsafe local states before any git runs.

- **Bug Fixes**
  - Use `--force-with-lease` + `--force-if-includes` to block pushes that would drop unseen remote commits.
  - Plan worktree start from fresh remote refs; reset to `origin/<branch>` when local is stale, create from base if new, and refuse local-ahead/diverged. `Worktree_setup` maps refusals to permanent `Local_state_unsafe`.
  - Plan pushes against the named branch and actual worktree state; refuse if branch switched, missing refs, or local behind/diverged, and map refusals to permanent `Local_state_unsafe`.
  - Treat `Worktree_setup.Refused` distinctly from `Missing` across callers to avoid ambiguous failures and escalate permanently.

- **Migration**
  - `Worktree.create` now returns `(t, Start_point_plan.refusal) Result.t`.
  - `Worktree_setup.ensure_worktree` now returns `Worktree_setup.ensure_result` (`Path` | `Missing` | `Refused`).
  - `Worktree.S` adds `fetch_origin_branch`; `Worktree_setup.ensure_worktree` calls it before `create`.
  - `Push_reject_classify.rejection` adds `Local_state_unsafe` (permanent).
  - Requires Git ≥ 2.30 for `--force-if-includes`.

<sup>Written for commit 593c5e5dfd32b016403ce6b2d05892b718bbe5c3. Summary will update on new commits. <a href="https://cubic.dev/pr/flowglad/onton/pull/318?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deterministic planners to validate worktree creation and push decisions, and safer push execution paths that classify outcomes.

* **API Changes**
  * Worktree creation now surfaces structured refusal results instead of only success.
  * Fetch-by-branch added to the public interface.

* **Tests**
  * Added extensive property-based and integration tests covering start-point and push planning, rejection classifications, and end-to-end flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flowglad/onton/pull/318?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->