### PR TITLE
Replace pr_number option with Patch_pr_status state machine

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -771,7 +771,7 @@ let construct_capabilities ~net (setup : runtime_setup) =
   Runtime.read setup.runtime (fun snap ->
       Orchestrator.all_agents snap.Runtime.orchestrator)
   |> Base.List.iter ~f:(fun (agent : Patch_agent.t) ->
-      Base.Option.iter agent.Patch_agent.pr_number ~f:(fun pr_number ->
+      Base.Option.iter (Patch_agent.pr_number agent) ~f:(fun pr_number ->
           Pr_registry.register pr_registry ~patch_id:agent.Patch_agent.patch_id
             ~pr_number));
   let branch_of = build_branch_map setup.gameplan ~default:main_branch in
@@ -859,7 +859,7 @@ let construct_capabilities ~net (setup : runtime_setup) =
         Orchestrator.all_agents snap.Runtime.orchestrator)
     |> Base.List.iter ~f:(fun (agent : Patch_agent.t) ->
         if Base.Hash_set.mem errored_ids agent.Patch_agent.patch_id then
-          Base.Option.iter agent.Patch_agent.pr_number ~f:(fun pr_number ->
+          Base.Option.iter (Patch_agent.pr_number agent) ~f:(fun pr_number ->
               Pr_registry.register pr_registry
                 ~patch_id:agent.Patch_agent.patch_id ~pr_number));
     let open Startup_reconciler in

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -882,14 +882,16 @@ let construct_capabilities ~net (setup : runtime_setup) =
                   Patch_pr_status.classify_recovery_on_observe
                     agent.Patch_agent.pr_status
                 with
-                | Lift_to_present _ ->
+                | Patch_pr_status.Lift_to_present _ ->
                     Pr_registry.register pr_registry ~patch_id:pid ~pr_number:pr;
                     let orch = Orchestrator.set_pr_number orch pid pr in
                     if merged then Orchestrator.mark_merged orch pid else orch
-                | No_recovery_needed when Patch_agent.is_pr_present agent ->
+                | Patch_pr_status.No_recovery_needed
+                  when Patch_agent.is_pr_present agent ->
                     Pr_registry.register pr_registry ~patch_id:pid ~pr_number:pr;
+                    let orch = Orchestrator.set_pr_number orch pid pr in
                     if merged then Orchestrator.mark_merged orch pid else orch
-                | No_recovery_needed ->
+                | Patch_pr_status.No_recovery_needed ->
                     Pr_registry.register pr_registry ~patch_id:pid ~pr_number:pr;
                     let orch =
                       Orchestrator.fire orch (Orchestrator.Start (pid, base))

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -867,18 +867,36 @@ let construct_capabilities ~net (setup : runtime_setup) =
       ~f:(fun { pr_number = pr; patch_id = pid; base_branch = base; merged } ->
         Runtime.update_orchestrator setup.runtime (fun orch ->
             match Orchestrator.find_agent orch pid with
-            | Some agent when Patch_agent.has_pr agent ->
-                Pr_registry.register pr_registry ~patch_id:pid ~pr_number:pr;
-                if merged then Orchestrator.mark_merged orch pid else orch
-            | Some _ ->
-                Pr_registry.register pr_registry ~patch_id:pid ~pr_number:pr;
-                let orch =
-                  Orchestrator.fire orch (Orchestrator.Start (pid, base))
-                in
-                let orch = Orchestrator.set_pr_number orch pid pr in
-                let orch = Orchestrator.complete orch pid in
-                if merged then Orchestrator.mark_merged orch pid else orch
-            | None -> orch));
+            | None -> orch
+            | Some agent -> (
+                (* Dispatch on the pure recovery classifier. Three cases:
+                   - agent was [Missing]: lift to [Present] via set_pr_number
+                     (Recover_same arm preserves world-state when [pr]
+                     matches the recorded number; Adopt_new arm resets if
+                     the remote disagrees).
+                   - agent was [Present _]: nothing to recover; register
+                     the externally-known number and pick up merged.
+                   - agent was [Absent]: bootstrap path — fire Start, set
+                     pr_number, complete. *)
+                match
+                  Patch_pr_status.classify_recovery_on_observe
+                    agent.Patch_agent.pr_status
+                with
+                | Lift_to_present _ ->
+                    Pr_registry.register pr_registry ~patch_id:pid ~pr_number:pr;
+                    let orch = Orchestrator.set_pr_number orch pid pr in
+                    if merged then Orchestrator.mark_merged orch pid else orch
+                | No_recovery_needed when Patch_agent.is_pr_present agent ->
+                    Pr_registry.register pr_registry ~patch_id:pid ~pr_number:pr;
+                    if merged then Orchestrator.mark_merged orch pid else orch
+                | No_recovery_needed ->
+                    Pr_registry.register pr_registry ~patch_id:pid ~pr_number:pr;
+                    let orch =
+                      Orchestrator.fire orch (Orchestrator.Start (pid, base))
+                    in
+                    let orch = Orchestrator.set_pr_number orch pid pr in
+                    let orch = Orchestrator.complete orch pid in
+                    if merged then Orchestrator.mark_merged orch pid else orch)));
     Base.List.iter startup.reset_pending ~f:(fun patch_id ->
         log_event setup.runtime ~patch_id
           "Reset stale busy agent from crashed session";

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -301,6 +301,9 @@ let set_pr_number t patch_id pr_number =
 
 let clear_pr t patch_id = update_agent t patch_id ~f:Patch_agent.clear_pr
 
+let mark_pr_missing t patch_id =
+  update_agent t patch_id ~f:Patch_agent.mark_pr_missing
+
 let set_branch_rebased_onto_sha t patch_id sha =
   update_agent t patch_id ~f:(fun a ->
       Patch_agent.set_branch_rebased_onto_sha a sha)

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -302,7 +302,25 @@ let set_pr_number t patch_id pr_number =
 let clear_pr t patch_id = update_agent t patch_id ~f:Patch_agent.clear_pr
 
 let mark_pr_missing t patch_id =
-  update_agent t patch_id ~f:Patch_agent.mark_pr_missing
+  (* Dispatch on the pure classifier so the integration-level API is
+     idempotent on an already-[Missing] agent. The low-level transition
+     [Patch_agent.mark_pr_missing] stays strict for testability — the
+     classifier above is what callers (production and tests) should
+     consult. *)
+  match find_agent t patch_id with
+  | None -> t
+  | Some a -> (
+      match Patch_pr_status.classify_mark_missing a.Patch_agent.pr_status with
+      | Mark_missing_already -> t
+      | Mark_missing_transition ->
+          update_agent t patch_id ~f:Patch_agent.mark_pr_missing
+      | Mark_missing_illegal ->
+          (* Caller bug: marking an [Absent] agent missing has no meaning.
+             Surface explicitly rather than silently transitioning. *)
+          invalid_arg
+            (Printf.sprintf
+               "Orchestrator.mark_pr_missing: agent %s has no PR (Absent)"
+               (Patch_id.to_string patch_id)))
 
 let set_branch_rebased_onto_sha t patch_id sha =
   update_agent t patch_id ~f:(fun a ->

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -78,12 +78,15 @@ val set_pr_number : t -> Patch_id.t -> Pr_number.t -> t
 val clear_pr : t -> Patch_id.t -> t
 
 val mark_pr_missing : t -> Patch_id.t -> t
-(** Transition the patch's [pr_status] from [Present] to [Missing]. The
-    effectful caller (typically the poller's PR-rediscovery path) uses this when
-    the remote has lost an ad-hoc PR — preserves the recorded number so the
-    operator can see what vanished and so a re-observation can adopt the same PR
-    back, while stripping functional PR state and dropping PR-coupled queue
-    entries. See {!Patch_agent.mark_pr_missing}. *)
+(** Transition the patch's [pr_status] from [Present] to [Missing], or no-op if
+    already [Missing]. The effectful caller (typically the poller's
+    PR-rediscovery path) uses this when the remote has lost an ad-hoc PR.
+
+    Idempotent on [Missing] (the second poll cycle after a vanish will hit the
+    same classification; without idempotency that would crash). Raises
+    [Invalid_argument] on [Absent] — that case represents a caller bug (cannot
+    lose what was never had). See {!Patch_pr_status.classify_mark_missing} for
+    the pure decision this dispatches on. *)
 
 val set_session_failed : t -> Patch_id.t -> t
 

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -76,6 +76,15 @@ val send_human_message : t -> Patch_id.t -> string -> t
 
 val set_pr_number : t -> Patch_id.t -> Pr_number.t -> t
 val clear_pr : t -> Patch_id.t -> t
+
+val mark_pr_missing : t -> Patch_id.t -> t
+(** Transition the patch's [pr_status] from [Present] to [Missing]. The
+    effectful caller (typically the poller's PR-rediscovery path) uses this when
+    the remote has lost an ad-hoc PR — preserves the recorded number so the
+    operator can see what vanished and so a re-observation can adopt the same PR
+    back, while stripping functional PR state and dropping PR-coupled queue
+    entries. See {!Patch_agent.mark_pr_missing}. *)
+
 val set_session_failed : t -> Patch_id.t -> t
 
 val set_branch_rebased_onto_sha : t -> Patch_id.t -> string option -> t

--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -91,6 +91,23 @@ let apply_poll_result t patch_id
       poll_observation) =
   let logs = ref [] in
   let log message = logs := { message; patch_id } :: !logs in
+  (* If the agent was [Missing] and we have a successful poll observation,
+     lift it back to [Present] before applying any world-state updates. The
+     pure classifier is total; the effectful dispatch is a flat match.
+     [set_pr_number]'s [Set_present_recover_same] arm preserves all state
+     that was held across the [Missing] phase. *)
+  let t =
+    let agent = Orchestrator.agent t patch_id in
+    match
+      Patch_pr_status.classify_recovery_on_observe agent.Patch_agent.pr_status
+    with
+    | Lift_to_present pr ->
+        log
+          (Printf.sprintf "PR #%d re-appeared on remote — restoring to Present"
+             (Pr_number.to_int pr));
+        Orchestrator.set_pr_number t patch_id pr
+    | No_recovery_needed -> t
+  in
   let t =
     if poll_result.merged then (
       let agent = Orchestrator.agent t patch_id in

--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -337,7 +337,12 @@ let branch_map_of_patches patches =
 let plan_action_for_patch t ~branch_map patch_id =
   let agent = Orchestrator.agent t patch_id in
   let has_merged pid = (Orchestrator.agent t pid).Patch_agent.merged in
-  let has_pr pid = Patch_agent.has_pr (Orchestrator.agent t pid) in
+  let has_pr pid =
+    (* Dependency satisfaction: a child cannot rebase onto a [Missing] parent
+       — the parent's branch may not exist on the remote. Gate on
+       is_pr_present rather than has_pr (which is true for [Missing] too). *)
+    Patch_agent.is_pr_present (Orchestrator.agent t pid)
+  in
   if
     (not (Patch_agent.has_pr agent))
     && (not agent.Patch_agent.busy)

--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -241,8 +241,12 @@ let reconcile_patch t ~project_name:_ ~gameplan:_ ~(patch : Patch.t) =
     let t = enqueue_pr_body_if_needed t patch_id agent in
     let agent = Orchestrator.agent t patch_id in
     let effects = ref [] in
-    (match agent.pr_number with
-    | Some pr_number -> (
+    (* Gate on [is_pr_present]: emitting Set_pr_draft / Set_pr_base against a
+       [Missing] PR would 404 against GitHub. A gameplan patch can in
+       principle reach Missing if the poller ever wires that for gameplan
+       patches in the future; defensively skip it here either way. *)
+    (match Patch_agent.pr_number agent with
+    | Some pr_number when Patch_agent.is_pr_present agent -> (
         match agent.base_branch with
         | Some actual_base ->
             let has_merged pid =
@@ -293,7 +297,7 @@ let reconcile_patch t ~project_name:_ ~gameplan:_ ~(patch : Patch.t) =
                   :: !effects
             end
         | None -> ())
-    | None -> ());
+    | Some _ | None -> ());
     (t, List.rev !effects)
 
 let reconcile_all t ~project_name ~gameplan =
@@ -345,8 +349,10 @@ let plan_action_for_patch t ~branch_map patch_id =
        would sit on a stale base until a human message happened to land and
        flip the Human exemption inside [Patch_agent.needs_intervention]. A
        conflict outcome still enqueues [Merge_conflict], which keeps the
-       patch blocked until an LLM session can run. *)
-    Patch_agent.has_pr agent
+       patch blocked until an LLM session can run. Gate on [is_pr_present]
+       (not [has_pr]) so a [Missing] PR is excluded — rebase pushes against
+       a vanished PR would 404. *)
+    Patch_agent.is_pr_present agent
     && (not agent.Patch_agent.merged)
     && (not agent.Patch_agent.busy)
     && (not agent.Patch_agent.branch_blocked)
@@ -400,6 +406,11 @@ let reconcile_action_message t action =
 
 let reconcile_messages t ~patches =
   let branch_map = branch_map_of_patches patches in
+  (* Invariant: every graph patch_id is either in the gameplan (branch_map) or
+     has a PR identity ([has_pr] is true for both Present and Missing). A
+     violation indicates an ad-hoc agent was [clear_pr]-ed instead of
+     [mark_pr_missing]-ed, leaving an orphan in the graph. See
+     [poller_fiber.ml]'s [Rediscover_pr] arm and [Patch_pr_status]. *)
   let missing =
     Graph.all_patch_ids (Orchestrator.graph t)
     |> List.filter ~f:(fun pid ->
@@ -409,9 +420,12 @@ let reconcile_messages t ~patches =
   if not (List.is_empty missing) then
     invalid_arg
       (Printf.sprintf
-         "Patch_controller.plan_messages: tick input missing %d patch id(s) \
-          from graph"
-         (List.length missing));
+         "Patch_controller.reconcile_messages: orchestrator invariant violated \
+          — %d ad-hoc patch(es) have no PR and are not in the gameplan (likely \
+          a [clear_pr] on an ad-hoc agent; should have been \
+          [mark_pr_missing]). patch_ids: %s"
+         (List.length missing)
+         (String.concat ~sep:", " (List.map missing ~f:Patch_id.to_string)));
   let patch_ids = Graph.all_patch_ids (Orchestrator.graph t) in
   let t =
     List.fold patch_ids ~init:t ~f:(fun acc patch_id ->
@@ -596,13 +610,13 @@ let reconcile_automerge t ~now =
             (Orchestrator.set_automerge_deadline t patch_id deadline, decisions)
         | true, Some deadline ->
             if Float.( >= ) now deadline then
-              match agent.Patch_agent.pr_number with
-              | Some pr_number ->
+              match Patch_agent.pr_number agent with
+              | Some pr_number when Patch_agent.is_pr_present agent ->
                   let t = Orchestrator.set_automerge_inflight t patch_id true in
                   ( t,
                     { merge_patch_id = patch_id; merge_pr_number = pr_number }
                     :: decisions )
-              | None ->
+              | Some _ | None ->
                   (* Unreachable today because [is_automerge_candidate]
                      requires [is_approved] which requires [has_pr]. Defensive
                      clear so a future predicate change can't leave a patch

--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -101,12 +101,12 @@ let apply_poll_result t patch_id
     match
       Patch_pr_status.classify_recovery_on_observe agent.Patch_agent.pr_status
     with
-    | Lift_to_present pr ->
+    | Patch_pr_status.Lift_to_present pr ->
         log
           (Printf.sprintf "PR #%d re-appeared on remote — restoring to Present"
              (Pr_number.to_int pr));
         Orchestrator.set_pr_number t patch_id pr
-    | No_recovery_needed -> t
+    | Patch_pr_status.No_recovery_needed -> t
   in
   let t =
     if poll_result.merged then (
@@ -399,7 +399,7 @@ let plan_action_for_patch t ~branch_map patch_id =
         Some (Orchestrator.Rebase (patch_id, new_base))
     | _ -> None
   else if
-    Patch_agent.has_pr agent
+    Patch_agent.is_pr_present agent
     && (not agent.Patch_agent.merged)
     && (not agent.Patch_agent.busy)
     && (not (Patch_agent.needs_intervention agent))

--- a/lib/persistence.ml
+++ b/lib/persistence.ml
@@ -125,8 +125,15 @@ let patch_agent_to_yojson (a : Patch_agent.t) =
     [
       ("patch_id", Patch_id.yojson_of_t a.patch_id);
       ("branch", Branch.yojson_of_t a.branch);
+      ("pr_status", Patch_pr_status.yojson_of_t a.pr_status);
+      (* Legacy field, written alongside [pr_status] so an older onton binary
+         can still load snapshots produced by this version. The legacy reader
+         maps null -> Absent and bare int -> Present, which silently
+         degrades a Missing PR to Present on downgrade — safe, because the
+         poller will re-evaluate and re-Mark on the next cycle. Remove once
+         the downgrade window has closed. *)
       ( "pr_number",
-        match a.pr_number with
+        match Patch_agent.pr_number a with
         | None -> `Null
         | Some n -> Pr_number.yojson_of_t n );
       ("has_session", `Bool a.has_session);
@@ -260,8 +267,26 @@ let patch_agent_of_yojson ~gameplan json =
                   with
                  | Some p -> Branch.to_string p.Patch.branch
                  | None -> pid)))
-       ~pr_number:
-         (int_member_opt "pr_number" json |> Option.map ~f:Pr_number.of_int)
+       ~pr_status:
+         (match Yojson.Safe.Util.member "pr_status" json with
+         | `Null -> (
+             (* Legacy snapshot: no [pr_status] field. Derive from the legacy
+                [pr_number] field: int -> Present, null -> Absent. Missing
+                cannot appear in legacy data (the field was added with the
+                state). *)
+             match int_member_opt "pr_number" json with
+             | None -> Patch_pr_status.Absent
+             | Some n -> Patch_pr_status.Present (Pr_number.of_int n))
+         | v -> (
+             match Patch_pr_status.t_of_yojson_compat v with
+             | Ok s -> s
+             | Error _ -> (
+                 (* Malformed [pr_status] — fall back to the legacy field as
+                     a last resort so a single bad write doesn't lose the
+                     agent entirely. *)
+                 match int_member_opt "pr_number" json with
+                 | None -> Patch_pr_status.Absent
+                 | Some n -> Patch_pr_status.Present (Pr_number.of_int n))))
        ~has_session ~busy:(bool_member "busy" json)
        ~merged:(bool_member "merged" json)
        ~queue
@@ -762,15 +787,15 @@ let%test_module "session_id_sidecars" =
 
     let snapshot ?(busy = false) ?llm_session_id () =
       let agent =
-        Patch_agent.restore ~patch_id ~branch:patch.branch ~pr_number:None
-          ~has_session:false ~busy ~merged:false ~queue:[] ~satisfies:false
-          ~changed:false ~has_conflict:false ~base_branch:None
-          ~notified_base_branch:None ~ci_failure_count:0
-          ~session_fallback:Patch_agent.Fresh_available ~human_messages:[]
-          ~inflight_human_messages:[] ~ci_checks:[] ~merge_ready:false
-          ~is_draft:false ~pr_body_delivered:true ~pr_body_artifact_miss_count:0
-          ~start_attempts_without_pr:0 ~conflict_noop_count:0
-          ~no_commits_push_count:0 ~push_failure_count:0
+        Patch_agent.restore ~patch_id ~branch:patch.branch
+          ~pr_status:Patch_pr_status.Absent ~has_session:false ~busy
+          ~merged:false ~queue:[] ~satisfies:false ~changed:false
+          ~has_conflict:false ~base_branch:None ~notified_base_branch:None
+          ~ci_failure_count:0 ~session_fallback:Patch_agent.Fresh_available
+          ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
+          ~merge_ready:false ~is_draft:false ~pr_body_delivered:true
+          ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
+          ~conflict_noop_count:0 ~no_commits_push_count:0 ~push_failure_count:0
           ~branch_rebased_onto:None ~branch_rebased_onto_sha:None
           ~anchor_history:Anchor_history.empty ~checks_passing:false
           ~current_op:None ~current_op_state:Patch_agent.Queued

--- a/lib/poller_fiber.ml
+++ b/lib/poller_fiber.ml
@@ -160,6 +160,28 @@ struct
             Stdlib.Hashtbl.replace skip_logged patch_id true;
             true))
     in
+    (* Per-patch "PR vanished" log dedup. Mirrors [skip_logged] above: the
+       poll loop re-classifies Mark_pr_missing on every cycle while the PR
+       remains absent (Orchestrator.mark_pr_missing is now idempotent), so
+       without dedup the activity log fills with duplicates. Reset on a
+       successful [Switch_to_pr] so a future vanish-reopen-vanish cycle
+       re-logs. *)
+    let vanish_logged : (Patch_id.t, bool) Stdlib.Hashtbl.t =
+      Stdlib.Hashtbl.create 16
+    in
+    let vanish_logged_mutex = Eio.Mutex.create () in
+    let vanish_already_logged patch_id =
+      Eio.Mutex.use_ro vanish_logged_mutex (fun () ->
+          Stdlib.Hashtbl.mem vanish_logged patch_id)
+    in
+    let mark_vanish_logged patch_id =
+      Eio.Mutex.use_rw ~protect:true vanish_logged_mutex (fun () ->
+          Stdlib.Hashtbl.replace vanish_logged patch_id true)
+    in
+    let clear_vanish_logged patch_id =
+      Eio.Mutex.use_rw ~protect:true vanish_logged_mutex (fun () ->
+          Stdlib.Hashtbl.remove vanish_logged patch_id)
+    in
     (* P1-A: detect when [origin/<main>] has advanced past local <main>. When
        it has, every agent currently based on <main> needs a rebase so it
        picks up the freshly squash-merged commits — without this poke,
@@ -353,6 +375,9 @@ struct
                       (Printf.sprintf "Switched to PR #%d"
                          (Pr_number.to_int new_pr));
                     register_pr_number ~patch_id ~pr_number:new_pr;
+                    (* Recovery transition: clear the vanish-log dedup so a
+                       future vanish/reopen/vanish cycle re-logs once. *)
+                    clear_vanish_logged patch_id;
                     Runtime.update_orchestrator runtime (fun orch ->
                         Patch_controller.apply_replacement_pr orch patch_id
                           ~pr_number:new_pr ~base_branch ~merged)
@@ -368,13 +393,25 @@ struct
                        intervention; keep the external pr_number registration
                        so a re-opened PR is discovered on the next poll. The
                        operator's [-N] clears the registration via
-                       [apply_remove_pr] when they intend to remove. *)
-                    Runtime_logging.log_event runtime ~patch_id
-                      (Printf.sprintf
-                         "PR #%d vanished from remote — marking agent for \
-                          intervention; use -%d to remove if intentional"
-                         (Pr_number.to_int pr_number)
-                         (Pr_number.to_int pr_number));
+                       [apply_remove_pr] when they intend to remove.
+
+                       Dedup the "vanished" log line via the pure
+                       [Rediscover_decision.classify_vanish_log] decision so
+                       the activity log stays clean while the agent remains
+                       Missing across many poll cycles. *)
+                    (match
+                       Rediscover_decision.classify_vanish_log cls
+                         ~already_logged:(vanish_already_logged patch_id)
+                     with
+                    | Rediscover_decision.Log_emit ->
+                        Runtime_logging.log_event runtime ~patch_id
+                          (Printf.sprintf
+                             "PR #%d vanished from remote — marking agent for \
+                              intervention; use -%d to remove if intentional"
+                             (Pr_number.to_int pr_number)
+                             (Pr_number.to_int pr_number));
+                        mark_vanish_logged patch_id
+                    | Rediscover_decision.Log_skip -> ());
                     Runtime.update_orchestrator runtime (fun orch ->
                         Orchestrator.mark_pr_missing orch patch_id)
                 | Rediscover_decision.Log_error { message } ->

--- a/lib/poller_fiber.ml
+++ b/lib/poller_fiber.ml
@@ -216,7 +216,8 @@ struct
                         ~equal:Operation_kind.equal
                     in
                     if
-                      is_on_main && Patch_agent.has_pr agent
+                      is_on_main
+                      && Patch_agent.is_pr_present agent
                       && (not agent.Patch_agent.merged)
                       && not already_rebasing
                     then
@@ -320,8 +321,34 @@ struct
                           | Some agent -> agent.Patch_agent.branch
                           | None -> branch_of patch_id)
                 in
-                (match StartupReconciler.discover_pr ~branch with
-                | Ok (Some (new_pr, base_branch, merged)) ->
+                let in_gameplan =
+                  Runtime.read runtime (fun snap ->
+                      List.exists snap.Runtime.gameplan.Gameplan.patches
+                        ~f:(fun (p : Patch.t) ->
+                          Patch_id.equal p.Patch.id patch_id))
+                in
+                let discover_result :
+                    (Rediscover_decision.replacement option, string) Result.t =
+                  match StartupReconciler.discover_pr ~branch with
+                  | Ok (Some (new_pr, base_branch, merged)) ->
+                      Ok
+                        (Some
+                           Rediscover_decision.{ new_pr; base_branch; merged })
+                  | Ok None -> Ok None
+                  | Error msg -> Error msg
+                in
+                let cls =
+                  Rediscover_decision.classify
+                    {
+                      patch_id;
+                      pr_number;
+                      in_gameplan;
+                      result = discover_result;
+                    }
+                in
+                (match cls with
+                | Rediscover_decision.Switch_to_pr
+                    { new_pr; base_branch; merged } ->
                     Runtime_logging.log_event runtime ~patch_id
                       (Printf.sprintf "Switched to PR #%d"
                          (Pr_number.to_int new_pr));
@@ -329,16 +356,30 @@ struct
                     Runtime.update_orchestrator runtime (fun orch ->
                         Patch_controller.apply_replacement_pr orch patch_id
                           ~pr_number:new_pr ~base_branch ~merged)
-                | Ok None ->
+                | Rediscover_decision.Clear_pr_for_recreate ->
                     Runtime_logging.log_event runtime ~patch_id
                       "No open PR found — cleared stale PR state, will create \
                        on next session";
                     unregister_pr_number ~patch_id;
                     Runtime.update_orchestrator runtime (fun orch ->
                         Orchestrator.clear_pr orch patch_id)
-                | Error msg ->
+                | Rediscover_decision.Mark_pr_missing ->
+                    (* Ad-hoc PR vanished from remote. Surface for
+                       intervention; keep the external pr_number registration
+                       so a re-opened PR is discovered on the next poll. The
+                       operator's [-N] clears the registration via
+                       [apply_remove_pr] when they intend to remove. *)
                     Runtime_logging.log_event runtime ~patch_id
-                      (Printf.sprintf "PR re-discovery failed — %s" msg));
+                      (Printf.sprintf
+                         "PR #%d vanished from remote — marking agent for \
+                          intervention; use -%d to remove if intentional"
+                         (Pr_number.to_int pr_number)
+                         (Pr_number.to_int pr_number));
+                    Runtime.update_orchestrator runtime (fun orch ->
+                        Orchestrator.mark_pr_missing orch patch_id)
+                | Rediscover_decision.Log_error { message } ->
+                    Runtime_logging.log_event runtime ~patch_id
+                      (Printf.sprintf "PR re-discovery failed — %s" message));
                 None
             | Poll_cycle.Apply_pr_state
                 { pr_state; poll_result; ci_checks_truncated } ->

--- a/lib/prune_runner.ml
+++ b/lib/prune_runner.ml
@@ -46,8 +46,12 @@ let rec remove_path path =
 let refresh_candidates (agents : Patch_agent.t Map.M(Patch_id).t) =
   Map.fold agents ~init:[] ~f:(fun ~key:patch_id ~data:agent acc ->
       if agent.Patch_agent.merged then acc
+        (* Skip Missing: the PR is gone from the forge, so refreshing it would
+           404. Wait for an explicit Rediscover_pr to bring it back to Present
+           or for the operator to remove it. *)
+      else if not (Patch_agent.is_pr_present agent) then acc
       else
-        match agent.Patch_agent.pr_number with
+        match Patch_agent.pr_number agent with
         | None -> acc
         | Some pr_number -> (patch_id, pr_number) :: acc)
 

--- a/lib/runner_fiber_impl.ml
+++ b/lib/runner_fiber_impl.ml
@@ -214,7 +214,7 @@ struct
                        the inflight short-circuit that the predicate applies
                        by default — necessary here because this re-check runs
                        while we hold the flag. *)
-                      (match agent.Patch_agent.pr_number with
+                      (match Patch_agent.pr_number agent with
                         | Some current -> Pr_number.equal current pr_number
                         | None -> false)
                       && Patch_controller.is_automerge_candidate
@@ -717,8 +717,8 @@ struct
                                           Prompt.render_patch_prompt
                                             ~project_name ?agents_md
                                             ?pr_number:
-                                              agent.Patch_agent.pr_number patch
-                                            gameplan
+                                              (Patch_agent.pr_number agent)
+                                            patch gameplan
                                             ~base_branch:
                                               (Branch.to_string base_branch)
                                         in
@@ -742,7 +742,7 @@ struct
                                           Prompt.render_patch_layer
                                             ~project_name patch
                                             ?pr_number:
-                                              agent.Patch_agent.pr_number
+                                              (Patch_agent.pr_number agent)
                                             ~functional_changes
                                             ~base_branch:
                                               (Branch.to_string base_branch)
@@ -1040,8 +1040,9 @@ struct
                     let is_ci = Operation_kind.equal kind Operation_kind.Ci in
                     let pr_number =
                       Runtime.read runtime (fun snap ->
-                          (Orchestrator.agent snap.Runtime.orchestrator patch_id)
-                            .Patch_agent.pr_number)
+                          Patch_agent.pr_number
+                            (Orchestrator.agent snap.Runtime.orchestrator
+                               patch_id))
                     in
                     let fresh_pr_state =
                       if is_review || is_ci then (
@@ -1215,7 +1216,7 @@ struct
                                    an enriched prompt to the agent. *)
                                       let deliver_to_agent ?conflict_info () =
                                         let pr_number =
-                                          agent.Patch_agent.pr_number
+                                          Patch_agent.pr_number agent
                                         in
                                         let rebase_still_in_progress =
                                           W.rebase_in_progress ~path:wt_path
@@ -1492,7 +1493,7 @@ struct
                                         base_change;
                                       } -> (
                                       let pr_number =
-                                        agent.Patch_agent.pr_number
+                                        Patch_agent.pr_number agent
                                       in
                                       let base_changed_prefix =
                                         render_base_changed_prefix base_change

--- a/lib/tui.ml
+++ b/lib/tui.ml
@@ -310,6 +310,10 @@ type patch_view = {
   ci_checks : Ci_check.t list;
   recent_stream : activity_entry list;
   pr_number : Pr_number.t option;
+  pr_missing : bool;
+      (** [true] when [pr_number] is set but the remote no longer has the PR.
+          Distinguishes "we lost the PR" from "we have the PR" so the row label
+          can render a distinctive marker. *)
   base_branch : Branch.t option;
   worktree_path : string option;
   intervention_reason : string option;
@@ -416,7 +420,8 @@ let patch_view_of_agent (agent : Patch_agent.t)
     human_messages = List.length agent.human_messages;
     ci_checks = agent.ci_checks;
     recent_stream = [];
-    pr_number = agent.pr_number;
+    pr_number = Patch_agent.pr_number agent;
+    pr_missing = Patch_agent.is_pr_missing agent;
     base_branch = agent.base_branch;
     worktree_path = agent.worktree_path;
     intervention_reason = None;
@@ -534,6 +539,10 @@ let render_patch_row ~width ~selected ~now (pv : patch_view) =
   in
   let pr_label =
     match pv.pr_number with
+    | Some n when pv.pr_missing ->
+        (* Vanished from remote — flag the number with a leading ! so the
+           operator can see which PR was lost. *)
+        Printf.sprintf "!%-5d" (Pr_number.to_int n)
     | Some n -> Printf.sprintf "#%-5d" (Pr_number.to_int n)
     | None -> "  --  "
   in
@@ -684,8 +693,10 @@ let detail_info_rows (pv : patch_view) ~width ~now =
         (match pv.model with Some m -> m | None -> "(backend default)");
       Printf.sprintf "  PR:          %s"
         (match pv.pr_number with
+        | Some n when pv.pr_missing ->
+            Printf.sprintf "#%d (vanished from remote)" (Pr_number.to_int n)
         | Some n -> Printf.sprintf "#%d" (Pr_number.to_int n)
-        | None -> if pv.has_pr then "yes" else "no");
+        | None -> "no");
       Printf.sprintf "  Dependencies: %s"
         (match pv.dep_ids with
         | [] -> "none"

--- a/lib/tui.mli
+++ b/lib/tui.mli
@@ -102,6 +102,10 @@ type patch_view = {
   ci_checks : Ci_check.t list;
   recent_stream : activity_entry list;
   pr_number : Pr_number.t option;
+  pr_missing : bool;
+      (** [true] when [pr_number] is set but the remote no longer has the PR
+          ([pr_status = Missing _]). Distinguishes "we lost it" from "we have
+          it" so the TUI can flag the row distinctively. *)
   base_branch : Branch.t option;
   worktree_path : string option;
   intervention_reason : string option;

--- a/lib/tui_fiber.ml
+++ b/lib/tui_fiber.ml
@@ -300,14 +300,16 @@ struct
                             Orchestrator.agent snap.Runtime.orchestrator
                               patch_id
                           in
-                          (agent.Patch_agent.busy, Patch_agent.has_pr agent))
+                          ( agent.Patch_agent.busy,
+                            Patch_agent.is_pr_present agent ))
                     in
                     if busy then
                       log_event Env.runtime ~patch_id
                         "Cannot force-mark as merged — patch is currently busy"
                     else if not has_pr then
                       log_event Env.runtime ~patch_id
-                        "Cannot force-mark as merged — patch has no PR"
+                        "Cannot force-mark as merged — patch has no usable PR \
+                         (Missing or Absent)"
                     else (
                       Runtime.update_orchestrator Env.runtime (fun orch ->
                           Orchestrator.mark_merged orch patch_id);

--- a/lib_core/patch_agent.ml
+++ b/lib_core/patch_agent.ml
@@ -459,14 +459,16 @@ let set_pr_number t pr_number =
        base_branch / notified_base_branch — those are owned by [start]
        (bootstrap) and the poller (renumbering). *)
   match Patch_pr_status.classify_set_present t.pr_status pr_number with
-  | Set_present_recover_same ->
+  | Patch_pr_status.Set_present_recover_same ->
       { t with pr_status = Patch_pr_status.set_present t.pr_status pr_number }
-  | Set_present_adopt_new ->
+  | Patch_pr_status.Set_present_adopt_new ->
       {
         t with
         pr_status = Patch_pr_status.set_present t.pr_status pr_number;
         is_draft = true;
+        merge_ready = false;
         pr_body_delivered = false;
+        checks_passing = false;
         start_attempts_without_pr = 0;
         ci_checks = [];
         ci_failure_count = 0;

--- a/lib_core/patch_agent.ml
+++ b/lib_core/patch_agent.ml
@@ -448,13 +448,30 @@ let restore ~patch_id ~branch ~pr_status ~has_session ~busy ~merged ~queue
   }
 
 let set_pr_number t pr_number =
-  {
-    t with
-    pr_status = Patch_pr_status.set_present t.pr_status pr_number;
-    is_draft = true;
-    pr_body_delivered = false;
-    start_attempts_without_pr = 0;
-  }
+  (* Dispatch on the pure classifier:
+     - [Set_present_recover_same] (Missing N → Present N or Present N →
+       Present N): preserve all world-state. The body is still delivered, CI
+       runs already accounted, notified_base_branch still authoritative.
+     - [Set_present_adopt_new] (Absent → Present, Missing M → Present N
+       M≠N, Present M → Present N M≠N): reset PR-bootstrap lifecycle fields
+       that the OLD setter cleared, plus the PR-keyed CI history that no
+       longer corresponds to the new PR's check runs. Does NOT touch
+       base_branch / notified_base_branch — those are owned by [start]
+       (bootstrap) and the poller (renumbering). *)
+  match Patch_pr_status.classify_set_present t.pr_status pr_number with
+  | Set_present_recover_same ->
+      { t with pr_status = Patch_pr_status.set_present t.pr_status pr_number }
+  | Set_present_adopt_new ->
+      {
+        t with
+        pr_status = Patch_pr_status.set_present t.pr_status pr_number;
+        is_draft = true;
+        pr_body_delivered = false;
+        start_attempts_without_pr = 0;
+        ci_checks = [];
+        ci_failure_count = 0;
+        delivered_ci_run_ids = [];
+      }
 
 let clear_pr t =
   (* Gameplan-recreate path: a gameplan patch's PR was closed and the next
@@ -475,20 +492,18 @@ let clear_pr t =
   }
 
 let mark_pr_missing t =
-  (* Ad-hoc PR vanished from remote. Preserves the recorded PR number (so the
-     TUI can show what was lost, and a poll that re-observes the PR can adopt
-     it back via [set_pr_number]), but strips functional PR state so no
-     downstream code tries to act against a number GitHub no longer has.
-     Queue entries that require an active PR are dropped; Human and
-     Merge_conflict survive (a human message can still be relevant, and the
-     conflict flag is informational). *)
-  let queue =
-    List.filter t.queue ~f:(fun k ->
-        match k with
-        | Operation_kind.Ci | Review_comments | Pr_body | Findings | Rebase ->
-            false
-        | Human | Merge_conflict -> true)
-  in
+  (* Minimal transition. Clears only the world-state assertions that are no
+     longer authoritative (is_draft, merge_ready, checks_passing, ci_checks);
+     preserves everything else so a Missing -> Present recovery via
+     [set_pr_number] (same-number, [Set_present_recover_same]) is a near
+     no-op.
+
+     Queue is preserved: the planner gates Rebase/Respond on [is_pr_present]
+     so PR-coupled entries cannot fire on a Missing agent. [busy] /
+     [current_op] are preserved too — any inflight session runs to
+     completion against the recorded number; its outcome is applied to the
+     agent normally (the session-level retry counters track real failures
+     even when GitHub returns 404). *)
   {
     t with
     pr_status = Patch_pr_status.mark_missing t.pr_status;
@@ -496,11 +511,6 @@ let mark_pr_missing t =
     merge_ready = false;
     checks_passing = false;
     ci_checks = [];
-    ci_failure_count = 0;
-    base_branch = None;
-    notified_base_branch = None;
-    delivered_ci_run_ids = [];
-    queue;
   }
 
 let start t ~base_branch =

--- a/lib_core/patch_agent.ml
+++ b/lib_core/patch_agent.ml
@@ -11,7 +11,7 @@ type op_state = Queued | Running
 type t = {
   patch_id : Patch_id.t;
   branch : Branch.t;
-  pr_number : Pr_number.t option;
+  pr_status : Patch_pr_status.t;
   has_session : bool;
   busy : bool;
   merged : bool;
@@ -86,7 +86,10 @@ type t = {
 
 let pp fmt t = Sexp.pp_hum fmt (sexp_of_t t)
 let show t = Sexp.to_string_hum (sexp_of_t t)
-let has_pr t = Option.is_some t.pr_number
+let has_pr t = Patch_pr_status.has_pr t.pr_status
+let is_pr_present t = Patch_pr_status.is_pr_present t.pr_status
+let is_pr_missing t = Patch_pr_status.is_missing t.pr_status
+let pr_number t = Patch_pr_status.pr_number t.pr_status
 
 let needs_intervention t =
   let human_in_queue =
@@ -106,7 +109,7 @@ let needs_intervention t =
      callers that don't pre-filter by [merged]. *)
   let given_up = equal_session_fallback t.session_fallback Given_up in
   (not t.merged)
-  && (given_up
+  && (given_up || is_pr_missing t
      || (not human_in_queue)
         && (t.ci_failure_count >= 3
            || ((not (has_pr t)) && t.start_attempts_without_pr >= 2)
@@ -119,7 +122,7 @@ let create ~branch patch_id =
   {
     patch_id;
     branch;
-    pr_number = None;
+    pr_status = Patch_pr_status.Absent;
     has_session = false;
     busy = false;
     merged = false;
@@ -164,7 +167,7 @@ let create_adhoc ~patch_id ~branch ~pr_number =
   {
     patch_id;
     branch;
-    pr_number = Some pr_number;
+    pr_status = Patch_pr_status.Present pr_number;
     has_session = false;
     busy = false;
     merged = false;
@@ -305,7 +308,7 @@ let set_checks_passing t v = { t with checks_passing = v }
 let set_worktree_path t path = { t with worktree_path = Some path }
 
 let is_approved t ~main_branch =
-  has_pr t && t.merge_ready && (not t.busy)
+  is_pr_present t && t.merge_ready && (not t.busy)
   && (not (needs_intervention t))
   && (not t.is_draft) && (not t.branch_blocked)
   && Option.equal Branch.equal t.base_branch (Some main_branch)
@@ -390,7 +393,7 @@ let reset_intervention_state t =
 
 let reset_busy t = if not t.busy then t else { t with busy = false }
 
-let restore ~patch_id ~branch ~pr_number ~has_session ~busy ~merged ~queue
+let restore ~patch_id ~branch ~pr_status ~has_session ~busy ~merged ~queue
     ~satisfies ~changed ~has_conflict ~base_branch ~notified_base_branch
     ~ci_failure_count ~session_fallback ~human_messages ~inflight_human_messages
     ~ci_checks ~merge_ready ~is_draft ~pr_body_delivered
@@ -403,7 +406,7 @@ let restore ~patch_id ~branch ~pr_number ~has_session ~busy ~merged ~queue
   {
     patch_id;
     branch;
-    pr_number;
+    pr_status;
     has_session;
     busy;
     merged;
@@ -447,16 +450,20 @@ let restore ~patch_id ~branch ~pr_number ~has_session ~busy ~merged ~queue
 let set_pr_number t pr_number =
   {
     t with
-    pr_number = Some pr_number;
+    pr_status = Patch_pr_status.set_present t.pr_status pr_number;
     is_draft = true;
     pr_body_delivered = false;
     start_attempts_without_pr = 0;
   }
 
 let clear_pr t =
+  (* Gameplan-recreate path: a gameplan patch's PR was closed and the next
+     [Start] should open a fresh one. Tightens to Present-only via
+     [Patch_pr_status.clear_for_recreate]. Calling this on Absent or Missing
+     is a caller bug — see [mark_pr_missing] for the ad-hoc-vanished path. *)
   {
     t with
-    pr_number = None;
+    pr_status = Patch_pr_status.clear_for_recreate t.pr_status;
     is_draft = false;
     merge_ready = false;
     checks_passing = false;
@@ -465,6 +472,35 @@ let clear_pr t =
     base_branch = None;
     notified_base_branch = None;
     delivered_ci_run_ids = [];
+  }
+
+let mark_pr_missing t =
+  (* Ad-hoc PR vanished from remote. Preserves the recorded PR number (so the
+     TUI can show what was lost, and a poll that re-observes the PR can adopt
+     it back via [set_pr_number]), but strips functional PR state so no
+     downstream code tries to act against a number GitHub no longer has.
+     Queue entries that require an active PR are dropped; Human and
+     Merge_conflict survive (a human message can still be relevant, and the
+     conflict flag is informational). *)
+  let queue =
+    List.filter t.queue ~f:(fun k ->
+        match k with
+        | Operation_kind.Ci | Review_comments | Pr_body | Findings | Rebase ->
+            false
+        | Human | Merge_conflict -> true)
+  in
+  {
+    t with
+    pr_status = Patch_pr_status.mark_missing t.pr_status;
+    is_draft = false;
+    merge_ready = false;
+    checks_passing = false;
+    ci_checks = [];
+    ci_failure_count = 0;
+    base_branch = None;
+    notified_base_branch = None;
+    delivered_ci_run_ids = [];
+    queue;
   }
 
 let start t ~base_branch =
@@ -510,7 +546,8 @@ let record_anchor t anchor =
 let anchor_history t = t.anchor_history
 
 let rebase t ~base_branch =
-  if not (has_pr t) then invalid_arg "Patch_agent.rebase: patch has no PR";
+  if not (is_pr_present t) then
+    invalid_arg "Patch_agent.rebase: patch has no PR (or PR is missing)";
   if t.merged then invalid_arg "Patch_agent.rebase: patch is merged";
 
   if t.busy then invalid_arg "Patch_agent.rebase: patch is busy";
@@ -541,7 +578,8 @@ let rebase t ~base_branch =
   }
 
 let respond t k =
-  if not (has_pr t) then invalid_arg "Patch_agent.respond: patch has no PR";
+  if not (is_pr_present t) then
+    invalid_arg "Patch_agent.respond: patch has no PR (or PR is missing)";
   if t.merged then invalid_arg "Patch_agent.respond: patch is merged";
 
   if t.busy then invalid_arg "Patch_agent.respond: patch is busy";

--- a/lib_core/patch_agent.mli
+++ b/lib_core/patch_agent.mli
@@ -419,8 +419,18 @@ val highest_priority : t -> Types.Operation_kind.t option
 (** {2 Persistence support} *)
 
 val set_pr_number : t -> Types.Pr_number.t -> t
-(** Store [pr_number] (making [has_pr] true). Not a plain field setter —
-    establishes the PR-present state and resets PR-bootstrap lifecycle facts. *)
+(** Store [pr_number] (making [has_pr] true). Dispatches on
+    {!Patch_pr_status.classify_set_present}:
+    - [Set_present_recover_same] (prior was [Missing N] or [Present N] with the
+      same number): preserves all world-state — the body is still delivered, CI
+      runs already accounted, [notified_base_branch] still authoritative.
+    - [Set_present_adopt_new] (prior was [Absent], or the number differs):
+      resets PR-bootstrap fields ([is_draft = true],
+      [pr_body_delivered = false], [start_attempts_without_pr = 0]) plus
+      PR-keyed CI history that no longer matches the new PR's check runs
+      ([ci_checks = []], [ci_failure_count = 0], [delivered_ci_run_ids = []]).
+      Does NOT touch [base_branch] / [notified_base_branch] — those are owned by
+      [start] during bootstrap and by the poller during renumbering. *)
 
 val clear_pr : t -> t
 (** Remove the PR number and reset PR-related state, returning the agent to the
@@ -430,13 +440,20 @@ val clear_pr : t -> t
 
 val mark_pr_missing : t -> t
 (** Transition the agent from [Present pr] to [Missing pr]: the remote no longer
-    has the PR. Preserves the recorded PR number (so the TUI can show what was
-    lost and a re-observation can adopt the same PR back). Strips functional PR
-    state (draft, merge_ready, ci_checks, base_branch, etc.) and drops
-    PR-coupled queue entries (Ci, Review_comments, Pr_body, Findings, Rebase).
-    Preserves [Human] and [Merge_conflict] queue entries. Raises
-    [Invalid_argument] on [Absent] (cannot mark missing what was never had) or
-    [Missing] (idempotency is the caller's responsibility). *)
+    has the PR. Minimal: clears only the world-state assertions that are no
+    longer authoritative ([is_draft], [merge_ready], [checks_passing],
+    [ci_checks]). Everything else — queue, counters, [notified_base_branch],
+    [delivered_ci_run_ids], [pr_body_delivered], [current_op], [busy],
+    [base_branch] — is preserved so a [Missing → Present] recovery via
+    {!set_pr_number} (same-number) is a near-no-op.
+
+    The planner gates Rebase/Respond on [is_pr_present] so PR-coupled queue
+    entries cannot fire while the agent is [Missing]; preserved Human and
+    Merge_conflict entries are dispatched once the PR is recovered.
+
+    Raises [Invalid_argument] on [Absent] (cannot mark missing what was never
+    had) or [Missing] (idempotency is the caller's responsibility — see
+    {!Orchestrator.mark_pr_missing} for the idempotent wrapper). *)
 
 val restore :
   patch_id:Types.Patch_id.t ->

--- a/lib_core/patch_agent.mli
+++ b/lib_core/patch_agent.mli
@@ -15,7 +15,10 @@ type op_state = Queued | Running
 type t = private {
   patch_id : Types.Patch_id.t;
   branch : Types.Branch.t;
-  pr_number : Types.Pr_number.t option;
+  pr_status : Patch_pr_status.t;
+      (** Lifecycle status of the patch's PR. Use the accessor functions
+          ([has_pr], [is_pr_present], [is_pr_missing], [pr_number]) rather than
+          pattern-matching the field — see {!Patch_pr_status}. *)
   has_session : bool;
   busy : bool;
   merged : bool;
@@ -114,7 +117,22 @@ val create_adhoc :
 (** {2 Derived predicates} *)
 
 val has_pr : t -> bool
-(** [true] when [pr_number] is [Some _]. *)
+(** [true] when this agent has a recorded PR identity (either [Present] or
+    [Missing] in [pr_status]). Used as the orchestrator-invariant predicate:
+    every graph node must be in the gameplan or have a PR identity. *)
+
+val is_pr_present : t -> bool
+(** [true] only when [pr_status = Present _]. Use this for any callsite that is
+    about to act on the PR (rebase, respond, merge, set draft) — a [Missing] PR
+    cannot be acted on. *)
+
+val is_pr_missing : t -> bool
+(** [true] only when [pr_status = Missing _]. Contributes to
+    {!needs_intervention}. *)
+
+val pr_number : t -> Types.Pr_number.t option
+(** The recorded PR number, if any. [Some] for both [Present] and [Missing];
+    [None] for [Absent]. *)
 
 val needs_intervention : t -> bool
 (** Derived predicate: true when [Human] is not in [queue] and any of:
@@ -405,13 +423,25 @@ val set_pr_number : t -> Types.Pr_number.t -> t
     establishes the PR-present state and resets PR-bootstrap lifecycle facts. *)
 
 val clear_pr : t -> t
-(** Remove the PR number and reset all PR-related state, returning the agent to
-    the no-PR bootstrap path. *)
+(** Remove the PR number and reset PR-related state, returning the agent to the
+    no-PR bootstrap path. Tightens to [Present]-only: raises [Invalid_argument]
+    on [Absent] or [Missing]. The gameplan-recreate path is the only legitimate
+    caller; ad-hoc-vanished should use {!mark_pr_missing} instead. *)
+
+val mark_pr_missing : t -> t
+(** Transition the agent from [Present pr] to [Missing pr]: the remote no longer
+    has the PR. Preserves the recorded PR number (so the TUI can show what was
+    lost and a re-observation can adopt the same PR back). Strips functional PR
+    state (draft, merge_ready, ci_checks, base_branch, etc.) and drops
+    PR-coupled queue entries (Ci, Review_comments, Pr_body, Findings, Rebase).
+    Preserves [Human] and [Merge_conflict] queue entries. Raises
+    [Invalid_argument] on [Absent] (cannot mark missing what was never had) or
+    [Missing] (idempotency is the caller's responsibility). *)
 
 val restore :
   patch_id:Types.Patch_id.t ->
   branch:Types.Branch.t ->
-  pr_number:Types.Pr_number.t option ->
+  pr_status:Patch_pr_status.t ->
   has_session:bool ->
   busy:bool ->
   merged:bool ->

--- a/lib_core/patch_agent.mli
+++ b/lib_core/patch_agent.mli
@@ -135,11 +135,15 @@ val pr_number : t -> Types.Pr_number.t option
     [None] for [Absent]. *)
 
 val needs_intervention : t -> bool
-(** Derived predicate: true when [Human] is not in [queue] and any of:
-    [ci_failure_count >= 3], [session_fallback = Given_up],
-    [(not has_pr) && start_attempts_without_pr >= 2],
-    [conflict_noop_count >= 2], [no_commits_push_count >= 2],
-    [push_failure_count >= 3], or [pr_body_artifact_miss_count >= 2]. *)
+(** Derived predicate. True iff the agent is not [merged] AND any of:
+    - [session_fallback = Given_up] (bypasses the Human exemption)
+    - [is_pr_missing t] (PR vanished from the remote — bypasses the Human
+      exemption; queued Human entries are deferred until [Missing → Present]
+      recovery rather than dispatched while [Missing])
+    - [Human] not in queue AND any of: [ci_failure_count >= 3],
+      [(not has_pr) && start_attempts_without_pr >= 2],
+      [conflict_noop_count >= 2], [no_commits_push_count >= 2],
+      [push_failure_count >= 3], [pr_body_artifact_miss_count >= 2]. *)
 
 (** {2 Spec actions} *)
 
@@ -442,18 +446,24 @@ val mark_pr_missing : t -> t
 (** Transition the agent from [Present pr] to [Missing pr]: the remote no longer
     has the PR. Minimal: clears only the world-state assertions that are no
     longer authoritative ([is_draft], [merge_ready], [checks_passing],
-    [ci_checks]). Everything else — queue, counters, [notified_base_branch],
-    [delivered_ci_run_ids], [pr_body_delivered], [current_op], [busy],
-    [base_branch] — is preserved so a [Missing → Present] recovery via
-    {!set_pr_number} (same-number) is a near-no-op.
+    [ci_checks]). Everything else — queue (including Human, Ci, Pr_body,
+    Findings, Rebase, Review_comments, Merge_conflict), counters,
+    [notified_base_branch], [delivered_ci_run_ids], [pr_body_delivered],
+    [current_op], [busy], [base_branch] — is preserved so a [Missing → Present]
+    recovery via {!set_pr_number} (same-number) is a near-no-op.
 
-    The planner gates Rebase/Respond on [is_pr_present] so PR-coupled queue
-    entries cannot fire while the agent is [Missing]; preserved Human and
-    Merge_conflict entries are dispatched once the PR is recovered.
+    {b Human messages on a [Missing] agent are deferred, not actively
+       dispatched.} {!needs_intervention} fires on [is_pr_missing], so the
+    planner's Respond/Rebase branches gate the agent off. Queued Human entries
+    survive the [Missing] phase and dispatch normally once the PR recovers to
+    [Present] (via {!Patch_pr_status.classify_recovery_on_observe} →
+    {!Orchestrator.set_pr_number}). The operator's escape if the PR is not
+    coming back is [Orchestrator.remove_agent] (i.e., [-N] in the TUI).
 
     Raises [Invalid_argument] on [Absent] (cannot mark missing what was never
     had) or [Missing] (idempotency is the caller's responsibility — see
-    {!Orchestrator.mark_pr_missing} for the idempotent wrapper). *)
+    {!Orchestrator.mark_pr_missing} for the idempotent integration-level
+    wrapper). *)
 
 val restore :
   patch_id:Types.Patch_id.t ->

--- a/lib_core/patch_pr_status.ml
+++ b/lib_core/patch_pr_status.ml
@@ -73,6 +73,10 @@ let t_of_yojson_compat (json : Yojson.Safe.t) : (t, string) Result.t =
         Error (Stdlib.Printexc.to_string exn)
     | Yojson.Safe.Util.Type_error (msg, _) ->
         Error (Printf.sprintf "malformed pr_number: %s" msg)
+    | exn ->
+        Error
+          (Printf.sprintf "malformed pr_number: %s"
+             (Stdlib.Printexc.to_string exn))
   in
   match json with
   | `Null ->

--- a/lib_core/patch_pr_status.ml
+++ b/lib_core/patch_pr_status.ml
@@ -1,0 +1,165 @@
+open Base
+open Types
+
+type t = Absent | Present of Pr_number.t | Missing of Pr_number.t
+[@@deriving show, eq, sexp_of, compare]
+
+let has_pr = function Absent -> false | Present _ | Missing _ -> true
+let is_pr_present = function Present _ -> true | Absent | Missing _ -> false
+let is_missing = function Missing _ -> true | Absent | Present _ -> false
+let pr_number = function Absent -> None | Present n | Missing n -> Some n
+let set_present _t n = Present n
+
+let clear_for_recreate = function
+  | Present _ -> Absent
+  | Absent -> invalid_arg "Patch_pr_status.clear_for_recreate: already Absent"
+  | Missing _ ->
+      invalid_arg
+        "Patch_pr_status.clear_for_recreate: cannot erase Missing; use \
+         remove_agent if the patch is truly gone"
+
+let mark_missing = function
+  | Present n -> Missing n
+  | Absent ->
+      invalid_arg "Patch_pr_status.mark_missing: cannot mark Absent as Missing"
+  | Missing _ ->
+      invalid_arg
+        "Patch_pr_status.mark_missing: already Missing — caller should guard"
+
+(* ── Persistence ── *)
+
+let yojson_of_t = function
+  | Absent -> `Assoc [ ("kind", `String "absent") ]
+  | Present n ->
+      `Assoc
+        [ ("kind", `String "present"); ("pr_number", Pr_number.yojson_of_t n) ]
+  | Missing n ->
+      `Assoc
+        [ ("kind", `String "missing"); ("pr_number", Pr_number.yojson_of_t n) ]
+
+let t_of_yojson_compat (json : Yojson.Safe.t) : (t, string) Result.t =
+  let decode_pr_number v =
+    try Ok (Pr_number.t_of_yojson v) with
+    | Ppx_yojson_conv_lib.Yojson_conv.Of_yojson_error (exn, _) ->
+        Error (Stdlib.Printexc.to_string exn)
+    | Yojson.Safe.Util.Type_error (msg, _) ->
+        Error (Printf.sprintf "malformed pr_number: %s" msg)
+  in
+  match json with
+  | `Null ->
+      (* Legacy form: pr_number = null *)
+      Ok Absent
+  | `Assoc fields -> (
+      match List.Assoc.find fields ~equal:String.equal "kind" with
+      | None ->
+          (* No "kind" tag — not the new form, not a primitive either. Probably
+             malformed; surface the structure to the operator. *)
+          Error
+            (Printf.sprintf "Patch_pr_status: unexpected object shape: %s"
+               (Yojson.Safe.to_string json))
+      | Some (`String "absent") -> Ok Absent
+      | Some (`String "present") -> (
+          match List.Assoc.find fields ~equal:String.equal "pr_number" with
+          | None -> Error "Patch_pr_status: present without pr_number"
+          | Some v -> Result.map (decode_pr_number v) ~f:(fun n -> Present n))
+      | Some (`String "missing") -> (
+          match List.Assoc.find fields ~equal:String.equal "pr_number" with
+          | None -> Error "Patch_pr_status: missing without pr_number"
+          | Some v -> Result.map (decode_pr_number v) ~f:(fun n -> Missing n))
+      | Some other ->
+          Error
+            (Printf.sprintf "Patch_pr_status: unknown kind %s"
+               (Yojson.Safe.to_string other)))
+  | other ->
+      (* Legacy form: bare integer (or whatever Pr_number accepts) → Present. *)
+      Result.map (decode_pr_number other) ~f:(fun n -> Present n)
+
+(* ── Inline smoke tests ── *)
+
+let mk_pr n = Pr_number.of_int n
+
+let%test "has_pr / is_pr_present / is_missing agreement" =
+  (not (has_pr Absent))
+  && (not (is_pr_present Absent))
+  && (not (is_missing Absent))
+  && has_pr (Present (mk_pr 1))
+  && is_pr_present (Present (mk_pr 1))
+  && (not (is_missing (Present (mk_pr 1))))
+  && has_pr (Missing (mk_pr 1))
+  && (not (is_pr_present (Missing (mk_pr 1))))
+  && is_missing (Missing (mk_pr 1))
+
+let%test "pr_number lifts Present and Missing, drops Absent" =
+  Option.is_none (pr_number Absent)
+  && Option.equal Pr_number.equal
+       (pr_number (Present (mk_pr 7)))
+       (Some (mk_pr 7))
+  && Option.equal Pr_number.equal
+       (pr_number (Missing (mk_pr 7)))
+       (Some (mk_pr 7))
+
+let%test "set_present is total and lands in Present" =
+  let n = mk_pr 42 in
+  equal (set_present Absent n) (Present n)
+  && equal (set_present (Present (mk_pr 1)) n) (Present n)
+  && equal (set_present (Missing (mk_pr 1)) n) (Present n)
+
+let%test "clear_for_recreate: Present -> Absent" =
+  equal (clear_for_recreate (Present (mk_pr 1))) Absent
+
+let%test "clear_for_recreate raises on Absent" =
+  try
+    let _ = clear_for_recreate Absent in
+    false
+  with Invalid_argument _ -> true
+
+let%test "clear_for_recreate raises on Missing" =
+  try
+    let _ = clear_for_recreate (Missing (mk_pr 1)) in
+    false
+  with Invalid_argument _ -> true
+
+let%test "mark_missing: Present n -> Missing n preserves number" =
+  let n = mk_pr 99 in
+  equal (mark_missing (Present n)) (Missing n)
+
+let%test "mark_missing raises on Absent" =
+  try
+    let _ = mark_missing Absent in
+    false
+  with Invalid_argument _ -> true
+
+let%test "mark_missing raises on Missing" =
+  try
+    let _ = mark_missing (Missing (mk_pr 1)) in
+    false
+  with Invalid_argument _ -> true
+
+let roundtrip_ok t =
+  match t_of_yojson_compat (yojson_of_t t) with
+  | Ok t' -> equal t t'
+  | Error _ -> false
+
+let%test "yojson round-trip: Absent" = roundtrip_ok Absent
+let%test "yojson round-trip: Present" = roundtrip_ok (Present (mk_pr 5))
+let%test "yojson round-trip: Missing" = roundtrip_ok (Missing (mk_pr 5))
+
+let%test "legacy null decodes to Absent" =
+  match t_of_yojson_compat `Null with
+  | Ok Absent -> true
+  | Ok (Present _ | Missing _) | Error _ -> false
+
+let%test "legacy bare int decodes to Present" =
+  match t_of_yojson_compat (`Int 42) with
+  | Ok (Present n) -> Pr_number.equal n (mk_pr 42)
+  | Ok (Absent | Missing _) | Error _ -> false
+
+let%test "unknown kind is an Error" =
+  match t_of_yojson_compat (`Assoc [ ("kind", `String "bogus") ]) with
+  | Error _ -> true
+  | Ok (Absent | Present _ | Missing _) -> false
+
+let%test "present without pr_number is an Error" =
+  match t_of_yojson_compat (`Assoc [ ("kind", `String "present") ]) with
+  | Error _ -> true
+  | Ok (Absent | Present _ | Missing _) -> false

--- a/lib_core/patch_pr_status.ml
+++ b/lib_core/patch_pr_status.ml
@@ -26,6 +26,19 @@ let mark_missing = function
       invalid_arg
         "Patch_pr_status.mark_missing: already Missing — caller should guard"
 
+(* ── Pure classifiers ── *)
+
+type mark_missing_decision =
+  | Mark_missing_already
+  | Mark_missing_transition
+  | Mark_missing_illegal
+[@@deriving show, eq]
+
+let classify_mark_missing = function
+  | Missing _ -> Mark_missing_already
+  | Present _ -> Mark_missing_transition
+  | Absent -> Mark_missing_illegal
+
 (* ── Persistence ── *)
 
 let yojson_of_t = function
@@ -134,6 +147,27 @@ let%test "mark_missing raises on Missing" =
     let _ = mark_missing (Missing (mk_pr 1)) in
     false
   with Invalid_argument _ -> true
+
+let%test "classify_mark_missing: Present -> Transition" =
+  equal_mark_missing_decision
+    (classify_mark_missing (Present (mk_pr 1)))
+    Mark_missing_transition
+
+let%test "classify_mark_missing: Missing -> Already" =
+  equal_mark_missing_decision
+    (classify_mark_missing (Missing (mk_pr 1)))
+    Mark_missing_already
+
+let%test "classify_mark_missing: Absent -> Illegal" =
+  equal_mark_missing_decision
+    (classify_mark_missing Absent)
+    Mark_missing_illegal
+
+let%test "classify_mark_missing agrees with mark_missing on Transition" =
+  let s = Present (mk_pr 5) in
+  match classify_mark_missing s with
+  | Mark_missing_transition -> equal (mark_missing s) (Missing (mk_pr 5))
+  | Mark_missing_already | Mark_missing_illegal -> false
 
 let roundtrip_ok t =
   match t_of_yojson_compat (yojson_of_t t) with

--- a/lib_core/patch_pr_status.ml
+++ b/lib_core/patch_pr_status.ml
@@ -39,6 +39,15 @@ let classify_mark_missing = function
   | Present _ -> Mark_missing_transition
   | Absent -> Mark_missing_illegal
 
+type set_present_decision = Set_present_recover_same | Set_present_adopt_new
+[@@deriving show, eq]
+
+let classify_set_present t pr_number =
+  match t with
+  | Present n when Pr_number.equal n pr_number -> Set_present_recover_same
+  | Missing n when Pr_number.equal n pr_number -> Set_present_recover_same
+  | Absent | Present _ | Missing _ -> Set_present_adopt_new
+
 (* ── Persistence ── *)
 
 let yojson_of_t = function
@@ -168,6 +177,31 @@ let%test "classify_mark_missing agrees with mark_missing on Transition" =
   match classify_mark_missing s with
   | Mark_missing_transition -> equal (mark_missing s) (Missing (mk_pr 5))
   | Mark_missing_already | Mark_missing_illegal -> false
+
+let%test "classify_set_present: Absent + any n -> Adopt_new" =
+  equal_set_present_decision
+    (classify_set_present Absent (mk_pr 1))
+    Set_present_adopt_new
+
+let%test "classify_set_present: Present n + same n -> Recover_same" =
+  equal_set_present_decision
+    (classify_set_present (Present (mk_pr 7)) (mk_pr 7))
+    Set_present_recover_same
+
+let%test "classify_set_present: Present n + different m -> Adopt_new" =
+  equal_set_present_decision
+    (classify_set_present (Present (mk_pr 7)) (mk_pr 8))
+    Set_present_adopt_new
+
+let%test "classify_set_present: Missing n + same n -> Recover_same" =
+  equal_set_present_decision
+    (classify_set_present (Missing (mk_pr 7)) (mk_pr 7))
+    Set_present_recover_same
+
+let%test "classify_set_present: Missing n + different m -> Adopt_new" =
+  equal_set_present_decision
+    (classify_set_present (Missing (mk_pr 7)) (mk_pr 8))
+    Set_present_adopt_new
 
 let roundtrip_ok t =
   match t_of_yojson_compat (yojson_of_t t) with

--- a/lib_core/patch_pr_status.ml
+++ b/lib_core/patch_pr_status.ml
@@ -48,6 +48,13 @@ let classify_set_present t pr_number =
   | Missing n when Pr_number.equal n pr_number -> Set_present_recover_same
   | Absent | Present _ | Missing _ -> Set_present_adopt_new
 
+type recovery_decision = Lift_to_present of Pr_number.t | No_recovery_needed
+[@@deriving show, eq]
+
+let classify_recovery_on_observe = function
+  | Missing n -> Lift_to_present n
+  | Absent | Present _ -> No_recovery_needed
+
 (* ── Persistence ── *)
 
 let yojson_of_t = function
@@ -202,6 +209,21 @@ let%test "classify_set_present: Missing n + different m -> Adopt_new" =
   equal_set_present_decision
     (classify_set_present (Missing (mk_pr 7)) (mk_pr 8))
     Set_present_adopt_new
+
+let%test "classify_recovery_on_observe: Missing n -> Lift n" =
+  equal_recovery_decision
+    (classify_recovery_on_observe (Missing (mk_pr 9)))
+    (Lift_to_present (mk_pr 9))
+
+let%test "classify_recovery_on_observe: Present -> No_recovery" =
+  equal_recovery_decision
+    (classify_recovery_on_observe (Present (mk_pr 9)))
+    No_recovery_needed
+
+let%test "classify_recovery_on_observe: Absent -> No_recovery" =
+  equal_recovery_decision
+    (classify_recovery_on_observe Absent)
+    No_recovery_needed
 
 let roundtrip_ok t =
   match t_of_yojson_compat (yojson_of_t t) with

--- a/lib_core/patch_pr_status.mli
+++ b/lib_core/patch_pr_status.mli
@@ -104,6 +104,21 @@ val classify_set_present : t -> Pr_number.t -> set_present_decision
     should preserve world-state (same-number recovery) or reset bootstrap state
     (different number). *)
 
+type recovery_decision =
+  | Lift_to_present of Pr_number.t
+      (** Prior status was [Missing n]; the remote now confirms the PR exists.
+          The effectful handler should call [set_pr_number] with the recorded
+          number (same-number recovery, preserves world-state). *)
+  | No_recovery_needed
+      (** Prior was [Present _] (no transition needed) or [Absent] (no PR to
+          recover). *)
+[@@deriving show, eq]
+
+val classify_recovery_on_observe : t -> recovery_decision
+(** Total. Used by callers that have a positive signal from the remote (the
+    poller's [Apply_pr_state] dispatch, the startup reconciler's discovery) to
+    decide whether to lift a [Missing] agent back to [Present]. *)
+
 (** {2 Persistence} *)
 
 val yojson_of_t : t -> Yojson.Safe.t

--- a/lib_core/patch_pr_status.mli
+++ b/lib_core/patch_pr_status.mli
@@ -85,6 +85,25 @@ val classify_mark_missing : t -> mark_missing_decision
     integration-level API idempotent on [Missing] while keeping the low-level
     {!mark_missing} transition strict. *)
 
+type set_present_decision =
+  | Set_present_recover_same
+      (** Prior status was [Missing n] or [Present n] with the same number n —
+          this is a same-PR recovery / restate. The effectful handler should
+          preserve world-state fields (the body is still delivered, CI runs
+          already accounted, notified_base_branch still authoritative). *)
+  | Set_present_adopt_new
+      (** Prior was [Absent], or the number differs. This is a fresh PR
+          (bootstrap) or renumbering — the handler should reset bootstrap
+          lifecycle fields (is_draft, pr_body_delivered, base_branch,
+          delivered_ci_run_ids, etc.) as if the PR is new. *)
+[@@deriving show, eq]
+
+val classify_set_present : t -> Pr_number.t -> set_present_decision
+(** Total. Compares the prior status against the new PR number. Used by
+    {!Patch_agent.set_pr_number} to decide whether a Missing↔Present roundtrip
+    should preserve world-state (same-number recovery) or reset bootstrap state
+    (different number). *)
+
 (** {2 Persistence} *)
 
 val yojson_of_t : t -> Yojson.Safe.t

--- a/lib_core/patch_pr_status.mli
+++ b/lib_core/patch_pr_status.mli
@@ -64,7 +64,26 @@ val mark_missing : t -> t
 (** Move to [Missing n] preserving the recorded number. Partial: requires
     [Present _]; raises [Invalid_argument] on [Absent] (cannot lose what was
     never had) and on [Missing _] (idempotency is the caller's responsibility —
-    re-marking would discard the original observation). *)
+    re-marking would discard the original observation).
+
+    For an idempotent variant, callers should classify with
+    {!classify_mark_missing} and dispatch on the result. The orchestrator
+    wrapper {!Orchestrator.mark_pr_missing} does this. *)
+
+(** {2 Pure classifiers} *)
+
+type mark_missing_decision =
+  | Mark_missing_already  (** Already [Missing] — re-marking is a no-op. *)
+  | Mark_missing_transition  (** [Present] — legal transition to [Missing]. *)
+  | Mark_missing_illegal
+      (** [Absent] — caller bug; cannot lose what was never had. *)
+[@@deriving show, eq]
+
+val classify_mark_missing : t -> mark_missing_decision
+(** Total. Inspects [t] and returns the decision the effectful handler should
+    dispatch on. Used by {!Orchestrator.mark_pr_missing} to make the
+    integration-level API idempotent on [Missing] while keeping the low-level
+    {!mark_missing} transition strict. *)
 
 (** {2 Persistence} *)
 

--- a/lib_core/patch_pr_status.mli
+++ b/lib_core/patch_pr_status.mli
@@ -1,0 +1,83 @@
+open Types
+
+(** The lifecycle state of a patch's GitHub pull request.
+
+    Distinguishes three honest states a patch can occupy along the PR axis,
+    eliminating the historical collapse where [Pr_number.t option = None] meant
+    both "no PR yet" (bootstrap) and "PR previously existed but is now gone"
+    (the remote lost it). That collision was the root cause of a crash in
+    {!Patch_controller.reconcile_messages}: an ad-hoc agent whose remote PR
+    vanished was [clear_pr]-ed back to [None], leaving the orchestrator's graph
+    holding a node with neither gameplan nor PR.
+
+    Do not confuse this module with {!Pr_state}, which is the forge-agnostic
+    view of a single PR's GitHub-side facts (status, merge_state, ci_checks,
+    findings, ...). [Patch_pr_status] is strictly the patch agent's own
+    lifecycle status. *)
+
+type t =
+  | Absent  (** No PR has been opened for this patch yet. *)
+  | Present of Pr_number.t  (** PR is open and tracked. *)
+  | Missing of Pr_number.t
+      (** PR previously existed and the remote no longer has it. The agent is
+          surfaced for intervention; the recorded number lets the poller adopt
+          the PR back if it reappears, and the TUI can tell the operator which
+          PR it was. *)
+[@@deriving show, eq, sexp_of, compare]
+
+(** {2 Predicates} *)
+
+val has_pr : t -> bool
+(** [true] for [Present] and [Missing] — the orchestrator-invariant sense: "we
+    know a PR identity for this patch." Drives the
+    {!Patch_controller.reconcile_messages} invariant that every graph node must
+    be in the gameplan or have a PR identity. *)
+
+val is_pr_present : t -> bool
+(** [true] only for [Present] — the functional sense: "the PR can be rebased /
+    responded to / merged." Callers about to call GitHub against the recorded
+    number should gate on this, not on [has_pr]. *)
+
+val is_missing : t -> bool
+(** [true] only for [Missing]. *)
+
+val pr_number : t -> Pr_number.t option
+(** The recorded PR number, if any. [Some] for both [Present] and [Missing];
+    [None] for [Absent]. *)
+
+(** {2 Smart constructors} *)
+
+val set_present : t -> Pr_number.t -> t
+(** Move to [Present n]. Total: accepts any source state. Used by all paths
+    where a PR has been observed on the remote — first discovery
+    ([Absent → Present]), re-discovery after a vanish ([Missing → Present]), and
+    replacement renumbering ([Present → Present]). *)
+
+val clear_for_recreate : t -> t
+(** Move to [Absent]. Partial: raises [Invalid_argument] on [Absent] or
+    [Missing]. Used only by the gameplan-recreate path: when a gameplan patch's
+    PR has been closed and we want the next [Start] to open a fresh one. Calling
+    this on [Missing] would erase the user-visible history of which PR vanished;
+    use {!mark_missing} for that case instead. *)
+
+val mark_missing : t -> t
+(** Move to [Missing n] preserving the recorded number. Partial: requires
+    [Present _]; raises [Invalid_argument] on [Absent] (cannot lose what was
+    never had) and on [Missing _] (idempotency is the caller's responsibility —
+    re-marking would discard the original observation). *)
+
+(** {2 Persistence} *)
+
+val yojson_of_t : t -> Yojson.Safe.t
+(** Tagged-variant encoding: emits [\{"kind": "absent"\}] /
+    [\{"kind": "present", "pr_number": n\}] /
+    [\{"kind": "missing", "pr_number": n\}]. *)
+
+val t_of_yojson_compat : Yojson.Safe.t -> (t, string) Result.t
+(** Decode tagged form, with backward-compatible fall-backs:
+    - [`Null] → [Absent] (legacy [pr_number = null]).
+    - bare integer or any value decodable by [Pr_number.t_of_yojson] →
+      [Present n] (legacy [pr_number = n]).
+    - unrecognized JSON → [Error _].
+
+    Wraps raises from [Pr_number]'s ppx-derived decoder. *)

--- a/lib_core/rediscover_decision.ml
+++ b/lib_core/rediscover_decision.ml
@@ -1,0 +1,134 @@
+open Base
+open Types
+
+(** Pure decision layer between [StartupReconciler.discover_pr]'s effectful PR
+    lookup and the orchestrator state change. See the [.mli] for the contract.
+    The classification depends only on [(in_gameplan, result)] — the [patch_id]
+    and [pr_number] flow through for the effectful caller's logs but never
+    affect the decision. *)
+
+type replacement = {
+  new_pr : Pr_number.t;
+  base_branch : Branch.t;
+  merged : bool;
+}
+[@@deriving show, eq]
+
+type input = {
+  patch_id : Patch_id.t;
+  pr_number : Pr_number.t;
+  in_gameplan : bool;
+  result : (replacement option, string) Result.t;
+}
+
+type classification =
+  | Switch_to_pr of replacement
+  | Clear_pr_for_recreate
+  | Mark_pr_missing
+  | Log_error of { message : string }
+[@@deriving show, eq]
+
+let classify (input : input) : classification =
+  match input.result with
+  | Ok (Some r) -> Switch_to_pr r
+  | Ok None ->
+      if input.in_gameplan then Clear_pr_for_recreate else Mark_pr_missing
+  | Error message -> Log_error { message }
+
+(* ── Inline tests: one per row of the decision table ── *)
+
+let mk_pid = Patch_id.of_string
+let mk_pr = Pr_number.of_int
+let mk_branch = Branch.of_string
+
+let sample_replacement =
+  { new_pr = mk_pr 42; base_branch = mk_branch "main"; merged = false }
+
+let%test "Ok (Some r) + in_gameplan=true -> Switch_to_pr" =
+  match
+    classify
+      {
+        patch_id = mk_pid "p1";
+        pr_number = mk_pr 1;
+        in_gameplan = true;
+        result = Ok (Some sample_replacement);
+      }
+  with
+  | Switch_to_pr r -> equal_replacement r sample_replacement
+  | Clear_pr_for_recreate | Mark_pr_missing | Log_error _ -> false
+
+let%test "Ok (Some r) + in_gameplan=false -> Switch_to_pr (ad-hoc adoption)" =
+  match
+    classify
+      {
+        patch_id = mk_pid "p1";
+        pr_number = mk_pr 1;
+        in_gameplan = false;
+        result = Ok (Some sample_replacement);
+      }
+  with
+  | Switch_to_pr r -> equal_replacement r sample_replacement
+  | Clear_pr_for_recreate | Mark_pr_missing | Log_error _ -> false
+
+let%test "Ok None + in_gameplan=true -> Clear_pr_for_recreate" =
+  match
+    classify
+      {
+        patch_id = mk_pid "p1";
+        pr_number = mk_pr 1;
+        in_gameplan = true;
+        result = Ok None;
+      }
+  with
+  | Clear_pr_for_recreate -> true
+  | Switch_to_pr _ | Mark_pr_missing | Log_error _ -> false
+
+let%test "Ok None + in_gameplan=false -> Mark_pr_missing (bug-prevention)" =
+  match
+    classify
+      {
+        patch_id = mk_pid "p1";
+        pr_number = mk_pr 1;
+        in_gameplan = false;
+        result = Ok None;
+      }
+  with
+  | Mark_pr_missing -> true
+  | Switch_to_pr _ | Clear_pr_for_recreate | Log_error _ -> false
+
+let%test "Error _ + in_gameplan=true -> Log_error" =
+  match
+    classify
+      {
+        patch_id = mk_pid "p1";
+        pr_number = mk_pr 1;
+        in_gameplan = true;
+        result = Error "boom";
+      }
+  with
+  | Log_error { message } -> String.equal message "boom"
+  | Switch_to_pr _ | Clear_pr_for_recreate | Mark_pr_missing -> false
+
+let%test "Error _ + in_gameplan=false -> Log_error" =
+  match
+    classify
+      {
+        patch_id = mk_pid "p1";
+        pr_number = mk_pr 1;
+        in_gameplan = false;
+        result = Error "boom";
+      }
+  with
+  | Log_error { message } -> String.equal message "boom"
+  | Switch_to_pr _ | Clear_pr_for_recreate | Mark_pr_missing -> false
+
+let%test "classify is deterministic" =
+  let input =
+    {
+      patch_id = mk_pid "p1";
+      pr_number = mk_pr 1;
+      in_gameplan = false;
+      result = Ok None;
+    }
+  in
+  equal_classification (classify input) (classify input)

--- a/lib_core/rediscover_decision.ml
+++ b/lib_core/rediscover_decision.ml
@@ -35,6 +35,13 @@ let classify (input : input) : classification =
       if input.in_gameplan then Clear_pr_for_recreate else Mark_pr_missing
   | Error message -> Log_error { message }
 
+type log_decision = Log_emit | Log_skip [@@deriving show, eq]
+
+let classify_vanish_log cls ~already_logged =
+  match cls with
+  | Mark_pr_missing -> if already_logged then Log_skip else Log_emit
+  | Switch_to_pr _ | Clear_pr_for_recreate | Log_error _ -> Log_skip
+
 (* ── Inline tests: one per row of the decision table ── *)
 
 let mk_pid = Patch_id.of_string
@@ -132,3 +139,28 @@ let%test "classify is deterministic" =
     }
   in
   equal_classification (classify input) (classify input)
+
+let%test "classify_vanish_log: Mark_pr_missing first time -> Log_emit" =
+  equal_log_decision
+    (classify_vanish_log Mark_pr_missing ~already_logged:false)
+    Log_emit
+
+let%test "classify_vanish_log: Mark_pr_missing already logged -> Log_skip" =
+  equal_log_decision
+    (classify_vanish_log Mark_pr_missing ~already_logged:true)
+    Log_skip
+
+let%test "classify_vanish_log: Switch_to_pr never emits" =
+  equal_log_decision
+    (classify_vanish_log (Switch_to_pr sample_replacement) ~already_logged:false)
+    Log_skip
+
+let%test "classify_vanish_log: Clear_pr_for_recreate never emits" =
+  equal_log_decision
+    (classify_vanish_log Clear_pr_for_recreate ~already_logged:false)
+    Log_skip
+
+let%test "classify_vanish_log: Log_error never emits" =
+  equal_log_decision
+    (classify_vanish_log (Log_error { message = "x" }) ~already_logged:false)
+    Log_skip

--- a/lib_core/rediscover_decision.mli
+++ b/lib_core/rediscover_decision.mli
@@ -1,0 +1,54 @@
+open Types
+
+(** Pure decision layer between [StartupReconciler.discover_pr]'s effectful PR
+    lookup and the orchestrator state change. The poller drives this when an
+    in-memory PR is reported closed by a normal poll and we need to decide what
+    to do with the agent. *)
+
+type replacement = {
+  new_pr : Pr_number.t;
+  base_branch : Branch.t;
+  merged : bool;
+}
+[@@deriving show, eq]
+
+type input = {
+  patch_id : Patch_id.t;
+  pr_number : Pr_number.t;
+      (** The PR number that was closed and triggered the rediscovery. Used only
+          for log composition by the effectful caller; the classification itself
+          does not depend on it. *)
+  in_gameplan : bool;
+      (** [true] iff [patch_id] currently appears in the gameplan. Drives the
+          split between [Clear_pr_for_recreate] (gameplan patch — let the next
+          tick re-Start with a fresh PR) and [Mark_pr_missing] (ad-hoc patch —
+          there is nothing to recreate; surface for intervention). *)
+  result : (replacement option, string) Result.t;
+      (** Outcome of [StartupReconciler.discover_pr]:
+          - [Ok (Some r)]: a replacement PR was found on the same branch.
+          - [Ok None]: no PR exists on the branch.
+          - [Error msg]: the lookup itself failed. *)
+}
+(* [show] omitted: [Result.t] has no derived pretty-printer in this codebase
+   and the classification carries enough context for logs. *)
+
+type classification =
+  | Switch_to_pr of replacement
+      (** Adopt the replacement PR. Effectful caller should
+          [Patch_controller.apply_replacement_pr] and re-register the PR number
+          in any external map. *)
+  | Clear_pr_for_recreate
+      (** Gameplan patch with no PR on the remote — reset the agent so the next
+          [Start] tick opens a fresh one. Pre-existing behavior. *)
+  | Mark_pr_missing
+      (** Ad-hoc patch with no PR on the remote — the user-added PR vanished.
+          Transition the agent to [Missing] (preserving the recorded number) so
+          it surfaces as [needs_intervention]; the operator can either re-open
+          the PR on GitHub or remove the agent via [-N]. *)
+  | Log_error of { message : string }
+      (** Transport / GitHub / GraphQL error. Log and leave the agent state
+          unchanged this tick — the next poll will retry. *)
+[@@deriving show, eq]
+
+val classify : input -> classification
+(** Total. Pure. Same input always yields the same classification. *)

--- a/lib_core/rediscover_decision.mli
+++ b/lib_core/rediscover_decision.mli
@@ -52,3 +52,15 @@ type classification =
 
 val classify : input -> classification
 (** Total. Pure. Same input always yields the same classification. *)
+
+(** {2 Log dedup} *)
+
+type log_decision = Log_emit | Log_skip [@@deriving show, eq]
+
+val classify_vanish_log : classification -> already_logged:bool -> log_decision
+(** Pure decision for "should the effectful handler emit the 'PR vanished from
+    remote' log line on this tick?". The handler maintains the [already_logged]
+    flag per-patch (mirroring [mark_skip_logged] in the poller fiber) and resets
+    it whenever a successful recovery transition fires (e.g. [Switch_to_pr]).
+    Returns [Log_skip] for non-[Mark_pr_missing] classifications regardless of
+    [already_logged]. *)

--- a/test/dune
+++ b/test/dune
@@ -272,6 +272,20 @@
  (ocamlc_flags (:standard -w -40-42)))
 
 (test
+ (name test_patch_pr_status_properties)
+ (modules test_patch_pr_status_properties)
+ (libraries onton_core qcheck-core qcheck-core.runner)
+ (ocamlopt_flags (:standard -w -40-42))
+ (ocamlc_flags (:standard -w -40-42)))
+
+(test
+ (name test_rediscover_decision_properties)
+ (modules test_rediscover_decision_properties)
+ (libraries onton_core qcheck-core qcheck-core.runner)
+ (ocamlopt_flags (:standard -w -40-42))
+ (ocamlc_flags (:standard -w -40-42)))
+
+(test
  (name test_patch_controller)
  (modules test_patch_controller)
  (libraries onton onton_core onton_test_support qcheck-core qcheck-core.runner)

--- a/test/test_interleaving_properties.ml
+++ b/test/test_interleaving_properties.ml
@@ -631,11 +631,20 @@ let rec apply_command orch patches cmd =
       Orchestrator.apply_force_complete orch pid
         (to_force_complete_reason reason)
   | Mark_pr_missing_adhoc i -> (
+      (* No is_pr_present guard: Orchestrator.mark_pr_missing is idempotent
+         on Missing per Patch_pr_status.classify_mark_missing. Exercises the
+         production path that fires re-Mark on consecutive poll cycles after
+         a vanish. *)
       let pid = adhoc_pid i in
       match Orchestrator.find_agent orch pid with
-      | Some agent when Patch_agent.is_pr_present agent ->
-          Orchestrator.mark_pr_missing orch pid
-      | Some _ | None -> orch)
+      | Some _ -> (
+          try Orchestrator.mark_pr_missing orch pid
+          with
+          (* Mark_missing_illegal (Absent) — swallow so the property test can
+             explore arbitrary interleavings without an explicit gate. *)
+          | Invalid_argument _ ->
+            orch)
+      | None -> orch)
   | Rediscover_replacement_adhoc i -> (
       let pid = adhoc_pid i in
       match Orchestrator.find_agent orch pid with

--- a/test/test_interleaving_properties.ml
+++ b/test/test_interleaving_properties.ml
@@ -2957,3 +2957,31 @@ let () =
   in
   QCheck2.Test.check_exn prop;
   Stdlib.print_endline "PI-AH-8 passed"
+
+(** PI-AH-9: a normal Apply_poll on a Missing ad-hoc agent lifts it back to
+    Present, exercising the Patch_pr_status.classify_recovery_on_observe
+    dispatch wired into Patch_controller.apply_poll_result. *)
+let () =
+  let prop =
+    QCheck2.Test.make
+      ~name:"PI-AH-9: Apply_poll on Missing ad-hoc lifts to Present" ~count:200
+      QCheck2.Gen.(int_range 0 (max_adhoc - 1))
+      (fun i ->
+        let patches = mk_patches 0 in
+        let orch = bootstrap patches in
+        let cmds =
+          [
+            Add_adhoc i;
+            Mark_pr_missing_adhoc i;
+            Apply_poll { patch_idx = i; poll_kind = Poll_normal };
+          ]
+        in
+        let orch = run_sequence orch patches cmds in
+        match Orchestrator.find_agent orch (adhoc_pid i) with
+        | Some agent ->
+            Patch_agent.is_pr_present agent
+            && not (Patch_agent.is_pr_missing agent)
+        | None -> false)
+  in
+  QCheck2.Test.check_exn prop;
+  Stdlib.print_endline "PI-AH-9 passed"

--- a/test/test_interleaving_properties.ml
+++ b/test/test_interleaving_properties.ml
@@ -2923,3 +2923,37 @@ let () =
   in
   QCheck2.Test.check_exn prop;
   Stdlib.print_endline "PI-AH-7 passed"
+
+(** PI-AH-8: same-PR-number recovery via [set_pr_number] after [mark_pr_missing]
+    preserves [notified_base_branch], [delivered_ci_run_ids],
+    [pr_body_delivered], and queue contents. Exercises Commit 2's
+    [Set_present_recover_same] path end-to-end. *)
+let () =
+  let prop =
+    QCheck2.Test.make
+      ~name:"PI-AH-8: Mark+set_pr_number same-number preserves state" ~count:200
+      QCheck2.Gen.(int_range 0 (max_adhoc - 1))
+      (fun i ->
+        let patches = mk_patches 0 in
+        let orch = bootstrap patches in
+        let pid = adhoc_pid i in
+        let orch = apply_command orch patches (Add_adhoc i) in
+        (* Populate world-state that should survive the roundtrip *)
+        let pr = adhoc_pr i in
+        let orch =
+          Orchestrator.record_delivered_ci_run_ids orch pid [ 11; 12 ]
+        in
+        let orch = Orchestrator.set_pr_body_delivered orch pid true in
+        let orch = Orchestrator.enqueue orch pid Operation_kind.Human in
+        let before = Orchestrator.agent orch pid in
+        let orch = Orchestrator.mark_pr_missing orch pid in
+        let orch = Orchestrator.set_pr_number orch pid pr in
+        let after = Orchestrator.agent orch pid in
+        Patch_agent.is_pr_present after
+        && List.equal Int.equal after.delivered_ci_run_ids
+             before.delivered_ci_run_ids
+        && Bool.equal after.pr_body_delivered before.pr_body_delivered
+        && List.equal Operation_kind.equal after.queue before.queue)
+  in
+  QCheck2.Test.check_exn prop;
+  Stdlib.print_endline "PI-AH-8 passed"

--- a/test/test_interleaving_properties.ml
+++ b/test/test_interleaving_properties.ml
@@ -638,12 +638,13 @@ let rec apply_command orch patches cmd =
       let pid = adhoc_pid i in
       match Orchestrator.find_agent orch pid with
       | Some _ -> (
-          try Orchestrator.mark_pr_missing orch pid
-          with
+          try Orchestrator.mark_pr_missing orch pid with
           (* Mark_missing_illegal (Absent) — swallow so the property test can
              explore arbitrary interleavings without an explicit gate. *)
-          | Invalid_argument _ ->
-            orch)
+          | Invalid_argument msg
+            when String.is_substring msg ~substring:"Mark_missing_illegal" ->
+              orch
+          | Invalid_argument _ as exn -> raise exn)
       | None -> orch)
   | Rediscover_replacement_adhoc i -> (
       let pid = adhoc_pid i in
@@ -2891,9 +2892,10 @@ let () =
              ]))
       (fun cmds ->
         let patches = mk_patches 0 in
-        let orch = bootstrap patches in
-        let _ : Orchestrator.t = run_sequence orch patches cmds in
-        true)
+        (safe_verbose cmds patches) (fun () ->
+            let orch = bootstrap patches in
+            let _ : Orchestrator.t = run_sequence orch patches cmds in
+            true))
   in
   QCheck2.Test.check_exn prop;
   Stdlib.print_endline "PI-AH-6 passed"
@@ -2908,18 +2910,19 @@ let () =
       QCheck2.Gen.(int_range 0 (max_adhoc - 1))
       (fun i ->
         let patches = mk_patches 0 in
-        let orch = bootstrap patches in
         let cmds =
           [
             Add_adhoc i; Mark_pr_missing_adhoc i; Rediscover_replacement_adhoc i;
           ]
         in
-        let orch = run_sequence orch patches cmds in
-        match Orchestrator.find_agent orch (adhoc_pid i) with
-        | Some agent ->
-            Patch_agent.is_pr_present agent
-            && not (Patch_agent.is_pr_missing agent)
-        | None -> false)
+        (safe_verbose cmds patches) (fun () ->
+            let orch = bootstrap patches in
+            let orch = run_sequence orch patches cmds in
+            match Orchestrator.find_agent orch (adhoc_pid i) with
+            | Some agent ->
+                Patch_agent.is_pr_present agent
+                && not (Patch_agent.is_pr_missing agent)
+            | None -> false))
   in
   QCheck2.Test.check_exn prop;
   Stdlib.print_endline "PI-AH-7 passed"
@@ -2952,6 +2955,8 @@ let () =
         Patch_agent.is_pr_present after
         && List.equal Int.equal after.delivered_ci_run_ids
              before.delivered_ci_run_ids
+        && Option.equal Branch.equal after.notified_base_branch
+             before.notified_base_branch
         && Bool.equal after.pr_body_delivered before.pr_body_delivered
         && List.equal Operation_kind.equal after.queue before.queue)
   in

--- a/test/test_interleaving_properties.ml
+++ b/test/test_interleaving_properties.ml
@@ -101,6 +101,14 @@ type command =
   | Add_adhoc of int
   | Remove_adhoc of int
   | Discover_pr of int
+  | Mark_pr_missing_adhoc of int
+      (** Simulates the poller's [Rediscover_decision.Mark_pr_missing] arm — an
+          ad-hoc PR has vanished from the remote. Idempotency is the caller's
+          responsibility, so the apply path guards on [is_pr_present]. *)
+  | Rediscover_replacement_adhoc of int
+      (** Simulates [Rediscover_decision.Switch_to_pr] on an ad-hoc agent whose
+          PR was Missing — adopts a synthetic replacement PR number. Should
+          bring [pr_status] back to Present. *)
   | Apply_sync_outcome of {
       patch_idx : int;
       kind : Operation_kind.t;
@@ -173,6 +181,9 @@ let show_command = function
   | Add_adhoc i -> Printf.sprintf "Add_adhoc(%d)" i
   | Remove_adhoc i -> Printf.sprintf "Remove_adhoc(%d)" i
   | Discover_pr i -> Printf.sprintf "Discover_pr(%d)" i
+  | Mark_pr_missing_adhoc i -> Printf.sprintf "Mark_pr_missing_adhoc(%d)" i
+  | Rediscover_replacement_adhoc i ->
+      Printf.sprintf "Rediscover_replacement_adhoc(%d)" i
   | Apply_sync_outcome { patch_idx; kind; outcome } ->
       Printf.sprintf "Apply_sync_outcome(%d, %s, %s)" patch_idx
         (Operation_kind.to_label kind)
@@ -305,6 +316,10 @@ let gen_command ~n =
         map (fun i -> Add_adhoc i) (int_range 0 (max_adhoc - 1));
         map (fun i -> Remove_adhoc i) (int_range 0 (max_adhoc - 1));
         map (fun i -> Discover_pr i) gen_idx;
+        map (fun i -> Mark_pr_missing_adhoc i) (int_range 0 (max_adhoc - 1));
+        map
+          (fun i -> Rediscover_replacement_adhoc i)
+          (int_range 0 (max_adhoc - 1));
         gen_sync_outcome_command ~gen_idx;
         map2
           (fun i r -> Force_complete { patch_idx = i; reason = r })
@@ -344,6 +359,10 @@ let gen_atomic_command ~n =
         map (fun i -> Add_adhoc i) (int_range 0 (max_adhoc - 1));
         map (fun i -> Remove_adhoc i) (int_range 0 (max_adhoc - 1));
         map (fun i -> Discover_pr i) gen_idx;
+        map (fun i -> Mark_pr_missing_adhoc i) (int_range 0 (max_adhoc - 1));
+        map
+          (fun i -> Rediscover_replacement_adhoc i)
+          (int_range 0 (max_adhoc - 1));
         gen_sync_outcome_command ~gen_idx;
         map2
           (fun i r -> Force_complete { patch_idx = i; reason = r })
@@ -611,6 +630,21 @@ let rec apply_command orch patches cmd =
       let pid = resolve_pid patches patch_idx in
       Orchestrator.apply_force_complete orch pid
         (to_force_complete_reason reason)
+  | Mark_pr_missing_adhoc i -> (
+      let pid = adhoc_pid i in
+      match Orchestrator.find_agent orch pid with
+      | Some agent when Patch_agent.is_pr_present agent ->
+          Orchestrator.mark_pr_missing orch pid
+      | Some _ | None -> orch)
+  | Rediscover_replacement_adhoc i -> (
+      let pid = adhoc_pid i in
+      match Orchestrator.find_agent orch pid with
+      | Some agent
+        when Patch_agent.is_pr_missing agent && not agent.Patch_agent.merged ->
+          let new_pr = Pr_number.of_int (200 + i) in
+          Patch_controller.apply_replacement_pr orch pid ~pr_number:new_pr
+            ~base_branch:main ~merged:false
+      | Some _ | None -> orch)
 
 type poll_log_info = {
   agent_before : Patch_agent.t;
@@ -662,7 +696,8 @@ let rec apply_command_with_logs orch patches cmd =
   | Reconcile | Runner_tick | Complete _ | Apply_session_result _
   | Apply_rebase_result _ | Send_human_message _ | Reset_intervention _
   | Apply_conflict_rebase_result _ | Apply_rebase_push_result _ | Add_adhoc _
-  | Remove_adhoc _ | Discover_pr _ | Apply_sync_outcome _ | Force_complete _ ->
+  | Remove_adhoc _ | Discover_pr _ | Apply_sync_outcome _ | Force_complete _
+  | Mark_pr_missing_adhoc _ | Rediscover_replacement_adhoc _ ->
       (apply_command orch patches cmd, None)
 
 (* ========== Log invariant checks ========== *)
@@ -880,6 +915,32 @@ let check_merged_no_github_effects orch patches =
                    (Patch_id.to_string a.patch_id)
                    (List.length effects)))
 
+(** I-15: orchestrator graph invariant — every patch_id in the graph either
+    belongs to the gameplan or has a recorded PR identity (has_pr = Present or
+    Missing). Violation means an ad-hoc agent was cleared back to Absent instead
+    of being marked Missing — the original crash bug. *)
+let check_graph_pid_in_gameplan_or_has_pr orch patches =
+  let branch_map =
+    List.fold patches
+      ~init:(Map.empty (module Patch_id))
+      ~f:(fun acc (p : Patch.t) ->
+        Map.set acc ~key:p.Patch.id ~data:p.Patch.branch)
+  in
+  Graph.all_patch_ids (Orchestrator.graph orch)
+  |> List.iter ~f:(fun pid ->
+      let in_gameplan = Map.mem branch_map pid in
+      let agent_has_pr =
+        match Orchestrator.find_agent orch pid with
+        | Some a -> Patch_agent.has_pr a
+        | None -> false
+      in
+      if (not in_gameplan) && not agent_has_pr then
+        failwith
+          (Printf.sprintf
+             "I-15 graph_pid_in_gameplan_or_has_pr violated for %s — orphan \
+              ad-hoc patch (no PR identity and not in gameplan)"
+             (Patch_id.to_string pid)))
+
 (** I-12: notified_base_branch coherence — when has_session is true and the
     agent has not been rebased (notified_base_branch is Some), then
     notified_base_branch must have been set at start time. The field should only
@@ -1012,7 +1073,8 @@ let check_sync_outcome_invariants ~patches ~prev_agents ~curr_orch cmd =
   | Apply_rebase_result _ | Send_human_message _ | Reset_intervention _
   | Atomic_poll_reconcile _ | Apply_conflict_rebase_result _
   | Apply_rebase_push_result _ | Add_adhoc _ | Remove_adhoc _ | Discover_pr _
-  | Force_complete _ ->
+  | Force_complete _ | Mark_pr_missing_adhoc _ | Rediscover_replacement_adhoc _
+    ->
       ()
 
 (* ========== Combined check ========== *)
@@ -1056,7 +1118,9 @@ let check_all_invariants orch patches ~prev_agents ~prev_merged ~curr_merged
       check_busy_mutual_exclusion orch action;
       check_base_branch_freshness orch patches action);
   (* Reconciliation invariants *)
-  check_merged_no_github_effects orch patches
+  check_merged_no_github_effects orch patches;
+  (* I-15: graph node ⟹ in_gameplan ∨ has_pr — bug-prevention invariant *)
+  check_graph_pid_in_gameplan_or_has_pr orch patches
 
 let delivered_pid_of_cmd cmd patches =
   match cmd with
@@ -1065,7 +1129,8 @@ let delivered_pid_of_cmd cmd patches =
   | Apply_rebase_result _ | Send_human_message _ | Reset_intervention _
   | Atomic_poll_reconcile _ | Apply_conflict_rebase_result _
   | Apply_rebase_push_result _ | Add_adhoc _ | Remove_adhoc _ | Discover_pr _
-  | Apply_sync_outcome _ | Force_complete _ ->
+  | Apply_sync_outcome _ | Force_complete _ | Mark_pr_missing_adhoc _
+  | Rediscover_replacement_adhoc _ ->
       None
 
 let removed_pids_of_cmd cmd prev_removed =
@@ -1075,7 +1140,8 @@ let removed_pids_of_cmd cmd prev_removed =
   | Apply_session_result _ | Apply_rebase_result _ | Send_human_message _
   | Reset_intervention _ | Atomic_poll_reconcile _
   | Apply_conflict_rebase_result _ | Apply_rebase_push_result _ | Discover_pr _
-  | Apply_sync_outcome _ | Force_complete _ ->
+  | Apply_sync_outcome _ | Force_complete _ | Mark_pr_missing_adhoc _
+  | Rediscover_replacement_adhoc _ ->
       prev_removed
 
 let run_sequence ?(debug = false) orch patches cmds =
@@ -1095,10 +1161,11 @@ let run_sequence ?(debug = false) orch patches cmds =
         (* Re-adding an adhoc patch resets its lifecycle — clear merge log. *)
         let merged_logged =
           match cmd with
-          | Add_adhoc i -> Set.remove merged_logged (adhoc_pid i)
-          | Remove_adhoc _ | Apply_poll _ | Reconcile | Runner_tick | Complete _
-          | Apply_session_result _ | Apply_rebase_result _
-          | Send_human_message _ | Reset_intervention _
+          | Add_adhoc i | Rediscover_replacement_adhoc i ->
+              Set.remove merged_logged (adhoc_pid i)
+          | Mark_pr_missing_adhoc _ | Remove_adhoc _ | Apply_poll _ | Reconcile
+          | Runner_tick | Complete _ | Apply_session_result _
+          | Apply_rebase_result _ | Send_human_message _ | Reset_intervention _
           | Atomic_poll_reconcile _ | Apply_conflict_rebase_result _
           | Apply_rebase_push_result _ | Discover_pr _ | Apply_sync_outcome _
           | Force_complete _ ->
@@ -2793,3 +2860,57 @@ let () =
   in
   QCheck2.Test.check_exn prop;
   Stdlib.print_endline "PI-AH-5 passed"
+
+(** PI-AH-6: ad-hoc + Mark_pr_missing + Remove_adhoc preserves I-15 (graph
+    invariant) under any interleaving. This is the bug-prevention property — the
+    original crash happened when an ad-hoc agent was cleared instead of marked
+    missing, leaving an orphan in the graph. *)
+let () =
+  let prop =
+    QCheck2.Test.make
+      ~name:"PI-AH-6: Add+Mark_pr_missing+Remove sequences preserve I-15"
+      ~count:500
+      QCheck2.Gen.(
+        list_size (int_range 1 12)
+          (oneof
+             [
+               map (fun i -> Add_adhoc i) (int_range 0 (max_adhoc - 1));
+               map
+                 (fun i -> Mark_pr_missing_adhoc i)
+                 (int_range 0 (max_adhoc - 1));
+               map (fun i -> Remove_adhoc i) (int_range 0 (max_adhoc - 1));
+             ]))
+      (fun cmds ->
+        let patches = mk_patches 0 in
+        let orch = bootstrap patches in
+        let _ : Orchestrator.t = run_sequence orch patches cmds in
+        true)
+  in
+  QCheck2.Test.check_exn prop;
+  Stdlib.print_endline "PI-AH-6 passed"
+
+(** PI-AH-7: ad-hoc + Mark_pr_missing + Rediscover_replacement leaves the agent
+    in Present after a successful replacement (no stuck-Missing state). *)
+let () =
+  let prop =
+    QCheck2.Test.make
+      ~name:"PI-AH-7: Rediscover_replacement after Mark_pr_missing -> Present"
+      ~count:200
+      QCheck2.Gen.(int_range 0 (max_adhoc - 1))
+      (fun i ->
+        let patches = mk_patches 0 in
+        let orch = bootstrap patches in
+        let cmds =
+          [
+            Add_adhoc i; Mark_pr_missing_adhoc i; Rediscover_replacement_adhoc i;
+          ]
+        in
+        let orch = run_sequence orch patches cmds in
+        match Orchestrator.find_agent orch (adhoc_pid i) with
+        | Some agent ->
+            Patch_agent.is_pr_present agent
+            && not (Patch_agent.is_pr_missing agent)
+        | None -> false)
+  in
+  QCheck2.Test.check_exn prop;
+  Stdlib.print_endline "PI-AH-7 passed"

--- a/test/test_patch_agent.ml
+++ b/test/test_patch_agent.ml
@@ -948,6 +948,71 @@ let () =
           let a = set_pr_number a (Pr_number.of_int 7) in
           has_pr a && a.is_draft && (not a.pr_body_delivered)
           && a.start_attempts_without_pr = 0);
+      (* -- mark_pr_missing is minimal: clears only world-state assertions -- *)
+      Test.make
+        ~name:"mark_pr_missing preserves queue + counters + delivered_ci"
+        ~count:1
+        Gen.(pure (pid0, br0))
+        (fun (pid, br) ->
+          try
+            let a =
+              create ~branch:br pid |> fun a -> start_with_pr a ~base_branch:br
+            in
+            let a = complete a in
+            let a = enqueue a Operation_kind.Pr_body in
+            let a = enqueue a Operation_kind.Human in
+            let a = record_delivered_ci_run_ids a [ 101; 102 ] in
+            let a = set_pr_body_delivered a true in
+            let before_queue = a.queue in
+            let before_delivered = a.delivered_ci_run_ids in
+            let before_notified = a.notified_base_branch in
+            let a = mark_pr_missing a in
+            is_pr_missing a
+            && List.equal Operation_kind.equal a.queue before_queue
+            && List.equal Int.equal a.delivered_ci_run_ids before_delivered
+            && Option.equal Branch.equal a.notified_base_branch before_notified
+            && a.pr_body_delivered && (not a.is_draft) && (not a.merge_ready)
+            && (not a.checks_passing) && List.is_empty a.ci_checks
+          with _ -> false);
+      (* -- set_pr_number Recover_same preserves bootstrap fields -- *)
+      Test.make ~name:"set_pr_number Recover_same preserves bootstrap fields"
+        ~count:1
+        Gen.(pure (pid0, br0))
+        (fun (pid, br) ->
+          try
+            let pr = Pr_number.of_int 42 in
+            let a = create ~branch:br pid |> fun a -> start a ~base_branch:br in
+            let a = set_pr_number a pr in
+            (* Now Present pr; populate state that should survive a roundtrip. *)
+            let a = set_pr_body_delivered a true in
+            let a = record_delivered_ci_run_ids a [ 101; 102 ] in
+            let before_delivered = a.delivered_ci_run_ids in
+            let before_notified = a.notified_base_branch in
+            let a = mark_pr_missing a in
+            let a = set_pr_number a pr in
+            (* same pr -> Recover_same: preserve everything *)
+            is_pr_present a && a.pr_body_delivered
+            && List.equal Int.equal a.delivered_ci_run_ids before_delivered
+            && Option.equal Branch.equal a.notified_base_branch before_notified
+          with _ -> false);
+      (* -- set_pr_number Adopt_new on different pr resets PR-keyed CI -- *)
+      Test.make ~name:"set_pr_number Adopt_new resets PR-keyed CI history"
+        ~count:1
+        Gen.(pure (pid0, br0))
+        (fun (pid, br) ->
+          try
+            let pr1 = Pr_number.of_int 1 in
+            let pr2 = Pr_number.of_int 2 in
+            let a = create ~branch:br pid |> fun a -> start a ~base_branch:br in
+            let a = set_pr_number a pr1 in
+            let a = record_delivered_ci_run_ids a [ 101 ] in
+            let a = set_pr_body_delivered a true in
+            let a = set_pr_number a pr2 in
+            (* different pr -> Adopt_new: reset CI history + bootstrap *)
+            is_pr_present a
+            && List.is_empty a.delivered_ci_run_ids
+            && (not a.pr_body_delivered) && a.is_draft
+          with _ -> false);
       Test.make ~name:"on_pr_discovery_failure increments durable attempt count"
         ~count:1
         Gen.(pure pid0)

--- a/test/test_patch_agent.ml
+++ b/test/test_patch_agent.ml
@@ -687,14 +687,14 @@ let () =
       (* -- create has no pr_number -- *)
       Test.make ~name:"create has no pr_number" gen_pid (fun pid ->
           let a = create ~branch:br0 pid in
-          Option.is_none a.pr_number);
+          Option.is_none (pr_number a));
       (* -- set_pr_number stores pr_number -- *)
       Test.make ~name:"set_pr_number stores pr_number"
         Gen.(pair gen_pid (map Pr_number.of_int (int_range 1 9999)))
         (fun (pid, pr) ->
           let a = create ~branch:br0 pid in
           let a = set_pr_number a pr in
-          Option.equal Pr_number.equal a.pr_number (Some pr));
+          Option.equal Pr_number.equal (pr_number a) (Some pr));
       (* -- start clears ci_checks -- *)
       Test.make ~name:"start clears ci_checks"
         Gen.(pair gen_pid gen_branch)
@@ -717,9 +717,10 @@ let () =
           let a = mark_merged a in
           let a =
             Onton_core.Patch_agent.restore ~patch_id:a.patch_id ~branch:br
-              ~pr_number:None ~has_session:false ~busy:false ~merged:false
-              ~queue:[] ~satisfies:false ~changed:false ~has_conflict:false
-              ~base_branch:None ~notified_base_branch:None ~ci_failure_count:0
+              ~pr_status:Onton_core.Patch_pr_status.Absent ~has_session:false
+              ~busy:false ~merged:false ~queue:[] ~satisfies:false
+              ~changed:false ~has_conflict:false ~base_branch:None
+              ~notified_base_branch:None ~ci_failure_count:0
               ~session_fallback:Fresh_available ~human_messages:[]
               ~inflight_human_messages:[] ~ci_checks:a.ci_checks
               ~merge_ready:false ~is_draft:false ~pr_body_delivered:false
@@ -800,7 +801,8 @@ let () =
              restore — rebase should promote has_session to true. *)
           let a =
             restore ~patch_id:pid ~branch:br
-              ~pr_number:(Some (Pr_number.of_int 1))
+              ~pr_status:
+                (Onton_core.Patch_pr_status.Present (Pr_number.of_int 1))
               ~has_session:false ~busy:false ~merged:false ~queue:[]
               ~satisfies:true ~changed:false ~has_conflict:false
               ~base_branch:(Some br) ~notified_base_branch:(Some br)

--- a/test/test_patch_controller.ml
+++ b/test/test_patch_controller.ml
@@ -1216,10 +1216,55 @@ let () =
              before.Patch_agent.pr_body_delivered)
   in
 
+  (* Child of a Missing parent must not be Start-eligible: the parent's
+     branch may not exist on the remote, so deps_satisfied gating on
+     is_pr_present (not has_pr) is the correct semantic. *)
+  let prop_child_of_missing_parent_not_startable =
+    Test.make
+      ~name:"plan_action_for_patch: child of Missing parent not Start-eligible"
+      ~count:1
+      Gen.(return ())
+      (fun () ->
+        let parent_pid = Patch_id.of_string "parent" in
+        let child_pid = Patch_id.of_string "child" in
+        let parent_branch = Branch.of_string "feat/parent" in
+        let child_branch = Branch.of_string "feat/child" in
+        let parent_patch = make_patch parent_pid parent_branch in
+        let child_patch =
+          {
+            (make_patch child_pid child_branch) with
+            dependencies = [ parent_pid ];
+          }
+        in
+        let patches = [ parent_patch; child_patch ] in
+        let gameplan = { (make_gameplan parent_patch) with patches } in
+        let orch = Orchestrator.create ~patches ~main_branch:main in
+        (* Bootstrap parent: Start, set_pr_number, complete, then mark Missing *)
+        let orch =
+          Orchestrator.fire orch (Orchestrator.Start (parent_pid, main))
+        in
+        let orch =
+          Orchestrator.set_pr_number orch parent_pid (Pr_number.of_int 11)
+        in
+        let orch = Orchestrator.complete orch parent_pid in
+        let orch = Orchestrator.mark_pr_missing orch parent_pid in
+        (* Plan: child should NOT be Start-eligible because parent is Missing. *)
+        let messages =
+          Patch_controller.plan_messages orch ~patches:gameplan.Gameplan.patches
+        in
+        not
+          (List.exists messages
+             ~f:(fun (msg : Orchestrator.patch_agent_message) ->
+               match msg.action with
+               | Orchestrator.Start (pid, _) -> Patch_id.equal pid child_pid
+               | Orchestrator.Respond _ | Orchestrator.Rebase _ -> false)))
+  in
+
   let suite =
     [
       prop_missing_adhoc_does_not_crash_reconcile;
       prop_apply_poll_lifts_missing_to_present;
+      prop_child_of_missing_parent_not_startable;
       prop_deterministic;
       prop_plan_tick_deterministic;
       prop_pr_body_queue_idempotent;

--- a/test/test_patch_controller.ml
+++ b/test/test_patch_controller.ml
@@ -1159,9 +1159,67 @@ let () =
         with Invalid_argument _ -> false)
   in
 
+  (* Missing -> Present recovery via apply_poll_result. A poll that returns a
+     non-merged, non-conflict state means the remote currently has the PR;
+     the controller must lift the agent from Missing back to Present so
+     downstream planning can proceed. *)
+  let prop_apply_poll_lifts_missing_to_present =
+    Test.make ~name:"apply_poll_result lifts Missing -> Present on observe"
+      ~count:1
+      Gen.(return ())
+      (fun () ->
+        let pid = Patch_id.of_string "777" in
+        let branch = Branch.of_string "feat/recovered" in
+        let orch = Orchestrator.create ~patches:[] ~main_branch:main in
+        let orch =
+          Orchestrator.add_agent orch ~patch_id:pid ~branch ~base_branch:main
+            ~pr_number:(Pr_number.of_int 777)
+        in
+        (* Populate state that should survive the roundtrip *)
+        let orch =
+          Orchestrator.record_delivered_ci_run_ids orch pid [ 11; 12 ]
+        in
+        let orch = Orchestrator.set_pr_body_delivered orch pid true in
+        let before = Orchestrator.agent orch pid in
+        let orch = Orchestrator.mark_pr_missing orch pid in
+        let poll_result =
+          Poller.
+            {
+              merged = false;
+              has_conflict = false;
+              ci_checks = [];
+              checks_passing = true;
+              merge_ready = false;
+              queue = [];
+              is_draft = false;
+              closed = false;
+            }
+        in
+        let observation =
+          Patch_controller.
+            {
+              poll_result;
+              base_branch = None;
+              branch_in_root = false;
+              worktree_path = None;
+            }
+        in
+        let orch, _logs, _newly_blocked =
+          Patch_controller.apply_poll_result orch pid observation
+        in
+        let after = Orchestrator.agent orch pid in
+        Patch_agent.is_pr_present after
+        && (not (Patch_agent.is_pr_missing after))
+        && List.equal Int.equal after.Patch_agent.delivered_ci_run_ids
+             before.Patch_agent.delivered_ci_run_ids
+        && Bool.equal after.Patch_agent.pr_body_delivered
+             before.Patch_agent.pr_body_delivered)
+  in
+
   let suite =
     [
       prop_missing_adhoc_does_not_crash_reconcile;
+      prop_apply_poll_lifts_missing_to_present;
       prop_deterministic;
       prop_plan_tick_deterministic;
       prop_pr_body_queue_idempotent;

--- a/test/test_patch_controller.ml
+++ b/test/test_patch_controller.ml
@@ -50,9 +50,9 @@ let make_orch patch agent =
     ~outbox:(Map.empty (module Message_id))
     ~main_branch:main
 
-let make_agent ~patch_id ~branch ~pr_number ~merged ~queue ~base_branch
+let make_agent ~patch_id ~branch ~pr_status ~merged ~queue ~base_branch
     ~is_draft ~pr_body_delivered ~start_attempts_without_pr =
-  Patch_agent.restore ~patch_id ~branch ~pr_number ~has_session:false
+  Patch_agent.restore ~patch_id ~branch ~pr_status ~has_session:false
     ~busy:false ~merged ~queue ~satisfies:false ~changed:false
     ~has_conflict:false ~base_branch ~notified_base_branch:base_branch
     ~ci_failure_count:0 ~session_fallback:Patch_agent.Fresh_available
@@ -115,10 +115,13 @@ let () =
       let base_branch =
         if has_pr then Some (if use_main_base then main else branch) else None
       in
-      let pr_number = if has_pr then Some (Pr_number.of_int 42) else None in
+      let pr_status =
+        if has_pr then Patch_pr_status.Present (Pr_number.of_int 42)
+        else Patch_pr_status.Absent
+      in
       let patch = make_patch pid branch in
       let agent =
-        make_agent ~patch_id:pid ~branch ~pr_number ~merged ~queue ~base_branch
+        make_agent ~patch_id:pid ~branch ~pr_status ~merged ~queue ~base_branch
           ~is_draft ~pr_body_delivered ~start_attempts_without_pr
       in
       return (patch, make_gameplan patch, make_orch patch agent))
@@ -182,7 +185,7 @@ let () =
         let gameplan = make_gameplan patch in
         let agent =
           make_agent ~patch_id:pid ~branch
-            ~pr_number:(Some (Pr_number.of_int 42))
+            ~pr_status:(Patch_pr_status.Present (Pr_number.of_int 42))
             ~merged:false ~queue:[] ~base_branch:(Some main) ~is_draft:true
             ~pr_body_delivered:false ~start_attempts_without_pr:0
         in
@@ -222,7 +225,7 @@ let () =
            direction (re-draft) is not exercised by this property. *)
         let agent =
           Patch_agent.restore ~patch_id:pid ~branch
-            ~pr_number:(Some (Pr_number.of_int 42))
+            ~pr_status:(Patch_pr_status.Present (Pr_number.of_int 42))
             ~has_session:false ~busy:false ~merged:false ~queue:[]
             ~satisfies:false ~changed:false ~has_conflict:false
             ~base_branch:(Some main) ~notified_base_branch:(Some main)
@@ -271,7 +274,7 @@ let () =
         let gameplan = make_gameplan patch in
         let agent =
           Patch_agent.restore ~patch_id:pid ~branch
-            ~pr_number:(Some (Pr_number.of_int 42))
+            ~pr_status:(Patch_pr_status.Present (Pr_number.of_int 42))
             ~has_session:false ~busy:false ~merged:false ~queue:[]
             ~satisfies:false ~changed:false ~has_conflict:false
             ~base_branch:(Some main) ~notified_base_branch:(Some main)
@@ -307,9 +310,9 @@ let () =
         let patch = make_patch pid branch in
         let gameplan = make_gameplan patch in
         let agent =
-          make_agent ~patch_id:pid ~branch ~pr_number:None ~merged:false
-            ~queue:[] ~base_branch:None ~is_draft:false ~pr_body_delivered:false
-            ~start_attempts_without_pr:2
+          make_agent ~patch_id:pid ~branch ~pr_status:Patch_pr_status.Absent
+            ~merged:false ~queue:[] ~base_branch:None ~is_draft:false
+            ~pr_body_delivered:false ~start_attempts_without_pr:2
         in
         let orch = make_orch patch agent in
         let orch1, effects1 =
@@ -339,7 +342,7 @@ let () =
         let gameplan = make_gameplan patch in
         let agent =
           make_agent ~patch_id:pid ~branch
-            ~pr_number:(Some (Pr_number.of_int 42))
+            ~pr_status:(Patch_pr_status.Present (Pr_number.of_int 42))
             ~merged:false ~queue:[] ~base_branch:(Some main) ~is_draft:true
             ~pr_body_delivered:false ~start_attempts_without_pr:0
         in
@@ -370,9 +373,9 @@ let () =
         let patch = make_patch pid branch in
         let gameplan = make_gameplan patch in
         let agent =
-          make_agent ~patch_id:pid ~branch ~pr_number:None ~merged:false
-            ~queue:[] ~base_branch:None ~is_draft:false ~pr_body_delivered:false
-            ~start_attempts_without_pr:2
+          make_agent ~patch_id:pid ~branch ~pr_status:Patch_pr_status.Absent
+            ~merged:false ~queue:[] ~base_branch:None ~is_draft:false
+            ~pr_body_delivered:false ~start_attempts_without_pr:2
         in
         let orch = make_orch patch agent in
         let orch, effects =
@@ -408,7 +411,7 @@ let () =
         let gameplan = make_gameplan patch in
         let agent =
           Patch_agent.restore ~patch_id:pid ~branch
-            ~pr_number:(Some (Pr_number.of_int 42))
+            ~pr_status:(Patch_pr_status.Present (Pr_number.of_int 42))
             ~has_session:true ~busy:false ~merged:false
             ~queue:[ Operation_kind.Rebase ] ~satisfies:false ~changed:false
             ~has_conflict:false ~base_branch:(Some branch)
@@ -452,7 +455,7 @@ let () =
         let gameplan = make_gameplan patch in
         let agent =
           Patch_agent.restore ~patch_id:pid ~branch
-            ~pr_number:(Some (Pr_number.of_int 42))
+            ~pr_status:(Patch_pr_status.Present (Pr_number.of_int 42))
             ~has_session:true ~busy:false ~merged:false
             ~queue:[ Operation_kind.Ci ] ~satisfies:false ~changed:false
             ~has_conflict:false ~base_branch:(Some branch)
@@ -497,7 +500,7 @@ let () =
         (* pr_body_delivered=false so Set_pr_description fires *)
         let agent =
           Patch_agent.restore ~patch_id:pid ~branch
-            ~pr_number:(Some (Pr_number.of_int 42))
+            ~pr_status:(Patch_pr_status.Present (Pr_number.of_int 42))
             ~has_session:false ~busy:false ~merged:false ~queue:[]
             ~satisfies:false ~changed:false ~has_conflict:false
             ~base_branch:(Some branch) ~notified_base_branch:(Some branch)
@@ -547,7 +550,7 @@ let () =
         let gameplan = make_gameplan patch in
         let agent =
           make_agent ~patch_id:pid ~branch
-            ~pr_number:(Some (Pr_number.of_int 42))
+            ~pr_status:(Patch_pr_status.Present (Pr_number.of_int 42))
             ~merged:false ~queue:[] ~base_branch:(Some main) ~is_draft:true
             ~pr_body_delivered:true ~start_attempts_without_pr:0
           |> fun agent -> Patch_agent.set_branch_rebased_onto agent main
@@ -589,7 +592,7 @@ let () =
         let gameplan = make_gameplan patch in
         let agent =
           make_agent ~patch_id:pid ~branch
-            ~pr_number:(Some (Pr_number.of_int 42))
+            ~pr_status:(Patch_pr_status.Present (Pr_number.of_int 42))
             ~merged:false ~queue:[] ~base_branch:(Some main) ~is_draft:true
             ~pr_body_delivered:false ~start_attempts_without_pr:0
         in
@@ -635,7 +638,7 @@ let () =
         let patch = make_patch pid branch in
         let agent =
           Patch_agent.restore ~patch_id:pid ~branch
-            ~pr_number:(Some (Pr_number.of_int 42))
+            ~pr_status:(Patch_pr_status.Present (Pr_number.of_int 42))
             ~has_session:false ~busy:false ~merged:false ~queue:[]
             ~satisfies:false ~changed:false ~has_conflict:false
             ~base_branch:(Some main) ~notified_base_branch:(Some main)
@@ -699,7 +702,7 @@ let () =
         in
         let agent =
           Patch_agent.restore ~patch_id:pid ~branch
-            ~pr_number:(Some (Pr_number.of_int 42))
+            ~pr_status:(Patch_pr_status.Present (Pr_number.of_int 42))
             ~has_session:true ~busy:false ~merged:false ~queue:[]
             ~satisfies:false ~changed:true ~has_conflict:false
             ~base_branch:(Some main) ~notified_base_branch:(Some main)
@@ -750,7 +753,7 @@ let () =
         let patch = make_patch pid branch in
         let agent =
           make_agent ~patch_id:pid ~branch
-            ~pr_number:(Some (Pr_number.of_int 42))
+            ~pr_status:(Patch_pr_status.Present (Pr_number.of_int 42))
             ~merged:false ~queue:[] ~base_branch:(Some main) ~is_draft:true
             ~pr_body_delivered:false ~start_attempts_without_pr:0
         in
@@ -789,7 +792,7 @@ let () =
         let patch = make_patch pid branch in
         let agent =
           make_agent ~patch_id:pid ~branch
-            ~pr_number:(Some (Pr_number.of_int 42))
+            ~pr_status:(Patch_pr_status.Present (Pr_number.of_int 42))
             ~merged:false ~queue:[] ~base_branch:None ~is_draft:true
             ~pr_body_delivered:false ~start_attempts_without_pr:0
         in
@@ -842,7 +845,7 @@ let () =
            draft effect and no more Respond actions. *)
         let agent =
           Patch_agent.restore ~patch_id:pid ~branch
-            ~pr_number:(Some (Pr_number.of_int 42))
+            ~pr_status:(Patch_pr_status.Present (Pr_number.of_int 42))
             ~has_session:false ~busy:false ~merged:false ~queue:[]
             ~satisfies:false ~changed:false ~has_conflict:false
             ~base_branch:(Some main) ~notified_base_branch:(Some main)
@@ -926,7 +929,7 @@ let () =
         (* Agent has base_branch = branch, but graph says main (no deps) *)
         let agent =
           make_agent ~patch_id:pid ~branch
-            ~pr_number:(Some (Pr_number.of_int 42))
+            ~pr_status:(Patch_pr_status.Present (Pr_number.of_int 42))
             ~merged:false ~queue:[] ~base_branch:(Some branch) ~is_draft:true
             ~pr_body_delivered:true ~start_attempts_without_pr:0
         in
@@ -956,7 +959,7 @@ let () =
         (* Agent has base_branch = main, graph says main (no deps) → match *)
         let agent =
           make_agent ~patch_id:pid ~branch
-            ~pr_number:(Some (Pr_number.of_int 42))
+            ~pr_status:(Patch_pr_status.Present (Pr_number.of_int 42))
             ~merged:false ~queue:[] ~base_branch:(Some main) ~is_draft:true
             ~pr_body_delivered:true ~start_attempts_without_pr:0
         in
@@ -979,7 +982,7 @@ let () =
         let gameplan = make_gameplan patch in
         let agent =
           make_agent ~patch_id:pid ~branch
-            ~pr_number:(Some (Pr_number.of_int 42))
+            ~pr_status:(Patch_pr_status.Present (Pr_number.of_int 42))
             ~merged:false ~queue:[] ~base_branch:(Some branch) ~is_draft:true
             ~pr_body_delivered:true ~start_attempts_without_pr:0
         in
@@ -1007,7 +1010,7 @@ let () =
         let patch = make_patch pid branch in
         let agent =
           make_agent ~patch_id:pid ~branch
-            ~pr_number:(Some (Pr_number.of_int 42))
+            ~pr_status:(Patch_pr_status.Present (Pr_number.of_int 42))
             ~merged:false ~queue:[] ~base_branch:(Some branch) ~is_draft:false
             ~pr_body_delivered:true ~start_attempts_without_pr:0
         in
@@ -1052,13 +1055,13 @@ let () =
         let patch = make_patch pid branch in
         (* Agent with session but no PR → should appear *)
         let agent_session_no_pr =
-          Patch_agent.restore ~patch_id:pid ~branch ~pr_number:None
-            ~has_session:true ~busy:false ~merged:false ~queue:[]
-            ~satisfies:false ~changed:false ~has_conflict:false
-            ~base_branch:None ~notified_base_branch:None ~ci_failure_count:0
-            ~session_fallback:Patch_agent.Fresh_available ~human_messages:[]
-            ~inflight_human_messages:[] ~ci_checks:[] ~merge_ready:false
-            ~is_draft:false ~pr_body_delivered:true
+          Patch_agent.restore ~patch_id:pid ~branch
+            ~pr_status:Patch_pr_status.Absent ~has_session:true ~busy:false
+            ~merged:false ~queue:[] ~satisfies:false ~changed:false
+            ~has_conflict:false ~base_branch:None ~notified_base_branch:None
+            ~ci_failure_count:0 ~session_fallback:Patch_agent.Fresh_available
+            ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
+            ~merge_ready:false ~is_draft:false ~pr_body_delivered:true
             ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
             ~conflict_noop_count:0 ~no_commits_push_count:0
             ~push_failure_count:0 ~branch_rebased_onto:None
@@ -1096,7 +1099,7 @@ let () =
         let patch = make_patch pid branch in
         let agent =
           Patch_agent.restore ~patch_id:pid ~branch
-            ~pr_number:(Some (Pr_number.of_int 42))
+            ~pr_status:(Patch_pr_status.Present (Pr_number.of_int 42))
             ~has_session:true ~busy:false ~merged:false ~queue:[]
             ~satisfies:false ~changed:false ~has_conflict:false
             ~base_branch:(Some main) ~notified_base_branch:(Some main)
@@ -1125,8 +1128,40 @@ let () =
         List.is_empty (Patch_controller.discovery_intents orch))
   in
 
+  (* Bug repro: an ad-hoc agent transitioned to Missing must not crash
+     reconcile_messages, and must surface as needs_intervention with no
+     Start message issued. *)
+  let prop_missing_adhoc_does_not_crash_reconcile =
+    Test.make ~name:"reconcile_messages tolerates Missing ad-hoc agent" ~count:1
+      Gen.(return ())
+      (fun () ->
+        let pid = Patch_id.of_string "999" in
+        let branch = Branch.of_string "feat/vanished" in
+        let orch = Orchestrator.create ~patches:[] ~main_branch:main in
+        let orch =
+          Orchestrator.add_agent orch ~patch_id:pid ~branch ~base_branch:main
+            ~pr_number:(Pr_number.of_int 999)
+        in
+        let orch = Orchestrator.mark_pr_missing orch pid in
+        try
+          let messages = Patch_controller.plan_messages orch ~patches:[] in
+          let agent = Orchestrator.agent orch pid in
+          let no_start_message =
+            List.for_all messages
+              ~f:(fun (msg : Orchestrator.patch_agent_message) ->
+                match msg.action with
+                | Orchestrator.Start _ -> false
+                | Orchestrator.Respond _ | Orchestrator.Rebase _ -> true)
+          in
+          Patch_agent.needs_intervention agent
+          && Patch_agent.is_pr_missing agent
+          && no_start_message
+        with Invalid_argument _ -> false)
+  in
+
   let suite =
     [
+      prop_missing_adhoc_does_not_crash_reconcile;
       prop_deterministic;
       prop_plan_tick_deterministic;
       prop_pr_body_queue_idempotent;

--- a/test/test_patch_pr_status_properties.ml
+++ b/test/test_patch_pr_status_properties.ml
@@ -1,0 +1,138 @@
+open Base
+open Onton_core
+open Onton_core.Types
+module Gen = QCheck2.Gen
+module Test = QCheck2.Test
+
+(** Property tests for [Patch_pr_status]: legal-only transitions, predicate
+    consistency, and yojson round-trips (forward + legacy backward-compat). *)
+
+let gen_pr_number = Gen.(map Pr_number.of_int (int_range 1 9999))
+let gen_absent : Patch_pr_status.t Gen.t = Gen.return Patch_pr_status.Absent
+let gen_present = Gen.(map (fun n -> Patch_pr_status.Present n) gen_pr_number)
+let gen_missing = Gen.(map (fun n -> Patch_pr_status.Missing n) gen_pr_number)
+let gen_any = Gen.oneof [ gen_absent; gen_present; gen_missing ]
+
+(* ── Helpers ── *)
+
+let is_absent : Patch_pr_status.t -> bool = function
+  | Absent -> true
+  | Present _ | Missing _ -> false
+
+let is_present : Patch_pr_status.t -> bool = function
+  | Present _ -> true
+  | Absent | Missing _ -> false
+
+let is_missing : Patch_pr_status.t -> bool = function
+  | Missing _ -> true
+  | Absent | Present _ -> false
+
+let raises_invalid_argument f =
+  try
+    let _ = f () in
+    false
+  with Invalid_argument _ -> true
+
+(* ── Properties ── *)
+
+let prop_predicates_consistent =
+  Test.make ~name:"has_pr / is_pr_present / pr_number agree" ~count:200 gen_any
+    (fun t ->
+      let h = Patch_pr_status.has_pr t in
+      let p = Patch_pr_status.is_pr_present t in
+      let m = Patch_pr_status.is_missing t in
+      let n = Patch_pr_status.pr_number t in
+      (* is_pr_present implies has_pr *)
+      ((not p) || h)
+      (* has_pr iff pr_number is Some *)
+      && Bool.equal h (Option.is_some n)
+      (* exactly one of is_present / is_missing / is_absent holds *)
+      && (p || m || not h)
+      && not (p && m))
+
+let prop_set_present_total =
+  Test.make ~name:"set_present is total and lands in Present" ~count:500
+    Gen.(pair gen_any gen_pr_number)
+    (fun (t, n) ->
+      match Patch_pr_status.set_present t n with
+      | Present n' -> Pr_number.equal n n'
+      | Absent | Missing _ -> false)
+
+let prop_clear_for_recreate_partial =
+  Test.make ~name:"clear_for_recreate: Present -> Absent; raises otherwise"
+    ~count:200 gen_any (fun t ->
+      match t with
+      | Present _ -> (
+          match Patch_pr_status.clear_for_recreate t with
+          | Absent -> true
+          | Present _ | Missing _ -> false)
+      | Absent | Missing _ ->
+          raises_invalid_argument (fun () ->
+              Patch_pr_status.clear_for_recreate t))
+
+let prop_mark_missing_partial =
+  Test.make
+    ~name:"mark_missing: Present n -> Missing n; raises on Absent and Missing"
+    ~count:200 gen_any (fun t ->
+      match t with
+      | Present n -> (
+          match Patch_pr_status.mark_missing t with
+          | Missing n' -> Pr_number.equal n n'
+          | Absent | Present _ -> false)
+      | Absent | Missing _ ->
+          raises_invalid_argument (fun () -> Patch_pr_status.mark_missing t))
+
+let prop_yojson_roundtrip_forward =
+  Test.make ~name:"yojson round-trip preserves equality" ~count:500 gen_any
+    (fun t ->
+      match
+        Patch_pr_status.t_of_yojson_compat (Patch_pr_status.yojson_of_t t)
+      with
+      | Ok t' -> Patch_pr_status.equal t t'
+      | Error _ -> false)
+
+let prop_legacy_null_decodes_to_absent =
+  Test.make ~name:"legacy `Null decodes to Absent" ~count:1 (Gen.return ())
+    (fun () ->
+      match Patch_pr_status.t_of_yojson_compat `Null with
+      | Ok Absent -> true
+      | Ok (Present _ | Missing _) | Error _ -> false)
+
+let prop_legacy_int_decodes_to_present =
+  Test.make ~name:"legacy bare int decodes to Present" ~count:100 gen_pr_number
+    (fun n ->
+      let int_payload = Pr_number.yojson_of_t n in
+      match Patch_pr_status.t_of_yojson_compat int_payload with
+      | Ok (Present n') -> Pr_number.equal n n'
+      | Ok (Absent | Missing _) | Error _ -> false)
+
+let prop_legacy_never_produces_missing =
+  Test.make ~name:"legacy formats never produce Missing" ~count:100
+    Gen.(oneof [ return `Null; map Pr_number.yojson_of_t gen_pr_number ])
+    (fun legacy_json ->
+      match Patch_pr_status.t_of_yojson_compat legacy_json with
+      | Ok (Absent | Present _) -> true
+      | Ok (Missing _) -> false
+      | Error _ -> false)
+
+(* I deliberately avoid declaring an _ pattern in the awareness predicates so
+   adding a new variant to [Patch_pr_status.t] forces an update here. *)
+let _ = is_absent
+let _ = is_present
+let _ = is_missing
+
+let suite =
+  [
+    prop_predicates_consistent;
+    prop_set_present_total;
+    prop_clear_for_recreate_partial;
+    prop_mark_missing_partial;
+    prop_yojson_roundtrip_forward;
+    prop_legacy_null_decodes_to_absent;
+    prop_legacy_int_decodes_to_present;
+    prop_legacy_never_produces_missing;
+  ]
+
+let () =
+  let errcode = QCheck_base_runner.run_tests ~verbose:true suite in
+  if errcode <> 0 then Stdlib.exit errcode

--- a/test/test_patch_pr_status_properties.ml
+++ b/test/test_patch_pr_status_properties.ml
@@ -124,6 +124,26 @@ let prop_classify_mark_missing_agrees =
           Patch_pr_status.is_missing (Patch_pr_status.mark_missing t)
       | Mark_missing_already | Mark_missing_illegal -> false)
 
+let prop_classify_set_present_total =
+  Test.make ~name:"classify_set_present partitions by prior-number-match"
+    ~count:300
+    Gen.(pair gen_any gen_pr_number)
+    (fun (t, n) ->
+      let prior_matches =
+        Option.equal Pr_number.equal (Patch_pr_status.pr_number t) (Some n)
+      in
+      match Patch_pr_status.classify_set_present t n with
+      | Set_present_recover_same -> prior_matches
+      | Set_present_adopt_new -> not prior_matches)
+
+let prop_set_present_idempotent =
+  Test.make ~name:"set_present same-number applied twice = once" ~count:200
+    Gen.(pair gen_any gen_pr_number)
+    (fun (t, n) ->
+      let once = Patch_pr_status.set_present t n in
+      let twice = Patch_pr_status.set_present once n in
+      Patch_pr_status.equal once twice)
+
 let prop_legacy_never_produces_missing =
   Test.make ~name:"legacy formats never produce Missing" ~count:100
     Gen.(oneof [ return `Null; map Pr_number.yojson_of_t gen_pr_number ])
@@ -151,6 +171,8 @@ let suite =
     prop_legacy_never_produces_missing;
     prop_classify_mark_missing_total;
     prop_classify_mark_missing_agrees;
+    prop_classify_set_present_total;
+    prop_set_present_idempotent;
   ]
 
 let () =

--- a/test/test_patch_pr_status_properties.ml
+++ b/test/test_patch_pr_status_properties.ml
@@ -106,6 +106,24 @@ let prop_legacy_int_decodes_to_present =
       | Ok (Present n') -> Pr_number.equal n n'
       | Ok (Absent | Missing _) | Error _ -> false)
 
+let prop_classify_mark_missing_total =
+  Test.make ~name:"classify_mark_missing is total and exhaustive" ~count:200
+    gen_any (fun t ->
+      match Patch_pr_status.classify_mark_missing t with
+      | Mark_missing_already -> Patch_pr_status.is_missing t
+      | Mark_missing_transition -> Patch_pr_status.is_pr_present t
+      | Mark_missing_illegal -> not (Patch_pr_status.has_pr t)
+      (* Absent only *))
+
+let prop_classify_mark_missing_agrees =
+  Test.make
+    ~name:"classify_mark_missing Transition agrees with mark_missing transition"
+    ~count:200 gen_present (fun t ->
+      match Patch_pr_status.classify_mark_missing t with
+      | Mark_missing_transition ->
+          Patch_pr_status.is_missing (Patch_pr_status.mark_missing t)
+      | Mark_missing_already | Mark_missing_illegal -> false)
+
 let prop_legacy_never_produces_missing =
   Test.make ~name:"legacy formats never produce Missing" ~count:100
     Gen.(oneof [ return `Null; map Pr_number.yojson_of_t gen_pr_number ])
@@ -131,6 +149,8 @@ let suite =
     prop_legacy_null_decodes_to_absent;
     prop_legacy_int_decodes_to_present;
     prop_legacy_never_produces_missing;
+    prop_classify_mark_missing_total;
+    prop_classify_mark_missing_agrees;
   ]
 
 let () =

--- a/test/test_persistence_properties.ml
+++ b/test/test_persistence_properties.ml
@@ -269,7 +269,66 @@ let () =
           let json = Onton.Persistence.patch_agent_to_yojson agent in
           match Onton.Persistence.patch_agent_of_yojson ~gameplan json with
           | Ok agent' ->
-              Option.equal Pr_number.equal agent.pr_number agent'.pr_number
+              Option.equal Pr_number.equal
+                (Onton_core.Patch_agent.pr_number agent)
+                (Onton_core.Patch_agent.pr_number agent')
+          | Error _ -> false
+        with _ -> false)
+  in
+  (* pr_status round-trip: every Patch_pr_status variant (Absent, Present,
+     Missing) survives serialize -> deserialize through patch_agent_*_yojson. *)
+  let pr_status_roundtrip =
+    QCheck2.Test.make ~name:"pr_status survives round-trip (all 3 variants)"
+      ~count:300
+      QCheck2.Gen.(
+        oneof
+          [
+            return Onton_core.Patch_pr_status.Absent;
+            map
+              (fun n -> Onton_core.Patch_pr_status.Present (Pr_number.of_int n))
+              (int_range 1 9999);
+            map
+              (fun n -> Onton_core.Patch_pr_status.Missing (Pr_number.of_int n))
+              (int_range 1 9999);
+          ])
+      (fun pr_status ->
+        try
+          let json = Onton_core.Patch_pr_status.yojson_of_t pr_status in
+          match Onton_core.Patch_pr_status.t_of_yojson_compat json with
+          | Ok pr_status' ->
+              Onton_core.Patch_pr_status.equal pr_status pr_status'
+          | Error _ -> false
+        with _ -> false)
+  in
+  (* Legacy pr_number-only snapshot (no pr_status key) decodes correctly:
+     null -> Absent, int -> Present. Missing cannot appear from legacy data. *)
+  let legacy_pr_number_decodes_correctly =
+    QCheck2.Test.make
+      ~name:"legacy pr_number field decodes to Absent or Present" ~count:200
+      gen_patch_agent_fully_populated (fun agent ->
+        try
+          let gameplan = gameplan_for_agent agent in
+          let json = Onton.Persistence.patch_agent_to_yojson agent in
+          (* Remove pr_status; keep legacy pr_number to simulate an older
+             snapshot. *)
+          let json =
+            match json with
+            | `Assoc fields ->
+                `Assoc
+                  (List.filter fields ~f:(fun (k, _) ->
+                       not (String.equal k "pr_status")))
+            | other -> other
+          in
+          match Onton.Persistence.patch_agent_of_yojson ~gameplan json with
+          | Ok agent' ->
+              (* Whatever the agent's original pr_status, the legacy-only
+                 decode preserves the pr_number value and avoids Missing. *)
+              let original_pr = Onton_core.Patch_agent.pr_number agent in
+              let decoded_pr = Onton_core.Patch_agent.pr_number agent' in
+              let not_missing =
+                not (Onton_core.Patch_agent.is_pr_missing agent')
+              in
+              Option.equal Pr_number.equal original_pr decoded_pr && not_missing
           | Error _ -> false
         with _ -> false)
   in
@@ -279,17 +338,20 @@ let () =
         try
           let gameplan = gameplan_for_agent agent in
           let json = Onton.Persistence.patch_agent_to_yojson agent in
-          (* Remove pr_number from JSON to simulate legacy snapshot *)
+          (* Remove both pr_number and pr_status from JSON to simulate a
+             legacy snapshot that predates either field. *)
           let json =
             match json with
             | `Assoc fields ->
                 `Assoc
                   (List.filter fields ~f:(fun (k, _) ->
-                       not (String.equal k "pr_number")))
+                       (not (String.equal k "pr_number"))
+                       && not (String.equal k "pr_status")))
             | other -> other
           in
           match Onton.Persistence.patch_agent_of_yojson ~gameplan json with
-          | Ok agent' -> Option.is_none agent'.pr_number
+          | Ok agent' ->
+              Option.is_none (Onton_core.Patch_agent.pr_number agent')
           | Error _ -> false
         with _ -> false)
   in
@@ -448,6 +510,8 @@ let () =
         anchor_history_roundtrip;
         missing_anchor_history_defaults_empty;
         pr_number_roundtrip;
+        pr_status_roundtrip;
+        legacy_pr_number_decodes_correctly;
         missing_pr_number_defaults_none;
         missing_branch_falls_back_to_gameplan;
         adhoc_snapshot_roundtrip;

--- a/test/test_poll_log_properties.ml
+++ b/test/test_poll_log_properties.ml
@@ -45,7 +45,7 @@ let make_agent ~patch_id ~branch ~has_conflict ~ci_failure_count ~current_op
     ~checks_passing ~queue ~merged ~is_draft ~branch_blocked ~worktree_path =
   let busy = Option.is_some current_op in
   Patch_agent.restore ~patch_id ~branch
-    ~pr_number:(Some (Pr_number.of_int 42))
+    ~pr_status:(Patch_pr_status.Present (Pr_number.of_int 42))
     ~has_session:busy ~busy ~merged ~queue ~satisfies:false ~changed:false
     ~has_conflict ~base_branch:(Some main) ~notified_base_branch:(Some main)
     ~ci_failure_count ~session_fallback:Patch_agent.Fresh_available

--- a/test/test_rediscover_decision_properties.ml
+++ b/test/test_rediscover_decision_properties.ml
@@ -1,0 +1,139 @@
+open Base
+open Onton_core
+open Onton_core.Types
+module Gen = QCheck2.Gen
+module Test = QCheck2.Test
+module RD = Rediscover_decision
+
+(** Property tests for [Rediscover_decision.classify]: total, deterministic,
+    exhaustive on the 2x3 decision table (2 in_gameplan x 3 result shapes). The
+    bug-prevention case is row "Ok None + ~in_gameplan -> Mark_pr_missing" —
+    assert it explicitly. *)
+
+let gen_patch_id = Gen.(map Patch_id.of_string (string_size (int_range 3 12)))
+let gen_pr_number = Gen.(map Pr_number.of_int (int_range 1 9999))
+let gen_branch = Gen.(map Branch.of_string (string_size (int_range 3 20)))
+
+let gen_replacement : RD.replacement Gen.t =
+  Gen.map3
+    (fun new_pr base_branch merged -> RD.{ new_pr; base_branch; merged })
+    gen_pr_number gen_branch Gen.bool
+
+let gen_result_ok_some = Gen.map (fun r -> Ok (Some r)) gen_replacement
+
+let gen_result_ok_none : (RD.replacement option, string) Result.t Gen.t =
+  Gen.return (Ok None)
+
+let gen_result_error : (RD.replacement option, string) Result.t Gen.t =
+  Gen.map (fun s -> Error s) Gen.(string_size (int_range 1 30))
+
+let gen_input ~gen_result ~in_gameplan : RD.input Gen.t =
+  Gen.map3
+    (fun patch_id pr_number result ->
+      RD.{ patch_id; pr_number; in_gameplan; result })
+    gen_patch_id gen_pr_number gen_result
+
+let gen_any_input : RD.input Gen.t =
+  let any_result =
+    Gen.oneof [ gen_result_ok_some; gen_result_ok_none; gen_result_error ]
+  in
+  Gen.(
+    bool >>= fun in_gameplan -> gen_input ~gen_result:any_result ~in_gameplan)
+
+(* ── Helpers to test variants without wildcard patterns ── *)
+
+let is_switch_to : RD.classification -> bool = function
+  | Switch_to_pr _ -> true
+  | Clear_pr_for_recreate | Mark_pr_missing | Log_error _ -> false
+
+let is_clear : RD.classification -> bool = function
+  | Clear_pr_for_recreate -> true
+  | Switch_to_pr _ | Mark_pr_missing | Log_error _ -> false
+
+let is_mark_missing : RD.classification -> bool = function
+  | Mark_pr_missing -> true
+  | Switch_to_pr _ | Clear_pr_for_recreate | Log_error _ -> false
+
+let is_log_error : RD.classification -> bool = function
+  | Log_error _ -> true
+  | Switch_to_pr _ | Clear_pr_for_recreate | Mark_pr_missing -> false
+
+(* ── Properties ── *)
+
+let prop_classify_total =
+  Test.make ~name:"classify is total (never raises)" ~count:1000 gen_any_input
+    (fun input ->
+      try
+        let _ = RD.classify input in
+        true
+      with _ -> false)
+
+let prop_classify_deterministic =
+  Test.make ~name:"classify is deterministic" ~count:500 gen_any_input
+    (fun input ->
+      RD.equal_classification (RD.classify input) (RD.classify input))
+
+let prop_ok_some_is_switch =
+  Test.make ~name:"Ok (Some _) -> Switch_to_pr regardless of in_gameplan"
+    ~count:500
+    Gen.(
+      bool >>= fun ig ->
+      gen_input ~gen_result:gen_result_ok_some ~in_gameplan:ig)
+    (fun input -> is_switch_to (RD.classify input))
+
+let prop_ok_none_gameplan_is_clear =
+  Test.make ~name:"Ok None + in_gameplan=true -> Clear_pr_for_recreate"
+    ~count:300 (gen_input ~gen_result:gen_result_ok_none ~in_gameplan:true)
+    (fun input -> is_clear (RD.classify input))
+
+let prop_ok_none_adhoc_is_mark_missing =
+  Test.make
+    ~name:"Ok None + in_gameplan=false -> Mark_pr_missing (bug-prevention case)"
+    ~count:300 (gen_input ~gen_result:gen_result_ok_none ~in_gameplan:false)
+    (fun input -> is_mark_missing (RD.classify input))
+
+let prop_error_is_log =
+  Test.make ~name:"Error _ -> Log_error regardless of in_gameplan" ~count:500
+    Gen.(
+      bool >>= fun ig -> gen_input ~gen_result:gen_result_error ~in_gameplan:ig)
+    (fun input -> is_log_error (RD.classify input))
+
+let prop_independent_of_patch_id_and_pr_number =
+  (* Vary patch_id and pr_number while fixing (in_gameplan, result); the
+     classification *tag* must remain the same. Compare via predicate match,
+     not equality, because Switch_to_pr's payload is data-bearing. *)
+  let same_tag a b =
+    Bool.equal (is_switch_to a) (is_switch_to b)
+    && Bool.equal (is_clear a) (is_clear b)
+    && Bool.equal (is_mark_missing a) (is_mark_missing b)
+    && Bool.equal (is_log_error a) (is_log_error b)
+  in
+  Test.make ~name:"classify depends only on (in_gameplan, result)" ~count:500
+    Gen.(
+      let base =
+        bool >>= fun in_gameplan ->
+        oneof [ gen_result_ok_some; gen_result_ok_none; gen_result_error ]
+        >>= fun result -> return (in_gameplan, result)
+      in
+      base >>= fun (in_gameplan, result) ->
+      pair gen_patch_id gen_pr_number >>= fun (p1, n1) ->
+      pair gen_patch_id gen_pr_number >>= fun (p2, n2) ->
+      return
+        ( RD.{ patch_id = p1; pr_number = n1; in_gameplan; result },
+          RD.{ patch_id = p2; pr_number = n2; in_gameplan; result } ))
+    (fun (a, b) -> same_tag (RD.classify a) (RD.classify b))
+
+let suite =
+  [
+    prop_classify_total;
+    prop_classify_deterministic;
+    prop_ok_some_is_switch;
+    prop_ok_none_gameplan_is_clear;
+    prop_ok_none_adhoc_is_mark_missing;
+    prop_error_is_log;
+    prop_independent_of_patch_id_and_pr_number;
+  ]
+
+let () =
+  let errcode = QCheck_base_runner.run_tests ~verbose:true suite in
+  if errcode <> 0 then Stdlib.exit errcode

--- a/test/test_tui_render_frame.ml
+++ b/test/test_tui_render_frame.ml
@@ -27,6 +27,7 @@ let make_view ~id ~title =
     ci_checks = [];
     recent_stream = [];
     pr_number = None;
+    pr_missing = false;
     base_branch = None;
     worktree_path = None;
     intervention_reason = None;


### PR DESCRIPTION
## Summary

- Fixes a crash in `Patch_controller.reconcile_messages` (`Invalid_argument "tick input missing N patch id(s) from graph"`) triggered when an ad-hoc PR's remote disappears: the poller called `clear_pr` on the agent, leaving the orchestrator's graph holding a node with neither gameplan membership nor PR identity.
- Root cause was that `pr_number : Pr_number.t option` collapsed two distinct lifecycle states ("no PR yet" and "PR previously existed and is now gone") into the same `None`. Replaced with an honest sum type `Absent | Present of Pr_number.t | Missing of Pr_number.t` plus a pure `Rediscover_decision` module that routes the gameplan-vs-ad-hoc split deterministically.
- Ad-hoc patches whose PR vanishes now transition to `Missing` and surface as `needs_intervention` with a diagnostic log; the operator can re-open the PR (rediscovery brings it back to `Present`) or remove with `-N`.

## Design

`lib_core/patch_pr_status.{ml,mli}`:
```ocaml
type t = Absent | Present of Pr_number.t | Missing of Pr_number.t
```
with smart constructors enforcing legal transitions (`set_present`, `clear_for_recreate`, `mark_missing`), predicates (`has_pr`, `is_pr_present`, `is_pr_missing`, `pr_number`), and a hand-rolled yojson codec with backward-compat for legacy `null`/bare-int forms.

`lib_core/rediscover_decision.{ml,mli}`: pure decision module mirroring the `poll_cycle.ml` template — `(in_gameplan, discover_result)` → `Switch_to_pr | Clear_pr_for_recreate | Mark_pr_missing | Log_error`.

`Patch_agent.t.pr_number` field → `pr_status : Patch_pr_status.t` (field private, accessed only via accessor functions). `needs_intervention` now includes `is_pr_missing` as a new disjunct. Ten `has_pr` call sites tightened to `is_pr_present` (rebase, respond, is_approved, automerge dispatch, prune candidate, mark-for-review effects, etc.); eleven sites kept at `has_pr` (start path / spawn eligibility / orchestrator guard / the invariant assertion itself).

`lib/poller_fiber.ml`'s `Rediscover_pr` arm now dispatches through `Rediscover_decision.classify`. The `Ok None + ad-hoc` arm calls `Orchestrator.mark_pr_missing` instead of `clear_pr` and does **not** call `unregister_pr_number` — leaves the registration so re-opening the PR on GitHub gets picked up by the next poll's `Switch_to_pr` arm.

Persistence emits the new `pr_status` field alongside the legacy `pr_number` (one downgrade-window release); the reader prefers `pr_status` and falls back to `pr_number` (null→Absent, int→Present) for snapshots that predate the field.

## Test plan

- [x] Inline `let%test` smoke tests in `patch_pr_status.ml` and `rediscover_decision.ml` covering every constructor / decision-table row.
- [x] `test/test_patch_pr_status_properties.ml` — 8 QCheck2 properties (totality, predicate consistency, legal-only transitions, yojson round-trip forward + legacy backward).
- [x] `test/test_rediscover_decision_properties.ml` — 7 QCheck2 properties including the bug-prevention case `Ok None ∧ ¬in_gameplan → Mark_pr_missing` and an independence-from-patch_id/pr_number assertion.
- [x] Bug-repro test in `test/test_patch_controller.ml` — reconstructs the exact pre-crash state (ad-hoc agent added, then `mark_pr_missing`, then `plan_messages` on empty gameplan); asserts no raise + `needs_intervention` + no `Start` action.
- [x] `test/test_interleaving_properties.ml` extended with `Mark_pr_missing_adhoc` and `Rediscover_replacement_adhoc` commands; new **I-15** invariant (`pid ∈ graph ⟹ in_gameplan ∨ has_pr`) checked after every step across all property tests; **PI-AH-6** (random sequences preserve I-15) and **PI-AH-7** (rediscovery after missing → `Present`, no stuck state) as named properties.
- [x] `test/test_persistence_properties.ml` extended with `pr_status` forward round-trip for all three variants and a legacy-only decode test confirming legacy snapshots never produce `Missing`.
- [x] Full suite: `dune runtest` green.
- [ ] Manual end-to-end: add `+N` for a PR, close that PR on GitHub, wait a poll cycle, confirm the agent shows `needs_intervention` with the new diagnostic log (and that the orchestrator does not crash).
- [ ] Re-open the closed PR; confirm the next poll's `Switch_to_pr` brings the agent back to `Present`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/320"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782250458&installation_id=126163856&pr_number=320&repository=flowglad%2Fonton&return_to=https%3A%2F%2Fgithub.com%2Fflowglad%2Fonton%2Fpull%2F320&signature=4a7fd84d74d68fbfcfba29bb6753d5a524160a05f24e35d7e0f5ec97c84bbc97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the `pr_number` option with a PR lifecycle state to prevent crashes when ad‑hoc PRs vanish. Missing PRs now show as needs_intervention, actions require a Present PR, recovery to Present is automatic on poll/startup, and state is preserved across the Missing↔Present roundtrip.

- **Bug Fixes**
  - Made `Orchestrator.mark_pr_missing` idempotent to avoid poller crashes on repeated vanish classification.
  - Lifted `Missing` → `Present` automatically on positive poll observation and startup; preserves CI/session and delivered state.
  - Gated planning and PR actions on `is_pr_present` (including `deps_satisfied`) to block scheduling against vanished parents and avoid 404s.
  - Skipped refresh/prune for `Missing` PRs and de‑duplicated “PR vanished” logs.

- **Refactors**
  - Added `Patch_pr_status` (`Absent | Present of Pr_number.t | Missing of Pr_number.t`) with smart constructors, predicates, and a legacy‑compatible Yojson codec.
  - Introduced pure classifiers for rediscovery routing, mark‑missing idempotency, and recovery on observe.
  - `Patch_agent` now exposes `has_pr`, `is_pr_present`, `is_pr_missing`, `pr_number`; `mark_pr_missing` clears only non‑authoritative PR fields; `set_pr_number` distinguishes adopt‑new vs recover‑same and preserves world state on recovery.
  - Persistence writes `pr_status` alongside legacy `pr_number`; the TUI flags missing PRs with a distinct row marker.

<sup>Written for commit fb3ce4ffad0bfd75475228785e7ec441b77462d3. Summary will update on new commits. <a href="https://cubic.dev/pr/flowglad/onton/pull/320?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Track a three-state PR lifecycle (Present / Missing / Absent) and preserve PR identity for recovery.
  * TUI surfaces vanished PRs (prefixed/annotated) and a pr_missing flag.

* **Bug Fixes**
  * Prevents start/rebase/automerge/actions on missing PRs; safer startup/rediscovery and recovery flows; clearer status messages.

* **Tests**
  * Added property and unit tests for PR-status transitions, rediscovery, persistence and recovery.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flowglad/onton/pull/320?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->