### PR TITLE
Permit divergent-rebase pushes + push/intervention/rebase telemetry

### DIFF
--- a/lib/event_log.ml
+++ b/lib/event_log.ml
@@ -300,7 +300,7 @@ type push_kind =
   | Session_end_push
   | Rebase_resolution_push
   | Conflict_resolution_push
-[@@deriving show, eq, sexp_of, compare]
+[@@deriving eq, sexp_of, compare]
 
 let push_kind_label = function
   | Session_end_push -> "session_end"

--- a/lib/event_log.ml
+++ b/lib/event_log.ml
@@ -23,6 +23,37 @@ let timestamp () =
 
 let agent_json (a : Patch_agent.t) = Persistence.patch_agent_to_yojson a
 let poll_json (p : Poller.t) = Poller.yojson_of_t p
+let opt_sha_json = function Some s -> `String s | None -> `Null
+
+(* Auto-emit a "needs_intervention" transition event when the predicate
+   flips false → true between [agent_before] and [agent_after]. Every
+   log_X helper below tail-calls this, so the transition is captured at
+   exactly the orchestrator update that caused it without each call site
+   having to remember to emit a second event. The reason string comes
+   from [Patch_agent.intervention_reason], which is the single source of
+   truth for the predicate. *)
+let emit_intervention_transition_if_needed ~patch_id ~agent_before ~agent_after
+    =
+  match
+    ( Patch_agent.intervention_reason agent_before,
+      Patch_agent.intervention_reason agent_after )
+  with
+  | None, Some reason ->
+      Telemetry_dispatch.emit
+        (Telemetry.Event.Action
+           {
+             patch_id;
+             session_uuid = None;
+             payload =
+               `Assoc
+                 [
+                   ("event_log_kind", `String "needs_intervention");
+                   ("reason", `String reason);
+                   ("agent_before", agent_json agent_before);
+                   ("agent_after", agent_json agent_after);
+                 ];
+           })
+  | Some _, _ | None, None -> ()
 
 let write_entry t (json : Yojson.Safe.t) =
   try
@@ -140,7 +171,8 @@ let log_poll t ~patch_id ~poll_result ~agent_before ~agent_after ~logs =
                ("agent_after", agent_json agent_after);
                ("logs", string_list_json logs);
              ];
-       })
+       });
+  emit_intervention_transition_if_needed ~patch_id ~agent_before ~agent_after
 
 let action_patch_id (action : Orchestrator.action) =
   match action with Start (pid, _) | Respond (pid, _) | Rebase (pid, _) -> pid
@@ -175,7 +207,8 @@ let log_complete t ~patch_id ~result ~agent_before ~agent_after =
                ("agent_before", agent_json agent_before);
                ("agent_after", agent_json agent_after);
              ];
-       })
+       });
+  emit_intervention_transition_if_needed ~patch_id ~agent_before ~agent_after
 
 let log_force_complete t ~patch_id ~reason ~agent_before ~agent_after =
   ignore t;
@@ -194,10 +227,11 @@ let log_force_complete t ~patch_id ~reason ~agent_before ~agent_after =
                ("agent_before", agent_json agent_before);
                ("agent_after", agent_json agent_after);
              ];
-       })
+       });
+  emit_intervention_transition_if_needed ~patch_id ~agent_before ~agent_after
 
-let log_conflict_rebase t ~patch_id ~result ~decision ~agent_before ~agent_after
-    =
+let log_conflict_rebase t ~patch_id ~result ~decision ~pre_rebase_head
+    ~post_rebase_head ~target_base_sha ~agent_before ~agent_after =
   ignore t;
   Telemetry_dispatch.emit
     (Telemetry.Event.Action
@@ -212,10 +246,14 @@ let log_conflict_rebase t ~patch_id ~result ~decision ~agent_before ~agent_after
                ( "decision",
                  `String (Orchestrator.show_conflict_rebase_decision decision)
                );
+               ("pre_rebase_head", opt_sha_json pre_rebase_head);
+               ("post_rebase_head", opt_sha_json post_rebase_head);
+               ("target_base_sha", opt_sha_json target_base_sha);
                ("agent_before", agent_json agent_before);
                ("agent_after", agent_json agent_after);
              ];
-       })
+       });
+  emit_intervention_transition_if_needed ~patch_id ~agent_before ~agent_after
 
 let log_conflict_delivery t ~patch_id ~path ~rebase_in_progress ~git_status
     ~git_diff =
@@ -236,7 +274,8 @@ let log_conflict_delivery t ~patch_id ~path ~rebase_in_progress ~git_status
              ];
        })
 
-let log_rebase t ~patch_id ~result ~agent_before ~agent_after =
+let log_rebase t ~patch_id ~result ~pre_rebase_head ~post_rebase_head
+    ~target_base_sha ~agent_before ~agent_after =
   ignore t;
   Telemetry_dispatch.emit
     (Telemetry.Event.Action
@@ -248,7 +287,56 @@ let log_rebase t ~patch_id ~result ~agent_before ~agent_after =
              [
                ("event_log_kind", `String "rebase");
                ("result", `String (Worktree.show_rebase_result result));
+               ("pre_rebase_head", opt_sha_json pre_rebase_head);
+               ("post_rebase_head", opt_sha_json post_rebase_head);
+               ("target_base_sha", opt_sha_json target_base_sha);
                ("agent_before", agent_json agent_before);
                ("agent_after", agent_json agent_after);
              ];
-       })
+       });
+  emit_intervention_transition_if_needed ~patch_id ~agent_before ~agent_after
+
+type push_kind =
+  | Session_end_push
+  | Rebase_resolution_push
+  | Conflict_resolution_push
+[@@deriving show, eq, sexp_of, compare]
+
+let push_kind_label = function
+  | Session_end_push -> "session_end"
+  | Rebase_resolution_push -> "rebase_resolution"
+  | Conflict_resolution_push -> "conflict_resolution"
+
+let push_result_kind (r : Worktree.push_result) =
+  match r with
+  | Worktree.Push_ok -> "push_ok"
+  | Worktree.Push_up_to_date -> "push_up_to_date"
+  | Worktree.Push_no_commits -> "push_no_commits"
+  | Worktree.Push_rejected rej ->
+      "push_rejected:" ^ Push_reject_classify.short_label rej
+  | Worktree.Push_worktree_missing -> "push_worktree_missing"
+  | Worktree.Push_error _ -> "push_error"
+
+let log_push t ~patch_id ~kind ~result ~local_sha ~remote_tracking_sha ~base_sha
+    ~agent_before ~agent_after =
+  ignore t;
+  Telemetry_dispatch.emit
+    (Telemetry.Event.Action
+       {
+         patch_id;
+         session_uuid = None;
+         payload =
+           `Assoc
+             [
+               ("event_log_kind", `String "push");
+               ("push_kind", `String (push_kind_label kind));
+               ("result", `String (Worktree.show_push_result result));
+               ("result_kind", `String (push_result_kind result));
+               ("local_sha", opt_sha_json local_sha);
+               ("remote_tracking_sha", opt_sha_json remote_tracking_sha);
+               ("base_sha", opt_sha_json base_sha);
+               ("agent_before", agent_json agent_before);
+               ("agent_after", agent_json agent_after);
+             ];
+       });
+  emit_intervention_transition_if_needed ~patch_id ~agent_before ~agent_after

--- a/lib/event_log.mli
+++ b/lib/event_log.mli
@@ -113,7 +113,7 @@ type push_kind =
   | Session_end_push
   | Rebase_resolution_push
   | Conflict_resolution_push
-[@@deriving show, eq, sexp_of, compare]
+[@@deriving eq, sexp_of, compare]
 
 val log_push :
   t ->

--- a/lib/event_log.mli
+++ b/lib/event_log.mli
@@ -60,10 +60,18 @@ val log_conflict_rebase :
   patch_id:Patch_id.t ->
   result:Worktree.rebase_result ->
   decision:Orchestrator.conflict_rebase_decision ->
+  pre_rebase_head:string option ->
+  post_rebase_head:string option ->
+  target_base_sha:string option ->
   agent_before:Patch_agent.t ->
   agent_after:Patch_agent.t ->
   unit
-(** Log a conflict rebase decision with before/after state. *)
+(** Log a conflict rebase decision with before/after state. [pre_rebase_head] is
+    the worktree's [refs/heads/<branch>] SHA before the rebase ran;
+    [post_rebase_head] after; [target_base_sha] is the SHA the rebase used as
+    [--onto]. Including these SHAs lets readers see at a glance whether the
+    rebase actually moved the branch and where it landed, without
+    cross-referencing the worktree filesystem. *)
 
 val log_conflict_delivery :
   t ->
@@ -81,7 +89,47 @@ val log_rebase :
   t ->
   patch_id:Patch_id.t ->
   result:Worktree.rebase_result ->
+  pre_rebase_head:string option ->
+  post_rebase_head:string option ->
+  target_base_sha:string option ->
   agent_before:Patch_agent.t ->
   agent_after:Patch_agent.t ->
   unit
-(** Log a rebase result with before/after state. *)
+(** Log a rebase result with before/after state and the SHAs involved.
+    [pre_rebase_head] is the worktree's [refs/heads/<branch>] SHA before the
+    rebase ran; [post_rebase_head] after; [target_base_sha] is the SHA the
+    rebase used as [--onto]. Including these SHAs lets readers diagnose "rebase
+    produced Noop / Ok — but did the branch actually move?" without consulting
+    the worktree. *)
+
+(** Distinguishes the push site that produced the event. [Session_end_push] is
+    the supervisor-owned end-of-session push in [session_driver.ml].
+    [Rebase_resolution_push] is the post-rebase push in [runner_fiber_impl.ml]'s
+    rebase branch. [Conflict_resolution_push] is the push that follows the
+    conflict-resolution rebase in the same module. Knowing which site fired lets
+    log readers correlate a refused push with the specific flow that triggered
+    it. *)
+type push_kind =
+  | Session_end_push
+  | Rebase_resolution_push
+  | Conflict_resolution_push
+[@@deriving show, eq, sexp_of, compare]
+
+val log_push :
+  t ->
+  patch_id:Patch_id.t ->
+  kind:push_kind ->
+  result:Worktree.push_result ->
+  local_sha:string option ->
+  remote_tracking_sha:string option ->
+  base_sha:string option ->
+  agent_before:Patch_agent.t ->
+  agent_after:Patch_agent.t ->
+  unit
+(** Log a [git push] outcome. Captures the push site ([kind]), the
+    [Worktree.push_result] variant (which carries the planner refusal label
+    inside [Push_rejected] via [Push_reject_classify.short_label]), and a
+    snapshot of [refs/heads/<branch>] / [refs/remotes/origin/<branch>] /
+    [refs/heads/<base>] SHAs at push time. Surfacing the SHAs directly avoids
+    the cross-checking dance that would otherwise be required to diagnose
+    post-rebase divergence symptoms after the fact. *)

--- a/lib/runner_fiber_impl.ml
+++ b/lib/runner_fiber_impl.ml
@@ -63,6 +63,7 @@ struct
     let worktree_mutex = Env.worktree_mutex
     let hook_mutex = Env.hook_mutex
     let fetch_mutex = Env.fetch_mutex
+    let event_log = Env.event_log
   end
 
   module WS = Worktree_setup.Make (W) (WS_Env)
@@ -930,11 +931,29 @@ struct
                                 (Orchestrator.graph snap.Runtime.orchestrator)
                                 patch_id)
                         in
+                        let rebase_branch_str =
+                          Types.Branch.to_string agent.Patch_agent.branch
+                        in
+                        let predicted_wt_path =
+                          WS.resolve_worktree_path ~patch_id ~agent ()
+                        in
+                        let pre_rebase_head =
+                          W.read_branch_sha ~path:predicted_wt_path
+                            ~ref_name:("refs/heads/" ^ rebase_branch_str)
+                        in
                         let rebase_result, wt_path, anchor_events =
                           Worktree_plan_executor.execute ~patch_id ~agent
                             ~fetch_lock:fetch_mutex ~fail_label:"rebase"
                             ~ancestor_ids
                             (Worktree_plan.for_rebase ~new_base)
+                        in
+                        let post_rebase_head =
+                          W.read_branch_sha ~path:wt_path
+                            ~ref_name:("refs/heads/" ^ rebase_branch_str)
+                        in
+                        let rebase_target_base_sha =
+                          W.read_branch_sha ~path:wt_path
+                            ~ref_name:("refs/heads/" ^ Branch.to_string new_base)
                         in
                         (match rebase_result with
                         | Worktree.Ok ->
@@ -965,10 +984,24 @@ struct
                               in
                               (orch, (agent_before, (agent_after, effects))))
                         in
-                        let push_outcome =
+                        let push_record =
                           Base.List.find_map effects
                             ~f:(fun Orchestrator.Push_branch ->
                               let branch = agent.Patch_agent.branch in
+                              let branch_str = Types.Branch.to_string branch in
+                              let base_str = Types.Branch.to_string new_base in
+                              let local_sha =
+                                W.read_branch_sha ~path:wt_path
+                                  ~ref_name:("refs/heads/" ^ branch_str)
+                              in
+                              let remote_tracking_sha =
+                                W.read_branch_sha ~path:wt_path
+                                  ~ref_name:("refs/remotes/origin/" ^ branch_str)
+                              in
+                              let base_sha =
+                                W.read_branch_sha ~path:wt_path
+                                  ~ref_name:("refs/heads/" ^ base_str)
+                              in
                               let result =
                                 W.force_push_with_lease ~path:wt_path ~branch
                                   ~base:new_base
@@ -998,17 +1031,36 @@ struct
                               | Worktree.Push_error msg ->
                                   log_event runtime ~patch_id
                                     (Printf.sprintf "Force-push failed — %s" msg));
-                              Some result)
+                              Some
+                                ( result,
+                                  local_sha,
+                                  remote_tracking_sha,
+                                  base_sha ))
                         in
-                        let resolution =
+                        let push_outcome =
+                          Base.Option.map push_record ~f:(fun (r, _, _, _) -> r)
+                        in
+                        let resolution, push_agent_after =
                           Runtime.update_orchestrator_returning runtime
                             (fun orch ->
                               let orch, resolution =
                                 Orchestrator.apply_rebase_push_result orch
                                   patch_id push_outcome
                               in
-                              (orch, resolution))
+                              let push_agent_after =
+                                Orchestrator.agent orch patch_id
+                              in
+                              (orch, (resolution, push_agent_after)))
                         in
+                        (match push_record with
+                        | Some (result, local_sha, remote_tracking_sha, base_sha)
+                          ->
+                            Event_log.log_push event_log ~patch_id
+                              ~kind:Event_log.Rebase_resolution_push ~result
+                              ~local_sha ~remote_tracking_sha ~base_sha
+                              ~agent_before:agent_after
+                              ~agent_after:push_agent_after
+                        | None -> ());
                         (match resolution with
                         | Orchestrator.Rebase_push_ok -> ()
                         | Orchestrator.Rebase_push_failed ->
@@ -1019,7 +1071,10 @@ struct
                             log_event runtime ~patch_id
                               "Enqueued rebase retry after push error");
                         Event_log.log_rebase event_log ~patch_id
-                          ~result:rebase_result ~agent_before ~agent_after))
+                          ~result:rebase_result ~pre_rebase_head
+                          ~post_rebase_head
+                          ~target_base_sha:rebase_target_base_sha ~agent_before
+                          ~agent_after))
             | Orchestrator.Respond (patch_id, kind) ->
                 (* Use pre-fire agent state for human_messages — fire/respond
                  clears them as a postcondition. *)
@@ -1337,8 +1392,23 @@ struct
                                      target origin/<base> so we rebase
                                      against fresh refs, not the stale
                                      local tracking ref. *)
+                                        let conflict_branch_str =
+                                          Types.Branch.to_string
+                                            agent.Patch_agent.branch
+                                        in
+                                        let predicted_wt_path =
+                                          WS.resolve_worktree_path ~patch_id
+                                            ~agent ()
+                                        in
+                                        let cr_pre_rebase_head =
+                                          W.read_branch_sha
+                                            ~path:predicted_wt_path
+                                            ~ref_name:
+                                              ("refs/heads/"
+                                             ^ conflict_branch_str)
+                                        in
                                         let ( rebase_result,
-                                              _wt_path,
+                                              executor_wt_path,
                                               anchor_events ) =
                                           Worktree_plan_executor.execute
                                             ~patch_id ~agent
@@ -1348,6 +1418,19 @@ struct
                                             (Worktree_plan.for_merge_conflict
                                                ~base:
                                                  (Types.Branch.of_string base))
+                                        in
+                                        let cr_post_rebase_head =
+                                          W.read_branch_sha
+                                            ~path:executor_wt_path
+                                            ~ref_name:
+                                              ("refs/heads/"
+                                             ^ conflict_branch_str)
+                                        in
+                                        let cr_target_base_sha =
+                                          W.read_branch_sha
+                                            ~path:executor_wt_path
+                                            ~ref_name:
+                                              ("refs/remotes/origin/" ^ base)
                                         in
                                         let conflict_info =
                                           match rebase_result with
@@ -1403,12 +1486,35 @@ struct
                                         in
                                         Event_log.log_conflict_rebase event_log
                                           ~patch_id ~result:rebase_result
-                                          ~decision ~agent_before ~agent_after;
-                                        let push_outcome =
+                                          ~decision
+                                          ~pre_rebase_head:cr_pre_rebase_head
+                                          ~post_rebase_head:cr_post_rebase_head
+                                          ~target_base_sha:cr_target_base_sha
+                                          ~agent_before ~agent_after;
+                                        let push_record =
                                           Base.List.find_map effects
                                             ~f:(fun Orchestrator.Push_branch ->
                                               let branch =
                                                 agent.Patch_agent.branch
+                                              in
+                                              let branch_str =
+                                                Types.Branch.to_string branch
+                                              in
+                                              let local_sha =
+                                                W.read_branch_sha ~path:wt_path
+                                                  ~ref_name:
+                                                    ("refs/heads/" ^ branch_str)
+                                              in
+                                              let remote_tracking_sha =
+                                                W.read_branch_sha ~path:wt_path
+                                                  ~ref_name:
+                                                    ("refs/remotes/origin/"
+                                                   ^ branch_str)
+                                              in
+                                              let base_sha =
+                                                W.read_branch_sha ~path:wt_path
+                                                  ~ref_name:
+                                                    ("refs/heads/" ^ base)
                                               in
                                               let result =
                                                 W.force_push_with_lease
@@ -1452,9 +1558,17 @@ struct
                                                        "Conflict force-push \
                                                         failed — %s"
                                                        msg));
-                                              Some result)
+                                              Some
+                                                ( result,
+                                                  local_sha,
+                                                  remote_tracking_sha,
+                                                  base_sha ))
                                         in
-                                        let resolution =
+                                        let push_outcome =
+                                          Base.Option.map push_record
+                                            ~f:(fun (r, _, _, _) -> r)
+                                        in
+                                        let resolution, push_agent_after =
                                           Runtime.update_orchestrator_returning
                                             runtime (fun orch ->
                                               let orch, resolution =
@@ -1462,8 +1576,29 @@ struct
                                                 .apply_conflict_push_result orch
                                                   patch_id decision push_outcome
                                               in
-                                              (orch, resolution))
+                                              let push_agent_after =
+                                                Orchestrator.agent orch patch_id
+                                              in
+                                              ( orch,
+                                                (resolution, push_agent_after)
+                                              ))
                                         in
+                                        (match push_record with
+                                        | Some
+                                            ( result,
+                                              local_sha,
+                                              remote_tracking_sha,
+                                              base_sha ) ->
+                                            Event_log.log_push event_log
+                                              ~patch_id
+                                              ~kind:
+                                                Event_log
+                                                .Conflict_resolution_push
+                                              ~result ~local_sha
+                                              ~remote_tracking_sha ~base_sha
+                                              ~agent_before:agent_after
+                                              ~agent_after:push_agent_after
+                                        | None -> ());
                                         match resolution with
                                         | Orchestrator.Conflict_done -> `Ok
                                         | Orchestrator.Conflict_retry_push ->

--- a/lib/runner_fiber_impl.ml
+++ b/lib/runner_fiber_impl.ml
@@ -947,6 +947,11 @@ struct
                             ~ancestor_ids
                             (Worktree_plan.for_rebase ~new_base)
                         in
+                        let pre_rebase_head =
+                          if Base.String.equal predicted_wt_path wt_path then
+                            pre_rebase_head
+                          else None
+                        in
                         let post_rebase_head =
                           W.read_branch_sha ~path:wt_path
                             ~ref_name:("refs/heads/" ^ rebase_branch_str)
@@ -1425,6 +1430,13 @@ struct
                                             ~ref_name:
                                               ("refs/heads/"
                                              ^ conflict_branch_str)
+                                        in
+                                        let cr_pre_rebase_head =
+                                          if
+                                            Base.String.equal predicted_wt_path
+                                              executor_wt_path
+                                          then cr_pre_rebase_head
+                                          else None
                                         in
                                         let cr_target_base_sha =
                                           W.read_branch_sha

--- a/lib/session_driver.ml
+++ b/lib/session_driver.ml
@@ -686,12 +686,13 @@ module Make (W : Worktree.S) (Env : ENV) = struct
                                  Persistence.patch_agent_to_yojson agent_after
                                );
                              ];
-                       })
+                       });
+                  (agent_before, agent_after)
                 in
                 (match !cancelled with
                 | None -> ()
                 | Some exn ->
-                    apply_result_and_emit_complete session_result;
+                    ignore (apply_result_and_emit_complete session_result);
                     raise exn);
                 (* Supervisor-owned push: agent commits locally; we push every
              local commit to the remote at session end. force_push_with_lease
@@ -759,16 +760,6 @@ module Make (W : Worktree.S) (Env : ENV) = struct
                 | Worktree.Push_error msg ->
                     log_event runtime ~patch_id
                       (Printf.sprintf "runner: push error after session: %s" msg));
-                let push_agent_after =
-                  Runtime.read runtime (fun snap ->
-                      Orchestrator.agent snap.Runtime.orchestrator patch_id)
-                in
-                Event_log.log_push Env.event_log ~patch_id
-                  ~kind:Event_log.Session_end_push ~result:push_outcome
-                  ~local_sha:push_local_sha
-                  ~remote_tracking_sha:push_remote_tracking_sha
-                  ~base_sha:push_base_sha ~agent_before:push_agent_before
-                  ~agent_after:push_agent_after;
                 (* Combine LLM session outcome with push outcome into a single
              session_result via the pure decision in
              [Orchestrator.combine_session_and_push]. user_result mirrors:
@@ -827,7 +818,15 @@ module Make (W : Worktree.S) (Env : ENV) = struct
                   | Orchestrator.Session_worktree_missing ->
                       `Failed
                 in
-                apply_result_and_emit_complete final_session_result;
+                let _, push_agent_after =
+                  apply_result_and_emit_complete final_session_result
+                in
+                Event_log.log_push Env.event_log ~patch_id
+                  ~kind:Event_log.Session_end_push ~result:push_outcome
+                  ~local_sha:push_local_sha
+                  ~remote_tracking_sha:push_remote_tracking_sha
+                  ~base_sha:push_base_sha ~agent_before:push_agent_before
+                  ~agent_after:push_agent_after;
                 (final_user_result, List.rev !tool_failures)))
 
   let run ~(kind : Types.Operation_kind.t option) ~patch_id ~prompt

--- a/lib/session_driver.ml
+++ b/lib/session_driver.ml
@@ -131,6 +131,7 @@ module type ENV = sig
   val owner : string
   val repo : string
   val transcripts : (Types.Patch_id.t, string) Stdlib.Hashtbl.t
+  val event_log : Event_log.t
 end
 
 module Make (W : Worktree.S) (Env : ENV) = struct
@@ -708,6 +709,24 @@ module Make (W : Worktree.S) (Env : ENV) = struct
                       Runtime.read runtime (fun snap ->
                           Orchestrator.main_branch snap.Runtime.orchestrator)
                 in
+                let branch_str = Types.Branch.to_string branch in
+                let base_str = Types.Branch.to_string base in
+                let push_local_sha =
+                  W.read_branch_sha ~path:worktree_path
+                    ~ref_name:("refs/heads/" ^ branch_str)
+                in
+                let push_remote_tracking_sha =
+                  W.read_branch_sha ~path:worktree_path
+                    ~ref_name:("refs/remotes/origin/" ^ branch_str)
+                in
+                let push_base_sha =
+                  W.read_branch_sha ~path:worktree_path
+                    ~ref_name:("refs/heads/" ^ base_str)
+                in
+                let push_agent_before =
+                  Runtime.read runtime (fun snap ->
+                      Orchestrator.agent snap.Runtime.orchestrator patch_id)
+                in
                 let push_outcome =
                   W.force_push_with_lease ~path:worktree_path ~branch ~base
                 in
@@ -740,6 +759,16 @@ module Make (W : Worktree.S) (Env : ENV) = struct
                 | Worktree.Push_error msg ->
                     log_event runtime ~patch_id
                       (Printf.sprintf "runner: push error after session: %s" msg));
+                let push_agent_after =
+                  Runtime.read runtime (fun snap ->
+                      Orchestrator.agent snap.Runtime.orchestrator patch_id)
+                in
+                Event_log.log_push Env.event_log ~patch_id
+                  ~kind:Event_log.Session_end_push ~result:push_outcome
+                  ~local_sha:push_local_sha
+                  ~remote_tracking_sha:push_remote_tracking_sha
+                  ~base_sha:push_base_sha ~agent_before:push_agent_before
+                  ~agent_after:push_agent_after;
                 (* Combine LLM session outcome with push outcome into a single
              session_result via the pure decision in
              [Orchestrator.combine_session_and_push]. user_result mirrors:

--- a/lib/session_driver.mli
+++ b/lib/session_driver.mli
@@ -18,6 +18,7 @@ module type ENV = sig
   val owner : string
   val repo : string
   val transcripts : (Types.Patch_id.t, string) Stdlib.Hashtbl.t
+  val event_log : Event_log.t
 end
 
 module Make (_ : Worktree.S) (_ : ENV) : sig

--- a/lib/worktree.ml
+++ b/lib/worktree.ml
@@ -792,8 +792,7 @@ let force_push_with_lease ~process_mgr ~path ~branch ~base =
   | Refuse Push_plan.No_commits_ahead_of_base -> Push_no_commits
   | Refuse
       (( Push_plan.Branch_ref_missing _ | Push_plan.Branch_switched _
-       | Push_plan.Local_missing_remote_commits _
-       | Push_plan.Local_diverged_from_remote_commits _ ) as r) -> (
+       | Push_plan.Local_missing_remote_commits _ ) as r) -> (
       match Push_plan.to_push_reject_classify_rejection r with
       | Some rej -> Push_rejected rej
       | None ->

--- a/lib_core/patch_agent.ml
+++ b/lib_core/patch_agent.ml
@@ -105,11 +105,20 @@ let intervention_reason t =
       List.mem t.queue Operation_kind.Human ~equal:Operation_kind.equal
     in
     let given_up = equal_session_fallback t.session_fallback Given_up in
-    (* [given_up] and [is_pr_missing] bypass the Human exemption (see the
-       comment below). All other counters defer to the exemption: a queued
-       Human message keeps the reconciler scheduling work. *)
     if given_up then Some "session_fallback=given_up"
     else if is_pr_missing t then Some "pr_missing"
+      (* The Human exemption lets a newly-arrived human message be delivered
+       even to an agent with a high ci_failure_count or other failure state.
+       However, the exemption does NOT apply when session_fallback = Given_up:
+       a Given_up agent cannot start any session, so the delivery attempt
+       immediately fails at the Give_up check and complete_failed re-enqueues
+       Human — creating an infinite loop. Override the exemption so the
+       reconciler stops scheduling actions and the agent surfaces for
+       manual intervention.
+
+       [merged] is terminal — a merged agent never needs intervention, so
+       short-circuit on it to keep the predicate self-consistent even for
+       callers that don't pre-filter by [merged]. *)
     else if human_in_queue then None
     else if t.ci_failure_count >= 3 then Some "ci_failure_count>=3"
     else if (not (has_pr t)) && t.start_attempts_without_pr >= 2 then
@@ -122,18 +131,6 @@ let intervention_reason t =
     else None
 
 let needs_intervention t = Option.is_some (intervention_reason t)
-(* The Human exemption lets a newly-arrived human message be delivered
-   even to an agent with a high ci_failure_count or other failure state.
-   However, the exemption does NOT apply when session_fallback = Given_up:
-   a Given_up agent cannot start any session, so the delivery attempt
-   immediately fails at the Give_up check and complete_failed re-enqueues
-   Human — creating an infinite loop.  Override the exemption so the
-   reconciler stops scheduling actions and the agent surfaces for
-   manual intervention.
-
-   [merged] is terminal — a merged agent never needs intervention, so
-   short-circuit on it to keep the predicate self-consistent even for
-   callers that don't pre-filter by [merged]. *)
 
 let create ~branch patch_id =
   {

--- a/lib_core/patch_agent.ml
+++ b/lib_core/patch_agent.ml
@@ -91,32 +91,49 @@ let is_pr_present t = Patch_pr_status.is_pr_present t.pr_status
 let is_pr_missing t = Patch_pr_status.is_missing t.pr_status
 let pr_number t = Patch_pr_status.pr_number t.pr_status
 
-let needs_intervention t =
-  let human_in_queue =
-    List.mem t.queue Operation_kind.Human ~equal:Operation_kind.equal
-  in
-  (* The Human exemption lets a newly-arrived human message be delivered
-     even to an agent with a high ci_failure_count or other failure state.
-     However, the exemption does NOT apply when session_fallback = Given_up:
-     a Given_up agent cannot start any session, so the delivery attempt
-     immediately fails at the Give_up check and complete_failed re-enqueues
-     Human — creating an infinite loop.  Override the exemption so the
-     reconciler stops scheduling actions and the agent surfaces for
-     manual intervention.
+(* Single source of truth for the needs-intervention reason. Returns the
+   first triggering condition's short label, or [None] when the predicate
+   is false. [needs_intervention] is then defined as
+   [Option.is_some (intervention_reason t)], so the two functions cannot
+   drift. The label strings are stable and intended to land verbatim in the
+   event log so operators can grep for "why is this patch stuck?" by
+   reason. *)
+let intervention_reason t =
+  if t.merged then None
+  else
+    let human_in_queue =
+      List.mem t.queue Operation_kind.Human ~equal:Operation_kind.equal
+    in
+    let given_up = equal_session_fallback t.session_fallback Given_up in
+    (* [given_up] and [is_pr_missing] bypass the Human exemption (see the
+       comment below). All other counters defer to the exemption: a queued
+       Human message keeps the reconciler scheduling work. *)
+    if given_up then Some "session_fallback=given_up"
+    else if is_pr_missing t then Some "pr_missing"
+    else if human_in_queue then None
+    else if t.ci_failure_count >= 3 then Some "ci_failure_count>=3"
+    else if (not (has_pr t)) && t.start_attempts_without_pr >= 2 then
+      Some "start_attempts_without_pr>=2"
+    else if t.conflict_noop_count >= 2 then Some "conflict_noop_count>=2"
+    else if t.no_commits_push_count >= 2 then Some "no_commits_push_count>=2"
+    else if t.push_failure_count >= 3 then Some "push_failure_count>=3"
+    else if t.pr_body_artifact_miss_count >= 2 then
+      Some "pr_body_artifact_miss_count>=2"
+    else None
 
-     [merged] is terminal — a merged agent never needs intervention, so
-     short-circuit on it to keep the predicate self-consistent even for
-     callers that don't pre-filter by [merged]. *)
-  let given_up = equal_session_fallback t.session_fallback Given_up in
-  (not t.merged)
-  && (given_up || is_pr_missing t
-     || (not human_in_queue)
-        && (t.ci_failure_count >= 3
-           || ((not (has_pr t)) && t.start_attempts_without_pr >= 2)
-           || t.conflict_noop_count >= 2
-           || t.no_commits_push_count >= 2
-           || t.push_failure_count >= 3
-           || t.pr_body_artifact_miss_count >= 2))
+let needs_intervention t = Option.is_some (intervention_reason t)
+(* The Human exemption lets a newly-arrived human message be delivered
+   even to an agent with a high ci_failure_count or other failure state.
+   However, the exemption does NOT apply when session_fallback = Given_up:
+   a Given_up agent cannot start any session, so the delivery attempt
+   immediately fails at the Give_up check and complete_failed re-enqueues
+   Human — creating an infinite loop.  Override the exemption so the
+   reconciler stops scheduling actions and the agent surfaces for
+   manual intervention.
+
+   [merged] is terminal — a merged agent never needs intervention, so
+   short-circuit on it to keep the predicate self-consistent even for
+   callers that don't pre-filter by [merged]. *)
 
 let create ~branch patch_id =
   {

--- a/lib_core/patch_agent.mli
+++ b/lib_core/patch_agent.mli
@@ -134,8 +134,17 @@ val pr_number : t -> Types.Pr_number.t option
 (** The recorded PR number, if any. [Some] for both [Present] and [Missing];
     [None] for [Absent]. *)
 
+val intervention_reason : t -> string option
+(** [Some reason] when the agent needs intervention; [None] otherwise. Returns
+    the first triggering condition's short label, in the same priority order as
+    the predicate. The label strings — ["pr_missing"], ["ci_failure_count>=3"],
+    ["conflict_noop_count>=2"], etc. — are stable and intended to land verbatim
+    in the event log so operators can grep "why is this patch stuck?" by reason.
+*)
+
 val needs_intervention : t -> bool
-(** Derived predicate. True iff the agent is not [merged] AND any of:
+(** [Option.is_some (intervention_reason t)]. Derived predicate. True iff the
+    agent is not [merged] AND any of:
     - [session_fallback = Given_up] (bypasses the Human exemption)
     - [is_pr_missing t] (PR vanished from the remote — bypasses the Human
       exemption; queued Human entries are deferred until [Missing → Present]

--- a/lib_core/push_plan.ml
+++ b/lib_core/push_plan.ml
@@ -13,13 +13,22 @@ type ancestry =
 type action = Force_push_if_includes | Initial_push
 [@@deriving show, eq, sexp_of, compare]
 
+(** [Local_diverged_from_remote_commits] used to live here as a defense against
+    the PR #315 stale-lease wipe, but it also refused the legitimate post-
+    rebase divergence pattern (local is the rebased version, remote is the
+    pre-rebase original) and stranded the orchestrator on the
+    [conflict_noop_count >= 2] needs-intervention threshold. The git-level
+    [--force-if-includes] flag already refuses the actually-unsafe edge case
+    (remote has commits local doesn't reach via its reflog), so the planner can
+    safely permit divergent pushes. [Local_missing_remote_commits] —
+    strictly-behind, the actual PR #315 shape — is the layered defense that
+    remains. *)
 type refusal =
   | No_commits_ahead_of_base
   | Worktree_missing
   | Branch_ref_missing of { branch : string }
   | Branch_switched of { expected : string; got : string option }
   | Local_missing_remote_commits of { local_sha : sha; remote_sha : sha }
-  | Local_diverged_from_remote_commits of { local_sha : sha; remote_sha : sha }
 [@@deriving show, eq, sexp_of, compare]
 
 type decision = Push of action | Refuse of refusal
@@ -49,15 +58,13 @@ let plan ~expected_branch ~worktree_path_exists ~worktree_head_branch
               | Local_missing_remote, Some remote_sha ->
                   Refuse
                     (Local_missing_remote_commits { local_sha; remote_sha })
-              | Local_diverged_from_remote, Some remote_sha ->
-                  Refuse
-                    (Local_diverged_from_remote_commits
-                       { local_sha; remote_sha })
               | ( ( Local_missing_remote | Local_diverged_from_remote
                   | Local_includes_remote | No_remote_yet | Unknown ),
                   None ) ->
                   Push Initial_push
-              | (Local_includes_remote | No_remote_yet | Unknown), Some _ ->
+              | ( ( Local_diverged_from_remote | Local_includes_remote
+                  | No_remote_yet | Unknown ),
+                  Some _ ) ->
                   Push Force_push_if_includes))
 
 let short_label = function
@@ -68,7 +75,6 @@ let short_label = function
   | Refuse (Branch_ref_missing _) -> "refuse_ref_missing"
   | Refuse (Branch_switched _) -> "refuse_branch_switched"
   | Refuse (Local_missing_remote_commits _) -> "refuse_local_behind"
-  | Refuse (Local_diverged_from_remote_commits _) -> "refuse_local_diverged"
 
 let to_push_reject_classify_rejection (r : refusal) :
     Push_reject_classify.rejection option =
@@ -86,7 +92,3 @@ let to_push_reject_classify_rejection (r : refusal) :
       Some
         (Push_reject_classify.Local_state_unsafe
            { reason = "refuse_local_behind" })
-  | Local_diverged_from_remote_commits _ ->
-      Some
-        (Push_reject_classify.Local_state_unsafe
-           { reason = "refuse_local_diverged" })

--- a/lib_core/push_plan.mli
+++ b/lib_core/push_plan.mli
@@ -26,11 +26,19 @@
     reason to the orchestrator).
 
     Refusals that map to a planner-only state ([Branch_ref_missing],
-    [Branch_switched], [Local_missing_remote_commits],
-    [Local_diverged_from_remote_commits]) are translated to
+    [Branch_switched], [Local_missing_remote_commits]) are translated to
     {!Push_reject_classify.Local_state_unsafe} so the existing [is_permanent] →
     [needs_intervention] escalation path applies without new orchestrator state.
-*)
+
+    Note: [ancestry = Local_diverged_from_remote] is NOT refused here. After a
+    conflict-resolution rebase, the local branch's new commits and the remote's
+    pre-rebase commits are legitimately divergent (same content, different SHAs
+    from the replay). Refusing here would strand the orchestrator on
+    [conflict_noop_count >= 2] needs-intervention. The git-level
+    [--force-if-includes] flag covers the actually-unsafe case (remote has
+    commits local doesn't reach via its reflog), so the planner delegates that
+    check to git. [Local_missing_remote_commits] — strictly-behind, the PR #315
+    incident shape — remains as the layered defense the planner enforces. *)
 
 type sha = string [@@deriving show, eq, sexp_of, compare]
 
@@ -73,10 +81,8 @@ type refusal =
   | Local_missing_remote_commits of { local_sha : sha; remote_sha : sha }
       (** [ancestry = Local_missing_remote] — pushing now would force-push a
           local that is strictly behind remote on real content, wiping commits.
-      *)
-  | Local_diverged_from_remote_commits of { local_sha : sha; remote_sha : sha }
-      (** [ancestry = Local_diverged_from_remote] — pushing now would force-push
-          a divergent local branch over remote-only commits. *)
+          [ancestry = Local_diverged_from_remote] is intentionally NOT a refusal
+          here; see the module-level comment. *)
 [@@deriving show, eq, sexp_of, compare]
 
 type decision = Push of action | Refuse of refusal
@@ -100,26 +106,24 @@ val plan :
     + [commits_ahead_of_base = Some 0] → [Refuse No_commits_ahead_of_base]
     + [ancestry = Local_missing_remote] (and both refs present) →
       [Refuse (Local_missing_remote_commits _)]
-    + [ancestry = Local_diverged_from_remote] (and both refs present) →
-      [Refuse (Local_diverged_from_remote_commits _)]
     + [remote_tracking_sha = None] → [Push Initial_push]
-    + otherwise → [Push Force_push_if_includes] *)
+    + otherwise (including [ancestry = Local_diverged_from_remote]) →
+      [Push Force_push_if_includes] *)
 
 val short_label : decision -> string
 (** A short, lowercase, snake_case identifier for the planner arm that fired,
     suitable for the activity log. Always non-empty and ≤ 32 characters.
     Examples: ["force_push"], ["initial_push"], ["refuse_no_commits"],
     ["refuse_wt_missing"], ["refuse_ref_missing"], ["refuse_branch_switched"],
-    ["refuse_local_behind"], ["refuse_local_diverged"]. *)
+    ["refuse_local_behind"]. *)
 
 val to_push_reject_classify_rejection :
   refusal -> Push_reject_classify.rejection option
 (** Map planner refusals onto the rejection variant used by the orchestrator's
     permanent-rejection escalation:
 
-    - [Branch_switched] / [Local_missing_remote_commits] /
-      [Local_diverged_from_remote_commits] / [Branch_ref_missing] →
-      [Some (Local_state_unsafe { reason = short_label_of_refusal })] — route
+    - [Branch_switched] / [Local_missing_remote_commits] / [Branch_ref_missing]
+      → [Some (Local_state_unsafe { reason = short_label_of_refusal })] — route
       through [needs_intervention].
     - [No_commits_ahead_of_base] / [Worktree_missing] → [None] — the
       orchestrator already has dedicated non-rejection handlers

--- a/test/test_dependency_injection_functors.ml
+++ b/test/test_dependency_injection_functors.ml
@@ -118,6 +118,7 @@ module Fake_sd_env : Session_driver.ENV = struct
   let repo = ""
   let transcripts = Stdlib.Hashtbl.create 0
   let user_config = { User_config.on_worktree_create = None }
+  let event_log = Event_log.create ~path:"/dev/null"
 end
 
 module SD = Session_driver.Make (Fake_worktree) (Fake_sd_env)
@@ -216,6 +217,7 @@ let () =
     let worktree_mutex = Eio.Mutex.create ()
     let hook_mutex = Eio.Mutex.create ()
     let fetch_mutex = Eio.Mutex.create ()
+    let event_log = Event_log.create ~path:"/dev/null"
   end in
   let module SD = Session_driver.Make (Fake_worktree) (SD_Env) in
   (* Compile-time assertion: run accepts only per-session inputs.
@@ -254,6 +256,7 @@ let () =
     let hook_mutex = Eio.Mutex.create ()
     let fetch_mutex = Eio.Mutex.create ()
     let transcripts = transcripts
+    let event_log = Event_log.create ~path:"/dev/null"
   end in
   let module WS3_Env : Worktree_setup.ENV = struct
     let runtime = Fake_fiber_env.runtime
@@ -277,6 +280,7 @@ let () =
     let worktree_mutex = Fake_fiber_env.worktree_mutex
     let hook_mutex = Fake_fiber_env.hook_mutex
     let fetch_mutex = Fake_fiber_env.fetch_mutex
+    let event_log = Fake_fiber_env.event_log
   end in
   let module WS3 = Worktree_setup.Make (Fake_worktree) (WS3_Env) in
   let module SD3 = Session_driver.Make (Fake_worktree) (SD3_Env) in

--- a/test/test_push_plan_properties.ml
+++ b/test/test_push_plan_properties.ml
@@ -15,9 +15,12 @@ open Onton_core
     - {b PPP-3 Local-missing-remote refused}: when
       [ancestry = Local_missing_remote] and both refs are present, decision is
       [Refuse (Local_missing_remote_commits _)].
-    - {b PPP-3b Local-diverged-from-remote refused}: when
-      [ancestry = Local_diverged_from_remote] and both refs are present,
-      decision is [Refuse (Local_diverged_from_remote_commits _)].
+    - {b PPP-3b Local-diverged-from-remote permitted}: when
+      [ancestry = Local_diverged_from_remote] and both refs are present, the
+      decision is [Push Force_push_if_includes] (post-rebase divergence — the
+      git-level [--force-if-includes] flag covers the unsafe edge case; refusing
+      here would strand the orchestrator on the [conflict_noop_count >= 2]
+      needs-intervention threshold).
     - {b PPP-4 Zero commits → skip}: [commits_ahead_of_base = Some 0] yields
       [Refuse No_commits_ahead_of_base] (after worktree-missing, branch-switch,
       branch-ref-missing pre-emptions).
@@ -53,8 +56,7 @@ let is_refuse_no_commits = function
   | PP.Refuse PP.No_commits_ahead_of_base -> true
   | PP.Refuse
       ( PP.Worktree_missing | PP.Branch_ref_missing _ | PP.Branch_switched _
-      | PP.Local_missing_remote_commits _
-      | PP.Local_diverged_from_remote_commits _ )
+      | PP.Local_missing_remote_commits _ )
   | PP.Push _ ->
       false
 
@@ -62,8 +64,7 @@ let is_refuse_wt_missing = function
   | PP.Refuse PP.Worktree_missing -> true
   | PP.Refuse
       ( PP.No_commits_ahead_of_base | PP.Branch_ref_missing _
-      | PP.Branch_switched _ | PP.Local_missing_remote_commits _
-      | PP.Local_diverged_from_remote_commits _ )
+      | PP.Branch_switched _ | PP.Local_missing_remote_commits _ )
   | PP.Push _ ->
       false
 
@@ -71,8 +72,7 @@ let is_refuse_ref_missing = function
   | PP.Refuse (PP.Branch_ref_missing _) -> true
   | PP.Refuse
       ( PP.No_commits_ahead_of_base | PP.Worktree_missing | PP.Branch_switched _
-      | PP.Local_missing_remote_commits _
-      | PP.Local_diverged_from_remote_commits _ )
+      | PP.Local_missing_remote_commits _ )
   | PP.Push _ ->
       false
 
@@ -80,8 +80,7 @@ let is_refuse_branch_switched = function
   | PP.Refuse (PP.Branch_switched _) -> true
   | PP.Refuse
       ( PP.No_commits_ahead_of_base | PP.Worktree_missing
-      | PP.Branch_ref_missing _ | PP.Local_missing_remote_commits _
-      | PP.Local_diverged_from_remote_commits _ )
+      | PP.Branch_ref_missing _ | PP.Local_missing_remote_commits _ )
   | PP.Push _ ->
       false
 
@@ -89,17 +88,7 @@ let is_refuse_local_behind = function
   | PP.Refuse (PP.Local_missing_remote_commits _) -> true
   | PP.Refuse
       ( PP.No_commits_ahead_of_base | PP.Worktree_missing
-      | PP.Branch_ref_missing _ | PP.Branch_switched _
-      | PP.Local_diverged_from_remote_commits _ )
-  | PP.Push _ ->
-      false
-
-let is_refuse_local_diverged = function
-  | PP.Refuse (PP.Local_diverged_from_remote_commits _) -> true
-  | PP.Refuse
-      ( PP.No_commits_ahead_of_base | PP.Worktree_missing
-      | PP.Branch_ref_missing _ | PP.Branch_switched _
-      | PP.Local_missing_remote_commits _ )
+      | PP.Branch_ref_missing _ | PP.Branch_switched _ )
   | PP.Push _ ->
       false
 
@@ -229,25 +218,34 @@ let prop_local_missing_remote_refused =
       in
       is_refuse_local_behind d)
 
-let prop_local_diverged_from_remote_refused =
+let prop_local_diverged_from_remote_permitted =
+  (* Regression: an earlier revision refused this case with
+     [Local_diverged_from_remote_commits], which stranded the orchestrator
+     on the [conflict_noop_count >= 2] needs-intervention threshold every
+     time a stacked patch was rebased onto a freshly-advanced base. Post-
+     rebase divergence is the legitimate state where local IS the rebased
+     version of remote; the git-level [--force-if-includes] flag handles
+     the actually-unsafe edge case (remote has commits local doesn't reach
+     via its reflog). *)
   Test.make ~count:500
     ~name:
-      "PPP-3b: ancestry=Local_diverged_from_remote + both refs present → \
-       Local_diverged_from_remote_commits"
+      "PPP-3b: ancestry=Local_diverged_from_remote + both refs present → Push \
+       Force_push_if_includes"
     Gen.(
       let* local_sha = gen_sha in
       let* remote_sha = gen_sha in
       let* branch = gen_branch_name in
-      return (local_sha, remote_sha, branch))
-    (fun (local_sha, remote_sha, branch) ->
+      let* commits = int_range 1 50 in
+      return (local_sha, remote_sha, branch, commits))
+    (fun (local_sha, remote_sha, branch, commits) ->
       let d =
         PP.plan ~expected_branch:branch ~worktree_path_exists:true
           ~worktree_head_branch:(Some branch) ~branch_ref_sha:(Some local_sha)
           ~remote_tracking_sha:(Some remote_sha)
           ~ancestry:PP.Local_diverged_from_remote
-          ~commits_ahead_of_base:(Some 3)
+          ~commits_ahead_of_base:(Some commits)
       in
-      is_refuse_local_diverged d)
+      is_push_force d)
 
 let prop_zero_commits_skip =
   Test.make ~count:500
@@ -293,7 +291,13 @@ let prop_happy_path =
       let* local_sha = gen_sha in
       let* remote_sha = gen_sha in
       let* anc =
-        oneof_array [| PP.Local_includes_remote; PP.No_remote_yet; PP.Unknown |]
+        oneof_array
+          [|
+            PP.Local_includes_remote;
+            PP.Local_diverged_from_remote;
+            PP.No_remote_yet;
+            PP.Unknown;
+          |]
       in
       let* commits = int_range 1 50 in
       return (branch, local_sha, remote_sha, anc, commits))
@@ -362,7 +366,7 @@ let prop_variants_reachable =
           ~remote_tracking_sha:(Some "r") ~ancestry:PP.Local_missing_remote
           ~commits_ahead_of_base:(Some 1)
       in
-      let local_diverged =
+      let local_diverged_now_pushes =
         PP.plan ~expected_branch:"b" ~worktree_path_exists:true
           ~worktree_head_branch:(Some "b") ~branch_ref_sha:(Some "l")
           ~remote_tracking_sha:(Some "r")
@@ -375,7 +379,7 @@ let prop_variants_reachable =
       && is_refuse_ref_missing ref_missing
       && is_refuse_branch_switched branch_switched
       && is_refuse_local_behind local_behind
-      && is_refuse_local_diverged local_diverged)
+      && is_push_force local_diverged_now_pushes)
 
 let prop_refusal_to_rejection_permanent =
   Test.make ~count:1
@@ -389,8 +393,6 @@ let prop_refusal_to_rejection_permanent =
           PP.Branch_ref_missing { branch = "b" };
           PP.Branch_switched { expected = "b"; got = Some "other" };
           PP.Local_missing_remote_commits { local_sha = "l"; remote_sha = "r" };
-          PP.Local_diverged_from_remote_commits
-            { local_sha = "l"; remote_sha = "r" };
         ]
       in
       List.for_all refusals ~f:(fun r ->
@@ -417,7 +419,7 @@ let () =
          prop_branch_switch_refused;
          prop_matching_head_branch_not_switched;
          prop_local_missing_remote_refused;
-         prop_local_diverged_from_remote_refused;
+         prop_local_diverged_from_remote_permitted;
          prop_zero_commits_skip;
          prop_initial_push;
          prop_happy_path;


### PR DESCRIPTION
## Summary

Two changes motivated by the same incident on the `ts2pant-let-mutation-ssa` gameplan: a stacked patch was rebased locally onto a freshly-advanced master, the push was refused by the planner on `ancestry = Local_diverged_from_remote`, the orchestrator retried, the retry rebase was a `Noop`, `conflict_noop_count` climbed past 2, and the patch surfaced as "Needs attention" — even though `git push --force-with-lease --force-if-includes` would have succeeded. Diagnosing this from `events.jsonl` required `cd`-ing into the worktree and running manual git commands because the push outcome, planner decision, and local/remote/base SHAs weren't captured anywhere structured.

### 1. Push_plan: stop refusing divergent-rebase pushes (the bug)

Drop `Local_diverged_from_remote_commits` from `lib_core/push_plan.ml`. After a conflict-resolution rebase, local has the rebased commits and remote has the pre-rebase originals — divergent ancestry is the legitimate state. The git-level `--force-if-includes` flag (added in `9490910`) refuses the actually-unsafe edge case (remote has commits local doesn't reach via its reflog); the planner delegates that check to git instead of stranding the orchestrator on `conflict_noop_count >= 2`. `Local_missing_remote_commits` — strictly-behind, the PR #315 incident shape — remains as the layered defense the planner enforces.

PPP-3b property test inverted from `Local_diverged_from_remote → Refuse` to `Local_diverged_from_remote → Push Force_push_if_includes` with a regression comment referencing this incident. PPP-6 (happy path) widened to include divergent ancestry. PPP-9 (variant reachability) updated. All 13 push_plan properties pass.

### 2. log_push event (observability)

New `Event_log.log_push` records push `kind` (`session_end` / `rebase_resolution` / `conflict_resolution`), `Worktree.push_result` variant, `result_kind` label (carries planner refusal label inside `Push_rejected` via `Push_reject_classify.short_label`), and `local_sha` / `remote_tracking_sha` / `base_sha` at push time. Wired into all three push call sites (`session_driver.ml`, `runner_fiber_impl.ml` rebase path, `runner_fiber_impl.ml` conflict path). Plumbed `event_log` into `Session_driver.ENV`.

### 3. needs_intervention transition event (observability)

`Patch_agent.intervention_reason : t -> string option` returns the specific triggering counter — `"pr_missing"`, `"ci_failure_count>=3"`, `"conflict_noop_count>=2"`, etc. `needs_intervention` is now defined as `Option.is_some` of that — single source of truth. Every `Event_log.log_X` helper that takes `agent_before` / `agent_after` tail-calls a transition emitter that fires a `"needs_intervention"` event when the predicate flips `false→true`, naming the reason. No call-site changes required.

### 4. Rebase SHA fields (observability)

`log_rebase` and `log_conflict_rebase` now take `pre_rebase_head`, `post_rebase_head`, `target_base_sha`. Callers compute via `W.read_branch_sha`. Makes "the rebase returned Noop — but did the branch actually move?" answerable from `events.jsonl` alone, without needing a worktree filesystem walk.

## Test plan

- [x] `dune build` clean (strict warnings; new `event_log` field in `Session_driver.ENV` propagated through `runner_fiber_impl.ml` and the three test fixtures in `test_dependency_injection_functors.ml`)
- [x] `dune test` green, including 13 QCheck2 properties for `Push_plan` (PPP-3b now asserts post-rebase divergence is permitted; PPP-6 widened; PPP-9 / PPP-10 updated)
- [ ] On next live run with a stacked-PR rebase: verify `events.jsonl` contains a `"push"` entry with `result_kind` and SHA fields for each push attempt, and a `"needs_intervention"` entry naming the reason at the first false→true flip per patch
- [ ] Verify previously-stuck patches (e.g. the `ts2pant-let-mutation-ssa` patch-2 / patch-3) recover automatically on the next conflict-resolution attempt instead of incrementing toward `conflict_noop_count >= 2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/322"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782407082&installation_id=126163856&pr_number=322&repository=flowglad%2Fonton&return_to=https%3A%2F%2Fgithub.com%2Fflowglad%2Fonton%2Fpull%2F322&signature=64bef763f3fa655cf73e9b2f965d66232693e4dce0f054560b9a80162adc2563"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Permit safe pushes after legitimate post-rebase divergence by delegating safety to git’s `--force-if-includes`, preventing stuck patches. Add structured push/rebase telemetry with SHAs and auto “needs_intervention” transition events for clearer diagnostics.

- **Bug Fixes**
  - Push_plan: allow `Local_diverged_from_remote`; still refuse `Local_missing_remote_commits`. Removed the diverged refusal path in `worktree`; property tests updated (PPP-3b inverted; PPP-6 widened; PPP-9/10 updated).
  - Worktree/Setup: typed `fetch_branch_result` to treat brand-new branches with no upstream as non-errors in logs.
  - Session end: emit `log_push` after applying the session result so `agent_after` reflects the final state.

- **New Features**
  - `Event_log.log_push`: records push site (`session_end`/`rebase_resolution`/`conflict_resolution`), `result`/`result_kind`, and local/remote-tracking/base SHAs; wired into all three push sites and plumbed via `Session_driver.ENV.event_log`.
  - Rebase logs: `log_rebase`/`log_conflict_rebase` include `pre_rebase_head`, `post_rebase_head`, and `target_base_sha`. `Patch_agent.intervention_reason` added; all loggers auto-emit a `"needs_intervention"` event on a false→true flip.

<sup>Written for commit 3267c37eb2d092d1953e66af860b57cdf3672404. Summary will update on new commits. <a href="https://cubic.dev/pr/flowglad/onton/pull/322?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

