### PR TITLE
Switch x86_64 release runner to paid macos-13-large

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,9 @@ jobs:
           - arch: arm64
             runner: macos-14
           - arch: x86_64
-            runner: macos-13
+            # macos-13 (free Intel runner) was retired by GitHub; the -large
+            # variant is the paid Intel/x86_64 runner that's still available.
+            runner: macos-13-large
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 


### PR DESCRIPTION
## Problem

The `Build (x86_64)` job in the Release workflow gets stuck "waiting for a runner" forever (e.g. [run 26479670824](https://github.com/flowglad/onton/actions/runs/26479670824)), blocking the `release` and `homebrew` jobs that depend on it.

The job is pinned to `runs-on: macos-13`, which was GitHub's last **free** Intel/x86_64 macOS hosted runner. GitHub has since retired the `macos-13` image, so the label no longer maps to any available runner and the job queues indefinitely. The arm64 job (`macos-14`, Apple Silicon) is unaffected.

## Fix

Switch the x86_64 job to `macos-13-large` — the **paid** Intel/x86_64 runner that's still available. Keeping macOS 13 preserves the same SDK the build was using.

> Note: `-large` runners bill at a higher per-minute rate than standard runners.

## Releasing v0.35.0

The Release workflow runs from the tagged commit's YAML, so v0.35.0 must be re-tagged onto this fix after it merges to actually pick up the new runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch x86_64 Release workflow to `macos-13-large` to unblock builds after GitHub retired `macos-13`. Restores Intel builds on the macOS 13 SDK; this uses a paid runner.

- **Migration**
  - Retag v0.35.0 after merge so the Release workflow picks up the updated runner.

<sup>Written for commit 79cc4d9956fc0ae3656e62d3dc0b9dc7dff01638. Summary will update on new commits. <a href="https://cubic.dev/pr/flowglad/onton/pull/327?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

