### PR TITLE
Fix poll crash on null mergeCommit for unmerged PRs

### DIFF
--- a/lib/github.ml
+++ b/lib/github.ml
@@ -392,7 +392,13 @@ let parse_response_json ~owner json =
             in
             let head_oid = pr |> member "headRefOid" |> to_string_option in
             let merge_commit_sha =
-              pr |> member "mergeCommit" |> member "oid" |> to_string_option
+              (* [mergeCommit] is [null] for every open/draft/unmerged PR.
+                 [member "oid"] on [`Null] raises [Type_error], which would
+                 fail the whole poll — guard the null arm explicitly, mirroring
+                 [parse_comment_node]'s [oid_of] helper above. *)
+              match pr |> member "mergeCommit" with
+              | `Null -> None
+              | commit -> commit |> member "oid" |> to_string_option
             in
             let base_branch =
               pr |> member "baseRefName" |> to_string_option

--- a/test/dune
+++ b/test/dune
@@ -4,6 +4,11 @@
  (libraries onton onton_core))
 
 (test
+ (name test_github_merge_commit_null)
+ (modules test_github_merge_commit_null)
+ (libraries onton onton_core yojson))
+
+(test
  (name test_patch_agent)
  (modules test_patch_agent)
  (libraries onton onton_core qcheck-core))

--- a/test/test_github_merge_commit_null.ml
+++ b/test/test_github_merge_commit_null.ml
@@ -1,0 +1,60 @@
+(* Regression test for the null-[mergeCommit] poll crash.
+
+   Every open/draft/unmerged PR comes back from GitHub with
+   [mergeCommit: null]. Reading [mergeCommit |> member "oid"] on that null
+   raised [Yojson.Safe.Util.Type_error], which the parser's catch-all turned
+   into [Json_parse_error] — failing the *entire* poll on every cycle and
+   blinding the orchestrator to the PR's state. See [lib/github.ml]. *)
+
+let pr_json ~merge_commit =
+  Printf.sprintf
+    {|{
+      "data": {
+        "repository": {
+          "pullRequest": {
+            "state": "OPEN",
+            "mergeable": "MERGEABLE",
+            "isDraft": true,
+            "mergeStateStatus": "BLOCKED",
+            "commits": { "nodes": [] },
+            "reviewThreads": { "nodes": [] },
+            "headRefName": "feature-branch",
+            "headRefOid": "abc123",
+            "mergeCommit": %s,
+            "baseRefName": "main",
+            "headRepositoryOwner": { "login": "flowglad" }
+          }
+        }
+      }
+    }|}
+    merge_commit
+
+let parse s =
+  Onton.Github.parse_response_json ~owner:"flowglad" (Yojson.Safe.from_string s)
+
+let () =
+  (* Open PR: mergeCommit is null. Must parse Ok with merge_commit_sha = None,
+     not crash the poll. *)
+  (match parse (pr_json ~merge_commit:"null") with
+  | Ok st ->
+      assert (Option.is_none st.Onton_core.Pr_state.merge_commit_sha);
+      Stdlib.print_endline "  open PR (mergeCommit:null): OK (None)"
+  | Error e ->
+      Printf.eprintf "  FAIL: open PR poll errored: %s\n"
+        (Onton.Github.show_error e);
+      Stdlib.exit 1);
+
+  (* Merged PR: mergeCommit present. Must still read the oid through. *)
+  (match parse (pr_json ~merge_commit:{|{ "oid": "deadbeef" }|}) with
+  | Ok st ->
+      assert (
+        match st.Onton_core.Pr_state.merge_commit_sha with
+        | Some "deadbeef" -> true
+        | _ -> false);
+      Stdlib.print_endline "  merged PR (mergeCommit.oid): OK (deadbeef)"
+  | Error e ->
+      Printf.eprintf "  FAIL: merged PR poll errored: %s\n"
+        (Onton.Github.show_error e);
+      Stdlib.exit 1);
+
+  Stdlib.print_endline "test_github_merge_commit_null: OK"


### PR DESCRIPTION
## Problem

`Github.parse_response_json` read the merge commit SHA with:

```ocaml
let merge_commit_sha =
  pr |> member "mergeCommit" |> member "oid" |> to_string_option
in
```

GitHub returns `mergeCommit: null` for **every open / draft / unmerged PR**. yojson's `member "oid"` raises `Type_error` when applied to `` `Null `` (`Can't get member 'oid' of non-object type null`). The parser's catch-all (`with Type_error -> Error (Json_parse_error msg)`) then turned that into a `Json_parse_error`, failing the **entire poll** on every 30s cycle for the PR's whole open lifetime.

Because the orchestrator can't parse the poll response, it goes blind to the PR's CI status, merge-readiness, and base-freshness — so it never observes when `main` advances and never drives the recovery (rebase the stale base, re-stack dependents). Observed in the field as repeated:

```
Poll error — JSON parse: Can't get member 'oid' of non-object type null
```

which stranded a fan-out of stacked patches behind a single open base PR.

Regressed in 5283a8d ("Gate Start/Rebase on dependency-aware base freshness").

## Fix

Guard the null arm explicitly, mirroring the existing `oid_of` helper already used in `parse_comment_node`:

```ocaml
match pr |> member "mergeCommit" with
| `Null -> None
| commit -> commit |> member "oid" |> to_string_option
```

## Test

Adds `test_github_merge_commit_null` covering both paths:
- open PR (`mergeCommit: null`) → `Ok` with `merge_commit_sha = None` (previously crashed)
- merged PR (`mergeCommit.oid`) → `Ok` with `merge_commit_sha = Some _`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash in the GitHub poller when `mergeCommit` is `null` on open/draft PRs. The parser now safely treats it as `merge_commit_sha = None` to keep polls running; adds a regression test for both `null` and `mergeCommit.oid` cases.

<sup>Written for commit f0982b0623b88e1f89d9068dfbf1ba3338581ed8. Summary will update on new commits. <a href="https://cubic.dev/pr/flowglad/onton/pull/333?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed handling of null merge commit data in GitHub API responses to prevent parsing failures.

* **Tests**
  * Added regression test for null merge commit scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flowglad/onton/pull/333?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->