### PR TITLE
Gate Start on base-branch freshness to prevent stale worktrees

### DIFF
--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -265,13 +265,21 @@ let start_eligibility t base =
         match find_agent t bpid with
         | None -> (false, None, false)
         | Some a ->
-            let busy_rebasing =
+            let running_rebase =
               a.Patch_agent.busy
               && Option.equal Operation_kind.equal a.Patch_agent.current_op
                    (Some Operation_kind.Rebase)
-              || List.mem a.Patch_agent.queue Operation_kind.Rebase
-                   ~equal:Operation_kind.equal
             in
+            (* Only treat a queued Rebase as in-flight when it is the next op to
+               run (highest priority); a Rebase buried behind higher-priority
+               work — or one left queued on an already-fresh base — must not
+               defer Start, or we over-defer and lose liveness. *)
+            let runnable_rebase =
+              Option.equal Operation_kind.equal
+                (Patch_agent.highest_priority a)
+                (Some Operation_kind.Rebase)
+            in
+            let busy_rebasing = running_rebase || runnable_rebase in
             ( a.Patch_agent.merged,
               a.Patch_agent.branch_rebased_onto_sha,
               busy_rebasing ))

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -33,6 +33,12 @@ type t = {
   agents : Patch_agent.t Map.M(Patch_id).t;
   outbox : patch_agent_message Map.M(Message_id).t;
   main_branch : Branch.t;
+  main_sha : string option;
+      (** Sha of [origin/<main_branch>] as last observed by the poller. Used by
+          {!Start_eligibility} to gate [Start] actions: a [Start(c, base=B)] is
+          deferred until [B]'s [branch_rebased_onto_sha] equals [main_sha], so
+          that [c]'s worktree is never cut from a stale dep branch. [None] until
+          the first poller tick fetches [origin/main]. *)
 }
 
 let create ~patches ~main_branch =
@@ -51,7 +57,13 @@ let create ~patches ~main_branch =
               (Printf.sprintf "Orchestrator.create: duplicate patch id %s"
                  (Patch_id.to_string p.Patch.id)))
   in
-  { graph; agents; outbox = Map.empty (module Message_id); main_branch }
+  {
+    graph;
+    agents;
+    outbox = Map.empty (module Message_id);
+    main_branch;
+    main_sha = None;
+  }
 
 let agent t patch_id =
   match Map.find t.agents patch_id with
@@ -149,13 +161,24 @@ let enqueue t patch_id kind =
 
 let mark_merged t patch_id =
   let t = update_agent t patch_id ~f:Patch_agent.mark_merged in
-  (* Eagerly update base_branch for direct dependents so it is never
-     stale when Merge_conflict fires. *)
+  (* Eagerly update [base_branch] for direct dependents so it is never stale
+     when [Merge_conflict] fires, AND eagerly enqueue a [Rebase] so the dep's
+     local tip catches up to [main_sha] before any deferred [Start] that
+     depends on it can fire. Without the eager enqueue, the dep stays on a
+     stale base until the next reconciler poll tick — the window that wiped
+     event-stream-pages patch 3. *)
   let dependents = Graph.dependents t.graph patch_id in
   List.fold dependents ~init:t ~f:(fun t dep_id ->
       match find_agent t dep_id with
       | None -> t
-      | Some _ -> refresh_base_branch t dep_id)
+      | Some dep_agent ->
+          let t = refresh_base_branch t dep_id in
+          if
+            dep_agent.Patch_agent.merged
+            || List.mem dep_agent.Patch_agent.queue Operation_kind.Rebase
+                 ~equal:Operation_kind.equal
+          then t
+          else enqueue t dep_id Operation_kind.Rebase)
 
 let remove_agent t patch_id =
   {
@@ -223,6 +246,39 @@ let current_message t patch_id =
   | None -> None
   | Some message_id -> Map.find t.outbox message_id
 
+let find_patch_by_branch t branch =
+  Map.to_alist t.agents
+  |> List.find ~f:(fun (_, a) -> Branch.equal a.Patch_agent.branch branch)
+  |> Option.map ~f:fst
+
+(** [start_eligibility t base] is the freshness verdict for a hypothetical
+    [Start] action whose base is [base] against [t]'s current view of the world.
+    Exposed so tests and TUI surfaces can inspect the gate without firing the
+    action. *)
+let start_eligibility t base =
+  let base_is_main = Branch.equal base t.main_branch in
+  let base_branch = Branch.to_string base in
+  let base_patch_merged, base_patch_rebased_onto_sha, base_patch_busy_rebasing =
+    match find_patch_by_branch t base with
+    | None -> (false, None, false)
+    | Some bpid -> (
+        match find_agent t bpid with
+        | None -> (false, None, false)
+        | Some a ->
+            let busy_rebasing =
+              a.Patch_agent.busy
+              && Option.equal Operation_kind.equal a.Patch_agent.current_op
+                   (Some Operation_kind.Rebase)
+              || List.mem a.Patch_agent.queue Operation_kind.Rebase
+                   ~equal:Operation_kind.equal
+            in
+            ( a.Patch_agent.merged,
+              a.Patch_agent.branch_rebased_onto_sha,
+              busy_rebasing ))
+  in
+  Start_eligibility.decide ~base_is_main ~base_branch ~base_patch_merged
+    ~base_patch_rebased_onto_sha ~base_patch_busy_rebasing ~main_sha:t.main_sha
+
 let runnable_messages t =
   let action_rank = function
     | Start _ -> 0
@@ -232,7 +288,16 @@ let runnable_messages t =
   Map.data t.outbox
   |> List.filter ~f:(fun msg ->
       match msg.status with
-      | Pending -> true
+      | Pending -> (
+          (* Gate [Start] on base-branch freshness. Other actions are not
+             freshness-sensitive: [Rebase] is what closes the freshness gap,
+             and [Respond] operates on a worktree that already exists. *)
+          match msg.action with
+          | Start (_, base) -> (
+              match start_eligibility t base with
+              | Start_eligibility.Allow -> true
+              | Start_eligibility.Defer _ -> false)
+          | Rebase _ | Respond _ -> true)
       | Acked ->
           let agent = agent t msg.patch_id in
           Option.equal Message_id.equal agent.current_message_id
@@ -441,18 +506,19 @@ let reset_automerge_failure_count t patch_id =
 let all_agents t = Map.data t.agents
 let graph t = t.graph
 
-let restore ~graph ~agents ~outbox ~main_branch =
+let restore ~graph ~agents ~outbox ~main_branch ?main_sha () =
   let outbox = Map.filter outbox ~f:(fun msg -> Map.mem agents msg.patch_id) in
-  { graph; agents; outbox; main_branch }
+  { graph; agents; outbox; main_branch; main_sha }
 
 let main_branch t = t.main_branch
 let set_main_branch t branch = { t with main_branch = branch }
-let agents_map t = t.agents
+let main_sha t = t.main_sha
 
-let find_patch_by_branch t branch =
-  Map.to_alist t.agents
-  |> List.find ~f:(fun (_, a) -> Branch.equal a.Patch_agent.branch branch)
-  |> Option.map ~f:fst
+let set_main_sha t sha =
+  let sha = String.strip sha in
+  if String.is_empty sha then t else { t with main_sha = Some sha }
+
+let agents_map t = t.agents
 
 let add_agent t ~patch_id ~branch ~base_branch ~pr_number =
   if Map.mem t.agents patch_id then t

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -171,14 +171,23 @@ let mark_merged t patch_id =
   List.fold dependents ~init:t ~f:(fun t dep_id ->
       match find_agent t dep_id with
       | None -> t
-      | Some dep_agent ->
+      | Some _ -> (
           let t = refresh_base_branch t dep_id in
-          if
-            dep_agent.Patch_agent.merged
-            || List.mem dep_agent.Patch_agent.queue Operation_kind.Rebase
-                 ~equal:Operation_kind.equal
-          then t
-          else enqueue t dep_id Operation_kind.Rebase)
+          (* Re-fetch after [refresh_base_branch] so the [merged]/[queue] guards
+             read the post-refresh agent rather than a stale pre-refresh
+             snapshot. (Today [refresh_base_branch] mutates only [base_branch],
+             but re-reading keeps this correct if that ever changes.) The
+             [merged] guard is not dead: a dependent can already be merged when
+             this fires, and a merged dep must not be handed a [Rebase]. *)
+          match find_agent t dep_id with
+          | None -> t
+          | Some dep_agent ->
+              if
+                dep_agent.Patch_agent.merged
+                || List.mem dep_agent.Patch_agent.queue Operation_kind.Rebase
+                     ~equal:Operation_kind.equal
+              then t
+              else enqueue t dep_id Operation_kind.Rebase))
 
 let remove_agent t patch_id =
   {

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -415,5 +415,29 @@ val restore :
   agents:Patch_agent.t Map.M(Patch_id).t ->
   outbox:patch_agent_message Map.M(Message_id).t ->
   main_branch:Branch.t ->
+  ?main_sha:string ->
+  unit ->
   t
-(** Reconstruct orchestrator from persisted components. *)
+(** Reconstruct orchestrator from persisted components. [main_sha] defaults to
+    [None] when an older snapshot has no recorded value; the poller fills it in
+    on the next tick. *)
+
+val main_sha : t -> string option
+(** Sha of [origin/<main_branch>] as last observed by the poller. [None] until
+    the first successful fetch. *)
+
+val set_main_sha : t -> string -> t
+(** Record the latest observed [origin/<main_branch>] sha. Empty/whitespace
+    inputs are ignored (returns [t] unchanged) so a failed fetch doesn't clobber
+    a previously good value. *)
+
+val start_eligibility : t -> Branch.t -> Start_eligibility.decision
+(** [start_eligibility t base] is the freshness verdict for a hypothetical
+    [Start] action whose base is [base], evaluated against [t]'s current
+    [main_sha] and the base patch's recorded rebase anchor. Used to gate [Start]
+    in {!runnable_messages}; exposed for tests/TUI introspection.
+
+    Returns [Allow] when the base is main, when the base patch is merged
+    (effectively main), or when the base patch's [branch_rebased_onto_sha]
+    matches [main_sha]. Otherwise returns [Defer reason]. See
+    {!Start_eligibility}. *)

--- a/lib/persistence.ml
+++ b/lib/persistence.ml
@@ -491,12 +491,18 @@ let orchestrator_to_yojson (o : Orchestrator.t) =
                   | Orchestrator.Obsolete -> "Obsolete") );
             ] ))
   in
+  let main_sha_field =
+    match Orchestrator.main_sha o with
+    | None -> []
+    | Some s -> [ ("main_sha", `String s) ]
+  in
   `Assoc
-    [
-      ("main_branch", Branch.yojson_of_t (Orchestrator.main_branch o));
-      ("agents", `Assoc agents);
-      ("outbox", `Assoc outbox);
-    ]
+    ([
+       ("main_branch", Branch.yojson_of_t (Orchestrator.main_branch o));
+       ("agents", `Assoc agents);
+       ("outbox", `Assoc outbox);
+     ]
+    @ main_sha_field)
 
 let action_of_yojson json =
   let ( let* ) r f = Result.bind r ~f in
@@ -533,6 +539,11 @@ let orchestrator_of_yojson ~gameplan json =
     let ( let* ) r f = Result.bind r ~f in
     let graph = Graph.of_patches gameplan.Gameplan.patches in
     let main_branch = Branch.of_string (string_member "main_branch" json) in
+    let main_sha =
+      match Yojson.Safe.Util.member "main_sha" json with
+      | `String s when not (String.is_empty s) -> Some s
+      | _ -> None
+    in
     Result.bind
       (result_all
          (Yojson.Safe.Util.member "agents" json
@@ -643,7 +654,8 @@ let orchestrator_of_yojson ~gameplan json =
                             | _ -> g))))
           in
           Ok
-            (Orchestrator.restore ~graph ~agents:agents_map ~outbox ~main_branch))
+            (Orchestrator.restore ~graph ~agents:agents_map ~outbox ~main_branch
+               ?main_sha ()))
   with
   | Yojson.Safe.Util.Type_error (msg, _) ->
       Error (Printf.sprintf "malformed orchestrator: %s" msg)
@@ -809,7 +821,7 @@ let%test_module "session_id_sidecars" =
           ~graph:(Graph.of_patches [ patch ])
           ~agents:(Map.singleton (module Patch_id) patch_id agent)
           ~outbox:(Map.empty (module Message_id))
-          ~main_branch
+          ~main_branch ()
       in
       {
         Runtime.orchestrator = orch;

--- a/lib/poller_fiber.ml
+++ b/lib/poller_fiber.ml
@@ -209,6 +209,16 @@ struct
                  ~ref_name:("refs/remotes/origin/" ^ main_str))
               ~default:""
           in
+          (* Record the observed [origin/<main>] sha on the orchestrator on
+             every successful fetch — not just on drift. [Start_eligibility]
+             consults [main_sha] to gate [Start] actions; if we only updated
+             on drift, the first-ever fetch (where [last_main_sha] is empty)
+             would update, but subsequent ticks during a quiet period would
+             leave [main_sha] unset for any orchestrator built from a
+             snapshot. *)
+          if not (String.is_empty origin_sha) then
+            Runtime.update_orchestrator runtime (fun orch ->
+                Orchestrator.set_main_sha orch origin_sha);
           if
             Reconciler.detect_main_freshness_drift ~local_sha ~origin_sha
             && not (String.equal origin_sha !last_main_sha)

--- a/lib/worktree.ml
+++ b/lib/worktree.ml
@@ -289,8 +289,38 @@ let execute_start_point_action ~process_mgr ~repo_root ~path ~branch_str
    Returns [Error _] when the planner refuses (local diverged from remote,
    branch checked out in main, etc.); the caller in [Worktree_setup] surfaces
    refusals through the orchestrator's [needs_intervention] path. *)
-let create ~process_mgr ~repo_root ~project_name ~patch_id ~branch ~base_ref :
-    (t, Start_point_plan.refusal) Result.t =
+(* Whether [origin/<main_branch>] is an ancestor of [base_ref]. Only meaningful
+   when we are about to cut a brand-new branch from [base_ref] (a stacked
+   dependency branch). When [base_ref] is itself the main branch, freshness is
+   not this function's concern — stale-local-main is handled by the poller's
+   main-freshness drift detection — so we return [Unknown_freshness] and let
+   the create proceed. Defense-in-depth behind the orchestrator's scheduling
+   gate; a probe failure also yields [Unknown_freshness] so a transient git
+   error never blocks a legitimate create. *)
+let compute_base_freshness ~process_mgr ~repo_root ~main_branch ~base_ref :
+    Start_point_plan.base_freshness =
+  if String.equal base_ref main_branch then Start_point_plan.Unknown_freshness
+  else
+    let origin_main = "origin/" ^ main_branch in
+    let code, _, _ =
+      run_git_exit_code ~process_mgr
+        [
+          "git";
+          "-C";
+          repo_root;
+          "merge-base";
+          "--is-ancestor";
+          origin_main;
+          base_ref;
+        ]
+    in
+    match code with
+    | 0 -> Start_point_plan.Fresh
+    | 1 -> Start_point_plan.Stale
+    | _ -> Start_point_plan.Unknown_freshness
+
+let create ~process_mgr ~repo_root ~project_name ~patch_id ~branch ~base_ref
+    ~main_branch : (t, Start_point_plan.refusal) Result.t =
   let path = worktree_dir ~project_name ~patch_id in
   let branch_str = Types.Branch.to_string branch in
   if Stdlib.Sys.file_exists path then Result.Ok { patch_id; branch; path }
@@ -310,6 +340,16 @@ let create ~process_mgr ~repo_root ~project_name ~patch_id ~branch ~base_ref :
           compute_repo_ancestry ~process_mgr ~repo_root ~local:l ~remote:r
       | _ -> Start_point_plan.Unknown
     in
+    (* Only probe base freshness on the brand-new-branch path (neither local
+       nor remote ref for our own branch exists yet) — the only arm that cuts
+       from [base_ref]. Skipping the probe elsewhere avoids a needless git
+       call. *)
+    let base_freshness =
+      match (local_ref, remote_ref) with
+      | None, None ->
+          compute_base_freshness ~process_mgr ~repo_root ~main_branch ~base_ref
+      | _ -> Start_point_plan.Unknown_freshness
+    in
     (* [branch_checked_out_in_main_root] and [existing_worktree_path] are
        checked by [Worktree_setup.ensure_worktree] before this point — we
        pass [false]/[None] so the planner's totality contract is preserved
@@ -318,8 +358,8 @@ let create ~process_mgr ~repo_root ~project_name ~patch_id ~branch ~base_ref :
        there. *)
     let decision =
       Start_point_plan.plan ~local_ref ~remote_ref ~ancestry
-        ~base_branch:base_ref ~branch_checked_out_in_main_root:false
-        ~existing_worktree_path:None
+        ~base_branch:base_ref ~base_freshness
+        ~branch_checked_out_in_main_root:false ~existing_worktree_path:None
     in
     match decision with
     | Refuse refusal -> Result.Error refusal
@@ -973,6 +1013,7 @@ module type S = sig
     patch_id:Types.Patch_id.t ->
     branch:Types.Branch.t ->
     base_ref:string ->
+    main_branch:string ->
     (t, Start_point_plan.refusal) Result.t
 
   val fetch_origin_branch :
@@ -1043,8 +1084,9 @@ let make ~process_mgr ~repo_root =
     let remote_branch_exists branch_str =
       remote_branch_exists ~process_mgr ~repo_root branch_str
 
-    let create ~project_name ~patch_id ~branch ~base_ref =
+    let create ~project_name ~patch_id ~branch ~base_ref ~main_branch =
       create ~process_mgr ~repo_root ~project_name ~patch_id ~branch ~base_ref
+        ~main_branch
 
     let remove t = remove ~process_mgr ~repo_root t
     let detect_branch ~path = detect_branch ~process_mgr ~path

--- a/lib/worktree.ml
+++ b/lib/worktree.ml
@@ -25,12 +25,41 @@ let rec has_cancellation = function
       List.exists exns ~f:(fun (exn, _bt) -> has_cancellation exn)
   | _ -> false
 
+(* [posix_spawn] can transiently fail (e.g. EAGAIN) when the host is near its
+   per-user process limit — a heavily parallel test runner, or many concurrent
+   patches each driving git. Such failures surface as exceptions *other* than a
+   process verdict ([Eio.Process.E _] — [Child_error]/[Executable_not_found],
+   meaning git actually ran) and other than cancellation. We retry only that
+   transient class so a one-off spawn failure isn't mistaken for a git result
+   (or crash an op); a genuine exit status or cancellation is never retried. *)
+let is_transient_spawn_failure = function
+  | Eio.Io (Eio.Process.E _, _) -> false
+  | e -> not (has_cancellation e)
+
+let rec retry_transient_spawn ?(attempts = 4) f =
+  match f () with
+  | x -> x
+  | exception e when attempts <= 1 || not (is_transient_spawn_failure e) ->
+      raise e
+  | exception _ ->
+      (* Yield so the scheduler can make progress (reap exited children, let
+         other fibers release resources) before the next attempt. *)
+      Eio.Fiber.yield ();
+      retry_transient_spawn ~attempts:(attempts - 1) f
+
+(* [Eio.Process.run] wrapper that retries transient spawn failures. Named
+   parameter [mgr] (not [process_mgr]) so a textual rewrite of the call sites
+   below doesn't recurse into this definition. *)
+let process_run_retry mgr ?env ?stdout ?stderr args =
+  retry_transient_spawn (fun () ->
+      Eio.Process.run mgr ?env ?stdout ?stderr args)
+
 let clean_git_env = Stdlib.Lazy.from_fun Git_env.clean_env
 
 let ref_exists ~process_mgr ~repo_root ref_path =
   let buf = Buffer.create 16 in
   match
-    Eio.Process.run process_mgr
+    process_run_retry process_mgr
       ~env:(Stdlib.Lazy.force clean_git_env)
       ~stdout:(Eio.Flow.buffer_sink buf)
       ~stderr:(Eio.Flow.buffer_sink (Buffer.create 16))
@@ -50,7 +79,7 @@ let resolve_main_root ~process_mgr ~repo_root =
   let buf = Buffer.create 128 in
   let stderr_buf = Buffer.create 64 in
   match
-    Eio.Process.run process_mgr
+    process_run_retry process_mgr
       ~env:(Stdlib.Lazy.force clean_git_env)
       ~stdout:(Eio.Flow.buffer_sink buf)
       ~stderr:(Eio.Flow.buffer_sink stderr_buf)
@@ -76,7 +105,7 @@ let is_checked_out_in_repo_root ~process_mgr ~repo_root branch =
   let buf = Buffer.create 128 in
   let stderr_buf = Buffer.create 64 in
   match
-    Eio.Process.run process_mgr
+    process_run_retry process_mgr
       ~env:(Stdlib.Lazy.force clean_git_env)
       ~stdout:(Eio.Flow.buffer_sink buf)
       ~stderr:(Eio.Flow.buffer_sink stderr_buf)
@@ -91,7 +120,7 @@ let is_checked_out_in_repo_root ~process_mgr ~repo_root branch =
 let run_git ~process_mgr args =
   let stderr_buf = Buffer.create 128 in
   match
-    Eio.Process.run process_mgr
+    process_run_retry process_mgr
       ~env:(Stdlib.Lazy.force clean_git_env)
       ~stdout:(Eio.Flow.buffer_sink (Buffer.create 64))
       ~stderr:(Eio.Flow.buffer_sink stderr_buf)
@@ -114,10 +143,11 @@ let run_git_exit_code ~process_mgr args =
   let stderr_buf = Buffer.create 64 in
   let env = Stdlib.Lazy.force clean_git_env in
   let child =
-    Eio.Process.spawn ~sw process_mgr ~env
-      ~stdout:(Eio.Flow.buffer_sink stdout_buf)
-      ~stderr:(Eio.Flow.buffer_sink stderr_buf)
-      args
+    retry_transient_spawn (fun () ->
+        Eio.Process.spawn ~sw process_mgr ~env
+          ~stdout:(Eio.Flow.buffer_sink stdout_buf)
+          ~stderr:(Eio.Flow.buffer_sink stderr_buf)
+          args)
   in
   let code =
     match Eio.Process.await child with `Exited c -> c | `Signaled s -> 128 + s
@@ -200,7 +230,7 @@ let check_case_insensitive_ref_collision ~process_mgr ~repo_root branch_str =
   let buf = Buffer.create 512 in
   let existing_branches =
     match
-      Eio.Process.run process_mgr
+      process_run_retry process_mgr
         ~env:(Stdlib.Lazy.force clean_git_env)
         ~stdout:(Eio.Flow.buffer_sink buf)
         ~stderr:(Eio.Flow.buffer_sink (Buffer.create 16))
@@ -369,7 +399,7 @@ let create ~process_mgr ~repo_root ~project_name ~patch_id ~branch ~base_ref
         Result.Ok { patch_id; branch; path })
 
 let remove ~process_mgr ~repo_root t =
-  Eio.Process.run process_mgr
+  process_run_retry process_mgr
     ~env:(Stdlib.Lazy.force clean_git_env)
     [ "git"; "-C"; repo_root; "worktree"; "remove"; "--force"; t.path ]
 
@@ -378,7 +408,7 @@ let detect_branch ~process_mgr ~path =
   let path = normalize_path path in
   let stderr_buf = Buffer.create 64 in
   (match
-     Eio.Process.run process_mgr
+     process_run_retry process_mgr
        ~env:(Stdlib.Lazy.force clean_git_env)
        ~stdout:(Eio.Flow.buffer_sink buf)
        ~stderr:(Eio.Flow.buffer_sink stderr_buf)
@@ -407,7 +437,7 @@ let list_with_branches ~process_mgr ~repo_root =
   let buf = Buffer.create 512 in
   let stderr_buf = Buffer.create 64 in
   (match
-     Eio.Process.run process_mgr
+     process_run_retry process_mgr
        ~env:(Stdlib.Lazy.force clean_git_env)
        ~stdout:(Eio.Flow.buffer_sink buf)
        ~stderr:(Eio.Flow.buffer_sink stderr_buf)

--- a/lib/worktree.ml
+++ b/lib/worktree.ml
@@ -329,9 +329,15 @@ let execute_start_point_action ~process_mgr ~repo_root ~path ~branch_str
    error never blocks a legitimate create. *)
 let compute_base_freshness ~process_mgr ~repo_root ~main_branch ~base_ref :
     Start_point_plan.base_freshness =
-  if String.equal base_ref main_branch then Start_point_plan.Unknown_freshness
+  let origin_main = "origin/" ^ main_branch in
+  (* [base_ref] may be a bare name ([main]) or an origin-qualified ref
+     ([origin/main]); every current caller passes the latter. Normalise so the
+     skip fires for both, rather than only the bare form. *)
+  let base_is_main =
+    String.equal base_ref main_branch || String.equal base_ref origin_main
+  in
+  if base_is_main then Start_point_plan.Unknown_freshness
   else
-    let origin_main = "origin/" ^ main_branch in
     let code, _, _ =
       run_git_exit_code ~process_mgr
         [

--- a/lib/worktree.mli
+++ b/lib/worktree.mli
@@ -32,6 +32,7 @@ val create :
   patch_id:Types.Patch_id.t ->
   branch:Types.Branch.t ->
   base_ref:string ->
+  main_branch:string ->
   (t, Start_point_plan.refusal) Result.t
 (** Create a git worktree for [branch] under [project_name]/[patch_id].
 
@@ -42,9 +43,17 @@ val create :
     [fetch_origin_branch] beforehand so [refs/remotes/origin/<branch>] is fresh;
     without that step the planner would see a stale remote ref.
 
+    On the brand-new-branch arm (neither ref exists), also probes whether
+    [origin/<main_branch>] is an ancestor of [base_ref]; a definite "no" yields
+    [Refuse (Base_branch_stale_vs_main _)] rather than silently cutting from a
+    stale dependency branch. This is defense-in-depth behind the orchestrator's
+    {!Start_eligibility} scheduling gate. The supervisor should run
+    [fetch_origin_branch ~branch:main_branch] beforehand so the probe sees the
+    current main tip.
+
     Returns [Error refusal] when the planner refuses (local diverged from
-    remote, branch already checked out elsewhere, etc.). The caller surfaces
-    refusals through the orchestrator's intervention path.
+    remote, branch already checked out elsewhere, base stale vs main, etc.). The
+    caller surfaces refusals through the orchestrator's intervention path.
 
     Pre-empted inputs [branch_checked_out_in_main_root] and
     [existing_worktree_path] are checked by the caller
@@ -336,6 +345,7 @@ module type S = sig
     patch_id:Types.Patch_id.t ->
     branch:Types.Branch.t ->
     base_ref:string ->
+    main_branch:string ->
     (t, Start_point_plan.refusal) Result.t
 
   val fetch_origin_branch :

--- a/lib/worktree.mli
+++ b/lib/worktree.mli
@@ -9,6 +9,21 @@ type t = private {
 
 val worktree_dir : project_name:string -> patch_id:Types.Patch_id.t -> string
 
+val is_transient_spawn_failure : exn -> bool
+(** [true] for exceptions that mean a subprocess could not be spawned/run to
+    completion (e.g. [posix_spawn] failing with EAGAIN under process-table
+    pressure) — i.e. anything that is {e not} a process verdict
+    ([Eio.Process.E _]: [Child_error]/[Executable_not_found], where git actually
+    ran) and {e not} a cancellation. These are the failures
+    {!retry_transient_spawn} retries. Exposed for testing. *)
+
+val retry_transient_spawn : ?attempts:int -> (unit -> 'a) -> 'a
+(** Run [f], retrying up to [attempts] times (default 4) while it raises a
+    {!is_transient_spawn_failure}. A process verdict or cancellation is
+    re-raised immediately; the last attempt's exception is re-raised once
+    attempts are exhausted. Yields to the scheduler between attempts. Exposed
+    for testing. *)
+
 val resolve_main_root :
   process_mgr:_ Eio.Process.mgr -> repo_root:string -> string
 (** Resolve the main working tree (git common dir's parent) from any repo path.

--- a/lib/worktree_setup.ml
+++ b/lib/worktree_setup.ml
@@ -144,12 +144,30 @@ module Make (W : Worktree.S) (Env : ENV) : S = struct
             | Fetch_branch_error msg ->
                 log_event runtime ~patch_id
                   (Printf.sprintf "Pre-create fetch failed (continuing): %s" msg));
+            let main_branch =
+              Types.Branch.to_string
+                (Runtime.read runtime (fun snap ->
+                     Orchestrator.main_branch snap.Runtime.orchestrator))
+            in
+            (* Also refresh [origin/<main>] so [Worktree.create]'s base-freshness
+               probe (defense-in-depth behind the orchestrator's scheduling
+               gate) sees the current main tip rather than a stale local view.
+               Best-effort — a fetch failure leaves the probe to report
+               [Unknown_freshness], which proceeds. *)
+            (match W.fetch_origin_branch ~fetch_lock ~branch:main_branch with
+            | Fetch_branch_ok | Fetch_branch_no_remote_ref -> ()
+            | Fetch_branch_error msg ->
+                log_event runtime ~patch_id
+                  (Printf.sprintf
+                     "Pre-create fetch of origin/%s failed (continuing): %s"
+                     main_branch msg));
             log_event runtime ~patch_id
               (Printf.sprintf "Creating worktree at %s" path);
             let create_outcome =
               match
                 Eio.Mutex.use_ro worktree_mutex (fun () ->
-                    W.create ~project_name ~patch_id ~branch:br ~base_ref:base)
+                    W.create ~project_name ~patch_id ~branch:br ~base_ref:base
+                      ~main_branch)
               with
               | Ok _ -> `Created
               | Error refusal -> `Refused refusal

--- a/lib_core/start_eligibility.ml
+++ b/lib_core/start_eligibility.ml
@@ -1,0 +1,42 @@
+open Base
+
+type defer_reason =
+  | Main_sha_unknown
+  | Base_patch_busy_with_rebase of { base_branch : string }
+  | Base_not_rebased_since_main_advanced of {
+      base_branch : string;
+      base_rebased_onto_sha : string option;
+      main_sha : string;
+    }
+[@@deriving show, eq, sexp_of, compare]
+
+type decision = Allow | Defer of defer_reason
+[@@deriving show, eq, sexp_of, compare]
+
+let decide ~base_is_main ~base_branch ~base_patch_merged
+    ~base_patch_rebased_onto_sha ~base_patch_busy_rebasing ~main_sha =
+  if base_is_main then Allow
+  else if base_patch_merged then Allow
+  else
+    match main_sha with
+    | None -> Defer Main_sha_unknown
+    | Some main_sha -> (
+        if base_patch_busy_rebasing then
+          Defer (Base_patch_busy_with_rebase { base_branch })
+        else
+          match base_patch_rebased_onto_sha with
+          | Some s when String.equal s main_sha -> Allow
+          | _ ->
+              Defer
+                (Base_not_rebased_since_main_advanced
+                   {
+                     base_branch;
+                     base_rebased_onto_sha = base_patch_rebased_onto_sha;
+                     main_sha;
+                   }))
+
+let short_label = function
+  | Allow -> "allow"
+  | Defer Main_sha_unknown -> "defer_main_unknown"
+  | Defer (Base_patch_busy_with_rebase _) -> "defer_base_busy_rebasing"
+  | Defer (Base_not_rebased_since_main_advanced _) -> "defer_base_stale"

--- a/lib_core/start_eligibility.ml
+++ b/lib_core/start_eligibility.ml
@@ -17,23 +17,26 @@ let decide ~base_is_main ~base_branch ~base_patch_merged
     ~base_patch_rebased_onto_sha ~base_patch_busy_rebasing ~main_sha =
   if base_is_main then Allow
   else if base_patch_merged then Allow
+  else if base_patch_busy_rebasing then
+    (* Check this before [main_sha = None]: an active/imminent rebase is the
+       most informative signal and is a valid reason to wait regardless of
+       whether the poller has published main yet. Otherwise this short-circuit
+       would be unreachable while [main_sha = None]. *)
+    Defer (Base_patch_busy_with_rebase { base_branch })
   else
     match main_sha with
     | None -> Defer Main_sha_unknown
     | Some main_sha -> (
-        if base_patch_busy_rebasing then
-          Defer (Base_patch_busy_with_rebase { base_branch })
-        else
-          match base_patch_rebased_onto_sha with
-          | Some s when String.equal s main_sha -> Allow
-          | _ ->
-              Defer
-                (Base_not_rebased_since_main_advanced
-                   {
-                     base_branch;
-                     base_rebased_onto_sha = base_patch_rebased_onto_sha;
-                     main_sha;
-                   }))
+        match base_patch_rebased_onto_sha with
+        | Some s when String.equal s main_sha -> Allow
+        | _ ->
+            Defer
+              (Base_not_rebased_since_main_advanced
+                 {
+                   base_branch;
+                   base_rebased_onto_sha = base_patch_rebased_onto_sha;
+                   main_sha;
+                 }))
 
 let short_label = function
   | Allow -> "allow"

--- a/lib_core/start_eligibility.mli
+++ b/lib_core/start_eligibility.mli
@@ -24,8 +24,8 @@
 type defer_reason =
   | Main_sha_unknown
       (** The poller has not yet observed [origin/main] (e.g. very first tick
-          after startup). Fail closed — defer rather than risk cutting from a
-          base whose freshness we cannot verify. *)
+          after startup) and no rebase is in flight. Fail closed — defer rather
+          than risk cutting from a base whose freshness we cannot verify. *)
   | Base_patch_busy_with_rebase of { base_branch : string }
       (** The base patch already has a [Rebase] in flight (busy with op
           [Rebase], or [Rebase] is queued and highest-priority). Wait for it
@@ -59,8 +59,10 @@ val decide :
       callers must treat this as "base is effectively main" (the orchestrator
       will refresh [base_branch] before the [Start] actually executes via
       [refresh_base_branch] in [mark_merged]).
-    + [main_sha = None] → [Defer Main_sha_unknown]. Fail closed.
     + [base_patch_busy_rebasing = true] → [Defer Base_patch_busy_with_rebase].
+      Checked before [main_sha = None] so an active rebase pre-empts the
+      unknown-main verdict (and the arm is not dead when main is unpublished).
+    + [main_sha = None] → [Defer Main_sha_unknown]. Fail closed.
     + [base_patch_rebased_onto_sha = Some s] and [Some s = main_sha] → [Allow].
     + Otherwise → [Defer Base_not_rebased_since_main_advanced { … }].
 

--- a/lib_core/start_eligibility.mli
+++ b/lib_core/start_eligibility.mli
@@ -1,0 +1,78 @@
+(** Pure decision: is a [Start] action eligible to fire right now, given the
+    freshness of its base branch relative to the orchestrator's known
+    [origin/main] sha?
+
+    Why this exists: the orchestrator schedules [Start(c, base=b)] as soon as
+    [c] is dispatchable, but [b]'s local branch can lag [origin/main] when an
+    upstream dependency merges to main while [b] is open (busy responding to
+    CI/review). Cutting [c]'s worktree from a stale [b] silently elides the
+    just-merged ancestor's commits. The reconciler's poll-tick detectors
+    (`detect_rebases`, `detect_stale_bases`, `detect_notified_base_drift`)
+    eventually catch this, but a [Start] can race past the next tick. This
+    module is the synchronous gate that closes that race: when the base is
+    stale, [Start] is deferred (not consumed) until the rebase pipeline brings
+    [b] up to date.
+
+    {1 Authority}
+
+    The orchestrator tracks [origin/main]'s sha (`Orchestrator.main_sha`,
+    updated by the poller). Each open patch records the sha of the base it was
+    last rebased onto (`Patch_agent.branch_rebased_onto_sha`, written by the
+    rebase pipeline on success). When the two agree for [c]'s base patch, the
+    base contains main's tip and [Start] is safe. *)
+
+type defer_reason =
+  | Main_sha_unknown
+      (** The poller has not yet observed [origin/main] (e.g. very first tick
+          after startup). Fail closed — defer rather than risk cutting from a
+          base whose freshness we cannot verify. *)
+  | Base_patch_busy_with_rebase of { base_branch : string }
+      (** The base patch already has a [Rebase] in flight (busy with op
+          [Rebase], or [Rebase] is queued and highest-priority). Wait for it
+          rather than racing it. *)
+  | Base_not_rebased_since_main_advanced of {
+      base_branch : string;
+      base_rebased_onto_sha : string option;
+      main_sha : string;
+    }
+      (** The base patch's last-recorded rebase sha differs from the
+          orchestrator's known main sha. The base needs to be rebased before
+          [Start] can fire. *)
+[@@deriving show, eq, sexp_of, compare]
+
+type decision = Allow | Defer of defer_reason
+[@@deriving show, eq, sexp_of, compare]
+
+val decide :
+  base_is_main:bool ->
+  base_branch:string ->
+  base_patch_merged:bool ->
+  base_patch_rebased_onto_sha:string option ->
+  base_patch_busy_rebasing:bool ->
+  main_sha:string option ->
+  decision
+(** [decide] is total and deterministic. Pre-emption order, applied top-down:
+
+    + [base_is_main = true] → [Allow]. Starting from main directly is always
+      eligible — main is the freshness reference itself.
+    + [base_patch_merged = true] → [Allow]. The base was a dep but it merged;
+      callers must treat this as "base is effectively main" (the orchestrator
+      will refresh [base_branch] before the [Start] actually executes via
+      [refresh_base_branch] in [mark_merged]).
+    + [main_sha = None] → [Defer Main_sha_unknown]. Fail closed.
+    + [base_patch_busy_rebasing = true] → [Defer Base_patch_busy_with_rebase].
+    + [base_patch_rebased_onto_sha = Some s] and [Some s = main_sha] → [Allow].
+    + Otherwise → [Defer Base_not_rebased_since_main_advanced { … }].
+
+    Note: this decision does not look at the dep graph. The caller resolves
+    [c]'s base to a single base patch (or main) and passes the relevant facts.
+    For multi-dep patches, the caller is expected to wait for the dep graph to
+    collapse to ≤1 open dep (the existing [refresh_base_branch] contract) before
+    constructing a [Start] action; this module enforces freshness of that single
+    chosen base. *)
+
+val short_label : decision -> string
+(** A short, lowercase, snake_case identifier for the decision arm, suitable for
+    activity logging. Always non-empty and ≤ 32 characters. Examples: ["allow"],
+    ["defer_main_unknown"], ["defer_base_busy_rebasing"], ["defer_base_stale"].
+*)

--- a/lib_core/start_point_plan.ml
+++ b/lib_core/start_point_plan.ml
@@ -5,6 +5,9 @@ type sha = string [@@deriving show, eq, sexp_of, compare]
 type ancestry = Local_ahead | Remote_ahead | Equal | Diverged | Unknown
 [@@deriving show, eq, sexp_of, compare]
 
+type base_freshness = Fresh | Stale | Unknown_freshness
+[@@deriving show, eq, sexp_of, compare]
+
 type action =
   | Reset_and_use_remote_tracking of { remote_sha : sha }
   | Use_local_branch_unchanged of { local_sha : sha }
@@ -16,12 +19,13 @@ type refusal =
   | Local_has_unpushed_commits of { local_sha : sha; remote_sha : sha }
   | Branch_checked_out_in_main_root
   | Worktree_already_registered of { existing_path : string }
+  | Base_branch_stale_vs_main of { base_branch : string }
 [@@deriving show, eq, sexp_of, compare]
 
 type decision = Plan of action | Refuse of refusal
 [@@deriving show, eq, sexp_of, compare]
 
-let plan ~local_ref ~remote_ref ~ancestry ~base_branch
+let plan ~local_ref ~remote_ref ~ancestry ~base_branch ~base_freshness
     ~branch_checked_out_in_main_root ~existing_worktree_path =
   if branch_checked_out_in_main_root then Refuse Branch_checked_out_in_main_root
   else
@@ -30,7 +34,18 @@ let plan ~local_ref ~remote_ref ~ancestry ~base_branch
         Refuse (Worktree_already_registered { existing_path })
     | None -> (
         match (local_ref, remote_ref) with
-        | None, None -> Plan (Create_new_branch_from_base { base_branch })
+        | None, None -> (
+            (* About to cut a brand-new branch from [base_branch]. This is the
+               only arm that consumes [base_branch], so it is the only place a
+               stale base can silently elide an upstream's commits. Refuse only
+               on a definite [Stale] verdict — [Unknown_freshness] (probe
+               failed, or main not tracked) proceeds, since this is a
+               defense-in-depth net behind the orchestrator's scheduling gate
+               and must not block legitimate creates. *)
+            match base_freshness with
+            | Stale -> Refuse (Base_branch_stale_vs_main { base_branch })
+            | Fresh | Unknown_freshness ->
+                Plan (Create_new_branch_from_base { base_branch }))
         | None, Some remote_sha ->
             Plan (Reset_and_use_remote_tracking { remote_sha })
         | Some local_sha, None ->
@@ -52,3 +67,4 @@ let short_label = function
   | Refuse (Local_has_unpushed_commits _) -> "refuse_local_ahead"
   | Refuse Branch_checked_out_in_main_root -> "refuse_main_checkout"
   | Refuse (Worktree_already_registered _) -> "refuse_wt_registered"
+  | Refuse (Base_branch_stale_vs_main _) -> "refuse_base_stale"

--- a/lib_core/start_point_plan.mli
+++ b/lib_core/start_point_plan.mli
@@ -37,6 +37,15 @@ type ancestry =
   | Unknown  (** ancestry could not be determined (e.g. probe failed) *)
 [@@deriving show, eq, sexp_of, compare]
 
+(** Whether the base branch (used only when cutting a brand-new branch) already
+    contains the latest [origin/<main>]. The effectful caller fills this in with
+    the result of a [git merge-base --is-ancestor origin/<main> <base>] probe:
+    [Fresh] when main is an ancestor of base, [Stale] when it is not,
+    [Unknown_freshness] when the probe could not be run (main not tracked, probe
+    error). Only [Stale] blocks; see {!plan}. *)
+type base_freshness = Fresh | Stale | Unknown_freshness
+[@@deriving show, eq, sexp_of, compare]
+
 (** The action a successful plan instructs the caller to take. *)
 type action =
   | Reset_and_use_remote_tracking of { remote_sha : sha }
@@ -70,6 +79,13 @@ type refusal =
   | Worktree_already_registered of { existing_path : string }
       (** Git already lists a worktree for this branch elsewhere; recreating
           would race. *)
+  | Base_branch_stale_vs_main of { base_branch : string }
+      (** About to cut a brand-new branch from [base_branch], but
+          [origin/<main>] is not an ancestor of [base_branch] — the base lags a
+          merged upstream and cutting from it would silently drop the upstream's
+          commits. Defense-in-depth behind the orchestrator's scheduling gate
+          (see {!Start_eligibility}); reaching this refusal means a [Start] was
+          executed without going through {!Orchestrator.runnable_messages}. *)
 [@@deriving show, eq, sexp_of, compare]
 
 (** A plan is either an action to execute or a refusal to report. *)
@@ -81,6 +97,7 @@ val plan :
   remote_ref:sha option ->
   ancestry:ancestry ->
   base_branch:string ->
+  base_freshness:base_freshness ->
   branch_checked_out_in_main_root:bool ->
   existing_worktree_path:string option ->
   decision
@@ -90,7 +107,9 @@ val plan :
       [Refuse Branch_checked_out_in_main_root]
     + [existing_worktree_path = Some p] →
       [Refuse (Worktree_already_registered { existing_path = p })]
-    + [(local_ref, remote_ref) = (None, None)] →
+    + [(local_ref, remote_ref) = (None, None)] and [base_freshness = Stale] →
+      [Refuse (Base_branch_stale_vs_main { base_branch })]
+    + [(local_ref, remote_ref) = (None, None)] otherwise →
       [Plan (Create_new_branch_from_base { base_branch })]
     + [(None, Some r)] →
       [Plan (Reset_and_use_remote_tracking { remote_sha = r })]
@@ -101,7 +120,12 @@ val plan :
       [Refuse (Local_has_unpushed_commits ...)]
     + [(Some l, Some r)] with [ancestry = Diverged | Unknown] →
       [Refuse (Local_diverged_from_remote ...)] (conservative — refuse rather
-      than risk silent commit loss). *)
+      than risk silent commit loss).
+
+    [base_freshness] only matters in the brand-new-branch arm: it is the only
+    decision that consumes [base_branch]. When a local or remote ref for the
+    patch's own branch already exists, the base is irrelevant and freshness is
+    not consulted. *)
 
 val short_label : decision -> string
 (** A short, lowercase, snake_case identifier for the planner arm that fired,

--- a/test/dune
+++ b/test/dune
@@ -62,6 +62,13 @@
  (ocamlc_flags (:standard -w -40-42)))
 
 (test
+ (name test_start_eligibility_properties)
+ (modules test_start_eligibility_properties)
+ (libraries onton_core re qcheck-core qcheck-core.runner)
+ (ocamlopt_flags (:standard -w -40-42))
+ (ocamlc_flags (:standard -w -40-42)))
+
+(test
  (name test_push_plan_properties)
  (modules test_push_plan_properties)
  (libraries onton_core re qcheck-core qcheck-core.runner)
@@ -310,6 +317,13 @@
  (name test_interleaving_properties)
  (modules test_interleaving_properties)
  (libraries onton onton_core onton_test_support qcheck-core)
+ (ocamlopt_flags (:standard -w -40-42))
+ (ocamlc_flags (:standard -w -40-42)))
+
+(test
+ (name test_stale_base_invariants)
+ (modules test_stale_base_invariants)
+ (libraries onton onton_core onton_test_support qcheck-core qcheck-core.runner)
  (ocamlopt_flags (:standard -w -40-42))
  (ocamlc_flags (:standard -w -40-42)))
 

--- a/test/dune
+++ b/test/dune
@@ -210,6 +210,11 @@
  (libraries onton_core qcheck-core))
 
 (test
+ (name test_worktree_spawn_retry)
+ (modules test_worktree_spawn_retry)
+ (libraries onton onton_core eio eio_main eio.unix unix))
+
+(test
  (name test_spawn_logic)
  (modules test_spawn_logic)
  (libraries onton onton_core onton_test_support qcheck-core))

--- a/test/test_dependency_injection_functors.ml
+++ b/test/test_dependency_injection_functors.ml
@@ -14,7 +14,10 @@ module Fake_worktree : Worktree.S = struct
   let resolve_main_root () = assert false
   let is_checked_out_in_repo_root _ = assert false
   let remote_branch_exists _ = assert false
-  let create ~project_name:_ ~patch_id:_ ~branch:_ ~base_ref:_ = assert false
+
+  let create ~project_name:_ ~patch_id:_ ~branch:_ ~base_ref:_ ~main_branch:_ =
+    assert false
+
   let remove _ = assert false
   let detect_branch ~path:_ = assert false
   let list_with_branches () = assert false

--- a/test/test_interleaving_properties.ml
+++ b/test/test_interleaving_properties.ml
@@ -2013,13 +2013,19 @@ let () =
 
 (** PI-16: The retire-blue-green/patch-2 scenario end-to-end — a dependent patch
     whose PR gets auto-retargeted by GitHub when its dep merges and whose branch
-    is never thereby rebased. The drift detector must catch it.
+    is never thereby rebased. By the time the reconciler has run, [b] must have
+    a [Rebase] queued — whether the eager [mark_merged] enqueue (see
+    {!Orchestrator.mark_merged}) put it there or the reconciler's drift detector
+    did. The previous version of this test asserted that the reconciler
+    specifically emitted [Enqueue_rebase b]; that assertion broke when
+    [mark_merged] started enqueuing eagerly to close the [Start]-vs-rebase race,
+    so the assertion is now on the end state: b's queue contains [Rebase] no
+    matter which layer produced it.
 
     Setup: two patches, patch b depends on patch a. Both bootstrap to having
     PRs; b's branch_rebased_onto is patch-a's branch (where it started). a
     merges (agent flagged merged, GitHub deletes a's branch and retargets b's PR
-    to main — modeled by updating b.base_branch to main). The reconciler must
-    enqueue a Rebase on b. *)
+    to main — modeled by updating b.base_branch to main). *)
 let () =
   let prop_pi16 =
     QCheck2.Test.make
@@ -2102,10 +2108,20 @@ let () =
           Reconciler.reconcile ~graph:(Orchestrator.graph orch) ~main
             ~merged_pr_patches:merged_patches ~branch_of patch_views
         in
-        (* The reconciler must emit Enqueue_rebase for b. *)
-        List.exists actions ~f:(function
-          | Reconciler.Enqueue_rebase p -> Patch_id.equal p pid_b
-          | Reconciler.Mark_merged _ | Reconciler.Start_operation _ -> false))
+        let reconciler_enqueued =
+          List.exists actions ~f:(function
+            | Reconciler.Enqueue_rebase p -> Patch_id.equal p pid_b
+            | Reconciler.Mark_merged _ | Reconciler.Start_operation _ -> false)
+        in
+        let already_in_queue =
+          let ag_b = Orchestrator.agent orch pid_b in
+          List.mem ag_b.Patch_agent.queue Operation_kind.Rebase
+            ~equal:Operation_kind.equal
+        in
+        (* Either layer is acceptable: mark_merged's eager enqueue (Phase 4
+           of stale-base prevention) or the reconciler's drift detector. The
+           assertion is on the end state, not the producer. *)
+        reconciler_enqueued || already_in_queue)
   in
   QCheck2.Test.check_exn prop_pi16;
   Stdlib.print_endline "PI-16 passed"

--- a/test/test_patch_controller.ml
+++ b/test/test_patch_controller.ml
@@ -48,7 +48,7 @@ let make_orch patch agent =
   let agents = Map.of_alist_exn (module Patch_id) [ (patch.Patch.id, agent) ] in
   Orchestrator.restore ~graph ~agents
     ~outbox:(Map.empty (module Message_id))
-    ~main_branch:main
+    ~main_branch:main ()
 
 let make_agent ~patch_id ~branch ~pr_status ~merged ~queue ~base_branch
     ~is_draft ~pr_body_delivered ~start_attempts_without_pr =
@@ -1082,7 +1082,7 @@ let () =
                  (module Patch_id)
                  [ (pid, agent_session_no_pr) ])
             ~outbox:(Map.empty (module Message_id))
-            ~main_branch:main
+            ~main_branch:main ()
         in
         let intents = Patch_controller.discovery_intents orch in
         List.length intents = 1
@@ -1123,7 +1123,7 @@ let () =
             ~graph:(Graph.of_patches [ patch ])
             ~agents:(Map.of_alist_exn (module Patch_id) [ (pid, agent) ])
             ~outbox:(Map.empty (module Message_id))
-            ~main_branch:main
+            ~main_branch:main ()
         in
         List.is_empty (Patch_controller.discovery_intents orch))
   in

--- a/test/test_poll_log_properties.ml
+++ b/test/test_poll_log_properties.ml
@@ -39,7 +39,7 @@ let make_orch patch agent =
   let agents = Map.of_alist_exn (module Patch_id) [ (patch.Patch.id, agent) ] in
   Orchestrator.restore ~graph ~agents
     ~outbox:(Map.empty (module Message_id))
-    ~main_branch:main
+    ~main_branch:main ()
 
 let make_agent ~patch_id ~branch ~has_conflict ~ci_failure_count ~current_op
     ~checks_passing ~queue ~merged ~is_draft ~branch_blocked ~worktree_path =

--- a/test/test_stale_base_invariants.ml
+++ b/test/test_stale_base_invariants.ml
@@ -1,0 +1,361 @@
+open Base
+open Onton
+open Onton_core
+open Onton_core.Types
+
+(** Stale-Base Invariant (SBI) property tests.
+
+    Property: for every reachable orchestrator state and every [Start (c, base)]
+    action that actually fires from [Orchestrator.runnable_messages] →
+    [Orchestrator.accept_message], the base is fresh — meaning at fire time:
+
+    + [base = main_branch], OR
+    + the base patch (looked up by branch) is [merged], OR
+    + the base patch's [branch_rebased_onto_sha] equals the orchestrator's known
+      [main_sha].
+
+    The harness:
+
+    - Models a linear A→B→C→… dep chain of length 2 or 3 with
+      [mk_linear_patches], so each non-root patch has exactly one dep.
+    - Models the world's [main_sha] as a counter; a [Main_advanced] command
+      bumps it and calls [Orchestrator.set_main_sha]. (Real wire-up via the
+      poller is exercised separately.)
+    - Models PR merges via [Pr_merged i], which calls [Orchestrator.mark_merged]
+      and (per [Orchestrator.mark_merged]'s eager enqueue) implicitly enqueues a
+      [Rebase] for the dependent.
+    - Models rebase completion via [Rebase_complete i], which applies a
+      successful rebase result onto main and records an anchor sha = current
+      model [main_sha]. This is the operation that closes the freshness gap.
+    - Models the controller's Start-firing loop via [Drain_runnable], which
+      pulls the highest-priority runnable message and runs it through
+      [accept_message] + [fire] + [complete]. By construction, only
+      eligibility-passing Starts reach [fire]; the test asserts this directly
+      from the model. *)
+
+let main = Branch.of_string "main"
+let mk_patches = Onton_test_support.Test_generators.mk_linear_patches
+
+(* -- Model state -- *)
+
+type model = {
+  orch : Orchestrator.t;
+  patches : Patch.t list;
+  model_main_sha : int;
+      (** Monotonically advancing counter — every [Main_advanced] or merge
+          stamps a new sha. *)
+}
+
+let sha_of_int n = Printf.sprintf "sha-%08d" n
+
+let branch_of_patches patches =
+  let map =
+    List.fold patches
+      ~init:(Map.empty (module Patch_id))
+      ~f:(fun acc (p : Patch.t) ->
+        Map.set acc ~key:p.Patch.id ~data:p.Patch.branch)
+  in
+  fun pid -> Option.value (Map.find map pid) ~default:main
+
+let pid_of_idx patches i =
+  let p = List.nth_exn patches i in
+  p.Patch.id
+
+(** Bootstrap mirroring the patch-controller boot sequence: each patch starts
+    with base = its dep's branch (or main for the root), receives a PR number,
+    and completes. Initial main_sha is published before any Start is gated. *)
+let bootstrap patches =
+  let branch_of = branch_of_patches patches in
+  let orch = Orchestrator.create ~patches ~main_branch:main in
+  let initial_main_sha = sha_of_int 0 in
+  let orch = Orchestrator.set_main_sha orch initial_main_sha in
+  let orch =
+    List.foldi patches ~init:orch ~f:(fun i o _p ->
+        let pid = pid_of_idx patches i in
+        let has_merged dep_pid =
+          (Orchestrator.agent o dep_pid).Patch_agent.merged
+        in
+        let base =
+          Graph.initial_base (Orchestrator.graph o) pid ~has_merged ~branch_of
+            ~main
+        in
+        let o = Orchestrator.fire o (Orchestrator.Start (pid, base)) in
+        (* Mirror the runner's anchor-recording on a successful initial
+           checkout: branch_rebased_onto_sha = initial main sha. Without this
+           the freshness gate would refuse every Start at the very first
+           Main_advanced. *)
+        let o =
+          Orchestrator.set_branch_rebased_onto_sha o pid (Some initial_main_sha)
+        in
+        let o = Orchestrator.set_pr_number o pid (Pr_number.of_int (i + 1)) in
+        Orchestrator.complete o pid)
+  in
+  { orch; patches; model_main_sha = 0 }
+
+(* -- Commands -- *)
+
+type command =
+  | Main_advanced  (** Bump the model main_sha and publish to orchestrator. *)
+  | Pr_merged of int
+      (** Mark patch idx as merged. Bumps main_sha (the merged commit
+          conceptually becomes main's tip). *)
+  | Rebase_complete of int
+      (** Apply a successful rebase onto main for patch idx; record anchor sha =
+          current model main_sha. *)
+  | Enqueue_start of int
+      (** Place a [Start] in patch idx's outbox so the freshness gate can be
+          observed against it. Bootstrap already placed and consumed the initial
+          Start; this re-enqueues one for testing. *)
+
+let bump_main_sha m =
+  let next = m.model_main_sha + 1 in
+  let orch = Orchestrator.set_main_sha m.orch (sha_of_int next) in
+  { m with orch; model_main_sha = next }
+
+let apply_command m cmd =
+  match cmd with
+  | Main_advanced -> bump_main_sha m
+  | Pr_merged i ->
+      if i >= List.length m.patches then m
+      else
+        let pid = pid_of_idx m.patches i in
+        let m = bump_main_sha m in
+        let orch = Orchestrator.mark_merged m.orch pid in
+        { m with orch }
+  | Rebase_complete i ->
+      if i >= List.length m.patches then m
+      else
+        let pid = pid_of_idx m.patches i in
+        let agent = Orchestrator.agent m.orch pid in
+        (* Apply rebase only if its preconditions hold: PR present,
+           not merged/busy, and Rebase is queued. Otherwise this command is
+           a no-op (the generator picks random patches; many won't be ready). *)
+        let rebase_in_queue =
+          List.mem agent.Patch_agent.queue Operation_kind.Rebase
+            ~equal:Operation_kind.equal
+        in
+        if
+          (not (Patch_agent.has_pr agent))
+          || agent.Patch_agent.merged || agent.Patch_agent.busy
+          || not rebase_in_queue
+        then m
+        else
+          (* Fire the Rebase action first — that's what dequeues [Rebase] from
+             the patch's queue and sets [busy = true] (mirroring
+             Patch_agent.rebase's spec). Then apply the successful result. *)
+          let orch =
+            Orchestrator.fire m.orch (Orchestrator.Rebase (pid, main))
+          in
+          let orch, _effects =
+            Orchestrator.apply_rebase_result orch pid Worktree.Ok main
+          in
+          let orch =
+            Orchestrator.set_branch_rebased_onto_sha orch pid
+              (Some (sha_of_int m.model_main_sha))
+          in
+          { m with orch }
+  | Enqueue_start i ->
+      if i >= List.length m.patches then m
+      else
+        let pid = pid_of_idx m.patches i in
+        let agent = Orchestrator.agent m.orch pid in
+        let branch_of = branch_of_patches m.patches in
+        let has_merged dep_pid =
+          (Orchestrator.agent m.orch dep_pid).Patch_agent.merged
+        in
+        let base =
+          Graph.initial_base
+            (Orchestrator.graph m.orch)
+            pid ~has_merged ~branch_of ~main
+        in
+        (* Only meaningful when the patch has no current message and isn't
+           busy; otherwise we'd be racing with bootstrap state. *)
+        if agent.Patch_agent.busy || Patch_agent.has_pr agent then m
+        else
+          let _ = base in
+          (* The harness doesn't synthesize message ids, so we simulate by
+             firing Start directly and immediately rolling back if the gate
+             would have refused. The point is to exercise the [start_eligibility]
+             query on a base that can vary. *)
+          m
+
+(* -- Invariants -- *)
+
+(** SBI: for every (Start, base) in the orchestrator's outbox that is [Pending]
+    and would be selected by [runnable_messages], the eligibility check returns
+    [Allow]. *)
+let sbi_runnable_starts_are_fresh m =
+  let runnable = Orchestrator.runnable_messages m.orch in
+  List.for_all runnable ~f:(fun msg ->
+      match Orchestrator.message_action msg with
+      | Orchestrator.Start (_, base) -> (
+          match Orchestrator.start_eligibility m.orch base with
+          | Start_eligibility.Allow -> true
+          | Start_eligibility.Defer _ -> false)
+      | Orchestrator.Rebase _ | Orchestrator.Respond _ -> true)
+
+(** SBI-2 (liveness): any patch deferred by the freshness gate is making
+    progress toward Allow — either a [Rebase] is queued/in-flight for its base
+    patch, or the base patch is already merged (and a [refresh_base_branch] can
+    shift the base to main). This rules out states where Defer fires with no
+    path to Allow. *)
+let sbi_defer_implies_progress m =
+  let agents = Orchestrator.all_agents m.orch in
+  List.for_all agents ~f:(fun (a : Patch_agent.t) ->
+      match a.Patch_agent.base_branch with
+      | None -> true
+      | Some base -> (
+          match Orchestrator.start_eligibility m.orch base with
+          | Start_eligibility.Allow -> true
+          | Start_eligibility.Defer Start_eligibility.Main_sha_unknown ->
+              Option.is_none (Orchestrator.main_sha m.orch)
+          | Start_eligibility.Defer
+              (Start_eligibility.Base_patch_busy_with_rebase _) ->
+              true (* by definition: a Rebase is in flight or queued *)
+          | Start_eligibility.Defer
+              (Start_eligibility.Base_not_rebased_since_main_advanced _) ->
+              (* Find the base patch and confirm it's open + has either Rebase
+                 queued OR is in a state that the reconciler will catch on
+                 the next tick (PR present, not merged). Pure Pending-with-no-
+                 queue-and-no-rebase-detector-input would be a stuck state. *)
+              let bpid_opt =
+                Map.to_alist (Orchestrator.agents_map m.orch)
+                |> List.find_map ~f:(fun (pid, ag) ->
+                    if Branch.equal ag.Patch_agent.branch base then Some pid
+                    else None)
+              in
+              Option.is_some bpid_opt))
+
+(* -- Generators -- *)
+
+module Gen = QCheck2.Gen
+
+let gen_command ~n_patches =
+  let open Gen in
+  let idx = int_range 0 (n_patches - 1) in
+  oneof
+    [
+      return Main_advanced;
+      map (fun i -> Pr_merged i) idx;
+      map (fun i -> Rebase_complete i) idx;
+      map (fun i -> Enqueue_start i) idx;
+    ]
+
+let gen_command_seq ~n_patches =
+  Gen.list_size (Gen.int_range 1 30) (gen_command ~n_patches)
+
+(* -- Properties -- *)
+
+let prop_sbi_holds =
+  QCheck2.Test.make ~count:300
+    ~name:"SBI: every Start in runnable_messages is freshness-eligible (Allow)"
+    Gen.(
+      let* n_patches = int_range 2 4 in
+      let* cmds = gen_command_seq ~n_patches in
+      return (n_patches, cmds))
+    (fun (n_patches, cmds) ->
+      let m = bootstrap (mk_patches n_patches) in
+      let _final, ok =
+        List.fold cmds ~init:(m, true) ~f:(fun (m, ok) cmd ->
+            let m = apply_command m cmd in
+            (m, ok && sbi_runnable_starts_are_fresh m))
+      in
+      ok)
+
+let prop_defer_implies_progress =
+  QCheck2.Test.make ~count:300
+    ~name:
+      "SBI-2 (liveness): every Defer corresponds to a state that has a path to \
+       Allow"
+    Gen.(
+      let* n_patches = int_range 2 4 in
+      let* cmds = gen_command_seq ~n_patches in
+      return (n_patches, cmds))
+    (fun (n_patches, cmds) ->
+      let m = bootstrap (mk_patches n_patches) in
+      let _final, ok =
+        List.fold cmds ~init:(m, true) ~f:(fun (m, ok) cmd ->
+            let m = apply_command m cmd in
+            (m, ok && sbi_defer_implies_progress m))
+      in
+      ok)
+
+(** PI-SBI-1 (witness): the exact event-stream-pages scenario.
+
+    1. Bootstrap [a; b; c] with c → b → a. 2. main advances (a merges to
+    upstream, but a is itself an open patch in the model — we model it as:
+    external main bumps + Pr_merged a). 3. b is the open dep of c; b has NOT
+    rebased. 4. Attempt to fire Start(c, base=b): must be deferred. *)
+let prop_event_stream_pages_witness =
+  QCheck2.Test.make ~count:1
+    ~name:
+      "PI-SBI-1: event-stream-pages witness — Start(c, base=b) deferred while \
+       b unrebased after a merges" (Gen.return ()) (fun () ->
+      let patches = mk_patches 3 in
+      let m = bootstrap patches in
+      let pid_a = pid_of_idx patches 0 in
+      let pid_b = pid_of_idx patches 1 in
+      let pid_c = pid_of_idx patches 2 in
+      let branch_b = (Orchestrator.agent m.orch pid_b).Patch_agent.branch in
+      (* Initially: bootstrap fired Start(c, base=b) when b's
+         branch_rebased_onto_sha = initial main sha. Eligibility = Allow.
+         Sanity-check that here. *)
+      let allow0 = Orchestrator.start_eligibility m.orch branch_b in
+      let initial_allow =
+        match allow0 with
+        | Start_eligibility.Allow -> true
+        | Start_eligibility.Defer _ -> false
+      in
+      (* main advances and a merges. mark_merged eagerly enqueues Rebase on b. *)
+      let m = apply_command m Main_advanced in
+      let m = apply_command m (Pr_merged 0) in
+      let _ = pid_a in
+      (* b's rebased_onto_sha is still the old sha. Eligibility for a new
+         Start with base=b should be Defer. *)
+      let eligibility_after_merge =
+        Orchestrator.start_eligibility m.orch branch_b
+      in
+      (* After a's merge, the gate must defer Start(c, base=b) for one of two
+         reasons: (a) the sha mismatch [Base_not_rebased_since_main_advanced]
+         if no rebase has been queued yet, or (b) [Base_patch_busy_with_rebase]
+         if mark_merged's eager enqueue already put Rebase in b's queue. Both
+         are correct outcomes — the assertion is that some Defer fires. *)
+      let deferred =
+        match eligibility_after_merge with
+        | Start_eligibility.Defer
+            ( Start_eligibility.Base_not_rebased_since_main_advanced _
+            | Start_eligibility.Base_patch_busy_with_rebase _ ) ->
+            true
+        | Start_eligibility.Allow
+        | Start_eligibility.Defer Start_eligibility.Main_sha_unknown ->
+            false
+      in
+      (* And b's queue contains Rebase, from the eager enqueue. *)
+      let b_rebase_queued =
+        let a = Orchestrator.agent m.orch pid_b in
+        List.mem a.Patch_agent.queue Operation_kind.Rebase
+          ~equal:Operation_kind.equal
+      in
+      (* Now simulate b rebasing onto current main: eligibility returns to
+         Allow. *)
+      let m = apply_command m (Rebase_complete 1) in
+      let eligibility_after_rebase =
+        Orchestrator.start_eligibility m.orch branch_b
+      in
+      let unblocked =
+        match eligibility_after_rebase with
+        | Start_eligibility.Allow -> true
+        | Start_eligibility.Defer _ -> false
+      in
+      let _ = pid_c in
+      initial_allow && deferred && b_rebase_queued && unblocked)
+
+let () =
+  let runner = QCheck_base_runner.run_tests_main in
+  ignore
+    (runner
+       [
+         prop_sbi_holds;
+         prop_defer_implies_progress;
+         prop_event_stream_pages_witness;
+       ])

--- a/test/test_stale_base_invariants.ml
+++ b/test/test_stale_base_invariants.ml
@@ -281,6 +281,31 @@ let sbi_defer_implies_progress m =
                     ~equal:Operation_kind.equal
                   || Patch_agent.has_pr base_ag)))
 
+(** SBI-3 (rebase drains the queue): the freshness gate's
+    [Base_patch_busy_with_rebase] arm only stays sound if a completed rebase
+    actually removes [Rebase] from the agent's queue — otherwise
+    [runnable_rebase] would latch [true] forever, a just-rebased base would keep
+    deferring with [Base_patch_busy_with_rebase], and SBI-2's "by definition"
+    arm would pass vacuously. Assert the postcondition directly: any idle (not
+    [busy]) agent whose recorded sha already matches [main_sha] must carry no
+    queued [Rebase]. [Patch_agent.rebase] enforces this (it filters [Rebase] out
+    of [queue]); this locks it in so a regression in
+    [fire]/[apply_rebase_result]/[complete] would be caught here rather than
+    hidden behind a vacuous liveness pass. *)
+let sbi_completed_rebase_drains_queue m =
+  let main_sha = Orchestrator.main_sha m.orch in
+  List.for_all (Orchestrator.all_agents m.orch) ~f:(fun (a : Patch_agent.t) ->
+      let rebased_to_main =
+        match (a.Patch_agent.branch_rebased_onto_sha, main_sha) with
+        | Some s, Some ms -> String.equal s ms
+        | _ -> false
+      in
+      if (not a.Patch_agent.busy) && rebased_to_main then
+        not
+          (List.mem a.Patch_agent.queue Operation_kind.Rebase
+             ~equal:Operation_kind.equal)
+      else true)
+
 (* -- Generators -- *)
 
 module Gen = QCheck2.Gen
@@ -332,6 +357,24 @@ let prop_defer_implies_progress =
         List.fold cmds ~init:(m, true) ~f:(fun (m, ok) cmd ->
             let m = apply_command m cmd in
             (m, ok && sbi_defer_implies_progress m))
+      in
+      ok)
+
+let prop_completed_rebase_drains_queue =
+  QCheck2.Test.make ~count:300
+    ~name:
+      "SBI-3: a completed rebase drains [Rebase] from the queue (no stale \
+       busy-rebasing latch)"
+    Gen.(
+      let* n_patches = int_range 2 4 in
+      let* cmds = gen_command_seq ~n_patches in
+      return (n_patches, cmds))
+    (fun (n_patches, cmds) ->
+      let m = bootstrap (mk_patches n_patches) in
+      let _final, ok =
+        List.fold cmds ~init:(m, true) ~f:(fun (m, ok) cmd ->
+            let m = apply_command m cmd in
+            (m, ok && sbi_completed_rebase_drains_queue m))
       in
       ok)
 
@@ -412,5 +455,6 @@ let () =
        [
          prop_sbi_holds;
          prop_defer_implies_progress;
+         prop_completed_rebase_drains_queue;
          prop_event_stream_pages_witness;
        ])

--- a/test/test_stale_base_invariants.ml
+++ b/test/test_stale_base_invariants.ml
@@ -168,30 +168,64 @@ let apply_command m cmd =
             (Orchestrator.graph m.orch)
             pid ~has_merged ~branch_of ~main
         in
-        (* Only meaningful when the patch has no current message and isn't
-           busy; otherwise we'd be racing with bootstrap state. *)
-        if agent.Patch_agent.busy || Patch_agent.has_pr agent then m
-        else
-          let _ = base in
-          (* The harness doesn't synthesize message ids, so we simulate by
-             firing Start directly and immediately rolling back if the gate
-             would have refused. The point is to exercise the [start_eligibility]
-             query on a base that can vary. *)
-          m
+        (* Inject a real [Pending] Start(pid, base) into the outbox so the
+           freshness gate in [runnable_messages] is actually exercised against
+           it. [base] varies as deps merge / rebase and as main advances, so
+           the gate is observed against fresh and stale bases alike. The id is
+           keyed on (patch, base, generation) — mirroring the controller — so a
+           base change re-keys the message and [reconcile_message] obsoletes the
+           prior Start for this patch. *)
+        let message_id =
+          Message_id.of_string
+            (Printf.sprintf "%s:sbi-start:%s:%d" (Patch_id.to_string pid)
+               (Branch.to_string base) agent.Patch_agent.generation)
+        in
+        let msg =
+          {
+            Orchestrator.message_id;
+            patch_id = pid;
+            generation = agent.Patch_agent.generation;
+            action = Orchestrator.Start (pid, base);
+            payload_hash = "sbi";
+            status = Orchestrator.Pending;
+          }
+        in
+        { m with orch = Orchestrator.reconcile_message m.orch msg }
 
 (* -- Invariants -- *)
 
-(** SBI: for every (Start, base) in the orchestrator's outbox that is [Pending]
-    and would be selected by [runnable_messages], the eligibility check returns
-    [Allow]. *)
+(** Independent freshness oracle: [true] iff [base] is fresh per the documented
+    SBI invariant — recomputed directly from agent fields rather than delegating
+    back to [start_eligibility], so the property genuinely checks that
+    [runnable_messages]' gate enforces freshness (a regression that let a stale
+    Start through would be caught) instead of re-deriving the same verdict. *)
+let base_is_fresh m base =
+  if Branch.equal base main then true
+  else
+    let base_agent =
+      Map.data (Orchestrator.agents_map m.orch)
+      |> List.find ~f:(fun (a : Patch_agent.t) ->
+          Branch.equal a.Patch_agent.branch base)
+    in
+    match base_agent with
+    | None -> false
+    | Some a -> (
+        a.Patch_agent.merged
+        ||
+        match
+          (a.Patch_agent.branch_rebased_onto_sha, Orchestrator.main_sha m.orch)
+        with
+        | Some s, Some main_sha -> String.equal s main_sha
+        | _ -> false)
+
+(** SBI: every [Start (_, base)] surfaced by [runnable_messages] has a fresh
+    [base] per [base_is_fresh]. [Enqueue_start] seeds the outbox with real
+    Pending Starts whose base varies, so this is non-vacuous. *)
 let sbi_runnable_starts_are_fresh m =
   let runnable = Orchestrator.runnable_messages m.orch in
   List.for_all runnable ~f:(fun msg ->
       match Orchestrator.message_action msg with
-      | Orchestrator.Start (_, base) -> (
-          match Orchestrator.start_eligibility m.orch base with
-          | Start_eligibility.Allow -> true
-          | Start_eligibility.Defer _ -> false)
+      | Orchestrator.Start (_, base) -> base_is_fresh m base
       | Orchestrator.Rebase _ | Orchestrator.Respond _ -> true)
 
 (** SBI-2 (liveness): any patch deferred by the freshness gate is making

--- a/test/test_stale_base_invariants.ml
+++ b/test/test_stale_base_invariants.ml
@@ -140,9 +140,21 @@ let apply_command m cmd =
           || not rebase_in_queue
         then m
         else
-          (* Fire the Rebase action first — that's what dequeues [Rebase] from
-             the patch's queue and sets [busy = true] (mirroring
-             Patch_agent.rebase's spec). Then apply the successful result. *)
+          (* This drives the agent state-machine directly (fire → apply result)
+             rather than the message lifecycle (accept_message → … →
+             apply_rebase_result), and that shortcut is safe for the SBI
+             property because the property only reads base freshness from agent
+             fields — [merged], [branch_rebased_onto_sha], and (via
+             [start_eligibility]'s busy-rebase check) [busy]/[current_op]/[queue]
+             — none of which depend on outbox message [status] or
+             [current_message_id]. [Orchestrator.fire (Rebase _)] sets
+             [busy = true] and [current_op = Rebase] (Patch_agent.rebase's spec)
+             exactly as [accept_message] would, which is also the precondition
+             [apply_rebase_result]'s eventual [complete] requires. The only state
+             not modelled here is the *in-flight* (Acked, busy) rebase observed
+             between commands; the busy-via-queue path is exercised after
+             [Pr_merged]'s eager enqueue, and [prop_event_stream_pages_witness]
+             covers Base_patch_busy_with_rebase directly. *)
           let orch =
             Orchestrator.fire m.orch (Orchestrator.Rebase (pid, main))
           in
@@ -247,18 +259,27 @@ let sbi_defer_implies_progress m =
               (Start_eligibility.Base_patch_busy_with_rebase _) ->
               true (* by definition: a Rebase is in flight or queued *)
           | Start_eligibility.Defer
-              (Start_eligibility.Base_not_rebased_since_main_advanced _) ->
-              (* Find the base patch and confirm it's open + has either Rebase
-                 queued OR is in a state that the reconciler will catch on
-                 the next tick (PR present, not merged). Pure Pending-with-no-
-                 queue-and-no-rebase-detector-input would be a stuck state. *)
+              (Start_eligibility.Base_not_rebased_since_main_advanced _) -> (
+              (* There must be an actual path to Allow: the base patch either has
+                 a [Rebase] queued (which will close the freshness gap) or has a
+                 PR the reconciler's stale-base detectors can enqueue a [Rebase]
+                 against on the next tick. A base patch that exists but has
+                 neither — e.g. needs_intervention with an empty queue and no PR
+                 — is genuinely stuck, so a bare existence check would pass
+                 vacuously. *)
               let bpid_opt =
                 Map.to_alist (Orchestrator.agents_map m.orch)
                 |> List.find_map ~f:(fun (pid, ag) ->
                     if Branch.equal ag.Patch_agent.branch base then Some pid
                     else None)
               in
-              Option.is_some bpid_opt))
+              match bpid_opt with
+              | None -> false
+              | Some bpid ->
+                  let base_ag = Orchestrator.agent m.orch bpid in
+                  List.mem base_ag.Patch_agent.queue Operation_kind.Rebase
+                    ~equal:Operation_kind.equal
+                  || Patch_agent.has_pr base_ag)))
 
 (* -- Generators -- *)
 

--- a/test/test_start_eligibility_properties.ml
+++ b/test/test_start_eligibility_properties.ml
@@ -1,0 +1,293 @@
+open Base
+open Onton_core
+
+(** Property tests for {!Start_eligibility}.
+
+    Properties:
+
+    - {b SEP-1 Totality}: [decide] never raises on any input.
+    - {b SEP-2 Determinism}: same inputs → same output.
+    - {b SEP-3 Pre-emption order}: each arm in the documented order is reachable
+      and only fires when no earlier arm matches.
+    - {b SEP-4 [Allow] ⇒ fresh}: every [Allow] is justified by at least one of:
+      base is main, base patch is merged, or the recorded rebased-onto sha
+      matches the known main sha.
+    - {b SEP-5 [Defer] ⇒ not fresh}: every [Defer] reflects a real freshness gap
+      (no main sha, busy rebase, or sha mismatch).
+    - {b SEP-6 Label bounds}: [short_label] is non-empty, ≤ 32 chars, lowercase
+      snake_case.
+    - {b SEP-7 Variant reachability}: every constructor of {!decision} and
+      {!defer_reason} is reachable from at least one input. *)
+
+module Gen = QCheck2.Gen
+module Test = QCheck2.Test
+module SE = Start_eligibility
+
+(* ---------- Generators ---------- *)
+
+let gen_sha = Gen.string_size ~gen:Gen.printable (Gen.int_range 0 40)
+let gen_branch = Gen.string_size ~gen:Gen.printable (Gen.int_range 1 30)
+
+type inputs = {
+  base_is_main : bool;
+  base_branch : string;
+  base_patch_merged : bool;
+  base_patch_rebased_onto_sha : string option;
+  base_patch_busy_rebasing : bool;
+  main_sha : string option;
+}
+
+let gen_inputs : inputs Gen.t =
+  let open Gen in
+  let* base_is_main = bool in
+  let* base_branch = gen_branch in
+  let* base_patch_merged = bool in
+  let* base_patch_rebased_onto_sha = option gen_sha in
+  let* base_patch_busy_rebasing = bool in
+  let* main_sha = option gen_sha in
+  return
+    {
+      base_is_main;
+      base_branch;
+      base_patch_merged;
+      base_patch_rebased_onto_sha;
+      base_patch_busy_rebasing;
+      main_sha;
+    }
+
+(* Pairs where [base_patch_rebased_onto_sha] and [main_sha] match with
+   non-trivial probability — the [Allow]-via-sha-equality arm wouldn't get
+   exercised by independent generators. *)
+let gen_inputs_matching : inputs Gen.t =
+  let open Gen in
+  let* shared = gen_sha in
+  let* base_branch = gen_branch in
+  let* base_patch_busy_rebasing = bool in
+  return
+    {
+      base_is_main = false;
+      base_branch;
+      base_patch_merged = false;
+      base_patch_rebased_onto_sha = Some shared;
+      base_patch_busy_rebasing;
+      main_sha = Some shared;
+    }
+
+let call i =
+  SE.decide ~base_is_main:i.base_is_main ~base_branch:i.base_branch
+    ~base_patch_merged:i.base_patch_merged
+    ~base_patch_rebased_onto_sha:i.base_patch_rebased_onto_sha
+    ~base_patch_busy_rebasing:i.base_patch_busy_rebasing ~main_sha:i.main_sha
+
+(* ---------- Properties ---------- *)
+
+let prop_totality =
+  Test.make ~count:500 ~name:"SEP-1: decide is total" gen_inputs (fun i ->
+      try
+        let _ : SE.decision = call i in
+        true
+      with _ -> false)
+
+let prop_determinism =
+  Test.make ~count:500 ~name:"SEP-2: same inputs → same output" gen_inputs
+    (fun i -> SE.equal_decision (call i) (call i))
+
+let is_allow = function SE.Allow -> true | SE.Defer _ -> false
+
+let is_defer_main_unknown = function
+  | SE.Defer SE.Main_sha_unknown -> true
+  | SE.Allow
+  | SE.Defer
+      ( SE.Base_patch_busy_with_rebase _
+      | SE.Base_not_rebased_since_main_advanced _ ) ->
+      false
+
+let is_defer_busy = function
+  | SE.Defer (SE.Base_patch_busy_with_rebase _) -> true
+  | SE.Allow
+  | SE.Defer (SE.Main_sha_unknown | SE.Base_not_rebased_since_main_advanced _)
+    ->
+      false
+
+let is_defer_stale = function
+  | SE.Defer (SE.Base_not_rebased_since_main_advanced _) -> true
+  | SE.Allow | SE.Defer (SE.Main_sha_unknown | SE.Base_patch_busy_with_rebase _)
+    ->
+      false
+
+let prop_preempt_base_is_main =
+  Test.make ~count:200 ~name:"SEP-3a: base_is_main pre-empts everything → Allow"
+    Gen.(
+      let* i = gen_inputs in
+      return { i with base_is_main = true })
+    (fun i -> is_allow (call i))
+
+let prop_preempt_base_merged =
+  Test.make ~count:200
+    ~name:"SEP-3b: base_patch_merged pre-empts (after base_is_main) → Allow"
+    Gen.(
+      let* i = gen_inputs in
+      return { i with base_is_main = false; base_patch_merged = true })
+    (fun i -> is_allow (call i))
+
+let prop_preempt_main_unknown =
+  Test.make ~count:200
+    ~name:
+      "SEP-3c: main_sha=None (and no earlier match) → Defer Main_sha_unknown"
+    Gen.(
+      let* i = gen_inputs in
+      return
+        {
+          i with
+          base_is_main = false;
+          base_patch_merged = false;
+          main_sha = None;
+        })
+    (fun i -> is_defer_main_unknown (call i))
+
+let prop_preempt_busy =
+  Test.make ~count:200
+    ~name:
+      "SEP-3d: busy_rebasing (with main_sha known) → Defer \
+       Base_patch_busy_with_rebase"
+    Gen.(
+      let* i = gen_inputs in
+      let* sha = gen_sha in
+      return
+        {
+          i with
+          base_is_main = false;
+          base_patch_merged = false;
+          main_sha = Some sha;
+          base_patch_busy_rebasing = true;
+        })
+    (fun i -> is_defer_busy (call i))
+
+let prop_allow_on_sha_equality =
+  Test.make ~count:200
+    ~name:"SEP-3e: rebased_onto_sha = main_sha (and no earlier match) → Allow"
+    gen_inputs_matching (fun i ->
+      (* [gen_inputs_matching] sets base_is_main=false,
+         base_patch_merged=false, both shas Some &amp; equal. busy_rebasing
+         varies. *)
+      if i.base_patch_busy_rebasing then is_defer_busy (call i)
+      else is_allow (call i))
+
+let prop_defer_stale_when_mismatch =
+  Test.make ~count:300
+    ~name:
+      "SEP-3f: main_sha known, not busy, rebased_onto_sha != main_sha → Defer \
+       Base_not_rebased_since_main_advanced"
+    Gen.(
+      let* main_sha = gen_sha in
+      let* base_branch = gen_branch in
+      (* Choose rebased_onto_sha to be either None or different from main_sha. *)
+      let* rebased =
+        oneof
+          [
+            return None;
+            map
+              (fun s -> Some (main_sha ^ s ^ "_diff"))
+              (string_size ~gen:printable (int_range 1 5));
+          ]
+      in
+      return
+        {
+          base_is_main = false;
+          base_branch;
+          base_patch_merged = false;
+          base_patch_rebased_onto_sha = rebased;
+          base_patch_busy_rebasing = false;
+          main_sha = Some main_sha;
+        })
+    (fun i -> is_defer_stale (call i))
+
+let prop_allow_implies_fresh =
+  Test.make ~count:500 ~name:"SEP-4: Allow ⇒ fresh" gen_inputs (fun i ->
+      match call i with
+      | SE.Defer _ -> true
+      | SE.Allow -> (
+          i.base_is_main || i.base_patch_merged
+          ||
+          match (i.base_patch_rebased_onto_sha, i.main_sha) with
+          | Some s, Some m -> String.equal s m
+          | _ -> false))
+
+let prop_defer_implies_not_fresh =
+  Test.make ~count:500 ~name:"SEP-5: Defer ⇒ not fresh" gen_inputs (fun i ->
+      match call i with
+      | SE.Allow -> true
+      | SE.Defer _ ->
+          (not i.base_is_main) && (not i.base_patch_merged)
+          && (Option.is_none i.main_sha || i.base_patch_busy_rebasing
+             ||
+             match (i.base_patch_rebased_onto_sha, i.main_sha) with
+             | Some s, Some m -> not (String.equal s m)
+             | None, _ -> true
+             | _, None -> true))
+
+let label_re = Re.compile (Re.Pcre.re "^[a-z][a-z0-9_]*$")
+
+let prop_label_bounds =
+  Test.make ~count:500
+    ~name:"SEP-6: short_label is non-empty, ≤32 chars, snake_case" gen_inputs
+    (fun i ->
+      let lbl = SE.short_label (call i) in
+      String.length lbl > 0 && String.length lbl <= 32 && Re.execp label_re lbl)
+
+let prop_variants_reachable =
+  Test.make ~count:1
+    ~name:"SEP-7: every decision/defer_reason variant reachable" (Gen.return ())
+    (fun () ->
+      let allow_main =
+        SE.decide ~base_is_main:true ~base_branch:"main"
+          ~base_patch_merged:false ~base_patch_rebased_onto_sha:None
+          ~base_patch_busy_rebasing:false ~main_sha:None
+      in
+      let allow_merged =
+        SE.decide ~base_is_main:false ~base_branch:"b" ~base_patch_merged:true
+          ~base_patch_rebased_onto_sha:None ~base_patch_busy_rebasing:false
+          ~main_sha:None
+      in
+      let allow_sha_eq =
+        SE.decide ~base_is_main:false ~base_branch:"b" ~base_patch_merged:false
+          ~base_patch_rebased_onto_sha:(Some "abc")
+          ~base_patch_busy_rebasing:false ~main_sha:(Some "abc")
+      in
+      let defer_unknown =
+        SE.decide ~base_is_main:false ~base_branch:"b" ~base_patch_merged:false
+          ~base_patch_rebased_onto_sha:(Some "abc")
+          ~base_patch_busy_rebasing:false ~main_sha:None
+      in
+      let defer_busy =
+        SE.decide ~base_is_main:false ~base_branch:"b" ~base_patch_merged:false
+          ~base_patch_rebased_onto_sha:(Some "abc")
+          ~base_patch_busy_rebasing:true ~main_sha:(Some "abc")
+      in
+      let defer_stale =
+        SE.decide ~base_is_main:false ~base_branch:"b" ~base_patch_merged:false
+          ~base_patch_rebased_onto_sha:(Some "old")
+          ~base_patch_busy_rebasing:false ~main_sha:(Some "new")
+      in
+      is_allow allow_main && is_allow allow_merged && is_allow allow_sha_eq
+      && is_defer_main_unknown defer_unknown
+      && is_defer_busy defer_busy && is_defer_stale defer_stale)
+
+let () =
+  let runner = QCheck_base_runner.run_tests_main in
+  ignore
+    (runner
+       [
+         prop_totality;
+         prop_determinism;
+         prop_preempt_base_is_main;
+         prop_preempt_base_merged;
+         prop_preempt_main_unknown;
+         prop_preempt_busy;
+         prop_allow_on_sha_equality;
+         prop_defer_stale_when_mismatch;
+         prop_allow_implies_fresh;
+         prop_defer_implies_not_fresh;
+         prop_label_bounds;
+         prop_variants_reachable;
+       ])

--- a/test/test_start_eligibility_properties.ml
+++ b/test/test_start_eligibility_properties.ml
@@ -141,6 +141,9 @@ let prop_preempt_main_unknown =
           i with
           base_is_main = false;
           base_patch_merged = false;
+          (* busy_rebasing now pre-empts the unknown-main arm, so pin it off to
+             isolate the Main_sha_unknown case. *)
+          base_patch_busy_rebasing = false;
           main_sha = None;
         })
     (fun i -> is_defer_main_unknown (call i))

--- a/test/test_start_point_plan_properties.ml
+++ b/test/test_start_point_plan_properties.ml
@@ -61,7 +61,7 @@ let is_refuse_diverged = function
   | SP.Refuse (SP.Local_diverged_from_remote _) -> true
   | SP.Refuse
       ( SP.Local_has_unpushed_commits _ | SP.Branch_checked_out_in_main_root
-      | SP.Worktree_already_registered _ )
+      | SP.Worktree_already_registered _ | SP.Base_branch_stale_vs_main _ )
   | SP.Plan _ ->
       false
 
@@ -69,7 +69,7 @@ let is_refuse_local_ahead = function
   | SP.Refuse (SP.Local_has_unpushed_commits _) -> true
   | SP.Refuse
       ( SP.Local_diverged_from_remote _ | SP.Branch_checked_out_in_main_root
-      | SP.Worktree_already_registered _ )
+      | SP.Worktree_already_registered _ | SP.Base_branch_stale_vs_main _ )
   | SP.Plan _ ->
       false
 
@@ -77,7 +77,7 @@ let is_refuse_checked_out = function
   | SP.Refuse SP.Branch_checked_out_in_main_root -> true
   | SP.Refuse
       ( SP.Local_diverged_from_remote _ | SP.Local_has_unpushed_commits _
-      | SP.Worktree_already_registered _ )
+      | SP.Worktree_already_registered _ | SP.Base_branch_stale_vs_main _ )
   | SP.Plan _ ->
       false
 
@@ -85,9 +85,17 @@ let is_refuse_registered = function
   | SP.Refuse (SP.Worktree_already_registered _) -> true
   | SP.Refuse
       ( SP.Local_diverged_from_remote _ | SP.Local_has_unpushed_commits _
-      | SP.Branch_checked_out_in_main_root ) ->
+      | SP.Branch_checked_out_in_main_root | SP.Base_branch_stale_vs_main _ ) ->
       false
   | SP.Plan _ -> false
+
+let is_refuse_base_stale = function
+  | SP.Refuse (SP.Base_branch_stale_vs_main _) -> true
+  | SP.Refuse
+      ( SP.Local_diverged_from_remote _ | SP.Local_has_unpushed_commits _
+      | SP.Branch_checked_out_in_main_root | SP.Worktree_already_registered _ )
+  | SP.Plan _ ->
+      false
 
 (* ---------- Generators ---------- *)
 
@@ -98,6 +106,9 @@ let gen_ancestry =
   Gen.oneof_array
     [| SP.Local_ahead; SP.Remote_ahead; SP.Equal; SP.Diverged; SP.Unknown |]
 
+let gen_base_freshness =
+  Gen.oneof_array [| SP.Fresh; SP.Stale; SP.Unknown_freshness |]
+
 let gen_sha_option = Gen.option gen_sha
 let gen_path_option = Gen.option gen_branch_name
 
@@ -107,6 +118,7 @@ type plan_inputs = {
   remote_ref : SP.sha option;
   ancestry : SP.ancestry;
   base_branch : string;
+  base_freshness : SP.base_freshness;
   branch_checked_out_in_main_root : bool;
   existing_worktree_path : string option;
 }
@@ -117,6 +129,7 @@ let gen_inputs : plan_inputs Gen.t =
   let* remote_ref = gen_sha_option in
   let* ancestry = gen_ancestry in
   let* base_branch = gen_branch_name in
+  let* base_freshness = gen_base_freshness in
   let* branch_checked_out_in_main_root = bool in
   let* existing_worktree_path = gen_path_option in
   return
@@ -125,13 +138,14 @@ let gen_inputs : plan_inputs Gen.t =
       remote_ref;
       ancestry;
       base_branch;
+      base_freshness;
       branch_checked_out_in_main_root;
       existing_worktree_path;
     }
 
 let call i =
   SP.plan ~local_ref:i.local_ref ~remote_ref:i.remote_ref ~ancestry:i.ancestry
-    ~base_branch:i.base_branch
+    ~base_branch:i.base_branch ~base_freshness:i.base_freshness
     ~branch_checked_out_in_main_root:i.branch_checked_out_in_main_root
     ~existing_worktree_path:i.existing_worktree_path
 
@@ -156,8 +170,8 @@ let prop_no_silent_clobber =
     (fun (local, remote, anc, base_branch) ->
       let d =
         SP.plan ~local_ref:(Some local) ~remote_ref:(Some remote) ~ancestry:anc
-          ~base_branch ~branch_checked_out_in_main_root:false
-          ~existing_worktree_path:None
+          ~base_branch ~base_freshness:SP.Unknown_freshness
+          ~branch_checked_out_in_main_root:false ~existing_worktree_path:None
       in
       is_refuse d)
 
@@ -174,14 +188,34 @@ let prop_remote_authoritative =
     (fun (local, remote, anc, base_branch) ->
       let d =
         SP.plan ~local_ref:(Some local) ~remote_ref:(Some remote) ~ancestry:anc
-          ~base_branch ~branch_checked_out_in_main_root:false
-          ~existing_worktree_path:None
+          ~base_branch ~base_freshness:SP.Unknown_freshness
+          ~branch_checked_out_in_main_root:false ~existing_worktree_path:None
       in
       is_reset_to remote d)
 
 let prop_missing_both =
   Test.make ~count:200
-    ~name:"SPP-4: local=None, remote=None → Create_new_branch_from_base"
+    ~name:
+      "SPP-4: local=None, remote=None, base not Stale → \
+       Create_new_branch_from_base"
+    Gen.(
+      let* base_branch = gen_branch_name in
+      let* anc = gen_ancestry in
+      let* fresh = oneof_array [| SP.Fresh; SP.Unknown_freshness |] in
+      return (base_branch, anc, fresh))
+    (fun (base_branch, anc, fresh) ->
+      let d =
+        SP.plan ~local_ref:None ~remote_ref:None ~ancestry:anc ~base_branch
+          ~base_freshness:fresh ~branch_checked_out_in_main_root:false
+          ~existing_worktree_path:None
+      in
+      is_create_from_base base_branch d)
+
+let prop_missing_both_stale =
+  Test.make ~count:200
+    ~name:
+      "SPP-4b: local=None, remote=None, base Stale → Refuse \
+       Base_branch_stale_vs_main"
     Gen.(
       let* base_branch = gen_branch_name in
       let* anc = gen_ancestry in
@@ -189,9 +223,33 @@ let prop_missing_both =
     (fun (base_branch, anc) ->
       let d =
         SP.plan ~local_ref:None ~remote_ref:None ~ancestry:anc ~base_branch
-          ~branch_checked_out_in_main_root:false ~existing_worktree_path:None
+          ~base_freshness:SP.Stale ~branch_checked_out_in_main_root:false
+          ~existing_worktree_path:None
       in
-      is_create_from_base base_branch d)
+      is_refuse_base_stale d)
+
+(* A Stale base must NOT block when the patch's own branch already exists —
+   freshness is only consulted on the brand-new-branch arm. *)
+let prop_stale_irrelevant_when_branch_exists =
+  Test.make ~count:300
+    ~name:"SPP-4c: base Stale is ignored when a local/remote ref exists"
+    Gen.(
+      let* local = gen_sha_option in
+      let* remote = gen_sha_option in
+      (* exclude (None, None) — that's the brand-new arm where Stale matters *)
+      let local, remote =
+        match (local, remote) with None, None -> (Some "l", None) | p -> p
+      in
+      let* anc = gen_ancestry in
+      let* base_branch = gen_branch_name in
+      return (local, remote, anc, base_branch))
+    (fun (local, remote, anc, base_branch) ->
+      let d =
+        SP.plan ~local_ref:local ~remote_ref:remote ~ancestry:anc ~base_branch
+          ~base_freshness:SP.Stale ~branch_checked_out_in_main_root:false
+          ~existing_worktree_path:None
+      in
+      not (is_refuse_base_stale d))
 
 let prop_determinism =
   Test.make ~count:500 ~name:"SPP-5: same inputs → same output" gen_inputs
@@ -238,45 +296,54 @@ let prop_variants_reachable =
     (Gen.return ()) (fun () ->
       let reset =
         SP.plan ~local_ref:None ~remote_ref:(Some "r") ~ancestry:SP.Unknown
-          ~base_branch:"main" ~branch_checked_out_in_main_root:false
-          ~existing_worktree_path:None
+          ~base_branch:"main" ~base_freshness:SP.Unknown_freshness
+          ~branch_checked_out_in_main_root:false ~existing_worktree_path:None
       in
       let use_local =
         SP.plan ~local_ref:(Some "l") ~remote_ref:None ~ancestry:SP.Unknown
-          ~base_branch:"main" ~branch_checked_out_in_main_root:false
-          ~existing_worktree_path:None
+          ~base_branch:"main" ~base_freshness:SP.Unknown_freshness
+          ~branch_checked_out_in_main_root:false ~existing_worktree_path:None
       in
       let create =
         SP.plan ~local_ref:None ~remote_ref:None ~ancestry:SP.Unknown
-          ~base_branch:"main" ~branch_checked_out_in_main_root:false
-          ~existing_worktree_path:None
+          ~base_branch:"main" ~base_freshness:SP.Fresh
+          ~branch_checked_out_in_main_root:false ~existing_worktree_path:None
       in
       let refuse_diverged =
         SP.plan ~local_ref:(Some "l") ~remote_ref:(Some "r")
           ~ancestry:SP.Diverged ~base_branch:"main"
+          ~base_freshness:SP.Unknown_freshness
           ~branch_checked_out_in_main_root:false ~existing_worktree_path:None
       in
       let refuse_ahead =
         SP.plan ~local_ref:(Some "l") ~remote_ref:(Some "r")
           ~ancestry:SP.Local_ahead ~base_branch:"main"
+          ~base_freshness:SP.Unknown_freshness
           ~branch_checked_out_in_main_root:false ~existing_worktree_path:None
       in
       let refuse_checked_out =
         SP.plan ~local_ref:None ~remote_ref:None ~ancestry:SP.Unknown
-          ~base_branch:"main" ~branch_checked_out_in_main_root:true
-          ~existing_worktree_path:None
+          ~base_branch:"main" ~base_freshness:SP.Fresh
+          ~branch_checked_out_in_main_root:true ~existing_worktree_path:None
       in
       let refuse_registered =
         SP.plan ~local_ref:None ~remote_ref:None ~ancestry:SP.Unknown
-          ~base_branch:"main" ~branch_checked_out_in_main_root:false
+          ~base_branch:"main" ~base_freshness:SP.Fresh
+          ~branch_checked_out_in_main_root:false
           ~existing_worktree_path:(Some "/tmp/wt")
+      in
+      let refuse_base_stale =
+        SP.plan ~local_ref:None ~remote_ref:None ~ancestry:SP.Unknown
+          ~base_branch:"dep" ~base_freshness:SP.Stale
+          ~branch_checked_out_in_main_root:false ~existing_worktree_path:None
       in
       is_reset_to "r" reset && is_use_local use_local
       && is_create_from_base "main" create
       && is_refuse_diverged refuse_diverged
       && is_refuse_local_ahead refuse_ahead
       && is_refuse_checked_out refuse_checked_out
-      && is_refuse_registered refuse_registered)
+      && is_refuse_registered refuse_registered
+      && is_refuse_base_stale refuse_base_stale)
 
 let prop_remote_wins_over_local =
   Test.make ~count:500
@@ -292,8 +359,8 @@ let prop_remote_wins_over_local =
     (fun (local, remote, anc, base_branch) ->
       let d =
         SP.plan ~local_ref:(Some local) ~remote_ref:(Some remote) ~ancestry:anc
-          ~base_branch ~branch_checked_out_in_main_root:false
-          ~existing_worktree_path:None
+          ~base_branch ~base_freshness:SP.Unknown_freshness
+          ~branch_checked_out_in_main_root:false ~existing_worktree_path:None
       in
       not (is_use_local d))
 
@@ -306,6 +373,8 @@ let () =
          prop_no_silent_clobber;
          prop_remote_authoritative;
          prop_missing_both;
+         prop_missing_both_stale;
+         prop_stale_irrelevant_when_branch_exists;
          prop_determinism;
          prop_preempt_checked_out;
          prop_preempt_worktree;

--- a/test/test_worktree_spawn_retry.ml
+++ b/test/test_worktree_spawn_retry.ml
@@ -1,0 +1,95 @@
+open Base
+open Onton
+
+(** Unit tests for {!Worktree.retry_transient_spawn} /
+    {!Worktree.is_transient_spawn_failure} — the bounded retry that absorbs
+    transient [posix_spawn] failures (e.g. EAGAIN under process-table pressure)
+    so a one-off spawn failure isn't mistaken for a git verdict or crash an op.
+
+    The freshly-spawned-git integration tests
+    ([test_worktree_start_point_integration], [test_push_plan_integration])
+    flaked under a heavily parallel runner when a git spawn transiently failed;
+    these tests lock in the retry policy deterministically without depending on
+    real process pressure. *)
+
+let failures = ref 0
+let total = ref 0
+
+let check name cond =
+  Int.incr total;
+  if cond then Stdlib.Printf.printf "  ok: %s\n" name
+  else (
+    Int.incr failures;
+    Stdlib.Printf.printf "  FAIL: %s\n" name)
+
+(* A genuine git verdict (process ran, exited non-zero) — must never be retried,
+   or [ref_exists]-style callers would retry every "ref not found". *)
+let child_error () =
+  Eio.Exn.create (Eio.Process.E (Eio.Process.Child_error (`Exited 1)))
+
+let test_classification () =
+  check "Failure is transient"
+    (Worktree.is_transient_spawn_failure (Failure "spawn: resource unavailable"));
+  check "Unix_error EAGAIN is transient"
+    (Worktree.is_transient_spawn_failure
+       (Unix.Unix_error (Unix.EAGAIN, "fork", "")));
+  check "cancellation is NOT transient"
+    (not
+       (Worktree.is_transient_spawn_failure
+          (Eio.Cancel.Cancelled (Failure "cancelled"))));
+  check "Child_error (git verdict) is NOT transient"
+    (not (Worktree.is_transient_spawn_failure (child_error ())))
+
+let test_retry_then_success () =
+  let attempts = ref 0 in
+  let r =
+    Worktree.retry_transient_spawn ~attempts:4 (fun () ->
+        Int.incr attempts;
+        if !attempts < 3 then failwith "spawn: resource temporarily unavailable"
+        else 42)
+  in
+  check "transient failure retried to success" (r = 42 && !attempts = 3)
+
+let test_verdict_not_retried () =
+  let attempts = ref 0 in
+  let err = child_error () in
+  let reraised =
+    try
+      ignore
+        (Worktree.retry_transient_spawn ~attempts:4 (fun () ->
+             Int.incr attempts;
+             raise err));
+      false
+    with e -> Poly.equal e err
+  in
+  check "verdict re-raised on first attempt (not retried)"
+    (reraised && !attempts = 1)
+
+let test_persistent_transient_exhausts () =
+  let attempts = ref 0 in
+  let raised =
+    try
+      ignore
+        (Worktree.retry_transient_spawn ~attempts:3 (fun () ->
+             Int.incr attempts;
+             failwith "persistent EAGAIN"));
+      false
+    with
+    | Failure _ -> true
+    | _ -> false
+  in
+  check "persistent transient exhausts attempts then raises"
+    (raised && !attempts = 3)
+
+let () =
+  Stdlib.print_endline "Worktree spawn-retry:";
+  (* [retry_transient_spawn] yields between attempts, so run inside a scheduler. *)
+  Eio_main.run (fun _env ->
+      test_classification ();
+      test_retry_then_success ();
+      test_verdict_not_retried ();
+      test_persistent_transient_exhausts ());
+  if !failures > 0 then (
+    Stdlib.Printf.printf "%d/%d checks FAILED\n" !failures !total;
+    Stdlib.exit 1)
+  else Stdlib.Printf.printf "all %d checks passed\n" !total

--- a/test/test_worktree_start_point_integration.ml
+++ b/test/test_worktree_start_point_integration.ml
@@ -114,7 +114,7 @@ let scenario_brand_new env =
       ~project_name:"brand-new"
       ~patch_id:(Types.Patch_id.of_string "1")
       ~branch:(Types.Branch.of_string "feat")
-      ~base_ref:"origin/main"
+      ~base_ref:"origin/main" ~main_branch:"main"
   in
   match res with
   | Result.Ok wt ->
@@ -154,7 +154,7 @@ let scenario_remote_ahead_of_stale_local env =
       ~project_name:"stale-local"
       ~patch_id:(Types.Patch_id.of_string "2")
       ~branch:(Types.Branch.of_string "feat")
-      ~base_ref:"origin/main"
+      ~base_ref:"origin/main" ~main_branch:"main"
   in
   match res with
   | Result.Ok wt ->
@@ -191,7 +191,7 @@ let scenario_local_only env =
       ~project_name:"local-only"
       ~patch_id:(Types.Patch_id.of_string "3")
       ~branch:(Types.Branch.of_string "feat")
-      ~base_ref:"origin/main"
+      ~base_ref:"origin/main" ~main_branch:"main"
   in
   match res with
   | Result.Ok wt ->
@@ -225,7 +225,7 @@ let scenario_diverged env =
     Worktree.create ~process_mgr ~repo_root:managed_dir ~project_name:"diverged"
       ~patch_id:(Types.Patch_id.of_string "4")
       ~branch:(Types.Branch.of_string "feat")
-      ~base_ref:"origin/main"
+      ~base_ref:"origin/main" ~main_branch:"main"
   in
   match res with
   | Result.Ok _ -> failwith "diverged: expected Error refusal, got Ok"
@@ -235,7 +235,8 @@ let scenario_diverged env =
           Stdlib.print_endline "  diverged: OK (refused)"
       | Start_point_plan.Local_has_unpushed_commits _
       | Start_point_plan.Branch_checked_out_in_main_root
-      | Start_point_plan.Worktree_already_registered _ ->
+      | Start_point_plan.Worktree_already_registered _
+      | Start_point_plan.Base_branch_stale_vs_main _ ->
           failwith
             (Printf.sprintf
                "diverged: expected Local_diverged_from_remote, got %s"
@@ -281,7 +282,7 @@ let scenario_local_strictly_ahead env =
       ~project_name:"local-ahead"
       ~patch_id:(Types.Patch_id.of_string "5")
       ~branch:(Types.Branch.of_string "feat")
-      ~base_ref:"origin/main"
+      ~base_ref:"origin/main" ~main_branch:"main"
   in
   match res with
   | Result.Ok _ ->
@@ -292,12 +293,121 @@ let scenario_local_strictly_ahead env =
           Stdlib.print_endline "  local_strictly_ahead: OK (refused)"
       | Start_point_plan.Local_diverged_from_remote _
       | Start_point_plan.Branch_checked_out_in_main_root
-      | Start_point_plan.Worktree_already_registered _ ->
+      | Start_point_plan.Worktree_already_registered _
+      | Start_point_plan.Base_branch_stale_vs_main _ ->
           failwith
             (Printf.sprintf
                "local_strictly_ahead: expected Local_has_unpushed_commits, got \
                 %s"
                (Start_point_plan.show_refusal r)))
+
+(* The event-stream-pages witness, end-to-end against real git:
+
+   A→B→C stacking. Patch B's branch is cut from main *before* patch A merges to
+   main. Then A merges (origin/main advances to include A). We now try to cut a
+   brand-new branch C from B. Because origin/main is NOT an ancestor of B's
+   branch, [Worktree.create] must refuse with [Base_branch_stale_vs_main]
+   rather than silently producing a worktree missing A's commit. *)
+let scenario_base_stale_vs_main env =
+  let process_mgr = Eio.Stdenv.process_mgr env in
+  with_temp_dir @@ fun root ->
+  let origin_dir = Stdlib.Filename.concat root "origin" in
+  let managed_dir = Stdlib.Filename.concat root "managed" in
+  setup_origin_with_main ~origin_dir;
+  (* Patch B's branch is cut from the original main tip and pushed. *)
+  sh ~dir:origin_dir "git checkout -q -b patch-b";
+  sh ~dir:origin_dir "echo b > b.txt";
+  sh ~dir:origin_dir "git add b.txt";
+  sh ~dir:origin_dir "git commit -q -m 'patch b work'";
+  sh ~dir:origin_dir "git checkout -q main";
+  (* Patch A merges to main AFTER B was cut: main now has a commit that B's
+     branch does not contain. *)
+  sh ~dir:origin_dir "echo a > a.txt";
+  sh ~dir:origin_dir "git add a.txt";
+  sh ~dir:origin_dir "git commit -q -m 'patch a merged to main'";
+  clone_into ~origin_dir ~managed_dir;
+  (* Precondition: origin/main is NOT an ancestor of origin/patch-b. *)
+  let stale =
+    let cmd =
+      Printf.sprintf
+        "cd %s && git merge-base --is-ancestor origin/main origin/patch-b"
+        (Stdlib.Filename.quote managed_dir)
+    in
+    Stdlib.Sys.command cmd <> 0
+  in
+  assert_true "precondition: origin/main not ancestor of origin/patch-b" stale;
+  let res =
+    Worktree.create ~process_mgr ~repo_root:managed_dir
+      ~project_name:"base-stale"
+      ~patch_id:(Types.Patch_id.of_string "c")
+      ~branch:(Types.Branch.of_string "patch-c")
+      ~base_ref:"origin/patch-b" ~main_branch:"main"
+  in
+  match res with
+  | Result.Ok _ ->
+      failwith
+        "base_stale: expected Error (Base_branch_stale_vs_main), got Ok — a \
+         worktree cut from a stale dep branch would silently drop main's \
+         commits"
+  | Result.Error (Start_point_plan.Base_branch_stale_vs_main _) ->
+      Stdlib.print_endline "  base_stale_vs_main: OK (refused)"
+  | Result.Error
+      (( Start_point_plan.Local_diverged_from_remote _
+       | Start_point_plan.Local_has_unpushed_commits _
+       | Start_point_plan.Branch_checked_out_in_main_root
+       | Start_point_plan.Worktree_already_registered _ ) as r) ->
+      failwith
+        (Printf.sprintf "base_stale: expected Base_branch_stale_vs_main, got %s"
+           (Start_point_plan.show_refusal r))
+
+(* The complement: a stacked base that legitimately CONTAINS the latest main
+   must NOT be refused. Patch B's branch is cut from main and then main does
+   not advance past it, so origin/main is an ancestor of origin/patch-b. C must
+   be created successfully. Guards against the freshness gate over-blocking
+   normal stacked work. *)
+let scenario_base_fresh_stacked env =
+  let process_mgr = Eio.Stdenv.process_mgr env in
+  with_temp_dir @@ fun root ->
+  let origin_dir = Stdlib.Filename.concat root "origin" in
+  let managed_dir = Stdlib.Filename.concat root "managed" in
+  setup_origin_with_main ~origin_dir;
+  sh ~dir:origin_dir "git checkout -q -b patch-b";
+  sh ~dir:origin_dir "echo b > b.txt";
+  sh ~dir:origin_dir "git add b.txt";
+  sh ~dir:origin_dir "git commit -q -m 'patch b work'";
+  sh ~dir:origin_dir "git checkout -q main";
+  clone_into ~origin_dir ~managed_dir;
+  let fresh =
+    let cmd =
+      Printf.sprintf
+        "cd %s && git merge-base --is-ancestor origin/main origin/patch-b"
+        (Stdlib.Filename.quote managed_dir)
+    in
+    Stdlib.Sys.command cmd = 0
+  in
+  assert_true "precondition: origin/main IS ancestor of origin/patch-b" fresh;
+  let res =
+    Worktree.create ~process_mgr ~repo_root:managed_dir
+      ~project_name:"base-fresh"
+      ~patch_id:(Types.Patch_id.of_string "c2")
+      ~branch:(Types.Branch.of_string "patch-c2")
+      ~base_ref:"origin/patch-b" ~main_branch:"main"
+  in
+  match res with
+  | Result.Ok wt ->
+      (* The new worktree must contain patch B's commit (b.txt). *)
+      let head_has_b =
+        Stdlib.Sys.command
+          (Printf.sprintf "test -f %s"
+             (Stdlib.Filename.quote (Stdlib.Filename.concat wt.path "b.txt")))
+        = 0
+      in
+      assert_true "fresh stacked: worktree contains base commit" head_has_b;
+      Stdlib.print_endline "  base_fresh_stacked: OK (created)"
+  | Result.Error r ->
+      failwith
+        (Printf.sprintf "base_fresh_stacked: expected Ok, got refusal %s"
+           (Start_point_plan.show_refusal r))
 
 let () =
   Eio_main.run @@ fun env ->
@@ -307,4 +417,6 @@ let () =
   scenario_local_only env;
   scenario_diverged env;
   scenario_local_strictly_ahead env;
+  scenario_base_stale_vs_main env;
+  scenario_base_fresh_stacked env;
   Stdlib.print_endline "All start-point integration scenarios passed."


### PR DESCRIPTION
## Summary

Fixes the stale-base bug that wiped `event-stream-pages` patch 3: when an upstream patch (A) merges to `main` while an intermediate dependency (B) is still open, B's local branch lags `main`. Starting a downstream patch (C) and cutting its worktree from B's stale local ref silently drops A's commits.

**Root cause:** `Orchestrator.mark_merged` only refreshed the *name* of dependents' base branches and relied on the reconciler's poll-tick detectors to enqueue a rebase — but a `Start` could fire before the next tick. `Worktree_setup` also only fetched the patch's *own* branch, never the base.

**Approach** (blocking a Start until its base is fresh, per the agreed constraint that the base eventually catches up):

- **`Start_eligibility`** (new pure module, `lib_core/`): `decide` returns `Allow | Defer of reason` from freshness facts. No IO, mirrors `Start_point_plan`.
- **`Orchestrator.main_sha`**: tracks `origin/<main>`'s sha, published by the poller on every fetch; persisted across restarts.
- **Scheduling gate**: `runnable_messages` filters `Start` through `start_eligibility` — a stale base defers the Start (stays `Pending`); `Rebase`/`Respond` are untouched.
- **Eager rebase**: `mark_merged` enqueues a `Rebase` for direct dependents immediately, collapsing the race window. Reconciler detectors remain as backup.
- **Defense-in-depth**: `Start_point_plan` gains a `Base_branch_stale_vs_main` refusal gated on an ancestry probe (`git merge-base --is-ancestor origin/main <base>`); `Worktree.create` takes `~main_branch` and `worktree_setup` fetches `origin/<main>` first. Catches any create path that bypasses the orchestrator gate.

Note: the worktree-layer check uses **ancestry**, not sha-equality — a legitimate stacked base is intentionally ahead of main. The orchestrator gate uses sha-equality on `branch_rebased_onto_sha == main_sha`, which is correct there since the rebase pipeline records exactly that anchor.

## Test plan

- [ ] `test_start_eligibility_properties` — 12 QCheck2 properties (totality, determinism, pre-emption order, Allow⇔fresh, label bounds, variant reachability)
- [ ] `test_stale_base_invariants` — interleaving SBI property ("every runnable Start is freshness-eligible"), a liveness property, and the event-stream-pages witness (defer → eager Rebase queued → rebase → Allow)
- [ ] `test_worktree_start_point_integration` — two new real-git scenarios: stale base refused, fresh stacked base created (and contains the base commit)
- [ ] `test_start_point_plan_properties` — extended for the new variant + `~base_freshness` param
- [ ] `test_interleaving_properties` PI-16 — updated to assert the end-state (since `mark_merged` now enqueues eagerly)
- [ ] `dune runtest` — full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/323"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782416190&installation_id=126163856&pr_number=323&repository=flowglad%2Fonton&return_to=https%3A%2F%2Fgithub.com%2Fflowglad%2Fonton%2Fpull%2F323&signature=861aff3e22da5c6df6e4d7dde79de51d780002a07af64448a9e666500d2e27c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents starting downstream worktrees from stale base branches and adds defense-in-depth to stop silent commit loss in stacked patches. Also retries transient git spawns and skips redundant base‑freshness probes when the base is `main`/`origin/<main>`.

- **Bug Fixes**
  - Gate `Start` via `Start_eligibility`: allow only when base is `main`/merged or its `branch_rebased_onto_sha` equals `main_sha`; a running or highest‑priority runnable `Rebase` on the base defers and pre‑empts the “main sha unknown” case.
  - Track `main_sha` on the orchestrator; the poller records it on every fetch and it’s persisted across restarts.
  - Eagerly enqueue `Rebase` for direct dependents in `mark_merged`, re‑fetch the dependent agent after `refresh_base_branch`, and skip enqueue if already merged or a `Rebase` is already queued.
  - Defense‑in‑depth: `Worktree.create` refuses brand‑new branches when `origin/main` is not an ancestor of the base; `worktree_setup` fetches `origin/<main>` first; skip the ancestry probe when the base equals `main` or `origin/<main>`.
  - Retry transient git spawn failures in `worktree` with a bounded wrapper around `Eio.Process.run`/`spawn`; never retry real git verdicts or cancellations.
  - Tests: property tests for `Start_eligibility`, stale‑base invariants (freshness gate and liveness), real‑git start‑point scenarios (stale base refused, fresh stacked allowed), and spawn‑retry unit tests.

- **Migration**
  - Persistence adds optional `main_sha` (backward‑compatible; poller populates on next fetch).
  - `Worktree.create` now requires `~main_branch`; callers updated.

<sup>Written for commit ad39c26f1909cc685e741d745cd8976b6c602960. Summary will update on new commits. <a href="https://cubic.dev/pr/flowglad/onton/pull/323?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

