### PR TITLE
Isolate integration-test git from the host repo environment

### DIFF
--- a/lib/worktree.ml
+++ b/lib/worktree.ml
@@ -359,6 +359,12 @@ let create ~process_mgr ~repo_root ~project_name ~patch_id ~branch ~base_ref
     ~main_branch : (t, Start_point_plan.refusal) Result.t =
   let path = worktree_dir ~project_name ~patch_id in
   let branch_str = Types.Branch.to_string branch in
+  (* The destination is keyed only on [$HOME] + [project_name] + [patch_id]
+     (see {!worktree_dir}). When the path already exists we trust it and skip
+     the git setup, so callers must guarantee an isolated [$HOME] — in
+     particular, tests redirect HOME into a temp sandbox so a stale
+     [~/worktrees/<project>/patch-<id>] from a prior run cannot make this
+     short-circuit return a spurious Ok. *)
   if Stdlib.Sys.file_exists path then Result.Ok { patch_id; branch; path }
   else (
     check_case_insensitive_ref_collision ~process_mgr ~repo_root branch_str;

--- a/lib_test/git_env.ml
+++ b/lib_test/git_env.ml
@@ -16,6 +16,47 @@ let read_all fd =
   loop ();
   Buffer.contents buf
 
+let read_both fd1 fd2 =
+  let buf1 = Buffer.create 256 in
+  let buf2 = Buffer.create 256 in
+  let bytes = Bytes.create 4096 in
+  let ready ready_fds fd =
+    List.exists ready_fds ~f:(fun ready_fd -> Stdlib.(ready_fd = fd))
+  in
+  let read_one fd buf =
+    match Unix.read fd bytes 0 (Bytes.length bytes) with
+    | 0 -> false
+    | n ->
+        Buffer.add_subbytes buf bytes ~pos:0 ~len:n;
+        true
+    | exception Unix.Unix_error (Unix.EINTR, _, _) -> true
+  in
+  let rec loop fd1_open fd2_open =
+    match (fd1_open, fd2_open) with
+    | false, false -> ()
+    | _ -> (
+        let fds =
+          List.concat
+            [
+              (if fd1_open then [ fd1 ] else []);
+              (if fd2_open then [ fd2 ] else []);
+            ]
+        in
+        match Unix.select fds [] [] (-1.) with
+        | ready_fds, _, _ ->
+            let fd1_open =
+              fd1_open && ((not (ready ready_fds fd1)) || read_one fd1 buf1)
+            in
+            let fd2_open =
+              fd2_open && ((not (ready ready_fds fd2)) || read_one fd2 buf2)
+            in
+            loop fd1_open fd2_open
+        | exception Unix.Unix_error (Unix.EINTR, _, _) -> loop fd1_open fd2_open
+        )
+  in
+  loop true true;
+  (Buffer.contents buf1, Buffer.contents buf2)
+
 let run_git ~cwd args =
   let argv = Array.of_list ("git" :: "-C" :: cwd :: args) in
   let env = clean_env () in
@@ -99,10 +140,7 @@ let git_capture ~cwd args =
             (fun () ->
               Unix.create_process_env "git" argv env devnull stdout_w stderr_w)
         in
-        (* Drain stdout (then stderr) before reaping. git writes its small
-           output and exits, closing both ends, so this cannot deadlock. *)
-        let out_buf = read_all stdout_r in
-        let err_buf = read_all stderr_r in
+        let out_buf, err_buf = read_both stdout_r stderr_r in
         let rec waitpid () =
           match Unix.waitpid [] pid with
           | result -> result
@@ -137,7 +175,13 @@ let git_exit_code ~cwd args =
   let argv = Array.of_list ("git" :: "-C" :: cwd :: args) in
   let env = clean_env () in
   let devnull_in = Unix.openfile "/dev/null" [ Unix.O_RDONLY ] 0 in
-  let devnull_out = Unix.openfile "/dev/null" [ Unix.O_WRONLY ] 0 in
+  let devnull_out =
+    match Unix.openfile "/dev/null" [ Unix.O_WRONLY ] 0 with
+    | fd -> fd
+    | exception exn ->
+        (try Unix.close devnull_in with _ -> ());
+        raise exn
+  in
   let pid =
     Stdlib.Fun.protect
       ~finally:(fun () ->

--- a/lib_test/git_env.ml
+++ b/lib_test/git_env.ml
@@ -67,6 +67,127 @@ let run_git ~cwd args =
            (String.concat ~sep:" " args)
            cwd n (String.strip stderr_buf))
 
+(* [git -C cwd args] returning trimmed stdout, spawned with {!clean_env} so no
+   inherited [GIT_*] var (e.g. a pre-commit hook's [GIT_DIR]/[GIT_INDEX_FILE])
+   can redirect it off [cwd]. Raises on nonzero exit, reporting stderr. *)
+let git_capture ~cwd args =
+  let argv = Array.of_list ("git" :: "-C" :: cwd :: args) in
+  let env = clean_env () in
+  let stdout_r, stdout_w = Unix.pipe ~cloexec:true () in
+  let stderr_r, stderr_w = Unix.pipe ~cloexec:true () in
+  let devnull =
+    match Unix.openfile "/dev/null" [ Unix.O_RDONLY ] 0 with
+    | fd -> fd
+    | exception exn ->
+        List.iter
+          ~f:(fun fd -> try Unix.close fd with _ -> ())
+          [ stdout_r; stdout_w; stderr_r; stderr_w ];
+        raise exn
+  in
+  let out_buf, err_buf, status =
+    Stdlib.Fun.protect
+      ~finally:(fun () ->
+        (try Unix.close stdout_r with _ -> ());
+        try Unix.close stderr_r with _ -> ())
+      (fun () ->
+        let pid =
+          Stdlib.Fun.protect
+            ~finally:(fun () ->
+              (try Unix.close stdout_w with _ -> ());
+              (try Unix.close stderr_w with _ -> ());
+              try Unix.close devnull with _ -> ())
+            (fun () ->
+              Unix.create_process_env "git" argv env devnull stdout_w stderr_w)
+        in
+        (* Drain stdout (then stderr) before reaping. git writes its small
+           output and exits, closing both ends, so this cannot deadlock. *)
+        let out_buf = read_all stdout_r in
+        let err_buf = read_all stderr_r in
+        let rec waitpid () =
+          match Unix.waitpid [] pid with
+          | result -> result
+          | exception Unix.Unix_error (Unix.EINTR, _, _) -> waitpid ()
+        in
+        let _, status = waitpid () in
+        (out_buf, err_buf, status))
+  in
+  match status with
+  | Unix.WEXITED 0 -> String.strip out_buf
+  | Unix.WEXITED n ->
+      Stdlib.failwith
+        (Printf.sprintf "git %s in %s: exit %d\nstderr: %s"
+           (String.concat ~sep:" " args)
+           cwd n (String.strip err_buf))
+  | Unix.WSIGNALED n ->
+      Stdlib.failwith
+        (Printf.sprintf "git %s in %s: signaled %d"
+           (String.concat ~sep:" " args)
+           cwd n)
+  | Unix.WSTOPPED n ->
+      Stdlib.failwith
+        (Printf.sprintf "git %s in %s: stopped %d"
+           (String.concat ~sep:" " args)
+           cwd n)
+
+(* Like {!run_git} but returns the process exit code instead of raising on a
+   nonzero status (still raises if the process is signaled). For git queries
+   whose exit code is the answer, e.g. [merge-base --is-ancestor]. Output is
+   discarded. Spawned with {!clean_env}. *)
+let git_exit_code ~cwd args =
+  let argv = Array.of_list ("git" :: "-C" :: cwd :: args) in
+  let env = clean_env () in
+  let devnull_in = Unix.openfile "/dev/null" [ Unix.O_RDONLY ] 0 in
+  let devnull_out = Unix.openfile "/dev/null" [ Unix.O_WRONLY ] 0 in
+  let pid =
+    Stdlib.Fun.protect
+      ~finally:(fun () ->
+        (try Unix.close devnull_in with _ -> ());
+        try Unix.close devnull_out with _ -> ())
+      (fun () ->
+        Unix.create_process_env "git" argv env devnull_in devnull_out
+          devnull_out)
+  in
+  let rec waitpid () =
+    match Unix.waitpid [] pid with
+    | result -> result
+    | exception Unix.Unix_error (Unix.EINTR, _, _) -> waitpid ()
+  in
+  match snd (waitpid ()) with
+  | Unix.WEXITED n -> n
+  | Unix.WSIGNALED n | Unix.WSTOPPED n ->
+      Stdlib.failwith
+        (Printf.sprintf "git %s in %s: terminated by signal %d"
+           (String.concat ~sep:" " args)
+           cwd n)
+
+(* Run a shell command in [dir] with the scrubbed git environment. Covers the
+   non-git shell steps in integration fixtures (e.g. [echo base > README.md],
+   [git clone ...]) without letting an inherited [GIT_*] var leak into any git
+   the command invokes. stdout/stderr pass through; raises on nonzero exit. *)
+let sh ~dir cmd =
+  let full = Printf.sprintf "cd %s && %s" (Stdlib.Filename.quote dir) cmd in
+  let argv = [| "/bin/sh"; "-c"; full |] in
+  let env = clean_env () in
+  let devnull = Unix.openfile "/dev/null" [ Unix.O_RDONLY ] 0 in
+  let pid =
+    Stdlib.Fun.protect
+      ~finally:(fun () -> try Unix.close devnull with _ -> ())
+      (fun () ->
+        Unix.create_process_env "/bin/sh" argv env devnull Unix.stdout
+          Unix.stderr)
+  in
+  let rec waitpid () =
+    match Unix.waitpid [] pid with
+    | result -> result
+    | exception Unix.Unix_error (Unix.EINTR, _, _) -> waitpid ()
+  in
+  match snd (waitpid ()) with
+  | Unix.WEXITED 0 -> ()
+  | Unix.WEXITED n ->
+      Stdlib.failwith (Printf.sprintf "command failed (exit %d): %s" n full)
+  | Unix.WSIGNALED n | Unix.WSTOPPED n ->
+      Stdlib.failwith (Printf.sprintf "command killed (signal %d): %s" n full)
+
 let init_repo dir =
   run_git ~cwd:dir [ "init"; "-q"; "-b"; "main" ];
   run_git ~cwd:dir [ "config"; "user.email"; "test@example.com" ];

--- a/lib_test/git_env.mli
+++ b/lib_test/git_env.mli
@@ -25,7 +25,26 @@ val run_git : cwd:string -> string list -> unit
 (** Spawn [git <args>] in [cwd] with {!clean_env}. Waits for exit. Raises
     [Failure] with the command, cwd, exit code, and captured stderr on non-zero
     exit (or signal). Stdout is discarded — for tests that need it, use
-    [Unix.create_process_env] directly with {!clean_env}. *)
+    {!git_capture}. *)
+
+val git_capture : cwd:string -> string list -> string
+(** Like {!run_git} but returns the command's trimmed stdout. Raises [Failure]
+    with the command, cwd, exit code, and captured stderr on non-zero exit (or
+    signal). Spawned with {!clean_env}. *)
+
+val git_exit_code : cwd:string -> string list -> int
+(** Spawn [git <args>] in [cwd] with {!clean_env} and return the exit code
+    instead of raising on a non-zero status (still raises if the process is
+    signaled). For queries whose exit code is the answer, e.g.
+    [merge-base --is-ancestor] or [ls-remote --exit-code]. Output is discarded.
+*)
+
+val sh : dir:string -> string -> unit
+(** Run a shell command in [dir] with {!clean_env}, for the non-git shell steps
+    in integration fixtures (e.g. [echo base > README.md], [git clone ...]).
+    stdout/stderr pass through. Raises [Failure] on non-zero exit (or signal).
+    Using {!clean_env} keeps any [git] the command invokes from inheriting a
+    poisoned environment. *)
 
 val init_repo : string -> unit
 (** Initialize a fresh git repo at [dir] with a deterministic identity: runs

--- a/test/dune
+++ b/test/dune
@@ -244,14 +244,14 @@
 (test
  (name test_worktree_start_point_integration)
  (modules test_worktree_start_point_integration)
- (libraries onton onton_core eio eio_main eio.unix unix)
+ (libraries onton onton_core onton_test_support eio eio_main eio.unix unix)
  (ocamlopt_flags (:standard -w -40-42))
  (ocamlc_flags (:standard -w -40-42)))
 
 (test
  (name test_push_plan_integration)
  (modules test_push_plan_integration)
- (libraries onton onton_core eio eio_main eio.unix unix)
+ (libraries onton onton_core onton_test_support eio eio_main eio.unix unix)
  (ocamlopt_flags (:standard -w -40-42))
  (ocamlc_flags (:standard -w -40-42)))
 

--- a/test/test_push_plan_integration.ml
+++ b/test/test_push_plan_integration.ml
@@ -39,7 +39,7 @@ let with_temp_dir f =
 (* Delegate to the scrubbed-env helpers in {!Onton_test_support.Git_env} so an
    inherited [GIT_*] var (e.g. from the pre-commit hook that runs [dune
    runtest]) cannot redirect these fixtures' git at the host repo. See
-   lib/git_env.mli. *)
+   lib_test/git_env.mli. *)
 let sh ?(dir = ".") cmd = Git_env.sh ~dir cmd
 let git_capture ?(dir = ".") args = Git_env.git_capture ~cwd:dir args
 

--- a/test/test_push_plan_integration.ml
+++ b/test/test_push_plan_integration.ml
@@ -1,6 +1,7 @@
 open Base
 open Onton
 open Onton_core
+module Git_env = Onton_test_support.Git_env
 
 (** Integration test: drive [Worktree.force_push_with_lease] against real git
     fixtures to cover the {!Push_plan} refusal arms that the unit/property tests
@@ -35,40 +36,12 @@ let with_temp_dir f =
       with _ -> ());
   f dir
 
-let sh ?(dir = ".") cmd =
-  let full = Printf.sprintf "cd %s && %s" (Stdlib.Filename.quote dir) cmd in
-  let code = Stdlib.Sys.command full in
-  if code <> 0 then
-    failwith (Printf.sprintf "command failed (exit %d): %s" code full)
-
-let git_capture ?(dir = ".") args =
-  let argstr =
-    String.concat ~sep:" " (List.map ~f:Stdlib.Filename.quote args)
-  in
-  let cmd =
-    Printf.sprintf "cd %s && git %s" (Stdlib.Filename.quote dir) argstr
-  in
-  let ic = Unix.open_process_in cmd in
-  let buf = Buffer.create 128 in
-  (try
-     while true do
-       Stdlib.Buffer.add_channel buf ic 4096
-     done
-   with End_of_file -> ());
-  let contents = Buffer.contents buf in
-  match Unix.close_process_in ic with
-  | Unix.WEXITED 0 -> String.strip contents
-  | Unix.WEXITED code ->
-      failwith
-        (Printf.sprintf "git command failed (exit %d): %s\n%s" code cmd contents)
-  | Unix.WSIGNALED signal ->
-      failwith
-        (Printf.sprintf "git command killed by signal %d: %s\n%s" signal cmd
-           contents)
-  | Unix.WSTOPPED signal ->
-      failwith
-        (Printf.sprintf "git command stopped by signal %d: %s\n%s" signal cmd
-           contents)
+(* Delegate to the scrubbed-env helpers in {!Onton_test_support.Git_env} so an
+   inherited [GIT_*] var (e.g. from the pre-commit hook that runs [dune
+   runtest]) cannot redirect these fixtures' git at the host repo. See
+   lib/git_env.mli. *)
+let sh ?(dir = ".") cmd = Git_env.sh ~dir cmd
+let git_capture ?(dir = ".") args = Git_env.git_capture ~cwd:dir args
 
 let setup_origin ~origin_dir =
   Unix.mkdir origin_dir 0o755;
@@ -129,10 +102,8 @@ let scenario_branch_switched env =
            (Worktree.show_push_result outcome)));
   (* Verify nothing was pushed to remote. *)
   let remote_has_feat =
-    Stdlib.Sys.command
-      (Printf.sprintf
-         "cd %s && git ls-remote --exit-code origin feat >/dev/null 2>&1"
-         (Stdlib.Filename.quote managed_dir))
+    Git_env.git_exit_code ~cwd:managed_dir
+      [ "ls-remote"; "--exit-code"; "origin"; "feat" ]
   in
   if remote_has_feat = 0 then
     failwith "branch_switched: remote received feat — push was not refused"

--- a/test/test_worktree_start_point_integration.ml
+++ b/test/test_worktree_start_point_integration.ml
@@ -49,10 +49,13 @@ let with_temp_dir f =
              about to delete would strand later [worktree_dir] lookups on a
              dangling path. Point it at a directory that exists. *)
           Unix.putenv "HOME" (Stdlib.Filename.get_temp_dir_name ()));
-      try
-        Git_env.sh ~dir:"/"
-          (Printf.sprintf "rm -rf %s" (Stdlib.Filename.quote dir))
-      with _ -> ());
+      let cleanup_temp_dir () =
+        try
+          Git_env.sh ~dir:"/"
+            (Printf.sprintf "rm -rf %s" (Stdlib.Filename.quote dir))
+        with _ -> ()
+      in
+      cleanup_temp_dir ());
   f dir
 
 (* Delegate to the scrubbed-env helpers in {!Onton_test_support.Git_env}. These

--- a/test/test_worktree_start_point_integration.ml
+++ b/test/test_worktree_start_point_integration.ml
@@ -50,11 +50,8 @@ let with_temp_dir f =
              dangling path. Point it at a directory that exists. *)
           Unix.putenv "HOME" (Stdlib.Filename.get_temp_dir_name ()));
       try
-        let _ =
-          Stdlib.Sys.command
-            (Printf.sprintf "rm -rf %s" (Stdlib.Filename.quote dir))
-        in
-        ()
+        Git_env.sh ~dir:"/"
+          (Printf.sprintf "rm -rf %s" (Stdlib.Filename.quote dir))
       with _ -> ());
   f dir
 

--- a/test/test_worktree_start_point_integration.ml
+++ b/test/test_worktree_start_point_integration.ml
@@ -313,9 +313,16 @@ let scenario_base_stale_vs_main env =
   clone_into ~origin_dir ~managed_dir;
   (* Precondition: origin/main is NOT an ancestor of origin/patch-b. *)
   let stale =
-    Git_env.git_exit_code ~cwd:managed_dir
-      [ "merge-base"; "--is-ancestor"; "origin/main"; "origin/patch-b" ]
-    <> 0
+    match
+      Git_env.git_exit_code ~cwd:managed_dir
+        [ "merge-base"; "--is-ancestor"; "origin/main"; "origin/patch-b" ]
+    with
+    | 1 -> true
+    | 0 -> false
+    | n ->
+        failwith
+          (Printf.sprintf
+             "precondition: merge-base --is-ancestor failed with exit %d" n)
   in
   assert_true "precondition: origin/main not ancestor of origin/patch-b" stale;
   let res =

--- a/test/test_worktree_start_point_integration.ml
+++ b/test/test_worktree_start_point_integration.ml
@@ -1,6 +1,7 @@
 open Base
 open Onton
 open Onton_core
+module Git_env = Onton_test_support.Git_env
 
 (** Integration test: drive [Worktree.create] against real git fixtures to cover
     every {!Start_point_plan} arm.
@@ -41,7 +42,13 @@ let with_temp_dir f =
   let prior_home = Stdlib.Sys.getenv_opt "HOME" in
   Unix.putenv "HOME" dir;
   Stdlib.at_exit (fun () ->
-      (match prior_home with Some h -> Unix.putenv "HOME" h | None -> ());
+      (match prior_home with
+      | Some h -> Unix.putenv "HOME" h
+      | None ->
+          (* HOME was unset on entry; leaving it pointed at the temp dir we are
+             about to delete would strand later [worktree_dir] lookups on a
+             dangling path. Point it at a directory that exists. *)
+          Unix.putenv "HOME" (Stdlib.Filename.get_temp_dir_name ()));
       try
         let _ =
           Stdlib.Sys.command
@@ -51,28 +58,13 @@ let with_temp_dir f =
       with _ -> ());
   f dir
 
-let sh ?(dir = ".") cmd =
-  let full = Printf.sprintf "cd %s && %s" (Stdlib.Filename.quote dir) cmd in
-  let code = Stdlib.Sys.command full in
-  if code <> 0 then
-    failwith (Printf.sprintf "command failed (exit %d): %s" code full)
-
-let git_capture ?(dir = ".") args =
-  let argstr =
-    String.concat ~sep:" " (List.map ~f:Stdlib.Filename.quote args)
-  in
-  let cmd =
-    Printf.sprintf "cd %s && git %s" (Stdlib.Filename.quote dir) argstr
-  in
-  let ic = Unix.open_process_in cmd in
-  let buf = Buffer.create 128 in
-  (try
-     while true do
-       Stdlib.Buffer.add_channel buf ic 4096
-     done
-   with End_of_file -> ());
-  let _ = Unix.close_process_in ic in
-  String.strip (Buffer.contents buf)
+(* Delegate to the scrubbed-env helpers in {!Onton_test_support.Git_env}. These
+   fixtures run under [dune runtest], which the pre-commit hook invokes with the
+   host repo's [GIT_DIR]/[GIT_INDEX_FILE]/[GIT_WORK_TREE] exported into the
+   environment; spawning git with the ambient env let those vars redirect a
+   sandbox commit onto the host worktree (see lib/git_env.mli). *)
+let sh ?(dir = ".") cmd = Git_env.sh ~dir cmd
+let git_capture ?(dir = ".") args = Git_env.git_capture ~cwd:dir args
 
 let setup_origin_with_main ~origin_dir =
   Unix.mkdir origin_dir 0o755;
@@ -267,13 +259,9 @@ let scenario_local_strictly_ahead env =
   let local = git_capture ~dir:managed_dir [ "rev-parse"; "feat" ] in
   let remote = git_capture ~dir:managed_dir [ "rev-parse"; "origin/feat" ] in
   let is_remote_ancestor_of_local =
-    let cmd =
-      Printf.sprintf "cd %s && git merge-base --is-ancestor %s %s"
-        (Stdlib.Filename.quote managed_dir)
-        (Stdlib.Filename.quote remote)
-        (Stdlib.Filename.quote local)
-    in
-    Stdlib.Sys.command cmd = 0
+    Git_env.git_exit_code ~cwd:managed_dir
+      [ "merge-base"; "--is-ancestor"; remote; local ]
+    = 0
   in
   assert_true "precondition: remote is ancestor of local"
     is_remote_ancestor_of_local;
@@ -328,12 +316,9 @@ let scenario_base_stale_vs_main env =
   clone_into ~origin_dir ~managed_dir;
   (* Precondition: origin/main is NOT an ancestor of origin/patch-b. *)
   let stale =
-    let cmd =
-      Printf.sprintf
-        "cd %s && git merge-base --is-ancestor origin/main origin/patch-b"
-        (Stdlib.Filename.quote managed_dir)
-    in
-    Stdlib.Sys.command cmd <> 0
+    Git_env.git_exit_code ~cwd:managed_dir
+      [ "merge-base"; "--is-ancestor"; "origin/main"; "origin/patch-b" ]
+    <> 0
   in
   assert_true "precondition: origin/main not ancestor of origin/patch-b" stale;
   let res =
@@ -378,12 +363,9 @@ let scenario_base_fresh_stacked env =
   sh ~dir:origin_dir "git checkout -q main";
   clone_into ~origin_dir ~managed_dir;
   let fresh =
-    let cmd =
-      Printf.sprintf
-        "cd %s && git merge-base --is-ancestor origin/main origin/patch-b"
-        (Stdlib.Filename.quote managed_dir)
-    in
-    Stdlib.Sys.command cmd = 0
+    Git_env.git_exit_code ~cwd:managed_dir
+      [ "merge-base"; "--is-ancestor"; "origin/main"; "origin/patch-b" ]
+    = 0
   in
   assert_true "precondition: origin/main IS ancestor of origin/patch-b" fresh;
   let res =


### PR DESCRIPTION
## Problem

The pre-commit hook runs `dune build && dune runtest && dune build @fmt`. Git exports its repository environment (`GIT_DIR` / `GIT_INDEX_FILE` / `GIT_WORK_TREE`) into the hook process. Two integration tests — `test_worktree_start_point_integration` and `test_push_plan_integration` — spawned git through local helpers that inherited the ambient environment (`Stdlib.Sys.command`, `Unix.open_process_in`).

Under the hook, that let a sandbox `cd <tempdir> && git commit -m 'base'` be redirected by the inherited `GIT_DIR`/`GIT_INDEX_FILE` onto the **host worktree being committed** — truncating tracked files (e.g. `README.md` → the fixture's "base") and landing stray commits on the real branch, plus `.git/config.lock` contention.

`lib/git_env.mli` already documents exactly this hazard and the project's production code spawns git with `Git_env.clean_env`; these two tests simply bypassed it.

## Fix

- Add `git_capture ~cwd`, `git_exit_code ~cwd`, and `sh ~dir` to `Onton_test_support.Git_env`, all spawning via `clean_env ()` so no inherited `GIT_*` can leak in.
- Route both integration tests through these helpers (the local `sh`/`git_capture` become thin wrappers); migrate the remaining raw `merge-base --is-ancestor` / `ls-remote` calls.
- Link `onton_test_support` in the two `test/dune` stanzas.

### Secondary hardening
- Fix the `HOME`-restore-when-unset branch in `with_temp_dir` (it left `HOME` pointed at a just-deleted temp dir if `HOME` was originally unset).
- Document the `$HOME`-keyed `Sys.file_exists` short-circuit precondition in `Worktree.create`.

## Verification

- `dune build`, `dune runtest`, `dune build @fmt` all pass (the commit itself passed the pre-commit hook without `--no-verify`).
- **Leak reproduction:** running the full suite with the host `GIT_*` exported (the exact pre-commit-hook condition) against a sentinel repo leaves its HEAD, `README`, and `core.bare` byte-for-byte unchanged. Before this change that scenario corrupted the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolates integration-test git from the host `GIT_*` environment to prevent accidental writes during pre-commit. Adds clean-env helpers, routes tests through them, hardens process handling, fixes `HOME` restore, and clarifies at-exit cleanup.

- **Bug Fixes**
  - Added `git_capture`, `git_exit_code`, and `sh` in `Onton_test_support.Git_env`; all spawn via `clean_env`. Concurrent stdout/stderr reads, EINTR-safe waits, `sh` pass-through output, clearer errors.
  - Routed `test_worktree_start_point_integration` and `test_push_plan_integration` through these helpers; moved `merge-base --is-ancestor` and `ls-remote` checks to `git_exit_code`, asserting exact exit codes.
  - Linked `onton_test_support` in the two `test/dune` stanzas.
  - Fixed `HOME` restore when unset in `with_temp_dir`; cleanup runs via scrubbed `sh` and clarifies the at-exit guard.
  - Documented the `$HOME`-keyed `Sys.file_exists` short-circuit precondition in `Worktree.create`.
  - Fixed a stale helper comment path in `lib_test/git_env`.

<sup>Written for commit 6a88a10361b32b14b0d33019e02979543d958ed3. Summary will update on new commits. <a href="https://cubic.dev/pr/flowglad/onton/pull/326?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified worktree creation behavior, path derivation, and requirements for isolated HOME to avoid reusing prior runs.

* **Tests**
  * Added richer test helpers to capture command stdout/stderr, return exit codes, and run shell/git commands in a scrubbed test environment.
  * Updated integration tests to use the standardized test support tooling and adjusted test config to include the shared test support library.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flowglad/onton/pull/326?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->