### PR TITLE
Drop x86_64 from release pipeline (no available Intel runner)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,10 @@ jobs:
         include:
           - arch: arm64
             runner: macos-14
-          - arch: x86_64
-            # macos-13 (free Intel runner) was retired by GitHub; the -large
-            # variant is the paid Intel/x86_64 runner that's still available.
-            runner: macos-13-large
+          # x86_64 dropped: GitHub retired the free macos-13 Intel runner and
+          # the paid macos-13-large runner also never provisions for this org,
+          # so the Intel build hung indefinitely. Tracked in #316 — restore the
+          # entry once an x86_64 macOS runner is available again.
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -77,8 +77,7 @@ jobs:
             --repo "$GITHUB_REPOSITORY" \
             --title "$GITHUB_REF_NAME" \
             --generate-notes \
-            onton-arm64-apple-darwin.tar.gz \
-            onton-x86_64-apple-darwin.tar.gz
+            onton-arm64-apple-darwin.tar.gz
 
   homebrew:
     name: Update Homebrew Formula
@@ -93,7 +92,6 @@ jobs:
         id: sha
         run: |
           echo "arm64=$(shasum -a 256 onton-arm64-apple-darwin.tar.gz | cut -d ' ' -f 1)" >> "$GITHUB_OUTPUT"
-          echo "x86_64=$(shasum -a 256 onton-x86_64-apple-darwin.tar.gz | cut -d ' ' -f 1)" >> "$GITHUB_OUTPUT"
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -104,7 +102,6 @@ jobs:
           VERSION="${GITHUB_REF_NAME#v}"
           sed -e "s/VERSION/$VERSION/g" \
               -e "s/SHA256_ARM64/${{ steps.sha.outputs.arm64 }}/g" \
-              -e "s/SHA256_X86_64/${{ steps.sha.outputs.x86_64 }}/g" \
               Formula/onton.rb.template > Formula/onton.rb
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/Formula/onton.rb.template
+++ b/Formula/onton.rb.template
@@ -7,14 +7,13 @@ class Onton < Formula
   version "VERSION"
   license "MIT"
 
+  # x86_64/Intel build temporarily dropped — no x86_64 macOS CI runner is
+  # available (GitHub retired macos-13). Tracked in #316. Without an on_intel
+  # block, `brew install` fails cleanly on Intel rather than installing an
+  # unrunnable ARM64 binary.
   on_arm do
     url "https://github.com/flowglad/onton/releases/download/vVERSION/onton-arm64-apple-darwin.tar.gz"
     sha256 "SHA256_ARM64"
-  end
-
-  on_intel do
-    url "https://github.com/flowglad/onton/releases/download/vVERSION/onton-x86_64-apple-darwin.tar.gz"
-    sha256 "SHA256_X86_64"
   end
 
   depends_on "gmp"


### PR DESCRIPTION
## Problem

The `Build (x86_64)` release job hangs indefinitely "waiting for a runner", blocking the dependent `release` and `homebrew` jobs and preventing any release from publishing.

GitHub retired the free `macos-13` Intel runner, and the paid `macos-13-large` runner (#327) never provisions for this org either — so there is currently **no x86_64 macOS runner available** to build the Intel binary.

## Change

Drop x86_64 everywhere for now:

- Remove the `x86_64` entry from the build matrix (kept the matrix structure + a comment so it's a one-line restore later).
- Stop uploading and checksumming the `onton-x86_64-apple-darwin.tar.gz` artifact in the `release` and `homebrew` jobs.
- Remove the `on_intel` block from the Homebrew formula template, so `brew install` **fails cleanly on Intel** instead of installing an unrunnable ARM64 binary (which was the original bug in #316).

## Follow-up

This reopens the Intel-support gap tracked in **#316**. Restore the matrix entry and `on_intel` block once an x86_64 macOS runner is available again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/328"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782429604&installation_id=126163856&pr_number=328&repository=flowglad%2Fonton&return_to=https%3A%2F%2Fgithub.com%2Fflowglad%2Fonton%2Fpull%2F328&signature=8b80def3f9ebd4f3c992f49b1b32accdf1a553bfee1363b79b39edc698fb44ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drop x86_64 from the build matrix, release artifacts, and Homebrew formula to unblock releases while no Intel macOS runner is available. ARM64 releases continue; on Intel, `brew install` now fails cleanly instead of installing an unusable ARM64 binary (Intel support tracked in #316).

<sup>Written for commit 25063beb4b5831dedc4195ef698b0e96834fe8b1. Summary will update on new commits. <a href="https://cubic.dev/pr/flowglad/onton/pull/328?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

