### PR TITLE
Distinguish 'no remote ref yet' from real pre-create fetch failures

### DIFF
--- a/lib/worktree.ml
+++ b/lib/worktree.ml
@@ -158,9 +158,11 @@ let compute_repo_ancestry ~process_mgr ~repo_root ~local ~remote :
   | _ -> Start_point_plan.Unknown
 
 (* Fetch a single branch from origin into the corresponding remote-tracking
-   ref. Best-effort: missing remote branch / network failure returns Error.
-   Caller is expected to log Error and proceed — the planner correctly handles
-   [remote_ref = None] for the "brand new branch" case.
+   ref. Returns a typed [fetch_branch_result] so callers can distinguish
+   the routine "brand-new branch — no upstream yet" case from genuine
+   fetch failures (network, auth, ref-lock contention). The planner
+   correctly handles [remote_ref = None] either way; the distinction is
+   load-bearing only for log clarity.
 
    Operates on [repo_root]; worktrees share the ref store with the main repo,
    so this updates [refs/remotes/origin/<branch>] for all workers. The
@@ -179,11 +181,11 @@ let fetch_origin_branch ~fetch_lock ~process_mgr ~repo_root ~branch_str =
               branch_str ^ ":refs/remotes/origin/" ^ branch_str;
             ]
         in
-        Worktree_parser.classify_fetch_result ~code ~stderr
+        Worktree_parser.classify_fetch_branch_result ~code ~stderr
       with
       | exn when has_cancellation exn -> raise exn
       | exn ->
-          Result.Error
+          Worktree_parser.Fetch_branch_error
             (Printf.sprintf "git fetch origin %s crashed: %s" branch_str
                (Exn.to_string exn)))
 
@@ -501,6 +503,14 @@ let find_old_base ~process_mgr ~path ~target ~project_name ~ancestor_ids =
         else Result.Ok (String.strip stdout, commits)
 
 let classify_fetch_result = Worktree_parser.classify_fetch_result
+
+type fetch_branch_result = Worktree_parser.fetch_branch_result =
+  | Fetch_branch_ok
+  | Fetch_branch_no_remote_ref
+  | Fetch_branch_error of string
+[@@deriving show, eq, sexp_of, compare]
+
+let classify_fetch_branch_result = Worktree_parser.classify_fetch_branch_result
 
 let fetch_origin ~fetch_lock ~process_mgr ~path =
   (* Serialize concurrent fetches across worktrees of the same repo. All
@@ -967,11 +977,12 @@ module type S = sig
     (t, Start_point_plan.refusal) Result.t
 
   val fetch_origin_branch :
-    fetch_lock:Eio.Mutex.t -> branch:string -> (unit, string) Result.t
+    fetch_lock:Eio.Mutex.t -> branch:string -> fetch_branch_result
   (** Fetch a single branch from origin into the corresponding remote-tracking
-      ref. Best-effort: missing remote branch / network failure returns [Error].
-      Caller in [Worktree_setup.ensure_worktree] runs this before [create] so
-      the planner sees a fresh view of [origin/<branch>]. *)
+      ref. Returns [Fetch_branch_no_remote_ref] for the routine brand-new-branch
+      case (no upstream yet — not a failure); [Fetch_branch_error msg] for real
+      fetch failures. Caller in [Worktree_setup.ensure_worktree] runs this
+      before [create] so the planner sees a fresh view of [origin/<branch>]. *)
 
   val remove : t -> unit
   val detect_branch : path:string -> Types.Branch.t

--- a/lib/worktree.mli
+++ b/lib/worktree.mli
@@ -51,16 +51,35 @@ val create :
     ({!Worktree_setup.ensure_worktree}) before this function runs; this function
     passes [false] / [None] to the planner. *)
 
+(** Outcome of [fetch_origin_branch]. The [Fetch_branch_no_remote_ref] case is
+    the routine "brand-new branch — no upstream yet" state, which trips on the
+    very first creation of every patch worktree and is not a failure; callers
+    log it calmly to avoid misleading the operator. Real fetch failures
+    (network, auth, ref-lock) surface as [Fetch_branch_error msg]. *)
+type fetch_branch_result = Worktree_parser.fetch_branch_result =
+  | Fetch_branch_ok
+  | Fetch_branch_no_remote_ref
+  | Fetch_branch_error of string
+[@@deriving show, eq, sexp_of, compare]
+
+val classify_fetch_branch_result :
+  code:int -> stderr:string -> fetch_branch_result
+(** Pure: classify a branch-scoped [git fetch origin <branch>:...] invocation
+    from its exit code and stderr. Detects the no-upstream case by matching
+    git's canonical phrasing ["couldn't find remote ref"]. Split out from
+    [fetch_origin_branch] so the decision can be property-tested without
+    spawning processes. *)
+
 val fetch_origin_branch :
   fetch_lock:Eio.Mutex.t ->
   process_mgr:_ Eio.Process.mgr ->
   repo_root:string ->
   branch_str:string ->
-  (unit, string) Result.t
+  fetch_branch_result
 (** Run [git -C <repo_root> fetch origin <branch>:refs/remotes/origin/<branch>]
-    under the shared [fetch_lock]. Best-effort: missing remote branch / network
-    failure returns [Error]; caller logs and proceeds (the planner correctly
-    handles [remote_ref = None] for the brand-new-branch case). *)
+    under the shared [fetch_lock]. The planner correctly handles
+    [remote_ref = None] for the brand-new-branch case, so callers proceed on
+    every result variant; the distinction matters for log clarity. *)
 
 val remove : process_mgr:_ Eio.Process.mgr -> repo_root:string -> t -> unit
 
@@ -320,7 +339,7 @@ module type S = sig
     (t, Start_point_plan.refusal) Result.t
 
   val fetch_origin_branch :
-    fetch_lock:Eio.Mutex.t -> branch:string -> (unit, string) Result.t
+    fetch_lock:Eio.Mutex.t -> branch:string -> fetch_branch_result
 
   val remove : t -> unit
   val detect_branch : path:string -> Types.Branch.t

--- a/lib/worktree_setup.ml
+++ b/lib/worktree_setup.ml
@@ -124,16 +124,24 @@ module Make (W : Worktree.S) (Env : ENV) : S = struct
             (* Refresh [refs/remotes/origin/<branch>] before we feed it to the
                start-point planner — without this the planner would observe a
                stale local view of remote, which is the failure mode that
-               wiped PR #315. Best-effort: the planner correctly handles
-               [remote_ref = None] (brand-new branch) so a missing-remote
-               fetch error is just logged and we continue. *)
+               wiped PR #315. The planner correctly handles
+               [remote_ref = None] (brand-new branch) so all three result
+               variants are non-fatal here; the typed result lets us log the
+               routine no-upstream case calmly and reserve the alarming
+               "failed" wording for real fetch errors. *)
             let fetch_lock = Env.fetch_mutex in
             (match
                W.fetch_origin_branch ~fetch_lock
                  ~branch:(Types.Branch.to_string br)
              with
-            | Ok () -> ()
-            | Error msg ->
+            | Fetch_branch_ok -> ()
+            | Fetch_branch_no_remote_ref ->
+                log_event runtime ~patch_id
+                  (Printf.sprintf
+                     "No remote ref for %s yet (brand-new branch — skipping \
+                      pre-create fetch)"
+                     (Types.Branch.to_string br))
+            | Fetch_branch_error msg ->
                 log_event runtime ~patch_id
                   (Printf.sprintf "Pre-create fetch failed (continuing): %s" msg));
             log_event runtime ~patch_id

--- a/lib_core/worktree_parser.ml
+++ b/lib_core/worktree_parser.ml
@@ -212,6 +212,33 @@ let classify_fetch_result ~code ~stderr =
       (Printf.sprintf "git fetch origin failed (exit %d): %s" code
          (String.strip stderr))
 
+(** Outcome of a branch-scoped
+    [git fetch origin <branch>:refs/remotes/origin/<branch>]. Distinguishes the
+    routine "brand-new branch has no upstream yet" case from a real fetch
+    failure (network, auth, ref-lock contention). The pre-create fetch in
+    [Worktree_setup.ensure_worktree] always trips the no-upstream case on the
+    very first creation of a patch worktree — it is the normal path, not an
+    error, and callers log it calmly so it doesn't masquerade as a problem in
+    the operator log. *)
+type fetch_branch_result =
+  | Fetch_branch_ok
+  | Fetch_branch_no_remote_ref
+  | Fetch_branch_error of string
+[@@deriving show, eq, sexp_of, compare]
+
+(** Pure classifier for branch-scoped fetches. The [no_remote_ref] case keys off
+    git's canonical phrasing ["couldn't find remote ref"]; any other non-zero
+    exit produces [Fetch_branch_error] with the exit code and stripped stderr
+    embedded, mirroring [classify_fetch_result]. *)
+let classify_fetch_branch_result ~code ~stderr =
+  if code = 0 then Fetch_branch_ok
+  else if String.is_substring stderr ~substring:"couldn't find remote ref" then
+    Fetch_branch_no_remote_ref
+  else
+    Fetch_branch_error
+      (Printf.sprintf "git fetch origin failed (exit %d): %s" code
+         (String.strip stderr))
+
 type push_result =
   | Push_ok
   | Push_up_to_date

--- a/test/test_dependency_injection_functors.ml
+++ b/test/test_dependency_injection_functors.ml
@@ -22,7 +22,11 @@ module Fake_worktree : Worktree.S = struct
   let prune_admin () = assert false
   let run_hook ~clock:_ ~script:_ ~cwd:_ ~env:_ () = assert false
   let fetch_origin ~fetch_lock:_ ~path:_ = assert false
-  let fetch_origin_branch ~fetch_lock:_ ~branch:_ = assert false
+
+  let fetch_origin_branch ~fetch_lock:_ ~branch:_ : Worktree.fetch_branch_result
+      =
+    assert false
+
   let git_status ~path:_ = assert false
   let conflict_diff ~path:_ = assert false
 

--- a/test/test_rebase_onto.ml
+++ b/test/test_rebase_onto.ml
@@ -383,6 +383,122 @@ let () =
   if errcode <> 0 then Stdlib.exit errcode
 
 (* ───────────────────────────────────────────────────────────────────────
+   Pure tests for [Worktree.classify_fetch_branch_result] — the typed
+   branch-scoped fetch classifier. Distinguishing the brand-new-branch
+   "couldn't find remote ref" case from real fetch failures keeps the
+   pre-create-fetch log non-alarming on the first creation of every
+   patch worktree.
+   ─────────────────────────────────────────────────────────────────────── *)
+
+let () =
+  let open QCheck2 in
+  let prop_branch_exit_zero_is_ok =
+    Test.make ~name:"classify_fetch_branch_result: exit 0 -> Fetch_branch_ok"
+      ~count:200 Gen.string (fun stderr ->
+        match Worktree.classify_fetch_branch_result ~code:0 ~stderr with
+        | Worktree.Fetch_branch_ok -> true
+        | Worktree.Fetch_branch_no_remote_ref | Worktree.Fetch_branch_error _ ->
+            false)
+  in
+  let prop_branch_couldnt_find_remote_ref =
+    (* Regression: the exact stderr produced by [git fetch origin
+       <branch>:refs/remotes/origin/<branch>] when [<branch>] has never
+       been pushed. This trips on the very first worktree create for
+       every patch in a fresh gameplan and must classify as the routine
+       no-upstream case, not as an error. *)
+    Test.make
+      ~name:
+        "classify_fetch_branch_result: 'couldn't find remote ref' -> \
+         Fetch_branch_no_remote_ref" ~count:1 Gen.unit (fun () ->
+        let stderr =
+          "fatal: couldn't find remote ref ts2pant-let-mutation-ssa/patch-2"
+        in
+        match Worktree.classify_fetch_branch_result ~code:128 ~stderr with
+        | Worktree.Fetch_branch_no_remote_ref -> true
+        | Worktree.Fetch_branch_ok | Worktree.Fetch_branch_error _ -> false)
+  in
+  let prop_branch_substring_anywhere =
+    (* The detector keys off git's canonical phrasing and must fire
+       regardless of surrounding noise in stderr. *)
+    Test.make
+      ~name:
+        "classify_fetch_branch_result: 'couldn't find remote ref' anywhere in \
+         stderr"
+      ~count:200
+      Gen.(pair string string)
+      (fun (prefix, suffix) ->
+        let stderr = prefix ^ "couldn't find remote ref " ^ suffix in
+        match Worktree.classify_fetch_branch_result ~code:128 ~stderr with
+        | Worktree.Fetch_branch_no_remote_ref -> true
+        | Worktree.Fetch_branch_ok | Worktree.Fetch_branch_error _ -> false)
+  in
+  let prop_branch_other_failures_are_error =
+    (* Stderr that does NOT contain the no-upstream marker classifies as
+       Fetch_branch_error with the exit code embedded — same shape as
+       [classify_fetch_result]. *)
+    Test.make
+      ~name:
+        "classify_fetch_branch_result: non-zero without marker -> \
+         Fetch_branch_error"
+      ~count:200
+      Gen.(pair (int_range 1 255) (string_size (int_range 0 60)))
+      (fun (code, stderr_raw) ->
+        (* Strip any accidentally-generated marker substring to keep the
+           negative property well-defined. *)
+        let stderr =
+          if
+            String.is_substring stderr_raw ~substring:"couldn't find remote ref"
+          then ""
+          else stderr_raw
+        in
+        match Worktree.classify_fetch_branch_result ~code ~stderr with
+        | Worktree.Fetch_branch_error msg ->
+            String.is_substring msg ~substring:(Printf.sprintf "exit %d" code)
+        | Worktree.Fetch_branch_ok | Worktree.Fetch_branch_no_remote_ref ->
+            false)
+  in
+  let prop_branch_ref_lock_is_error =
+    (* Regression carry-over from [classify_fetch_result]: ref-lock
+       contention is a real failure, not a no-upstream signal. *)
+    Test.make
+      ~name:
+        "classify_fetch_branch_result: ref-lock stderr -> Fetch_branch_error"
+      ~count:1 Gen.unit (fun () ->
+        let stderr =
+          "error: cannot lock ref 'refs/remotes/origin/main': is at \
+           11ea3d8d67b9c481e7c8ddec7a6e1d46f2db1ba8 but expected \
+           d97cc64a88e05401a2f8fdf3624b79dbfb16671d"
+        in
+        match Worktree.classify_fetch_branch_result ~code:1 ~stderr with
+        | Worktree.Fetch_branch_error msg ->
+            String.is_substring msg ~substring:"cannot lock ref"
+        | Worktree.Fetch_branch_ok | Worktree.Fetch_branch_no_remote_ref ->
+            false)
+  in
+  let prop_branch_total_no_raise =
+    Test.make ~name:"classify_fetch_branch_result: total (never raises)"
+      ~count:500
+      Gen.(pair (int_range (-256) 512) string)
+      (fun (code, stderr) ->
+        try
+          let _ = Worktree.classify_fetch_branch_result ~code ~stderr in
+          true
+        with _ -> false)
+  in
+  let suite =
+    [
+      prop_branch_exit_zero_is_ok;
+      prop_branch_couldnt_find_remote_ref;
+      prop_branch_substring_anywhere;
+      prop_branch_other_failures_are_error;
+      prop_branch_ref_lock_is_error;
+      prop_branch_total_no_raise;
+    ]
+  in
+  let errcode = QCheck_base_runner.run_tests ~verbose:true suite in
+  if errcode <> 0 then Stdlib.exit errcode
+
+(* ───────────────────────────────────────────────────────────────────────
    Pure tests for [Worktree.classify_unique_commits] —
    the new decision layer that returns BOTH the per-commit list and the
    oldest SHA. [oldest_non_ancestor_commit] is now a thin wrapper, so the


### PR DESCRIPTION
## Summary
- Every brand-new patch worktree tripped the pre-create fetch with exit 128 `couldn't find remote ref <branch>` and logged it as `Pre-create fetch failed (continuing): ...`. The planner already handles `remote_ref = None` correctly, so the behavior was right but the wording made the routine new-branch path look like an error.
- Introduce a typed `fetch_branch_result = Fetch_branch_ok | Fetch_branch_no_remote_ref | Fetch_branch_error of string` in `lib_core/worktree_parser.ml`, classified by `classify_fetch_branch_result` keying off git's canonical `"couldn't find remote ref"` phrasing. `fetch_origin_branch` now returns the typed result.
- `Worktree_setup.ensure_worktree` logs the no-upstream case calmly (`"No remote ref for <branch> yet (brand-new branch — skipping pre-create fetch)"`) and keeps the existing `"Pre-create fetch failed (continuing): ..."` wording for real fetch errors (network, auth, ref-lock contention).

## Test plan
- [x] `dune build` clean (no new warnings under the strict-warning config)
- [x] `dune test` green, including 6 new QCheck2 properties in `test/test_rebase_onto.ml` covering: exit-0 → `Fetch_branch_ok`; exact regression stderr from the `ts2pant-let-mutation-ssa` run → `Fetch_branch_no_remote_ref`; substring-anywhere fuzz → `Fetch_branch_no_remote_ref`; non-marker non-zero exits → `Fetch_branch_error` with exit code embedded; `cannot lock ref` regression → `Fetch_branch_error`; totality (never raises).
- [ ] Spot-check operator log on the next fresh gameplan run: brand-new-branch lines should read "No remote ref for ... yet (brand-new branch — skipping pre-create fetch)" instead of "Pre-create fetch failed (continuing)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782404756&installation_id=126163856&pr_number=321&repository=flowglad%2Fonton&return_to=https%3A%2F%2Fgithub.com%2Fflowglad%2Fonton%2Fpull%2F321&signature=e852756e25777d0f0381fa0e9a28a9a1461d53c2d31fea128572575cd99911d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Distinguishes the “no remote ref yet” case from real pre-create fetch failures, so first-time patch worktree creation no longer logs a scary error. Adds a typed result and classifier; planner behavior is unchanged.

- **Bug Fixes**
  - Brand-new branches log “No remote ref for <branch> yet (brand-new branch — skipping pre-create fetch)” instead of “Pre-create fetch failed (continuing)”.
  - Real failures (network/auth/ref-lock) still log as “Pre-create fetch failed (continuing)”.

- **Refactors**
  - Introduced `fetch_branch_result` and `classify_fetch_branch_result` in `lib_core/worktree_parser.ml`.
  - `fetch_origin_branch` now returns the typed result; `Worktree_setup.ensure_worktree` logs per variant.

<sup>Written for commit 45f72e4a75bac5573bee9cdfa1aec7387a88fc48. Summary will update on new commits. <a href="https://cubic.dev/pr/flowglad/onton/pull/321?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced branch fetch operations with better error classification, distinguishing genuine fetch failures from cases where branches lack remote references yet.
  * Improved error handling and logging during branch setup, with better support for brand-new branches.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flowglad/onton/pull/321?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->