### PR TITLE
Gate Start/Rebase on dependency-aware base freshness

### DIFF
--- a/lib/github.ml
+++ b/lib/github.ml
@@ -137,6 +137,7 @@ let graphql_query =
       headRefName
       headRefOid
       baseRefName
+      mergeCommit { oid }
       headRepositoryOwner { login }
       commits(last: 1) {
         nodes {
@@ -390,6 +391,9 @@ let parse_response_json ~owner json =
               |> Option.map ~f:Types.Branch.of_string
             in
             let head_oid = pr |> member "headRefOid" |> to_string_option in
+            let merge_commit_sha =
+              pr |> member "mergeCommit" |> member "oid" |> to_string_option
+            in
             let base_branch =
               pr |> member "baseRefName" |> to_string_option
               |> Option.map ~f:Types.Branch.of_string
@@ -420,6 +424,7 @@ let parse_response_json ~owner json =
                      configured review-service backends. *)
                 head_branch;
                 head_oid;
+                merge_commit_sha;
                 base_branch;
                 is_fork;
               })

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -248,11 +248,13 @@ let find_patch_by_branch t branch =
   |> List.find ~f:(fun (_, a) -> Branch.equal a.Patch_agent.branch branch)
   |> Option.map ~f:fst
 
-(** [start_eligibility t base] is the freshness verdict for a hypothetical
-    [Start] action whose base is [base] against [t]'s current view of the world.
-    Exposed so tests and TUI surfaces can inspect the gate without firing the
-    action. *)
-let start_eligibility t base =
+(** [start_eligibility t ~base_contains_merged_siblings base] is the freshness
+    verdict for a hypothetical [Start]/[Rebase] action whose base is [base]
+    against [t]'s current view of the world. [base_contains_merged_siblings] is
+    the launching patch's poll-derived base-containment cache (whether [base]
+    already carries the launching patch's merged sibling deps). Exposed so tests
+    and TUI surfaces can inspect the gate without firing the action. *)
+let start_eligibility t ~base_contains_merged_siblings base =
   let base_is_main = Branch.equal base t.main_branch in
   let base_branch = Branch.to_string base in
   let has_merged pid =
@@ -313,6 +315,7 @@ let start_eligibility t base =
   in
   Start_eligibility.decide ~base_is_main ~base_branch ~base_patch_merged
     ~base_patch_busy_rebasing ~base_structurally_fresh
+    ~base_contains_merged_siblings
 
 let runnable_messages t =
   let action_rank = function
@@ -324,15 +327,26 @@ let runnable_messages t =
   |> List.filter ~f:(fun msg ->
       match msg.status with
       | Pending -> (
-          (* Gate [Start] on base-branch freshness. Other actions are not
-             freshness-sensitive: [Rebase] is what closes the freshness gap,
-             and [Respond] operates on a worktree that already exists. *)
+          (* Gate both [Start] and [Rebase] on base freshness. A [Rebase] of a
+             dependent must not run while its base is itself stale or mid-rebase
+             — otherwise it lands on a stale branch and needs a second rebase.
+             Gating it makes a fan-in/chain cascade block on its dependency
+             layers and converge bottom-up (main is always fresh), one rebase
+             per branch. The launching patch's [base_contains_merged_siblings]
+             cache supplies the sibling-containment input. [Respond] operates on
+             a worktree that already exists and is not freshness-sensitive. *)
+          let eligibility patch_id base =
+            let base_contains_merged_siblings =
+              (agent t patch_id).Patch_agent.base_contains_merged_siblings
+            in
+            match start_eligibility t ~base_contains_merged_siblings base with
+            | Start_eligibility.Allow -> true
+            | Start_eligibility.Defer _ -> false
+          in
           match msg.action with
-          | Start (_, base) -> (
-              match start_eligibility t base with
-              | Start_eligibility.Allow -> true
-              | Start_eligibility.Defer _ -> false)
-          | Rebase _ | Respond _ -> true)
+          | Start (patch_id, base) -> eligibility patch_id base
+          | Rebase (patch_id, base) -> eligibility patch_id base
+          | Respond _ -> true)
       | Acked ->
           let agent = agent t msg.patch_id in
           Option.equal Message_id.equal agent.current_message_id
@@ -476,6 +490,13 @@ let set_checks_passing t patch_id v =
 
 let set_merge_ready t patch_id v =
   update_agent t patch_id ~f:(fun a -> Patch_agent.set_merge_ready a v)
+
+let set_merge_commit_sha t patch_id sha =
+  update_agent t patch_id ~f:(fun a -> Patch_agent.set_merge_commit_sha a sha)
+
+let set_base_contains_merged_siblings t patch_id v =
+  update_agent t patch_id ~f:(fun a ->
+      Patch_agent.set_base_contains_merged_siblings a v)
 
 let set_is_draft t patch_id v =
   update_agent t patch_id ~f:(fun a -> Patch_agent.set_is_draft a v)

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -115,6 +115,8 @@ val record_delivered_ci_run_ids : t -> Patch_id.t -> int list -> t
 
 val set_checks_passing : t -> Patch_id.t -> bool -> t
 val set_merge_ready : t -> Patch_id.t -> bool -> t
+val set_merge_commit_sha : t -> Patch_id.t -> string option -> t
+val set_base_contains_merged_siblings : t -> Patch_id.t -> bool -> t
 val set_is_draft : t -> Patch_id.t -> bool -> t
 val set_pr_body_delivered : t -> Patch_id.t -> bool -> t
 val reset_pr_body_artifact_miss_count : t -> Patch_id.t -> t
@@ -419,15 +421,21 @@ val restore :
   t
 (** Reconstruct orchestrator from persisted components. *)
 
-val start_eligibility : t -> Branch.t -> Start_eligibility.decision
-(** [start_eligibility t base] is the freshness verdict for a hypothetical
-    [Start] action whose base is [base], evaluated against [t]'s dependency
-    graph and the base patch's recorded rebase anchor. Used to gate [Start] in
+val start_eligibility :
+  t ->
+  base_contains_merged_siblings:bool ->
+  Branch.t ->
+  Start_eligibility.decision
+(** [start_eligibility t ~base_contains_merged_siblings base] is the freshness
+    verdict for a hypothetical [Start]/[Rebase] action whose base is [base],
+    evaluated against [t]'s dependency graph and the base patch's recorded
+    rebase anchor. [base_contains_merged_siblings] is the launching patch's
+    poll-derived base-containment cache. Used to gate [Start] and [Rebase] in
     {!runnable_messages}; exposed for tests/TUI introspection.
 
     Returns [Allow] when the base is main, when the base patch is merged
     (effectively main), or when the base patch's local branch is rebased onto
-    its structurally-correct base ([branch_rebased_onto = Graph.initial_base]).
-    Otherwise returns [Defer reason]. Freshness is dependency-scoped: an
-    unrelated advance of [origin/main] never defers a [Start]. See
-    {!Start_eligibility}. *)
+    its structurally-correct base ([branch_rebased_onto = Graph.initial_base])
+    and contains the launching patch's merged siblings. Otherwise returns
+    [Defer reason]. Freshness is dependency-scoped: an unrelated advance of
+    [origin/main] never defers a [Start]. See {!Start_eligibility}. *)

--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -112,7 +112,15 @@ let apply_poll_result t patch_id
     if poll_result.merged then (
       let agent = Orchestrator.agent t patch_id in
       if not agent.Patch_agent.merged then log "Merged";
-      Orchestrator.mark_merged t patch_id)
+      let t = Orchestrator.mark_merged t patch_id in
+      (* Record the squash/merge commit SHA so dependents' base-containment gate
+         can ancestry-check it. Only overwrite when present, so a late/absent
+         [mergeCommit.oid] does not clobber a previously recorded SHA. Merged
+         agents that still lack a SHA are kept in the poll loop (see
+         [poller_fiber]) until it arrives. *)
+      match poll_result.Poller.merge_commit_sha with
+      | Some _ as sha -> Orchestrator.set_merge_commit_sha t patch_id sha
+      | None -> t)
     else t
   in
   let t =
@@ -1016,6 +1024,7 @@ let%test "no merge-conflict re-enqueue after noop" =
         merge_ready = false;
         checks_passing = false;
         ci_checks = [];
+        merge_commit_sha = None;
       }
   in
   let obs =

--- a/lib/persistence.ml
+++ b/lib/persistence.ml
@@ -175,6 +175,9 @@ let patch_agent_to_yojson (a : Patch_agent.t) =
         match a.branch_rebased_onto_sha with
         | None -> `Null
         | Some s -> `String s );
+      ( "merge_commit_sha",
+        match a.merge_commit_sha with None -> `Null | Some s -> `String s );
+      ("base_contains_merged_siblings", `Bool a.base_contains_merged_siblings);
       ("anchor_history", Anchor_history.yojson_of_t a.anchor_history);
       ("checks_passing", `Bool a.checks_passing);
       ( "current_op",
@@ -308,6 +311,11 @@ let patch_agent_of_yojson ~gameplan json =
        ~ci_failure_count:(int_member "ci_failure_count" json)
        ~session_fallback ~human_messages ~inflight_human_messages ~ci_checks
        ~merge_ready:(bool_member "merge_ready" json)
+       ~merge_commit_sha:(string_member_opt "merge_commit_sha" json)
+       ~base_contains_merged_siblings:
+         (Option.value
+            (bool_member_opt "base_contains_merged_siblings" json)
+            ~default:true)
        ~is_draft:(bool_member "is_draft" json)
        ~pr_body_delivered:
          (Option.value (bool_member_opt "pr_body_delivered" json) ~default:true)
@@ -794,9 +802,11 @@ let%test_module "session_id_sidecars" =
           ~has_conflict:false ~base_branch:None ~notified_base_branch:None
           ~ci_failure_count:0 ~session_fallback:Patch_agent.Fresh_available
           ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
-          ~merge_ready:false ~is_draft:false ~pr_body_delivered:true
-          ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
-          ~conflict_noop_count:0 ~no_commits_push_count:0 ~push_failure_count:0
+          ~merge_ready:false ~merge_commit_sha:None
+          ~base_contains_merged_siblings:true ~is_draft:false
+          ~pr_body_delivered:true ~pr_body_artifact_miss_count:0
+          ~start_attempts_without_pr:0 ~conflict_noop_count:0
+          ~no_commits_push_count:0 ~push_failure_count:0
           ~branch_rebased_onto:None ~branch_rebased_onto_sha:None
           ~anchor_history:Anchor_history.empty ~checks_passing:false
           ~current_op:None ~current_op_state:Patch_agent.Queued

--- a/lib/persistence.ml
+++ b/lib/persistence.ml
@@ -313,9 +313,14 @@ let patch_agent_of_yojson ~gameplan json =
        ~merge_ready:(bool_member "merge_ready" json)
        ~merge_commit_sha:(string_member_opt "merge_commit_sha" json)
        ~base_contains_merged_siblings:
+         (* Default [false] (fail-closed) when the key is absent — an older
+            snapshot predating this field must not fail-open the Start/Rebase
+            gate for a fan-in patch on load. Snapshots written by this version
+            always include the key, so round-trip identity is preserved; the
+            first poll recomputes the live value either way. *)
          (Option.value
             (bool_member_opt "base_contains_merged_siblings" json)
-            ~default:true)
+            ~default:false)
        ~is_draft:(bool_member "is_draft" json)
        ~pr_body_delivered:
          (Option.value (bool_member_opt "pr_body_delivered" json) ~default:true)

--- a/lib/poller_fiber.ml
+++ b/lib/poller_fiber.ml
@@ -187,7 +187,19 @@ struct
         Runtime.read runtime (fun snap ->
             let agents = Orchestrator.all_agents snap.Runtime.orchestrator in
             List.filter_map agents ~f:(fun (agent : Patch_agent.t) ->
-                if Patch_agent.has_pr agent && not agent.Patch_agent.merged then
+                (* Poll open PRs. Also keep polling a *merged* agent whose
+                   merge-commit SHA has not yet been recorded, so dependents'
+                   base-containment gate can eventually resolve (the SHA almost
+                   always arrives in the same poll as the merge, but this
+                   self-heals the rare lag / a pre-existing merged snapshot). *)
+                let needs_merge_sha =
+                  agent.Patch_agent.merged
+                  && Option.is_none agent.Patch_agent.merge_commit_sha
+                in
+                if
+                  Patch_agent.has_pr agent
+                  && ((not agent.Patch_agent.merged) || needs_merge_sha)
+                then
                   match find_pr_number ~patch_id:agent.Patch_agent.patch_id with
                   | None -> Some (Skip_no_pr agent.Patch_agent.patch_id)
                   | Some pr_number ->
@@ -431,6 +443,41 @@ struct
                           ci_truncated )
                         :: sides ))
             in
+            (* Recompute the base-containment cache for every agent: does each
+               patch's resolved base branch already contain the squash commit of
+               every *merged* dependency of that patch? This is the only git I/O
+               of the reconcile phase; it is skipped (trivially [true]) for
+               patches based on main or with no merged deps, so the [is_ancestor]
+               calls are limited to fan-in patches mid-merge. Fail-closed to
+               [false] when a dep's merge SHA is not yet recorded — the
+               dependent then defers until [detect_sibling_stale_bases] rebases
+               the base (which also fetches the merge commit into the repo). *)
+            let graph = Orchestrator.graph orch in
+            let has_merged pid =
+              match Orchestrator.find_agent orch pid with
+              | Some a -> a.Patch_agent.merged
+              | None -> false
+            in
+            let merge_sha pid =
+              match Orchestrator.find_agent orch pid with
+              | Some a -> a.Patch_agent.merge_commit_sha
+              | None -> None
+            in
+            let main_root = W.resolve_main_root () in
+            let ancestor_oracle ancestor ~descendant =
+              W.is_ancestor ~path:main_root ~ancestor ~descendant
+            in
+            let orch =
+              List.fold (Orchestrator.all_agents orch) ~init:orch
+                ~f:(fun orch (a : Patch_agent.t) ->
+                  let contains =
+                    Base_containment.contains_merged_siblings ~graph
+                      ~patch_id:a.Patch_agent.patch_id ~has_merged ~merge_sha
+                      ~branch_of ~main ~ancestor_oracle
+                  in
+                  Orchestrator.set_base_contains_merged_siblings orch
+                    a.Patch_agent.patch_id contains)
+            in
             (* Reconcile — detect merges and enqueue rebases *)
             let agents = Orchestrator.all_agents orch in
             let patch_views =
@@ -447,6 +494,8 @@ struct
                       base_branch =
                         Option.value a.Patch_agent.base_branch ~default:main;
                       branch_rebased_onto = a.Patch_agent.branch_rebased_onto;
+                      base_contains_merged_siblings =
+                        a.Patch_agent.base_contains_merged_siblings;
                     })
             in
             let merged_patches =

--- a/lib/poller_fiber.ml
+++ b/lib/poller_fiber.ml
@@ -479,6 +479,13 @@ struct
               | _ -> false
             in
             let orch =
+              (* Cancellation can interrupt this fold after updating only a
+                 prefix of agents. That partial cache is acceptable: the tick is
+                 aborting anyway, and the next reconcile invocation recomputes
+                 every agent from a fresh [main_root] lazy value. Agents skipped
+                 by a cancelled tick simply retain a fail-closed/stale cache for
+                 at most that aborted tick, deferring Start/Rebase until the next
+                 successful pass. *)
               List.fold (Orchestrator.all_agents orch) ~init:orch
                 ~f:(fun orch (a : Patch_agent.t) ->
                   let contains =

--- a/lib/poller_fiber.ml
+++ b/lib/poller_fiber.ml
@@ -463,9 +463,20 @@ struct
               | Some a -> a.Patch_agent.merge_commit_sha
               | None -> None
             in
-            let main_root = W.resolve_main_root () in
+            (* [main_root] and the [is_ancestor] git calls are deferred until
+               actually needed: [contains_merged_siblings] short-circuits
+               (no oracle call) for a base on main or a patch with no merged
+               deps, so projects with no fan-in-mid-merge pay no git cost here.
+               The oracle is fail-closed: a transient git spawn failure returns
+               [false] rather than aborting the whole reconcile tick (it runs
+               under the runtime lock). Cancellation must still propagate. *)
+            let main_root = lazy (W.resolve_main_root ()) in
             let ancestor_oracle ancestor ~descendant =
-              W.is_ancestor ~path:main_root ~ancestor ~descendant
+              try
+                W.is_ancestor ~path:(Lazy.force main_root) ~ancestor ~descendant
+              with
+              | Eio.Cancel.Cancelled _ as exn -> raise exn
+              | _ -> false
             in
             let orch =
               List.fold (Orchestrator.all_agents orch) ~init:orch

--- a/lib/prune_runner.ml
+++ b/lib/prune_runner.ml
@@ -104,7 +104,14 @@ let refresh_agents_from_forge ~net ~clock ~(cfg : Project_store.stored_config)
                   let agents =
                     Map.change agents patch_id ~f:(function
                       | None -> None
-                      | Some agent -> Some (Patch_agent.mark_merged agent))
+                      | Some agent ->
+                          (* Record the merge-commit SHA we already have in
+                             hand so dependents' base-containment gate can
+                             ancestry-check it without waiting for a re-poll. *)
+                          Some
+                            (Patch_agent.set_merge_commit_sha
+                               (Patch_agent.mark_merged agent)
+                               pr_state.Pr_state.merge_commit_sha))
                   in
                   (agents, merged_count + 1, errs)
                 else (agents, merged_count, errs))

--- a/lib_core/base_containment.ml
+++ b/lib_core/base_containment.ml
@@ -1,0 +1,22 @@
+open Base
+
+let contains_merged_siblings ~graph ~patch_id ~has_merged ~merge_sha ~branch_of
+    ~main ~ancestor_oracle =
+  match Graph.open_pr_deps graph patch_id ~has_merged with
+  | _ :: _ :: _ ->
+      (* Not at the last-but-one-merge edge; the patch is not startable and
+         [initial_base] would raise. Report [false] (irrelevant — the patch
+         defers on [deps_satisfied] anyway). *)
+      false
+  | [] | [ _ ] ->
+      let base =
+        Graph.initial_base graph patch_id ~has_merged ~branch_of ~main
+      in
+      if Types.Branch.equal base main then true
+      else
+        Graph.deps graph patch_id |> List.filter ~f:has_merged
+        |> List.for_all ~f:(fun d ->
+            match merge_sha d with
+            | None -> false (* fail-closed until the merge SHA is known *)
+            | Some sha ->
+                ancestor_oracle sha ~descendant:(Types.Branch.to_string base))

--- a/lib_core/base_containment.ml
+++ b/lib_core/base_containment.ml
@@ -9,6 +9,10 @@ let contains_merged_siblings ~graph ~patch_id ~has_merged ~merge_sha ~branch_of
          defers on [deps_satisfied] anyway). *)
       false
   | [] | [ _ ] ->
+      (* [Graph.initial_base] is total for [<= 1] open dep: [[]] (all deps
+         merged, including a root patch with no deps) resolves to [main]; [[d]]
+         resolves to [d]'s branch. It only raises for [> 1] open deps, which the
+         arm above excludes — so this call never raises. *)
       let base =
         Graph.initial_base graph patch_id ~has_merged ~branch_of ~main
       in

--- a/lib_core/base_containment.mli
+++ b/lib_core/base_containment.mli
@@ -1,0 +1,40 @@
+(** Pure decision: does a patch's resolved base branch already contain the
+    squash commit of every *merged* dependency of that patch?
+
+    This closes the fan-in blind spot: when a patch [p] depends on several
+    patches and exactly one is still open, [p]'s base is that sole open dep [b];
+    [b]'s branch carries its own lineage but not a *sibling* dependency of [p]
+    that merged to main independently (its squash commit lives on main, never an
+    ancestor of [b]). Cutting/rebasing [p] from such a [b] would start it from a
+    base missing one of its dependencies.
+
+    Git ancestry is supplied as an [ancestor_oracle] (effectfully backed by
+    [git merge-base --is-ancestor]), keeping this function pure and testable —
+    the same pattern as {!Rebase_decision.plan}. The result feeds the
+    [base_contains_merged_siblings] cache and the Start/Rebase eligibility gate.
+*)
+
+val contains_merged_siblings :
+  graph:Graph.t ->
+  patch_id:Types.Patch_id.t ->
+  has_merged:(Types.Patch_id.t -> bool) ->
+  merge_sha:(Types.Patch_id.t -> string option) ->
+  branch_of:(Types.Patch_id.t -> Types.Branch.t) ->
+  main:Types.Branch.t ->
+  ancestor_oracle:(string -> descendant:string -> bool) ->
+  bool
+(** [contains_merged_siblings ~graph ~patch_id ~has_merged ~merge_sha ~branch_of
+     ~main ~ancestor_oracle] is:
+
+    - [true] when the patch's structurally-correct base ([Graph.initial_base])
+      is [main] (every merged dep is already a squash commit on main), or when
+      every merged dependency's [merge_sha] is an ancestor of the base branch;
+    - [false] (fail-closed) when any merged dependency's [merge_sha] is unknown
+      ([None]) or is not yet an ancestor of the base branch;
+    - [false] when the patch has more than one open dependency (not at the
+      last-but-one-merge edge; the value is irrelevant because the patch defers
+      on dependency satisfaction anyway, and [Graph.initial_base] is undefined
+      there).
+
+    Only the patch's own dependencies are consulted, so an unrelated advance of
+    main never flips this to [false]. *)

--- a/lib_core/patch_agent.ml
+++ b/lib_core/patch_agent.ml
@@ -27,6 +27,17 @@ type t = {
   inflight_human_messages : string list;
   ci_checks : Ci_check.t list;
   merge_ready : bool;
+  merge_commit_sha : string option;
+      (** Squash/merge commit SHA once this patch's PR is merged (GitHub
+          [mergeCommit.oid]). Persisted, because merged agents are not
+          re-polled; dependents' base-containment gate ancestry-checks it. *)
+  base_contains_merged_siblings : bool;
+      (** Poll-derived cache (like [merge_ready]): whether this patch's resolved
+          base branch already contains the squash commit of every *merged*
+          dependency of this patch. Recomputed each poll tick by [poller_fiber]
+          via [git merge-base --is-ancestor]; fail-closed to [false] until
+          known. Read by the reconciler ([detect_sibling_stale_bases]) and the
+          Start/Rebase eligibility gate. *)
   is_draft : bool;
   pr_body_delivered : bool;
   pr_body_artifact_miss_count : int;
@@ -152,6 +163,11 @@ let create ~branch patch_id =
     inflight_human_messages = [];
     ci_checks = [];
     merge_ready = false;
+    merge_commit_sha = None;
+    (* Defaults to [true] ("no known missing sibling"): the poller recomputes
+       this every tick before any fan-in start can become eligible, and a fresh
+       agent has no merged deps yet. Fail-open at birth, recomputed-to-truth. *)
+    base_contains_merged_siblings = true;
     is_draft = false;
     pr_body_delivered = false;
     pr_body_artifact_miss_count = 0;
@@ -197,6 +213,11 @@ let create_adhoc ~patch_id ~branch ~pr_number =
     inflight_human_messages = [];
     ci_checks = [];
     merge_ready = false;
+    merge_commit_sha = None;
+    (* Defaults to [true] ("no known missing sibling"): the poller recomputes
+       this every tick before any fan-in start can become eligible, and a fresh
+       agent has no merged deps yet. Fail-open at birth, recomputed-to-truth. *)
+    base_contains_merged_siblings = true;
     is_draft = false;
     pr_body_delivered = true;
     pr_body_artifact_miss_count = 0;
@@ -302,6 +323,11 @@ let base_branch_changed t =
   | _ -> false
 
 let set_merge_ready t v = { t with merge_ready = v }
+let set_merge_commit_sha t sha = { t with merge_commit_sha = sha }
+
+let set_base_contains_merged_siblings t v =
+  { t with base_contains_merged_siblings = v }
+
 let set_is_draft t v = { t with is_draft = v }
 let set_pr_body_delivered t v = { t with pr_body_delivered = v }
 
@@ -410,13 +436,14 @@ let reset_busy t = if not t.busy then t else { t with busy = false }
 let restore ~patch_id ~branch ~pr_status ~has_session ~busy ~merged ~queue
     ~satisfies ~changed ~has_conflict ~base_branch ~notified_base_branch
     ~ci_failure_count ~session_fallback ~human_messages ~inflight_human_messages
-    ~ci_checks ~merge_ready ~is_draft ~pr_body_delivered
-    ~pr_body_artifact_miss_count ~start_attempts_without_pr ~conflict_noop_count
-    ~no_commits_push_count ~push_failure_count ~branch_rebased_onto
-    ~branch_rebased_onto_sha ~anchor_history ~checks_passing ~current_op
-    ~current_op_state ~current_message_id ~generation ~worktree_path
-    ~branch_blocked ~llm_session_id ~automerge_enabled ~automerge_deadline
-    ~automerge_inflight ~automerge_failure_count ~delivered_ci_run_ids =
+    ~ci_checks ~merge_ready ~merge_commit_sha ~base_contains_merged_siblings
+    ~is_draft ~pr_body_delivered ~pr_body_artifact_miss_count
+    ~start_attempts_without_pr ~conflict_noop_count ~no_commits_push_count
+    ~push_failure_count ~branch_rebased_onto ~branch_rebased_onto_sha
+    ~anchor_history ~checks_passing ~current_op ~current_op_state
+    ~current_message_id ~generation ~worktree_path ~branch_blocked
+    ~llm_session_id ~automerge_enabled ~automerge_deadline ~automerge_inflight
+    ~automerge_failure_count ~delivered_ci_run_ids =
   {
     patch_id;
     branch;
@@ -436,6 +463,8 @@ let restore ~patch_id ~branch ~pr_status ~has_session ~busy ~merged ~queue
     inflight_human_messages;
     ci_checks;
     merge_ready;
+    merge_commit_sha;
+    base_contains_merged_siblings;
     is_draft;
     pr_body_delivered;
     pr_body_artifact_miss_count;

--- a/lib_core/patch_agent.mli
+++ b/lib_core/patch_agent.mli
@@ -34,6 +34,16 @@ type t = private {
   inflight_human_messages : string list;
   ci_checks : Types.Ci_check.t list;
   merge_ready : bool;
+  merge_commit_sha : string option;
+      (** Squash/merge commit SHA once this patch's PR is merged (GitHub
+          [mergeCommit.oid]). Persisted, because merged agents are not
+          re-polled; dependents' base-containment gate ancestry-checks it. *)
+  base_contains_merged_siblings : bool;
+      (** Poll-derived cache (like [merge_ready]): whether this patch's resolved
+          base branch already contains the squash commit of every *merged*
+          dependency of this patch. Recomputed each poll tick; fail-closed to
+          [false] until known. Read by the reconciler and the Start/Rebase
+          eligibility gate. *)
   is_draft : bool;
   pr_body_delivered : bool;
   pr_body_artifact_miss_count : int;
@@ -266,6 +276,13 @@ val base_branch_changed : t -> bool
 val set_merge_ready : t -> bool -> t
 (** Set the merge_ready flag from GitHub mergeStateStatus. *)
 
+val set_merge_commit_sha : t -> string option -> t
+(** Record the squash/merge commit SHA (GitHub [mergeCommit.oid]) when the PR is
+    observed merged. *)
+
+val set_base_contains_merged_siblings : t -> bool -> t
+(** Set the poll-derived base-containment cache. *)
+
 val set_is_draft : t -> bool -> t
 (** Set the draft flag from GitHub PR state. *)
 
@@ -493,6 +510,8 @@ val restore :
   inflight_human_messages:string list ->
   ci_checks:Types.Ci_check.t list ->
   merge_ready:bool ->
+  merge_commit_sha:string option ->
+  base_contains_merged_siblings:bool ->
   is_draft:bool ->
   pr_body_delivered:bool ->
   pr_body_artifact_miss_count:int ->

--- a/lib_core/poller.ml
+++ b/lib_core/poller.ml
@@ -12,9 +12,10 @@ type t = {
   checks_passing : bool;
   ci_checks : Types.Ci_check.t list;
   merge_commit_sha : string option; [@yojson.option]
-      (** Squash/merge commit SHA when [merged]; [None] otherwise. Annotated
-          [@yojson.option] so older persisted snapshots/events that predate this
-          field decode to [None] instead of failing. *)
+      (** Squash/merge commit SHA when [merged]; [None] otherwise. [Poller.t] is
+          only serialized (to the event log), never deserialized; the
+          [@yojson.option] annotation just omits the field from event JSON when
+          [None]. *)
 }
 [@@deriving show, eq, yojson]
 

--- a/lib_core/poller.ml
+++ b/lib_core/poller.ml
@@ -11,6 +11,10 @@ type t = {
   merge_ready : bool;
   checks_passing : bool;
   ci_checks : Types.Ci_check.t list;
+  merge_commit_sha : string option; [@yojson.option]
+      (** Squash/merge commit SHA when [merged]; [None] otherwise. Annotated
+          [@yojson.option] so older persisted snapshots/events that predate this
+          field decode to [None] instead of failing. *)
 }
 [@@deriving show, eq, yojson]
 
@@ -44,4 +48,5 @@ let poll ~was_merged (pr : Pr_state.t) =
     merge_ready = Pr_state.merge_ready pr;
     checks_passing = Pr_state.checks_passing pr;
     ci_checks = pr.Pr_state.ci_checks;
+    merge_commit_sha = pr.Pr_state.merge_commit_sha;
   }

--- a/lib_core/poller.mli
+++ b/lib_core/poller.mli
@@ -35,8 +35,9 @@ type t = {
   merge_commit_sha : string option; [@yojson.option]
       (** Squash/merge commit SHA when the PR is [merged]; [None] otherwise.
           Recorded on the agent when [merged] flips true so the base-containment
-          gate can ancestry-check it. [@yojson.option] so pre-existing persisted
-          snapshots/events decode to [None]. *)
+          gate can ancestry-check it. [Poller.t] is only serialized (to the
+          event log), never deserialized; [@yojson.option] just omits the field
+          from event JSON when [None]. *)
 }
 [@@deriving show, eq, yojson]
 (** The result of polling a single patch's PR state. *)

--- a/lib_core/poller.mli
+++ b/lib_core/poller.mli
@@ -32,6 +32,11 @@ type t = {
   checks_passing : bool;  (** [true] if CI checks are currently passing. *)
   ci_checks : Ci_check.t list;
       (** Individual CI check results from the most recent poll. *)
+  merge_commit_sha : string option; [@yojson.option]
+      (** Squash/merge commit SHA when the PR is [merged]; [None] otherwise.
+          Recorded on the agent when [merged] flips true so the base-containment
+          gate can ancestry-check it. [@yojson.option] so pre-existing persisted
+          snapshots/events decode to [None]. *)
 }
 [@@deriving show, eq, yojson]
 (** The result of polling a single patch's PR state. *)

--- a/lib_core/pr_state.ml
+++ b/lib_core/pr_state.ml
@@ -22,6 +22,10 @@ type t = {
           {!Operation_kind.Findings}. *)
   head_branch : Types.Branch.t option;
   head_oid : string option;
+  merge_commit_sha : string option;
+      (** For a merged PR, the squash/merge commit SHA on the base branch
+          (GitHub [mergeCommit.oid]). [None] for open/closed PRs or when the
+          forge has not yet reported it. *)
   base_branch : Types.Branch.t option;
   is_fork : bool;
 }

--- a/lib_core/pr_state.mli
+++ b/lib_core/pr_state.mli
@@ -23,6 +23,10 @@ type t = {
   findings : Review_service.finding list;
   head_branch : Branch.t option;
   head_oid : string option;
+  merge_commit_sha : string option;
+      (** For a merged PR, the squash/merge commit SHA on the base branch
+          (GitHub [mergeCommit.oid]). [None] for open/closed PRs or when the
+          forge has not yet reported it. *)
   base_branch : Branch.t option;
   is_fork : bool;
 }

--- a/lib_core/reconciler.ml
+++ b/lib_core/reconciler.ml
@@ -141,7 +141,15 @@ let detect_sibling_stale_bases graph views ~has_merged =
   let view_by_id =
     List.fold views
       ~init:(Map.empty (module Patch_id))
-      ~f:(fun acc v -> Map.set acc ~key:v.id ~data:v)
+      ~f:(fun acc v ->
+        match Map.add acc ~key:v.id ~data:v with
+        | `Ok m -> m
+        | `Duplicate ->
+            invalid_arg
+              (Printf.sprintf
+                 "Reconciler.detect_sibling_stale_bases: duplicate patch view \
+                  %s"
+                 (Patch_id.to_string v.id)))
   in
   (* [b] is rebasable only once it has a PR and does not already have a Rebase
      queued. Guarding on [b]'s own view (not the fan-in patch [v]'s) keeps this

--- a/lib_core/reconciler.ml
+++ b/lib_core/reconciler.ml
@@ -146,7 +146,9 @@ let detect_sibling_stale_bases graph views ~has_merged =
   (* [b] is rebasable only once it has a PR and does not already have a Rebase
      queued. Guarding on [b]'s own view (not the fan-in patch [v]'s) keeps this
      detector as disciplined as the other three, which only ever enqueue a
-     rebase for a patch they have validated. *)
+     rebase for a patch they have validated. In particular, an unstarted/queued
+     dep with no worktree leaves the fan-in patch fail-closed for now; once [b]
+     starts and obtains a PR, the next reconcile tick can enqueue its rebase. *)
   let base_rebasable b =
     match Map.find view_by_id b with
     | Some bv ->

--- a/lib_core/reconciler.ml
+++ b/lib_core/reconciler.ml
@@ -11,6 +11,15 @@ type patch_view = {
   queue : Operation_kind.t list;
   base_branch : Branch.t;
   branch_rebased_onto : Branch.t option;
+  base_contains_merged_siblings : bool;
+      (** Whether this patch's resolved base branch already contains the squash
+          commit of every *merged* dependency of this patch. Computed
+          effectfully by the caller ([poller_fiber]) via [Worktree.is_ancestor]
+          over each merged dep's recorded merge-commit SHA, fail-closed to
+          [false] when a SHA is not yet known. [true] when the base is main (all
+          deps merged into main) or the base branch already carries the merged
+          siblings. Drives [detect_sibling_stale_bases] and the Start/Rebase
+          gate. *)
 }
 [@@deriving sexp_of]
 
@@ -111,6 +120,45 @@ let detect_stale_bases graph views ~has_merged ~branch_of ~main =
         else None
       else None)
 
+(** Detect fan-in patches whose resolved base branch does not yet contain a
+    merged *sibling* dependency. When [P] depends on several patches and exactly
+    one is still open, [P]'s base is that sole open dep [B]; [B]'s branch is a
+    sibling of [P]'s already-merged deps and does not carry their squash
+    commits. The other rebase detectors never fix this: [B] is not a dependent
+    of the merged sibling, so none of [detect_rebases] / [detect_stale_bases] /
+    [detect_notified_base_drift] enqueues [B]'s rebase. This detector creates
+    that demand — it enqueues a [Rebase] of [B] (the dependency), which on its
+    next run rebases onto [Graph.initial_base B] (= main once [B]'s own deps are
+    merged) and thereby absorbs [P]'s merged siblings. [P]'s own
+    [Start]/[Rebase] stays deferred by the eligibility gate
+    ([Base_missing_merged_sibling]) until [B] is fresh.
+
+    Guards mirror the other detectors (has_pr, ~merged, and skip when [B]
+    already has a [Rebase] queued). The [open_pr_deps = 1] guard keeps
+    [sole_open_dep] total and pins this to the "last-but-one dependency merged"
+    edge, where a single rebase of [B] realizes containment for [P]. *)
+let detect_sibling_stale_bases graph views ~has_merged =
+  let view_by_id =
+    List.fold views
+      ~init:(Map.empty (module Patch_id))
+      ~f:(fun acc v -> Map.set acc ~key:v.id ~data:v)
+  in
+  let base_has_rebase_queued b =
+    match Map.find view_by_id b with
+    | Some bv ->
+        List.mem bv.queue Operation_kind.Rebase ~equal:Operation_kind.equal
+    | None -> false
+  in
+  List.filter_map views ~f:(fun v ->
+      if
+        v.has_pr && (not v.merged)
+        && List.length (Graph.open_pr_deps graph v.id ~has_merged) = 1
+        && not v.base_contains_merged_siblings
+      then
+        let b = Graph.sole_open_dep graph v.id ~has_merged in
+        if base_has_rebase_queued b then None else Some (Enqueue_rebase b)
+      else None)
+
 let plan_operations views ~has_merged ~branch_of ~graph ~main =
   List.filter_map views ~f:(fun v ->
       if
@@ -155,6 +203,7 @@ let reconcile ~graph ~main ~merged_pr_patches ~branch_of views =
     detect_stale_bases graph views ~has_merged ~branch_of ~main
   in
   let drift_rebases = detect_notified_base_drift views in
+  let sibling_rebases = detect_sibling_stale_bases graph views ~has_merged in
   (* Deduplicate across the three rebase detectors. Priority is arbitrary —
      they all emit the same [Enqueue_rebase] with the same patch_id — but we
      must not emit duplicates, since the orchestrator's [enqueue] is
@@ -173,8 +222,9 @@ let reconcile ~graph ~main ~merged_pr_patches ~branch_of views =
     in
     let seen, kept1 = add_unseen (Set.empty (module Patch_id)) event_rebases in
     let seen, kept2 = add_unseen seen stale_rebases in
-    let _seen, kept3 = add_unseen seen drift_rebases in
-    List.rev kept1 @ List.rev kept2 @ List.rev kept3
+    let seen, kept3 = add_unseen seen drift_rebases in
+    let _seen, kept4 = add_unseen seen sibling_rebases in
+    List.rev kept1 @ List.rev kept2 @ List.rev kept3 @ List.rev kept4
   in
   let rebase_set =
     List.filter_map rebases ~f:(function

--- a/lib_core/reconciler.ml
+++ b/lib_core/reconciler.ml
@@ -143,10 +143,17 @@ let detect_sibling_stale_bases graph views ~has_merged =
       ~init:(Map.empty (module Patch_id))
       ~f:(fun acc v -> Map.set acc ~key:v.id ~data:v)
   in
-  let base_has_rebase_queued b =
+  (* [b] is rebasable only once it has a PR and does not already have a Rebase
+     queued. Guarding on [b]'s own view (not the fan-in patch [v]'s) keeps this
+     detector as disciplined as the other three, which only ever enqueue a
+     rebase for a patch they have validated. *)
+  let base_rebasable b =
     match Map.find view_by_id b with
     | Some bv ->
-        List.mem bv.queue Operation_kind.Rebase ~equal:Operation_kind.equal
+        bv.has_pr
+        && not
+             (List.mem bv.queue Operation_kind.Rebase
+                ~equal:Operation_kind.equal)
     | None -> false
   in
   List.filter_map views ~f:(fun v ->
@@ -156,7 +163,7 @@ let detect_sibling_stale_bases graph views ~has_merged =
         && not v.base_contains_merged_siblings
       then
         let b = Graph.sole_open_dep graph v.id ~has_merged in
-        if base_has_rebase_queued b then None else Some (Enqueue_rebase b)
+        if base_rebasable b then Some (Enqueue_rebase b) else None
       else None)
 
 let plan_operations views ~has_merged ~branch_of ~graph ~main =
@@ -204,7 +211,7 @@ let reconcile ~graph ~main ~merged_pr_patches ~branch_of views =
   in
   let drift_rebases = detect_notified_base_drift views in
   let sibling_rebases = detect_sibling_stale_bases graph views ~has_merged in
-  (* Deduplicate across the three rebase detectors. Priority is arbitrary —
+  (* Deduplicate across the four rebase detectors. Priority is arbitrary —
      they all emit the same [Enqueue_rebase] with the same patch_id — but we
      must not emit duplicates, since the orchestrator's [enqueue] is
      idempotent but tests assert on action counts. *)

--- a/lib_core/reconciler.mli
+++ b/lib_core/reconciler.mli
@@ -98,9 +98,10 @@ val detect_sibling_stale_bases :
     base does not yet contain its merged siblings
     ([base_contains_merged_siblings = false]). [B] is enqueued (not [P]); [P]'s
     own start/rebase is gated separately by [Start_eligibility]. Skips when [B]
-    already has a [Rebase] queued. This is the demand that the other three
-    detectors miss, because [B] is a *sibling* of [P]'s merged deps, not a
-    dependent of them. *)
+    has no PR yet or already has a [Rebase] queued, so queued/unstarted
+    dependencies are never rebase-enqueued by this detector. This is the demand
+    that the other three detectors miss, because [B] is a *sibling* of [P]'s
+    merged deps, not a dependent of them. *)
 
 val plan_operations :
   patch_view list ->

--- a/lib_core/reconciler.mli
+++ b/lib_core/reconciler.mli
@@ -25,6 +25,14 @@ type patch_view = {
           [base_branch], the local branch still carries the old dep's commits
           even if GitHub auto-retargeted the PR — a rebase is required. Used by
           [detect_notified_base_drift]. *)
+  base_contains_merged_siblings : bool;
+      (** Whether this patch's resolved base branch already contains the squash
+          commit of every *merged* dependency of this patch. Computed
+          effectfully by the caller ([poller_fiber]) via [Worktree.is_ancestor]
+          over each merged dep's recorded merge-commit SHA, fail-closed to
+          [false] when a SHA is not yet known. [true] when the base is main or
+          the base branch already carries the merged siblings. Drives
+          [detect_sibling_stale_bases] and the Start/Rebase eligibility gate. *)
 }
 [@@deriving sexp_of]
 (** Observable state of a single patch, projected for reconciliation. *)
@@ -79,6 +87,21 @@ val detect_notified_base_drift : patch_view list -> action list
     Same precondition guards as other rebase detectors: has_pr, !merged,
     !Rebase-in-queue. *)
 
+val detect_sibling_stale_bases :
+  Graph.t ->
+  patch_view list ->
+  has_merged:(Types.Patch_id.t -> bool) ->
+  action list
+(** [detect_sibling_stale_bases graph views ~has_merged] returns
+    [Enqueue_rebase B] for the sole open dependency [B] of every fan-in patch
+    [P] that has a PR, is not merged, has exactly one open dependency, and whose
+    base does not yet contain its merged siblings
+    ([base_contains_merged_siblings = false]). [B] is enqueued (not [P]); [P]'s
+    own start/rebase is gated separately by [Start_eligibility]. Skips when [B]
+    already has a [Rebase] queued. This is the demand that the other three
+    detectors miss, because [B] is a *sibling* of [P]'s merged deps, not a
+    dependent of them. *)
+
 val plan_operations :
   patch_view list ->
   has_merged:(Types.Patch_id.t -> bool) ->
@@ -98,6 +121,8 @@ val reconcile :
   branch_of:(Types.Patch_id.t -> Types.Branch.t) ->
   patch_view list ->
   action list
-(** [reconcile] composes [detect_merges], [detect_rebases], and
-    [plan_operations] into a single pass. Returns actions in priority order:
-    merges first, then rebases, then operations. *)
+(** [reconcile] composes [detect_merges], the four rebase detectors
+    ([detect_rebases], [detect_stale_bases], [detect_notified_base_drift],
+    [detect_sibling_stale_bases]), and [plan_operations] into a single pass.
+    Rebase actions are deduplicated by patch id across the detectors. Returns
+    actions in priority order: merges first, then rebases, then operations. *)

--- a/lib_core/start_eligibility.ml
+++ b/lib_core/start_eligibility.ml
@@ -3,13 +3,15 @@ open Base
 type defer_reason =
   | Base_patch_busy_with_rebase of { base_branch : string }
   | Base_not_fresh_for_cut of { base_branch : string }
+  | Base_missing_merged_sibling of { base_branch : string }
 [@@deriving show, eq, sexp_of, compare]
 
 type decision = Allow | Defer of defer_reason
 [@@deriving show, eq, sexp_of, compare]
 
 let decide ~base_is_main ~base_branch ~base_patch_merged
-    ~base_patch_busy_rebasing ~base_structurally_fresh =
+    ~base_patch_busy_rebasing ~base_structurally_fresh
+    ~base_contains_merged_siblings =
   if base_is_main then Allow
   else if base_patch_merged then Allow
   else if base_patch_busy_rebasing then
@@ -22,9 +24,20 @@ let decide ~base_is_main ~base_branch ~base_patch_merged
        absorbs it has not landed), so cutting a downstream worktree here would
        elide the just-merged ancestor's commits. *)
     Defer (Base_not_fresh_for_cut { base_branch })
+  else if not base_contains_merged_siblings then
+    (* The base is structurally settled on its own dependency lineage, but the
+       patch being started/rebased fans in on a *sibling* dependency that has
+       merged to main independently of this base. The base's branch does not
+       yet contain that sibling's squash commit, so cutting/rebasing here would
+       start from a base missing one of the patch's dependencies. This flag is
+       computed against the *launching patch's* full merged-dep set (not the
+       base patch's own deps), so an arbitrarily deep fan-in gap cannot slip
+       through: the base must be freshened first. *)
+    Defer (Base_missing_merged_sibling { base_branch })
   else Allow
 
 let short_label = function
   | Allow -> "allow"
   | Defer (Base_patch_busy_with_rebase _) -> "defer_base_busy_rebasing"
   | Defer (Base_not_fresh_for_cut _) -> "defer_base_stale"
+  | Defer (Base_missing_merged_sibling _) -> "defer_base_missing_sibling"

--- a/lib_core/start_eligibility.mli
+++ b/lib_core/start_eligibility.mli
@@ -24,7 +24,24 @@
     even if main has since advanced for unrelated reasons; an unrelated merge to
     main never makes [b] stale for the purpose of cutting [c]. The caller
     computes the [base_structurally_fresh] flag from the dep graph and the base
-    patch's recorded rebase anchor. *)
+    patch's recorded rebase anchor.
+
+    {1 Sibling containment for fan-in patches}
+
+    Structural freshness alone is blind to a second hazard. When [c] fans in on
+    several dependencies (e.g. [c -> {1,2,3}] where [2] is a stacked child of
+    [1] and [3] is an independent sibling), [c]'s base resolves to the sole
+    still-open dep [b]. [b]'s branch transitively carries its own lineage, but
+    NOT a *sibling* dependency of [c] that merged to main independently — that
+    sibling's squash commit lives on main, never an ancestor of [b]. Cutting [c]
+    from such a [b] starts it from a base missing one of its own dependencies.
+    The [base_contains_merged_siblings] flag — computed by the caller against
+    [c]'s full merged-dep set via [Worktree.is_ancestor] over each merged dep's
+    [merge_commit_sha] — closes this. It never trips on unrelated main movement
+    (only [c]'s actual deps are checked), so it preserves the dependency-scoped
+    (not main-scoped) discipline above. The same gate is consulted for [Rebase]
+    actions, which is what makes a fan-in/chain rebase cascade block on its
+    dependency layers in topological order. *)
 
 type defer_reason =
   | Base_patch_busy_with_rebase of { base_branch : string }
@@ -36,6 +53,13 @@ type defer_reason =
           structurally-correct base — a dependency has merged but the rebase
           that absorbs it has not landed. The base needs that rebase before
           [Start] can fire. *)
+  | Base_missing_merged_sibling of { base_branch : string }
+      (** The base is structurally settled on its own lineage, but the launching
+          patch fans in on a sibling dependency that merged to main
+          independently and whose squash commit the base does not yet contain.
+          The base must be rebased to absorb that sibling before
+          [Start]/[Rebase] can fire. Computed against the launching patch's full
+          merged-dep set, so it also covers arbitrarily deep fan-in nesting. *)
 [@@deriving show, eq, sexp_of, compare]
 
 type decision = Allow | Defer of defer_reason
@@ -47,6 +71,7 @@ val decide :
   base_patch_merged:bool ->
   base_patch_busy_rebasing:bool ->
   base_structurally_fresh:bool ->
+  base_contains_merged_siblings:bool ->
   decision
 (** [decide] is total and deterministic. Pre-emption order, applied top-down:
 
@@ -59,13 +84,20 @@ val decide :
     + [base_patch_busy_rebasing = true] → [Defer Base_patch_busy_with_rebase].
       Checked before the freshness flag so an active rebase pre-empts.
     + [base_structurally_fresh = false] → [Defer Base_not_fresh_for_cut].
+    + [base_contains_merged_siblings = false] →
+      [Defer Base_missing_merged_sibling]. Checked last: only fires when the
+      base is otherwise settled on its own lineage but still lacks a merged
+      sibling dep's squash commit. The first two arms
+      ([base_is_main]/[base_patch_merged]) already imply containment.
     + Otherwise → [Allow].
 
     Note: this decision does not look at the dep graph itself. The caller
     resolves [c]'s base to a single base patch (or main) and passes the relevant
-    facts, including whether that base is structurally fresh. *)
+    facts, including whether that base is structurally fresh and whether it
+    contains [c]'s merged siblings. *)
 
 val short_label : decision -> string
 (** A short, lowercase, snake_case identifier for the decision arm, suitable for
     activity logging. Always non-empty and ≤ 32 characters. Examples: ["allow"],
-    ["defer_base_busy_rebasing"], ["defer_base_stale"]. *)
+    ["defer_base_busy_rebasing"], ["defer_base_stale"],
+    ["defer_base_missing_sibling"]. *)

--- a/lib_test/test_generators.ml
+++ b/lib_test/test_generators.ml
@@ -306,6 +306,7 @@ let gen_pr_state =
           head_oid = None;
           base_branch;
           is_fork;
+          merge_commit_sha = None;
         })
       (pair gen_pr_status gen_merge_state)
       bool
@@ -349,6 +350,7 @@ let gen_poller =
             merge_ready;
             checks_passing;
             ci_checks;
+            merge_commit_sha = None;
           })
       gen_operation_kind_queue (triple bool bool bool) bool bool
       (list_small gen_ci_check))
@@ -471,6 +473,7 @@ let gen_patch_view =
                construct views explicitly rather than relying on this
                generator. *)
             branch_rebased_onto = Some base_branch;
+            base_contains_merged_siblings = true;
           })
       (pair gen_patch_id gen_branch)
       (quad bool bool bool bool)
@@ -750,6 +753,7 @@ let apply_reconcile_actions orch ~main ~branch_of =
             base_branch =
               Option.value a.Onton_core.Patch_agent.base_branch ~default:main;
             branch_rebased_onto = a.Onton_core.Patch_agent.branch_rebased_onto;
+            base_contains_merged_siblings = true;
           })
   in
   let merged_patches =

--- a/test/dune
+++ b/test/dune
@@ -69,6 +69,13 @@
  (ocamlc_flags (:standard -w -40-42)))
 
 (test
+ (name test_base_containment)
+ (modules test_base_containment)
+ (libraries onton_core qcheck-core qcheck-core.runner)
+ (ocamlopt_flags (:standard -w -40-42))
+ (ocamlc_flags (:standard -w -40-42)))
+
+(test
  (name test_push_plan_properties)
  (modules test_push_plan_properties)
  (libraries onton_core re qcheck-core qcheck-core.runner)

--- a/test/test_base_containment.ml
+++ b/test/test_base_containment.ml
@@ -1,0 +1,187 @@
+open Base
+open Onton_core
+
+(** Property/regression tests for {!Base_containment.contains_merged_siblings}.
+
+    Git ancestry is mocked: [contained] is the set of merge-commit SHAs the base
+    branch is treated as containing; the oracle ignores [descendant] and just
+    membership-checks [ancestor]. This exercises every fan-in permutation,
+    fail-closed-on-missing-SHA, and the "only the patch's own deps are
+    consulted" invariant, purely. *)
+
+module Gen = QCheck2.Gen
+module Test = QCheck2.Test
+module BC = Base_containment
+
+let pid s = Types.Patch_id.of_string s
+let br s = Types.Branch.of_string s
+let main = br "main"
+
+let mk_patch ~id ~deps : Types.Patch.t =
+  {
+    id = pid id;
+    title = "";
+    description = "";
+    branch = br id;
+    dependencies = List.map deps ~f:pid;
+    spec = "";
+    acceptance_criteria = [];
+    files = [];
+    classification = "";
+    changes = [];
+    test_stubs_introduced = [];
+    test_stubs_implemented = [];
+    complexity = None;
+    precedents = [];
+    required_context = [];
+  }
+
+(* P -> {d1, d2, d3}, d2 a stacked child of d1, d3 an independent sibling. *)
+let fanin_graph =
+  Graph.of_patches
+    [
+      mk_patch ~id:"p" ~deps:[ "d1"; "d2"; "d3" ];
+      mk_patch ~id:"d1" ~deps:[];
+      mk_patch ~id:"d2" ~deps:[ "d1" ];
+      mk_patch ~id:"d3" ~deps:[];
+    ]
+
+let branch_of p = br (Types.Patch_id.to_string p)
+let merge_sha p = Some ("sha-" ^ Types.Patch_id.to_string p)
+let sha_of s = "sha-" ^ s
+
+(* Oracle from a set of contained SHAs (descendant ignored). *)
+let oracle_of contained ancestor ~descendant:_ =
+  List.mem contained ancestor ~equal:String.equal
+
+let contains ~merged ~contained ?(merge_sha = merge_sha) () =
+  BC.contains_merged_siblings ~graph:fanin_graph ~patch_id:(pid "p")
+    ~has_merged:(fun d -> List.mem merged d ~equal:Types.Patch_id.equal)
+    ~merge_sha ~branch_of ~main ~ancestor_oracle:(oracle_of contained)
+
+(* ---------- regression: each last-but-one-merge permutation ---------- *)
+
+(* {d1,d3 merged, d2 open}: base is d2's branch. It contains d1 (stacked child)
+   but NOT d3 (independent sibling). → not contained. *)
+let prop_open_d2_missing_d3 =
+  Test.make ~name:"BC: {d1,d3 merged, d2 open}, base lacks d3 → false" ~count:1
+    (Gen.return ()) (fun () ->
+      not
+        (contains ~merged:[ pid "d1"; pid "d3" ] ~contained:[ sha_of "d1" ] ()))
+
+(* Same, but the base (d2) has since been rebased to absorb d3 → contained. *)
+let prop_open_d2_after_rebase =
+  Test.make ~name:"BC: {d1,d3 merged, d2 open}, base has d1+d3 → true" ~count:1
+    (Gen.return ()) (fun () ->
+      contains
+        ~merged:[ pid "d1"; pid "d3" ]
+        ~contained:[ sha_of "d1"; sha_of "d3" ]
+        ())
+
+let prop_open_d1 =
+  Test.make ~name:"BC: {d2,d3 merged, d1 open}, base lacks them → false"
+    ~count:1 (Gen.return ()) (fun () ->
+      not (contains ~merged:[ pid "d2"; pid "d3" ] ~contained:[] ()))
+
+let prop_open_d3 =
+  Test.make ~name:"BC: {d1,d2 merged, d3 open}, base lacks them → false"
+    ~count:1 (Gen.return ()) (fun () ->
+      not (contains ~merged:[ pid "d1"; pid "d2" ] ~contained:[] ()))
+
+(* ---------- boundary cases ---------- *)
+
+let prop_all_merged_base_main =
+  Test.make ~name:"BC: all deps merged → base main → true (no oracle)" ~count:1
+    (Gen.return ()) (fun () ->
+      contains ~merged:[ pid "d1"; pid "d2"; pid "d3" ] ~contained:[] ())
+
+let prop_multi_open_false =
+  Test.make ~name:"BC: >1 open dep → false (not at edge)" ~count:1
+    (Gen.return ()) (fun () ->
+      (* nothing merged → 3 open deps *)
+      (not (contains ~merged:[] ~contained:[ sha_of "d1" ] ()))
+      (* one merged → 2 open deps *)
+      && not (contains ~merged:[ pid "d1" ] ~contained:[ sha_of "d1" ] ()))
+
+let prop_fail_closed_missing_sha =
+  Test.make ~name:"BC: merged dep with unknown merge_sha → false (fail-closed)"
+    ~count:1 (Gen.return ()) (fun () ->
+      let merge_sha p =
+        if Types.Patch_id.equal p (pid "d3") then None else merge_sha p
+      in
+      (* d3 is contained by ancestry, but its SHA is unknown → still false. *)
+      not
+        (contains
+           ~merged:[ pid "d1"; pid "d3" ]
+           ~contained:[ sha_of "d1"; sha_of "d3" ]
+           ~merge_sha ()))
+
+(* Invariant (ii): only the patch's own merged deps are consulted. In a graph
+   where [p -> {a, b}] (b open, a merged) and an unrelated patch [q] has also
+   merged, [q]'s squash commit being absent from the base must NOT flip the
+   result — the oracle is only asked about [a]. *)
+let prop_only_own_deps_consulted =
+  Test.make ~name:"BC: unrelated merges never flip containment (invariant ii)"
+    ~count:1 (Gen.return ()) (fun () ->
+      let graph =
+        Graph.of_patches
+          [
+            mk_patch ~id:"p" ~deps:[ "a"; "b" ];
+            mk_patch ~id:"a" ~deps:[];
+            mk_patch ~id:"b" ~deps:[];
+            mk_patch ~id:"q" ~deps:[];
+            (* unrelated *)
+          ]
+      in
+      let merged = [ pid "a"; pid "q" ] in
+      (* base is b; it contains a but not q. q is not a dep of p. *)
+      BC.contains_merged_siblings ~graph ~patch_id:(pid "p")
+        ~has_merged:(fun d -> List.mem merged d ~equal:Types.Patch_id.equal)
+        ~merge_sha ~branch_of ~main
+        ~ancestor_oracle:(oracle_of [ sha_of "a" ]))
+
+(* Property: with exactly one open dep and a non-main base, containment holds
+   iff every *other* (merged) dep's SHA is in [contained]. *)
+let prop_iff_all_merged_in_contained =
+  Test.make ~name:"BC: contained iff all merged-dep SHAs ∈ base" ~count:300
+    Gen.(
+      (* choose which single dep stays open; the rest are merged *)
+      let* open_dep = oneof_list [ "d1"; "d2"; "d3" ] in
+      (* independently decide, per merged dep, whether its SHA is in the base *)
+      let* d1_in = bool in
+      let* d2_in = bool in
+      let* d3_in = bool in
+      return (open_dep, d1_in, d2_in, d3_in))
+    (fun (open_dep, d1_in, d2_in, d3_in) ->
+      let all = [ ("d1", d1_in); ("d2", d2_in); ("d3", d3_in) ] in
+      let merged =
+        List.filter_map all ~f:(fun (d, _) ->
+            if String.equal d open_dep then None else Some (pid d))
+      in
+      let contained =
+        List.filter_map all ~f:(fun (d, in_base) ->
+            if String.equal d open_dep then None
+            else if in_base then Some (sha_of d)
+            else None)
+      in
+      let expected =
+        List.for_all all ~f:(fun (d, in_base) ->
+            String.equal d open_dep || in_base)
+      in
+      Bool.equal (contains ~merged ~contained ()) expected)
+
+let () =
+  let runner = QCheck_base_runner.run_tests_main in
+  ignore
+    (runner
+       [
+         prop_open_d2_missing_d3;
+         prop_open_d2_after_rebase;
+         prop_open_d1;
+         prop_open_d3;
+         prop_all_merged_base_main;
+         prop_multi_open_false;
+         prop_fail_closed_missing_sha;
+         prop_only_own_deps_consulted;
+         prop_iff_all_merged_in_contained;
+       ])

--- a/test/test_interleaving_properties.ml
+++ b/test/test_interleaving_properties.ml
@@ -399,6 +399,7 @@ let make_poll_result ~has_conflict ~merged ~ci_failed ~checks_passing
         && not review_comments;
       checks_passing;
       ci_checks = [];
+      merge_commit_sha = None;
     }
 
 let apply_reconcile orch patches =
@@ -2097,6 +2098,7 @@ let () =
                   base_branch =
                     Option.value ag.Patch_agent.base_branch ~default:main;
                   branch_rebased_onto = ag.Patch_agent.branch_rebased_onto;
+                  base_contains_merged_siblings = true;
                 })
         in
         let merged_patches =
@@ -2741,6 +2743,7 @@ let reconcile_views_of orch =
           queue = ag.Patch_agent.queue;
           base_branch = Option.value ag.Patch_agent.base_branch ~default:main;
           branch_rebased_onto = ag.Patch_agent.branch_rebased_onto;
+          base_contains_merged_siblings = true;
         })
 
 let () =

--- a/test/test_orchestrator_properties.ml
+++ b/test/test_orchestrator_properties.ml
@@ -1082,6 +1082,7 @@ let () =
                     merge_ready = false;
                     checks_passing = true;
                     ci_checks = [];
+                    merge_commit_sha = None;
                   }
               in
               let orch', _logs, _newly_blocked =
@@ -1121,6 +1122,7 @@ let () =
                     merge_ready = false;
                     checks_passing = true;
                     ci_checks = [];
+                    merge_commit_sha = None;
                   }
               in
               let orch', _logs, _newly_blocked =
@@ -1161,6 +1163,7 @@ let () =
                     merge_ready = false;
                     checks_passing = true;
                     ci_checks = [];
+                    merge_commit_sha = None;
                   }
               in
               let orch', _logs, _newly_blocked =
@@ -1205,6 +1208,7 @@ let () =
                     merge_ready = false;
                     checks_passing = true;
                     ci_checks = [];
+                    merge_commit_sha = None;
                   }
               in
               let orch', _logs, _newly_blocked =
@@ -1245,6 +1249,7 @@ let () =
                     merge_ready = false;
                     checks_passing = true;
                     ci_checks = [];
+                    merge_commit_sha = None;
                   }
               in
               let orch', _logs, _newly_blocked =
@@ -1294,6 +1299,7 @@ let () =
                     merge_ready = false;
                     checks_passing = false;
                     ci_checks = [];
+                    merge_commit_sha = None;
                   }
               in
               let orch', _logs, _newly_blocked =
@@ -1346,6 +1352,7 @@ let () =
                     merge_ready = false;
                     checks_passing = false;
                     ci_checks = [];
+                    merge_commit_sha = None;
                   }
               in
               let orch', _logs, _newly_blocked =
@@ -1388,6 +1395,7 @@ let () =
                     merge_ready = false;
                     checks_passing = true;
                     ci_checks = [];
+                    merge_commit_sha = None;
                   }
               in
               let orch', _logs, _newly_blocked =

--- a/test/test_patch_agent.ml
+++ b/test/test_patch_agent.ml
@@ -727,7 +727,8 @@ let () =
               ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
               ~conflict_noop_count:0 ~no_commits_push_count:0
               ~push_failure_count:0 ~branch_rebased_onto:None
-              ~branch_rebased_onto_sha:None
+              ~branch_rebased_onto_sha:None ~merge_commit_sha:None
+              ~base_contains_merged_siblings:true
               ~anchor_history:Onton_core.Anchor_history.empty
               ~checks_passing:false ~current_op:None
               ~current_op_state:Onton_core.Patch_agent.Queued
@@ -812,7 +813,8 @@ let () =
               ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
               ~conflict_noop_count:0 ~no_commits_push_count:0
               ~push_failure_count:0 ~branch_rebased_onto:None
-              ~branch_rebased_onto_sha:None
+              ~branch_rebased_onto_sha:None ~merge_commit_sha:None
+              ~base_contains_merged_siblings:true
               ~anchor_history:Onton_core.Anchor_history.empty
               ~checks_passing:false ~current_op:None
               ~current_op_state:Onton_core.Patch_agent.Queued

--- a/test/test_patch_controller.ml
+++ b/test/test_patch_controller.ml
@@ -61,6 +61,7 @@ let make_agent ~patch_id ~branch ~pr_status ~merged ~queue ~base_branch
     ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr
     ~conflict_noop_count:0 ~no_commits_push_count:0 ~push_failure_count:0
     ~branch_rebased_onto:None ~branch_rebased_onto_sha:None
+    ~merge_commit_sha:None ~base_contains_merged_siblings:true
     ~anchor_history:Onton_core.Anchor_history.empty ~checks_passing:false
     ~current_op:None ~current_op_state:Patch_agent.Queued
     ~current_message_id:None ~generation:0 ~worktree_path:None
@@ -235,7 +236,8 @@ let () =
             ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
             ~conflict_noop_count:0 ~no_commits_push_count:0
             ~push_failure_count:0 ~branch_rebased_onto:(Some main)
-            ~branch_rebased_onto_sha:None
+            ~branch_rebased_onto_sha:None ~merge_commit_sha:None
+            ~base_contains_merged_siblings:true
             ~anchor_history:Onton_core.Anchor_history.empty ~checks_passing:true
             ~current_op:None ~current_op_state:Patch_agent.Queued
             ~current_message_id:None ~generation:0 ~worktree_path:None
@@ -284,7 +286,8 @@ let () =
             ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
             ~conflict_noop_count:0 ~no_commits_push_count:0
             ~push_failure_count:0 ~branch_rebased_onto:None
-            ~branch_rebased_onto_sha:None
+            ~branch_rebased_onto_sha:None ~merge_commit_sha:None
+            ~base_contains_merged_siblings:true
             ~anchor_history:Onton_core.Anchor_history.empty ~checks_passing:true
             ~current_op:None ~current_op_state:Patch_agent.Queued
             ~current_message_id:None ~generation:0 ~worktree_path:None
@@ -422,7 +425,8 @@ let () =
             ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
             ~conflict_noop_count:0 ~no_commits_push_count:0
             ~push_failure_count:0 ~branch_rebased_onto:None
-            ~branch_rebased_onto_sha:None
+            ~branch_rebased_onto_sha:None ~merge_commit_sha:None
+            ~base_contains_merged_siblings:true
             ~anchor_history:Onton_core.Anchor_history.empty
             ~checks_passing:false ~current_op:None
             ~current_op_state:Patch_agent.Queued ~current_message_id:None
@@ -466,7 +470,8 @@ let () =
             ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
             ~conflict_noop_count:0 ~no_commits_push_count:0
             ~push_failure_count:0 ~branch_rebased_onto:None
-            ~branch_rebased_onto_sha:None
+            ~branch_rebased_onto_sha:None ~merge_commit_sha:None
+            ~base_contains_merged_siblings:true
             ~anchor_history:Onton_core.Anchor_history.empty
             ~checks_passing:false ~current_op:None
             ~current_op_state:Patch_agent.Queued ~current_message_id:None
@@ -510,7 +515,8 @@ let () =
             ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
             ~conflict_noop_count:0 ~no_commits_push_count:0
             ~push_failure_count:0 ~branch_rebased_onto:None
-            ~branch_rebased_onto_sha:None
+            ~branch_rebased_onto_sha:None ~merge_commit_sha:None
+            ~base_contains_merged_siblings:true
             ~anchor_history:Onton_core.Anchor_history.empty
             ~checks_passing:false ~current_op:None
             ~current_op_state:Patch_agent.Queued ~current_message_id:None
@@ -567,6 +573,7 @@ let () =
               merge_ready = false;
               checks_passing = true;
               ci_checks = [];
+              merge_commit_sha = None;
             }
         in
         let orch, _logs, _newly_blocked =
@@ -608,6 +615,7 @@ let () =
               merge_ready = false;
               checks_passing = false;
               ci_checks = [];
+              merge_commit_sha = None;
             }
         in
         let orch, _logs, _newly_blocked =
@@ -648,7 +656,8 @@ let () =
             ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
             ~conflict_noop_count:0 ~no_commits_push_count:0
             ~push_failure_count:0 ~branch_rebased_onto:None
-            ~branch_rebased_onto_sha:None
+            ~branch_rebased_onto_sha:None ~merge_commit_sha:None
+            ~base_contains_merged_siblings:true
             ~anchor_history:Onton_core.Anchor_history.empty
             ~checks_passing:false ~current_op:None
             ~current_op_state:Patch_agent.Queued ~current_message_id:None
@@ -669,6 +678,7 @@ let () =
               merge_ready = false;
               checks_passing = false;
               ci_checks = [];
+              merge_commit_sha = None;
             }
         in
         let orch, _logs, _newly_blocked =
@@ -712,7 +722,8 @@ let () =
             ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
             ~conflict_noop_count:0 ~no_commits_push_count:0
             ~push_failure_count:0 ~branch_rebased_onto:None
-            ~branch_rebased_onto_sha:None
+            ~branch_rebased_onto_sha:None ~merge_commit_sha:None
+            ~base_contains_merged_siblings:true
             ~anchor_history:Onton_core.Anchor_history.empty
             ~checks_passing:false ~current_op:None
             ~current_op_state:Patch_agent.Queued ~current_message_id:None
@@ -733,6 +744,7 @@ let () =
               merge_ready = false;
               checks_passing = false;
               ci_checks = [ check ];
+              merge_commit_sha = None;
             }
         in
         let orch, _logs, _newly_blocked =
@@ -769,6 +781,7 @@ let () =
               merge_ready;
               checks_passing;
               ci_checks = [];
+              merge_commit_sha = None;
             }
         in
         let orch, _logs, _newly_blocked =
@@ -808,6 +821,7 @@ let () =
               merge_ready = false;
               checks_passing = false;
               ci_checks = [];
+              merge_commit_sha = None;
             }
         in
         let observation =
@@ -855,7 +869,8 @@ let () =
             ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
             ~conflict_noop_count:0 ~no_commits_push_count:0
             ~push_failure_count:0 ~branch_rebased_onto:(Some main)
-            ~branch_rebased_onto_sha:None
+            ~branch_rebased_onto_sha:None ~merge_commit_sha:None
+            ~base_contains_merged_siblings:true
             ~anchor_history:Onton_core.Anchor_history.empty
             ~checks_passing:false ~current_op:None
             ~current_op_state:Patch_agent.Queued ~current_message_id:None
@@ -1029,6 +1044,7 @@ let () =
                     merge_ready = false;
                     checks_passing = false;
                     ci_checks = [];
+                    merge_commit_sha = None;
                   };
               base_branch = Some new_base;
               branch_in_root = false;
@@ -1065,7 +1081,8 @@ let () =
             ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
             ~conflict_noop_count:0 ~no_commits_push_count:0
             ~push_failure_count:0 ~branch_rebased_onto:None
-            ~branch_rebased_onto_sha:None
+            ~branch_rebased_onto_sha:None ~merge_commit_sha:None
+            ~base_contains_merged_siblings:true
             ~anchor_history:Onton_core.Anchor_history.empty
             ~checks_passing:false ~current_op:None
             ~current_op_state:Patch_agent.Queued ~current_message_id:None
@@ -1109,7 +1126,8 @@ let () =
             ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
             ~conflict_noop_count:0 ~no_commits_push_count:0
             ~push_failure_count:0 ~branch_rebased_onto:None
-            ~branch_rebased_onto_sha:None
+            ~branch_rebased_onto_sha:None ~merge_commit_sha:None
+            ~base_contains_merged_siblings:true
             ~anchor_history:Onton_core.Anchor_history.empty
             ~checks_passing:false ~current_op:None
             ~current_op_state:Patch_agent.Queued ~current_message_id:None
@@ -1193,6 +1211,7 @@ let () =
               queue = [];
               is_draft = false;
               closed = false;
+              merge_commit_sha = None;
             }
         in
         let observation =

--- a/test/test_poll_log_properties.ml
+++ b/test/test_poll_log_properties.ml
@@ -54,6 +54,7 @@ let make_agent ~patch_id ~branch ~has_conflict ~ci_failure_count ~current_op
     ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
     ~conflict_noop_count:0 ~no_commits_push_count:0 ~push_failure_count:0
     ~branch_rebased_onto:None ~branch_rebased_onto_sha:None
+    ~merge_commit_sha:None ~base_contains_merged_siblings:true
     ~anchor_history:Onton_core.Anchor_history.empty ~checks_passing ~current_op
     ~current_op_state:(if busy then Patch_agent.Running else Patch_agent.Queued)
     ~current_message_id:None ~generation:0 ~worktree_path ~branch_blocked
@@ -76,6 +77,7 @@ let make_poll ~has_conflict ~merged ~checks_passing ~is_draft ~queue =
       merge_ready = false;
       checks_passing;
       ci_checks = [];
+      merge_commit_sha = None;
     }
 
 let has_log_matching needle logs =

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -433,7 +433,8 @@ let () =
   let pid = Types.Patch_id.of_string "p1" in
   let main = Types.Branch.of_string "main" in
   let mk_view ?(has_pr = true) ?(merged = false) ?(busy = false)
-      ?(needs_intervention = false) ?(branch_blocked = false) ?(queue = []) id =
+      ?(needs_intervention = false) ?(branch_blocked = false) ?(queue = [])
+      ?(base_contains_merged_siblings = true) id =
     Reconciler.
       {
         id;
@@ -445,6 +446,7 @@ let () =
         queue;
         base_branch = main;
         branch_rebased_onto = Some main;
+        base_contains_merged_siblings;
       }
   in
   let mk_patch id =

--- a/test/test_reconciler_properties.ml
+++ b/test/test_reconciler_properties.ml
@@ -762,6 +762,31 @@ let prop_fanin_idempotent_when_queued =
         (Reconciler.detect_sibling_stale_bases graph views
            ~has_merged:(merged_in merged)))
 
+(* A queued/unstarted sole-open dep has no PR/worktree yet. The containment
+   oracle may therefore fail-closed for P's base branch, but the sibling detector
+   must not enqueue a Rebase for B until B itself has a PR. Once B starts and the
+   branch exists locally, a later tick can recompute containment or enqueue the
+   rebase normally. *)
+let prop_fanin_silent_when_base_has_no_pr =
+  QCheck2.Test.make ~name:"sibling: silent when sole open dep has no PR"
+    ~count:1
+    QCheck2.Gen.(return ())
+    (fun () ->
+      let graph = fanin_graph () in
+      let merged = [ pid "d1"; pid "d3" ] in
+      let views =
+        [
+          mk_view ~id:(pid "p")
+            ~base_branch:(branch_of (pid "d2"))
+            ~branch_rebased_onto:(Some (branch_of (pid "d2")))
+            ~base_contains_merged_siblings:false ();
+          mk_view ~id:(pid "d2") ~has_pr:false ();
+        ]
+      in
+      List.is_empty
+        (Reconciler.detect_sibling_stale_bases graph views
+           ~has_merged:(merged_in merged)))
+
 (* Only Enqueue_rebase, never other action kinds; total over which-dep-open. *)
 let prop_fanin_only_enqueue_rebase =
   QCheck2.Test.make
@@ -861,6 +886,7 @@ let () =
       prop_fanin_contains_silent;
       prop_fanin_no_rebase_when_contained;
       prop_fanin_idempotent_when_queued;
+      prop_fanin_silent_when_base_has_no_pr;
       prop_fanin_only_enqueue_rebase;
       prop_fanin_silent_off_edge;
       prop_fanin_reconcile_enqueues_base_rebase;

--- a/test/test_reconciler_properties.ml
+++ b/test/test_reconciler_properties.ml
@@ -93,6 +93,7 @@ let gen_rebase_scenario =
                   queue = [];
                   base_branch = main;
                   branch_rebased_onto = Some main;
+                  base_contains_merged_siblings = true;
                 })
         in
         (graph, views, newly_merged))
@@ -155,6 +156,7 @@ let prop_detect_rebases_skips_already_queued =
                 queue = [ Types.Operation_kind.Rebase ];
                 base_branch = main;
                 branch_rebased_onto = Some main;
+                base_contains_merged_siblings = true;
               })
       in
       return (graph, views, ids))
@@ -192,6 +194,7 @@ let gen_plan_scenario =
                   queue;
                   base_branch = main;
                   branch_rebased_onto = Some main;
+                  base_contains_merged_siblings = true;
                 }))))
 
 let prop_plan_skips_busy =
@@ -359,6 +362,7 @@ let gen_reconcile_scenario =
                   queue = [];
                   base_branch = main;
                   branch_rebased_onto = Some main;
+                  base_contains_merged_siblings = true;
                 }))))
 
 let prop_reconcile_merges_subset =
@@ -418,7 +422,8 @@ let dep_br = Types.Branch.of_string "dep"
 let other_br = Types.Branch.of_string "other"
 
 let mk_view ~id ?(has_pr = true) ?(merged = false) ?(queue = [])
-    ?(base_branch = main_br) ?(branch_rebased_onto = Some main_br) () =
+    ?(base_branch = main_br) ?(branch_rebased_onto = Some main_br)
+    ?(base_contains_merged_siblings = true) () =
   Reconciler.
     {
       id;
@@ -430,6 +435,7 @@ let mk_view ~id ?(has_pr = true) ?(merged = false) ?(queue = [])
       queue;
       base_branch;
       branch_rebased_onto;
+      base_contains_merged_siblings;
     }
 
 let pid s = Types.Patch_id.of_string s
@@ -618,6 +624,207 @@ let prop_reconcile_dedup_rebase =
       in
       List.length rebases = 1)
 
+(* ========== detect_sibling_stale_bases (fan-in) ========== *)
+
+let mk_patch ~id ~deps : Types.Patch.t =
+  {
+    id = pid id;
+    title = "";
+    description = "";
+    branch = Types.Branch.of_string id;
+    dependencies = List.map deps ~f:pid;
+    spec = "";
+    acceptance_criteria = [];
+    files = [];
+    classification = "";
+    changes = [];
+    test_stubs_introduced = [];
+    test_stubs_implemented = [];
+    complexity = None;
+    precedents = [];
+    required_context = [];
+  }
+
+(* P -> {d1, d2, d3}, with d2 a stacked child of d1 and d3 an independent
+   sibling — the exact fan-in shape from the bug report. *)
+let fanin_graph () =
+  Graph.of_patches
+    [
+      mk_patch ~id:"p" ~deps:[ "d1"; "d2"; "d3" ];
+      mk_patch ~id:"d1" ~deps:[];
+      mk_patch ~id:"d2" ~deps:[ "d1" ];
+      mk_patch ~id:"d3" ~deps:[];
+    ]
+
+let br s = Types.Branch.of_string s
+let branch_of p = br (Types.Patch_id.to_string p)
+let merged_in ids p = List.mem ids p ~equal:Types.Patch_id.equal
+
+(* Build the fan-in view set for P given which deps are merged and whether P's
+   base (the sole open dep) is believed to contain P's merged siblings. *)
+let fanin_views ~merged ~contains =
+  let p_view =
+    let open_deps =
+      List.filter
+        [ pid "d1"; pid "d2"; pid "d3" ]
+        ~f:(fun d -> not (merged_in merged d))
+    in
+    let base = match open_deps with [ d ] -> branch_of d | _ -> main_br in
+    mk_view ~id:(pid "p") ~base_branch:base ~branch_rebased_onto:(Some base)
+      ~base_contains_merged_siblings:contains ()
+  in
+  [
+    p_view;
+    mk_view ~id:(pid "d1") ();
+    mk_view ~id:(pid "d2") ();
+    mk_view ~id:(pid "d3") ();
+  ]
+
+let sibling_rebase_targets ~merged ~contains =
+  let graph = fanin_graph () in
+  let views = fanin_views ~merged ~contains in
+  Reconciler.detect_sibling_stale_bases graph views
+    ~has_merged:(merged_in merged)
+  |> List.filter_map ~f:(function
+    | Reconciler.Enqueue_rebase p -> Some p
+    | Reconciler.Mark_merged _ | Reconciler.Start_operation _ -> None)
+
+(* REG-perm-{1,2,3}: for each "last-but-one merged" permutation, the detector
+   enqueues a rebase of the *sole open dep* (the base B), so B absorbs P's
+   merged siblings before P is cut from it. *)
+let prop_fanin_perm_open_d2 =
+  QCheck2.Test.make
+    ~name:"sibling: {d1,d3 merged, d2 open}, base stale → rebase d2" ~count:1
+    QCheck2.Gen.(return ())
+    (fun () ->
+      List.equal Types.Patch_id.equal
+        (sibling_rebase_targets ~merged:[ pid "d1"; pid "d3" ] ~contains:false)
+        [ pid "d2" ])
+
+let prop_fanin_perm_open_d1 =
+  QCheck2.Test.make
+    ~name:"sibling: {d2,d3 merged, d1 open}, base stale → rebase d1" ~count:1
+    QCheck2.Gen.(return ())
+    (fun () ->
+      List.equal Types.Patch_id.equal
+        (sibling_rebase_targets ~merged:[ pid "d2"; pid "d3" ] ~contains:false)
+        [ pid "d1" ])
+
+let prop_fanin_perm_open_d3 =
+  QCheck2.Test.make
+    ~name:"sibling: {d1,d2 merged, d3 open}, base stale → rebase d3" ~count:1
+    QCheck2.Gen.(return ())
+    (fun () ->
+      List.equal Types.Patch_id.equal
+        (sibling_rebase_targets ~merged:[ pid "d1"; pid "d2" ] ~contains:false)
+        [ pid "d3" ])
+
+(* Positive: once the base contains the merged siblings, the detector is
+   silent — no over-rebasing (and the eligibility gate would Allow P). *)
+let prop_fanin_contains_silent =
+  QCheck2.Test.make
+    ~name:"sibling: base already contains merged siblings → no rebase" ~count:1
+    QCheck2.Gen.(return ())
+    (fun () ->
+      List.is_empty
+        (sibling_rebase_targets ~merged:[ pid "d1"; pid "d3" ] ~contains:true))
+
+(* Invariant (ii): a merged dep that the base already contains never triggers a
+   sibling rebase — i.e. unrelated/already-absorbed merges do not cause churn. *)
+let prop_fanin_no_rebase_when_contained =
+  QCheck2.Test.make
+    ~name:"sibling: no rebase from already-absorbed merges (invariant ii)"
+    ~count:1
+    QCheck2.Gen.(return ())
+    (fun () ->
+      (* d1 merged, d2 open; base (d2) already contains d1. No rebase. *)
+      List.is_empty (sibling_rebase_targets ~merged:[ pid "d1" ] ~contains:true))
+
+(* Idempotent: if the base B already has a Rebase queued, no new emission. *)
+let prop_fanin_idempotent_when_queued =
+  QCheck2.Test.make ~name:"sibling: silent when base already has Rebase queued"
+    ~count:1
+    QCheck2.Gen.(return ())
+    (fun () ->
+      let graph = fanin_graph () in
+      let merged = [ pid "d1"; pid "d3" ] in
+      let views =
+        [
+          mk_view ~id:(pid "p")
+            ~base_branch:(branch_of (pid "d2"))
+            ~branch_rebased_onto:(Some (branch_of (pid "d2")))
+            ~base_contains_merged_siblings:false ();
+          (* d2 (the base B) already has a Rebase queued *)
+          mk_view ~id:(pid "d2") ~queue:[ Types.Operation_kind.Rebase ] ();
+        ]
+      in
+      List.is_empty
+        (Reconciler.detect_sibling_stale_bases graph views
+           ~has_merged:(merged_in merged)))
+
+(* Only Enqueue_rebase, never other action kinds; total over which-dep-open. *)
+let prop_fanin_only_enqueue_rebase =
+  QCheck2.Test.make
+    ~name:"sibling: only emits Enqueue_rebase, over all open-dep choices"
+    ~count:200
+    QCheck2.Gen.(oneof_list [ "d1"; "d2"; "d3" ])
+    (fun open_dep ->
+      let merged =
+        List.filter
+          [ pid "d1"; pid "d2"; pid "d3" ]
+          ~f:(fun d -> not (Types.Patch_id.equal d (pid open_dep)))
+      in
+      let graph = fanin_graph () in
+      let views = fanin_views ~merged ~contains:false in
+      let actions =
+        Reconciler.detect_sibling_stale_bases graph views
+          ~has_merged:(merged_in merged)
+      in
+      List.for_all actions ~f:(function
+        | Reconciler.Enqueue_rebase _ -> true
+        | Reconciler.Mark_merged _ | Reconciler.Start_operation _ -> false))
+
+(* No raise / no emission when P is not at the last-but-one edge (>1 open dep)
+   or when all deps merged (0 open deps, base = main). *)
+let prop_fanin_silent_off_edge =
+  QCheck2.Test.make ~name:"sibling: silent at 0 or >1 open deps (totality)"
+    ~count:1
+    QCheck2.Gen.(return ())
+    (fun () ->
+      (* >1 open dep: nothing merged → 3 open deps. *)
+      let none_merged =
+        List.is_empty (sibling_rebase_targets ~merged:[] ~contains:false)
+      in
+      (* 0 open deps: all merged → base is main, no sole open dep. *)
+      let all_merged =
+        List.is_empty
+          (sibling_rebase_targets
+             ~merged:[ pid "d1"; pid "d2"; pid "d3" ]
+             ~contains:true)
+      in
+      none_merged && all_merged)
+
+(* reconcile-level: the sibling-stale scenario surfaces Enqueue_rebase d2 (the
+   demand for freshening the base B before P is cut from it). P's own deferral
+   is enforced separately by the orchestrator's runnable_messages gate
+   (Start_eligibility), exercised by the SEP-3f property; at the pure reconcile
+   layer P legitimately also gets a dependent rebase from detect_rebases. *)
+let prop_fanin_reconcile_enqueues_base_rebase =
+  QCheck2.Test.make ~name:"sibling: reconcile enqueues base (d2) rebase"
+    ~count:1
+    QCheck2.Gen.(return ())
+    (fun () ->
+      let graph = fanin_graph () in
+      let merged = [ pid "d1"; pid "d3" ] in
+      let views = fanin_views ~merged ~contains:false in
+      let actions =
+        Reconciler.reconcile ~graph ~main:main_br ~merged_pr_patches:merged
+          ~branch_of views
+      in
+      List.exists actions ~f:(function
+        | Reconciler.Enqueue_rebase p -> Types.Patch_id.equal p (pid "d2")
+        | Reconciler.Mark_merged _ | Reconciler.Start_operation _ -> false))
+
 let () =
   let tests =
     [
@@ -648,6 +855,15 @@ let () =
       prop_drift_always_produces_enqueue_rebase;
       prop_reconcile_e2e_catches_drift;
       prop_reconcile_dedup_rebase;
+      prop_fanin_perm_open_d2;
+      prop_fanin_perm_open_d1;
+      prop_fanin_perm_open_d3;
+      prop_fanin_contains_silent;
+      prop_fanin_no_rebase_when_contained;
+      prop_fanin_idempotent_when_queued;
+      prop_fanin_only_enqueue_rebase;
+      prop_fanin_silent_off_edge;
+      prop_fanin_reconcile_enqueues_base_rebase;
     ]
   in
   List.iter tests ~f:(fun t -> QCheck2.Test.check_exn t);

--- a/test/test_stale_base_invariants.ml
+++ b/test/test_stale_base_invariants.ml
@@ -240,11 +240,19 @@ let sbi_defer_implies_progress m =
       match a.Patch_agent.base_branch with
       | None -> true
       | Some base -> (
-          match Orchestrator.start_eligibility m.orch base with
+          match
+            Orchestrator.start_eligibility m.orch
+              ~base_contains_merged_siblings:true base
+          with
           | Start_eligibility.Allow -> true
           | Start_eligibility.Defer
               (Start_eligibility.Base_patch_busy_with_rebase _) ->
               true (* by definition: a Rebase is in flight or queued *)
+          | Start_eligibility.Defer
+              (Start_eligibility.Base_missing_merged_sibling _) ->
+              (* Unreachable: this invariant evaluates the gate with
+                 [~base_contains_merged_siblings:true]. *)
+              true
           | Start_eligibility.Defer (Start_eligibility.Base_not_fresh_for_cut _)
             -> (
               (* There must be an actual path to Allow: the base patch either has
@@ -383,7 +391,10 @@ let prop_event_stream_pages_witness =
       let branch_b = (Orchestrator.agent m.orch pid_b).Patch_agent.branch in
       (* Initially: bootstrap fired Start(c, base=b) with b's
          branch_rebased_onto = its structural base. Eligibility = Allow. *)
-      let allow0 = Orchestrator.start_eligibility m.orch branch_b in
+      let allow0 =
+        Orchestrator.start_eligibility m.orch
+          ~base_contains_merged_siblings:true branch_b
+      in
       let initial_allow =
         match allow0 with
         | Start_eligibility.Allow -> true
@@ -394,7 +405,8 @@ let prop_event_stream_pages_witness =
          branch. *)
       let m = apply_command m (Pr_merged 0) in
       let eligibility_after_merge =
-        Orchestrator.start_eligibility m.orch branch_b
+        Orchestrator.start_eligibility m.orch
+          ~base_contains_merged_siblings:true branch_b
       in
       (* The gate must defer Start(c, base=b): either [Base_not_fresh_for_cut]
          (branch still on a's branch, not main) or [Base_patch_busy_with_rebase]
@@ -405,6 +417,11 @@ let prop_event_stream_pages_witness =
         | Start_eligibility.Defer
             ( Start_eligibility.Base_not_fresh_for_cut _
             | Start_eligibility.Base_patch_busy_with_rebase _ ) ->
+            true
+        (* Unreachable here: this scenario passes [~base_contains_merged_siblings]
+           via the structural path, not the sibling gate. *)
+        | Start_eligibility.Defer
+            (Start_eligibility.Base_missing_merged_sibling _) ->
             true
         | Start_eligibility.Allow -> false
       in
@@ -418,7 +435,8 @@ let prop_event_stream_pages_witness =
          returns to Allow. *)
       let m = apply_command m (Rebase_complete 1) in
       let eligibility_after_rebase =
-        Orchestrator.start_eligibility m.orch branch_b
+        Orchestrator.start_eligibility m.orch
+          ~base_contains_merged_siblings:true branch_b
       in
       let unblocked =
         match eligibility_after_rebase with
@@ -443,7 +461,10 @@ let prop_unrelated_main_advance_does_not_defer =
         (Orchestrator.agent m.orch pid_root).Patch_agent.branch
       in
       let allow_before =
-        match Orchestrator.start_eligibility m.orch branch_root with
+        match
+          Orchestrator.start_eligibility m.orch
+            ~base_contains_merged_siblings:true branch_root
+        with
         | Start_eligibility.Allow -> true
         | Start_eligibility.Defer _ -> false
       in
@@ -454,7 +475,10 @@ let prop_unrelated_main_advance_does_not_defer =
           ~init:m ~f:apply_command
       in
       let allow_after =
-        match Orchestrator.start_eligibility m.orch branch_root with
+        match
+          Orchestrator.start_eligibility m.orch
+            ~base_contains_merged_siblings:true branch_root
+        with
         | Start_eligibility.Allow -> true
         | Start_eligibility.Defer _ -> false
       in

--- a/test/test_stale_base_invariants.ml
+++ b/test/test_stale_base_invariants.ml
@@ -252,7 +252,7 @@ let sbi_defer_implies_progress m =
               (Start_eligibility.Base_missing_merged_sibling _) ->
               (* Unreachable: this invariant evaluates the gate with
                  [~base_contains_merged_siblings:true]. *)
-              true
+              false
           | Start_eligibility.Defer (Start_eligibility.Base_not_fresh_for_cut _)
             -> (
               (* There must be an actual path to Allow: the base patch either has
@@ -422,7 +422,7 @@ let prop_event_stream_pages_witness =
            via the structural path, not the sibling gate. *)
         | Start_eligibility.Defer
             (Start_eligibility.Base_missing_merged_sibling _) ->
-            true
+            false
         | Start_eligibility.Allow -> false
       in
       (* And b's queue contains Rebase, from the eager enqueue. *)

--- a/test/test_start_eligibility_properties.ml
+++ b/test/test_start_eligibility_properties.ml
@@ -39,6 +39,7 @@ type inputs = {
   base_patch_merged : bool;
   base_patch_busy_rebasing : bool;
   base_structurally_fresh : bool;
+  base_contains_merged_siblings : bool;
 }
 
 let gen_inputs : inputs Gen.t =
@@ -48,6 +49,7 @@ let gen_inputs : inputs Gen.t =
   let* base_patch_merged = bool in
   let* base_patch_busy_rebasing = bool in
   let* base_structurally_fresh = bool in
+  let* base_contains_merged_siblings = bool in
   return
     {
       base_is_main;
@@ -55,6 +57,7 @@ let gen_inputs : inputs Gen.t =
       base_patch_merged;
       base_patch_busy_rebasing;
       base_structurally_fresh;
+      base_contains_merged_siblings;
     }
 
 let call i =
@@ -62,6 +65,7 @@ let call i =
     ~base_patch_merged:i.base_patch_merged
     ~base_patch_busy_rebasing:i.base_patch_busy_rebasing
     ~base_structurally_fresh:i.base_structurally_fresh
+    ~base_contains_merged_siblings:i.base_contains_merged_siblings
 
 (* ---------- Properties ---------- *)
 
@@ -80,11 +84,24 @@ let is_allow = function SE.Allow -> true | SE.Defer _ -> false
 
 let is_defer_busy = function
   | SE.Defer (SE.Base_patch_busy_with_rebase _) -> true
-  | SE.Allow | SE.Defer (SE.Base_not_fresh_for_cut _) -> false
+  | SE.Allow
+  | SE.Defer (SE.Base_not_fresh_for_cut _)
+  | SE.Defer (SE.Base_missing_merged_sibling _) ->
+      false
 
 let is_defer_stale = function
   | SE.Defer (SE.Base_not_fresh_for_cut _) -> true
-  | SE.Allow | SE.Defer (SE.Base_patch_busy_with_rebase _) -> false
+  | SE.Allow
+  | SE.Defer (SE.Base_patch_busy_with_rebase _)
+  | SE.Defer (SE.Base_missing_merged_sibling _) ->
+      false
+
+let is_defer_missing_sibling = function
+  | SE.Defer (SE.Base_missing_merged_sibling _) -> true
+  | SE.Allow
+  | SE.Defer (SE.Base_patch_busy_with_rebase _)
+  | SE.Defer (SE.Base_not_fresh_for_cut _) ->
+      false
 
 let prop_preempt_base_is_main =
   Test.make ~count:200 ~name:"SEP-3a: base_is_main pre-empts everything → Allow"
@@ -129,6 +146,7 @@ let prop_defer_when_not_fresh =
           base_patch_merged = false;
           base_patch_busy_rebasing = false;
           base_structurally_fresh = false;
+          base_contains_merged_siblings = true;
         })
     (fun i -> is_defer_stale (call i))
 
@@ -144,6 +162,83 @@ let prop_allow_when_fresh =
           base_patch_merged = false;
           base_patch_busy_rebasing = false;
           base_structurally_fresh = true;
+          base_contains_merged_siblings = true;
+        })
+    (fun i -> is_allow (call i))
+
+let prop_defer_when_missing_sibling =
+  Test.make ~count:300
+    ~name:
+      "SEP-3f: structurally fresh but missing merged sibling → Defer \
+       Base_missing_merged_sibling"
+    Gen.(
+      let* base_branch = gen_branch in
+      return
+        {
+          base_is_main = false;
+          base_branch;
+          base_patch_merged = false;
+          base_patch_busy_rebasing = false;
+          base_structurally_fresh = true;
+          base_contains_merged_siblings = false;
+        })
+    (fun i -> is_defer_missing_sibling (call i))
+
+let prop_stale_preempts_missing_sibling =
+  Test.make ~count:300
+    ~name:
+      "SEP-3g: not structurally fresh pre-empts the sibling gate → \
+       Base_not_fresh_for_cut"
+    Gen.(
+      let* base_branch = gen_branch in
+      return
+        {
+          base_is_main = false;
+          base_branch;
+          base_patch_merged = false;
+          base_patch_busy_rebasing = false;
+          base_structurally_fresh = false;
+          base_contains_merged_siblings = false;
+        })
+    (fun i -> is_defer_stale (call i))
+
+let prop_busy_merged_main_preempt_missing_sibling =
+  Test.make ~count:400
+    ~name:"SEP-3h: base_is_main / merged / busy each pre-empt the sibling gate"
+    Gen.(
+      (* missing sibling, but an earlier arm also holds; the earlier arm wins *)
+      let* which = int_range 0 2 in
+      let* base_branch = gen_branch in
+      let base =
+        {
+          base_is_main = false;
+          base_branch;
+          base_patch_merged = false;
+          base_patch_busy_rebasing = false;
+          base_structurally_fresh = true;
+          base_contains_merged_siblings = false;
+        }
+      in
+      return
+        (match which with
+        | 0 -> { base with base_is_main = true }
+        | 1 -> { base with base_patch_merged = true }
+        | _ -> { base with base_patch_busy_rebasing = true }))
+    (fun i -> not (is_defer_missing_sibling (call i)))
+
+let prop_allow_when_contains_siblings =
+  Test.make ~count:300
+    ~name:"SEP-3i: fresh and contains siblings, non-main, unmerged → Allow"
+    Gen.(
+      let* base_branch = gen_branch in
+      return
+        {
+          base_is_main = false;
+          base_branch;
+          base_patch_merged = false;
+          base_patch_busy_rebasing = false;
+          base_structurally_fresh = true;
+          base_contains_merged_siblings = true;
         })
     (fun i -> is_allow (call i))
 
@@ -153,7 +248,8 @@ let prop_allow_implies_fresh =
       | SE.Defer _ -> true
       | SE.Allow ->
           i.base_is_main || i.base_patch_merged
-          || ((not i.base_patch_busy_rebasing) && i.base_structurally_fresh))
+          || (not i.base_patch_busy_rebasing)
+             && i.base_structurally_fresh && i.base_contains_merged_siblings)
 
 let prop_defer_implies_not_fresh =
   Test.make ~count:500 ~name:"SEP-5: Defer ⇒ not fresh" gen_inputs (fun i ->
@@ -161,7 +257,9 @@ let prop_defer_implies_not_fresh =
       | SE.Allow -> true
       | SE.Defer _ ->
           (not i.base_is_main) && (not i.base_patch_merged)
-          && (i.base_patch_busy_rebasing || not i.base_structurally_fresh))
+          && (i.base_patch_busy_rebasing
+             || (not i.base_structurally_fresh)
+             || not i.base_contains_merged_siblings))
 
 let label_re = Re.compile (Re.Pcre.re "^[a-z][a-z0-9_]*$")
 
@@ -179,26 +277,36 @@ let prop_variants_reachable =
       let allow_main =
         SE.decide ~base_is_main:true ~base_branch:"main"
           ~base_patch_merged:false ~base_patch_busy_rebasing:false
-          ~base_structurally_fresh:false
+          ~base_structurally_fresh:false ~base_contains_merged_siblings:true
       in
       let allow_merged =
         SE.decide ~base_is_main:false ~base_branch:"b" ~base_patch_merged:true
           ~base_patch_busy_rebasing:false ~base_structurally_fresh:false
+          ~base_contains_merged_siblings:true
       in
       let allow_fresh =
         SE.decide ~base_is_main:false ~base_branch:"b" ~base_patch_merged:false
           ~base_patch_busy_rebasing:false ~base_structurally_fresh:true
+          ~base_contains_merged_siblings:true
       in
       let defer_busy =
         SE.decide ~base_is_main:false ~base_branch:"b" ~base_patch_merged:false
           ~base_patch_busy_rebasing:true ~base_structurally_fresh:true
+          ~base_contains_merged_siblings:true
       in
       let defer_stale =
         SE.decide ~base_is_main:false ~base_branch:"b" ~base_patch_merged:false
           ~base_patch_busy_rebasing:false ~base_structurally_fresh:false
+          ~base_contains_merged_siblings:true
+      in
+      let defer_missing_sibling =
+        SE.decide ~base_is_main:false ~base_branch:"b" ~base_patch_merged:false
+          ~base_patch_busy_rebasing:false ~base_structurally_fresh:true
+          ~base_contains_merged_siblings:false
       in
       is_allow allow_main && is_allow allow_merged && is_allow allow_fresh
-      && is_defer_busy defer_busy && is_defer_stale defer_stale)
+      && is_defer_busy defer_busy && is_defer_stale defer_stale
+      && is_defer_missing_sibling defer_missing_sibling)
 
 let () =
   let runner = QCheck_base_runner.run_tests_main in
@@ -212,6 +320,10 @@ let () =
          prop_preempt_busy;
          prop_defer_when_not_fresh;
          prop_allow_when_fresh;
+         prop_defer_when_missing_sibling;
+         prop_stale_preempts_missing_sibling;
+         prop_busy_merged_main_preempt_missing_sibling;
+         prop_allow_when_contains_siblings;
          prop_allow_implies_fresh;
          prop_defer_implies_not_fresh;
          prop_label_bounds;


### PR DESCRIPTION
## Problem

Tracing a real run (`ts-lowerability-effect-boundary-cleanup`, where patch 5 → {1,2,3} re-implemented patch 3 byte-for-byte) surfaced two related defects in how patch branches are cut and rebased:

1. **Fan-in blind spot.** When a patch `P` depends on several patches and exactly one is still open, `P` is cut from that sole open dep `B` (`Graph.initial_base`). `B` carries its own lineage but **not** a *sibling* dependency of `P` that squash-merged to `main` independently — that squash commit lives on `main`, never an ancestor of `B`. So `P` starts from a base missing one of its dependencies, and the agent re-implements it. The old start gate (`Start_eligibility`) only checked `B`'s *own* deps, so it was blind to `P`'s siblings.

2. **No topological ordering of the rebase cascade.** `runnable_messages` explicitly did not gate `Rebase` on base freshness (*"Rebase is what closes the freshness gap"*). For a chain `B ← C ← E`, `C` could rebase onto `B` while `B` was itself stale or mid-rebase, landing on a stale base.

## Approach

A **sibling-containment gate** plus **topological rebase ordering**, keeping the pure-decision (`lib_core`) / effectful-handler (`lib`) split:

- **`Base_containment.contains_merged_siblings`** (new pure module): does the patch's resolved base contain the squash commit of every *merged* dependency? Fed by an injected `ancestor_oracle` (same pattern as `Rebase_decision.plan`). Fail-closed on unknown SHA; trivially true for base = `main`; **only the patch's own deps are consulted**, so unrelated `main` movement never trips it.
- **Merge-commit SHA plumbing**: fetch GitHub `mergeCommit.oid` → `Pr_state` → `Poller` → recorded on `Patch_agent` when merged. Persisted (merged agents aren't re-polled) with a self-heal that keeps polling a merged agent until its SHA is known.
- **`poller_fiber`** recomputes a `base_contains_merged_siblings` cache each tick via `git merge-base --is-ancestor`, against `initial_base` (the actual cut base, not the `None` pre-start `base_branch`).
- **`Start_eligibility.decide`** gains the containment input + a `Base_missing_merged_sibling` defer reason (checked last; `main`/merged already imply containment).
- **`reconciler.detect_sibling_stale_bases`** enqueues a rebase of the **sole open dep `B`** — the demand the existing three detectors miss, since `B` is a *sibling* of the merged dep, not a dependent — deduped with them.
- **`runnable_messages` now gates BOTH `Start` and `Rebase`** on the unified predicate. This reverses the old "Rebase is not freshness-sensitive" decision and makes a fan-in/chain cascade **block on its dependency layers and converge bottom-up** (`main` is always fresh), one rebase per branch, never onto a stale base.

## Tests

- **`test_base_containment.ml`** (new): every fan-in permutation, fail-closed-on-missing-SHA, and the "unrelated merges never flip containment" invariant — pure, via a mocked oracle.
- **`test_start_eligibility_properties.ml`**: new-arm reachability + precedence (`Base_missing_merged_sibling`), strengthened SEP-4/SEP-5.
- **`test_reconciler_properties.ml`**: `detect_sibling_stale_bases` matrix — the three real-bug permutations targeting the correct base, silent/idempotent/off-edge cases, and the reconcile-level demand.

All pre-existing suites (incl. inline `let%test`s and `stale_base_invariants`) pass under the new gate. `dune build`, `dune test`, and `dune build @fmt` are green.

## Note for reviewers

The pure decision logic and detector are exhaustively property-tested, and the containment computation is unit-tested via the extracted oracle-injected function. A real-git end-to-end test exercising `is_ancestor` + `merge_commit_sha` through the live `poller_fiber` functor was **not** added (heavyweight to wire); the git-subprocess layer remains covered by the existing `Worktree.is_ancestor` tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gates Start and Rebase on dependency‑aware base freshness so fan‑in patches don’t cut from bases missing merged sibling deps and cascades run bottom‑up. Adds a fail‑closed, pure containment check with lazy git I/O, plumbs/persists `mergeCommit.oid` (incl. prune path), and keeps polling merged PRs until the SHA is known; older snapshots default fail‑closed.

- **Bug Fixes**
  - Compute a `base_contains_merged_siblings` cache each poll via `git merge-base --is-ancestor`; fail‑closed on missing SHA and transient git errors; lazy main root; keep polling merged PRs without a SHA.
  - Gate both Start and Rebase on this predicate so cascades block on deps and converge bottom‑up (no rebases onto stale or mid‑rebase bases).
  - Add a sibling‑stale detector that enqueues a Rebase for the sole open dependency; only if that base has a PR and no Rebase queued; deduplicated across detectors and tightened for invariant edge cases.
  - Plumb and persist GitHub `mergeCommit.oid`; record it on the prune path to avoid waiting for a re‑poll.
  - Persistence: default `base_contains_merged_siblings` to `false` when absent in older snapshots to avoid fail‑open on load.

<sup>Written for commit df3799b0c1aace968b890e61e677c9eae25930cf. Summary will update on new commits. <a href="https://cubic.dev/pr/flowglad/onton/pull/332?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic rebase detection for fan-in patches when merged sibling dependencies are missing from the base branch.
  * Implemented merge commit SHA tracking to improve ancestry verification and dependency resolution.
  * Enhanced eligibility gating to prevent operations when bases lack required merged sibling commits.

* **Improvements**
  * Strengthened handling of complex multi-dependency patch scenarios through improved base containment checking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flowglad/onton/pull/332?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->