### PR TITLE
Prefix agent commit subjects with [<project>] Patch <N>

### DIFF
--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -271,10 +271,14 @@ let render_patch_layer ~(project_name : string) (patch : Patch.t) ?pr_number
   in
   let pr_instructions =
     let commit_block =
-      {|
+      Printf.sprintf
+        {|
 **Commit your work with `git commit` before ending the session.** Every code change you make must land in a commit — uncommitted changes are discarded by the supervisor's push, and no PR can be opened from an empty branch. Multiple commits are fine; commit whenever it makes sense.
 
+**Prefix every commit subject with `[%s] Patch %s: `** (the same project name and patch number used by this branch and its PR title), e.g. `[%s] Patch %s: <short summary>`. This lets the supervisor recognize your commits as belonging to this patch when rebasing onto dependency branches later.
+
 **Do NOT run `git push` or `gh pr create` yourself.** The supervisor pushes your commits and opens/updates the PR.|}
+        project_name patch_id project_name patch_id
     in
     match pr_number with
     | Some _ -> commit_block

--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -270,6 +270,11 @@ let render_patch_layer ~(project_name : string) (patch : Patch.t) ?pr_number
         base_branch base_branch
   in
   let pr_instructions =
+    (* Commit subjects are not rewritten or rejected downstream. The rebase
+       subject filter in [Worktree.rebase_onto] treats this prompt convention as
+       a best-effort agent contract: malformed subjects simply will not match
+       [Worktree.is_ancestor_patch_subject], so rebase falls back to the other
+       ancestry / patch-id paths. *)
     let commit_block =
       Printf.sprintf
         {|


### PR DESCRIPTION
## Motivation

Patch-agent commits (e.g. those in [provisioning-agent#3428](https://github.com/flowglad/provisioning-agent/pull/3428)) had free-form subjects like `Add bun effect test helper`, with no project/patch prefix — even though the branch name (`<project>/patch-<N>`) and PR title (`[<project>] Patch <N>: …`) both embed it.

This matters for rebases: `Worktree.is_ancestor_patch_subject` keys on the `[<project>] Patch <N>:` commit-subject format to recognize **squash-merged** ancestor patches whose patch-ids no longer match (squash collapses commits into one with a fresh id). Without the prefix on agent commits, that fallback can't fire, making later rebases onto dependency branches harder.

## Change

Extend the commit-instruction block in `render_patch_layer` (`lib/prompt.ml`) to tell the agent to prefix every commit subject with `[<project>] Patch <N>: `. The prefix is built from the in-scope `project_name` / `patch_id` via `Printf.sprintf` rather than `{{...}}` placeholders, because `pr_instructions` is injected into the template as a value and isn't re-substituted.

## Notes

- Forward-fix only; existing commits in #3428 are not rewritten.
- Per-project prompt overrides of the `"patch"` template supply their own commit instructions and won't pick this up.
- Full test suite (incl. `is_ancestor_patch_subject` / `classify_unique_commits` consumers of this format) passes via the pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/330"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782486287&installation_id=126163856&pr_number=330&repository=flowglad%2Fonton&return_to=https%3A%2F%2Fgithub.com%2Fflowglad%2Fonton%2Fpull%2F330&signature=403b022ba2485ddb74e3018392350ebdf1926c1dc2c27e740fbc40c8bc03dea8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced patch-agent commit message formatting to include project name and patch ID prefix in commit subjects, improving patch identification and organization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flowglad/onton/pull/330?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->