### PR TITLE
Reliable stacked-PR rebase anchors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,54 @@ unattended supervisor session. There are two supported transports:
   authenticated for HTTPS pushes to github.com, run `gh auth setup-git` once
   to install gh's credential helper into your global git config.
 
+## Rebase anchor lifecycle
+
+A patch agent's rebase upstream is chosen by `lib_core/rebase_decision.ml`'s
+`plan` from the agent's `anchor_history` (newest-first list of
+`Anchor.t = { base; sha; observed_at_remote }`, cap 8, in `lib_core/`).
+
+Anchors get recorded at three moments by `lib/runner_fiber_impl.ml`,
+mediated by `Worktree_plan` capture/record ops the executor interprets:
+
+- **Start** — `Worktree_plan.for_start` runs after the worktree is created
+  and before the LLM session begins. It fetches origin, reads
+  `origin/<base_branch>`'s tip, and records that SHA as the agent's
+  initial anchor via `Orchestrator.apply_anchor_events`. Closes the
+  production-bug case where a patch branched off a dep and never rebased
+  before the dep squash-merged.
+- **Rebase (Ok / Noop)** — `Worktree_plan.for_rebase` captures
+  `origin/<new_base>` post-fetch and a `Record_anchor_on_success` op
+  emits the anchor event after the rebase succeeds. `Noop` refreshes the
+  anchor too — a noop proves local HEAD already contains the remote tip.
+- **Merge-conflict resolution (Ok / Noop)** — `for_merge_conflict` mirrors
+  the rebase plan; a successful conflict rebase also refreshes the
+  anchor.
+
+`Conflict` and `Error` rebase results preserve the prior anchor unchanged
+(via `Rebase_decision.anchor_after_result`); a failed attempt never
+corrupts what was recorded.
+
+At rebase time the executor calls `Rebase_decision.plan` with the agent's
+`anchor_history` and an `is_ancestor` oracle (`git merge-base
+--is-ancestor` via `Worktree.S.is_ancestor`). The plan picks the newest
+anchor whose SHA is reachable from the patch's HEAD; if none is
+reachable it falls back to history, then to `Plain { No_anchor }` which
+runs the legacy 2-arg `git rebase <target>`. The cherry-pick / patch-id
+detection inside `Worktree.rebase_onto` (`find_old_base`) remains as
+defense-in-depth: it tries first; the planner's chosen `upstream` is
+used only on its fallback path.
+
+`Orchestrator.refresh_base_branch` deliberately does NOT invalidate the
+anchor when the base retargets — the planner handles staleness via its
+ancestor oracle at rebase time, and touching `branch_rebased_onto` here
+would hide the drift the detector exists to surface (see PI-16 in
+`test_interleaving_properties.ml`).
+
+The pure decision is covered by `test/test_rebase_decision_properties.ml`
+(RD-PLAN-1..8, RD-AAR-1..5) plus `test/test_anchor.ml`. Realistic event
+sequences are covered by `test/test_rebase_state_machine.ml` (SM-1, SM-2
+= production bug, SM-3a/b, SM-4, SM-7, SM-8, SM-no-anchor).
+
 ## Reference
 - Reference implementation (Elixir): `../orchestrate-gameplan/`
 - Reference specification: `../orchestrate-gameplan/spec/anton.pant`

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -570,6 +570,8 @@ let apply_conflict_rebase_with_anchor t patch_id rebase_result new_base
   let t = fold_anchor_events t patch_id anchor_events in
   (t, decision, effects)
 
+let apply_anchor_events t patch_id events = fold_anchor_events t patch_id events
+
 type conflict_resolution =
   | Conflict_done
   | Conflict_retry_push

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -562,6 +562,14 @@ let apply_conflict_rebase_result t patch_id rebase_result new_base =
       let t = complete t patch_id in
       (t, Conflict_failed, [])
 
+let apply_conflict_rebase_with_anchor t patch_id rebase_result new_base
+    anchor_events =
+  let t, decision, effects =
+    apply_conflict_rebase_result t patch_id rebase_result new_base
+  in
+  let t = fold_anchor_events t patch_id anchor_events in
+  (t, decision, effects)
+
 type conflict_resolution =
   | Conflict_done
   | Conflict_retry_push

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -109,6 +109,15 @@ let refresh_base_branch t patch_id =
           Graph.initial_base t.graph patch_id ~has_merged ~branch_of
             ~main:t.main_branch
         in
+        (* Intentionally do NOT touch branch_rebased_onto here, even when
+           [fresh] differs from the current base. branch_rebased_onto
+           tracks where the local branch was LAST REBASED — clearing it
+           would hide the drift the detector exists to surface. The
+           rebase planner reads [anchor_history] directly and uses an
+           [is_ancestor] oracle at rebase time to decide whether the
+           recorded anchor is still safe for the new base; orchestrator-
+           level invalidation would be redundant and would also break
+           drift detection (PI-16). *)
         update_agent t patch_id ~f:(fun a ->
             Patch_agent.set_base_branch a fresh)
 

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -482,6 +482,18 @@ let apply_rebase_result t patch_id rebase_result new_base =
       let t = set_tried_fresh t patch_id in
       (complete t patch_id, [])
 
+let fold_anchor_events t patch_id events =
+  List.fold events ~init:t ~f:(fun t (ev : Worktree_plan.anchor_event) ->
+      match ev with
+      | Worktree_plan.Anchor_recorded a ->
+          update_agent t patch_id ~f:(fun ag -> Patch_agent.record_anchor ag a)
+      | Worktree_plan.Anchor_capture_failed -> t)
+
+let apply_rebase_with_anchor t patch_id rebase_result new_base anchor_events =
+  let t, effects = apply_rebase_result t patch_id rebase_result new_base in
+  let t = fold_anchor_events t patch_id anchor_events in
+  (t, effects)
+
 type rebase_push_resolution =
   | Rebase_push_ok
   | Rebase_push_failed

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -352,6 +352,18 @@ val apply_conflict_rebase_result :
     [Conflict] -> set_has_conflict + [Deliver_to_agent] + [[]]. [Error _] ->
     set_session_failed + complete + [Conflict_failed]. *)
 
+val apply_conflict_rebase_with_anchor :
+  t ->
+  Patch_id.t ->
+  Worktree.rebase_result ->
+  Branch.t ->
+  Worktree_plan.anchor_event list ->
+  t * conflict_rebase_decision * rebase_effect list
+(** Atomic variant of {!apply_conflict_rebase_result} that also folds
+    {!Worktree_plan.anchor_event} observations into the agent. Same policy as
+    {!apply_rebase_with_anchor}: [Anchor_recorded] calls
+    {!Patch_agent.record_anchor}; [Anchor_capture_failed] is ignored. *)
+
 type conflict_resolution =
   | Conflict_done
   | Conflict_retry_push

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -298,6 +298,21 @@ val apply_rebase_result :
     -> set_base_branch + set_has_conflict + enqueue Merge_conflict + complete.
     [Error _] -> set_session_failed + set_tried_fresh + complete. *)
 
+val apply_rebase_with_anchor :
+  t ->
+  Patch_id.t ->
+  Worktree.rebase_result ->
+  Branch.t ->
+  Worktree_plan.anchor_event list ->
+  t * rebase_effect list
+(** Atomic variant of {!apply_rebase_result} that also folds the executor's
+    {!Worktree_plan.anchor_event} observations into the agent. The two
+    transitions are combined so the orchestrator can never observe a half-
+    applied state where (say) the rebase succeeded but the anchor was not
+    recorded. Each [Anchor_recorded] event calls {!Patch_agent.record_anchor};
+    [Anchor_capture_failed] events are ignored (the prior anchor is preserved).
+*)
+
 type rebase_push_resolution =
   | Rebase_push_ok
   | Rebase_push_failed

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -364,6 +364,13 @@ val apply_conflict_rebase_with_anchor :
     {!apply_rebase_with_anchor}: [Anchor_recorded] calls
     {!Patch_agent.record_anchor}; [Anchor_capture_failed] is ignored. *)
 
+val apply_anchor_events :
+  t -> Patch_id.t -> Worktree_plan.anchor_event list -> t
+(** Fold {!Worktree_plan.anchor_event} observations into the agent without any
+    other transition. Called by the runner Start path after executing
+    {!Worktree_plan.for_start} to record the initial anchor for a
+    freshly-branched-off-dep patch, before the LLM session begins. *)
+
 type conflict_resolution =
   | Conflict_done
   | Conflict_retry_push

--- a/lib/persistence.ml
+++ b/lib/persistence.ml
@@ -168,6 +168,7 @@ let patch_agent_to_yojson (a : Patch_agent.t) =
         match a.branch_rebased_onto_sha with
         | None -> `Null
         | Some s -> `String s );
+      ("anchor_history", Anchor_history.yojson_of_t a.anchor_history);
       ("checks_passing", `Bool a.checks_passing);
       ( "current_op",
         match a.current_op with
@@ -298,6 +299,13 @@ let patch_agent_of_yojson ~gameplan json =
          (Option.value (int_member_opt "push_failure_count" json) ~default:0)
        ~branch_rebased_onto_sha:
          (string_member_opt "branch_rebased_onto_sha" json)
+       ~anchor_history:
+         (match Yojson.Safe.Util.member "anchor_history" json with
+         | `Null -> Anchor_history.empty
+         | v -> (
+             match Anchor_history.of_yojson_opt v with
+             | Some h -> h
+             | None -> Anchor_history.empty))
        ~branch_rebased_onto:
          (match string_member_opt "branch_rebased_onto" json with
          | Some s -> Some (Branch.of_string s)
@@ -764,12 +772,12 @@ let%test_module "session_id_sidecars" =
           ~start_attempts_without_pr:0 ~conflict_noop_count:0
           ~no_commits_push_count:0 ~push_failure_count:0
           ~branch_rebased_onto:None ~branch_rebased_onto_sha:None
-          ~checks_passing:false ~current_op:None
-          ~current_op_state:Patch_agent.Queued ~current_message_id:None
-          ~generation:0 ~worktree_path:None ~branch_blocked:false
-          ~llm_session_id ~automerge_enabled:false ~automerge_deadline:None
-          ~automerge_inflight:false ~automerge_failure_count:0
-          ~delivered_ci_run_ids:[]
+          ~anchor_history:Anchor_history.empty ~checks_passing:false
+          ~current_op:None ~current_op_state:Patch_agent.Queued
+          ~current_message_id:None ~generation:0 ~worktree_path:None
+          ~branch_blocked:false ~llm_session_id ~automerge_enabled:false
+          ~automerge_deadline:None ~automerge_inflight:false
+          ~automerge_failure_count:0 ~delivered_ci_run_ids:[]
       in
       let orch =
         Orchestrator.restore

--- a/lib/runner_fiber_impl.ml
+++ b/lib/runner_fiber_impl.ml
@@ -1300,7 +1300,9 @@ struct
                                      target origin/<base> so we rebase
                                      against fresh refs, not the stale
                                      local tracking ref. *)
-                                        let rebase_result, _wt_path, _evs =
+                                        let ( rebase_result,
+                                              _wt_path,
+                                              anchor_events ) =
                                           Worktree_plan_executor.execute
                                             ~patch_id ~agent
                                             ~fetch_lock:fetch_mutex
@@ -1348,9 +1350,10 @@ struct
                                               in
                                               let orch, decision, effects =
                                                 Orchestrator
-                                                .apply_conflict_rebase_result
+                                                .apply_conflict_rebase_with_anchor
                                                   orch patch_id rebase_result
                                                   (Types.Branch.of_string base)
+                                                  anchor_events
                                               in
                                               let agent_after =
                                                 Orchestrator.agent orch patch_id

--- a/lib/runner_fiber_impl.ml
+++ b/lib/runner_fiber_impl.ml
@@ -895,25 +895,11 @@ struct
                                 (Orchestrator.graph snap.Runtime.orchestrator)
                                 patch_id)
                         in
-                        let rebase_result, wt_path, _anchor_events =
+                        let rebase_result, wt_path, anchor_events =
                           Worktree_plan_executor.execute ~patch_id ~agent
                             ~fetch_lock:fetch_mutex ~fail_label:"rebase"
                             ~ancestor_ids
                             (Worktree_plan.for_rebase ~new_base)
-                        in
-                        (* On a successful rebase, capture the SHA the new
-                           base resolved to so the next rebase can pass it
-                           as [prev_base_sha] and trim commits absorbed into
-                           a squash-merge on origin. Records via
-                           [Orchestrator.set_branch_rebased_onto_sha]. *)
-                        let post_rebase_sha =
-                          match rebase_result with
-                          | Worktree.Ok ->
-                              W.read_branch_sha ~path:wt_path
-                                ~ref_name:("origin/" ^ Branch.to_string new_base)
-                          | Worktree.Noop | Worktree.Conflict _
-                          | Worktree.Error _ ->
-                              None
                         in
                         (match rebase_result with
                         | Worktree.Ok ->
@@ -936,15 +922,8 @@ struct
                                 Orchestrator.agent orch patch_id
                               in
                               let orch, effects =
-                                Orchestrator.apply_rebase_result orch patch_id
-                                  rebase_result new_base
-                              in
-                              let orch =
-                                match post_rebase_sha with
-                                | Some _ ->
-                                    Orchestrator.set_branch_rebased_onto_sha
-                                      orch patch_id post_rebase_sha
-                                | None -> orch
+                                Orchestrator.apply_rebase_with_anchor orch
+                                  patch_id rebase_result new_base anchor_events
                               in
                               let agent_after =
                                 Orchestrator.agent orch patch_id

--- a/lib/runner_fiber_impl.ml
+++ b/lib/runner_fiber_impl.ml
@@ -673,6 +673,40 @@ struct
                                               .Session_worktree_missing);
                                         `Failed
                                     | Some _wt_path ->
+                                        (* Capture the initial anchor for this
+                                           Start: resolve origin/<base_branch>'s
+                                           current tip so the first rebase has
+                                           a usable [<upstream>] for [git rebase
+                                           --onto]. Closes the production-bug
+                                           blind spot where a Start-then-dep-
+                                           squash-merge sequence left the agent
+                                           with no anchor at first-rebase time
+                                           and forced the legacy 2-arg fallback
+                                           into a "both added" conflict. *)
+                                        let ancestor_ids =
+                                          Runtime.read runtime (fun snap ->
+                                              Graph.transitive_ancestors
+                                                (Orchestrator.graph
+                                                   snap.Runtime.orchestrator)
+                                                patch_id)
+                                        in
+                                        let _, _, start_anchor_events =
+                                          Worktree_plan_executor.execute
+                                            ~patch_id ~agent
+                                            ~fetch_lock:fetch_mutex
+                                            ~fail_label:"start anchor capture"
+                                            ~ancestor_ids
+                                            (Worktree_plan.for_start
+                                               ~base:base_branch)
+                                        in
+                                        (match start_anchor_events with
+                                        | [] -> ()
+                                        | _ ->
+                                            Runtime.update_orchestrator runtime
+                                              (fun orch ->
+                                                Orchestrator.apply_anchor_events
+                                                  orch patch_id
+                                                  start_anchor_events));
                                         let agents_md =
                                           read_optional_file
                                             (Stdlib.Filename.concat _wt_path

--- a/lib/runner_fiber_impl.ml
+++ b/lib/runner_fiber_impl.ml
@@ -895,7 +895,7 @@ struct
                                 (Orchestrator.graph snap.Runtime.orchestrator)
                                 patch_id)
                         in
-                        let rebase_result, wt_path =
+                        let rebase_result, wt_path, _anchor_events =
                           Worktree_plan_executor.execute ~patch_id ~agent
                             ~fetch_lock:fetch_mutex ~fail_label:"rebase"
                             ~ancestor_ids
@@ -1321,7 +1321,7 @@ struct
                                      target origin/<base> so we rebase
                                      against fresh refs, not the stale
                                      local tracking ref. *)
-                                        let rebase_result, _wt_path =
+                                        let rebase_result, _wt_path, _evs =
                                           Worktree_plan_executor.execute
                                             ~patch_id ~agent
                                             ~fetch_lock:fetch_mutex

--- a/lib/worktree.ml
+++ b/lib/worktree.ml
@@ -425,8 +425,15 @@ let read_branch_sha ~process_mgr ~path ~ref_name =
     if String.is_empty s then None else Some s
   else None
 
-let rebase_onto ?(prev_base_sha = None) ~process_mgr ~path ~target ~project_name
-    ~ancestor_ids () =
+let is_ancestor ~process_mgr ~path ~ancestor ~descendant =
+  let code, _, _ =
+    run_git_exit_code ~process_mgr
+      [ "git"; "-C"; path; "merge-base"; "--is-ancestor"; ancestor; descendant ]
+  in
+  code = 0
+
+let rebase_onto ~upstream ~process_mgr ~path ~target ~project_name ~ancestor_ids
+    () =
   let target = Types.Branch.to_string target in
   let ancestor_code, _, ancestor_stderr =
     run_git_exit_code ~process_mgr
@@ -455,19 +462,13 @@ let rebase_onto ?(prev_base_sha = None) ~process_mgr ~path ~target ~project_name
       find_old_base ~process_mgr ~path ~target ~project_name ~ancestor_ids
     with
     | Result.Error msg ->
-        (* If we can't find unique commits, decide what upstream to pass to
-           [git rebase]:
-           - [prev_base_sha = Some sha]: do [git rebase --onto target sha]. This
-             is the patch-6 case — the orchestrator recorded the SHA the
-             previous base resolved to, and the patch's own commits live in
-             [sha..HEAD]. Drops squash-merged-equivalent dep commits.
-           - [None]: legacy plain [git rebase target] — replays everything in
-             [target..HEAD] including possibly-stale dep commits, preserved
-             for back-compat with agents whose [branch_rebased_onto_sha] was
-             never recorded. *)
-        let upstream =
-          Rebase_decision.upstream ~prev_base_sha ~fallback:target
-        in
+        (* The cherry-pick / patch-id detection in [find_old_base] failed,
+           so use the caller-supplied [upstream] (computed by the executor
+           via [Rebase_decision.plan] from the agent's anchor history). If
+           [upstream] equals [target], no usable anchor exists and we fall
+           back to the 2-arg form; otherwise [git rebase --onto target
+           upstream HEAD] replays exactly the patch's own commits past
+           [upstream]. *)
         let rebase_args =
           if String.equal upstream target then
             [ "git"; "-C"; path; "rebase"; target ]
@@ -727,9 +728,9 @@ module type S = sig
   val conflict_diff : path:string -> string
 
   val rebase_onto :
-    ?prev_base_sha:string option ->
     path:string ->
     target:Types.Branch.t ->
+    upstream:string ->
     project_name:string ->
     ancestor_ids:Types.Patch_id.t list ->
     unit ->
@@ -737,8 +738,9 @@ module type S = sig
 
   val read_branch_sha : path:string -> ref_name:string -> string option
   (** Resolve [ref_name] to a SHA in the worktree at [path]. [None] on any error
-      (missing ref, git failure). Used by the runner fiber to capture
-      [branch_rebased_onto_sha] after a successful rebase. *)
+      (missing ref, git failure). *)
+
+  val is_ancestor : path:string -> ancestor:string -> descendant:string -> bool
 
   val read_in_progress_conflict_info :
     path:string ->
@@ -783,13 +785,15 @@ let make ~process_mgr ~repo_root =
     let git_status ~path = git_status ~process_mgr ~path
     let conflict_diff ~path = conflict_diff ~process_mgr ~path
 
-    let rebase_onto ?(prev_base_sha = None) ~path ~target ~project_name
-        ~ancestor_ids () =
-      rebase_onto ~prev_base_sha ~process_mgr ~path ~target ~project_name
+    let rebase_onto ~path ~target ~upstream ~project_name ~ancestor_ids () =
+      rebase_onto ~upstream ~process_mgr ~path ~target ~project_name
         ~ancestor_ids ()
 
     let read_branch_sha ~path ~ref_name =
       read_branch_sha ~process_mgr ~path ~ref_name
+
+    let is_ancestor ~path ~ancestor ~descendant =
+      is_ancestor ~process_mgr ~path ~ancestor ~descendant
 
     let read_in_progress_conflict_info ~path ~target ~project_name ~ancestor_ids
         =

--- a/lib/worktree.mli
+++ b/lib/worktree.mli
@@ -175,7 +175,7 @@ type rebase_result = Worktree_parser.rebase_result =
 [@@deriving show, eq, sexp_of, compare]
 
 val rebase_onto :
-  ?prev_base_sha:string option ->
+  upstream:string ->
   process_mgr:_ Eio.Process.mgr ->
   path:string ->
   target:Types.Branch.t ->
@@ -183,13 +183,11 @@ val rebase_onto :
   ancestor_ids:Types.Patch_id.t list ->
   unit ->
   rebase_result
-(** Rebase HEAD onto [target]. [?prev_base_sha] (default [None]) is the SHA the
-    previous base ref resolved to at the last successful rebase / start (see
-    [Patch_agent.branch_rebased_onto_sha]). When [Some sha] is supplied and the
-    cherry-pick / subject-pattern heuristic fails to isolate the patch's
-    commits, the rebase uses [git rebase --onto target sha] instead of the
-    legacy plain [git rebase target], dropping commits whose content was
-    absorbed into a squash-merge on origin (the patch-6 case).
+(** Rebase HEAD onto [target]. [upstream] is the resolved [<upstream>] argument
+    for [git rebase --onto <target> <upstream> HEAD], computed by the caller via
+    {!Rebase_decision.plan} from the agent's anchor history. If [upstream]
+    equals the rendered [target], the legacy 2-arg [git rebase <target>] form is
+    used instead.
 
     Uses [git log --cherry-pick] to detect already-applied commits, and
     supplements that with subject-pattern matching against
@@ -313,15 +311,27 @@ module type S = sig
   val conflict_diff : path:string -> string
 
   val rebase_onto :
-    ?prev_base_sha:string option ->
     path:string ->
     target:Types.Branch.t ->
+    upstream:string ->
     project_name:string ->
     ancestor_ids:Types.Patch_id.t list ->
     unit ->
     rebase_result
+  (** [upstream] is the resolved [<upstream>] argument for
+      [git rebase --onto <target> <upstream> HEAD]. It is computed by the caller
+      from {!Rebase_decision.plan} (which consults the agent's
+      {!Anchor_history.t}). If [upstream] equals [target]'s rendered string, the
+      2-arg [git rebase <target>] form is used instead. *)
 
   val read_branch_sha : path:string -> ref_name:string -> string option
+
+  val is_ancestor : path:string -> ancestor:string -> descendant:string -> bool
+  (** [is_ancestor ~path ~ancestor ~descendant] returns [true] iff [ancestor] is
+      an ancestor of [descendant] in the repo at [path], via
+      [git merge-base --is-ancestor]. Returns [false] on any error (including
+      unresolvable SHAs), so callers can treat it as a total
+      pure-from-the-outside oracle. *)
 
   val read_in_progress_conflict_info :
     path:string ->

--- a/lib/worktree_plan_executor.ml
+++ b/lib/worktree_plan_executor.ml
@@ -70,7 +70,13 @@ module Make (W : Worktree.S) (Env : Run_env.S) : S = struct
               recorded_history =
                 Anchor_history.to_list (Patch_agent.anchor_history agent);
               base_branch =
-                Base.Option.value agent.Patch_agent.base_branch ~default:target;
+                Base.Option.value agent.Patch_agent.base_branch
+                  ~default:
+                    (let target_s = Types.Branch.to_string target in
+                     Types.Branch.of_string
+                       (Base.Option.value
+                          (Base.String.chop_prefix target_s ~prefix:"origin/")
+                          ~default:target_s));
               head_sha;
             }
           in

--- a/lib/worktree_plan_executor.ml
+++ b/lib/worktree_plan_executor.ml
@@ -87,7 +87,7 @@ module Make (W : Worktree.S) (Env : Run_env.S) : S = struct
           let upstream =
             match plan with
             | Rebase_decision.Onto { upstream; _ } -> upstream
-            | Rebase_decision.Plain { target; _ } -> target
+            | Rebase_decision.Plain _ -> Types.Branch.to_string target
           in
           match
             W.rebase_onto ~path ~target ~upstream ~project_name:Env.project_name

--- a/lib/worktree_plan_executor.ml
+++ b/lib/worktree_plan_executor.ml
@@ -6,7 +6,7 @@ module type S = sig
     fail_label:string ->
     ancestor_ids:Types.Patch_id.t list ->
     Worktree_plan.t ->
-    Worktree.rebase_result * string
+    Worktree.rebase_result * string * Worktree_plan.anchor_event list
 end
 
 module Make (W : Worktree.S) (Env : Run_env.S) : S = struct
@@ -17,11 +17,23 @@ module Make (W : Worktree.S) (Env : Run_env.S) : S = struct
     let default_path =
       Worktree.worktree_dir ~project_name:Env.project_name ~patch_id
     in
-    let rec loop ~path = function
-      | [] -> (Worktree.Ok, path)
+    (* Slot table for [Capture_anchor] -> [Record_anchor_on_success]
+       handoff. Slots are sparse, so a small association list is plenty. *)
+    let slots : (int * string option) list ref = ref [] in
+    let set_slot k v =
+      slots :=
+        (k, v)
+        :: Base.List.filter !slots ~f:(fun (k', _) -> not (Base.Int.equal k k'))
+    in
+    let get_slot k =
+      Base.List.Assoc.find !slots ~equal:Base.Int.equal k
+      |> Base.Option.bind ~f:(fun x -> x)
+    in
+    let rec loop ~path ~last_rebase ~events = function
+      | [] -> (last_rebase, path, Base.List.rev events)
       | Worktree_plan.Ensure_worktree :: rest -> (
           match WS.ensure_worktree ~patch_id ~agent () with
-          | Some p -> loop ~path:p rest
+          | Some p -> loop ~path:p ~last_rebase ~events rest
           | None ->
               Runtime_logging.log_event Env.runtime ~patch_id
                 (Printf.sprintf
@@ -29,25 +41,45 @@ module Make (W : Worktree.S) (Env : Run_env.S) : S = struct
                    fail_label);
               ( Worktree.Error
                   (Printf.sprintf "%s failed: worktree missing" fail_label),
-                path ))
+                path,
+                Base.List.rev events ))
       | Worktree_plan.Fetch_origin :: rest -> (
           match W.fetch_origin ~fetch_lock ~path with
-          | Result.Ok () -> loop ~path rest
+          | Result.Ok () -> loop ~path ~last_rebase ~events rest
           | Result.Error msg ->
               Runtime_logging.log_event Env.runtime ~patch_id
                 (Printf.sprintf "Fetch failed before %s — %s" fail_label msg);
               ( Worktree.Error
                   (Printf.sprintf "fetch before rebase failed: %s" msg),
-                path ))
+                path,
+                Base.List.rev events ))
+      | Worktree_plan.Capture_anchor { ref_name; slot } :: rest ->
+          let sha = W.read_branch_sha ~path ~ref_name in
+          set_slot slot sha;
+          loop ~path ~last_rebase ~events rest
       | Worktree_plan.Rebase_onto target :: rest -> (
           match
             W.rebase_onto
               ~prev_base_sha:agent.Patch_agent.branch_rebased_onto_sha ~path
               ~target ~project_name:Env.project_name ~ancestor_ids ()
           with
-          | Worktree.Ok -> loop ~path rest
-          | (Worktree.Noop | Worktree.Conflict _ | Worktree.Error _) as r ->
-              (r, path))
+          | (Worktree.Ok | Worktree.Noop) as r ->
+              loop ~path ~last_rebase:r ~events rest
+          | (Worktree.Conflict _ | Worktree.Error _) as r ->
+              (r, path, Base.List.rev events))
+      | Worktree_plan.Record_anchor_on_success { slot; base } :: rest ->
+          let events' =
+            match last_rebase with
+            | Worktree.Conflict _ | Worktree.Error _ -> events
+            | Worktree.Ok | Worktree.Noop -> (
+                match get_slot slot with
+                | None -> Worktree_plan.Anchor_capture_failed :: events
+                | Some sha -> (
+                    match Anchor.make ~base ~sha ~observed_at_remote:true with
+                    | Some a -> Worktree_plan.Anchor_recorded a :: events
+                    | None -> Worktree_plan.Anchor_capture_failed :: events))
+          in
+          loop ~path ~last_rebase ~events:events' rest
     in
-    loop ~path:default_path plan
+    loop ~path:default_path ~last_rebase:Worktree.Ok ~events:[] plan
 end

--- a/lib/worktree_plan_executor.ml
+++ b/lib/worktree_plan_executor.ml
@@ -58,10 +58,34 @@ module Make (W : Worktree.S) (Env : Run_env.S) : S = struct
           set_slot slot sha;
           loop ~path ~last_rebase ~events rest
       | Worktree_plan.Rebase_onto target :: rest -> (
+          (* Compute the upstream argument via Rebase_decision.plan, using
+             the agent's recorded anchor history and a live HEAD-sha
+             observation. The cherry-pick / patch-id detection inside
+             W.rebase_onto remains as defense-in-depth; this resolved
+             [upstream] is used only on its fallback path. *)
+          let head_sha = W.read_branch_sha ~path ~ref_name:"HEAD" in
+          let plan_input : Rebase_decision.input =
+            {
+              anchor = Anchor_history.newest (Patch_agent.anchor_history agent);
+              recorded_history =
+                Anchor_history.to_list (Patch_agent.anchor_history agent);
+              base_branch =
+                Base.Option.value agent.Patch_agent.base_branch ~default:target;
+              head_sha;
+            }
+          in
+          let ancestor_oracle ancestor ~descendant =
+            W.is_ancestor ~path ~ancestor ~descendant
+          in
+          let plan = Rebase_decision.plan plan_input ~ancestor_oracle in
+          let upstream =
+            match plan with
+            | Rebase_decision.Onto { upstream; _ } -> upstream
+            | Rebase_decision.Plain { target; _ } -> target
+          in
           match
-            W.rebase_onto
-              ~prev_base_sha:agent.Patch_agent.branch_rebased_onto_sha ~path
-              ~target ~project_name:Env.project_name ~ancestor_ids ()
+            W.rebase_onto ~path ~target ~upstream ~project_name:Env.project_name
+              ~ancestor_ids ()
           with
           | (Worktree.Ok | Worktree.Noop) as r ->
               loop ~path ~last_rebase:r ~events rest

--- a/lib/worktree_plan_executor.mli
+++ b/lib/worktree_plan_executor.mli
@@ -6,7 +6,19 @@ module type S = sig
     fail_label:string ->
     ancestor_ids:Types.Patch_id.t list ->
     Worktree_plan.t ->
-    Worktree.rebase_result * string
+    Worktree.rebase_result * string * Worktree_plan.anchor_event list
+  (** Execute a {!Worktree_plan.t} sequentially. Returns the final rebase result
+      (defaulting to [Ok] for plans without any [Rebase_onto] op), the resolved
+      worktree path, and the list of {!Worktree_plan.anchor_event} observations
+      emitted as the plan ran, in execution order.
+
+      Loop semantics:
+      - [Conflict] / [Error] from a [Rebase_onto] short-circuit the plan; any
+        later [Record_anchor_on_success] is NOT executed.
+      - [Ok] and [Noop] both allow the plan to continue. A
+        [Record_anchor_on_success] following a successful [Rebase_onto] (or
+        appearing in a [Capture_anchor]-only plan such as [for_start]) emits its
+        event. *)
 end
 
 module Make (_ : Worktree.S) (_ : Run_env.S) : S

--- a/lib_core/anchor.ml
+++ b/lib_core/anchor.ml
@@ -1,0 +1,39 @@
+open Base
+open Ppx_yojson_conv_lib.Yojson_conv.Primitives
+
+type raw = { base : Types.Branch.t; sha : string; observed_at_remote : bool }
+[@@deriving yojson]
+
+type t = raw = {
+  base : Types.Branch.t;
+  sha : string;
+  observed_at_remote : bool;
+}
+[@@deriving show, eq, ord, sexp_of, compare, hash]
+
+let is_hex_lower_40 s =
+  String.length s = 40
+  && String.for_all s ~f:(fun c ->
+      Char.between c ~low:'0' ~high:'9' || Char.between c ~low:'a' ~high:'f')
+
+let make ~base ~sha ~observed_at_remote =
+  let sha = String.strip sha in
+  if is_hex_lower_40 sha then Some { base; sha; observed_at_remote } else None
+
+let base t = t.base
+let sha t = t.sha
+let is_remote t = t.observed_at_remote
+let yojson_of_t = yojson_of_raw
+
+let of_yojson_opt json =
+  match raw_of_yojson json with
+  | exception _ -> None
+  | r -> make ~base:r.base ~sha:r.sha ~observed_at_remote:r.observed_at_remote
+
+let t_of_yojson json =
+  match of_yojson_opt json with
+  | Some t -> t
+  | None ->
+      raise
+        (Ppx_yojson_conv_lib.Yojson_conv.Of_yojson_error
+           (Failure "Anchor.t_of_yojson: invalid SHA or structure", json))

--- a/lib_core/anchor.mli
+++ b/lib_core/anchor.mli
@@ -1,0 +1,40 @@
+(** A recorded fact: the patch agent's branch was, at some past moment, anchored
+    against [base] at the resolved tip SHA [sha]. The orchestrator uses anchors
+    to compute the safe [<upstream>] argument for
+    [git rebase --onto <target> <upstream> HEAD] — replaying only the commits
+    the patch contributed since the recorded anchor, never the dep's pre-squash
+    commits.
+
+    Anchors are value objects: either fully valid or absent. The smart
+    constructor {!make} rejects any SHA that is not exactly 40 lowercase hex
+    digits, so [Some sha] always carries a usable SHA. *)
+
+type t = private {
+  base : Types.Branch.t;
+  sha : string;  (** 40-char lowercase hex, enforced by {!make}. *)
+  observed_at_remote : bool;
+      (** [true] iff [sha] came from resolving [origin/<base>] at recording
+          time; [false] when [sha] came from a local ref or a synthetic
+          observation. The decision logic prefers remote-observed anchors when
+          choosing between candidates. *)
+}
+[@@deriving show, eq, ord, sexp_of, compare, hash]
+
+val make :
+  base:Types.Branch.t -> sha:string -> observed_at_remote:bool -> t option
+(** Construct an anchor. Returns [None] if [sha] is not exactly 40 lowercase hex
+    digits. Whitespace is stripped before validation. Pure and total. *)
+
+val base : t -> Types.Branch.t
+val sha : t -> string
+val is_remote : t -> bool
+
+val yojson_of_t : t -> Yojson.Safe.t
+(** Serialize. Always succeeds. *)
+
+val t_of_yojson : Yojson.Safe.t -> t
+(** Deserialize. Raises [Of_yojson_error] when the JSON is well-typed but the
+    SHA fails the {!make} validation, or when the structure is wrong. *)
+
+val of_yojson_opt : Yojson.Safe.t -> t option
+(** Non-raising variant; returns [None] on any parse or validation failure. *)

--- a/lib_core/anchor_history.ml
+++ b/lib_core/anchor_history.ml
@@ -1,0 +1,37 @@
+open Base
+open Ppx_yojson_conv_lib.Yojson_conv.Primitives
+
+type raw = Anchor.t list [@@deriving yojson]
+type t = Anchor.t list [@@deriving show, eq, ord, sexp_of, compare, hash]
+
+let cap = 8
+let empty : t = []
+
+let same_key (a : Anchor.t) (b : Anchor.t) =
+  Types.Branch.equal (Anchor.base a) (Anchor.base b)
+  && String.equal (Anchor.sha a) (Anchor.sha b)
+
+let push (t : t) (a : Anchor.t) : t =
+  let rest = List.filter t ~f:(fun e -> not (same_key e a)) in
+  let combined = a :: rest in
+  List.take combined cap
+
+let newest = List.hd
+let to_list t = t
+let length = List.length
+let yojson_of_t = yojson_of_raw
+
+let of_yojson_opt json =
+  match raw_of_yojson json with
+  | exception _ -> None
+  | xs -> Some (List.take xs cap)
+
+let t_of_yojson json =
+  match of_yojson_opt json with
+  | Some t -> t
+  | None ->
+      raise
+        (Ppx_yojson_conv_lib.Yojson_conv.Of_yojson_error
+           ( Failure
+               "Anchor_history.t_of_yojson: invalid structure or anchor SHA",
+             json ))

--- a/lib_core/anchor_history.ml
+++ b/lib_core/anchor_history.ml
@@ -24,7 +24,7 @@ let yojson_of_t = yojson_of_raw
 let of_yojson_opt json =
   match raw_of_yojson json with
   | exception _ -> None
-  | xs -> Some (List.take xs cap)
+  | xs -> Some (List.fold_right xs ~init:empty ~f:(fun a acc -> push acc a))
 
 let t_of_yojson json =
   match of_yojson_opt json with

--- a/lib_core/anchor_history.mli
+++ b/lib_core/anchor_history.mli
@@ -1,0 +1,34 @@
+(** A bounded log of {!Anchor.t} values recorded over a patch agent's lifetime,
+    used by the rebase decision to fall back from a force-pushed-or-deleted
+    newest anchor to an older one that is still reachable from the upstream.
+
+    Invariants enforced by the smart constructors:
+    - newest-first ordering;
+    - no two entries share the same [(base, sha)] pair (push deduplicates);
+    - length never exceeds {!cap} entries (older entries are dropped). *)
+
+type t = private Anchor.t list
+[@@deriving show, eq, ord, sexp_of, compare, hash]
+
+val cap : int
+(** Maximum number of anchors retained. Anchors older than the cap are dropped
+    silently on push. *)
+
+val empty : t
+
+val push : t -> Anchor.t -> t
+(** Add [a] as the newest entry. If an entry with the same [(base, sha)] already
+    exists, it is removed before [a] is prepended (so [a] becomes the new
+    "newest"). The list is truncated to {!cap} entries. *)
+
+val newest : t -> Anchor.t option
+val to_list : t -> Anchor.t list
+val length : t -> int
+val yojson_of_t : t -> Yojson.Safe.t
+
+val t_of_yojson : Yojson.Safe.t -> t
+(** Deserialize. Raises [Of_yojson_error] on structural failure or when any
+    contained anchor fails validation. Truncates to {!cap} on load if a
+    persisted snapshot ever exceeded it (forward-compatible). *)
+
+val of_yojson_opt : Yojson.Safe.t -> t option

--- a/lib_core/patch_agent.ml
+++ b/lib_core/patch_agent.ml
@@ -40,6 +40,12 @@ type t = {
   push_failure_count : int;
   branch_rebased_onto : Branch.t option;
   branch_rebased_onto_sha : string option;
+  anchor_history : Anchor_history.t;
+      (** Newest-first log of {!Anchor.t} values recorded over this agent's
+          lifetime. The newest entry mirrors
+          [(branch_rebased_onto, branch_rebased_onto_sha)] as a derived view;
+          older entries serve as divergence fallbacks for
+          {!Rebase_decision.plan}. Capped at {!Anchor_history.cap}. *)
   checks_passing : bool;
   current_op : Operation_kind.t option;
   current_op_state : op_state;
@@ -138,6 +144,7 @@ let create ~branch patch_id =
     push_failure_count = 0;
     branch_rebased_onto = None;
     branch_rebased_onto_sha = None;
+    anchor_history = Anchor_history.empty;
     checks_passing = false;
     current_op = None;
     current_op_state = Queued;
@@ -182,6 +189,7 @@ let create_adhoc ~patch_id ~branch ~pr_number =
     push_failure_count = 0;
     branch_rebased_onto = None;
     branch_rebased_onto_sha = None;
+    anchor_history = Anchor_history.empty;
     checks_passing = false;
     current_op = None;
     current_op_state = Queued;
@@ -388,10 +396,10 @@ let restore ~patch_id ~branch ~pr_number ~has_session ~busy ~merged ~queue
     ~ci_checks ~merge_ready ~is_draft ~pr_body_delivered
     ~pr_body_artifact_miss_count ~start_attempts_without_pr ~conflict_noop_count
     ~no_commits_push_count ~push_failure_count ~branch_rebased_onto
-    ~branch_rebased_onto_sha ~checks_passing ~current_op ~current_op_state
-    ~current_message_id ~generation ~worktree_path ~branch_blocked
-    ~llm_session_id ~automerge_enabled ~automerge_deadline ~automerge_inflight
-    ~automerge_failure_count ~delivered_ci_run_ids =
+    ~branch_rebased_onto_sha ~anchor_history ~checks_passing ~current_op
+    ~current_op_state ~current_message_id ~generation ~worktree_path
+    ~branch_blocked ~llm_session_id ~automerge_enabled ~automerge_deadline
+    ~automerge_inflight ~automerge_failure_count ~delivered_ci_run_ids =
   {
     patch_id;
     branch;
@@ -420,6 +428,7 @@ let restore ~patch_id ~branch ~pr_number ~has_session ~busy ~merged ~queue
     push_failure_count;
     branch_rebased_onto;
     branch_rebased_onto_sha;
+    anchor_history;
     checks_passing;
     current_op;
     current_op_state;
@@ -488,6 +497,25 @@ let set_branch_rebased_onto_sha t sha =
       let s = String.strip s in
       if String.is_empty s then { t with branch_rebased_onto_sha = None }
       else { t with branch_rebased_onto_sha = Some s }
+
+let record_anchor t anchor =
+  let anchor_history = Anchor_history.push t.anchor_history anchor in
+  {
+    t with
+    anchor_history;
+    branch_rebased_onto = Some (Anchor.base anchor);
+    branch_rebased_onto_sha = Some (Anchor.sha anchor);
+  }
+
+let clear_anchor_for_base t new_base =
+  (* Drop the legacy SHA view when the orchestrator retargets the agent's
+     base to one whose recorded anchor SHA is no longer authoritative. The
+     anchor history is preserved — [Rebase_decision.plan] can still use older
+     entries as divergence fallbacks. The legacy [branch_rebased_onto] field
+     is set to the new base so the drift detector sees a coherent view. *)
+  { t with branch_rebased_onto = Some new_base; branch_rebased_onto_sha = None }
+
+let anchor_history t = t.anchor_history
 
 let rebase t ~base_branch =
   if not (has_pr t) then invalid_arg "Patch_agent.rebase: patch has no PR";

--- a/lib_core/patch_agent.ml
+++ b/lib_core/patch_agent.ml
@@ -507,14 +507,6 @@ let record_anchor t anchor =
     branch_rebased_onto_sha = Some (Anchor.sha anchor);
   }
 
-let clear_anchor_for_base t new_base =
-  (* Drop the legacy SHA view when the orchestrator retargets the agent's
-     base to one whose recorded anchor SHA is no longer authoritative. The
-     anchor history is preserved — [Rebase_decision.plan] can still use older
-     entries as divergence fallbacks. The legacy [branch_rebased_onto] field
-     is set to the new base so the drift detector sees a coherent view. *)
-  { t with branch_rebased_onto = Some new_base; branch_rebased_onto_sha = None }
-
 let anchor_history t = t.anchor_history
 
 let rebase t ~base_branch =

--- a/lib_core/patch_agent.mli
+++ b/lib_core/patch_agent.mli
@@ -226,14 +226,6 @@ val record_anchor : t -> Anchor.t -> t
     [(base, sha)]) and update the legacy view fields [branch_rebased_onto] and
     [branch_rebased_onto_sha] to mirror the new anchor. Pure and total. *)
 
-val clear_anchor_for_base : t -> Types.Branch.t -> t
-(** Called by the orchestrator when retargeting the agent's base to [new_base]
-    whose anchor SHA is no longer authoritative (e.g. a dep squash-merged so the
-    legacy single-anchor view is stale). Sets
-    [branch_rebased_onto = Some new_base] and clears [branch_rebased_onto_sha];
-    preserves {!field-anchor_history} so {!Rebase_decision.plan} can still use
-    older entries as fallbacks. *)
-
 val anchor_history : t -> Anchor_history.t
 
 val base_branch_changed : t -> bool

--- a/lib_core/patch_agent.mli
+++ b/lib_core/patch_agent.mli
@@ -65,6 +65,13 @@ type t = private {
           [None] when no rebase has succeeded yet, or when the orchestrator was
           restarted before this field was added (it is back-filled to [None] via
           [Patch_agent.restore], and old snapshots persist with [null]). *)
+  anchor_history : Anchor_history.t;
+      (** Newest-first log of {!Anchor.t} values recorded over this agent's
+          lifetime. Updated via {!record_anchor}; mirrored into
+          [branch_rebased_onto] and [branch_rebased_onto_sha] as a derived view.
+          {!Rebase_decision.plan} consults the history when the newest anchor is
+          unreachable from HEAD and walks back to the oldest still- reachable
+          entry. Capped at {!Anchor_history.cap}. *)
   checks_passing : bool;
   current_op : Types.Operation_kind.t option;
   current_op_state : op_state;
@@ -213,6 +220,21 @@ val set_branch_rebased_onto_sha : t -> string option -> t
     / start. [None] (or a whitespace-only string) clears the field — used when
     the SHA could not be read; the next rebase will then fall back to the legacy
     plain [git rebase target] semantics. *)
+
+val record_anchor : t -> Anchor.t -> t
+(** Push [anchor] onto {!field-anchor_history} (newest-first, deduped by
+    [(base, sha)]) and update the legacy view fields [branch_rebased_onto] and
+    [branch_rebased_onto_sha] to mirror the new anchor. Pure and total. *)
+
+val clear_anchor_for_base : t -> Types.Branch.t -> t
+(** Called by the orchestrator when retargeting the agent's base to [new_base]
+    whose anchor SHA is no longer authoritative (e.g. a dep squash-merged so the
+    legacy single-anchor view is stale). Sets
+    [branch_rebased_onto = Some new_base] and clears [branch_rebased_onto_sha];
+    preserves {!field-anchor_history} so {!Rebase_decision.plan} can still use
+    older entries as fallbacks. *)
+
+val anchor_history : t -> Anchor_history.t
 
 val base_branch_changed : t -> bool
 (** [true] when [base_branch] differs from [notified_base_branch], meaning the
@@ -422,6 +444,7 @@ val restore :
   push_failure_count:int ->
   branch_rebased_onto:Types.Branch.t option ->
   branch_rebased_onto_sha:string option ->
+  anchor_history:Anchor_history.t ->
   checks_passing:bool ->
   current_op:Types.Operation_kind.t option ->
   current_op_state:op_state ->

--- a/lib_core/rebase_decision.ml
+++ b/lib_core/rebase_decision.ml
@@ -1,8 +1,89 @@
 open Base
 
+(* ── Legacy shim — preserved for the fallback path in Worktree.rebase_onto.
+   Removed in step 5 once the runner computes [plan] directly and passes the
+   chosen upstream into the handler as an argument. ─────────────────────── *)
+
 let upstream ~prev_base_sha ~fallback =
   match prev_base_sha with
   | Some sha ->
       let sha = String.strip sha in
       if String.is_empty sha then fallback else sha
   | None -> fallback
+
+(* ── Structured plan ─────────────────────────────────────────────────── *)
+
+type reason =
+  | Anchor_matches_head
+  | History_fallback of string
+  | No_anchor
+  | Anchor_unreachable_from_head
+  | Head_unobservable
+[@@deriving show, eq, sexp_of, compare]
+
+type plan =
+  | Onto of { target : string; upstream : string; reason : reason }
+  | Plain of { target : string; reason : reason }
+[@@deriving show, eq, sexp_of, compare]
+
+type input = {
+  anchor : Anchor.t option;
+  recorded_history : Anchor.t list;
+  base_branch : Types.Branch.t;
+  head_sha : string option;
+}
+
+(* Canonical, newest-first SHA candidate list. The newest anchor is preferred
+   and duplicates are removed so [List.hd candidates] is unambiguously "the
+   primary anchor" for the [Anchor_matches_head] vs [History_fallback]
+   reason distinction. *)
+let candidates_of (input : input) : string list =
+  let from_history = List.map input.recorded_history ~f:Anchor.sha in
+  let with_primary =
+    match input.anchor with
+    | None -> from_history
+    | Some a ->
+        let asha = Anchor.sha a in
+        if List.mem from_history asha ~equal:String.equal then
+          asha
+          :: List.filter from_history ~f:(fun s -> not (String.equal s asha))
+        else asha :: from_history
+  in
+  List.remove_consecutive_duplicates with_primary ~equal:String.equal
+
+let plan input ~ancestor_oracle =
+  let target = Types.Branch.to_string input.base_branch in
+  let candidates = candidates_of input in
+  match input.head_sha with
+  | None -> Plain { target; reason = Head_unobservable }
+  | Some head -> (
+      let reachable =
+        List.find candidates ~f:(fun sha ->
+            ancestor_oracle sha ~descendant:head)
+      in
+      match reachable with
+      | None -> (
+          match candidates with
+          | [] -> Plain { target; reason = No_anchor }
+          | _ -> Plain { target; reason = Anchor_unreachable_from_head })
+      | Some sha ->
+          let primary =
+            match List.hd candidates with
+            | Some h -> String.equal h sha
+            | None -> false
+          in
+          if primary then
+            Onto { target; upstream = sha; reason = Anchor_matches_head }
+          else Onto { target; upstream = sha; reason = History_fallback sha })
+
+let anchor_after_result ~prev ~(result : Worktree_parser.rebase_result)
+    ~resolved_remote_sha ~base_branch =
+  match result with
+  | Worktree_parser.Conflict _ | Worktree_parser.Error _ -> prev
+  | Worktree_parser.Ok | Worktree_parser.Noop -> (
+      match resolved_remote_sha with
+      | None -> prev
+      | Some sha -> (
+          match Anchor.make ~base:base_branch ~sha ~observed_at_remote:true with
+          | Some a -> Some a
+          | None -> prev))

--- a/lib_core/rebase_decision.ml
+++ b/lib_core/rebase_decision.ml
@@ -1,16 +1,5 @@
 open Base
 
-(* ── Legacy shim — preserved for the fallback path in Worktree.rebase_onto.
-   Removed in step 5 once the runner computes [plan] directly and passes the
-   chosen upstream into the handler as an argument. ─────────────────────── *)
-
-let upstream ~prev_base_sha ~fallback =
-  match prev_base_sha with
-  | Some sha ->
-      let sha = String.strip sha in
-      if String.is_empty sha then fallback else sha
-  | None -> fallback
-
 (* ── Structured plan ─────────────────────────────────────────────────── *)
 
 type reason =

--- a/lib_core/rebase_decision.mli
+++ b/lib_core/rebase_decision.mli
@@ -27,15 +27,6 @@
     exactly the patch's own commits, the dep's commits stay on [main] untouched,
     and no conflict arises. *)
 
-(** {2 Legacy shim — single SHA in, single string out} *)
-
-val upstream : prev_base_sha:string option -> fallback:string -> string
-(** [upstream ~prev_base_sha ~fallback] returns the value to pass as
-    [<upstream>] to [git rebase --onto <target> <upstream>]. When
-    [prev_base_sha = Some sha] (with [sha] non-empty after stripping), [sha] is
-    returned. Otherwise [fallback] is returned (typically the previous
-    base-branch name, preserving today's 2-arg semantics). Pure and total. *)
-
 (** {2 Structured plan + reasoning} *)
 
 type reason =

--- a/lib_core/rebase_decision.mli
+++ b/lib_core/rebase_decision.mli
@@ -1,28 +1,113 @@
-(** Pure decision: what value should the orchestrator pass as the [<upstream>]
-    argument to [git rebase --onto <target> <upstream>] when it re-bases a patch
-    branch?
+(** Pure decision: what arguments should the orchestrator pass to [git rebase]
+    when re-basing a patch branch?
 
-    Git's three-arg rebase replays exactly the commits in [upstream..HEAD] onto
-    [target]. When [upstream] is the {e current} tip of the previous base
-    branch, that range is precisely "the patch's own work" — every commit the
-    patch contributed since the last rebase. When [upstream] is stale (or set to
-    the local main), the range can include commits that were absorbed into a
-    squash-merge on origin/main and now live there as a single squash commit —
-    leaving the original un-squashed commits stuck in the rebased branch's
-    history (the case we saw on patch-6).
+    The decision answers two related questions:
 
-    {!Patch_agent.branch_rebased_onto_sha} records the SHA the base ref resolved
-    to at the moment of the last successful rebase / Start. [upstream] returns
-    that SHA when it is present; otherwise it falls back to the supplied default
-    (the branch name, mirroring today's behavior). The handler
-    [Worktree.rebase_onto] consults this decision before invoking [git rebase].
-*)
+    + {!plan} — what [<target>] / [<upstream>] should be on the command line?
+    + {!anchor_after_result} — what {!Anchor.t} should be recorded after a
+      rebase attempt completes?
+
+    Both functions are pure; the effectful runner supplies live git observations
+    (a HEAD SHA, an [is-ancestor] oracle) and the resolved-remote SHA captured
+    before the rebase.
+
+    {2 Why anchors matter — the squash-merge trap}
+
+    A patch agent branched off a dependency's tip and never rebased before that
+    dependency's PR squash-merged to [main] will, on its first rebase, try to
+    replay the dep's pre-squash commits on top of the post-squash version of
+    [main] — every file the dep added produces a "both added" conflict. Today
+    the orchestrator records an anchor SHA only after a successful rebase, so
+    such a patch has no anchor at first-rebase time and falls back to the legacy
+    2-arg rebase, which is the failure mode.
+
+    With anchors recorded at every base transition (Start, Noop, Conflict-
+    resolved, base retarget), {!plan} returns an [Onto] invocation whose
+    [<upstream>] is the dep's pre-squash tip — git's 3-arg rebase then replays
+    exactly the patch's own commits, the dep's commits stay on [main] untouched,
+    and no conflict arises. *)
+
+(** {2 Legacy shim — single SHA in, single string out} *)
 
 val upstream : prev_base_sha:string option -> fallback:string -> string
-(** [upstream ~prev_base_sha ~fallback] returns the upstream argument for
-    [git rebase --onto NEW_BASE <result>]. When [prev_base_sha = Some sha],
-    [sha] is returned (the recorded old-base tip). When [None] or the SHA is
-    empty / whitespace, [fallback] is returned — typically the previous
-    base-branch ref name, preserving the legacy 2-arg rebase semantics so an
-    agent whose [branch_rebased_onto_sha] was never recorded still rebases onto
-    something sensible. Pure and total. *)
+(** [upstream ~prev_base_sha ~fallback] returns the value to pass as
+    [<upstream>] to [git rebase --onto <target> <upstream>]. When
+    [prev_base_sha = Some sha] (with [sha] non-empty after stripping), [sha] is
+    returned. Otherwise [fallback] is returned (typically the previous
+    base-branch name, preserving today's 2-arg semantics). Pure and total. *)
+
+(** {2 Structured plan + reasoning} *)
+
+type reason =
+  | Anchor_matches_head
+      (** The newest anchor's SHA is an ancestor of the patch's HEAD, so
+          [anchor.sha..HEAD] is exactly the patch's own work. The standard
+          success path. *)
+  | History_fallback of string
+      (** The newest anchor was unreachable from HEAD (e.g. HEAD was reset), so
+          we fell back to the named older anchor's SHA from {!Anchor_history.t}.
+      *)
+  | No_anchor
+      (** No anchor has ever been recorded for this agent and the history is
+          empty. The legacy 2-arg rebase is the only option. *)
+  | Anchor_unreachable_from_head
+      (** At least one anchor exists, but none of them are reachable from HEAD.
+          Fall back to the legacy 2-arg rebase. *)
+  | Head_unobservable
+      (** The runner could not resolve the patch's HEAD SHA (e.g. worktree
+          missing). Cannot validate anchors, so fall back to the legacy 2-arg
+          rebase. *)
+[@@deriving show, eq, sexp_of, compare]
+
+type plan =
+  | Onto of { target : string; upstream : string; reason : reason }
+      (** Issue [git rebase --onto <target> <upstream>]. *)
+  | Plain of { target : string; reason : reason }
+      (** Issue legacy [git rebase <target>]. *)
+[@@deriving show, eq, sexp_of, compare]
+
+type input = {
+  anchor : Anchor.t option;
+      (** The newest anchor known for this agent. Should equal
+          [List.hd recorded_history] when both are present, but is passed
+          separately for ergonomics. *)
+  recorded_history : Anchor.t list;
+      (** Newest-first anchor history, used for divergence fallback when the
+          newest anchor is unreachable from HEAD. May be empty. *)
+  base_branch : Types.Branch.t;
+      (** The branch to rebase onto. Becomes the [<target>] component of the
+          issued plan (rendered via [Types.Branch.to_string]). *)
+  head_sha : string option;
+      (** The patch's local HEAD, resolved by the runner immediately before
+          calling {!plan}. [None] when the worktree is missing or HEAD is
+          unresolvable; in that case no anchor can be validated. *)
+}
+
+val plan :
+  input -> ancestor_oracle:(string -> descendant:string -> bool) -> plan
+(** [plan input ~ancestor_oracle] picks the safest rebase invocation given the
+    recorded anchors and live observations. [ancestor_oracle sha ~descendant]
+    returns [true] iff [sha] is an ancestor of [descendant] (i.e. reachable from
+    it in the commit DAG). The runner supplies [git merge-base --is-ancestor];
+    tests supply an in-memory DAG. *)
+
+(** {2 Anchor recording after a rebase attempt} *)
+
+val anchor_after_result :
+  prev:Anchor.t option ->
+  result:Worktree_parser.rebase_result ->
+  resolved_remote_sha:string option ->
+  base_branch:Types.Branch.t ->
+  Anchor.t option
+(** Compute the anchor to record after a rebase attempt. Policy:
+
+    - {!Worktree_parser.Ok} or {!Worktree_parser.Noop} with a resolvable remote
+      SHA — produce a fresh anchor for [base_branch] with that SHA. Noop
+      refreshes too: a noop proves local HEAD already contains the remote tip,
+      which is exactly the post-condition we want anchored.
+    - {!Worktree_parser.Conflict} or {!Worktree_parser.Error} — return [prev]
+      unchanged. A failed attempt must not erase or corrupt the
+      previously-recorded anchor.
+    - Missing remote SHA on Ok/Noop — return [prev]. The handler observed a
+      rebase outcome but couldn't record a SHA, so keep the older anchor rather
+      than fabricate one. *)

--- a/lib_core/worktree_plan.ml
+++ b/lib_core/worktree_plan.ml
@@ -21,7 +21,13 @@ let ref_string_of branch =
   Printf.sprintf "origin/%s" (Types.Branch.to_string branch)
 
 let for_rebase ~new_base =
-  [ Ensure_worktree; Fetch_origin; Rebase_onto (origin_of new_base) ]
+  [
+    Ensure_worktree;
+    Fetch_origin;
+    Capture_anchor { ref_name = ref_string_of new_base; slot = 0 };
+    Rebase_onto (origin_of new_base);
+    Record_anchor_on_success { slot = 0; base = new_base };
+  ]
 
 let for_merge_conflict ~base =
   [ Ensure_worktree; Fetch_origin; Rebase_onto (origin_of base) ]

--- a/lib_core/worktree_plan.ml
+++ b/lib_core/worktree_plan.ml
@@ -1,13 +1,24 @@
 open Base
 
-type op = Ensure_worktree | Fetch_origin | Rebase_onto of Types.Branch.t
+type op =
+  | Ensure_worktree
+  | Fetch_origin
+  | Capture_anchor of { ref_name : string; slot : int }
+  | Rebase_onto of Types.Branch.t
+  | Record_anchor_on_success of { slot : int; base : Types.Branch.t }
 [@@deriving show, eq, sexp_of, compare]
 
 type t = op list [@@deriving show, eq, sexp_of, compare]
 
+type anchor_event = Anchor_recorded of Anchor.t | Anchor_capture_failed
+[@@deriving show, eq, sexp_of, compare]
+
 let origin_of branch =
   Types.Branch.of_string
     (Printf.sprintf "origin/%s" (Types.Branch.to_string branch))
+
+let ref_string_of branch =
+  Printf.sprintf "origin/%s" (Types.Branch.to_string branch)
 
 let for_rebase ~new_base =
   [ Ensure_worktree; Fetch_origin; Rebase_onto (origin_of new_base) ]
@@ -15,10 +26,21 @@ let for_rebase ~new_base =
 let for_merge_conflict ~base =
   [ Ensure_worktree; Fetch_origin; Rebase_onto (origin_of base) ]
 
+let for_start ~base =
+  [
+    Ensure_worktree;
+    Fetch_origin;
+    Capture_anchor { ref_name = ref_string_of base; slot = 0 };
+    Record_anchor_on_success { slot = 0; base };
+  ]
+
 let ensures_worktree_before_fs (plan : t) =
   let rec loop ensured = function
     | [] -> true
     | Ensure_worktree :: rest -> loop true rest
-    | (Fetch_origin | Rebase_onto _) :: rest -> ensured && loop ensured rest
+    | ( Fetch_origin | Capture_anchor _ | Rebase_onto _
+      | Record_anchor_on_success _ )
+      :: rest ->
+        ensured && loop ensured rest
   in
   loop false plan

--- a/lib_core/worktree_plan.ml
+++ b/lib_core/worktree_plan.ml
@@ -30,7 +30,13 @@ let for_rebase ~new_base =
   ]
 
 let for_merge_conflict ~base =
-  [ Ensure_worktree; Fetch_origin; Rebase_onto (origin_of base) ]
+  [
+    Ensure_worktree;
+    Fetch_origin;
+    Capture_anchor { ref_name = ref_string_of base; slot = 0 };
+    Rebase_onto (origin_of base);
+    Record_anchor_on_success { slot = 0; base };
+  ]
 
 let for_start ~base =
   [

--- a/lib_core/worktree_plan.mli
+++ b/lib_core/worktree_plan.mli
@@ -16,12 +16,32 @@ type op =
       (** Materialize the worktree on disk if missing. Must precede any
           subsequent op in the plan. *)
   | Fetch_origin  (** [git fetch origin] inside the worktree. *)
+  | Capture_anchor of { ref_name : string; slot : int }
+      (** Resolve [ref_name] (e.g. ["origin/main"]) to a SHA via
+          [Worktree.read_branch_sha] and store it in [slot]. The slot is
+          consumed later by a {!Record_anchor_on_success} op. A failed
+          resolution stores [None] in the slot and causes a subsequent
+          [Record_anchor_on_success] to emit [Anchor_capture_failed]. *)
   | Rebase_onto of Types.Branch.t
       (** [git rebase --onto <branch>] inside the worktree. The branch is
           typically [origin/<base>]. *)
+  | Record_anchor_on_success of { slot : int; base : Types.Branch.t }
+      (** Emit an {!anchor_event} from [slot]'s captured SHA iff the most recent
+          {!Rebase_onto} returned [Ok] or [Noop] (or no rebase ran). A populated
+          slot yields [Anchor_recorded { base; sha; ... }]; an empty slot or a
+          SHA that fails {!Anchor.make}'s validation yields
+          [Anchor_capture_failed]. *)
 [@@deriving show, eq, sexp_of, compare]
 
 type t = op list [@@deriving show, eq, sexp_of, compare]
+
+(** Side-channel observations the executor emits as it runs a plan, folded into
+    agent state by the runner. *)
+type anchor_event = Anchor_recorded of Anchor.t | Anchor_capture_failed
+[@@deriving show, eq, sexp_of, compare]
+
+val origin_of : Types.Branch.t -> Types.Branch.t
+(** Prepends ["origin/"] to a branch name. *)
 
 val for_rebase : new_base:Types.Branch.t -> t
 (** Plan for [Orchestrator.Rebase]: ensure the worktree, fetch fresh refs, then
@@ -31,6 +51,14 @@ val for_merge_conflict : base:Types.Branch.t -> t
 (** Plan for the merge-conflict resolution path (post rebase-in-progress check):
     ensure the worktree, fetch, then rebase onto [origin/<base>]. *)
 
+val for_start : base:Types.Branch.t -> t
+(** Plan executed by the runner Start path BEFORE the LLM session begins: ensure
+    worktree, fetch, capture [origin/<base>]'s tip into slot 0, then record an
+    anchor referencing that SHA. Records the initial anchor for a
+    freshly-branched-off-dep patch — closing the production bug blind spot where
+    Start never wrote an anchor and the first rebase (post-squash) had nothing
+    safe to fall back to. *)
+
 val ensures_worktree_before_fs : t -> bool
-(** Returns [true] iff every [Fetch_origin] / [Rebase_onto] is preceded by an
+(** Returns [true] iff every non-{!Ensure_worktree} op is preceded by an
     [Ensure_worktree] in the plan. The safety invariant. *)

--- a/test/dune
+++ b/test/dune
@@ -69,6 +69,13 @@
  (ocamlc_flags (:standard -w -40-42)))
 
 (test
+ (name test_rebase_state_machine)
+ (modules test_rebase_state_machine)
+ (libraries onton_core)
+ (ocamlopt_flags (:standard -w -40-42))
+ (ocamlc_flags (:standard -w -40-42)))
+
+(test
  (name test_backend_parser_totality)
  (modules test_backend_parser_totality)
  (libraries onton_core qcheck-core qcheck-core.runner yojson)

--- a/test/dune
+++ b/test/dune
@@ -62,6 +62,13 @@
  (ocamlc_flags (:standard -w -40-42)))
 
 (test
+ (name test_anchor)
+ (modules test_anchor)
+ (libraries onton_core qcheck-core qcheck-core.runner yojson)
+ (ocamlopt_flags (:standard -w -40-42))
+ (ocamlc_flags (:standard -w -40-42)))
+
+(test
  (name test_backend_parser_totality)
  (modules test_backend_parser_totality)
  (libraries onton_core qcheck-core qcheck-core.runner yojson)

--- a/test/test_anchor.ml
+++ b/test/test_anchor.ml
@@ -1,0 +1,203 @@
+open Base
+open Onton_core
+open Onton_core.Types
+
+(** Unit and property tests for {!Anchor} and {!Anchor_history}. *)
+
+module Gen = QCheck2.Gen
+module Test = QCheck2.Test
+
+(* ── Generators ───────────────────────────────────────────────────────── *)
+
+let gen_hex_sha : string Gen.t =
+  Gen.string_size
+    ~gen:Gen.(oneof [ char_range '0' '9'; char_range 'a' 'f' ])
+    (Gen.return 40)
+
+let gen_branch : Branch.t Gen.t =
+  Gen.map Branch.of_string
+    (Gen.string_size ~gen:(Gen.char_range 'a' 'z') (Gen.int_range 1 20))
+
+let gen_anchor : Anchor.t Gen.t =
+  Gen.map3
+    (fun base sha observed_at_remote ->
+      match Anchor.make ~base ~sha ~observed_at_remote with
+      | Some a -> a
+      | None -> assert false (* gen_hex_sha is always valid *))
+    gen_branch gen_hex_sha Gen.bool
+
+(* Anything that is not a 40-char lowercase hex string. *)
+let gen_invalid_sha : string Gen.t =
+  Gen.oneof
+    [
+      Gen.return "";
+      Gen.return "   ";
+      Gen.return "deadbeef" (* too short *);
+      Gen.return (String.make 41 '0') (* too long *);
+      Gen.return (String.make 40 'g') (* not hex *);
+      Gen.return (String.make 40 'A') (* uppercase *);
+      Gen.string_size ~gen:Gen.printable (Gen.int_range 0 60);
+    ]
+
+(* ── Anchor.make / validation ──────────────────────────────────────────── *)
+
+let prop_make_accepts_hex40 =
+  Test.make ~count:200 ~name:"Anchor.make accepts 40-char lowercase hex"
+    (Gen.pair gen_branch gen_hex_sha) (fun (base, sha) ->
+      Option.is_some (Anchor.make ~base ~sha ~observed_at_remote:false))
+
+let prop_make_strips_whitespace =
+  Test.make ~count:200
+    ~name:"Anchor.make strips surrounding whitespace before validating"
+    (Gen.pair gen_branch gen_hex_sha) (fun (base, sha) ->
+      let padded = "  " ^ sha ^ "  \n" in
+      match Anchor.make ~base ~sha:padded ~observed_at_remote:false with
+      | Some a -> String.equal (Anchor.sha a) sha
+      | None -> false)
+
+let prop_make_rejects_invalid =
+  Test.make ~count:500 ~name:"Anchor.make rejects malformed SHAs"
+    (Gen.pair gen_branch gen_invalid_sha) (fun (base, sha) ->
+      Option.is_none (Anchor.make ~base ~sha ~observed_at_remote:false))
+
+let prop_make_preserves_fields =
+  Test.make ~count:200 ~name:"Anchor accessors round-trip make"
+    (Gen.triple gen_branch gen_hex_sha Gen.bool)
+    (fun (base, sha, observed_at_remote) ->
+      match Anchor.make ~base ~sha ~observed_at_remote with
+      | None -> false
+      | Some a ->
+          Branch.equal (Anchor.base a) base
+          && String.equal (Anchor.sha a) sha
+          && Bool.equal (Anchor.is_remote a) observed_at_remote)
+
+(* ── Anchor yojson round-trip ──────────────────────────────────────────── *)
+
+let prop_anchor_yojson_roundtrip =
+  Test.make ~count:300 ~name:"Anchor: yojson_of_t / t_of_yojson round-trip"
+    gen_anchor (fun a ->
+      let json = Anchor.yojson_of_t a in
+      let a' = Anchor.t_of_yojson json in
+      Anchor.equal a a')
+
+let prop_anchor_of_yojson_opt_rejects_bad_sha =
+  Test.make ~count:200
+    ~name:"Anchor.of_yojson_opt returns None for invalid persisted SHA"
+    (Gen.pair gen_branch gen_invalid_sha) (fun (base, sha) ->
+      let json : Yojson.Safe.t =
+        `Assoc
+          [
+            ("base", Branch.yojson_of_t base);
+            ("sha", `String sha);
+            ("observed_at_remote", `Bool false);
+          ]
+      in
+      Option.is_none (Anchor.of_yojson_opt json))
+
+(* ── Anchor_history.push semantics ─────────────────────────────────────── *)
+
+let prop_push_puts_newest_first =
+  Test.make ~count:300 ~name:"Anchor_history.push: newest entry is at head"
+    (Gen.pair (Gen.list_size (Gen.int_range 0 12) gen_anchor) gen_anchor)
+    (fun (seed, fresh) ->
+      let h =
+        List.fold seed ~init:Anchor_history.empty ~f:Anchor_history.push
+      in
+      let h' = Anchor_history.push h fresh in
+      match Anchor_history.newest h' with
+      | Some a -> Anchor.equal a fresh
+      | None -> false)
+
+let prop_push_caps_at_8 =
+  Test.make ~count:200 ~name:"Anchor_history.push: length never exceeds cap"
+    (Gen.list_size (Gen.int_range 0 30) gen_anchor)
+    (fun seed ->
+      let h =
+        List.fold seed ~init:Anchor_history.empty ~f:Anchor_history.push
+      in
+      Anchor_history.length h <= Anchor_history.cap)
+
+let prop_push_dedups_by_key =
+  Test.make ~count:200
+    ~name:
+      "Anchor_history.push: re-pushing same (base, sha) moves it to head, does \
+       not duplicate"
+    (Gen.pair (Gen.list_size (Gen.int_range 0 6) gen_anchor) gen_anchor)
+    (fun (seed, a) ->
+      let h =
+        List.fold seed ~init:Anchor_history.empty ~f:Anchor_history.push
+      in
+      let h1 = Anchor_history.push h a in
+      let h2 = Anchor_history.push h1 a in
+      let list1 = Anchor_history.to_list h1 in
+      let list2 = Anchor_history.to_list h2 in
+      let count_a xs =
+        List.count xs ~f:(fun e ->
+            Branch.equal (Anchor.base e) (Anchor.base a)
+            && String.equal (Anchor.sha e) (Anchor.sha a))
+      in
+      count_a list1 = 1
+      && count_a list2 = 1
+      && List.equal Anchor.equal list1 list2)
+
+let prop_push_monotone_membership =
+  Test.make ~count:200
+    ~name:"Anchor_history.push: pushed anchor is a member of the result"
+    (Gen.pair (Gen.list_size (Gen.int_range 0 12) gen_anchor) gen_anchor)
+    (fun (seed, fresh) ->
+      let h =
+        List.fold seed ~init:Anchor_history.empty ~f:Anchor_history.push
+      in
+      let h' = Anchor_history.push h fresh in
+      List.exists (Anchor_history.to_list h') ~f:(Anchor.equal fresh))
+
+(* ── Anchor_history yojson round-trip ─────────────────────────────────── *)
+
+let prop_history_yojson_roundtrip =
+  Test.make ~count:200
+    ~name:"Anchor_history: yojson_of_t / t_of_yojson round-trip"
+    (Gen.list_size (Gen.int_range 0 8) gen_anchor)
+    (fun seed ->
+      let h =
+        List.fold seed ~init:Anchor_history.empty ~f:Anchor_history.push
+      in
+      let json = Anchor_history.yojson_of_t h in
+      let h' = Anchor_history.t_of_yojson json in
+      Anchor_history.equal h h')
+
+let prop_history_load_truncates_to_cap =
+  Test.make ~count:50
+    ~name:"Anchor_history.of_yojson truncates over-cap legacy snapshots"
+    (Gen.list_size (Gen.int_range 9 30) gen_anchor)
+    (fun seed ->
+      (* Build a raw JSON list longer than cap, bypassing push's truncation. *)
+      let json : Yojson.Safe.t = `List (List.map seed ~f:Anchor.yojson_of_t) in
+      let h = Anchor_history.t_of_yojson json in
+      Anchor_history.length h <= Anchor_history.cap)
+
+(* ── Anchor_history.empty / newest invariants ─────────────────────────── *)
+
+let test_empty_invariants () =
+  assert (Anchor_history.length Anchor_history.empty = 0);
+  assert (Option.is_none (Anchor_history.newest Anchor_history.empty));
+  assert (List.is_empty (Anchor_history.to_list Anchor_history.empty))
+
+let () =
+  test_empty_invariants ();
+  List.iter
+    ~f:(fun t -> QCheck2.Test.check_exn t)
+    [
+      prop_make_accepts_hex40;
+      prop_make_strips_whitespace;
+      prop_make_rejects_invalid;
+      prop_make_preserves_fields;
+      prop_anchor_yojson_roundtrip;
+      prop_anchor_of_yojson_opt_rejects_bad_sha;
+      prop_push_puts_newest_first;
+      prop_push_caps_at_8;
+      prop_push_dedups_by_key;
+      prop_push_monotone_membership;
+      prop_history_yojson_roundtrip;
+      prop_history_load_truncates_to_cap;
+    ];
+  Stdlib.print_endline "Anchor / Anchor_history: all properties passed"

--- a/test/test_dependency_injection_functors.ml
+++ b/test/test_dependency_injection_functors.ml
@@ -25,11 +25,12 @@ module Fake_worktree : Worktree.S = struct
   let git_status ~path:_ = assert false
   let conflict_diff ~path:_ = assert false
 
-  let rebase_onto ?prev_base_sha:_ ~path:_ ~target:_ ~project_name:_
-      ~ancestor_ids:_ () =
+  let rebase_onto ~path:_ ~target:_ ~upstream:_ ~project_name:_ ~ancestor_ids:_
+      () =
     assert false
 
   let read_branch_sha ~path:_ ~ref_name:_ = None
+  let is_ancestor ~path:_ ~ancestor:_ ~descendant:_ = false
 
   let read_in_progress_conflict_info ~path:_ ~target:_ ~project_name:_
       ~ancestor_ids:_ =

--- a/test/test_patch_agent.ml
+++ b/test/test_patch_agent.ml
@@ -726,8 +726,10 @@ let () =
               ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
               ~conflict_noop_count:0 ~no_commits_push_count:0
               ~push_failure_count:0 ~branch_rebased_onto:None
-              ~branch_rebased_onto_sha:None ~checks_passing:false
-              ~current_op:None ~current_op_state:Onton_core.Patch_agent.Queued
+              ~branch_rebased_onto_sha:None
+              ~anchor_history:Onton_core.Anchor_history.empty
+              ~checks_passing:false ~current_op:None
+              ~current_op_state:Onton_core.Patch_agent.Queued
               ~current_message_id:None ~generation:0 ~worktree_path:None
               ~branch_blocked:false ~llm_session_id:None
               ~automerge_enabled:false ~automerge_deadline:None
@@ -808,8 +810,10 @@ let () =
               ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
               ~conflict_noop_count:0 ~no_commits_push_count:0
               ~push_failure_count:0 ~branch_rebased_onto:None
-              ~branch_rebased_onto_sha:None ~checks_passing:false
-              ~current_op:None ~current_op_state:Onton_core.Patch_agent.Queued
+              ~branch_rebased_onto_sha:None
+              ~anchor_history:Onton_core.Anchor_history.empty
+              ~checks_passing:false ~current_op:None
+              ~current_op_state:Onton_core.Patch_agent.Queued
               ~current_message_id:None ~generation:0 ~worktree_path:None
               ~branch_blocked:false ~llm_session_id:None
               ~automerge_enabled:false ~automerge_deadline:None

--- a/test/test_patch_controller.ml
+++ b/test/test_patch_controller.ml
@@ -61,7 +61,8 @@ let make_agent ~patch_id ~branch ~pr_number ~merged ~queue ~base_branch
     ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr
     ~conflict_noop_count:0 ~no_commits_push_count:0 ~push_failure_count:0
     ~branch_rebased_onto:None ~branch_rebased_onto_sha:None
-    ~checks_passing:false ~current_op:None ~current_op_state:Patch_agent.Queued
+    ~anchor_history:Onton_core.Anchor_history.empty ~checks_passing:false
+    ~current_op:None ~current_op_state:Patch_agent.Queued
     ~current_message_id:None ~generation:0 ~worktree_path:None
     ~branch_blocked:false ~llm_session_id:None ~automerge_enabled:false
     ~automerge_deadline:None ~automerge_inflight:false
@@ -231,10 +232,11 @@ let () =
             ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
             ~conflict_noop_count:0 ~no_commits_push_count:0
             ~push_failure_count:0 ~branch_rebased_onto:(Some main)
-            ~branch_rebased_onto_sha:None ~checks_passing:true ~current_op:None
-            ~current_op_state:Patch_agent.Queued ~current_message_id:None
-            ~generation:0 ~worktree_path:None ~branch_blocked:false
-            ~llm_session_id:None ~automerge_enabled:false
+            ~branch_rebased_onto_sha:None
+            ~anchor_history:Onton_core.Anchor_history.empty ~checks_passing:true
+            ~current_op:None ~current_op_state:Patch_agent.Queued
+            ~current_message_id:None ~generation:0 ~worktree_path:None
+            ~branch_blocked:false ~llm_session_id:None ~automerge_enabled:false
             ~automerge_deadline:None ~automerge_inflight:false
             ~automerge_failure_count:0 ~delivered_ci_run_ids:[]
         in
@@ -279,10 +281,11 @@ let () =
             ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
             ~conflict_noop_count:0 ~no_commits_push_count:0
             ~push_failure_count:0 ~branch_rebased_onto:None
-            ~branch_rebased_onto_sha:None ~checks_passing:true ~current_op:None
-            ~current_op_state:Patch_agent.Queued ~current_message_id:None
-            ~generation:0 ~worktree_path:None ~branch_blocked:false
-            ~llm_session_id:None ~automerge_enabled:false
+            ~branch_rebased_onto_sha:None
+            ~anchor_history:Onton_core.Anchor_history.empty ~checks_passing:true
+            ~current_op:None ~current_op_state:Patch_agent.Queued
+            ~current_message_id:None ~generation:0 ~worktree_path:None
+            ~branch_blocked:false ~llm_session_id:None ~automerge_enabled:false
             ~automerge_deadline:None ~automerge_inflight:false
             ~automerge_failure_count:0 ~delivered_ci_run_ids:[]
         in
@@ -416,7 +419,9 @@ let () =
             ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
             ~conflict_noop_count:0 ~no_commits_push_count:0
             ~push_failure_count:0 ~branch_rebased_onto:None
-            ~branch_rebased_onto_sha:None ~checks_passing:false ~current_op:None
+            ~branch_rebased_onto_sha:None
+            ~anchor_history:Onton_core.Anchor_history.empty
+            ~checks_passing:false ~current_op:None
             ~current_op_state:Patch_agent.Queued ~current_message_id:None
             ~generation:0 ~worktree_path:None ~branch_blocked:false
             ~llm_session_id:None ~automerge_enabled:false
@@ -458,7 +463,9 @@ let () =
             ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
             ~conflict_noop_count:0 ~no_commits_push_count:0
             ~push_failure_count:0 ~branch_rebased_onto:None
-            ~branch_rebased_onto_sha:None ~checks_passing:false ~current_op:None
+            ~branch_rebased_onto_sha:None
+            ~anchor_history:Onton_core.Anchor_history.empty
+            ~checks_passing:false ~current_op:None
             ~current_op_state:Patch_agent.Queued ~current_message_id:None
             ~generation:0 ~worktree_path:None ~branch_blocked:false
             ~llm_session_id:None ~automerge_enabled:false
@@ -500,7 +507,9 @@ let () =
             ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
             ~conflict_noop_count:0 ~no_commits_push_count:0
             ~push_failure_count:0 ~branch_rebased_onto:None
-            ~branch_rebased_onto_sha:None ~checks_passing:false ~current_op:None
+            ~branch_rebased_onto_sha:None
+            ~anchor_history:Onton_core.Anchor_history.empty
+            ~checks_passing:false ~current_op:None
             ~current_op_state:Patch_agent.Queued ~current_message_id:None
             ~generation:0 ~worktree_path:None ~branch_blocked:false
             ~llm_session_id:None ~automerge_enabled:false
@@ -636,7 +645,9 @@ let () =
             ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
             ~conflict_noop_count:0 ~no_commits_push_count:0
             ~push_failure_count:0 ~branch_rebased_onto:None
-            ~branch_rebased_onto_sha:None ~checks_passing:false ~current_op:None
+            ~branch_rebased_onto_sha:None
+            ~anchor_history:Onton_core.Anchor_history.empty
+            ~checks_passing:false ~current_op:None
             ~current_op_state:Patch_agent.Queued ~current_message_id:None
             ~generation:0 ~worktree_path:None ~branch_blocked:false
             ~llm_session_id:None ~automerge_enabled:false
@@ -698,7 +709,9 @@ let () =
             ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
             ~conflict_noop_count:0 ~no_commits_push_count:0
             ~push_failure_count:0 ~branch_rebased_onto:None
-            ~branch_rebased_onto_sha:None ~checks_passing:false ~current_op:None
+            ~branch_rebased_onto_sha:None
+            ~anchor_history:Onton_core.Anchor_history.empty
+            ~checks_passing:false ~current_op:None
             ~current_op_state:Patch_agent.Queued ~current_message_id:None
             ~generation:0 ~worktree_path:None ~branch_blocked:false
             ~llm_session_id:None ~automerge_enabled:false
@@ -839,7 +852,9 @@ let () =
             ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
             ~conflict_noop_count:0 ~no_commits_push_count:0
             ~push_failure_count:0 ~branch_rebased_onto:(Some main)
-            ~branch_rebased_onto_sha:None ~checks_passing:false ~current_op:None
+            ~branch_rebased_onto_sha:None
+            ~anchor_history:Onton_core.Anchor_history.empty
+            ~checks_passing:false ~current_op:None
             ~current_op_state:Patch_agent.Queued ~current_message_id:None
             ~generation:0 ~worktree_path:None ~branch_blocked:false
             ~llm_session_id:None ~automerge_enabled:false
@@ -1047,7 +1062,9 @@ let () =
             ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
             ~conflict_noop_count:0 ~no_commits_push_count:0
             ~push_failure_count:0 ~branch_rebased_onto:None
-            ~branch_rebased_onto_sha:None ~checks_passing:false ~current_op:None
+            ~branch_rebased_onto_sha:None
+            ~anchor_history:Onton_core.Anchor_history.empty
+            ~checks_passing:false ~current_op:None
             ~current_op_state:Patch_agent.Queued ~current_message_id:None
             ~generation:0 ~worktree_path:None ~branch_blocked:false
             ~llm_session_id:None ~automerge_enabled:false
@@ -1089,7 +1106,9 @@ let () =
             ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
             ~conflict_noop_count:0 ~no_commits_push_count:0
             ~push_failure_count:0 ~branch_rebased_onto:None
-            ~branch_rebased_onto_sha:None ~checks_passing:false ~current_op:None
+            ~branch_rebased_onto_sha:None
+            ~anchor_history:Onton_core.Anchor_history.empty
+            ~checks_passing:false ~current_op:None
             ~current_op_state:Patch_agent.Queued ~current_message_id:None
             ~generation:0 ~worktree_path:None ~branch_blocked:false
             ~llm_session_id:None ~automerge_enabled:false

--- a/test/test_persistence_properties.ml
+++ b/test/test_persistence_properties.ml
@@ -191,6 +191,76 @@ let () =
           | Error _msg -> false
         with _ -> false)
   in
+  (* anchor_history is a new field; exercise it explicitly by pushing 1-8
+     synthetic anchors onto an agent before round-tripping. The generic
+     gen_patch_agent_fully_populated leaves history empty, which would
+     trivially round-trip; this test confirms non-empty histories survive
+     yojson_of_t / patch_agent_of_yojson identically. *)
+  let gen_hex_sha =
+    QCheck2.Gen.string_size
+      ~gen:QCheck2.Gen.(oneof [ char_range '0' '9'; char_range 'a' 'f' ])
+      (QCheck2.Gen.return 40)
+  in
+  let gen_anchor =
+    QCheck2.Gen.map2
+      (fun branch sha ->
+        match
+          Onton_core.Anchor.make ~base:branch ~sha ~observed_at_remote:true
+        with
+        | Some a -> a
+        | None -> assert false)
+      (QCheck2.Gen.map Branch.of_string
+         (QCheck2.Gen.string_size
+            ~gen:(QCheck2.Gen.char_range 'a' 'z')
+            (QCheck2.Gen.int_range 1 20)))
+      gen_hex_sha
+  in
+  let anchor_history_roundtrip =
+    QCheck2.Test.make
+      ~name:"patch_agent.anchor_history survives JSON round-trip" ~count:100
+      QCheck2.Gen.(
+        pair gen_patch_agent_fully_populated
+          (list_size (int_range 1 8) gen_anchor))
+      (fun (agent, anchors) ->
+        try
+          let agent =
+            List.fold anchors ~init:agent
+              ~f:Onton_core.Patch_agent.record_anchor
+          in
+          let gameplan = gameplan_for_agent agent in
+          let json = Onton.Persistence.patch_agent_to_yojson agent in
+          match Onton.Persistence.patch_agent_of_yojson ~gameplan json with
+          | Ok agent' ->
+              Onton_core.Anchor_history.equal
+                (Onton_core.Patch_agent.anchor_history agent)
+                (Onton_core.Patch_agent.anchor_history agent')
+          | Error _msg -> false
+        with _ -> false)
+  in
+  (* Old snapshots predating anchor_history must load as empty history. *)
+  let missing_anchor_history_defaults_empty =
+    QCheck2.Test.make
+      ~name:"missing anchor_history key defaults to Anchor_history.empty"
+      ~count:50 gen_patch_agent_fully_populated (fun agent ->
+        try
+          let gameplan = gameplan_for_agent agent in
+          let json = Onton.Persistence.patch_agent_to_yojson agent in
+          let json =
+            match json with
+            | `Assoc fields ->
+                `Assoc
+                  (List.filter fields ~f:(fun (k, _) ->
+                       not (String.equal k "anchor_history")))
+            | other -> other
+          in
+          match Onton.Persistence.patch_agent_of_yojson ~gameplan json with
+          | Ok agent' ->
+              Onton_core.Anchor_history.equal
+                (Onton_core.Patch_agent.anchor_history agent')
+                Onton_core.Anchor_history.empty
+          | Error _ -> false
+        with _ -> false)
+  in
   let pr_number_roundtrip =
     QCheck2.Test.make ~name:"pr_number survives round-trip" ~count:200
       gen_patch_agent_fully_populated (fun agent ->
@@ -375,6 +445,8 @@ let () =
         snapshot_json_structure;
         file_roundtrip;
         patch_agent_roundtrip_fully_populated;
+        anchor_history_roundtrip;
+        missing_anchor_history_defaults_empty;
         pr_number_roundtrip;
         missing_pr_number_defaults_none;
         missing_branch_falls_back_to_gameplan;

--- a/test/test_poll_log_properties.ml
+++ b/test/test_poll_log_properties.ml
@@ -53,8 +53,8 @@ let make_agent ~patch_id ~branch ~has_conflict ~ci_failure_count ~current_op
     ~merge_ready:false ~is_draft ~pr_body_delivered:true
     ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
     ~conflict_noop_count:0 ~no_commits_push_count:0 ~push_failure_count:0
-    ~branch_rebased_onto:None ~branch_rebased_onto_sha:None ~checks_passing
-    ~current_op
+    ~branch_rebased_onto:None ~branch_rebased_onto_sha:None
+    ~anchor_history:Onton_core.Anchor_history.empty ~checks_passing ~current_op
     ~current_op_state:(if busy then Patch_agent.Running else Patch_agent.Queued)
     ~current_message_id:None ~generation:0 ~worktree_path ~branch_blocked
     ~llm_session_id:None ~automerge_enabled:false ~automerge_deadline:None

--- a/test/test_rebase_decision_properties.ml
+++ b/test/test_rebase_decision_properties.ml
@@ -75,6 +75,439 @@ let prop_idempotent_when_well_formed =
          with a strip-aware check. *)
       String.equal (String.strip r1) (String.strip r2))
 
+(** ── Structured-plan property tests ─────────────────────────────────────
+
+    These exercise {!Rebase_decision.plan} and
+    {!Rebase_decision.anchor_after_result}. They use a simple in-memory commit
+    DAG model: nodes are 40-char hex SHAs, each with a (possibly-empty) parent
+    SHA. [is_ancestor sha ~descendant:d] walks parents from [d] looking for
+    [sha]. *)
+
+module Dag = struct
+  type t = (string, string option) Hashtbl.t
+
+  let create () : t = Hashtbl.create (module String)
+
+  let add_commit (t : t) sha ~parent =
+    Hashtbl.set t ~key:sha ~data:parent;
+    sha
+
+  let rec is_ancestor (t : t) sha ~descendant =
+    if String.equal sha descendant then true
+    else
+      match Hashtbl.find t descendant with
+      | None | Some None -> false
+      | Some (Some parent) -> is_ancestor t sha ~descendant:parent
+end
+
+let gen_hex40 : string QCheck2.Gen.t =
+  QCheck2.Gen.string_size
+    ~gen:QCheck2.Gen.(oneof [ char_range '0' '9'; char_range 'a' 'f' ])
+    (QCheck2.Gen.return 40)
+
+let gen_typed_branch : Onton_core.Types.Branch.t QCheck2.Gen.t =
+  QCheck2.Gen.map Onton_core.Types.Branch.of_string gen_branch
+
+let mk_anchor ~base sha =
+  match Anchor.make ~base ~sha ~observed_at_remote:true with
+  | Some a -> a
+  | None -> assert false (* gen_hex40 always produces valid SHAs *)
+
+(* Build a linear DAG of [n] commits, returning the SHAs oldest-first. *)
+let build_linear_chain dag n =
+  let rec loop i parent acc =
+    if i > n then List.rev acc
+    else
+      let sha = Printf.sprintf "%040x" i in
+      let _ : string = Dag.add_commit dag sha ~parent in
+      loop (i + 1) (Some sha) (sha :: acc)
+  in
+  loop 1 None []
+
+(* Pattern-match helpers — strict-warnings disallow wildcard variants in
+   tests. Each helper enumerates every plan + reason constructor so adding
+   a new variant forces an explicit decision per test. *)
+
+let plan_is_plain_no_anchor : Rebase_decision.plan -> bool = function
+  | Plain { reason = No_anchor; _ } -> true
+  | Plain
+      {
+        reason =
+          ( Anchor_matches_head | History_fallback _
+          | Anchor_unreachable_from_head | Head_unobservable );
+        _;
+      }
+  | Onto _ ->
+      false
+
+let plan_is_plain_head_unobservable : Rebase_decision.plan -> bool = function
+  | Plain { reason = Head_unobservable; _ } -> true
+  | Plain
+      {
+        reason =
+          ( Anchor_matches_head | History_fallback _ | No_anchor
+          | Anchor_unreachable_from_head );
+        _;
+      }
+  | Onto _ ->
+      false
+
+let plan_is_plain_anchor_unreachable : Rebase_decision.plan -> bool = function
+  | Plain { reason = Anchor_unreachable_from_head; _ } -> true
+  | Plain
+      {
+        reason =
+          ( Anchor_matches_head | History_fallback _ | No_anchor
+          | Head_unobservable );
+        _;
+      }
+  | Onto _ ->
+      false
+
+let plan_onto_matches_head : Rebase_decision.plan -> string option = function
+  | Onto { upstream; reason = Anchor_matches_head; _ } -> Some upstream
+  | Onto
+      {
+        reason =
+          ( History_fallback _ | No_anchor | Anchor_unreachable_from_head
+          | Head_unobservable );
+        _;
+      }
+  | Plain _ ->
+      None
+
+let plan_onto_history_fallback :
+    Rebase_decision.plan -> (string * string) option = function
+  | Onto { upstream; reason = History_fallback s; _ } -> Some (upstream, s)
+  | Onto
+      {
+        reason =
+          ( Anchor_matches_head | No_anchor | Anchor_unreachable_from_head
+          | Head_unobservable );
+        _;
+      }
+  | Plain _ ->
+      None
+
+let plan_onto_upstream : Rebase_decision.plan -> string option = function
+  | Onto { upstream; _ } -> Some upstream
+  | Plain _ -> None
+
+let plan_onto_target_upstream : Rebase_decision.plan -> (string * string) option
+    = function
+  | Onto { target; upstream; reason = Anchor_matches_head } ->
+      Some (target, upstream)
+  | Onto
+      {
+        reason =
+          ( History_fallback _ | No_anchor | Anchor_unreachable_from_head
+          | Head_unobservable );
+        _;
+      }
+  | Plain _ ->
+      None
+
+(** RD-PLAN-1: Plain {No_anchor} when no anchor / no history. *)
+let prop_plan_no_anchor =
+  Test.make ~count:100 ~name:"plan: empty input -> Plain No_anchor"
+    (Gen.pair gen_typed_branch (Gen.option gen_hex40))
+    (fun (base, head_sha) ->
+      let oracle _sha ~descendant:_ = false in
+      let p =
+        Rebase_decision.plan
+          { anchor = None; recorded_history = []; base_branch = base; head_sha }
+          ~ancestor_oracle:oracle
+      in
+      match head_sha with
+      | Some _ -> plan_is_plain_no_anchor p
+      | None -> plan_is_plain_head_unobservable p)
+
+(** RD-PLAN-2: Anchor_matches_head when newest anchor is ancestor of HEAD. *)
+let prop_plan_anchor_matches_head =
+  Test.make ~count:100
+    ~name:"plan: anchor reachable from HEAD -> Onto Anchor_matches_head"
+    gen_typed_branch (fun base ->
+      let dag = Dag.create () in
+      let chain = build_linear_chain dag 5 in
+      let anchor_sha = List.nth_exn chain 2 in
+      let head = List.last_exn chain in
+      let a = mk_anchor ~base anchor_sha in
+      let oracle sha ~descendant = Dag.is_ancestor dag sha ~descendant in
+      let p =
+        Rebase_decision.plan
+          {
+            anchor = Some a;
+            recorded_history = [ a ];
+            base_branch = base;
+            head_sha = Some head;
+          }
+          ~ancestor_oracle:oracle
+      in
+      match plan_onto_matches_head p with
+      | Some upstream -> String.equal upstream anchor_sha
+      | None -> false)
+
+(** RD-PLAN-3: History_fallback when newest anchor not in HEAD but an older
+    history entry is. *)
+let prop_plan_history_fallback =
+  Test.make ~count:50
+    ~name:"plan: stale newest, old history entry reachable -> History_fallback"
+    gen_typed_branch (fun base ->
+      let dag = Dag.create () in
+      let chain = build_linear_chain dag 5 in
+      let old_anchor_sha = List.nth_exn chain 1 in
+      let head = List.last_exn chain in
+      (* A divergent SHA that isn't in the DAG: never an ancestor of anything. *)
+      let stale_sha = String.make 40 'a' in
+      let _ = Dag.add_commit dag stale_sha ~parent:None in
+      let stale = mk_anchor ~base stale_sha in
+      let old_a = mk_anchor ~base old_anchor_sha in
+      let oracle sha ~descendant = Dag.is_ancestor dag sha ~descendant in
+      let p =
+        Rebase_decision.plan
+          {
+            anchor = Some stale;
+            recorded_history = [ stale; old_a ];
+            base_branch = base;
+            head_sha = Some head;
+          }
+          ~ancestor_oracle:oracle
+      in
+      match plan_onto_history_fallback p with
+      | Some (upstream, s) ->
+          String.equal upstream old_anchor_sha && String.equal s old_anchor_sha
+      | None -> false)
+
+(** RD-PLAN-4: Anchor_unreachable_from_head when nothing in history is in HEAD.
+*)
+let prop_plan_anchor_unreachable =
+  Test.make ~count:50
+    ~name:
+      "plan: no anchor reachable from HEAD -> Plain \
+       Anchor_unreachable_from_head"
+    gen_typed_branch (fun base ->
+      let dag = Dag.create () in
+      let chain = build_linear_chain dag 3 in
+      let head = List.last_exn chain in
+      let unrelated1 = String.make 40 'a' in
+      let unrelated2 = String.make 40 'b' in
+      let _ = Dag.add_commit dag unrelated1 ~parent:None in
+      let _ = Dag.add_commit dag unrelated2 ~parent:None in
+      let a1 = mk_anchor ~base unrelated1 in
+      let a2 = mk_anchor ~base unrelated2 in
+      let oracle sha ~descendant = Dag.is_ancestor dag sha ~descendant in
+      let p =
+        Rebase_decision.plan
+          {
+            anchor = Some a1;
+            recorded_history = [ a1; a2 ];
+            base_branch = base;
+            head_sha = Some head;
+          }
+          ~ancestor_oracle:oracle
+      in
+      plan_is_plain_anchor_unreachable p)
+
+(** RD-PLAN-5: Head_unobservable when head_sha = None. *)
+let prop_plan_head_unobservable =
+  Test.make ~count:50 ~name:"plan: head_sha=None -> Plain Head_unobservable"
+    (Gen.pair gen_typed_branch (Gen.list_size (Gen.int_range 0 3) gen_hex40))
+    (fun (base, shas) ->
+      let anchors = List.map shas ~f:(fun s -> mk_anchor ~base s) in
+      let oracle _ ~descendant:_ = true in
+      let p =
+        Rebase_decision.plan
+          {
+            anchor = List.hd anchors;
+            recorded_history = anchors;
+            base_branch = base;
+            head_sha = None;
+          }
+          ~ancestor_oracle:oracle
+      in
+      plan_is_plain_head_unobservable p)
+
+(** RD-PLAN-6: If [plan] returns [Onto {upstream;_}], then [upstream] is an
+    ancestor of [head_sha] under the oracle. This is the central safety
+    invariant — what makes [git rebase --onto target upstream HEAD] sound. *)
+let prop_plan_onto_implies_ancestor =
+  Test.make ~count:200
+    ~name:"plan: Onto.upstream is always an ancestor of head_sha"
+    gen_typed_branch (fun base ->
+      let dag = Dag.create () in
+      let chain = build_linear_chain dag 6 in
+      let head = List.last_exn chain in
+      let unrelated = String.make 40 'a' in
+      let _ = Dag.add_commit dag unrelated ~parent:None in
+      let anchor_shas = unrelated :: List.take chain 4 in
+      let anchors = List.map anchor_shas ~f:(fun s -> mk_anchor ~base s) in
+      let oracle sha ~descendant = Dag.is_ancestor dag sha ~descendant in
+      let p =
+        Rebase_decision.plan
+          {
+            anchor = List.hd anchors;
+            recorded_history = anchors;
+            base_branch = base;
+            head_sha = Some head;
+          }
+          ~ancestor_oracle:oracle
+      in
+      match plan_onto_upstream p with
+      | Some upstream -> Dag.is_ancestor dag upstream ~descendant:head
+      | None -> true)
+
+(** RD-PLAN-7: Idempotence — calling [plan] twice with the same input yields the
+    same plan (the function reads no hidden state). *)
+let prop_plan_idempotent =
+  Test.make ~count:100 ~name:"plan: idempotent on repeat invocation"
+    gen_typed_branch (fun base ->
+      let dag = Dag.create () in
+      let chain = build_linear_chain dag 4 in
+      let head = List.last_exn chain in
+      let a = mk_anchor ~base (List.nth_exn chain 1) in
+      let oracle sha ~descendant = Dag.is_ancestor dag sha ~descendant in
+      let input : Rebase_decision.input =
+        {
+          anchor = Some a;
+          recorded_history = [ a ];
+          base_branch = base;
+          head_sha = Some head;
+        }
+      in
+      let p1 = Rebase_decision.plan input ~ancestor_oracle:oracle in
+      let p2 = Rebase_decision.plan input ~ancestor_oracle:oracle in
+      Rebase_decision.equal_plan p1 p2)
+
+(** RD-PLAN-8: Squash-merge production-bug scenario. p4 was branched off patch-2
+    at SHA X. patch-2 squash-merged to main as Y. p4 has one commit (Z) on top
+    of X. With anchor recorded at Start, plan must produce
+    [Onto {upstream = X; ...}] so [X..Z] = just Z replays cleanly. *)
+let prop_plan_squash_merge_scenario =
+  Test.make ~count:1
+    ~name:"plan: production squash-merge scenario yields Onto with old-dep-tip"
+    (Gen.return ()) (fun () ->
+      let dag = Dag.create () in
+      (* main has commits m1..m3, with m3 being the squash of patch-2. *)
+      let m1 = String.make 40 '1' in
+      let m2 = String.make 40 '2' in
+      let m3 = String.make 40 '3' in
+      let _ = Dag.add_commit dag m1 ~parent:None in
+      let _ = Dag.add_commit dag m2 ~parent:(Some m1) in
+      let _ = Dag.add_commit dag m3 ~parent:(Some m2) in
+      (* patch-2 forked at m1, has its own pre-squash commits x1, x2. *)
+      let x1 = String.make 40 '4' in
+      let x2 = String.make 40 '5' in
+      let _ = Dag.add_commit dag x1 ~parent:(Some m1) in
+      let _ = Dag.add_commit dag x2 ~parent:(Some x1) in
+      (* p4 was branched off patch-2 at x2 (= old_dep_tip), has commit z. *)
+      let z = String.make 40 '6' in
+      let _ = Dag.add_commit dag z ~parent:(Some x2) in
+      let base = Onton_core.Types.Branch.of_string "main" in
+      let anchor =
+        mk_anchor ~base:(Onton_core.Types.Branch.of_string "patch-2") x2
+      in
+      let oracle sha ~descendant = Dag.is_ancestor dag sha ~descendant in
+      let p =
+        Rebase_decision.plan
+          {
+            anchor = Some anchor;
+            recorded_history = [ anchor ];
+            base_branch = base;
+            head_sha = Some z;
+          }
+          ~ancestor_oracle:oracle
+      in
+      match plan_onto_target_upstream p with
+      | Some (target, upstream) ->
+          String.equal target "main" && String.equal upstream x2
+      | None -> false)
+
+(** ── anchor_after_result properties ─────────────────────────────────── *)
+
+let some_anchor () =
+  let base = Onton_core.Types.Branch.of_string "main" in
+  let sha = String.make 40 'c' in
+  mk_anchor ~base sha
+
+let some_result : Worktree_parser.rebase_result = Worktree_parser.Ok
+
+(** RD-AAR-1: Ok with Some resolved SHA -> Some new anchor. *)
+let prop_aar_ok_returns_new =
+  Test.make ~count:50
+    ~name:"anchor_after_result: Ok + Some sha -> Some new anchor"
+    (Gen.pair gen_typed_branch gen_hex40) (fun (base, sha) ->
+      let a =
+        Rebase_decision.anchor_after_result ~prev:None
+          ~result:Worktree_parser.Ok ~resolved_remote_sha:(Some sha)
+          ~base_branch:base
+      in
+      match a with
+      | Some anchor ->
+          String.equal (Anchor.sha anchor) sha
+          && Onton_core.Types.Branch.equal (Anchor.base anchor) base
+      | None -> false)
+
+(** RD-AAR-2: Noop with Some resolved SHA -> Some new anchor (refresh). *)
+let prop_aar_noop_refreshes =
+  Test.make ~count:50
+    ~name:"anchor_after_result: Noop + Some sha -> Some new anchor"
+    (Gen.pair gen_typed_branch gen_hex40) (fun (base, sha) ->
+      let prev = Some (some_anchor ()) in
+      let a =
+        Rebase_decision.anchor_after_result ~prev ~result:Worktree_parser.Noop
+          ~resolved_remote_sha:(Some sha) ~base_branch:base
+      in
+      match a with
+      | Some anchor -> String.equal (Anchor.sha anchor) sha
+      | None -> false)
+
+(** RD-AAR-3: Conflict preserves prev unchanged. *)
+let prop_aar_conflict_preserves =
+  Test.make ~count:50 ~name:"anchor_after_result: Conflict -> prev unchanged"
+    (Gen.pair gen_typed_branch (Gen.option gen_hex40))
+    (fun (base, resolved) ->
+      let prev = Some (some_anchor ()) in
+      let conflict : Worktree_parser.rebase_result =
+        Worktree_parser.Conflict
+          {
+            target = "main";
+            old_base = "";
+            unique_commits = [];
+            strategy = Worktree_parser.Plain;
+            orig_head = "";
+          }
+      in
+      let a =
+        Rebase_decision.anchor_after_result ~prev ~result:conflict
+          ~resolved_remote_sha:resolved ~base_branch:base
+      in
+      Option.equal Anchor.equal a prev)
+
+(** RD-AAR-4: Error preserves prev unchanged. *)
+let prop_aar_error_preserves =
+  Test.make ~count:50 ~name:"anchor_after_result: Error -> prev unchanged"
+    (Gen.pair gen_typed_branch (Gen.option gen_hex40))
+    (fun (base, resolved) ->
+      let prev = Some (some_anchor ()) in
+      let a =
+        Rebase_decision.anchor_after_result ~prev
+          ~result:(Worktree_parser.Error "boom") ~resolved_remote_sha:resolved
+          ~base_branch:base
+      in
+      Option.equal Anchor.equal a prev)
+
+(** RD-AAR-5: Ok with None resolved -> prev unchanged (no fabricated anchor). *)
+let prop_aar_ok_no_sha_preserves =
+  Test.make ~count:50
+    ~name:"anchor_after_result: Ok + None sha -> prev unchanged"
+    gen_typed_branch (fun base ->
+      let prev = Some (some_anchor ()) in
+      let a =
+        Rebase_decision.anchor_after_result ~prev ~result:some_result
+          ~resolved_remote_sha:None ~base_branch:base
+      in
+      Option.equal Anchor.equal a prev)
+
 let () =
   List.iter
     ~f:(fun t -> QCheck2.Test.check_exn t)
@@ -84,5 +517,18 @@ let () =
       prop_none_uses_fallback;
       prop_empty_sha_uses_fallback;
       prop_idempotent_when_well_formed;
+      prop_plan_no_anchor;
+      prop_plan_anchor_matches_head;
+      prop_plan_history_fallback;
+      prop_plan_anchor_unreachable;
+      prop_plan_head_unobservable;
+      prop_plan_onto_implies_ancestor;
+      prop_plan_idempotent;
+      prop_plan_squash_merge_scenario;
+      prop_aar_ok_returns_new;
+      prop_aar_noop_refreshes;
+      prop_aar_conflict_preserves;
+      prop_aar_error_preserves;
+      prop_aar_ok_no_sha_preserves;
     ];
   Stdlib.print_endline "Rebase_decision: all properties passed"

--- a/test/test_rebase_decision_properties.ml
+++ b/test/test_rebase_decision_properties.ml
@@ -207,7 +207,7 @@ let plan_onto_target_upstream : Rebase_decision.plan -> (string * string) option
   | Plain _ ->
       None
 
-(** RD-PLAN-1: Plain {No_anchor} when no anchor / no history. *)
+(** RD-PLAN-1: [Plain No_anchor] when no anchor / no history. *)
 let prop_plan_no_anchor =
   Test.make ~count:100 ~name:"plan: empty input -> Plain No_anchor"
     (Gen.pair gen_typed_branch (Gen.option gen_hex40))

--- a/test/test_rebase_decision_properties.ml
+++ b/test/test_rebase_decision_properties.ml
@@ -1,79 +1,17 @@
 open Base
 open Onton_core
 
-(** Property tests for {!Rebase_decision.upstream}.
+(** Property tests for {!Rebase_decision.plan} and
+    {!Rebase_decision.anchor_after_result}.
 
-    The pure decision answers: "what [<upstream>] should I pass to
-    [git rebase --onto <new_base> <upstream>]?" When the orchestrator recorded
-    the previous base's SHA at the last successful rebase / start, that SHA is
-    the right anchor — anything older than it is shared with the old base and
-    gets dropped, anything newer is the patch's own work. Without the SHA, we
-    fall back to the supplied branch name (today's behavior). Properties:
-
-    - {b Totality}: never raises over arbitrary input.
-    - {b Some-wins}: a non-empty SHA always beats the fallback.
-    - {b None-falls-back}: [None] and empty / whitespace-only SHAs use the
-      fallback verbatim.
-    - {b Idempotence}: the result of [upstream] fed back as the SHA returns
-      itself. *)
+    The legacy [Rebase_decision.upstream] shim was removed in step 5; its
+    properties (RD-1..5) have been replaced by the structured-plan suite below.
+*)
 
 module Gen = QCheck2.Gen
 module Test = QCheck2.Test
 
-let gen_sha = Gen.string_size ~gen:(Gen.char_range 'a' 'f') (Gen.int_range 7 40)
 let gen_branch = Gen.string_size ~gen:Gen.printable (Gen.int_range 1 40)
-
-let prop_total =
-  Test.make ~count:500 ~name:"RD-1: upstream is total over arbitrary input"
-    (Gen.pair
-       (Gen.option (Gen.string_size ~gen:Gen.printable (Gen.int_range 0 60)))
-       (Gen.string_size ~gen:Gen.printable (Gen.int_range 0 60)))
-    (fun (prev_base_sha, fallback) ->
-      try
-        let _ = Rebase_decision.upstream ~prev_base_sha ~fallback in
-        true
-      with _ -> false)
-
-let prop_some_sha_wins =
-  Test.make ~name:"RD-2: Some <non-empty SHA> wins over fallback" ~count:200
-    (Gen.pair gen_sha gen_branch) (fun (sha, fallback) ->
-      String.equal
-        (Rebase_decision.upstream ~prev_base_sha:(Some sha) ~fallback)
-        sha)
-
-let prop_none_uses_fallback =
-  Test.make ~name:"RD-3: None falls back to the supplied branch name" ~count:200
-    gen_branch (fun fallback ->
-      String.equal
-        (Rebase_decision.upstream ~prev_base_sha:None ~fallback)
-        fallback)
-
-let prop_empty_sha_uses_fallback =
-  Test.make
-    ~name:"RD-4: Some empty / whitespace SHA falls back to the branch name"
-    (Gen.pair (Gen.oneof_list [ ""; " "; "  \t  "; "\n" ]) gen_branch)
-    (fun (sha, fallback) ->
-      String.equal
-        (Rebase_decision.upstream ~prev_base_sha:(Some sha) ~fallback)
-        fallback)
-
-let prop_idempotent_when_well_formed =
-  Test.make
-    ~name:
-      "RD-5: upstream is idempotent under re-feeding the result, for \
-       well-formed SHAs / fallbacks (no surrounding whitespace)"
-    ~count:300
-    (Gen.pair (Gen.option gen_sha) gen_branch)
-    (fun (prev_base_sha, fallback) ->
-      (* gen_sha and gen_branch don't generate whitespace-only strings, so
-         the strip-then-empty branch never triggers — the result fed back as
-         a SHA always survives unchanged. *)
-      let r1 = Rebase_decision.upstream ~prev_base_sha ~fallback in
-      let r2 = Rebase_decision.upstream ~prev_base_sha:(Some r1) ~fallback in
-      (* gen_branch includes printable chars that may surround whitespace
-         after a strip operation inside [upstream], so guard the equality
-         with a strip-aware check. *)
-      String.equal (String.strip r1) (String.strip r2))
 
 (** ── Structured-plan property tests ─────────────────────────────────────
 
@@ -512,11 +450,6 @@ let () =
   List.iter
     ~f:(fun t -> QCheck2.Test.check_exn t)
     [
-      prop_total;
-      prop_some_sha_wins;
-      prop_none_uses_fallback;
-      prop_empty_sha_uses_fallback;
-      prop_idempotent_when_well_formed;
       prop_plan_no_anchor;
       prop_plan_anchor_matches_head;
       prop_plan_history_fallback;

--- a/test/test_rebase_onto.ml
+++ b/test/test_rebase_onto.ml
@@ -777,7 +777,7 @@ let () =
    let result =
      Worktree.rebase_onto ~process_mgr ~path:dir
        ~target:(Types.Branch.of_string "main")
-       ~project_name:"" ~ancestor_ids:[] ()
+       ~upstream:"main" ~project_name:"" ~ancestor_ids:[] ()
    in
    assert_rebase_ok "test1: simple rebase" result;
    (* C should now be on top of B *)
@@ -818,7 +818,7 @@ let () =
    let result =
      Worktree.rebase_onto ~process_mgr ~path:dir
        ~target:(Types.Branch.of_string "main")
-       ~project_name:"" ~ancestor_ids:[] ()
+       ~upstream:"main" ~project_name:"" ~ancestor_ids:[] ()
    in
    assert_rebase_ok "test2: onto after squash" result;
    let log = git ~process_mgr ~dir [ "log"; "--oneline"; "--format=%s" ] in
@@ -857,7 +857,7 @@ let () =
    let result =
      Worktree.rebase_onto ~process_mgr ~path:dir
        ~target:(Types.Branch.of_string "main")
-       ~project_name:"" ~ancestor_ids:[] ()
+       ~upstream:"main" ~project_name:"" ~ancestor_ids:[] ()
    in
    assert_rebase_ok "test3: multi-commit" result;
    let log = git ~process_mgr ~dir [ "log"; "--oneline"; "--format=%s" ] in
@@ -879,7 +879,7 @@ let () =
    let result =
      Worktree.rebase_onto ~process_mgr ~path:dir
        ~target:(Types.Branch.of_string "main")
-       ~project_name:"" ~ancestor_ids:[] ()
+       ~upstream:"main" ~project_name:"" ~ancestor_ids:[] ()
    in
    assert_rebase_noop "test4: already up-to-date" result;
    Stdlib.Sys.command (Printf.sprintf "rm -rf %s" dir) |> ignore);
@@ -905,7 +905,7 @@ let () =
    let result =
      Worktree.rebase_onto ~process_mgr ~path:dir
        ~target:(Types.Branch.of_string "main")
-       ~project_name:"" ~ancestor_ids:[] ()
+       ~upstream:"main" ~project_name:"" ~ancestor_ids:[] ()
    in
    assert_rebase_conflict "test5: conflict" result;
    (* Rebase should be left in progress for the agent to resolve *)
@@ -941,7 +941,7 @@ let () =
    let result =
      Worktree.rebase_onto ~process_mgr ~path:dir
        ~target:(Types.Branch.of_string "dep2")
-       ~project_name:"" ~ancestor_ids:[] ()
+       ~upstream:"dep2" ~project_name:"" ~ancestor_ids:[] ()
    in
    assert_rebase_noop "test6: dep2 already ancestor" result;
    Stdlib.Sys.command (Printf.sprintf "rm -rf %s" dir) |> ignore);
@@ -968,7 +968,7 @@ let () =
    let result =
      Worktree.rebase_onto ~process_mgr ~path:dir
        ~target:(Types.Branch.of_string "main")
-       ~project_name:"" ~ancestor_ids:[] ()
+       ~upstream:"main" ~project_name:"" ~ancestor_ids:[] ()
    in
    (* With a real merge, D1 is in main's history so cherry-pick should
       identify only F1 as unique. Result should be Ok or Noop depending
@@ -1000,7 +1000,7 @@ let () =
    let result =
      Worktree.rebase_onto ~process_mgr ~path:dir
        ~target:(Types.Branch.of_string "main")
-       ~project_name:"" ~ancestor_ids:[] ()
+       ~upstream:"main" ~project_name:"" ~ancestor_ids:[] ()
    in
    (* find_old_base returns Error "no unique commits found" so we fall
       back to plain rebase. Plain rebase should produce Ok or conflict
@@ -1031,7 +1031,7 @@ let () =
    let result =
      Worktree.rebase_onto ~process_mgr ~path:dir
        ~target:(Types.Branch.of_string "main")
-       ~project_name:"" ~ancestor_ids:[] ()
+       ~upstream:"main" ~project_name:"" ~ancestor_ids:[] ()
    in
    assert_rebase_ok "test9: modify dep file" result;
    let log = git ~process_mgr ~dir [ "log"; "--oneline"; "--format=%s" ] in
@@ -1119,7 +1119,7 @@ let () =
    let result =
      Worktree.rebase_onto ~process_mgr ~path:dir
        ~target:(Types.Branch.of_string "main")
-       ~project_name:"proj"
+       ~upstream:"main" ~project_name:"proj"
        ~ancestor_ids:[ Types.Patch_id.of_string "1" ]
        ()
    in

--- a/test/test_rebase_state_machine.ml
+++ b/test/test_rebase_state_machine.ml
@@ -1,0 +1,392 @@
+open Base
+open Onton_core
+
+(** Interleaving state-machine tests for the rebase anchor pipeline.
+
+    Each named scenario (SM-N) simulates a realistic sequence of orchestrator
+    actions + external git events against an in-memory commit DAG. After each
+    Rebase action, the test asserts that the [Rebase_decision.plan] invocation
+    produces a [<upstream>] argument that would NOT cause
+    [git rebase --onto <target> <upstream> HEAD] to replay commits already
+    present on the new base. Together with the property suite in
+    [test_rebase_decision_properties], these tests pin down the integration
+    between {!Patch_agent.record_anchor}, {!Rebase_decision.plan}, and
+    {!Rebase_decision.anchor_after_result} over sequences. *)
+
+module Branch = Types.Branch
+
+(* ── In-memory commit DAG model ────────────────────────────────────────── *)
+
+module Dag = struct
+  type t = {
+    parents : (string, string option) Hashtbl.t;
+    refs : (string, string) Hashtbl.t;
+  }
+
+  let create () =
+    {
+      parents = Hashtbl.create (module String);
+      refs = Hashtbl.create (module String);
+    }
+
+  let add_commit t sha ~parent =
+    Hashtbl.set t.parents ~key:sha ~data:parent;
+    sha
+
+  let set_ref t name sha = Hashtbl.set t.refs ~key:name ~data:sha
+  let resolve t name = Hashtbl.find t.refs name
+
+  let rec is_ancestor t sha ~descendant =
+    if String.equal sha descendant then true
+    else
+      match Hashtbl.find t.parents descendant with
+      | None | Some None -> false
+      | Some (Some parent) -> is_ancestor t sha ~descendant:parent
+
+  (* Pure predicate: would [git rebase --onto target upstream HEAD] try to
+     replay any commit reachable from [upstream] but ALSO reachable from
+     [target]? If yes, those commits are "already there" and replaying them
+     produces "both added" or duplicate-application conflicts. This is the
+     production bug the anchor pipeline exists to prevent. *)
+  let _rebase_would_replay_merged_commits _t ~upstream:_ ~target:_ ~head:_ =
+    (* Not directly checked in these scenarios — instead we check the
+       stronger property: the chosen upstream is itself reachable from
+       head, which means [upstream..head] is exactly the patch's own
+       commits (per git's range semantics). *)
+    false
+
+  let oracle t sha ~descendant = is_ancestor t sha ~descendant
+end
+
+(* ── Helpers ────────────────────────────────────────────────────────────── *)
+
+let mk_anchor ~base ~sha =
+  match Anchor.make ~base ~sha ~observed_at_remote:true with
+  | Some a -> a
+  | None -> failwith ("mk_anchor: bad SHA " ^ sha)
+
+let sha_for n = Printf.sprintf "%040x" n
+
+let run_plan ~history ~base_branch ~head ~dag =
+  let input : Rebase_decision.input =
+    {
+      anchor = Anchor_history.newest history;
+      recorded_history = Anchor_history.to_list history;
+      base_branch;
+      head_sha = Some head;
+    }
+  in
+  Rebase_decision.plan input ~ancestor_oracle:(Dag.oracle dag)
+
+(* Plan accessors — strict-warnings disallow wildcard variants. *)
+let plan_upstream : Rebase_decision.plan -> string = function
+  | Onto { upstream; _ } -> upstream
+  | Plain { target; _ } -> target
+
+let plan_reason : Rebase_decision.plan -> Rebase_decision.reason = function
+  | Onto { reason; _ } | Plain { reason; _ } -> reason
+
+let reason_is_anchor_matches_head : Rebase_decision.reason -> bool = function
+  | Anchor_matches_head -> true
+  | History_fallback _ | No_anchor | Anchor_unreachable_from_head
+  | Head_unobservable ->
+      false
+
+let reason_is_history_fallback : Rebase_decision.reason -> bool = function
+  | History_fallback _ -> true
+  | Anchor_matches_head | No_anchor | Anchor_unreachable_from_head
+  | Head_unobservable ->
+      false
+
+let reason_is_no_anchor : Rebase_decision.reason -> bool = function
+  | No_anchor -> true
+  | Anchor_matches_head | History_fallback _ | Anchor_unreachable_from_head
+  | Head_unobservable ->
+      false
+
+(* ── SM-2: production-bug scenario, end-to-end ─────────────────────────── *)
+(* p4 was branched off patch-2 at Start. patch-2 squash-merges to main while
+   p4 is idle. p4's first rebase must produce Onto with the old patch-2 tip
+   as upstream — git's `upstream..HEAD` is then exactly p4's own work and
+   replays cleanly onto post-squash main. *)
+let test_sm2_production_bug () =
+  let dag = Dag.create () in
+  let main_branch = Branch.of_string "main" in
+  let dep_branch = Branch.of_string "patch-2" in
+
+  (* Initial main: m1. patch-2 = m1 -> x1 -> x2. p4 branched off patch-2 at
+     x2 with one commit z on top. *)
+  let m1 = Dag.add_commit dag (sha_for 1) ~parent:None in
+  let x1 = Dag.add_commit dag (sha_for 2) ~parent:(Some m1) in
+  let x2 = Dag.add_commit dag (sha_for 3) ~parent:(Some x1) in
+  let z = Dag.add_commit dag (sha_for 4) ~parent:(Some x2) in
+  Dag.set_ref dag "origin/main" m1;
+  Dag.set_ref dag "origin/patch-2" x2;
+  Dag.set_ref dag "HEAD@p4" z;
+
+  (* Step 1: p4's Start runs for_start which captures origin/patch-2 = x2.
+     The anchor (base=patch-2, sha=x2) goes into anchor_history. *)
+  let history =
+    Anchor_history.push Anchor_history.empty
+      (mk_anchor ~base:dep_branch ~sha:x2)
+  in
+
+  (* Step 2: patch-2 squash-merges. Main advances to m1 -> m3 (the squash).
+     origin/patch-2 may still exist (we model it as still pointing at x2). *)
+  let m3 = Dag.add_commit dag (sha_for 5) ~parent:(Some m1) in
+  Dag.set_ref dag "origin/main" m3;
+
+  (* Step 3: orchestrator's refresh_base_branch (post-merge) shifts p4's
+     base_branch from patch-2 to main. anchor_history is preserved per
+     the step-8 design. *)
+  let plan = run_plan ~history ~base_branch:main_branch ~head:z ~dag in
+
+  let upstream = plan_upstream plan in
+  let reason = plan_reason plan in
+
+  (* Assert: upstream = x2 (the old patch-2 tip). *)
+  assert (String.equal upstream x2);
+  (* Assert: reason = Anchor_matches_head (the anchor is reachable from HEAD). *)
+  assert (reason_is_anchor_matches_head reason);
+  (* Critical invariant: upstream is an ancestor of HEAD. This is what
+     makes [git rebase --onto main x2 z] sound — the range x2..z is
+     exactly {z}, p4's own commit. The dep's commits (x1, x2) are NOT
+     replayed because they're at-or-below upstream. *)
+  assert (Dag.is_ancestor dag upstream ~descendant:z);
+  Stdlib.print_endline "SM-2 (production bug) passed"
+
+(* ── SM-3: force-push of dep branch; history fallback ──────────────────── *)
+(* Setup: same as SM-2 but the dep branch (patch-2) is force-pushed so its
+   origin tip moves to a divergent SHA. p4's HEAD still descends from the
+   pre-force-push tip (force-pushing a dep doesn't affect a dependent's
+   local HEAD). The newest anchor is still reachable from HEAD; SM-3 verifies
+   that the plan picks Anchor_matches_head, not History_fallback (because
+   the newest anchor IS still good). *)
+let test_sm3_force_push_dep () =
+  let dag = Dag.create () in
+  let main_branch = Branch.of_string "main" in
+  let dep_branch = Branch.of_string "patch-2" in
+  let m1 = Dag.add_commit dag (sha_for 1) ~parent:None in
+  let x1 = Dag.add_commit dag (sha_for 2) ~parent:(Some m1) in
+  let x2 = Dag.add_commit dag (sha_for 3) ~parent:(Some x1) in
+  let z = Dag.add_commit dag (sha_for 4) ~parent:(Some x2) in
+  Dag.set_ref dag "origin/main" m1;
+  Dag.set_ref dag "origin/patch-2" x2;
+
+  let history =
+    Anchor_history.push Anchor_history.empty
+      (mk_anchor ~base:dep_branch ~sha:x2)
+  in
+
+  (* Force-push patch-2 to a new SHA divergent from p4's HEAD. *)
+  let divergent = Dag.add_commit dag (String.make 40 'a') ~parent:None in
+  Dag.set_ref dag "origin/patch-2" divergent;
+
+  (* p4's HEAD still descends from x2 (force-push doesn't touch local p4). *)
+  let plan = run_plan ~history ~base_branch:main_branch ~head:z ~dag in
+  let upstream = plan_upstream plan in
+  assert (String.equal upstream x2);
+  assert (reason_is_anchor_matches_head (plan_reason plan));
+  Stdlib.print_endline "SM-3a (dep force-push, anchor still in HEAD) passed";
+
+  (* Scenario variant: p4's HEAD ITSELF gets reset (e.g. via `git reset
+     --hard`) such that x2 is no longer an ancestor of HEAD. Then the
+     anchor diverges; without a history fallback, plan returns
+     Plain {Anchor_unreachable_from_head}. *)
+  let fresh_head = Dag.add_commit dag (String.make 40 'b') ~parent:None in
+  let plan2 =
+    run_plan ~history ~base_branch:main_branch ~head:fresh_head ~dag
+  in
+  assert (
+    match plan2 with
+    | Plain { reason; _ } -> (
+        match reason with
+        | Anchor_unreachable_from_head -> true
+        | Anchor_matches_head | History_fallback _ | No_anchor
+        | Head_unobservable ->
+            false)
+    | Onto _ -> false);
+  Stdlib.print_endline "SM-3b (HEAD reset, anchor unreachable) passed"
+
+(* ── SM-7: Noop rebase refreshes the anchor ────────────────────────────── *)
+(* When a rebase returns Noop (local HEAD already contains origin/<base>),
+   anchor_after_result must still produce a fresh anchor — previously this
+   was a blind spot because the SHA was captured only on Ok. *)
+let test_sm7_noop_refreshes_anchor () =
+  let main_branch = Branch.of_string "main" in
+  let prev = Some (mk_anchor ~base:main_branch ~sha:(sha_for 1)) in
+
+  let after =
+    Rebase_decision.anchor_after_result ~prev ~result:Worktree_parser.Noop
+      ~resolved_remote_sha:(Some (sha_for 2))
+      ~base_branch:main_branch
+  in
+  (match after with
+  | None -> failwith "SM-7: Noop should refresh anchor"
+  | Some a ->
+      assert (String.equal (Anchor.sha a) (sha_for 2));
+      assert (Branch.equal (Anchor.base a) main_branch));
+  Stdlib.print_endline "SM-7 (Noop refreshes anchor) passed"
+
+(* ── SM-8: Conflict preserves prior anchor; retry uses the same one ───── *)
+(* A Conflict result must NOT clear or replace the prior anchor. The next
+   rebase attempt sees the same input and picks the same plan. *)
+let test_sm8_conflict_preserves_prior () =
+  let main_branch = Branch.of_string "main" in
+  let prev = Some (mk_anchor ~base:main_branch ~sha:(sha_for 1)) in
+  let conflict : Worktree_parser.rebase_result =
+    Worktree_parser.Conflict
+      {
+        target = "main";
+        old_base = "";
+        unique_commits = [];
+        strategy = Worktree_parser.Plain;
+        orig_head = "";
+      }
+  in
+  let after =
+    Rebase_decision.anchor_after_result ~prev ~result:conflict
+      ~resolved_remote_sha:(Some (sha_for 2))
+      ~base_branch:main_branch
+  in
+  assert (Option.equal Anchor.equal after prev);
+  Stdlib.print_endline "SM-8 (Conflict preserves prior anchor) passed"
+
+(* ── SM-1: dep merges WHILE dependent's rebase is in flight ───────────── *)
+(* Sequence:
+   1. p2's anchor recorded at Start as {patch-1, p1_tip}.
+   2. p2's Rebase begins; planner reads anchor_history at this point.
+   3. EXTERNALLY: patch-1 squash-merges to main (changes origin/main but
+      NOT origin/patch-1).
+   4. The in-flight rebase completes Ok; anchor_after_result on Ok records
+      a fresh anchor against the (now-updated) origin/main tip.
+   Invariant: even if step 3 happens between steps 2 and 4, the recorded
+   anchor remains coherent: it's either the pre-merge p1_tip (correct
+   for the rebase that was in flight) or the post-merge main_tip (correct
+   for subsequent rebases). It is NEVER a fabricated value or empty. *)
+let test_sm1_concurrent_merge_during_rebase () =
+  let dag = Dag.create () in
+  let main_branch = Branch.of_string "main" in
+  let dep_branch = Branch.of_string "patch-1" in
+  let m1 = Dag.add_commit dag (sha_for 1) ~parent:None in
+  let x = Dag.add_commit dag (sha_for 2) ~parent:(Some m1) in
+  Dag.set_ref dag "origin/main" m1;
+  Dag.set_ref dag "origin/patch-1" x;
+
+  (* Step 1: p2 Start records anchor on dep at x. *)
+  let history =
+    Anchor_history.push Anchor_history.empty (mk_anchor ~base:dep_branch ~sha:x)
+  in
+  assert (
+    Option.equal Anchor.equal
+      (Anchor_history.newest history)
+      (Some (mk_anchor ~base:dep_branch ~sha:x)));
+
+  (* Step 2: Rebase dispatched against base=patch-1. The planner is going
+     to be called from inside the executor; here we simulate one execution. *)
+  let plan_during_rebase =
+    run_plan ~history ~base_branch:dep_branch ~head:(sha_for 3) ~dag
+  in
+  (* Sanity: we have a coherent plan. (No assertion on outcome; the patch's
+     HEAD = sha_for 3 isn't in the DAG so the plan can be either Plain
+     unreachable or otherwise — both are coherent.) *)
+  let _ = plan_during_rebase in
+
+  (* Step 3 (external): patch-1 squash-merges to main. *)
+  let m3 = Dag.add_commit dag (sha_for 4) ~parent:(Some m1) in
+  Dag.set_ref dag "origin/main" m3;
+
+  (* Step 4: the rebase completes Ok against the new main. Record fresh
+     anchor via anchor_after_result. *)
+  let after =
+    Rebase_decision.anchor_after_result
+      ~prev:(Anchor_history.newest history)
+      ~result:Worktree_parser.Ok
+      ~resolved_remote_sha:(Dag.resolve dag "origin/main")
+      ~base_branch:main_branch
+  in
+  let history =
+    match after with Some a -> Anchor_history.push history a | None -> history
+  in
+  (* Invariant: history now contains BOTH the pre-merge anchor (still
+     reachable as the second-newest) and the fresh post-merge anchor. *)
+  let entries = Anchor_history.to_list history in
+  assert (List.length entries = 2);
+  assert (String.equal (Anchor.sha (List.nth_exn entries 0)) m3);
+  assert (String.equal (Anchor.sha (List.nth_exn entries 1)) x);
+  Stdlib.print_endline "SM-1 (concurrent merge during rebase) passed"
+
+(* ── SM-4: 4-deep stack, multiple concurrent merges ─────────────────────── *)
+(* p1 ← p2 ← p3 ← p4. p1, p2, p3 squash-merge in sequence. p4's anchor
+   history grows; at each step, plan picks the right anchor for the
+   currently-targeted base, never replaying merged work. *)
+let test_sm4_deep_stack_sequential_merges () =
+  let dag = Dag.create () in
+  let main_branch = Branch.of_string "main" in
+  let p1_branch = Branch.of_string "p1" in
+  let p2_branch = Branch.of_string "p2" in
+  let p3_branch = Branch.of_string "p3" in
+
+  let m0 = Dag.add_commit dag (sha_for 100) ~parent:None in
+  let p1_tip = Dag.add_commit dag (sha_for 101) ~parent:(Some m0) in
+  let p2_tip = Dag.add_commit dag (sha_for 102) ~parent:(Some p1_tip) in
+  let p3_tip = Dag.add_commit dag (sha_for 103) ~parent:(Some p2_tip) in
+  let p4_commit = Dag.add_commit dag (sha_for 104) ~parent:(Some p3_tip) in
+  Dag.set_ref dag "origin/main" m0;
+
+  (* p4 Start: anchor on p3 at p3_tip. *)
+  let history =
+    Anchor_history.push Anchor_history.empty
+      (mk_anchor ~base:p3_branch ~sha:p3_tip)
+  in
+
+  (* p1 squash-merges into main. p4 still has p1_tip..p4 in its history. *)
+  let m1 = Dag.add_commit dag (sha_for 200) ~parent:(Some m0) in
+  Dag.set_ref dag "origin/main" m1;
+  let plan1 = run_plan ~history ~base_branch:main_branch ~head:p4_commit ~dag in
+  assert (String.equal (plan_upstream plan1) p3_tip);
+  assert (reason_is_anchor_matches_head (plan_reason plan1));
+
+  (* p2 squash-merges. *)
+  let m2 = Dag.add_commit dag (sha_for 201) ~parent:(Some m1) in
+  Dag.set_ref dag "origin/main" m2;
+  let plan2 = run_plan ~history ~base_branch:main_branch ~head:p4_commit ~dag in
+  assert (String.equal (plan_upstream plan2) p3_tip);
+
+  (* p3 squash-merges. Now p3_tip is no longer the dep tip but it's
+     STILL an ancestor of p4's HEAD (since p4 was branched off p3 at
+     p3_tip and hasn't been rebased). Anchor still valid. *)
+  let m3 = Dag.add_commit dag (sha_for 202) ~parent:(Some m2) in
+  Dag.set_ref dag "origin/main" m3;
+  let plan3 = run_plan ~history ~base_branch:main_branch ~head:p4_commit ~dag in
+  assert (String.equal (plan_upstream plan3) p3_tip);
+  assert (Dag.is_ancestor dag p3_tip ~descendant:p4_commit);
+  let _ = (p1_branch, p2_branch) in
+  Stdlib.print_endline "SM-4 (deep stack sequential merges) passed"
+
+(* ── SM-no-anchor: bare baseline ───────────────────────────────────────── *)
+(* No anchor has ever been recorded (legacy agent, no Start ever ran since
+   the upgrade). Plan returns Plain {No_anchor}, which the executor
+   translates to upstream = target → the 2-arg legacy form. This is
+   bit-equivalent to today's behavior. *)
+let test_sm_no_anchor_baseline () =
+  let dag = Dag.create () in
+  let main_branch = Branch.of_string "main" in
+  let m = Dag.add_commit dag (sha_for 1) ~parent:None in
+  Dag.set_ref dag "origin/main" m;
+  let plan =
+    run_plan ~history:Anchor_history.empty ~base_branch:main_branch ~head:m ~dag
+  in
+  assert (reason_is_no_anchor (plan_reason plan));
+  Stdlib.print_endline "SM-no-anchor (baseline) passed"
+
+let () =
+  test_sm1_concurrent_merge_during_rebase ();
+  test_sm2_production_bug ();
+  test_sm3_force_push_dep ();
+  test_sm4_deep_stack_sequential_merges ();
+  test_sm7_noop_refreshes_anchor ();
+  test_sm8_conflict_preserves_prior ();
+  test_sm_no_anchor_baseline ();
+  let _ = reason_is_history_fallback in
+  Stdlib.print_endline "All rebase state-machine tests passed"

--- a/test/test_worktree_plan.ml
+++ b/test/test_worktree_plan.ml
@@ -63,9 +63,10 @@ let plan_has_rebase_target (plan : t) target =
     | Record_anchor_on_success _ ->
         false)
 
-let plan_has_capture_for (plan : t) ref_name =
+let plan_has_capture_for_slot (plan : t) ref_name slot =
   List.exists plan ~f:(function
-    | Capture_anchor { ref_name = r; _ } -> String.equal r ref_name
+    | Capture_anchor { ref_name = r; slot = s } ->
+        String.equal r ref_name && Int.equal s slot
     | Ensure_worktree | Fetch_origin | Rebase_onto _
     | Record_anchor_on_success _ ->
         false)
@@ -114,8 +115,9 @@ let () =
       Test.make
         ~name:"for_start: includes Capture_anchor for origin/<base> in slot 0"
         gen_branch (fun base ->
-          plan_has_capture_for (for_start ~base)
-            ("origin/" ^ Branch.to_string base));
+          plan_has_capture_for_slot (for_start ~base)
+            ("origin/" ^ Branch.to_string base)
+            0);
       Test.make ~name:"for_start: includes Record_anchor_on_success for base"
         gen_branch (fun base -> plan_has_record_for (for_start ~base) base);
       Test.make ~name:"ensures_worktree_before_fs: agrees with reference"

--- a/test/test_worktree_plan.ml
+++ b/test/test_worktree_plan.ml
@@ -9,84 +9,138 @@ let gen_branch =
     map Branch.of_string
       (string_size ~gen:(char_range 'a' 'z') (int_range 1 20)))
 
+let gen_ref_name =
+  QCheck2.Gen.(
+    map
+      (fun b -> "origin/" ^ b)
+      (string_size ~gen:(char_range 'a' 'z') (int_range 1 20)))
+
 let gen_op : op QCheck2.Gen.t =
   QCheck2.Gen.oneof
     [
       QCheck2.Gen.return Ensure_worktree;
       QCheck2.Gen.return Fetch_origin;
+      QCheck2.Gen.map2
+        (fun ref_name slot -> Capture_anchor { ref_name; slot })
+        gen_ref_name
+        (QCheck2.Gen.int_range 0 4);
       QCheck2.Gen.map (fun b -> Rebase_onto b) gen_branch;
+      QCheck2.Gen.map2
+        (fun slot base -> Record_anchor_on_success { slot; base })
+        (QCheck2.Gen.int_range 0 4)
+        gen_branch;
     ]
 
 let gen_plan = QCheck2.Gen.list_size (QCheck2.Gen.int_range 0 8) gen_op
 
 (* Reference predicate, written independently of the implementation: every
-   filesystem op (Fetch_origin / Rebase_onto) must have an Ensure_worktree
-   somewhere earlier in the list. *)
+   non-[Ensure_worktree] op must have an [Ensure_worktree] somewhere earlier
+   in the list. *)
 let reference_invariant (plan : t) =
   let rec loop ensured = function
     | [] -> true
     | Ensure_worktree :: rest -> loop true rest
     | Fetch_origin :: rest -> ensured && loop ensured rest
+    | Capture_anchor _ :: rest -> ensured && loop ensured rest
     | Rebase_onto _ :: rest -> ensured && loop ensured rest
+    | Record_anchor_on_success _ :: rest -> ensured && loop ensured rest
   in
   loop false plan
+
+let first_op_is_ensure_worktree (plan : t) =
+  match plan with
+  | Ensure_worktree :: _ -> true
+  | ( Fetch_origin | Capture_anchor _ | Rebase_onto _
+    | Record_anchor_on_success _ )
+    :: _
+  | [] ->
+      false
+
+let plan_has_rebase_target (plan : t) target =
+  List.exists plan ~f:(function
+    | Rebase_onto t -> Branch.equal t target
+    | Ensure_worktree | Fetch_origin | Capture_anchor _
+    | Record_anchor_on_success _ ->
+        false)
+
+let plan_has_capture_for (plan : t) ref_name =
+  List.exists plan ~f:(function
+    | Capture_anchor { ref_name = r; _ } -> String.equal r ref_name
+    | Ensure_worktree | Fetch_origin | Rebase_onto _
+    | Record_anchor_on_success _ ->
+        false)
+
+let plan_has_record_for (plan : t) base =
+  List.exists plan ~f:(function
+    | Record_anchor_on_success { base = b; _ } -> Branch.equal b base
+    | Ensure_worktree | Fetch_origin | Capture_anchor _ | Rebase_onto _ -> false)
 
 let () =
   let open QCheck2 in
   let tests =
     [
-      (* The safety invariant: any plan returned by [for_rebase] satisfies
-         [ensures_worktree_before_fs]. This is the property the patch-48
-         bug would have failed. *)
       Test.make ~name:"for_rebase: ensures worktree before any fs op" gen_branch
         (fun new_base -> ensures_worktree_before_fs (for_rebase ~new_base));
       Test.make ~name:"for_merge_conflict: ensures worktree before any fs op"
         gen_branch (fun base ->
           ensures_worktree_before_fs (for_merge_conflict ~base));
-      (* Stronger: the very first op of these scenarios is Ensure_worktree.
-         Catches regressions where someone reorders or prepends. *)
+      Test.make ~name:"for_start: ensures worktree before any fs op" gen_branch
+        (fun base -> ensures_worktree_before_fs (for_start ~base));
       Test.make ~name:"for_rebase: first op is Ensure_worktree" gen_branch
-        (fun new_base ->
-          match for_rebase ~new_base with
-          | Ensure_worktree :: _ -> true
-          | (Fetch_origin | Rebase_onto _) :: _ | [] -> false);
+        (fun new_base -> first_op_is_ensure_worktree (for_rebase ~new_base));
       Test.make ~name:"for_merge_conflict: first op is Ensure_worktree"
         gen_branch (fun base ->
-          match for_merge_conflict ~base with
-          | Ensure_worktree :: _ -> true
-          | (Fetch_origin | Rebase_onto _) :: _ | [] -> false);
-      (* Plans target origin/<base> rather than the local tracking ref —
-         this is the "fail closed against stale local refs" requirement
-         from the comments at the original bin/main.ml call sites. *)
+          first_op_is_ensure_worktree (for_merge_conflict ~base));
+      Test.make ~name:"for_start: first op is Ensure_worktree" gen_branch
+        (fun base -> first_op_is_ensure_worktree (for_start ~base));
       Test.make ~name:"for_rebase: rebase target is origin/<new_base>"
         gen_branch (fun new_base ->
           let target =
             Branch.of_string ("origin/" ^ Branch.to_string new_base)
           in
-          List.exists (for_rebase ~new_base) ~f:(function
-            | Rebase_onto t -> Branch.equal t target
-            | Ensure_worktree | Fetch_origin -> false));
+          plan_has_rebase_target (for_rebase ~new_base) target);
       Test.make ~name:"for_merge_conflict: rebase target is origin/<base>"
         gen_branch (fun base ->
           let target = Branch.of_string ("origin/" ^ Branch.to_string base) in
-          List.exists (for_merge_conflict ~base) ~f:(function
-            | Rebase_onto t -> Branch.equal t target
-            | Ensure_worktree | Fetch_origin -> false));
-      (* ensures_worktree_before_fs agrees with the independently-written
-         reference predicate over arbitrary plans, including malformed ones
-         (so we know the predicate itself is right, not just the planners). *)
+          plan_has_rebase_target (for_merge_conflict ~base) target);
+      (* for_start has no Rebase_onto — it just captures and records. *)
+      Test.make ~name:"for_start: no Rebase_onto op" gen_branch (fun base ->
+          not
+            (List.exists (for_start ~base) ~f:(function
+              | Rebase_onto _ -> true
+              | Ensure_worktree | Fetch_origin | Capture_anchor _
+              | Record_anchor_on_success _ ->
+                  false)));
+      Test.make
+        ~name:"for_start: includes Capture_anchor for origin/<base> in slot 0"
+        gen_branch (fun base ->
+          plan_has_capture_for (for_start ~base)
+            ("origin/" ^ Branch.to_string base));
+      Test.make ~name:"for_start: includes Record_anchor_on_success for base"
+        gen_branch (fun base -> plan_has_record_for (for_start ~base) base);
       Test.make ~name:"ensures_worktree_before_fs: agrees with reference"
         gen_plan (fun plan ->
           Bool.equal
             (ensures_worktree_before_fs plan)
             (reference_invariant plan));
-      (* Negative cases: a plan that does fs work without Ensure_worktree
-         must be rejected. This is what would have caught patch 48's bug
-         had the planner produced such a sequence. *)
       Test.make ~name:"ensures_worktree_before_fs: [Fetch_origin] is rejected"
         Gen.unit (fun () -> not (ensures_worktree_before_fs [ Fetch_origin ]));
       Test.make ~name:"ensures_worktree_before_fs: [Rebase_onto] is rejected"
         gen_branch (fun b -> not (ensures_worktree_before_fs [ Rebase_onto b ]));
+      Test.make
+        ~name:"ensures_worktree_before_fs: [Capture_anchor] alone is rejected"
+        (Gen.pair gen_ref_name (Gen.int_range 0 4))
+        (fun (ref_name, slot) ->
+          not (ensures_worktree_before_fs [ Capture_anchor { ref_name; slot } ]));
+      Test.make
+        ~name:
+          "ensures_worktree_before_fs: [Record_anchor_on_success] alone is \
+           rejected"
+        (Gen.pair (Gen.int_range 0 4) gen_branch)
+        (fun (slot, base) ->
+          not
+            (ensures_worktree_before_fs
+               [ Record_anchor_on_success { slot; base } ]));
       Test.make
         ~name:
           "ensures_worktree_before_fs: Fetch before Ensure (wrong order) is \


### PR DESCRIPTION
## Summary
Fixes the squash-merge stacked-PR rebase trap observed in production at `~/.local/share/onton/ts-lowerability-effect-boundary-checker` (p4/p5). A patch branched off a dependency at Start, idle through the dep's squash-merge, would on its first rebase try to replay the dep's pre-squash commits on top of the post-squash main and conflict on every file the dep added.

Root cause: `branch_rebased_onto_sha` was recorded at exactly one site — successful Rebase. A patch branched-off-dep had no anchor at first-rebase time, fell back to the legacy 2-arg form, and conflicted.

The fix is structural, not a patch: records anchors at every base transition (Start, Ok/Noop rebase, Ok/Noop merge-conflict rebase), keeps a bounded history for divergence fallback, splits the decision into pure (`Rebase_decision.plan`) and effectful (executor + handler), and deletes the legacy `upstream` shim now that the planner is consulted directly.

### Commit sequence (11 commits, each green on its own)
1. `Anchor` + `Anchor_history` value modules (validation, dedup, cap 8) + property tests.
2. Restructured `Rebase_decision`: `plan` + `anchor_after_result` with reason variants.
3. `anchor_history` on `Patch_agent` + persistence round-trip.
4. `Worktree_plan` gains `Capture_anchor` / `Record_anchor_on_success` ops and `for_start`.
5.1 Runner Rebase path uses atomic `Orchestrator.apply_rebase_with_anchor`.
5.2 Executor computes `Rebase_decision.plan` from anchor history; legacy `Rebase_decision.upstream` shim deleted; `Worktree.rebase_onto` takes `~upstream:string`.
6. Same wire-up for Merge_conflict path.
7. **`for_start` runs at Start before the LLM session — closes the production bug.**
8. Documented why `refresh_base_branch` deliberately preserves the anchor (drift detector relies on it; PI-16).
9. State-machine interleaving tests (SM-1, SM-2 = production bug, SM-3a/b, SM-4, SM-7, SM-8, baseline).
10. AGENTS.md anchor lifecycle section.

## Test plan
- [x] `dune build` strict-warnings clean
- [x] `dune runtest` full suite green at every commit
- [x] New property suite `test_rebase_decision_properties.ml` (RD-PLAN-1..8, RD-AAR-1..5)
- [x] New unit + property suite `test_anchor.ml` (12 tests)
- [x] New state-machine suite `test_rebase_state_machine.ml` (8 named scenarios, production bug among them)
- [x] Existing `test_rebase_onto.ml` integration tests pass against the new `~upstream` signature
- [x] `test_persistence_properties.ml` extended with `anchor_history` round-trip + missing-key default
- [x] Pre-existing PI-16 drift detector test still passes (step 8 explicitly preserves its semantics)

In-flight broken agents (p4/p5 in production) are out of scope per prior discussion — they will be unstuck manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/319"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782236136&installation_id=126163856&pr_number=319&repository=flowglad%2Fonton&return_to=https%3A%2F%2Fgithub.com%2Fflowglad%2Fonton%2Fpull%2F319&signature=ba389caf5de3207548591626da3abadc06707cbf2429c9fdc4d4b234db478741"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes stacked-PR rebases reliable by recording and using rebase anchors to compute safe git --onto upstreams. This stops replaying dependency commits after squash-merges and removes “both added” conflicts.

- New Features
  - Record anchors at Start and after Ok/Noop rebase and merge-conflict flows; keep a capped, deduped Anchor_history.
  - New pure planner (Rebase_decision.plan) picks the best upstream from history using reachability (Worktree.is_ancestor), with clear reasons and fallbacks.
  - Executor captures anchors via Worktree_plan ops (Capture_anchor/Record_anchor_on_success) and returns anchor events; orchestrator applies rebase + anchor updates atomically (apply_rebase_with_anchor). Start uses Worktree_plan.for_start to capture the initial anchor.
  - Worktree.rebase_onto now requires ~upstream; the legacy upstream shim is removed. refresh_base_branch intentionally preserves anchors for drift detection.
  - Docs: added AGENTS.md section explaining the anchor lifecycle.

- Bug Fixes
  - Fixes the squash-merge trap in stacked PRs: dependent branches no longer replay a dependency’s pre-squash commits onto post-squash main.
  - Corrects the plain rebase fallback so the executor uses the correct target ref as upstream when no anchor is available.

<sup>Written for commit f97057aae27edd4e94175b58ce4ffcf86ce6e0ef. Summary will update on new commits. <a href="https://cubic.dev/pr/flowglad/onton/pull/319?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added anchor tracking: the system now records the base branch and commit SHA when patches are created or rebased, storing up to 8 most recent anchors.
  * Improved rebase decision-making using recorded anchor history for more stable upstream selection.
  * Anchor information is now automatically captured at patch creation, rebase, and merge-conflict resolution points.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flowglad/onton/pull/319?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->