### PR TITLE
Make start-gate freshness dependency-scoped, not main-SHA-scoped

### DIFF
--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -33,12 +33,6 @@ type t = {
   agents : Patch_agent.t Map.M(Patch_id).t;
   outbox : patch_agent_message Map.M(Message_id).t;
   main_branch : Branch.t;
-  main_sha : string option;
-      (** Sha of [origin/<main_branch>] as last observed by the poller. Used by
-          {!Start_eligibility} to gate [Start] actions: a [Start(c, base=B)] is
-          deferred until [B]'s [branch_rebased_onto_sha] equals [main_sha], so
-          that [c]'s worktree is never cut from a stale dep branch. [None] until
-          the first poller tick fetches [origin/main]. *)
 }
 
 let create ~patches ~main_branch =
@@ -57,13 +51,7 @@ let create ~patches ~main_branch =
               (Printf.sprintf "Orchestrator.create: duplicate patch id %s"
                  (Patch_id.to_string p.Patch.id)))
   in
-  {
-    graph;
-    agents;
-    outbox = Map.empty (module Message_id);
-    main_branch;
-    main_sha = None;
-  }
+  { graph; agents; outbox = Map.empty (module Message_id); main_branch }
 
 let agent t patch_id =
   match Map.find t.agents patch_id with
@@ -163,8 +151,8 @@ let mark_merged t patch_id =
   let t = update_agent t patch_id ~f:Patch_agent.mark_merged in
   (* Eagerly update [base_branch] for direct dependents so it is never stale
      when [Merge_conflict] fires, AND eagerly enqueue a [Rebase] so the dep's
-     local tip catches up to [main_sha] before any deferred [Start] that
-     depends on it can fire. Without the eager enqueue, the dep stays on a
+     local branch absorbs the just-merged ancestor before any deferred [Start]
+     that depends on it can fire. Without the eager enqueue, the dep stays on a
      stale base until the next reconciler poll tick — the window that wiped
      event-stream-pages patch 3. *)
   let dependents = Graph.dependents t.graph patch_id in
@@ -267,12 +255,20 @@ let find_patch_by_branch t branch =
 let start_eligibility t base =
   let base_is_main = Branch.equal base t.main_branch in
   let base_branch = Branch.to_string base in
-  let base_patch_merged, base_patch_rebased_onto_sha, base_patch_busy_rebasing =
+  let has_merged pid =
+    match find_agent t pid with Some a -> a.Patch_agent.merged | None -> false
+  in
+  let branch_of pid =
+    match find_agent t pid with
+    | Some a -> a.Patch_agent.branch
+    | None -> t.main_branch
+  in
+  let base_patch_merged, base_patch_busy_rebasing, base_structurally_fresh =
     match find_patch_by_branch t base with
-    | None -> (false, None, false)
+    | None -> (false, false, false)
     | Some bpid -> (
         match find_agent t bpid with
-        | None -> (false, None, false)
+        | None -> (false, false, false)
         | Some a ->
             let running_rebase =
               a.Patch_agent.busy
@@ -289,12 +285,29 @@ let start_eligibility t base =
                 (Some Operation_kind.Rebase)
             in
             let busy_rebasing = running_rebase || runnable_rebase in
-            ( a.Patch_agent.merged,
-              a.Patch_agent.branch_rebased_onto_sha,
-              busy_rebasing ))
+            (* Freshness is dependency-scoped, not main-scoped: the base is
+               fresh iff its local branch was actually rebased onto the
+               structurally-correct base for the current merge state
+               ([branch_rebased_onto = initial_base]). A base on main is fresh
+               even if main later advanced for unrelated reasons. [initial_base]
+               raises with >1 open dep, so guard on that first and treat the
+               ambiguous case as not-fresh (fail closed). A redundant [Rebase]
+               left queued on an already-fresh base does not defer Start —
+               [busy_rebasing] above gates only an imminent rebase. *)
+            let structurally_fresh =
+              List.length (Graph.open_pr_deps t.graph bpid ~has_merged) <= 1
+              &&
+              match a.Patch_agent.branch_rebased_onto with
+              | Some b ->
+                  Branch.equal b
+                    (Graph.initial_base t.graph bpid ~has_merged ~branch_of
+                       ~main:t.main_branch)
+              | None -> false
+            in
+            (a.Patch_agent.merged, busy_rebasing, structurally_fresh))
   in
   Start_eligibility.decide ~base_is_main ~base_branch ~base_patch_merged
-    ~base_patch_rebased_onto_sha ~base_patch_busy_rebasing ~main_sha:t.main_sha
+    ~base_patch_busy_rebasing ~base_structurally_fresh
 
 let runnable_messages t =
   let action_rank = function
@@ -523,18 +536,12 @@ let reset_automerge_failure_count t patch_id =
 let all_agents t = Map.data t.agents
 let graph t = t.graph
 
-let restore ~graph ~agents ~outbox ~main_branch ?main_sha () =
+let restore ~graph ~agents ~outbox ~main_branch () =
   let outbox = Map.filter outbox ~f:(fun msg -> Map.mem agents msg.patch_id) in
-  { graph; agents; outbox; main_branch; main_sha }
+  { graph; agents; outbox; main_branch }
 
 let main_branch t = t.main_branch
 let set_main_branch t branch = { t with main_branch = branch }
-let main_sha t = t.main_sha
-
-let set_main_sha t sha =
-  let sha = String.strip sha in
-  if String.is_empty sha then t else { t with main_sha = Some sha }
-
 let agents_map t = t.agents
 
 let add_agent t ~patch_id ~branch ~base_branch ~pr_number =

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -290,19 +290,24 @@ let start_eligibility t base =
                structurally-correct base for the current merge state
                ([branch_rebased_onto = initial_base]). A base on main is fresh
                even if main later advanced for unrelated reasons. [initial_base]
-               raises with >1 open dep, so guard on that first and treat the
-               ambiguous case as not-fresh (fail closed). A redundant [Rebase]
-               left queued on an already-fresh base does not defer Start —
-               [busy_rebasing] above gates only an imminent rebase. *)
+               raises with >1 open dep, so derive the structural base from
+               [open_deps] directly here ([] -> main, [d] -> d's branch) and
+               treat the ambiguous >1 case as not-fresh (fail closed). That fail
+               closed does not deadlock: a base with >1 open deps reaches Allow
+               once its extra deps merge (dropping it to <=1 open dep, then a
+               rebase), and every merge re-evaluates the deferred Start via the
+               reconciler tick. Computing [open_deps] once also avoids the
+               redundant graph traversal [initial_base] would repeat. A redundant
+               [Rebase] left queued on an already-fresh base does not defer Start
+               — [busy_rebasing] above gates only an imminent rebase, and a
+               completed rebase drains the queue (SBI-3), so [runnable_rebase]
+               cannot latch on a fresh base. *)
+            let open_deps = Graph.open_pr_deps t.graph bpid ~has_merged in
             let structurally_fresh =
-              List.length (Graph.open_pr_deps t.graph bpid ~has_merged) <= 1
-              &&
-              match a.Patch_agent.branch_rebased_onto with
-              | Some b ->
-                  Branch.equal b
-                    (Graph.initial_base t.graph bpid ~has_merged ~branch_of
-                       ~main:t.main_branch)
-              | None -> false
+              match (open_deps, a.Patch_agent.branch_rebased_onto) with
+              | [], Some b -> Branch.equal b t.main_branch
+              | [ d ], Some b -> Branch.equal b (branch_of d)
+              | _ -> false
             in
             (a.Patch_agent.merged, busy_rebasing, structurally_fresh))
   in

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -415,29 +415,19 @@ val restore :
   agents:Patch_agent.t Map.M(Patch_id).t ->
   outbox:patch_agent_message Map.M(Message_id).t ->
   main_branch:Branch.t ->
-  ?main_sha:string ->
   unit ->
   t
-(** Reconstruct orchestrator from persisted components. [main_sha] defaults to
-    [None] when an older snapshot has no recorded value; the poller fills it in
-    on the next tick. *)
-
-val main_sha : t -> string option
-(** Sha of [origin/<main_branch>] as last observed by the poller. [None] until
-    the first successful fetch. *)
-
-val set_main_sha : t -> string -> t
-(** Record the latest observed [origin/<main_branch>] sha. Empty/whitespace
-    inputs are ignored (returns [t] unchanged) so a failed fetch doesn't clobber
-    a previously good value. *)
+(** Reconstruct orchestrator from persisted components. *)
 
 val start_eligibility : t -> Branch.t -> Start_eligibility.decision
 (** [start_eligibility t base] is the freshness verdict for a hypothetical
-    [Start] action whose base is [base], evaluated against [t]'s current
-    [main_sha] and the base patch's recorded rebase anchor. Used to gate [Start]
-    in {!runnable_messages}; exposed for tests/TUI introspection.
+    [Start] action whose base is [base], evaluated against [t]'s dependency
+    graph and the base patch's recorded rebase anchor. Used to gate [Start] in
+    {!runnable_messages}; exposed for tests/TUI introspection.
 
     Returns [Allow] when the base is main, when the base patch is merged
-    (effectively main), or when the base patch's [branch_rebased_onto_sha]
-    matches [main_sha]. Otherwise returns [Defer reason]. See
+    (effectively main), or when the base patch's local branch is rebased onto
+    its structurally-correct base ([branch_rebased_onto = Graph.initial_base]).
+    Otherwise returns [Defer reason]. Freshness is dependency-scoped: an
+    unrelated advance of [origin/main] never defers a [Start]. See
     {!Start_eligibility}. *)

--- a/lib/persistence.ml
+++ b/lib/persistence.ml
@@ -491,18 +491,12 @@ let orchestrator_to_yojson (o : Orchestrator.t) =
                   | Orchestrator.Obsolete -> "Obsolete") );
             ] ))
   in
-  let main_sha_field =
-    match Orchestrator.main_sha o with
-    | None -> []
-    | Some s -> [ ("main_sha", `String s) ]
-  in
   `Assoc
-    ([
-       ("main_branch", Branch.yojson_of_t (Orchestrator.main_branch o));
-       ("agents", `Assoc agents);
-       ("outbox", `Assoc outbox);
-     ]
-    @ main_sha_field)
+    [
+      ("main_branch", Branch.yojson_of_t (Orchestrator.main_branch o));
+      ("agents", `Assoc agents);
+      ("outbox", `Assoc outbox);
+    ]
 
 let action_of_yojson json =
   let ( let* ) r f = Result.bind r ~f in
@@ -539,11 +533,6 @@ let orchestrator_of_yojson ~gameplan json =
     let ( let* ) r f = Result.bind r ~f in
     let graph = Graph.of_patches gameplan.Gameplan.patches in
     let main_branch = Branch.of_string (string_member "main_branch" json) in
-    let main_sha =
-      match Yojson.Safe.Util.member "main_sha" json with
-      | `String s when not (String.is_empty s) -> Some s
-      | _ -> None
-    in
     Result.bind
       (result_all
          (Yojson.Safe.Util.member "agents" json
@@ -655,7 +644,7 @@ let orchestrator_of_yojson ~gameplan json =
           in
           Ok
             (Orchestrator.restore ~graph ~agents:agents_map ~outbox ~main_branch
-               ?main_sha ()))
+               ()))
   with
   | Yojson.Safe.Util.Type_error (msg, _) ->
       Error (Printf.sprintf "malformed orchestrator: %s" msg)

--- a/lib/poller_fiber.ml
+++ b/lib/poller_fiber.ml
@@ -182,93 +182,6 @@ struct
       Eio.Mutex.use_rw ~protect:true vanish_logged_mutex (fun () ->
           Stdlib.Hashtbl.remove vanish_logged patch_id)
     in
-    (* P1-A: detect when [origin/<main>] has advanced past local <main>. When
-       it has, every agent currently based on <main> needs a rebase so it
-       picks up the freshly squash-merged commits — without this poke,
-       [Reconciler.detect_stale_bases] silently passes because both
-       [base_branch] and [Graph.initial_base] read the same stale name.
-
-       The fetch uses [Env.fetch_mutex], the same mutex the runner fiber
-       holds for per-worktree fetches, so the two never race on the shared
-       ref store. *)
-    let fetch_lock = Env.fetch_mutex in
-    let last_main_sha = ref "" in
-    let main_str = Branch.to_string main in
-    let check_main_freshness () =
-      match W.fetch_origin ~fetch_lock ~path:repo_root with
-      | Result.Error _ -> ()
-      | Result.Ok () ->
-          let local_sha =
-            Option.value
-              (W.read_branch_sha ~path:repo_root ~ref_name:main_str)
-              ~default:""
-          in
-          let origin_sha =
-            Option.value
-              (W.read_branch_sha ~path:repo_root
-                 ~ref_name:("refs/remotes/origin/" ^ main_str))
-              ~default:""
-          in
-          (* Record the observed [origin/<main>] sha on the orchestrator on
-             every successful fetch — not just on drift. [Start_eligibility]
-             consults [main_sha] to gate [Start] actions; if we only updated
-             on drift, the first-ever fetch (where [last_main_sha] is empty)
-             would update, but subsequent ticks during a quiet period would
-             leave [main_sha] unset for any orchestrator built from a
-             snapshot. *)
-          if not (String.is_empty origin_sha) then
-            Runtime.update_orchestrator runtime (fun orch ->
-                Orchestrator.set_main_sha orch origin_sha);
-          if
-            Reconciler.detect_main_freshness_drift ~local_sha ~origin_sha
-            && not (String.equal origin_sha !last_main_sha)
-          then begin
-            last_main_sha := origin_sha;
-            Runtime_logging.log_event runtime
-              (Printf.sprintf
-                 "origin/%s advanced to %s (local %s) — enqueueing rebases for \
-                  agents on %s"
-                 main_str
-                 (if String.length origin_sha >= 8 then
-                    String.prefix origin_sha 8
-                  else origin_sha)
-                 (if String.length local_sha >= 8 then String.prefix local_sha 8
-                  else local_sha)
-                 main_str);
-            Runtime.update_orchestrator runtime (fun orch ->
-                let agents = Orchestrator.all_agents orch in
-                List.fold agents ~init:orch ~f:(fun acc agent ->
-                    let is_on_main =
-                      match agent.Patch_agent.base_branch with
-                      | Some b -> Branch.equal b main
-                      | None -> false
-                    in
-                    let already_rebasing =
-                      List.mem agent.Patch_agent.queue Operation_kind.Rebase
-                        ~equal:Operation_kind.equal
-                    in
-                    if
-                      is_on_main
-                      && Patch_agent.is_pr_present agent
-                      && (not agent.Patch_agent.merged)
-                      && not already_rebasing
-                    then
-                      Orchestrator.enqueue acc agent.Patch_agent.patch_id
-                        Operation_kind.Rebase
-                    else acc))
-          end
-    in
-    (* Freshness fiber: runs in parallel with the per-patch poll loop so a
-       slow [git fetch] for [origin/<main>] doesn't block the per-patch
-       fan-out. Same cadence as the patch poll loop for now; could be
-       independent later if needed. Sleeps before its first check so it
-       doesn't duplicate the fetch [Managed_repo.ensure_managed_repo] already
-       ran at startup. *)
-    let rec freshness_loop () =
-      Eio.Time.sleep clock poll_interval;
-      check_main_freshness ();
-      freshness_loop ()
-    in
     let rec loop () =
       let intents =
         Runtime.read runtime (fun snap ->
@@ -593,5 +506,5 @@ struct
       Eio.Time.sleep clock poll_interval;
       loop ()
     in
-    Eio.Fiber.both loop freshness_loop
+    loop ()
 end

--- a/lib_core/reconciler.ml
+++ b/lib_core/reconciler.ml
@@ -77,12 +77,6 @@ let detect_rebases graph views ~newly_merged =
     [base_branch vs initial_base] both read [main] and agreed, so no rebase was
     enqueued. *)
 
-let detect_main_freshness_drift ~local_sha ~origin_sha =
-  let l = String.strip local_sha in
-  let r = String.strip origin_sha in
-  if String.is_empty l || String.is_empty r then false
-  else not (String.equal l r)
-
 let detect_notified_base_drift views =
   List.filter_map views ~f:(fun v ->
       if

--- a/lib_core/reconciler.mli
+++ b/lib_core/reconciler.mli
@@ -66,18 +66,6 @@ val detect_rebases :
     dependents of [newly_merged] patches that have a PR, are not merged, and do
     not already have a rebase queued. *)
 
-val detect_main_freshness_drift : local_sha:string -> origin_sha:string -> bool
-(** [detect_main_freshness_drift ~local_sha ~origin_sha] returns [true] when the
-    local [main] branch tip differs from [origin/main]. Pure predicate over two
-    strings — the effectful side reads the SHAs via [git rev-parse] and passes
-    them in. Used by the poller to decide whether to fast-forward local [main]
-    before the next reconciler tick: when the SHAs disagree,
-    [detect_stale_bases] cannot fire (it consults [Graph.initial_base], which
-    reads the {e same} stale local main name), so every agent ends up rebasing
-    onto a target that already missed recently-merged commits. Empty strings
-    (treat as "unknown") return [false] — conservative: don't claim drift on
-    missing data. *)
-
 val detect_notified_base_drift : patch_view list -> action list
 (** [detect_notified_base_drift views] returns [Enqueue_rebase] for agents whose
     [branch_rebased_onto] is [Some b] and differs from the current

--- a/lib_core/start_eligibility.ml
+++ b/lib_core/start_eligibility.ml
@@ -1,45 +1,30 @@
 open Base
 
 type defer_reason =
-  | Main_sha_unknown
   | Base_patch_busy_with_rebase of { base_branch : string }
-  | Base_not_rebased_since_main_advanced of {
-      base_branch : string;
-      base_rebased_onto_sha : string option;
-      main_sha : string;
-    }
+  | Base_not_fresh_for_cut of { base_branch : string }
 [@@deriving show, eq, sexp_of, compare]
 
 type decision = Allow | Defer of defer_reason
 [@@deriving show, eq, sexp_of, compare]
 
 let decide ~base_is_main ~base_branch ~base_patch_merged
-    ~base_patch_rebased_onto_sha ~base_patch_busy_rebasing ~main_sha =
+    ~base_patch_busy_rebasing ~base_structurally_fresh =
   if base_is_main then Allow
   else if base_patch_merged then Allow
   else if base_patch_busy_rebasing then
-    (* Check this before [main_sha = None]: an active/imminent rebase is the
-       most informative signal and is a valid reason to wait regardless of
-       whether the poller has published main yet. Otherwise this short-circuit
-       would be unreachable while [main_sha = None]. *)
+    (* An active/imminent rebase is the most informative signal — wait for it
+       rather than racing it. *)
     Defer (Base_patch_busy_with_rebase { base_branch })
-  else
-    match main_sha with
-    | None -> Defer Main_sha_unknown
-    | Some main_sha -> (
-        match base_patch_rebased_onto_sha with
-        | Some s when String.equal s main_sha -> Allow
-        | _ ->
-            Defer
-              (Base_not_rebased_since_main_advanced
-                 {
-                   base_branch;
-                   base_rebased_onto_sha = base_patch_rebased_onto_sha;
-                   main_sha;
-                 }))
+  else if not base_structurally_fresh then
+    (* The base patch's local branch is not yet sitting on its
+       structurally-correct base (a dependency merged but the rebase that
+       absorbs it has not landed), so cutting a downstream worktree here would
+       elide the just-merged ancestor's commits. *)
+    Defer (Base_not_fresh_for_cut { base_branch })
+  else Allow
 
 let short_label = function
   | Allow -> "allow"
-  | Defer Main_sha_unknown -> "defer_main_unknown"
   | Defer (Base_patch_busy_with_rebase _) -> "defer_base_busy_rebasing"
-  | Defer (Base_not_rebased_since_main_advanced _) -> "defer_base_stale"
+  | Defer (Base_not_fresh_for_cut _) -> "defer_base_stale"

--- a/lib_core/start_eligibility.mli
+++ b/lib_core/start_eligibility.mli
@@ -1,42 +1,40 @@
-(** Pure decision: is a [Start] action eligible to fire right now, given the
-    freshness of its base branch relative to the orchestrator's known
-    [origin/main] sha?
+(** Pure decision: is a [Start] action eligible to fire right now, given whether
+    its base patch's local branch has already incorporated the merged form of
+    its dependencies?
 
     Why this exists: the orchestrator schedules [Start(c, base=b)] as soon as
-    [c] is dispatchable, but [b]'s local branch can lag [origin/main] when an
+    [c] is dispatchable, but [b]'s local branch can lag its dependencies when an
     upstream dependency merges to main while [b] is open (busy responding to
-    CI/review). Cutting [c]'s worktree from a stale [b] silently elides the
-    just-merged ancestor's commits. The reconciler's poll-tick detectors
-    (`detect_rebases`, `detect_stale_bases`, `detect_notified_base_drift`)
-    eventually catch this, but a [Start] can race past the next tick. This
-    module is the synchronous gate that closes that race: when the base is
-    stale, [Start] is deferred (not consumed) until the rebase pipeline brings
-    [b] up to date.
+    CI/review). Cutting [c]'s worktree from such a [b] silently elides the
+    just-merged ancestor's commits — and under squash merges [b] still carries
+    the dep's pre-squash commits, so a later rebase of [b] would leave [c]
+    stranded on history that no longer exists. The reconciler's poll-tick
+    detectors ([detect_rebases], [detect_stale_bases],
+    [detect_notified_base_drift]) enqueue the rebase that fixes this, but a
+    [Start] can race past the next tick. This module is the synchronous gate
+    that closes that race: when the base is not yet fresh, [Start] is deferred
+    (not consumed) until the rebase pipeline brings [b] up to date.
 
-    {1 Authority}
+    {1 Freshness is dependency-scoped, not main-scoped}
 
-    The orchestrator tracks [origin/main]'s sha (`Orchestrator.main_sha`,
-    updated by the poller). Each open patch records the sha of the base it was
-    last rebased onto (`Patch_agent.branch_rebased_onto_sha`, written by the
-    rebase pipeline on success). When the two agree for [c]'s base patch, the
-    base contains main's tip and [Start] is safe. *)
+    The gate does NOT require [b] to be current with the latest [origin/main].
+    It only requires [b]'s local branch to sit on its structurally-correct base
+    given the current merge state — i.e. [Patch_agent.branch_rebased_onto]
+    equals [Graph.initial_base b]. A [b] based directly on main is always fresh,
+    even if main has since advanced for unrelated reasons; an unrelated merge to
+    main never makes [b] stale for the purpose of cutting [c]. The caller
+    computes the [base_structurally_fresh] flag from the dep graph and the base
+    patch's recorded rebase anchor. *)
 
 type defer_reason =
-  | Main_sha_unknown
-      (** The poller has not yet observed [origin/main] (e.g. very first tick
-          after startup) and no rebase is in flight. Fail closed — defer rather
-          than risk cutting from a base whose freshness we cannot verify. *)
   | Base_patch_busy_with_rebase of { base_branch : string }
       (** The base patch already has a [Rebase] in flight (busy with op
           [Rebase], or [Rebase] is queued and highest-priority). Wait for it
           rather than racing it. *)
-  | Base_not_rebased_since_main_advanced of {
-      base_branch : string;
-      base_rebased_onto_sha : string option;
-      main_sha : string;
-    }
-      (** The base patch's last-recorded rebase sha differs from the
-          orchestrator's known main sha. The base needs to be rebased before
+  | Base_not_fresh_for_cut of { base_branch : string }
+      (** The base patch's local branch is not yet rebased onto its
+          structurally-correct base — a dependency has merged but the rebase
+          that absorbs it has not landed. The base needs that rebase before
           [Start] can fire. *)
 [@@deriving show, eq, sexp_of, compare]
 
@@ -47,9 +45,8 @@ val decide :
   base_is_main:bool ->
   base_branch:string ->
   base_patch_merged:bool ->
-  base_patch_rebased_onto_sha:string option ->
   base_patch_busy_rebasing:bool ->
-  main_sha:string option ->
+  base_structurally_fresh:bool ->
   decision
 (** [decide] is total and deterministic. Pre-emption order, applied top-down:
 
@@ -60,21 +57,15 @@ val decide :
       will refresh [base_branch] before the [Start] actually executes via
       [refresh_base_branch] in [mark_merged]).
     + [base_patch_busy_rebasing = true] → [Defer Base_patch_busy_with_rebase].
-      Checked before [main_sha = None] so an active rebase pre-empts the
-      unknown-main verdict (and the arm is not dead when main is unpublished).
-    + [main_sha = None] → [Defer Main_sha_unknown]. Fail closed.
-    + [base_patch_rebased_onto_sha = Some s] and [Some s = main_sha] → [Allow].
-    + Otherwise → [Defer Base_not_rebased_since_main_advanced { … }].
+      Checked before the freshness flag so an active rebase pre-empts.
+    + [base_structurally_fresh = false] → [Defer Base_not_fresh_for_cut].
+    + Otherwise → [Allow].
 
-    Note: this decision does not look at the dep graph. The caller resolves
-    [c]'s base to a single base patch (or main) and passes the relevant facts.
-    For multi-dep patches, the caller is expected to wait for the dep graph to
-    collapse to ≤1 open dep (the existing [refresh_base_branch] contract) before
-    constructing a [Start] action; this module enforces freshness of that single
-    chosen base. *)
+    Note: this decision does not look at the dep graph itself. The caller
+    resolves [c]'s base to a single base patch (or main) and passes the relevant
+    facts, including whether that base is structurally fresh. *)
 
 val short_label : decision -> string
 (** A short, lowercase, snake_case identifier for the decision arm, suitable for
     activity logging. Always non-empty and ≤ 32 characters. Examples: ["allow"],
-    ["defer_main_unknown"], ["defer_base_busy_rebasing"], ["defer_base_stale"].
-*)
+    ["defer_base_busy_rebasing"], ["defer_base_stale"]. *)

--- a/test/test_reconciler_properties.ml
+++ b/test/test_reconciler_properties.ml
@@ -618,64 +618,6 @@ let prop_reconcile_dedup_rebase =
       in
       List.length rebases = 1)
 
-(* P1-A: detect_main_freshness_drift covers the SHA-vs-SHA case that
-   detect_stale_bases misses (both sides read the same stale local main name,
-   so structural check passes). *)
-let prop_main_drift_total =
-  QCheck2.Test.make ~count:500
-    ~name:"MFD-1: detect_main_freshness_drift is total over arbitrary strings"
-    (QCheck2.Gen.pair
-       (QCheck2.Gen.string_size (QCheck2.Gen.int_range 0 60))
-       (QCheck2.Gen.string_size (QCheck2.Gen.int_range 0 60)))
-    (fun (local_sha, origin_sha) ->
-      try
-        let _ = Reconciler.detect_main_freshness_drift ~local_sha ~origin_sha in
-        true
-      with _ -> false)
-
-let prop_main_drift_equal_shas_no_drift =
-  QCheck2.Test.make ~name:"MFD-2: equal non-empty SHAs -> no drift" ~count:200
-    (QCheck2.Gen.string_size
-       ~gen:(QCheck2.Gen.char_range 'a' 'f')
-       (QCheck2.Gen.int_range 7 40))
-    (fun sha ->
-      not
-        (Reconciler.detect_main_freshness_drift ~local_sha:sha ~origin_sha:sha))
-
-let prop_main_drift_different_shas_drifts =
-  QCheck2.Test.make ~name:"MFD-3: distinct non-empty SHAs -> drift fires"
-    ~count:200
-    (QCheck2.Gen.pair
-       (QCheck2.Gen.string_size
-          ~gen:(QCheck2.Gen.char_range 'a' 'f')
-          (QCheck2.Gen.int_range 7 40))
-       (QCheck2.Gen.string_size
-          ~gen:(QCheck2.Gen.char_range '0' '9')
-          (QCheck2.Gen.int_range 7 40)))
-    (fun (l, r) ->
-      if Base.String.equal l r then true
-      else Reconciler.detect_main_freshness_drift ~local_sha:l ~origin_sha:r)
-
-let prop_main_drift_empty_is_silent =
-  QCheck2.Test.make ~name:"MFD-4: empty SHA on either side -> silent (no drift)"
-    (QCheck2.Gen.pair
-       (QCheck2.Gen.string_size (QCheck2.Gen.int_range 0 40))
-       (QCheck2.Gen.string_size (QCheck2.Gen.int_range 0 40)))
-    (fun (l, r) ->
-      let l_empty = Base.String.is_empty (Base.String.strip l) in
-      let r_empty = Base.String.is_empty (Base.String.strip r) in
-      if l_empty || r_empty then
-        not (Reconciler.detect_main_freshness_drift ~local_sha:l ~origin_sha:r)
-      else true)
-
-let prop_main_drift_strip_whitespace =
-  QCheck2.Test.make
-    ~name:"MFD-5: whitespace around the SHA is stripped before compare"
-    (QCheck2.Gen.return ()) (fun () ->
-      not
-        (Reconciler.detect_main_freshness_drift ~local_sha:"  abc1234  "
-           ~origin_sha:"abc1234\n"))
-
 let () =
   let tests =
     [
@@ -706,11 +648,6 @@ let () =
       prop_drift_always_produces_enqueue_rebase;
       prop_reconcile_e2e_catches_drift;
       prop_reconcile_dedup_rebase;
-      prop_main_drift_total;
-      prop_main_drift_equal_shas_no_drift;
-      prop_main_drift_different_shas_drifts;
-      prop_main_drift_empty_is_silent;
-      prop_main_drift_strip_whitespace;
     ]
   in
   List.iter tests ~f:(fun t -> QCheck2.Test.check_exn t);

--- a/test/test_stale_base_invariants.ml
+++ b/test/test_stale_base_invariants.ml
@@ -199,17 +199,25 @@ let base_is_fresh m base =
     in
     match base_entry with
     | None -> false
-    | Some (bpid, a) -> (
-        a.Patch_agent.merged
-        || List.length
-             (Graph.open_pr_deps (Orchestrator.graph m.orch) bpid
-                ~has_merged:(fun dep ->
-                  (Orchestrator.agent m.orch dep).Patch_agent.merged))
-           <= 1
-           &&
-           match a.Patch_agent.branch_rebased_onto with
-           | Some b -> Branch.equal b (initial_base_of m.orch m.patches bpid)
-           | None -> false)
+    | Some (bpid, a) ->
+        if a.Patch_agent.merged then true
+        else
+          (* Bind [open_deps] once and pattern-match to derive the structural
+             base directly ([] -> main, [d] -> d's branch), treating >1 open
+             deps as not-fresh — mirroring [Orchestrator.start_eligibility].
+             Keeping the guard and the base derivation in a single match means
+             no reordering can leave [Graph.initial_base] (which raises on >1
+             open deps) called unguarded; deriving the base inline also keeps
+             this oracle independent of [start_eligibility]. *)
+          let open_deps =
+            Graph.open_pr_deps (Orchestrator.graph m.orch) bpid
+              ~has_merged:(fun dep ->
+                (Orchestrator.agent m.orch dep).Patch_agent.merged)
+          in
+          (match (open_deps, a.Patch_agent.branch_rebased_onto) with
+          | [], Some b -> Branch.equal b main
+          | [ d ], Some b -> Branch.equal b (branch_of_patches m.patches d)
+          | _ -> false)
 
 (** SBI: every [Start (_, base)] surfaced by [runnable_messages] has a fresh
     [base] per [base_is_fresh]. [Enqueue_start] seeds the outbox with real

--- a/test/test_stale_base_invariants.ml
+++ b/test/test_stale_base_invariants.ml
@@ -199,7 +199,7 @@ let base_is_fresh m base =
     in
     match base_entry with
     | None -> false
-    | Some (bpid, a) ->
+    | Some (bpid, a) -> (
         if a.Patch_agent.merged then true
         else
           (* Bind [open_deps] once and pattern-match to derive the structural
@@ -214,7 +214,7 @@ let base_is_fresh m base =
               ~has_merged:(fun dep ->
                 (Orchestrator.agent m.orch dep).Patch_agent.merged)
           in
-          (match (open_deps, a.Patch_agent.branch_rebased_onto) with
+          match (open_deps, a.Patch_agent.branch_rebased_onto) with
           | [], Some b -> Branch.equal b main
           | [ d ], Some b -> Branch.equal b (branch_of_patches m.patches d)
           | _ -> false)

--- a/test/test_stale_base_invariants.ml
+++ b/test/test_stale_base_invariants.ml
@@ -5,48 +5,48 @@ open Onton_core.Types
 
 (** Stale-Base Invariant (SBI) property tests.
 
-    Property: for every reachable orchestrator state and every [Start (c, base)]
-    action that actually fires from [Orchestrator.runnable_messages] →
-    [Orchestrator.accept_message], the base is fresh — meaning at fire time:
+    Freshness is dependency-scoped, not main-scoped. For every reachable
+    orchestrator state and every [Start (c, base)] action that actually fires
+    from [Orchestrator.runnable_messages] → [Orchestrator.accept_message], the
+    base is fresh — meaning at fire time:
 
     + [base = main_branch], OR
     + the base patch (looked up by branch) is [merged], OR
-    + the base patch's [branch_rebased_onto_sha] equals the orchestrator's known
-      [main_sha].
+    + the base patch's local branch is rebased onto its structurally-correct
+      base for the current merge state
+      ([branch_rebased_onto = Graph.initial_base]).
+
+    Crucially, an unrelated advance of [origin/main] never makes a base stale:
+    the gate does not consult any main sha. A base sitting directly on main, or
+    a base that already absorbed its merged deps, stays eligible no matter how
+    far main moves.
 
     The harness:
 
     - Models a linear A→B→C→… dep chain of length 2 or 3 with
       [mk_linear_patches], so each non-root patch has exactly one dep.
-    - Models the world's [main_sha] as a counter; a [Main_advanced] command
-      bumps it and calls [Orchestrator.set_main_sha]. (Real wire-up via the
-      poller is exercised separately.)
+    - Models an unrelated advance of main via [Main_advanced]. Since freshness
+      is no longer main-scoped, this is a no-op on orchestrator state — included
+      to assert that interleaving main movement never trips the gate.
     - Models PR merges via [Pr_merged i], which calls [Orchestrator.mark_merged]
       and (per [Orchestrator.mark_merged]'s eager enqueue) implicitly enqueues a
-      [Rebase] for the dependent.
+      [Rebase] for the dependent. This is the only thing that makes a
+      dependent's base stale.
     - Models rebase completion via [Rebase_complete i], which applies a
-      successful rebase result onto main and records an anchor sha = current
-      model [main_sha]. This is the operation that closes the freshness gap.
-    - Models the controller's Start-firing loop via [Drain_runnable], which
-      pulls the highest-priority runnable message and runs it through
-      [accept_message] + [fire] + [complete]. By construction, only
-      eligibility-passing Starts reach [fire]; the test asserts this directly
-      from the model. *)
+      successful rebase onto the patch's current structural base
+      ([Graph.initial_base]); [apply_rebase_result] records
+      [branch_rebased_onto = that base]. This is the operation that closes the
+      freshness gap.
+    - Models the controller's Start-firing loop indirectly: only
+      eligibility-passing Starts reach [runnable_messages]; the test asserts
+      freshness directly from the model. *)
 
 let main = Branch.of_string "main"
 let mk_patches = Onton_test_support.Test_generators.mk_linear_patches
 
 (* -- Model state -- *)
 
-type model = {
-  orch : Orchestrator.t;
-  patches : Patch.t list;
-  model_main_sha : int;
-      (** Monotonically advancing counter — every [Main_advanced] or merge
-          stamps a new sha. *)
-}
-
-let sha_of_int n = Printf.sprintf "sha-%08d" n
+type model = { orch : Orchestrator.t; patches : Patch.t list }
 
 let branch_of_patches patches =
   let map =
@@ -61,67 +61,64 @@ let pid_of_idx patches i =
   let p = List.nth_exn patches i in
   p.Patch.id
 
-(** Bootstrap mirroring the patch-controller boot sequence: each patch starts
-    with base = its dep's branch (or main for the root), receives a PR number,
-    and completes. Initial main_sha is published before any Start is gated. *)
-let bootstrap patches =
+(** Structural base for [pid] given the current orchestrator merge state. *)
+let initial_base_of orch patches pid =
   let branch_of = branch_of_patches patches in
+  let has_merged dep_pid =
+    (Orchestrator.agent orch dep_pid).Patch_agent.merged
+  in
+  Graph.initial_base (Orchestrator.graph orch) pid ~has_merged ~branch_of ~main
+
+(** Bootstrap mirroring the patch-controller boot sequence: each patch starts
+    with base = its structural base (its dep's branch, or main for the root),
+    receives a PR number, and completes. [Patch_agent.start] records
+    [branch_rebased_onto = base], so every base is structurally fresh at boot.
+*)
+let bootstrap patches =
   let orch = Orchestrator.create ~patches ~main_branch:main in
-  let initial_main_sha = sha_of_int 0 in
-  let orch = Orchestrator.set_main_sha orch initial_main_sha in
   let orch =
     List.foldi patches ~init:orch ~f:(fun i o _p ->
         let pid = pid_of_idx patches i in
-        let has_merged dep_pid =
-          (Orchestrator.agent o dep_pid).Patch_agent.merged
-        in
-        let base =
-          Graph.initial_base (Orchestrator.graph o) pid ~has_merged ~branch_of
-            ~main
-        in
+        let base = initial_base_of o patches pid in
         let o = Orchestrator.fire o (Orchestrator.Start (pid, base)) in
-        (* Mirror the runner's anchor-recording on a successful initial
-           checkout: branch_rebased_onto_sha = initial main sha. Without this
-           the freshness gate would refuse every Start at the very first
-           Main_advanced. *)
-        let o =
-          Orchestrator.set_branch_rebased_onto_sha o pid (Some initial_main_sha)
-        in
         let o = Orchestrator.set_pr_number o pid (Pr_number.of_int (i + 1)) in
         Orchestrator.complete o pid)
   in
-  { orch; patches; model_main_sha = 0 }
+  { orch; patches }
 
 (* -- Commands -- *)
 
 type command =
-  | Main_advanced  (** Bump the model main_sha and publish to orchestrator. *)
+  | Main_advanced
+      (** An unrelated advance of [origin/main]. No-op on orchestrator state —
+          freshness is dependency-scoped, so this must never defer a Start. *)
   | Pr_merged of int
-      (** Mark patch idx as merged. Bumps main_sha (the merged commit
-          conceptually becomes main's tip). *)
+      (** Mark patch idx as merged. [mark_merged] eagerly enqueues a [Rebase]
+          for the dependent, whose base is now stale until that rebase lands. *)
   | Rebase_complete of int
-      (** Apply a successful rebase onto main for patch idx; record anchor sha =
-          current model main_sha. *)
+      (** Apply a successful rebase onto patch idx's current structural base;
+          records [branch_rebased_onto = that base]. Closes the freshness gap.
+      *)
   | Enqueue_start of int
       (** Place a [Start] in patch idx's outbox so the freshness gate can be
           observed against it. Bootstrap already placed and consumed the initial
           Start; this re-enqueues one for testing. *)
 
-let bump_main_sha m =
-  let next = m.model_main_sha + 1 in
-  let orch = Orchestrator.set_main_sha m.orch (sha_of_int next) in
-  { m with orch; model_main_sha = next }
-
 let apply_command m cmd =
   match cmd with
-  | Main_advanced -> bump_main_sha m
+  | Main_advanced -> m
   | Pr_merged i ->
       if i >= List.length m.patches then m
       else
         let pid = pid_of_idx m.patches i in
-        let m = bump_main_sha m in
-        let orch = Orchestrator.mark_merged m.orch pid in
-        { m with orch }
+        (* The reconciler only ever marks a *newly* merged patch
+           ([detect_merges] guards on [not v.merged]); re-marking is never
+           issued. Mirror that here, else a redundant [mark_merged] would
+           re-enqueue a [Rebase] on an already-fresh dependent. *)
+        if (Orchestrator.agent m.orch pid).Patch_agent.merged then m
+        else
+          let orch = Orchestrator.mark_merged m.orch pid in
+          { m with orch }
   | Rebase_complete i ->
       if i >= List.length m.patches then m
       else
@@ -140,30 +137,19 @@ let apply_command m cmd =
           || not rebase_in_queue
         then m
         else
-          (* This drives the agent state-machine directly (fire → apply result)
-             rather than the message lifecycle (accept_message → … →
-             apply_rebase_result), and that shortcut is safe for the SBI
-             property because the property only reads base freshness from agent
-             fields — [merged], [branch_rebased_onto_sha], and (via
-             [start_eligibility]'s busy-rebase check) [busy]/[current_op]/[queue]
-             — none of which depend on outbox message [status] or
-             [current_message_id]. [Orchestrator.fire (Rebase _)] sets
-             [busy = true] and [current_op = Rebase] (Patch_agent.rebase's spec)
-             exactly as [accept_message] would, which is also the precondition
-             [apply_rebase_result]'s eventual [complete] requires. The only state
-             not modelled here is the *in-flight* (Acked, busy) rebase observed
-             between commands; the busy-via-queue path is exercised after
-             [Pr_merged]'s eager enqueue, and [prop_event_stream_pages_witness]
-             covers Base_patch_busy_with_rebase directly. *)
+          (* Drives the agent state-machine directly (fire → apply result)
+             rather than the message lifecycle; safe for the SBI property, which
+             only reads base freshness from agent fields — [merged],
+             [branch_rebased_onto], and (via [start_eligibility]'s busy-rebase
+             check) [busy]/[current_op]/[queue]. The rebase target is the
+             patch's current structural base, which [apply_rebase_result] then
+             records as [branch_rebased_onto]. *)
+          let target = initial_base_of m.orch m.patches pid in
           let orch =
-            Orchestrator.fire m.orch (Orchestrator.Rebase (pid, main))
+            Orchestrator.fire m.orch (Orchestrator.Rebase (pid, target))
           in
           let orch, _effects =
-            Orchestrator.apply_rebase_result orch pid Worktree.Ok main
-          in
-          let orch =
-            Orchestrator.set_branch_rebased_onto_sha orch pid
-              (Some (sha_of_int m.model_main_sha))
+            Orchestrator.apply_rebase_result orch pid Worktree.Ok target
           in
           { m with orch }
   | Enqueue_start i ->
@@ -171,21 +157,13 @@ let apply_command m cmd =
       else
         let pid = pid_of_idx m.patches i in
         let agent = Orchestrator.agent m.orch pid in
-        let branch_of = branch_of_patches m.patches in
-        let has_merged dep_pid =
-          (Orchestrator.agent m.orch dep_pid).Patch_agent.merged
-        in
-        let base =
-          Graph.initial_base
-            (Orchestrator.graph m.orch)
-            pid ~has_merged ~branch_of ~main
-        in
+        let base = initial_base_of m.orch m.patches pid in
         (* Inject a real [Pending] Start(pid, base) into the outbox so the
            freshness gate in [runnable_messages] is actually exercised against
-           it. [base] varies as deps merge / rebase and as main advances, so
-           the gate is observed against fresh and stale bases alike. The id is
-           keyed on (patch, base, generation) — mirroring the controller — so a
-           base change re-keys the message and [reconcile_message] obsoletes the
+           it. [base] varies as deps merge / rebase, so the gate is observed
+           against fresh and stale bases alike. The id is keyed on
+           (patch, base, generation) — mirroring the controller — so a base
+           change re-keys the message and [reconcile_message] obsoletes the
            prior Start for this patch. *)
         let message_id =
           Message_id.of_string
@@ -207,28 +185,31 @@ let apply_command m cmd =
 (* -- Invariants -- *)
 
 (** Independent freshness oracle: [true] iff [base] is fresh per the documented
-    SBI invariant — recomputed directly from agent fields rather than delegating
-    back to [start_eligibility], so the property genuinely checks that
-    [runnable_messages]' gate enforces freshness (a regression that let a stale
-    Start through would be caught) instead of re-deriving the same verdict. *)
+    SBI invariant — recomputed directly from agent fields and the dep graph
+    rather than delegating back to [start_eligibility], so the property
+    genuinely checks that [runnable_messages]' gate enforces freshness (a
+    regression that let a stale Start through would be caught) instead of
+    re-deriving the same verdict. *)
 let base_is_fresh m base =
   if Branch.equal base main then true
   else
-    let base_agent =
-      Map.data (Orchestrator.agents_map m.orch)
-      |> List.find ~f:(fun (a : Patch_agent.t) ->
-          Branch.equal a.Patch_agent.branch base)
+    let base_entry =
+      Map.to_alist (Orchestrator.agents_map m.orch)
+      |> List.find ~f:(fun (_, a) -> Branch.equal a.Patch_agent.branch base)
     in
-    match base_agent with
+    match base_entry with
     | None -> false
-    | Some a -> (
+    | Some (bpid, a) -> (
         a.Patch_agent.merged
-        ||
-        match
-          (a.Patch_agent.branch_rebased_onto_sha, Orchestrator.main_sha m.orch)
-        with
-        | Some s, Some main_sha -> String.equal s main_sha
-        | _ -> false)
+        || List.length
+             (Graph.open_pr_deps (Orchestrator.graph m.orch) bpid
+                ~has_merged:(fun dep ->
+                  (Orchestrator.agent m.orch dep).Patch_agent.merged))
+           <= 1
+           &&
+           match a.Patch_agent.branch_rebased_onto with
+           | Some b -> Branch.equal b (initial_base_of m.orch m.patches bpid)
+           | None -> false)
 
 (** SBI: every [Start (_, base)] surfaced by [runnable_messages] has a fresh
     [base] per [base_is_fresh]. [Enqueue_start] seeds the outbox with real
@@ -253,13 +234,11 @@ let sbi_defer_implies_progress m =
       | Some base -> (
           match Orchestrator.start_eligibility m.orch base with
           | Start_eligibility.Allow -> true
-          | Start_eligibility.Defer Start_eligibility.Main_sha_unknown ->
-              Option.is_none (Orchestrator.main_sha m.orch)
           | Start_eligibility.Defer
               (Start_eligibility.Base_patch_busy_with_rebase _) ->
               true (* by definition: a Rebase is in flight or queued *)
-          | Start_eligibility.Defer
-              (Start_eligibility.Base_not_rebased_since_main_advanced _) -> (
+          | Start_eligibility.Defer (Start_eligibility.Base_not_fresh_for_cut _)
+            -> (
               (* There must be an actual path to Allow: the base patch either has
                  a [Rebase] queued (which will close the freshness gap) or has a
                  PR the reconciler's stale-base detectors can enqueue a [Rebase]
@@ -284,23 +263,23 @@ let sbi_defer_implies_progress m =
 (** SBI-3 (rebase drains the queue): the freshness gate's
     [Base_patch_busy_with_rebase] arm only stays sound if a completed rebase
     actually removes [Rebase] from the agent's queue — otherwise
-    [runnable_rebase] would latch [true] forever, a just-rebased base would keep
-    deferring with [Base_patch_busy_with_rebase], and SBI-2's "by definition"
-    arm would pass vacuously. Assert the postcondition directly: any idle (not
-    [busy]) agent whose recorded sha already matches [main_sha] must carry no
-    queued [Rebase]. [Patch_agent.rebase] enforces this (it filters [Rebase] out
-    of [queue]); this locks it in so a regression in
+    [runnable_rebase] would latch [true] forever and a just-rebased base would
+    keep deferring. Assert the postcondition directly: any idle (not [busy])
+    agent that is structurally fresh (its local branch sits on its current
+    structural base) must carry no queued [Rebase]. [Patch_agent.complete] after
+    a successful rebase enforces this; this locks it in so a regression in
     [fire]/[apply_rebase_result]/[complete] would be caught here rather than
     hidden behind a vacuous liveness pass. *)
 let sbi_completed_rebase_drains_queue m =
-  let main_sha = Orchestrator.main_sha m.orch in
-  List.for_all (Orchestrator.all_agents m.orch) ~f:(fun (a : Patch_agent.t) ->
-      let rebased_to_main =
-        match (a.Patch_agent.branch_rebased_onto_sha, main_sha) with
-        | Some s, Some ms -> String.equal s ms
-        | _ -> false
+  List.for_all
+    (Map.to_alist (Orchestrator.agents_map m.orch))
+    ~f:(fun (pid, a) ->
+      let structurally_fresh =
+        match a.Patch_agent.branch_rebased_onto with
+        | Some b -> Branch.equal b (initial_base_of m.orch m.patches pid)
+        | None -> false
       in
-      if (not a.Patch_agent.busy) && rebased_to_main then
+      if (not a.Patch_agent.busy) && structurally_fresh then
         not
           (List.mem a.Patch_agent.queue Operation_kind.Rebase
              ~equal:Operation_kind.equal)
@@ -378,12 +357,13 @@ let prop_completed_rebase_drains_queue =
       in
       ok)
 
-(** PI-SBI-1 (witness): the exact event-stream-pages scenario.
+(** PI-SBI-1 (witness): the exact event-stream-pages scenario, now driven by a
+    dependency merge rather than a main advance.
 
-    1. Bootstrap [a; b; c] with c → b → a. 2. main advances (a merges to
-    upstream, but a is itself an open patch in the model — we model it as:
-    external main bumps + Pr_merged a). 3. b is the open dep of c; b has NOT
-    rebased. 4. Attempt to fire Start(c, base=b): must be deferred. *)
+    1. Bootstrap [a; b; c] with c → b → a. 2. a merges ([Pr_merged 0]);
+    [mark_merged] eagerly enqueues a Rebase on b and b's structural base becomes
+    main. 3. b has NOT rebased yet. 4. Start(c, base=b) must be deferred. 5.
+    After b rebases, Start(c, base=b) returns to Allow. *)
 let prop_event_stream_pages_witness =
   QCheck2.Test.make ~count:1
     ~name:
@@ -391,42 +371,34 @@ let prop_event_stream_pages_witness =
        b unrebased after a merges" (Gen.return ()) (fun () ->
       let patches = mk_patches 3 in
       let m = bootstrap patches in
-      let pid_a = pid_of_idx patches 0 in
       let pid_b = pid_of_idx patches 1 in
-      let pid_c = pid_of_idx patches 2 in
       let branch_b = (Orchestrator.agent m.orch pid_b).Patch_agent.branch in
-      (* Initially: bootstrap fired Start(c, base=b) when b's
-         branch_rebased_onto_sha = initial main sha. Eligibility = Allow.
-         Sanity-check that here. *)
+      (* Initially: bootstrap fired Start(c, base=b) with b's
+         branch_rebased_onto = its structural base. Eligibility = Allow. *)
       let allow0 = Orchestrator.start_eligibility m.orch branch_b in
       let initial_allow =
         match allow0 with
         | Start_eligibility.Allow -> true
         | Start_eligibility.Defer _ -> false
       in
-      (* main advances and a merges. mark_merged eagerly enqueues Rebase on b. *)
-      let m = apply_command m Main_advanced in
+      (* a merges. mark_merged eagerly enqueues Rebase on b and b's structural
+         base flips to main, but b's branch_rebased_onto still points at a's
+         branch. *)
       let m = apply_command m (Pr_merged 0) in
-      let _ = pid_a in
-      (* b's rebased_onto_sha is still the old sha. Eligibility for a new
-         Start with base=b should be Defer. *)
       let eligibility_after_merge =
         Orchestrator.start_eligibility m.orch branch_b
       in
-      (* After a's merge, the gate must defer Start(c, base=b) for one of two
-         reasons: (a) the sha mismatch [Base_not_rebased_since_main_advanced]
-         if no rebase has been queued yet, or (b) [Base_patch_busy_with_rebase]
-         if mark_merged's eager enqueue already put Rebase in b's queue. Both
-         are correct outcomes — the assertion is that some Defer fires. *)
+      (* The gate must defer Start(c, base=b): either [Base_not_fresh_for_cut]
+         (branch still on a's branch, not main) or [Base_patch_busy_with_rebase]
+         (mark_merged's eager enqueue already put Rebase highest in b's queue).
+         Both are correct — the assertion is that some Defer fires. *)
       let deferred =
         match eligibility_after_merge with
         | Start_eligibility.Defer
-            ( Start_eligibility.Base_not_rebased_since_main_advanced _
+            ( Start_eligibility.Base_not_fresh_for_cut _
             | Start_eligibility.Base_patch_busy_with_rebase _ ) ->
             true
-        | Start_eligibility.Allow
-        | Start_eligibility.Defer Start_eligibility.Main_sha_unknown ->
-            false
+        | Start_eligibility.Allow -> false
       in
       (* And b's queue contains Rebase, from the eager enqueue. *)
       let b_rebase_queued =
@@ -434,8 +406,8 @@ let prop_event_stream_pages_witness =
         List.mem a.Patch_agent.queue Operation_kind.Rebase
           ~equal:Operation_kind.equal
       in
-      (* Now simulate b rebasing onto current main: eligibility returns to
-         Allow. *)
+      (* Now simulate b rebasing onto its structural base (main): eligibility
+         returns to Allow. *)
       let m = apply_command m (Rebase_complete 1) in
       let eligibility_after_rebase =
         Orchestrator.start_eligibility m.orch branch_b
@@ -445,8 +417,40 @@ let prop_event_stream_pages_witness =
         | Start_eligibility.Allow -> true
         | Start_eligibility.Defer _ -> false
       in
-      let _ = pid_c in
       initial_allow && deferred && b_rebase_queued && unblocked)
+
+(** PI-SBI-2 (witness): an unrelated advance of main never defers a Start. A
+    base sitting directly on main (the root patch) stays eligible for cutting
+    its downstream no matter how many times main advances — the regression the
+    old SHA-equality gate would have flagged. *)
+let prop_unrelated_main_advance_does_not_defer =
+  QCheck2.Test.make ~count:1
+    ~name:
+      "PI-SBI-2: unrelated main advance does not defer a Start off a \
+       main-based base" (Gen.return ()) (fun () ->
+      let patches = mk_patches 2 in
+      let m = bootstrap patches in
+      let pid_root = pid_of_idx patches 0 in
+      let branch_root =
+        (Orchestrator.agent m.orch pid_root).Patch_agent.branch
+      in
+      let allow_before =
+        match Orchestrator.start_eligibility m.orch branch_root with
+        | Start_eligibility.Allow -> true
+        | Start_eligibility.Defer _ -> false
+      in
+      (* main advances repeatedly with nothing of the root's merging. *)
+      let m =
+        List.fold
+          [ Main_advanced; Main_advanced; Main_advanced ]
+          ~init:m ~f:apply_command
+      in
+      let allow_after =
+        match Orchestrator.start_eligibility m.orch branch_root with
+        | Start_eligibility.Allow -> true
+        | Start_eligibility.Defer _ -> false
+      in
+      allow_before && allow_after)
 
 let () =
   let runner = QCheck_base_runner.run_tests_main in
@@ -457,4 +461,5 @@ let () =
          prop_defer_implies_progress;
          prop_completed_rebase_drains_queue;
          prop_event_stream_pages_witness;
+         prop_unrelated_main_advance_does_not_defer;
        ])

--- a/test/test_start_eligibility_properties.ml
+++ b/test/test_start_eligibility_properties.ml
@@ -3,6 +3,11 @@ open Onton_core
 
 (** Property tests for {!Start_eligibility}.
 
+    Freshness here is dependency-scoped: the gate asks whether the base patch's
+    local branch has been rebased onto its structurally-correct base
+    ([base_structurally_fresh]), NOT whether it is current with the latest
+    [origin/main]. An unrelated advance of main never defers a [Start].
+
     Properties:
 
     - {b SEP-1 Totality}: [decide] never raises on any input.
@@ -10,10 +15,11 @@ open Onton_core
     - {b SEP-3 Pre-emption order}: each arm in the documented order is reachable
       and only fires when no earlier arm matches.
     - {b SEP-4 [Allow] ⇒ fresh}: every [Allow] is justified by at least one of:
-      base is main, base patch is merged, or the recorded rebased-onto sha
-      matches the known main sha.
+      base is main, base patch is merged, or (not busy-rebasing and the base is
+      structurally fresh).
     - {b SEP-5 [Defer] ⇒ not fresh}: every [Defer] reflects a real freshness gap
-      (no main sha, busy rebase, or sha mismatch).
+      (base patch busy rebasing, or base not structurally fresh) on a non-main,
+      unmerged base.
     - {b SEP-6 Label bounds}: [short_label] is non-empty, ≤ 32 chars, lowercase
       snake_case.
     - {b SEP-7 Variant reachability}: every constructor of {!decision} and
@@ -25,16 +31,14 @@ module SE = Start_eligibility
 
 (* ---------- Generators ---------- *)
 
-let gen_sha = Gen.string_size ~gen:Gen.printable (Gen.int_range 0 40)
 let gen_branch = Gen.string_size ~gen:Gen.printable (Gen.int_range 1 30)
 
 type inputs = {
   base_is_main : bool;
   base_branch : string;
   base_patch_merged : bool;
-  base_patch_rebased_onto_sha : string option;
   base_patch_busy_rebasing : bool;
-  main_sha : string option;
+  base_structurally_fresh : bool;
 }
 
 let gen_inputs : inputs Gen.t =
@@ -42,42 +46,22 @@ let gen_inputs : inputs Gen.t =
   let* base_is_main = bool in
   let* base_branch = gen_branch in
   let* base_patch_merged = bool in
-  let* base_patch_rebased_onto_sha = option gen_sha in
   let* base_patch_busy_rebasing = bool in
-  let* main_sha = option gen_sha in
+  let* base_structurally_fresh = bool in
   return
     {
       base_is_main;
       base_branch;
       base_patch_merged;
-      base_patch_rebased_onto_sha;
       base_patch_busy_rebasing;
-      main_sha;
-    }
-
-(* Pairs where [base_patch_rebased_onto_sha] and [main_sha] match with
-   non-trivial probability — the [Allow]-via-sha-equality arm wouldn't get
-   exercised by independent generators. *)
-let gen_inputs_matching : inputs Gen.t =
-  let open Gen in
-  let* shared = gen_sha in
-  let* base_branch = gen_branch in
-  let* base_patch_busy_rebasing = bool in
-  return
-    {
-      base_is_main = false;
-      base_branch;
-      base_patch_merged = false;
-      base_patch_rebased_onto_sha = Some shared;
-      base_patch_busy_rebasing;
-      main_sha = Some shared;
+      base_structurally_fresh;
     }
 
 let call i =
   SE.decide ~base_is_main:i.base_is_main ~base_branch:i.base_branch
     ~base_patch_merged:i.base_patch_merged
-    ~base_patch_rebased_onto_sha:i.base_patch_rebased_onto_sha
-    ~base_patch_busy_rebasing:i.base_patch_busy_rebasing ~main_sha:i.main_sha
+    ~base_patch_busy_rebasing:i.base_patch_busy_rebasing
+    ~base_structurally_fresh:i.base_structurally_fresh
 
 (* ---------- Properties ---------- *)
 
@@ -94,26 +78,13 @@ let prop_determinism =
 
 let is_allow = function SE.Allow -> true | SE.Defer _ -> false
 
-let is_defer_main_unknown = function
-  | SE.Defer SE.Main_sha_unknown -> true
-  | SE.Allow
-  | SE.Defer
-      ( SE.Base_patch_busy_with_rebase _
-      | SE.Base_not_rebased_since_main_advanced _ ) ->
-      false
-
 let is_defer_busy = function
   | SE.Defer (SE.Base_patch_busy_with_rebase _) -> true
-  | SE.Allow
-  | SE.Defer (SE.Main_sha_unknown | SE.Base_not_rebased_since_main_advanced _)
-    ->
-      false
+  | SE.Allow | SE.Defer (SE.Base_not_fresh_for_cut _) -> false
 
 let is_defer_stale = function
-  | SE.Defer (SE.Base_not_rebased_since_main_advanced _) -> true
-  | SE.Allow | SE.Defer (SE.Main_sha_unknown | SE.Base_patch_busy_with_rebase _)
-    ->
-      false
+  | SE.Defer (SE.Base_not_fresh_for_cut _) -> true
+  | SE.Allow | SE.Defer (SE.Base_patch_busy_with_rebase _) -> false
 
 let prop_preempt_base_is_main =
   Test.make ~count:200 ~name:"SEP-3a: base_is_main pre-empts everything → Allow"
@@ -130,91 +101,59 @@ let prop_preempt_base_merged =
       return { i with base_is_main = false; base_patch_merged = true })
     (fun i -> is_allow (call i))
 
-let prop_preempt_main_unknown =
-  Test.make ~count:200
-    ~name:
-      "SEP-3c: main_sha=None (and no earlier match) → Defer Main_sha_unknown"
-    Gen.(
-      let* i = gen_inputs in
-      return
-        {
-          i with
-          base_is_main = false;
-          base_patch_merged = false;
-          (* busy_rebasing now pre-empts the unknown-main arm, so pin it off to
-             isolate the Main_sha_unknown case. *)
-          base_patch_busy_rebasing = false;
-          main_sha = None;
-        })
-    (fun i -> is_defer_main_unknown (call i))
-
 let prop_preempt_busy =
   Test.make ~count:200
-    ~name:
-      "SEP-3d: busy_rebasing (with main_sha known) → Defer \
-       Base_patch_busy_with_rebase"
+    ~name:"SEP-3c: busy_rebasing → Defer Base_patch_busy_with_rebase"
     Gen.(
       let* i = gen_inputs in
-      let* sha = gen_sha in
       return
         {
           i with
           base_is_main = false;
           base_patch_merged = false;
-          main_sha = Some sha;
           base_patch_busy_rebasing = true;
         })
     (fun i -> is_defer_busy (call i))
 
-let prop_allow_on_sha_equality =
-  Test.make ~count:200
-    ~name:"SEP-3e: rebased_onto_sha = main_sha (and no earlier match) → Allow"
-    gen_inputs_matching (fun i ->
-      (* [gen_inputs_matching] sets base_is_main=false,
-         base_patch_merged=false, both shas Some &amp; equal. busy_rebasing
-         varies. *)
-      if i.base_patch_busy_rebasing then is_defer_busy (call i)
-      else is_allow (call i))
-
-let prop_defer_stale_when_mismatch =
+let prop_defer_when_not_fresh =
   Test.make ~count:300
     ~name:
-      "SEP-3f: main_sha known, not busy, rebased_onto_sha != main_sha → Defer \
-       Base_not_rebased_since_main_advanced"
+      "SEP-3d: not fresh, not busy, non-main, unmerged → Defer \
+       Base_not_fresh_for_cut"
     Gen.(
-      let* main_sha = gen_sha in
       let* base_branch = gen_branch in
-      (* Choose rebased_onto_sha to be either None or different from main_sha. *)
-      let* rebased =
-        oneof
-          [
-            return None;
-            map
-              (fun s -> Some (main_sha ^ s ^ "_diff"))
-              (string_size ~gen:printable (int_range 1 5));
-          ]
-      in
       return
         {
           base_is_main = false;
           base_branch;
           base_patch_merged = false;
-          base_patch_rebased_onto_sha = rebased;
           base_patch_busy_rebasing = false;
-          main_sha = Some main_sha;
+          base_structurally_fresh = false;
         })
     (fun i -> is_defer_stale (call i))
+
+let prop_allow_when_fresh =
+  Test.make ~count:300
+    ~name:"SEP-3e: structurally fresh, not busy, non-main, unmerged → Allow"
+    Gen.(
+      let* base_branch = gen_branch in
+      return
+        {
+          base_is_main = false;
+          base_branch;
+          base_patch_merged = false;
+          base_patch_busy_rebasing = false;
+          base_structurally_fresh = true;
+        })
+    (fun i -> is_allow (call i))
 
 let prop_allow_implies_fresh =
   Test.make ~count:500 ~name:"SEP-4: Allow ⇒ fresh" gen_inputs (fun i ->
       match call i with
       | SE.Defer _ -> true
-      | SE.Allow -> (
+      | SE.Allow ->
           i.base_is_main || i.base_patch_merged
-          ||
-          match (i.base_patch_rebased_onto_sha, i.main_sha) with
-          | Some s, Some m -> String.equal s m
-          | _ -> false))
+          || ((not i.base_patch_busy_rebasing) && i.base_structurally_fresh))
 
 let prop_defer_implies_not_fresh =
   Test.make ~count:500 ~name:"SEP-5: Defer ⇒ not fresh" gen_inputs (fun i ->
@@ -222,12 +161,7 @@ let prop_defer_implies_not_fresh =
       | SE.Allow -> true
       | SE.Defer _ ->
           (not i.base_is_main) && (not i.base_patch_merged)
-          && (Option.is_none i.main_sha || i.base_patch_busy_rebasing
-             ||
-             match (i.base_patch_rebased_onto_sha, i.main_sha) with
-             | Some s, Some m -> not (String.equal s m)
-             | None, _ -> true
-             | _, None -> true))
+          && (i.base_patch_busy_rebasing || not i.base_structurally_fresh))
 
 let label_re = Re.compile (Re.Pcre.re "^[a-z][a-z0-9_]*$")
 
@@ -244,36 +178,26 @@ let prop_variants_reachable =
     (fun () ->
       let allow_main =
         SE.decide ~base_is_main:true ~base_branch:"main"
-          ~base_patch_merged:false ~base_patch_rebased_onto_sha:None
-          ~base_patch_busy_rebasing:false ~main_sha:None
+          ~base_patch_merged:false ~base_patch_busy_rebasing:false
+          ~base_structurally_fresh:false
       in
       let allow_merged =
         SE.decide ~base_is_main:false ~base_branch:"b" ~base_patch_merged:true
-          ~base_patch_rebased_onto_sha:None ~base_patch_busy_rebasing:false
-          ~main_sha:None
+          ~base_patch_busy_rebasing:false ~base_structurally_fresh:false
       in
-      let allow_sha_eq =
+      let allow_fresh =
         SE.decide ~base_is_main:false ~base_branch:"b" ~base_patch_merged:false
-          ~base_patch_rebased_onto_sha:(Some "abc")
-          ~base_patch_busy_rebasing:false ~main_sha:(Some "abc")
-      in
-      let defer_unknown =
-        SE.decide ~base_is_main:false ~base_branch:"b" ~base_patch_merged:false
-          ~base_patch_rebased_onto_sha:(Some "abc")
-          ~base_patch_busy_rebasing:false ~main_sha:None
+          ~base_patch_busy_rebasing:false ~base_structurally_fresh:true
       in
       let defer_busy =
         SE.decide ~base_is_main:false ~base_branch:"b" ~base_patch_merged:false
-          ~base_patch_rebased_onto_sha:(Some "abc")
-          ~base_patch_busy_rebasing:true ~main_sha:(Some "abc")
+          ~base_patch_busy_rebasing:true ~base_structurally_fresh:true
       in
       let defer_stale =
         SE.decide ~base_is_main:false ~base_branch:"b" ~base_patch_merged:false
-          ~base_patch_rebased_onto_sha:(Some "old")
-          ~base_patch_busy_rebasing:false ~main_sha:(Some "new")
+          ~base_patch_busy_rebasing:false ~base_structurally_fresh:false
       in
-      is_allow allow_main && is_allow allow_merged && is_allow allow_sha_eq
-      && is_defer_main_unknown defer_unknown
+      is_allow allow_main && is_allow allow_merged && is_allow allow_fresh
       && is_defer_busy defer_busy && is_defer_stale defer_stale)
 
 let () =
@@ -285,10 +209,9 @@ let () =
          prop_determinism;
          prop_preempt_base_is_main;
          prop_preempt_base_merged;
-         prop_preempt_main_unknown;
          prop_preempt_busy;
-         prop_allow_on_sha_equality;
-         prop_defer_stale_when_mismatch;
+         prop_defer_when_not_fresh;
+         prop_allow_when_fresh;
          prop_allow_implies_fresh;
          prop_defer_implies_not_fresh;
          prop_label_bounds;


### PR DESCRIPTION
## Problem

The start-eligibility gate required a base patch `B` to be rebased onto the **latest `origin/main` SHA** before a dependent `C` could start (`Start_eligibility.decide` keyed on `base_patch_rebased_onto_sha == main_sha`). To keep that equality satisfiable as main moved, the poller's `check_main_freshness` blast re-rebased + force-pushed **every** open PR on **every** advance of main — triggering a full CI re-run each time. That's a thundering herd scaling with `(merge-rate × open-PRs)`.

## Insight

The quality property we actually need is narrower: **a downstream worktree must never be cut from a base that hasn't incorporated the merged form of its dependencies.** That's a *dependency* property, not a *main-currency* property. In `[A] <- [B] <- [C]`, we rebase `B` because **`A` — a dependency of `B` — merged**, not because main moved for unrelated reasons.

Under squash merges (the norm) this matters more: `A`'s branch commits aren't literally in main (only a squashed commit is), so cutting `C` from a `B` still carrying `A`'s pre-squash commits strands `C` once `B` later rebases.

## Change

- **`start_eligibility.decide`** now gates on `~base_structurally_fresh` (`branch_rebased_onto = Graph.initial_base`) instead of `~main_sha` / `~base_patch_rebased_onto_sha`. New `Base_not_fresh_for_cut` defer reason; `Main_sha_unknown` removed.
- **Orchestrator** computes structural freshness at the call site from the dep graph + the base patch's recorded rebase anchor (`branch_rebased_onto`).
- **Removed** the main-freshness blast (`poller_fiber` `check_main_freshness`/`freshness_loop`), `Reconciler.detect_main_freshness_drift`, and the `Orchestrator.main_sha` field + persistence plumbing (old snapshots with the field are ignored on read).
- **No merge-time main-currency requirement** (deliberate): a behind-main PR squash-merges directly; any textual conflict at merge time is handled by the existing `Merge_conflict` op.

The localized dependency trigger that already existed is kept: `mark_merged`'s eager enqueue + `detect_rebases` / `detect_stale_bases` / `detect_notified_base_drift`.

### Effect

`B` now rebases only when one of `B`'s dependencies merges (≈ once per merged dep) rather than once per main advance. A direct-on-main base with a downstream also stops being needlessly blocked when main moves.

## Tests

Re-derived from the new invariant (not patched to pass):
- Rewrote `test_start_eligibility_properties.ml` against the new signature/reasons.
- Re-specified the SBI state machine in `test_stale_base_invariants.ml`; `Main_advanced` is now a no-op and `prop_event_stream_pages_witness` is driven by a dep merge. Added `PI-SBI-2`: an unrelated main advance never defers a Start off a main-based base.
- Deleted the orphaned `detect_main_freshness_drift` (MFD-*) properties.

Full `dune build` + `dune runtest` + ocamlformat check green (via pre-commit hook). Net −278 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Start gate dependency-scoped instead of main-SHA-scoped. Rebases now happen only when a dependency merges, cutting unnecessary CI reruns and avoiding blocks when `main` moves for unrelated reasons.

- **Refactors**
  - Gate `Start` on structural freshness (`branch_rebased_onto = Graph.initial_base`); add `Base_not_fresh_for_cut`, remove `Main_sha_unknown`.
  - Compute freshness in `orchestrator`; derive the structural base once via `open_pr_deps` ([] → `main`, [d] → d’s branch; >1 open deps = not fresh).
  - Remove main-SHA plumbing and polling: delete the `poller_fiber` freshness loop, `Reconciler.detect_main_freshness_drift`, `Orchestrator.main_sha`, and related persistence; old snapshots ignore the field.
  - Keep dependency-triggered rebases (`mark_merged` eager enqueue + stale-base detectors). Behind-`main` PRs squash-merge directly; conflicts go through `Merge_conflict`.
  - Tests updated to the new invariant; SBI oracle mirrors the single-pass `open_pr_deps` derivation and includes a witness that unrelated `main` advances never defer `Start`. Applied `ocamlformat` to the oracle refactor (no behavior change).

<sup>Written for commit 5b762c1d0e16b6b182fa970cd8527167b192bf2c. Summary will update on new commits. <a href="https://cubic.dev/pr/flowglad/onton/pull/325?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782425893&installation_id=126163856&pr_number=325&repository=flowglad%2Fonton&return_to=https%3A%2F%2Fgithub.com%2Fflowglad%2Fonton%2Fpull%2F325&signature=cd499fd022108fca4aff0c9635057546388036671a071de4b3bdb1c668a1ad5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->