### PR TITLE
ci: drop poisonable _opam switch cache from release & format jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,15 +101,15 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Cache opam switch
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
-        with:
-          path: _opam
-          key: opam-${{ runner.os }}-ocaml-5.4.1-${{ hashFiles('*.opam') }}
-
+      # Same reasoning as build-and-test above: do NOT cache [_opam/]. The
+      # manual switch cache drifts from setup-ocaml's [~/.opam/] state and, via
+      # actions/cache's frozen-first-entry behavior, a single half-consistent
+      # [_opam/] poisons every later run ("zarith ... META already exists").
+      # [dune-cache: true] plus the archive mirror cover the speed win.
       - uses: ocaml/setup-ocaml@e32b06a3e831ff2fbc6f08cf35be2085e3918014 # v3.6.1
         with:
           ocaml-compiler: '5.4.1'
+          dune-cache: true
 
       - name: Use opam.ocaml.org archive cache
         run: opam option 'archive-mirrors=["https://opam.ocaml.org/cache"]'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         id: build
         run: |
           opam exec -- dune build 2>&1 | tee build.log
-          exit ${PIPESTATUS[0]}
+          exit "${PIPESTATUS[0]}"
 
       - name: Annotate build errors
         if: failure() && steps.build.outcome == 'failure'
@@ -77,7 +77,7 @@ jobs:
         # property tests; non-property tests ignore it.
         run: |
           opam exec -- dune runtest 2>&1 | tee test.log
-          exit ${PIPESTATUS[0]}
+          exit "${PIPESTATUS[0]}"
         env:
           QCHECK_COUNT: "10000"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,12 +24,16 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Cache opam switch
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
-        with:
-          path: _opam
-          key: opam-${{ matrix.runner }}-ocaml-5.4.1-${{ hashFiles('*.opam') }}
-
+      # We deliberately do NOT cache [_opam/]. setup-ocaml@v3 caches its own
+      # opam-root state at [~/.opam/]; caching the local switch alongside lets
+      # the two drift — a stale [~/.opam/] without the switch registered makes
+      # opam treat [_opam/] as a fresh switch and reinstall packages whose files
+      # still exist on disk (the "zarith ... META already exists" failure). Worse
+      # here: actions/cache freezes the first entry for a given `*.opam` hash, so
+      # one half-consistent [_opam/] (e.g. from a cancelled run) poisons every
+      # later run until the cache is manually evicted. See the build-and-test job
+      # in ci.yml for the full rationale. [dune-cache: true] plus the
+      # opam.ocaml.org archive mirror keep `opam install` fast without it.
       - uses: ocaml/setup-ocaml@e32b06a3e831ff2fbc6f08cf35be2085e3918014 # v3.6.1
         with:
           ocaml-compiler: '5.4.1'


### PR DESCRIPTION
## Problem

The `v0.35.0` release run failed twice in a row at the **Install dependencies** step:

```
ocamlfind: Package zarith is already installed
 - (file .../_opam/lib/zarith/META already exists)
make: *** [install] Error 2   → exit 31
```

Re-running couldn't fix it. The release `Build` job (and the CI `Format Check` job) cached the local `_opam` switch with:

```yaml
- name: Cache opam switch
  uses: actions/cache@...
  with:
    path: _opam
    key: opam-${{ matrix.runner }}-ocaml-5.4.1-${{ hashFiles('*.opam') }}
```

That key is a content hash of `*.opam`, and `actions/cache` **freezes the first entry** for a given key. So once a half-consistent `_opam/` got saved (zarith's lib files on disk, but `~/.opam/`/switch metadata not recording it as installed — e.g. from a cancelled run), every subsequent run restored the same poisoned switch and failed identically. The only recovery was manually evicting the cache.

## Fix

Drop the `Cache opam switch` step from both jobs, mirroring what `build-and-test` **already does** — its comment in `ci.yml` documents this exact failure ("the classic 'zarith ... META already exists' symptom we kept hitting whenever a cancel-in-progress run saved a half-consistent `_opam/`"). `dune-cache: true` plus the opam.ocaml.org archive mirror cover the speed win, so removing the switch cache costs little. (Added `dune-cache: true` to the format job, which previously had neither.)

## Note

The immediate `v0.35.0` release was already unblocked out-of-band by deleting the poisoned cache and re-running (attempt 3 went green, release published). This PR prevents recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/329"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782483321&installation_id=126163856&pr_number=329&repository=flowglad%2Fonton&return_to=https%3A%2F%2Fgithub.com%2Fflowglad%2Fonton%2Fpull%2F329&signature=247ec480008e4eb167c0b3fc432a6de6a357ec32e7f94bcff614514874b6db3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the local `_opam` switch cache from the release and format CI jobs to prevent poisoned installs, and quote `${PIPESTATUS[0]}` in build/test to satisfy shellcheck with no behavior change. Enable `dune-cache: true` and rely on the opam archive mirror to keep runs fast.

- **Bug Fixes**
  - Drop `actions/cache` of `_opam/` in release and format jobs to match build-and-test.
  - Set `dune-cache: true` in the format job and keep the `opam.ocaml.org` archive mirror.
  - Quote `${PIPESTATUS[0]}` in build/test steps (SC2086).

<sup>Written for commit 3fb9bdf89ef2c4cf4e1f562f5995cfead10d4034. Summary will update on new commits. <a href="https://cubic.dev/pr/flowglad/onton/pull/329?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

## Also: shellcheck cleanup

Quoted the two `exit ${PIPESTATUS[0]}` expansions in the Build / Run-tests steps (SC2086) that `actionlint`/`shellcheck` had been flagging. `PIPESTATUS[0]` is always a bare integer, so behavior is unchanged — `actionlint` now reports both workflows clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD pipeline caching strategy for faster and more reliable builds
  * Enhanced build automation workflows for improved consistency and performance
  * Streamlined internal build infrastructure

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flowglad/onton/pull/329?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->