### PR TITLE
Build and ship macOS x86_64 binary (#316)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,16 @@ permissions:
 
 jobs:
   build:
-    name: Build (arm64)
-    runs-on: macos-14
+    name: Build (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: arm64
+            runner: macos-14
+          - arch: x86_64
+            runner: macos-13
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -18,7 +26,7 @@ jobs:
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
         with:
           path: _opam
-          key: opam-macos-14-ocaml-5.4.1-${{ hashFiles('*.opam') }}
+          key: opam-${{ matrix.runner }}-ocaml-5.4.1-${{ hashFiles('*.opam') }}
 
       - uses: ocaml/setup-ocaml@e32b06a3e831ff2fbc6f08cf35be2085e3918014 # v3.6.1
         with:
@@ -43,12 +51,12 @@ jobs:
         run: |
           mkdir -p _dist/bin
           cp _build/default/bin/main.exe _dist/bin/onton
-          tar czf onton-arm64-apple-darwin.tar.gz -C _dist/bin onton
+          tar czf onton-${{ matrix.arch }}-apple-darwin.tar.gz -C _dist/bin onton
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: onton-arm64-apple-darwin
-          path: onton-arm64-apple-darwin.tar.gz
+          name: onton-${{ matrix.arch }}-apple-darwin
+          path: onton-${{ matrix.arch }}-apple-darwin.tar.gz
 
   release:
     name: Create Release
@@ -67,7 +75,8 @@ jobs:
             --repo "$GITHUB_REPOSITORY" \
             --title "$GITHUB_REF_NAME" \
             --generate-notes \
-            onton-arm64-apple-darwin.tar.gz
+            onton-arm64-apple-darwin.tar.gz \
+            onton-x86_64-apple-darwin.tar.gz
 
   homebrew:
     name: Update Homebrew Formula
@@ -82,6 +91,7 @@ jobs:
         id: sha
         run: |
           echo "arm64=$(shasum -a 256 onton-arm64-apple-darwin.tar.gz | cut -d ' ' -f 1)" >> "$GITHUB_OUTPUT"
+          echo "x86_64=$(shasum -a 256 onton-x86_64-apple-darwin.tar.gz | cut -d ' ' -f 1)" >> "$GITHUB_OUTPUT"
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -92,6 +102,7 @@ jobs:
           VERSION="${GITHUB_REF_NAME#v}"
           sed -e "s/VERSION/$VERSION/g" \
               -e "s/SHA256_ARM64/${{ steps.sha.outputs.arm64 }}/g" \
+              -e "s/SHA256_X86_64/${{ steps.sha.outputs.x86_64 }}/g" \
               Formula/onton.rb.template > Formula/onton.rb
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/Formula/onton.rb.template
+++ b/Formula/onton.rb.template
@@ -7,8 +7,15 @@ class Onton < Formula
   version "VERSION"
   license "MIT"
 
-  url "https://github.com/flowglad/onton/releases/download/vVERSION/onton-arm64-apple-darwin.tar.gz"
-  sha256 "SHA256_ARM64"
+  on_arm do
+    url "https://github.com/flowglad/onton/releases/download/vVERSION/onton-arm64-apple-darwin.tar.gz"
+    sha256 "SHA256_ARM64"
+  end
+
+  on_intel do
+    url "https://github.com/flowglad/onton/releases/download/vVERSION/onton-x86_64-apple-darwin.tar.gz"
+    sha256 "SHA256_X86_64"
+  end
 
   depends_on "gmp"
 

--- a/README.md
+++ b/README.md
@@ -560,8 +560,8 @@ need reproducibility. The names below are accurate as of February 2026 —
 | `opencode` | Provider-prefixed, e.g. `anthropic/claude-sonnet-4-5`, `openai/gpt-5` | [OpenCode docs](https://opencode.ai/docs) |
 | `pi` | Run `pi --help` for the current list | Pi CLI |
 
-Pushing a `v*` tag builds a macOS ARM64 binary, creates a GitHub release, and
-updates the Homebrew formula.
+Pushing a `v*` tag builds macOS ARM64 and x86_64 binaries, creates a GitHub
+release, and updates the Homebrew formula.
 
 ## TUI
 


### PR DESCRIPTION
Fixes #316.

## Problem

`brew install onton` on Intel macOS installs an ARM64-only binary that fails at runtime (`dyld: ... incompatible architecture`), because:

1. The release workflow built and uploaded only the macOS **ARM64** artifact.
2. `Formula/onton.rb` was hardcoded to the ARM64 release asset.

So Intel Homebrew users got an ARM64 binary pointed at `/usr/local` Intel gmp.

## Fix — no Intel hardware required

GitHub's `macos-13` runner is natively Intel x86_64, so we build the second binary there directly.

- **`.github/workflows/release.yml`** — `build` job becomes a `{macos-14 → arm64, macos-13 → x86_64}` matrix (`fail-fast: false`). Cache key, tarball, and artifact names are arch-keyed. The `release` job attaches both tarballs; the `homebrew` job computes both SHAs and feeds `SHA256_X86_64` into the template.
- **`Formula/onton.rb.template`** — `url`/`sha256` split into `on_arm` / `on_intel` blocks selecting the matching asset. The `install_name_tool` gmp rewrite is unchanged; it runs at install time so each arch self-corrects to its own Homebrew prefix (`/opt/homebrew` ARM, `/usr/local` Intel).
- **`README.md`** — release line now says ARM64 **and x86_64**.

## Note

`Formula/onton.rb` (currently 0.33.0) regenerates from the template on the **next `v*` tag**; this PR does not backfill an x86_64 binary for the existing 0.33.0 release. Intel users are unblocked once the next release is cut.

## Verification

- Apple Silicon: `brew install onton && onton --version`
- Intel macOS: `brew install onton && onton --version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/324"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782419549&installation_id=126163856&pr_number=324&repository=flowglad%2Fonton&return_to=https%3A%2F%2Fgithub.com%2Fflowglad%2Fonton%2Fpull%2F324&signature=ffc2b00028b7053a65d2ad2bf7d33ddc0a8e168029fb54d67ae3e3ec2440b86e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Build and ship a native macOS x86_64 binary and update the Homebrew formula to select the right asset per CPU. This fixes Intel installs that failed because `brew install onton` pulled an ARM64-only binary.

- **Bug Fixes**
  - Release workflow: matrix builds (arm64 on `macos-14`, x86_64 on `macos-13`), arch-keyed cache/artifacts, and both tarballs attached to the release.
  - Homebrew: formula template uses `on_arm`/`on_intel` with separate URLs and `SHA256_ARM64`/`SHA256_X86_64`.
  - Note: Fix takes effect on the next `v*` tag; no backfill for 0.33.0.

<sup>Written for commit 6e58301438da684409984348c610c0e53d55e644. Summary will update on new commits. <a href="https://cubic.dev/pr/flowglad/onton/pull/324?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

