### PR TITLE
Remove main-scoped freshness veto; add total Json accessors + ban

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,3 +188,15 @@ jobs:
           set -euo pipefail
           # shellcheck disable=SC2086 # SHFMT_FLAGS intentionally word-splits
           xargs -0 shfmt $SHFMT_FLAGS -d < "$RUNNER_TEMP/shell-files.nul"
+
+  lint-yojson:
+    name: No raw Yojson.Safe.Util
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      # Guards against new partial-accessor (member/to_string/to_*) call sites
+      # creeping back in outside lib_core/json.ml. See the script header and
+      # scripts/yojson-util-allowlist.txt.
+      - name: check-no-raw-yojson
+        run: bash scripts/check-no-raw-yojson.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,6 +194,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       # Guards against new partial-accessor (member/to_string/to_*) call sites
       # creeping back in outside lib_core/json.ml. See the script header and

--- a/lib/persistence.ml
+++ b/lib/persistence.ml
@@ -110,13 +110,10 @@ let result_all xs =
   List.fold_right xs ~init:(Ok []) ~f:(fun x acc ->
       Result.bind acc ~f:(fun tl -> Result.map x ~f:(fun hd -> hd :: tl)))
 
-(** Wrap a raising ppx_yojson_conv deserializer into a Result.t. *)
-let try_of_yojson f json =
-  try Ok (f json) with
-  | Ppx_yojson_conv_lib.Yojson_conv.Of_yojson_error (exn, _) ->
-      Error (Stdlib.Printexc.to_string exn)
-  | Yojson.Safe.Util.Type_error (msg, _) ->
-      Error (Printf.sprintf "malformed json: %s" msg)
+(** Wrap a raising ppx_yojson_conv deserializer into a Result.t. Delegates to
+    {!Onton_core.Json.try_of_yojson} (the sanctioned home for the
+    [Yojson.Safe.Util.Type_error] catch). *)
+let try_of_yojson = Json.try_of_yojson
 
 (* ---------- Patch_agent ---------- *)
 

--- a/lib/worktree.ml
+++ b/lib/worktree.ml
@@ -319,44 +319,8 @@ let execute_start_point_action ~process_mgr ~repo_root ~path ~branch_str
    Returns [Error _] when the planner refuses (local diverged from remote,
    branch checked out in main, etc.); the caller in [Worktree_setup] surfaces
    refusals through the orchestrator's [needs_intervention] path. *)
-(* Whether [origin/<main_branch>] is an ancestor of [base_ref]. Only meaningful
-   when we are about to cut a brand-new branch from [base_ref] (a stacked
-   dependency branch). When [base_ref] is itself the main branch, freshness is
-   not this function's concern — stale-local-main is handled by the poller's
-   main-freshness drift detection — so we return [Unknown_freshness] and let
-   the create proceed. Defense-in-depth behind the orchestrator's scheduling
-   gate; a probe failure also yields [Unknown_freshness] so a transient git
-   error never blocks a legitimate create. *)
-let compute_base_freshness ~process_mgr ~repo_root ~main_branch ~base_ref :
-    Start_point_plan.base_freshness =
-  let origin_main = "origin/" ^ main_branch in
-  (* [base_ref] may be a bare name ([main]) or an origin-qualified ref
-     ([origin/main]); every current caller passes the latter. Normalise so the
-     skip fires for both, rather than only the bare form. *)
-  let base_is_main =
-    String.equal base_ref main_branch || String.equal base_ref origin_main
-  in
-  if base_is_main then Start_point_plan.Unknown_freshness
-  else
-    let code, _, _ =
-      run_git_exit_code ~process_mgr
-        [
-          "git";
-          "-C";
-          repo_root;
-          "merge-base";
-          "--is-ancestor";
-          origin_main;
-          base_ref;
-        ]
-    in
-    match code with
-    | 0 -> Start_point_plan.Fresh
-    | 1 -> Start_point_plan.Stale
-    | _ -> Start_point_plan.Unknown_freshness
-
-let create ~process_mgr ~repo_root ~project_name ~patch_id ~branch ~base_ref
-    ~main_branch : (t, Start_point_plan.refusal) Result.t =
+let create ~process_mgr ~repo_root ~project_name ~patch_id ~branch ~base_ref :
+    (t, Start_point_plan.refusal) Result.t =
   let path = worktree_dir ~project_name ~patch_id in
   let branch_str = Types.Branch.to_string branch in
   (* The destination is keyed only on [$HOME] + [project_name] + [patch_id]
@@ -382,16 +346,6 @@ let create ~process_mgr ~repo_root ~project_name ~patch_id ~branch ~base_ref
           compute_repo_ancestry ~process_mgr ~repo_root ~local:l ~remote:r
       | _ -> Start_point_plan.Unknown
     in
-    (* Only probe base freshness on the brand-new-branch path (neither local
-       nor remote ref for our own branch exists yet) — the only arm that cuts
-       from [base_ref]. Skipping the probe elsewhere avoids a needless git
-       call. *)
-    let base_freshness =
-      match (local_ref, remote_ref) with
-      | None, None ->
-          compute_base_freshness ~process_mgr ~repo_root ~main_branch ~base_ref
-      | _ -> Start_point_plan.Unknown_freshness
-    in
     (* [branch_checked_out_in_main_root] and [existing_worktree_path] are
        checked by [Worktree_setup.ensure_worktree] before this point — we
        pass [false]/[None] so the planner's totality contract is preserved
@@ -400,8 +354,8 @@ let create ~process_mgr ~repo_root ~project_name ~patch_id ~branch ~base_ref
        there. *)
     let decision =
       Start_point_plan.plan ~local_ref ~remote_ref ~ancestry
-        ~base_branch:base_ref ~base_freshness
-        ~branch_checked_out_in_main_root:false ~existing_worktree_path:None
+        ~base_branch:base_ref ~branch_checked_out_in_main_root:false
+        ~existing_worktree_path:None
     in
     match decision with
     | Refuse refusal -> Result.Error refusal
@@ -1055,7 +1009,6 @@ module type S = sig
     patch_id:Types.Patch_id.t ->
     branch:Types.Branch.t ->
     base_ref:string ->
-    main_branch:string ->
     (t, Start_point_plan.refusal) Result.t
 
   val fetch_origin_branch :
@@ -1126,9 +1079,8 @@ let make ~process_mgr ~repo_root =
     let remote_branch_exists branch_str =
       remote_branch_exists ~process_mgr ~repo_root branch_str
 
-    let create ~project_name ~patch_id ~branch ~base_ref ~main_branch =
+    let create ~project_name ~patch_id ~branch ~base_ref =
       create ~process_mgr ~repo_root ~project_name ~patch_id ~branch ~base_ref
-        ~main_branch
 
     let remove t = remove ~process_mgr ~repo_root t
     let detect_branch ~path = detect_branch ~process_mgr ~path

--- a/lib/worktree.mli
+++ b/lib/worktree.mli
@@ -47,7 +47,6 @@ val create :
   patch_id:Types.Patch_id.t ->
   branch:Types.Branch.t ->
   base_ref:string ->
-  main_branch:string ->
   (t, Start_point_plan.refusal) Result.t
 (** Create a git worktree for [branch] under [project_name]/[patch_id].
 
@@ -58,17 +57,15 @@ val create :
     [fetch_origin_branch] beforehand so [refs/remotes/origin/<branch>] is fresh;
     without that step the planner would see a stale remote ref.
 
-    On the brand-new-branch arm (neither ref exists), also probes whether
-    [origin/<main_branch>] is an ancestor of [base_ref]; a definite "no" yields
-    [Refuse (Base_branch_stale_vs_main _)] rather than silently cutting from a
-    stale dependency branch. This is defense-in-depth behind the orchestrator's
-    {!Start_eligibility} scheduling gate. The supervisor should run
-    [fetch_origin_branch ~branch:main_branch] beforehand so the probe sees the
-    current main tip.
+    Base freshness vs [origin/<main>] is intentionally not gated here — it is
+    dependency-scoped and enforced by the orchestrator's {!Start_eligibility}
+    scheduling gate. A stacked dependent cut from its base's tip contains
+    everything in that base, so a base lagging main for unrelated reasons must
+    not block the cut.
 
     Returns [Error refusal] when the planner refuses (local diverged from
-    remote, branch already checked out elsewhere, base stale vs main, etc.). The
-    caller surfaces refusals through the orchestrator's intervention path.
+    remote, branch already checked out elsewhere, etc.). The caller surfaces
+    refusals through the orchestrator's intervention path.
 
     Pre-empted inputs [branch_checked_out_in_main_root] and
     [existing_worktree_path] are checked by the caller
@@ -360,7 +357,6 @@ module type S = sig
     patch_id:Types.Patch_id.t ->
     branch:Types.Branch.t ->
     base_ref:string ->
-    main_branch:string ->
     (t, Start_point_plan.refusal) Result.t
 
   val fetch_origin_branch :

--- a/lib/worktree_setup.ml
+++ b/lib/worktree_setup.ml
@@ -144,30 +144,12 @@ module Make (W : Worktree.S) (Env : ENV) : S = struct
             | Fetch_branch_error msg ->
                 log_event runtime ~patch_id
                   (Printf.sprintf "Pre-create fetch failed (continuing): %s" msg));
-            let main_branch =
-              Types.Branch.to_string
-                (Runtime.read runtime (fun snap ->
-                     Orchestrator.main_branch snap.Runtime.orchestrator))
-            in
-            (* Also refresh [origin/<main>] so [Worktree.create]'s base-freshness
-               probe (defense-in-depth behind the orchestrator's scheduling
-               gate) sees the current main tip rather than a stale local view.
-               Best-effort — a fetch failure leaves the probe to report
-               [Unknown_freshness], which proceeds. *)
-            (match W.fetch_origin_branch ~fetch_lock ~branch:main_branch with
-            | Fetch_branch_ok | Fetch_branch_no_remote_ref -> ()
-            | Fetch_branch_error msg ->
-                log_event runtime ~patch_id
-                  (Printf.sprintf
-                     "Pre-create fetch of origin/%s failed (continuing): %s"
-                     main_branch msg));
             log_event runtime ~patch_id
               (Printf.sprintf "Creating worktree at %s" path);
             let create_outcome =
               match
                 Eio.Mutex.use_ro worktree_mutex (fun () ->
-                    W.create ~project_name ~patch_id ~branch:br ~base_ref:base
-                      ~main_branch)
+                    W.create ~project_name ~patch_id ~branch:br ~base_ref:base)
               with
               | Ok _ -> `Created
               | Error refusal -> `Refused refusal

--- a/lib_core/json.ml
+++ b/lib_core/json.ml
@@ -1,0 +1,43 @@
+open Base
+
+type t = Yojson.Safe.t
+
+(* Total accessors. None of these raise: a missing key, an explicit [`Null], or
+   a type mismatch all collapse to [None]. This is the sanctioned alternative to
+   [Yojson.Safe.Util], whose [member]/[to_string]/[to_*] are partial (they raise
+   at runtime, invisibly to the type checker — the failure mode behind PR #333's
+   poll crash). Field access here is by direct variant match, so the only thing
+   in this module that names [Yojson.Safe.Util] is the exception caught by
+   [try_of_yojson]. *)
+
+let field key (j : t) : t option =
+  match j with
+  | `Assoc kvs -> (
+      match List.Assoc.find kvs ~equal:String.equal key with
+      | None | Some `Null -> None
+      | Some v -> Some v)
+  | _ -> None
+
+let string : t -> string option = function `String s -> Some s | _ -> None
+let int : t -> int option = function `Int i -> Some i | _ -> None
+let bool : t -> bool option = function `Bool b -> Some b | _ -> None
+let list : t -> t list option = function `List xs -> Some xs | _ -> None
+
+let assoc : t -> (string * t) list option = function
+  | `Assoc kvs -> Some kvs
+  | _ -> None
+
+let string_field key j = Option.bind (field key j) ~f:string
+let int_field key j = Option.bind (field key j) ~f:int
+let bool_field key j = Option.bind (field key j) ~f:bool
+
+(* Wrap a raising [ppx_yojson_conv]-generated deserializer into a Result.t. The
+   generated [t_of_yojson] raises [Of_yojson_error] on a shape mismatch (and a
+   hand-written decoder may still let a [Type_error] through); this is the one
+   place those are caught and turned into an [Error string]. *)
+let try_of_yojson f json =
+  try Ok (f json) with
+  | Ppx_yojson_conv_lib.Yojson_conv.Of_yojson_error (exn, _) ->
+      Error (Stdlib.Printexc.to_string exn)
+  | Yojson.Safe.Util.Type_error (msg, _) ->
+      Error (Printf.sprintf "malformed json: %s" msg)

--- a/lib_core/json.mli
+++ b/lib_core/json.mli
@@ -1,0 +1,42 @@
+(** Total accessors over [Yojson.Safe.t] — the sanctioned alternative to
+    [Yojson.Safe.Util], whose [member]/[to_string]/[to_*] are partial (they
+    raise on a type mismatch or on [`Null], invisibly to the type checker). Here
+    a missing key, an explicit [`Null], and a type mismatch all collapse to
+    [None], so nullability becomes an [option] the caller must handle rather
+    than a latent runtime exception. This is the only module permitted to
+    reference [Yojson.Safe.Util] (see [scripts/check-no-raw-yojson.sh]). *)
+
+type t = Yojson.Safe.t
+
+val field : string -> t -> t option
+(** [field key j] is the value at [key] when [j] is an object and the value is
+    present and non-[`Null]; otherwise [None]. Never raises. *)
+
+val string : t -> string option
+(** [Some s] iff [j] is [`String s]; else [None]. *)
+
+val int : t -> int option
+(** [Some i] iff [j] is [`Int i]; else [None]. *)
+
+val bool : t -> bool option
+(** [Some b] iff [j] is [`Bool b]; else [None]. *)
+
+val list : t -> t list option
+(** [Some xs] iff [j] is [`List xs]; else [None]. *)
+
+val assoc : t -> (string * t) list option
+(** [Some kvs] iff [j] is [`Assoc kvs]; else [None]. *)
+
+val string_field : string -> t -> string option
+(** [field] composed with [string]. *)
+
+val int_field : string -> t -> int option
+(** [field] composed with [int]. *)
+
+val bool_field : string -> t -> bool option
+(** [field] composed with [bool]. *)
+
+val try_of_yojson : (t -> 'a) -> t -> ('a, string) result
+(** Run a raising [ppx_yojson_conv] deserializer, catching
+    [Ppx_yojson_conv_lib.Yojson_conv.Of_yojson_error] and
+    [Yojson.Safe.Util.Type_error] and returning them as [Error string]. *)

--- a/lib_core/start_point_plan.ml
+++ b/lib_core/start_point_plan.ml
@@ -5,9 +5,6 @@ type sha = string [@@deriving show, eq, sexp_of, compare]
 type ancestry = Local_ahead | Remote_ahead | Equal | Diverged | Unknown
 [@@deriving show, eq, sexp_of, compare]
 
-type base_freshness = Fresh | Stale | Unknown_freshness
-[@@deriving show, eq, sexp_of, compare]
-
 type action =
   | Reset_and_use_remote_tracking of { remote_sha : sha }
   | Use_local_branch_unchanged of { local_sha : sha }
@@ -19,13 +16,12 @@ type refusal =
   | Local_has_unpushed_commits of { local_sha : sha; remote_sha : sha }
   | Branch_checked_out_in_main_root
   | Worktree_already_registered of { existing_path : string }
-  | Base_branch_stale_vs_main of { base_branch : string }
 [@@deriving show, eq, sexp_of, compare]
 
 type decision = Plan of action | Refuse of refusal
 [@@deriving show, eq, sexp_of, compare]
 
-let plan ~local_ref ~remote_ref ~ancestry ~base_branch ~base_freshness
+let plan ~local_ref ~remote_ref ~ancestry ~base_branch
     ~branch_checked_out_in_main_root ~existing_worktree_path =
   if branch_checked_out_in_main_root then Refuse Branch_checked_out_in_main_root
   else
@@ -34,18 +30,13 @@ let plan ~local_ref ~remote_ref ~ancestry ~base_branch ~base_freshness
         Refuse (Worktree_already_registered { existing_path })
     | None -> (
         match (local_ref, remote_ref) with
-        | None, None -> (
-            (* About to cut a brand-new branch from [base_branch]. This is the
-               only arm that consumes [base_branch], so it is the only place a
-               stale base can silently elide an upstream's commits. Refuse only
-               on a definite [Stale] verdict — [Unknown_freshness] (probe
-               failed, or main not tracked) proceeds, since this is a
-               defense-in-depth net behind the orchestrator's scheduling gate
-               and must not block legitimate creates. *)
-            match base_freshness with
-            | Stale -> Refuse (Base_branch_stale_vs_main { base_branch })
-            | Fresh | Unknown_freshness ->
-                Plan (Create_new_branch_from_base { base_branch }))
+        | None, None ->
+            (* Cut a brand-new branch from [base_branch]. Whether the base is up
+               to date with [origin/<main>] is intentionally not gated here:
+               freshness is dependency-scoped and enforced by the orchestrator's
+               scheduling gate (see {!Start_eligibility}). A base lagging main
+               for unrelated reasons must not block the cut. *)
+            Plan (Create_new_branch_from_base { base_branch })
         | None, Some remote_sha ->
             Plan (Reset_and_use_remote_tracking { remote_sha })
         | Some local_sha, None ->
@@ -67,4 +58,3 @@ let short_label = function
   | Refuse (Local_has_unpushed_commits _) -> "refuse_local_ahead"
   | Refuse Branch_checked_out_in_main_root -> "refuse_main_checkout"
   | Refuse (Worktree_already_registered _) -> "refuse_wt_registered"
-  | Refuse (Base_branch_stale_vs_main _) -> "refuse_base_stale"

--- a/lib_core/start_point_plan.mli
+++ b/lib_core/start_point_plan.mli
@@ -37,15 +37,6 @@ type ancestry =
   | Unknown  (** ancestry could not be determined (e.g. probe failed) *)
 [@@deriving show, eq, sexp_of, compare]
 
-(** Whether the base branch (used only when cutting a brand-new branch) already
-    contains the latest [origin/<main>]. The effectful caller fills this in with
-    the result of a [git merge-base --is-ancestor origin/<main> <base>] probe:
-    [Fresh] when main is an ancestor of base, [Stale] when it is not,
-    [Unknown_freshness] when the probe could not be run (main not tracked, probe
-    error). Only [Stale] blocks; see {!plan}. *)
-type base_freshness = Fresh | Stale | Unknown_freshness
-[@@deriving show, eq, sexp_of, compare]
-
 (** The action a successful plan instructs the caller to take. *)
 type action =
   | Reset_and_use_remote_tracking of { remote_sha : sha }
@@ -79,13 +70,6 @@ type refusal =
   | Worktree_already_registered of { existing_path : string }
       (** Git already lists a worktree for this branch elsewhere; recreating
           would race. *)
-  | Base_branch_stale_vs_main of { base_branch : string }
-      (** About to cut a brand-new branch from [base_branch], but
-          [origin/<main>] is not an ancestor of [base_branch] — the base lags a
-          merged upstream and cutting from it would silently drop the upstream's
-          commits. Defense-in-depth behind the orchestrator's scheduling gate
-          (see {!Start_eligibility}); reaching this refusal means a [Start] was
-          executed without going through {!Orchestrator.runnable_messages}. *)
 [@@deriving show, eq, sexp_of, compare]
 
 (** A plan is either an action to execute or a refusal to report. *)
@@ -97,7 +81,6 @@ val plan :
   remote_ref:sha option ->
   ancestry:ancestry ->
   base_branch:string ->
-  base_freshness:base_freshness ->
   branch_checked_out_in_main_root:bool ->
   existing_worktree_path:string option ->
   decision
@@ -107,9 +90,7 @@ val plan :
       [Refuse Branch_checked_out_in_main_root]
     + [existing_worktree_path = Some p] →
       [Refuse (Worktree_already_registered { existing_path = p })]
-    + [(local_ref, remote_ref) = (None, None)] and [base_freshness = Stale] →
-      [Refuse (Base_branch_stale_vs_main { base_branch })]
-    + [(local_ref, remote_ref) = (None, None)] otherwise →
+    + [(local_ref, remote_ref) = (None, None)] →
       [Plan (Create_new_branch_from_base { base_branch })]
     + [(None, Some r)] →
       [Plan (Reset_and_use_remote_tracking { remote_sha = r })]
@@ -122,10 +103,13 @@ val plan :
       [Refuse (Local_diverged_from_remote ...)] (conservative — refuse rather
       than risk silent commit loss).
 
-    [base_freshness] only matters in the brand-new-branch arm: it is the only
-    decision that consumes [base_branch]. When a local or remote ref for the
-    patch's own branch already exists, the base is irrelevant and freshness is
-    not consulted. *)
+    The base is consumed only in the brand-new-branch arm
+    ([Create_new_branch_from_base]). Whether that base is up to date with
+    [origin/<main>] is intentionally {e not} gated here: freshness is
+    dependency-scoped and enforced by the orchestrator's scheduling gate (see
+    {!Start_eligibility}). A stacked dependent cut from its base's tip contains
+    everything in that base; main integration cascades at merge boundaries, so a
+    base lagging main for unrelated reasons must not block the cut. *)
 
 val short_label : decision -> string
 (** A short, lowercase, snake_case identifier for the planner arm that fired,

--- a/scripts/check-no-raw-yojson.sh
+++ b/scripts/check-no-raw-yojson.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+# check-no-raw-yojson — fail if Yojson.Safe.Util is used outside the allowlist.
+#
+# Yojson.Safe.Util's member/to_string/to_* are partial: they raise at runtime,
+# invisibly to the type checker. That is the failure class behind PR #333's poll
+# crash. lib_core/json.ml exposes total, option-returning accessors; all other
+# decoding should go through Onton_core.Json (or ppx_yojson_conv). This guard
+# stops new raw call sites from creeping in.
+#
+# The allowlist (scripts/yojson-util-allowlist.txt) names the files still
+# permitted to reference Yojson.Safe.Util — long-term only lib_core/json.ml; the
+# rest are pre-existing sites being migrated, each removed as it is converted.
+#
+# Exit 0 = clean. Exit 1 = an unallowlisted reference, or a stale allowlist
+# entry (file gone, or no longer references the pattern — prune it).
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+ALLOWLIST="$SCRIPT_DIR/yojson-util-allowlist.txt"
+PATTERN='Yojson\.Safe\.Util'
+
+cd "$REPO_ROOT" || exit 1
+
+# Allowlisted paths, comments/blank lines stripped and trailing space trimmed.
+allowed="$(grep -vE '^[[:space:]]*(#|$)' "$ALLOWLIST" | sed 's/[[:space:]]*$//')"
+
+# Tracked OCaml sources in the libraries/binaries we police.
+files="$(git ls-files 'lib/*.ml' 'lib_core/*.ml' 'api/*.ml' 'bin/*.ml')"
+
+status=0
+
+# 1. Any file that references the pattern must be allowlisted.
+# shellcheck disable=SC2086 # git paths are newline-separated and space-free
+for f in $files; do
+  grep -q "$PATTERN" "$f" || continue
+  if ! printf '%s\n' "$allowed" | grep -qxF "$f"; then
+    echo "ERROR: $f references Yojson.Safe.Util but is not allowlisted." >&2
+    echo "       Decode through Onton_core.Json instead, or (last resort)" >&2
+    echo "       add $f to scripts/yojson-util-allowlist.txt." >&2
+    status=1
+  fi
+done
+
+# 2. Every allowlisted entry must still exist and reference the pattern —
+#    otherwise it is stale and should be pruned so the list ratchets to json.ml.
+# shellcheck disable=SC2086 # allowlist paths are space-free
+for f in $allowed; do
+  if [ ! -f "$f" ]; then
+    echo "ERROR: allowlist entry '$f' does not exist — remove it." >&2
+    status=1
+  elif ! grep -q "$PATTERN" "$f"; then
+    echo "ERROR: allowlist entry '$f' no longer references Yojson.Safe.Util" >&2
+    echo "       — remove it from scripts/yojson-util-allowlist.txt." >&2
+    status=1
+  fi
+done
+
+if [ "$status" -eq 0 ]; then
+  echo "check-no-raw-yojson: OK"
+fi
+exit "$status"

--- a/scripts/check-no-raw-yojson.sh
+++ b/scripts/check-no-raw-yojson.sh
@@ -26,8 +26,9 @@ cd "$REPO_ROOT" || exit 1
 # Allowlisted paths, comments/blank lines stripped and trailing space trimmed.
 allowed="$(grep -vE '^[[:space:]]*(#|$)' "$ALLOWLIST" | sed 's/[[:space:]]*$//')"
 
-# Tracked OCaml sources in the libraries/binaries we police.
-files="$(git ls-files 'lib/*.ml' 'lib_core/*.ml' 'api/*.ml' 'bin/*.ml')"
+# Tracked OCaml sources in the libraries/binaries we police, including nested
+# modules — the leading-anchored grep keeps it to those top-level directories.
+files="$(git ls-files '*.ml' | grep -E '^(lib|lib_core|api|bin)/')"
 
 status=0
 

--- a/scripts/yojson-util-allowlist.txt
+++ b/scripts/yojson-util-allowlist.txt
@@ -1,0 +1,30 @@
+# Files permitted to reference Yojson.Safe.Util.
+#
+# Yojson.Safe.Util's member/to_string/to_* are partial — they raise at runtime,
+# invisibly to the type checker (the failure mode behind PR #333's poll crash).
+# lib_core/json.ml wraps the safe subset into total, option-returning accessors;
+# every other module should decode through Onton_core.Json (or ppx_yojson_conv).
+#
+# The end state is that only lib_core/json.ml remains here. The other entries are
+# pre-existing call sites being migrated; each conversion PR deletes its line.
+# Enforced by scripts/check-no-raw-yojson.sh (run in CI). Blank lines and
+# #-comments are ignored.
+
+lib_core/json.ml
+
+# --- pending migration (remove each line as its module is converted) ---
+lib/github.ml
+lib/persistence.ml
+lib/session_driver.ml
+lib_core/claude_event_parser.ml
+lib_core/codex_cost.ml
+lib_core/codex_event_parser.ml
+lib_core/failure_subkind.ml
+lib_core/gameplan_parser.ml
+lib_core/gemini_event_parser.ml
+lib_core/opencode_event_parser.ml
+lib_core/patch_pr_status.ml
+lib_core/pi_event_parser.ml
+lib_core/repo_config.ml
+lib_core/review_backend.ml
+lib_core/review_service.ml

--- a/test/dune
+++ b/test/dune
@@ -9,6 +9,11 @@
  (libraries onton onton_core yojson))
 
 (test
+ (name test_json)
+ (modules test_json)
+ (libraries onton_core base yojson ppx_yojson_conv_lib))
+
+(test
  (name test_patch_agent)
  (modules test_patch_agent)
  (libraries onton onton_core qcheck-core))

--- a/test/test_dependency_injection_functors.ml
+++ b/test/test_dependency_injection_functors.ml
@@ -14,10 +14,7 @@ module Fake_worktree : Worktree.S = struct
   let resolve_main_root () = assert false
   let is_checked_out_in_repo_root _ = assert false
   let remote_branch_exists _ = assert false
-
-  let create ~project_name:_ ~patch_id:_ ~branch:_ ~base_ref:_ ~main_branch:_ =
-    assert false
-
+  let create ~project_name:_ ~patch_id:_ ~branch:_ ~base_ref:_ = assert false
   let remove _ = assert false
   let detect_branch ~path:_ = assert false
   let list_with_branches () = assert false

--- a/test/test_json.ml
+++ b/test/test_json.ml
@@ -1,0 +1,80 @@
+open Base
+
+(* Tests for the total JSON accessors in Onton_core.Json. The contract under
+   test: a missing key, an explicit null, and a type mismatch all collapse to
+   None — never a raise. *)
+
+module J = Onton_core.Json
+
+let parse = Yojson.Safe.from_string
+
+let check name cond =
+  if cond then Stdlib.Printf.printf "  %s: OK\n" name
+  else (
+    Stdlib.Printf.eprintf "  %s: FAIL\n" name;
+    Stdlib.exit 1)
+
+let opt_eq eq a b =
+  match (a, b) with None, None -> true | Some x, Some y -> eq x y | _ -> false
+
+let () =
+  let obj =
+    parse
+      {|{ "s": "hi", "n": 7, "b": true, "xs": [1,2],
+          "nested": { "k": "v" }, "nul": null }|}
+  in
+
+  (* field: present non-null -> Some; absent / null / non-object -> None *)
+  check "field present" (Option.is_some (J.field "s" obj));
+  check "field absent" (Option.is_none (J.field "missing" obj));
+  check "field explicit null" (Option.is_none (J.field "nul" obj));
+  check "field on non-object" (Option.is_none (J.field "s" (parse "42")));
+  check "field on null" (Option.is_none (J.field "s" (parse "null")));
+
+  (* leaf accessors: right type -> Some; wrong type -> None *)
+  check "string ok" (opt_eq String.equal (J.string (parse {|"x"|})) (Some "x"));
+  check "string wrong type" (Option.is_none (J.string (parse "1")));
+  check "int ok" (opt_eq Int.equal (J.int (parse "5")) (Some 5));
+  check "int wrong type" (Option.is_none (J.int (parse {|"5"|})));
+  check "bool ok" (opt_eq Bool.equal (J.bool (parse "true")) (Some true));
+  check "bool wrong type" (Option.is_none (J.bool (parse "1")));
+  check "list ok"
+    (match J.list (parse "[1,2,3]") with
+    | Some l -> List.length l = 3
+    | None -> false);
+  check "list wrong type" (Option.is_none (J.list (parse "{}")));
+  check "assoc ok"
+    (match J.assoc obj with Some kvs -> List.length kvs = 6 | None -> false);
+  check "assoc wrong type" (Option.is_none (J.assoc (parse "[]")));
+
+  (* *_field composition *)
+  check "string_field ok"
+    (opt_eq String.equal (J.string_field "s" obj) (Some "hi"));
+  check "string_field type mismatch" (Option.is_none (J.string_field "n" obj));
+  check "string_field absent" (Option.is_none (J.string_field "missing" obj));
+  check "int_field ok" (opt_eq Int.equal (J.int_field "n" obj) (Some 7));
+  check "int_field null" (Option.is_none (J.int_field "nul" obj));
+  check "bool_field ok" (opt_eq Bool.equal (J.bool_field "b" obj) (Some true));
+
+  (* nested chaining via field + leaf *)
+  check "nested chain"
+    (opt_eq String.equal
+       (Option.bind (J.field "nested" obj) ~f:(J.string_field "k"))
+       (Some "v"));
+
+  (* try_of_yojson: success path and caught failure path *)
+  (match J.try_of_yojson (fun j -> J.string_field "s" j) obj with
+  | Ok s -> check "try_of_yojson ok" (opt_eq String.equal s (Some "hi"))
+  | Error _ -> check "try_of_yojson ok" false);
+  (match
+     J.try_of_yojson
+       (fun _ ->
+         raise
+           (Ppx_yojson_conv_lib.Yojson_conv.Of_yojson_error
+              (Failure "boom", `Null)))
+       obj
+   with
+  | Error _ -> check "try_of_yojson catches Of_yojson_error" true
+  | Ok _ -> check "try_of_yojson catches Of_yojson_error" false);
+
+  Stdlib.print_endline "test_json: OK"

--- a/test/test_json.ml
+++ b/test/test_json.ml
@@ -76,5 +76,12 @@ let () =
    with
   | Error _ -> check "try_of_yojson catches Of_yojson_error" true
   | Ok _ -> check "try_of_yojson catches Of_yojson_error" false);
+  (match
+     J.try_of_yojson
+       (fun _ -> raise (Yojson.Safe.Util.Type_error ("expected string", `Null)))
+       obj
+   with
+  | Error _ -> check "try_of_yojson catches Type_error" true
+  | Ok _ -> check "try_of_yojson catches Type_error" false);
 
   Stdlib.print_endline "test_json: OK"

--- a/test/test_start_point_plan_properties.ml
+++ b/test/test_start_point_plan_properties.ml
@@ -12,7 +12,8 @@ open Onton_core
     - {b SPP-3 Remote authoritative}: when both refs are present and ancestry is
       [Equal] or [Remote_ahead], the action is [Reset_and_use_remote_tracking].
     - {b SPP-4 Missing both → create from base}: both refs absent ⇒
-      [Create_new_branch_from_base].
+      [Create_new_branch_from_base], unconditionally (base freshness vs main is
+      not gated here — see {!Start_point_plan.plan}).
     - {b SPP-5 Determinism}: same inputs yield identical output.
     - {b SPP-6 Pre-emption}: [branch_checked_out_in_main_root = true] always
       yields [Refuse Branch_checked_out_in_main_root] regardless of every other
@@ -61,7 +62,7 @@ let is_refuse_diverged = function
   | SP.Refuse (SP.Local_diverged_from_remote _) -> true
   | SP.Refuse
       ( SP.Local_has_unpushed_commits _ | SP.Branch_checked_out_in_main_root
-      | SP.Worktree_already_registered _ | SP.Base_branch_stale_vs_main _ )
+      | SP.Worktree_already_registered _ )
   | SP.Plan _ ->
       false
 
@@ -69,7 +70,7 @@ let is_refuse_local_ahead = function
   | SP.Refuse (SP.Local_has_unpushed_commits _) -> true
   | SP.Refuse
       ( SP.Local_diverged_from_remote _ | SP.Branch_checked_out_in_main_root
-      | SP.Worktree_already_registered _ | SP.Base_branch_stale_vs_main _ )
+      | SP.Worktree_already_registered _ )
   | SP.Plan _ ->
       false
 
@@ -77,7 +78,7 @@ let is_refuse_checked_out = function
   | SP.Refuse SP.Branch_checked_out_in_main_root -> true
   | SP.Refuse
       ( SP.Local_diverged_from_remote _ | SP.Local_has_unpushed_commits _
-      | SP.Worktree_already_registered _ | SP.Base_branch_stale_vs_main _ )
+      | SP.Worktree_already_registered _ )
   | SP.Plan _ ->
       false
 
@@ -85,17 +86,9 @@ let is_refuse_registered = function
   | SP.Refuse (SP.Worktree_already_registered _) -> true
   | SP.Refuse
       ( SP.Local_diverged_from_remote _ | SP.Local_has_unpushed_commits _
-      | SP.Branch_checked_out_in_main_root | SP.Base_branch_stale_vs_main _ ) ->
+      | SP.Branch_checked_out_in_main_root ) ->
       false
   | SP.Plan _ -> false
-
-let is_refuse_base_stale = function
-  | SP.Refuse (SP.Base_branch_stale_vs_main _) -> true
-  | SP.Refuse
-      ( SP.Local_diverged_from_remote _ | SP.Local_has_unpushed_commits _
-      | SP.Branch_checked_out_in_main_root | SP.Worktree_already_registered _ )
-  | SP.Plan _ ->
-      false
 
 (* ---------- Generators ---------- *)
 
@@ -106,9 +99,6 @@ let gen_ancestry =
   Gen.oneof_array
     [| SP.Local_ahead; SP.Remote_ahead; SP.Equal; SP.Diverged; SP.Unknown |]
 
-let gen_base_freshness =
-  Gen.oneof_array [| SP.Fresh; SP.Stale; SP.Unknown_freshness |]
-
 let gen_sha_option = Gen.option gen_sha
 let gen_path_option = Gen.option gen_branch_name
 
@@ -118,7 +108,6 @@ type plan_inputs = {
   remote_ref : SP.sha option;
   ancestry : SP.ancestry;
   base_branch : string;
-  base_freshness : SP.base_freshness;
   branch_checked_out_in_main_root : bool;
   existing_worktree_path : string option;
 }
@@ -129,7 +118,6 @@ let gen_inputs : plan_inputs Gen.t =
   let* remote_ref = gen_sha_option in
   let* ancestry = gen_ancestry in
   let* base_branch = gen_branch_name in
-  let* base_freshness = gen_base_freshness in
   let* branch_checked_out_in_main_root = bool in
   let* existing_worktree_path = gen_path_option in
   return
@@ -138,14 +126,13 @@ let gen_inputs : plan_inputs Gen.t =
       remote_ref;
       ancestry;
       base_branch;
-      base_freshness;
       branch_checked_out_in_main_root;
       existing_worktree_path;
     }
 
 let call i =
   SP.plan ~local_ref:i.local_ref ~remote_ref:i.remote_ref ~ancestry:i.ancestry
-    ~base_branch:i.base_branch ~base_freshness:i.base_freshness
+    ~base_branch:i.base_branch
     ~branch_checked_out_in_main_root:i.branch_checked_out_in_main_root
     ~existing_worktree_path:i.existing_worktree_path
 
@@ -170,8 +157,8 @@ let prop_no_silent_clobber =
     (fun (local, remote, anc, base_branch) ->
       let d =
         SP.plan ~local_ref:(Some local) ~remote_ref:(Some remote) ~ancestry:anc
-          ~base_branch ~base_freshness:SP.Unknown_freshness
-          ~branch_checked_out_in_main_root:false ~existing_worktree_path:None
+          ~base_branch ~branch_checked_out_in_main_root:false
+          ~existing_worktree_path:None
       in
       is_refuse d)
 
@@ -188,34 +175,14 @@ let prop_remote_authoritative =
     (fun (local, remote, anc, base_branch) ->
       let d =
         SP.plan ~local_ref:(Some local) ~remote_ref:(Some remote) ~ancestry:anc
-          ~base_branch ~base_freshness:SP.Unknown_freshness
-          ~branch_checked_out_in_main_root:false ~existing_worktree_path:None
+          ~base_branch ~branch_checked_out_in_main_root:false
+          ~existing_worktree_path:None
       in
       is_reset_to remote d)
 
 let prop_missing_both =
   Test.make ~count:200
-    ~name:
-      "SPP-4: local=None, remote=None, base not Stale → \
-       Create_new_branch_from_base"
-    Gen.(
-      let* base_branch = gen_branch_name in
-      let* anc = gen_ancestry in
-      let* fresh = oneof_array [| SP.Fresh; SP.Unknown_freshness |] in
-      return (base_branch, anc, fresh))
-    (fun (base_branch, anc, fresh) ->
-      let d =
-        SP.plan ~local_ref:None ~remote_ref:None ~ancestry:anc ~base_branch
-          ~base_freshness:fresh ~branch_checked_out_in_main_root:false
-          ~existing_worktree_path:None
-      in
-      is_create_from_base base_branch d)
-
-let prop_missing_both_stale =
-  Test.make ~count:200
-    ~name:
-      "SPP-4b: local=None, remote=None, base Stale → Refuse \
-       Base_branch_stale_vs_main"
+    ~name:"SPP-4: local=None, remote=None → Create_new_branch_from_base"
     Gen.(
       let* base_branch = gen_branch_name in
       let* anc = gen_ancestry in
@@ -223,33 +190,9 @@ let prop_missing_both_stale =
     (fun (base_branch, anc) ->
       let d =
         SP.plan ~local_ref:None ~remote_ref:None ~ancestry:anc ~base_branch
-          ~base_freshness:SP.Stale ~branch_checked_out_in_main_root:false
-          ~existing_worktree_path:None
+          ~branch_checked_out_in_main_root:false ~existing_worktree_path:None
       in
-      is_refuse_base_stale d)
-
-(* A Stale base must NOT block when the patch's own branch already exists —
-   freshness is only consulted on the brand-new-branch arm. *)
-let prop_stale_irrelevant_when_branch_exists =
-  Test.make ~count:300
-    ~name:"SPP-4c: base Stale is ignored when a local/remote ref exists"
-    Gen.(
-      let* local = gen_sha_option in
-      let* remote = gen_sha_option in
-      (* exclude (None, None) — that's the brand-new arm where Stale matters *)
-      let local, remote =
-        match (local, remote) with None, None -> (Some "l", None) | p -> p
-      in
-      let* anc = gen_ancestry in
-      let* base_branch = gen_branch_name in
-      return (local, remote, anc, base_branch))
-    (fun (local, remote, anc, base_branch) ->
-      let d =
-        SP.plan ~local_ref:local ~remote_ref:remote ~ancestry:anc ~base_branch
-          ~base_freshness:SP.Stale ~branch_checked_out_in_main_root:false
-          ~existing_worktree_path:None
-      in
-      not (is_refuse_base_stale d))
+      is_create_from_base base_branch d)
 
 let prop_determinism =
   Test.make ~count:500 ~name:"SPP-5: same inputs → same output" gen_inputs
@@ -296,54 +239,45 @@ let prop_variants_reachable =
     (Gen.return ()) (fun () ->
       let reset =
         SP.plan ~local_ref:None ~remote_ref:(Some "r") ~ancestry:SP.Unknown
-          ~base_branch:"main" ~base_freshness:SP.Unknown_freshness
-          ~branch_checked_out_in_main_root:false ~existing_worktree_path:None
+          ~base_branch:"main" ~branch_checked_out_in_main_root:false
+          ~existing_worktree_path:None
       in
       let use_local =
         SP.plan ~local_ref:(Some "l") ~remote_ref:None ~ancestry:SP.Unknown
-          ~base_branch:"main" ~base_freshness:SP.Unknown_freshness
-          ~branch_checked_out_in_main_root:false ~existing_worktree_path:None
+          ~base_branch:"main" ~branch_checked_out_in_main_root:false
+          ~existing_worktree_path:None
       in
       let create =
         SP.plan ~local_ref:None ~remote_ref:None ~ancestry:SP.Unknown
-          ~base_branch:"main" ~base_freshness:SP.Fresh
-          ~branch_checked_out_in_main_root:false ~existing_worktree_path:None
+          ~base_branch:"main" ~branch_checked_out_in_main_root:false
+          ~existing_worktree_path:None
       in
       let refuse_diverged =
         SP.plan ~local_ref:(Some "l") ~remote_ref:(Some "r")
           ~ancestry:SP.Diverged ~base_branch:"main"
-          ~base_freshness:SP.Unknown_freshness
           ~branch_checked_out_in_main_root:false ~existing_worktree_path:None
       in
       let refuse_ahead =
         SP.plan ~local_ref:(Some "l") ~remote_ref:(Some "r")
           ~ancestry:SP.Local_ahead ~base_branch:"main"
-          ~base_freshness:SP.Unknown_freshness
           ~branch_checked_out_in_main_root:false ~existing_worktree_path:None
       in
       let refuse_checked_out =
         SP.plan ~local_ref:None ~remote_ref:None ~ancestry:SP.Unknown
-          ~base_branch:"main" ~base_freshness:SP.Fresh
-          ~branch_checked_out_in_main_root:true ~existing_worktree_path:None
+          ~base_branch:"main" ~branch_checked_out_in_main_root:true
+          ~existing_worktree_path:None
       in
       let refuse_registered =
         SP.plan ~local_ref:None ~remote_ref:None ~ancestry:SP.Unknown
-          ~base_branch:"main" ~base_freshness:SP.Fresh
-          ~branch_checked_out_in_main_root:false
+          ~base_branch:"main" ~branch_checked_out_in_main_root:false
           ~existing_worktree_path:(Some "/tmp/wt")
-      in
-      let refuse_base_stale =
-        SP.plan ~local_ref:None ~remote_ref:None ~ancestry:SP.Unknown
-          ~base_branch:"dep" ~base_freshness:SP.Stale
-          ~branch_checked_out_in_main_root:false ~existing_worktree_path:None
       in
       is_reset_to "r" reset && is_use_local use_local
       && is_create_from_base "main" create
       && is_refuse_diverged refuse_diverged
       && is_refuse_local_ahead refuse_ahead
       && is_refuse_checked_out refuse_checked_out
-      && is_refuse_registered refuse_registered
-      && is_refuse_base_stale refuse_base_stale)
+      && is_refuse_registered refuse_registered)
 
 let prop_remote_wins_over_local =
   Test.make ~count:500
@@ -359,8 +293,8 @@ let prop_remote_wins_over_local =
     (fun (local, remote, anc, base_branch) ->
       let d =
         SP.plan ~local_ref:(Some local) ~remote_ref:(Some remote) ~ancestry:anc
-          ~base_branch ~base_freshness:SP.Unknown_freshness
-          ~branch_checked_out_in_main_root:false ~existing_worktree_path:None
+          ~base_branch ~branch_checked_out_in_main_root:false
+          ~existing_worktree_path:None
       in
       not (is_use_local d))
 
@@ -373,8 +307,6 @@ let () =
          prop_no_silent_clobber;
          prop_remote_authoritative;
          prop_missing_both;
-         prop_missing_both_stale;
-         prop_stale_irrelevant_when_branch_exists;
          prop_determinism;
          prop_preempt_checked_out;
          prop_preempt_worktree;

--- a/test/test_worktree_start_point_integration.ml
+++ b/test/test_worktree_start_point_integration.ml
@@ -106,7 +106,7 @@ let scenario_brand_new env =
       ~project_name:"brand-new"
       ~patch_id:(Types.Patch_id.of_string "1")
       ~branch:(Types.Branch.of_string "feat")
-      ~base_ref:"origin/main" ~main_branch:"main"
+      ~base_ref:"origin/main"
   in
   match res with
   | Result.Ok wt ->
@@ -146,7 +146,7 @@ let scenario_remote_ahead_of_stale_local env =
       ~project_name:"stale-local"
       ~patch_id:(Types.Patch_id.of_string "2")
       ~branch:(Types.Branch.of_string "feat")
-      ~base_ref:"origin/main" ~main_branch:"main"
+      ~base_ref:"origin/main"
   in
   match res with
   | Result.Ok wt ->
@@ -183,7 +183,7 @@ let scenario_local_only env =
       ~project_name:"local-only"
       ~patch_id:(Types.Patch_id.of_string "3")
       ~branch:(Types.Branch.of_string "feat")
-      ~base_ref:"origin/main" ~main_branch:"main"
+      ~base_ref:"origin/main"
   in
   match res with
   | Result.Ok wt ->
@@ -217,7 +217,7 @@ let scenario_diverged env =
     Worktree.create ~process_mgr ~repo_root:managed_dir ~project_name:"diverged"
       ~patch_id:(Types.Patch_id.of_string "4")
       ~branch:(Types.Branch.of_string "feat")
-      ~base_ref:"origin/main" ~main_branch:"main"
+      ~base_ref:"origin/main"
   in
   match res with
   | Result.Ok _ -> failwith "diverged: expected Error refusal, got Ok"
@@ -227,8 +227,7 @@ let scenario_diverged env =
           Stdlib.print_endline "  diverged: OK (refused)"
       | Start_point_plan.Local_has_unpushed_commits _
       | Start_point_plan.Branch_checked_out_in_main_root
-      | Start_point_plan.Worktree_already_registered _
-      | Start_point_plan.Base_branch_stale_vs_main _ ->
+      | Start_point_plan.Worktree_already_registered _ ->
           failwith
             (Printf.sprintf
                "diverged: expected Local_diverged_from_remote, got %s"
@@ -270,7 +269,7 @@ let scenario_local_strictly_ahead env =
       ~project_name:"local-ahead"
       ~patch_id:(Types.Patch_id.of_string "5")
       ~branch:(Types.Branch.of_string "feat")
-      ~base_ref:"origin/main" ~main_branch:"main"
+      ~base_ref:"origin/main"
   in
   match res with
   | Result.Ok _ ->
@@ -281,22 +280,25 @@ let scenario_local_strictly_ahead env =
           Stdlib.print_endline "  local_strictly_ahead: OK (refused)"
       | Start_point_plan.Local_diverged_from_remote _
       | Start_point_plan.Branch_checked_out_in_main_root
-      | Start_point_plan.Worktree_already_registered _
-      | Start_point_plan.Base_branch_stale_vs_main _ ->
+      | Start_point_plan.Worktree_already_registered _ ->
           failwith
             (Printf.sprintf
                "local_strictly_ahead: expected Local_has_unpushed_commits, got \
                 %s"
                (Start_point_plan.show_refusal r)))
 
-(* The event-stream-pages witness, end-to-end against real git:
+(* Part B regression, end-to-end against real git:
 
    A→B→C stacking. Patch B's branch is cut from main *before* patch A merges to
-   main. Then A merges (origin/main advances to include A). We now try to cut a
-   brand-new branch C from B. Because origin/main is NOT an ancestor of B's
-   branch, [Worktree.create] must refuse with [Base_branch_stale_vs_main]
-   rather than silently producing a worktree missing A's commit. *)
-let scenario_base_stale_vs_main env =
+   main. Then A merges (origin/main advances to include A). We now cut a
+   brand-new branch C from B while origin/main is NOT an ancestor of B's
+   branch. This must SUCCEED: base freshness vs main is dependency-scoped and
+   enforced by the orchestrator's scheduling gate, not here. A dependent cut
+   from B's tip contains everything in B; main advancing for unrelated reasons
+   must not block the cut (the previous main-scoped veto livelocked the run —
+   main moves faster than rebase-and-restart). The new worktree must contain
+   B's commit; it need not contain A's. *)
+let scenario_base_stale_vs_main_now_allowed env =
   let process_mgr = Eio.Stdenv.process_mgr env in
   with_temp_dir @@ fun root ->
   let origin_dir = Stdlib.Filename.concat root "origin" in
@@ -333,23 +335,26 @@ let scenario_base_stale_vs_main env =
       ~project_name:"base-stale"
       ~patch_id:(Types.Patch_id.of_string "c")
       ~branch:(Types.Branch.of_string "patch-c")
-      ~base_ref:"origin/patch-b" ~main_branch:"main"
+      ~base_ref:"origin/patch-b"
   in
   match res with
-  | Result.Ok _ ->
+  | Result.Ok wt ->
+      (* The new worktree must contain patch B's commit (b.txt), proving it was
+         cut from B's tip; it need not (and does not) contain A's a.txt. *)
+      let has_file name =
+        Stdlib.Sys.command
+          (Printf.sprintf "test -f %s"
+             (Stdlib.Filename.quote (Stdlib.Filename.concat wt.path name)))
+        = 0
+      in
+      assert_true "stale-vs-main: worktree contains base commit"
+        (has_file "b.txt");
+      Stdlib.print_endline "  base_stale_vs_main_now_allowed: OK (created)"
+  | Result.Error r ->
       failwith
-        "base_stale: expected Error (Base_branch_stale_vs_main), got Ok — a \
-         worktree cut from a stale dep branch would silently drop main's \
-         commits"
-  | Result.Error (Start_point_plan.Base_branch_stale_vs_main _) ->
-      Stdlib.print_endline "  base_stale_vs_main: OK (refused)"
-  | Result.Error
-      (( Start_point_plan.Local_diverged_from_remote _
-       | Start_point_plan.Local_has_unpushed_commits _
-       | Start_point_plan.Branch_checked_out_in_main_root
-       | Start_point_plan.Worktree_already_registered _ ) as r) ->
-      failwith
-        (Printf.sprintf "base_stale: expected Base_branch_stale_vs_main, got %s"
+        (Printf.sprintf
+           "base_stale_vs_main_now_allowed: expected Ok (main-freshness must \
+            not block a stacked cut), got refusal %s"
            (Start_point_plan.show_refusal r))
 
 (* The complement: a stacked base that legitimately CONTAINS the latest main
@@ -380,7 +385,7 @@ let scenario_base_fresh_stacked env =
       ~project_name:"base-fresh"
       ~patch_id:(Types.Patch_id.of_string "c2")
       ~branch:(Types.Branch.of_string "patch-c2")
-      ~base_ref:"origin/patch-b" ~main_branch:"main"
+      ~base_ref:"origin/patch-b"
   in
   match res with
   | Result.Ok wt ->
@@ -406,6 +411,6 @@ let () =
   scenario_local_only env;
   scenario_diverged env;
   scenario_local_strictly_ahead env;
-  scenario_base_stale_vs_main env;
+  scenario_base_stale_vs_main_now_allowed env;
   scenario_base_fresh_stacked env;
   Stdlib.print_endline "All start-point integration scenarios passed."


### PR DESCRIPTION
Two independent fixes surfaced by one stranded 10-patch stacked run.

## Part B — remove the main-scoped base-freshness veto (livelock fix)

When a stacked dependent (`patch-8 → [patch-1]`) starts on a base whose PR is still open, the orchestrator's **authoritative** gate (`Start_eligibility.decide`) uses a **dependency-scoped** freshness model — per its own comment (`orchestrator.ml:290-313`), *"a base on main is fresh even if main later advanced for unrelated reasons,"* so it returns `Allow`.

But the low-level defense-in-depth probe `Worktree.compute_base_freshness` still ran a **main-scoped** `git merge-base --is-ancestor origin/main <base>` (with `worktree_setup` re-fetching `origin/main` to the latest tip immediately beforehand), and hard-refused with `Base_branch_stale_vs_main` whenever an unrelated PR merged to `main` — **overriding the gate's correct `Allow`**. Because `main` advances faster than rebase-and-restart, this **livelocked** the run: manually rebasing `patch-1` onto `main` could never win the race. The probe also only fired for non-main bases (it returned `Unknown_freshness` when `base_is_main`), i.e. exactly the stacked-dependency case where main-freshness is orthogonal to what the dependent needs. A dependent cut from its base's tip already contains everything in the base; main integration cascades at merge boundaries.

Changes:
- `start_point_plan`: drop the `Base_branch_stale_vs_main` refusal, the `base_freshness` type, and the `~base_freshness` param — the brand-new-branch arm now unconditionally `Create_new_branch_from_base`.
- `worktree`: delete `compute_base_freshness` and the `~main_branch` plumbing on `create`; `worktree_setup` drops the pre-create `origin/main` re-fetch.
- tests: the former `scenario_base_stale_vs_main` now asserts the cut **succeeds** (end-to-end regression guard for the livelock — `base_stale_vs_main_now_allowed: OK (created)`); the stale-vs-main properties are removed. The orchestrator's recursive dependency-scoped rebase cascade is untouched.

## Part A.1 — generalize the PR #333 null-`mergeCommit` fix into a class guard

`Yojson.Safe.Util`'s `member`/`to_string`/`to_*` are **total in type but partial in behavior** — they raise at runtime, invisibly to the type checker. That is the exact failure class behind #333's poll crash. This lays the foundation to make it unwriteable:

- **`lib_core/json.ml`**: total, option-returning accessors (`field`/`string`/`int`/`bool`/`list`/`assoc` + `*_field`) plus `try_of_yojson` (lifted from `persistence.ml`, which now delegates). Field access is by direct variant match, so a missing key, an explicit `null`, and a type mismatch all collapse to `None` — never a raise.
- **`scripts/check-no-raw-yojson.sh`** + allowlist + a CI job: ban raw `Yojson.Safe.Util` outside `lib_core/json.ml`, via a **ratcheting allowlist** seeded with the existing call sites. Each follow-up PR migrates one module to `Json` and deletes its allowlist line until only `json.ml` remains.
- **`test/test_json.ml`** covers every combinator on object/null/absent/wrong-type, plus `try_of_yojson` success and caught-failure paths.

Follow-up PRs (tracked separately) convert `github.ml` to typed `ppx_yojson_conv` records and migrate the remaining call sites to `Json`.

## Verification
- `dune build` / `dune runtest` / `dune build @fmt` all green (pre-commit hook + this PR's CI).
- `scripts/check-no-raw-yojson.sh` passes; validated that removing `json.ml` from the allowlist, adding a new raw reference, or leaving a stale entry each fail it.
- `shellcheck` + `shfmt -i 2 -ci` clean on the new script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix livelock when creating stacked branches by removing the main-scoped freshness veto and relying on the orchestrator’s dependency-scoped gate. Add total JSON accessors and a CI guard to prevent raw `Yojson.Safe.Util` usage, with tighter linting and tests to avoid null/type crashes.

- **Bug Fixes**
  - Drop the `Base_branch_stale_vs_main` refusal and `base_freshness` from the planner; brand-new branches now always cut from the given base.
  - Remove `compute_base_freshness`, the `~main_branch` plumbing, and the pre-create `origin/main` fetch; update tests to assert the stacked cut now succeeds.
  - Keep all other start-point decisions unchanged (remote authoritative, refuse on diverged/local-ahead, pre-emption checks).

- **New Features**
  - Add `Onton_core.Json` with total, option-returning accessors (`field`/`string`/`int`/`bool`/`list`/`assoc`, plus `*_field`) and `try_of_yojson`; `lib/persistence.ml` now delegates.
  - Enforce a ban on raw `Yojson.Safe.Util` outside `lib_core/json.ml` via `scripts/check-no-raw-yojson.sh` and an allowlist, with a CI job that uses read-only checkout and scans nested modules.
  - Add `test/test_json.ml` covering all combinators and error-wrap behavior, including the `Type_error` catch arm of `try_of_yojson`.

<sup>Written for commit 34d80d8059d4891f4a314c9317877ebb34827156. Summary will update on new commits. <a href="https://cubic.dev/pr/flowglad/onton/pull/334?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/334"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782500653&installation_id=126163856&pr_number=334&repository=flowglad%2Fonton&return_to=https%3A%2F%2Fgithub.com%2Fflowglad%2Fonton%2Fpull%2F334&signature=687bdf3cfd112bbbaeb3061cbf6600dcc7105820200efa8d07d8a6cd267ad0d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactoring**
  * Simplified worktree creation by delegating base branch freshness validation to orchestrator scheduling.
  * Improved JSON deserialization handling with safer accessor utilities.
  * Consolidated JSON error conversion logic into core module.

* **Testing**
  * Extended test coverage for JSON accessors and worktree creation scenarios.
  * Added linting enforcement for safe JSON usage patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flowglad/onton/pull/334?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->