### PR TITLE
JSON hardening: typed github.ml decode + migrate all parsers to Json

### DIFF
--- a/lib/github.ml
+++ b/lib/github.ml
@@ -851,9 +851,11 @@ let parse_repo_merge_methods body : repo_merge_methods option =
   match Yojson.Safe.from_string body with
   | exception Yojson.Json_error _ -> None
   | json ->
-      let open Yojson.Safe.Util in
+      (* Absent (or non-bool) → [true]: see comment above. [Json.bool_field]
+         returns [None] for both, which [Option.value ~default:true] maps to the
+         permissive default. *)
       let allowed field =
-        match member field json with `Bool v -> v | _ -> true
+        Option.value (Json.bool_field field json) ~default:true
       in
       Some
         {

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -212,13 +212,13 @@ let parse_merge_state = function
   | _ -> Pr_state.Unknown
 
 (* Typed model of the GraphQL PR response. Every nullable scalar/object is an
-   [option] ([@yojson.option] tolerates both a missing key and an explicit
+   [option] ([@yojson.default None] tolerates both a missing key and an explicit
    [null]); every record allows unmodeled fields so a schema addition never
    fails the parse. Decoding goes through [Json.try_of_yojson], so a shape
    mismatch becomes [Error (Json_parse_error _)] rather than a raised exception
    that fails the whole poll — the failure class behind PR #333. *)
 
-type oid_obj = { oid : string option [@yojson.option] }
+type oid_obj = { oid : string option [@yojson.default None] }
 [@@deriving of_yojson] [@@yojson.allow_extra_fields]
 
 (* A check-context node is an internally-tagged union on [__typename]
@@ -228,18 +228,18 @@ type oid_obj = { oid : string option [@yojson.option] }
    Optional [typename]/[name]/[context] preserve the "skip unrecognized or
    incomplete node" behavior of the previous hand-rolled parser. *)
 type context_node = {
-  typename : string option; [@key "__typename"] [@yojson.option]
-  database_id : int option; [@key "databaseId"] [@yojson.option]
-  name : string option; [@yojson.option]
-  conclusion : string option; [@yojson.option]
-  details_url : string option; [@key "detailsUrl"] [@yojson.option]
-  text : string option; [@yojson.option]
-  started_at : string option; [@key "startedAt"] [@yojson.option]
-  context : string option; [@yojson.option]
-  state : string option; [@yojson.option]
-  target_url : string option; [@key "targetUrl"] [@yojson.option]
-  description : string option; [@yojson.option]
-  created_at : string option; [@key "createdAt"] [@yojson.option]
+  typename : string option; [@key "__typename"] [@yojson.default None]
+  database_id : int option; [@key "databaseId"] [@yojson.default None]
+  name : string option; [@yojson.default None]
+  conclusion : string option; [@yojson.default None]
+  details_url : string option; [@key "detailsUrl"] [@yojson.default None]
+  text : string option; [@yojson.default None]
+  started_at : string option; [@key "startedAt"] [@yojson.default None]
+  context : string option; [@yojson.default None]
+  state : string option; [@yojson.default None]
+  target_url : string option; [@key "targetUrl"] [@yojson.default None]
+  description : string option; [@yojson.default None]
+  created_at : string option; [@key "createdAt"] [@yojson.default None]
 }
 [@@deriving of_yojson] [@@yojson.allow_extra_fields]
 
@@ -263,7 +263,7 @@ type status_check_rollup = {
 
 type commit = {
   status_check_rollup : status_check_rollup option;
-      [@key "statusCheckRollup"] [@yojson.option]
+      [@key "statusCheckRollup"] [@yojson.default None]
 }
 [@@deriving of_yojson] [@@yojson.allow_extra_fields]
 
@@ -276,12 +276,12 @@ type commits = { nodes : commit_node list [@yojson.default []] }
 [@@deriving of_yojson] [@@yojson.allow_extra_fields]
 
 type comment_node = {
-  database_id : int option; [@key "databaseId"] [@yojson.option]
+  database_id : int option; [@key "databaseId"] [@yojson.default None]
   body : string;
-  path : string option; [@yojson.option]
-  line : int option; [@yojson.option]
-  commit : oid_obj option; [@yojson.option]
-  original_commit : oid_obj option; [@key "originalCommit"] [@yojson.option]
+  path : string option; [@yojson.default None]
+  line : int option; [@yojson.default None]
+  commit : oid_obj option; [@yojson.default None]
+  original_commit : oid_obj option; [@key "originalCommit"] [@yojson.default None]
 }
 [@@deriving of_yojson] [@@yojson.allow_extra_fields]
 
@@ -289,7 +289,7 @@ type comment_connection = { nodes : comment_node list [@yojson.default []] }
 [@@deriving of_yojson] [@@yojson.allow_extra_fields]
 
 type review_thread = {
-  id : string option; [@yojson.option]
+  id : string option; [@yojson.default None]
   is_resolved : bool; [@key "isResolved"]
   is_outdated : bool; [@key "isOutdated"] [@yojson.default false]
   comments : comment_connection; [@yojson.default { nodes = [] }]
@@ -299,34 +299,34 @@ type review_thread = {
 type review_threads = { nodes : review_thread list [@yojson.default []] }
 [@@deriving of_yojson] [@@yojson.allow_extra_fields]
 
-type repo_owner = { login : string option [@yojson.option] }
+type repo_owner = { login : string option [@yojson.default None] }
 [@@deriving of_yojson] [@@yojson.allow_extra_fields]
 
 type pull_request = {
   state : string;
-  mergeable : string option; [@yojson.option]
+  mergeable : string option; [@yojson.default None]
   is_draft : bool; [@key "isDraft"] [@yojson.default false]
-  merge_state_status : string option; [@key "mergeStateStatus"] [@yojson.option]
-  head_ref_name : string option; [@key "headRefName"] [@yojson.option]
-  head_ref_oid : string option; [@key "headRefOid"] [@yojson.option]
-  base_ref_name : string option; [@key "baseRefName"] [@yojson.option]
-  merge_commit : oid_obj option; [@key "mergeCommit"] [@yojson.option]
+  merge_state_status : string option; [@key "mergeStateStatus"] [@yojson.default None]
+  head_ref_name : string option; [@key "headRefName"] [@yojson.default None]
+  head_ref_oid : string option; [@key "headRefOid"] [@yojson.default None]
+  base_ref_name : string option; [@key "baseRefName"] [@yojson.default None]
+  merge_commit : oid_obj option; [@key "mergeCommit"] [@yojson.default None]
   commits : commits; [@yojson.default { nodes = [] }]
   review_threads : review_threads; [@key "reviewThreads"] [@yojson.default { nodes = [] }]
   head_repository_owner : repo_owner option;
-      [@key "headRepositoryOwner"] [@yojson.option]
+      [@key "headRepositoryOwner"] [@yojson.default None]
 }
 [@@deriving of_yojson] [@@yojson.allow_extra_fields]
 
 type repository = {
-  pull_request : pull_request option; [@key "pullRequest"] [@yojson.option]
+  pull_request : pull_request option; [@key "pullRequest"] [@yojson.default None]
 }
 [@@deriving of_yojson] [@@yojson.allow_extra_fields]
 
-type data = { repository : repository option [@yojson.option] }
+type data = { repository : repository option [@yojson.default None] }
 [@@deriving of_yojson] [@@yojson.allow_extra_fields]
 
-type response = { data : data option [@yojson.option] }
+type response = { data : data option [@yojson.default None] }
 [@@deriving of_yojson] [@@yojson.allow_extra_fields]
 
 (* Map a decoded context node to a [Ci_check.t], or [None] to skip it.
@@ -341,29 +341,27 @@ let ci_check_of_context (n : context_node) : Types.Ci_check.t option =
           let conclusion =
             match n.conclusion with Some c -> String.lowercase c | None -> "pending"
           in
-          Types.Ci_check.
-            {
-              name;
-              conclusion;
-              details_url = n.details_url;
-              description = n.text;
-              started_at = n.started_at;
-              id = n.database_id;
-            })
+          {
+            Types.Ci_check.name;
+            conclusion;
+            details_url = n.details_url;
+            description = n.text;
+            started_at = n.started_at;
+            id = n.database_id;
+          })
   | Some "StatusContext" ->
       Option.map n.context ~f:(fun name ->
           let conclusion =
             match n.state with Some s -> String.lowercase s | None -> "pending"
           in
-          Types.Ci_check.
-            {
-              name;
-              conclusion;
-              details_url = n.target_url;
-              description = n.description;
-              started_at = n.created_at;
-              id = None;
-            })
+          {
+            Types.Ci_check.name;
+            conclusion;
+            details_url = n.target_url;
+            description = n.description;
+            started_at = n.created_at;
+            id = None;
+          })
   | Some _ | None -> None
 
 let comment_of_node ~thread_id ~outdated (n : comment_node) : Types.Comment.t =
@@ -372,17 +370,16 @@ let comment_of_node ~thread_id ~outdated (n : comment_node) : Types.Comment.t =
     | Some raw_id -> Types.Comment_id.of_int raw_id
     | None -> Types.Comment_id.next_synthetic ()
   in
-  Types.Comment.
-    {
-      id;
-      thread_id;
-      body = n.body;
-      path = n.path;
-      line = n.line;
-      commit_sha = Option.bind n.commit ~f:(fun o -> o.oid);
-      original_commit_sha = Option.bind n.original_commit ~f:(fun o -> o.oid);
-      outdated;
-    }
+  {
+    Types.Comment.id;
+    thread_id;
+    body = n.body;
+    path = n.path;
+    line = n.line;
+    commit_sha = Option.bind n.commit ~f:(fun o -> o.oid);
+    original_commit_sha = Option.bind n.original_commit ~f:(fun o -> o.oid);
+    outdated;
+  }
 
 let pr_state_of_pull_request ~owner (pr : pull_request) : Pr_state.t =
   let status =

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -271,7 +271,7 @@ type commits = { nodes : commit_node list [@yojson.default []] }
 
 type comment_node = {
   database_id : int option; [@key "databaseId"] [@yojson.default None]
-  body : string;
+  body : string; [@yojson.default ""]
   path : string option; [@yojson.default None]
   line : int option; [@yojson.default None]
   commit : oid_obj option; [@yojson.default None]

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -18,15 +18,11 @@ let extract_github_message body =
   in
   try
     let json = Yojson.Safe.from_string body in
-    let top_message =
-      Yojson.Safe.Util.(json |> member "message" |> to_string_option)
-    in
+    let top_message = Json.string_field "message" json in
     let validation_messages =
-      match Yojson.Safe.Util.(json |> member "errors") with
-      | `List errors ->
-          List.filter_map errors ~f:(fun err ->
-              Yojson.Safe.Util.(err |> member "message" |> to_string_option))
-      | _ -> []
+      match Json.field "errors" json |> Option.bind ~f:Json.list with
+      | Some errors -> List.filter_map errors ~f:(Json.string_field "message")
+      | None -> []
     in
     let messages = validation_messages @ Option.to_list top_message in
     let messages = List.stable_dedup messages ~compare:String.compare in
@@ -39,21 +35,19 @@ let extract_github_message body =
 let response_error_messages body =
   try
     let json = Yojson.Safe.from_string body in
-    let top_message =
-      Yojson.Safe.Util.(json |> member "message" |> to_string_option)
-    in
+    let top_message = Json.string_field "message" json in
     let validation_messages =
-      match Yojson.Safe.Util.(json |> member "errors") with
-      | `List errors ->
+      match Json.field "errors" json |> Option.bind ~f:Json.list with
+      | Some errors ->
           List.concat_map errors ~f:(fun err ->
               [
-                Yojson.Safe.Util.(err |> member "message" |> to_string_option);
-                Yojson.Safe.Util.(err |> member "code" |> to_string_option);
-                Yojson.Safe.Util.(err |> member "field" |> to_string_option);
-                Yojson.Safe.Util.(err |> member "resource" |> to_string_option);
+                Json.string_field "message" err;
+                Json.string_field "code" err;
+                Json.string_field "field" err;
+                Json.string_field "resource" err;
               ]
               |> List.filter_opt)
-      | _ -> []
+      | None -> []
     in
     Option.to_list top_message @ validation_messages
   with _ -> []
@@ -249,15 +243,15 @@ type page_info = {
 [@@deriving of_yojson] [@@yojson.allow_extra_fields]
 
 type contexts = {
-  page_info : page_info; [@key "pageInfo"] [@yojson.default { has_next_page = false }]
+  page_info : page_info;
+      [@key "pageInfo"] [@yojson.default { has_next_page = false }]
   nodes : context_node list; [@yojson.default []]
 }
 [@@deriving of_yojson] [@@yojson.allow_extra_fields]
 
 type status_check_rollup = {
   contexts : contexts;
-      [@yojson.default
-        { page_info = { has_next_page = false }; nodes = [] }]
+      [@yojson.default { page_info = { has_next_page = false }; nodes = [] }]
 }
 [@@deriving of_yojson] [@@yojson.allow_extra_fields]
 
@@ -281,7 +275,8 @@ type comment_node = {
   path : string option; [@yojson.default None]
   line : int option; [@yojson.default None]
   commit : oid_obj option; [@yojson.default None]
-  original_commit : oid_obj option; [@key "originalCommit"] [@yojson.default None]
+  original_commit : oid_obj option;
+      [@key "originalCommit"] [@yojson.default None]
 }
 [@@deriving of_yojson] [@@yojson.allow_extra_fields]
 
@@ -306,13 +301,15 @@ type pull_request = {
   state : string;
   mergeable : string option; [@yojson.default None]
   is_draft : bool; [@key "isDraft"] [@yojson.default false]
-  merge_state_status : string option; [@key "mergeStateStatus"] [@yojson.default None]
+  merge_state_status : string option;
+      [@key "mergeStateStatus"] [@yojson.default None]
   head_ref_name : string option; [@key "headRefName"] [@yojson.default None]
   head_ref_oid : string option; [@key "headRefOid"] [@yojson.default None]
   base_ref_name : string option; [@key "baseRefName"] [@yojson.default None]
   merge_commit : oid_obj option; [@key "mergeCommit"] [@yojson.default None]
   commits : commits; [@yojson.default { nodes = [] }]
-  review_threads : review_threads; [@key "reviewThreads"] [@yojson.default { nodes = [] }]
+  review_threads : review_threads;
+      [@key "reviewThreads"] [@yojson.default { nodes = [] }]
   head_repository_owner : repo_owner option;
       [@key "headRepositoryOwner"] [@yojson.default None]
 }
@@ -339,7 +336,9 @@ let ci_check_of_context (n : context_node) : Types.Ci_check.t option =
   | Some "CheckRun" ->
       Option.map n.name ~f:(fun name ->
           let conclusion =
-            match n.conclusion with Some c -> String.lowercase c | None -> "pending"
+            match n.conclusion with
+            | Some c -> String.lowercase c
+            | None -> "pending"
           in
           {
             Types.Ci_check.name;
@@ -352,7 +351,9 @@ let ci_check_of_context (n : context_node) : Types.Ci_check.t option =
   | Some "StatusContext" ->
       Option.map n.context ~f:(fun name ->
           let conclusion =
-            match n.state with Some s -> String.lowercase s | None -> "pending"
+            match n.state with
+            | Some s -> String.lowercase s
+            | None -> "pending"
           in
           {
             Types.Ci_check.name;
@@ -426,11 +427,11 @@ let pr_state_of_pull_request ~owner (pr : pull_request) : Pr_state.t =
              [commit] vs [originalCommit] — GitHub advances [commit] to whatever
              commit still contains the line, flagging false positives. *)
           List.map thread.comments.nodes
-            ~f:(comment_of_node ~thread_id:thread.id ~outdated:thread.is_outdated))
+            ~f:
+              (comment_of_node ~thread_id:thread.id ~outdated:thread.is_outdated))
   in
   let unresolved_comment_count =
-    List.count pr.review_threads.nodes ~f:(fun thread ->
-        not thread.is_resolved)
+    List.count pr.review_threads.nodes ~f:(fun thread -> not thread.is_resolved)
   in
   let is_fork =
     match Option.bind pr.head_repository_owner ~f:(fun r -> r.login) with
@@ -602,36 +603,36 @@ let pr_state ~net ~clock ?timeout t pr =
     of [(pr_number, base_branch, merged)] for non-CLOSED PRs, newest first. Pure
     function — no I/O. *)
 let parse_rest_pr_list body =
-  try
-    match Yojson.Safe.from_string body with
-    | `List entries ->
-        let prs =
-          List.filter_map entries ~f:(fun entry ->
-              let open Yojson.Safe.Util in
-              let number = entry |> member "number" |> to_int in
-              let state =
-                entry |> member "state" |> to_string |> String.lowercase
-              in
-              let merged_at = entry |> member "merged_at" in
-              let base_ref =
-                entry |> member "base" |> member "ref" |> to_string
-              in
-              match (state, merged_at) with
-              | "closed", `Null -> None (* truly closed, not merged *)
-              | _ ->
-                  let merged =
-                    match merged_at with `Null -> false | _ -> true
-                  in
+  match Yojson.Safe.from_string body with
+  | exception Yojson.Json_error msg -> Error (Json_parse_error msg)
+  | `List entries ->
+      let prs =
+        List.filter_map entries ~f:(fun entry ->
+            (* A null/absent [merged_at] means "not merged"; [Json.field]
+               collapses both to [None]. Entries missing [number] or [base.ref]
+               are skipped (malformed) rather than failing the whole list. *)
+            let merged = Option.is_some (Json.field "merged_at" entry) in
+            let state =
+              Json.string_field "state" entry |> Option.map ~f:String.lowercase
+            in
+            let base_ref =
+              Option.bind (Json.field "base" entry) ~f:(Json.string_field "ref")
+            in
+            match (Json.int_field "number" entry, base_ref) with
+            | Some number, Some base_ref ->
+                let truly_closed =
+                  match state with Some "closed" -> not merged | _ -> false
+                in
+                if truly_closed then None
+                else
                   Some
                     ( Types.Pr_number.of_int number,
                       Types.Branch.of_string base_ref,
-                      merged ))
-        in
-        Ok prs
-    | _ -> Error (Json_parse_error "expected JSON array from REST PR list")
-  with
-  | Yojson.Json_error msg -> Error (Json_parse_error msg)
-  | Yojson.Safe.Util.Type_error (msg, _) -> Error (Json_parse_error msg)
+                      merged )
+            | _ -> None)
+      in
+      Ok prs
+  | _ -> Error (Json_parse_error "expected JSON array from REST PR list")
 
 (** List PRs for a branch via REST API. Returns non-CLOSED PRs. *)
 let list_prs ~net ~clock ?timeout t ~branch ?(base = None) ~state () =
@@ -680,13 +681,15 @@ let create_pull_request ~net ~clock ?timeout t ~title ~head ~base ~body ~draft =
   match request ~net ~clock ?timeout t ~meth:`POST ~path ~body:req_body () with
   | Error _ as e -> e
   | Ok resp_str -> (
-      try
-        let json = Yojson.Safe.from_string resp_str in
-        let number = Yojson.Safe.Util.(json |> member "number" |> to_int) in
-        Ok (Types.Pr_number.of_int number)
-      with
-      | Yojson.Json_error msg -> Error (Json_parse_error msg)
-      | Yojson.Safe.Util.Type_error (msg, _) -> Error (Json_parse_error msg))
+      match Yojson.Safe.from_string resp_str with
+      | exception Yojson.Json_error msg -> Error (Json_parse_error msg)
+      | json -> (
+          match Json.int_field "number" json with
+          | Some number -> Ok (Types.Pr_number.of_int number)
+          | None ->
+              Error
+                (Json_parse_error "PR create response missing numeric 'number'")
+          ))
 
 (** Update the base (target) branch of a PR via REST API. *)
 let update_pr_base ~net ~clock ?timeout t ~pr_number ~base =
@@ -711,15 +714,12 @@ let pr_node_id ~net ~clock ?timeout t ~pr_number =
   match request ~net ~clock ?timeout t ~meth:`GET ~path () with
   | Error _ as e -> e
   | Ok body -> (
-      try
-        let json = Yojson.Safe.from_string body in
-        let node_id =
-          Yojson.Safe.Util.(json |> member "node_id" |> to_string)
-        in
-        Ok node_id
-      with
-      | Yojson.Json_error msg -> Error (Json_parse_error msg)
-      | Yojson.Safe.Util.Type_error (msg, _) -> Error (Json_parse_error msg))
+      match Yojson.Safe.from_string body with
+      | exception Yojson.Json_error msg -> Error (Json_parse_error msg)
+      | json -> (
+          match Json.string_field "node_id" json with
+          | Some node_id -> Ok node_id
+          | None -> Error (Json_parse_error "PR response missing 'node_id'")))
 
 (** Set or unset draft status on a PR via GraphQL mutation. REST API does not
     support changing the draft field. *)
@@ -747,21 +747,16 @@ let set_draft ~net ~clock ?timeout t ~pr_number ~draft =
           ~body:req_body ()
       with
       | Ok resp -> (
-          try
-            let json = Yojson.Safe.from_string resp in
-            let open Yojson.Safe.Util in
-            match json |> member "errors" with
-            | `Null | `List [] -> Ok ()
-            | errors ->
-                let msgs =
-                  errors |> to_list
-                  |> List.map ~f:(fun e -> e |> member "message" |> to_string)
-                in
-                Error (Graphql_error msgs)
-          with
-          | Yojson.Json_error msg -> Error (Json_parse_error msg)
-          | Yojson.Safe.Util.Type_error (msg, _) -> Error (Json_parse_error msg)
-          )
+          match Yojson.Safe.from_string resp with
+          | exception Yojson.Json_error msg -> Error (Json_parse_error msg)
+          | json -> (
+              match Json.field "errors" json |> Option.bind ~f:Json.list with
+              | None | Some [] -> Ok () (* null / absent / empty errors *)
+              | Some errors ->
+                  Error
+                    (Graphql_error
+                       (List.filter_map errors ~f:(Json.string_field "message")))
+              ))
       | Error _ as e -> e)
 
 (** Outcome of a [PUT /pulls/:n/merge] call that returned a 2xx status. GitHub
@@ -788,19 +783,19 @@ type merge_result =
       [merged : bool], so absence is suspicious and we let the poller confirm
       rather than guessing. *)
 let interpret_merge_response body =
-  try
-    let json = Yojson.Safe.from_string body in
-    match Yojson.Safe.Util.(member "merged" json |> to_bool_option) with
-    | Some true -> Merge_succeeded
-    | Some false ->
-        let msg =
-          Yojson.Safe.Util.(member "message" json |> to_string_option)
-          |> Option.value ~default:"merged=false"
-        in
-        Merge_queued msg
-    | None -> Merge_unconfirmed
-  with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ ->
-    Merge_unconfirmed
+  match Yojson.Safe.from_string body with
+  | exception Yojson.Json_error _ -> Merge_unconfirmed
+  | json -> (
+      match Json.bool_field "merged" json with
+      | Some true -> Merge_succeeded
+      | Some false ->
+          let msg =
+            Option.value
+              (Json.string_field "message" json)
+              ~default:"merged=false"
+          in
+          Merge_queued msg
+      | None -> Merge_unconfirmed)
 
 (** Merge a pull request via the REST API. Maps to
     [PUT /repos/:owner/:repo/pulls/:number/merge]. Returns the parsed

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -1,4 +1,5 @@
 open Base
+open Ppx_yojson_conv_lib.Yojson_conv.Primitives
 
 type error =
   | Http_error of { meth : string; path : string; status : int; body : string }
@@ -210,237 +211,280 @@ let parse_merge_state = function
   | "CONFLICTING" -> Pr_state.Conflicting
   | _ -> Pr_state.Unknown
 
-let parse_check_context_node node =
-  let open Yojson.Safe.Util in
-  let typename = node |> member "__typename" |> to_string_option in
-  match typename with
-  | Some "CheckRun" -> (
-      match node |> member "name" |> to_string_option with
-      | None -> None
-      | Some name ->
-          let conclusion =
-            match node |> member "conclusion" |> to_string_option with
-            | Some c -> String.lowercase c
-            | None -> "pending"
-          in
-          let details_url = node |> member "detailsUrl" |> to_string_option in
-          let description = node |> member "text" |> to_string_option in
-          let started_at = node |> member "startedAt" |> to_string_option in
-          let id = node |> member "databaseId" |> to_int_option in
-          Some
-            Types.Ci_check.
-              { name; conclusion; details_url; description; started_at; id })
-  | Some "StatusContext" -> (
-      match node |> member "context" |> to_string_option with
-      | None -> None
-      | Some name ->
-          let conclusion =
-            match node |> member "state" |> to_string_option with
-            | Some s -> String.lowercase s
-            | None -> "pending"
-          in
-          let details_url = node |> member "targetUrl" |> to_string_option in
-          let description = node |> member "description" |> to_string_option in
-          let started_at = node |> member "createdAt" |> to_string_option in
-          Some
-            Types.Ci_check.
-              {
-                name;
-                conclusion;
-                details_url;
-                description;
-                started_at;
-                id = None;
-              })
-  | _ -> None
+(* Typed model of the GraphQL PR response. Every nullable scalar/object is an
+   [option] ([@yojson.option] tolerates both a missing key and an explicit
+   [null]); every record allows unmodeled fields so a schema addition never
+   fails the parse. Decoding goes through [Json.try_of_yojson], so a shape
+   mismatch becomes [Error (Json_parse_error _)] rather than a raised exception
+   that fails the whole poll — the failure class behind PR #333. *)
 
-let parse_comment_node ~thread_id ~outdated node =
-  let open Yojson.Safe.Util in
+type oid_obj = { oid : string option [@yojson.option] }
+[@@deriving of_yojson] [@@yojson.allow_extra_fields]
+
+(* A check-context node is an internally-tagged union on [__typename]
+   (CheckRun | StatusContext) whose two arms share no keys. ppx's derived
+   variant encoding does not match that wire shape, so decode every node into
+   one flat all-optional record and dispatch in OCaml ([ci_check_of_context]).
+   Optional [typename]/[name]/[context] preserve the "skip unrecognized or
+   incomplete node" behavior of the previous hand-rolled parser. *)
+type context_node = {
+  typename : string option; [@key "__typename"] [@yojson.option]
+  database_id : int option; [@key "databaseId"] [@yojson.option]
+  name : string option; [@yojson.option]
+  conclusion : string option; [@yojson.option]
+  details_url : string option; [@key "detailsUrl"] [@yojson.option]
+  text : string option; [@yojson.option]
+  started_at : string option; [@key "startedAt"] [@yojson.option]
+  context : string option; [@yojson.option]
+  state : string option; [@yojson.option]
+  target_url : string option; [@key "targetUrl"] [@yojson.option]
+  description : string option; [@yojson.option]
+  created_at : string option; [@key "createdAt"] [@yojson.option]
+}
+[@@deriving of_yojson] [@@yojson.allow_extra_fields]
+
+type page_info = {
+  has_next_page : bool; [@key "hasNextPage"] [@yojson.default false]
+}
+[@@deriving of_yojson] [@@yojson.allow_extra_fields]
+
+type contexts = {
+  page_info : page_info; [@key "pageInfo"] [@yojson.default { has_next_page = false }]
+  nodes : context_node list; [@yojson.default []]
+}
+[@@deriving of_yojson] [@@yojson.allow_extra_fields]
+
+type status_check_rollup = {
+  contexts : contexts;
+      [@yojson.default
+        { page_info = { has_next_page = false }; nodes = [] }]
+}
+[@@deriving of_yojson] [@@yojson.allow_extra_fields]
+
+type commit = {
+  status_check_rollup : status_check_rollup option;
+      [@key "statusCheckRollup"] [@yojson.option]
+}
+[@@deriving of_yojson] [@@yojson.allow_extra_fields]
+
+type commit_node = {
+  commit : commit; [@yojson.default { status_check_rollup = None }]
+}
+[@@deriving of_yojson] [@@yojson.allow_extra_fields]
+
+type commits = { nodes : commit_node list [@yojson.default []] }
+[@@deriving of_yojson] [@@yojson.allow_extra_fields]
+
+type comment_node = {
+  database_id : int option; [@key "databaseId"] [@yojson.option]
+  body : string;
+  path : string option; [@yojson.option]
+  line : int option; [@yojson.option]
+  commit : oid_obj option; [@yojson.option]
+  original_commit : oid_obj option; [@key "originalCommit"] [@yojson.option]
+}
+[@@deriving of_yojson] [@@yojson.allow_extra_fields]
+
+type comment_connection = { nodes : comment_node list [@yojson.default []] }
+[@@deriving of_yojson] [@@yojson.allow_extra_fields]
+
+type review_thread = {
+  id : string option; [@yojson.option]
+  is_resolved : bool; [@key "isResolved"]
+  is_outdated : bool; [@key "isOutdated"] [@yojson.default false]
+  comments : comment_connection; [@yojson.default { nodes = [] }]
+}
+[@@deriving of_yojson] [@@yojson.allow_extra_fields]
+
+type review_threads = { nodes : review_thread list [@yojson.default []] }
+[@@deriving of_yojson] [@@yojson.allow_extra_fields]
+
+type repo_owner = { login : string option [@yojson.option] }
+[@@deriving of_yojson] [@@yojson.allow_extra_fields]
+
+type pull_request = {
+  state : string;
+  mergeable : string option; [@yojson.option]
+  is_draft : bool; [@key "isDraft"] [@yojson.default false]
+  merge_state_status : string option; [@key "mergeStateStatus"] [@yojson.option]
+  head_ref_name : string option; [@key "headRefName"] [@yojson.option]
+  head_ref_oid : string option; [@key "headRefOid"] [@yojson.option]
+  base_ref_name : string option; [@key "baseRefName"] [@yojson.option]
+  merge_commit : oid_obj option; [@key "mergeCommit"] [@yojson.option]
+  commits : commits; [@yojson.default { nodes = [] }]
+  review_threads : review_threads; [@key "reviewThreads"] [@yojson.default { nodes = [] }]
+  head_repository_owner : repo_owner option;
+      [@key "headRepositoryOwner"] [@yojson.option]
+}
+[@@deriving of_yojson] [@@yojson.allow_extra_fields]
+
+type repository = {
+  pull_request : pull_request option; [@key "pullRequest"] [@yojson.option]
+}
+[@@deriving of_yojson] [@@yojson.allow_extra_fields]
+
+type data = { repository : repository option [@yojson.option] }
+[@@deriving of_yojson] [@@yojson.allow_extra_fields]
+
+type response = { data : data option [@yojson.option] }
+[@@deriving of_yojson] [@@yojson.allow_extra_fields]
+
+(* Map a decoded context node to a [Ci_check.t], or [None] to skip it.
+   Byte-for-byte equivalent to the former [parse_check_context_node]: unknown or
+   incomplete nodes are skipped, conclusion is lowercased with a "pending"
+   default, and the CheckRun/StatusContext field asymmetry (text vs description,
+   id present only for CheckRun) is preserved. *)
+let ci_check_of_context (n : context_node) : Types.Ci_check.t option =
+  match n.typename with
+  | Some "CheckRun" ->
+      Option.map n.name ~f:(fun name ->
+          let conclusion =
+            match n.conclusion with Some c -> String.lowercase c | None -> "pending"
+          in
+          Types.Ci_check.
+            {
+              name;
+              conclusion;
+              details_url = n.details_url;
+              description = n.text;
+              started_at = n.started_at;
+              id = n.database_id;
+            })
+  | Some "StatusContext" ->
+      Option.map n.context ~f:(fun name ->
+          let conclusion =
+            match n.state with Some s -> String.lowercase s | None -> "pending"
+          in
+          Types.Ci_check.
+            {
+              name;
+              conclusion;
+              details_url = n.target_url;
+              description = n.description;
+              started_at = n.created_at;
+              id = None;
+            })
+  | Some _ | None -> None
+
+let comment_of_node ~thread_id ~outdated (n : comment_node) : Types.Comment.t =
   let id =
-    match node |> member "databaseId" |> to_int_option with
+    match n.database_id with
     | Some raw_id -> Types.Comment_id.of_int raw_id
     | None -> Types.Comment_id.next_synthetic ()
   in
-  let body = node |> member "body" |> to_string in
-  let path = node |> member "path" |> to_string_option in
-  let line = node |> member "line" |> to_int_option in
-  (* If [field] is absent or null we return [None]; if it's present but the
-     nested [oid] is missing/non-string, [to_string_option] also returns [None].
-     That second case is a GraphQL-schema-change red flag, but there's no
-     structured logger here — callers treat a [None] SHA as "no anchor info",
-     which is the safest fallback. *)
-  let oid_of field =
-    match node |> member field with
-    | `Null -> None
-    | obj -> obj |> member "oid" |> to_string_option
-  in
-  let commit_sha = oid_of "commit" in
-  let original_commit_sha = oid_of "originalCommit" in
   Types.Comment.
     {
       id;
       thread_id;
-      body;
-      path;
-      line;
-      commit_sha;
-      original_commit_sha;
+      body = n.body;
+      path = n.path;
+      line = n.line;
+      commit_sha = Option.bind n.commit ~f:(fun o -> o.oid);
+      original_commit_sha = Option.bind n.original_commit ~f:(fun o -> o.oid);
       outdated;
     }
 
-let parse_response_json ~owner json =
-  let open Yojson.Safe.Util in
-  try
-    let errors = json |> member "errors" in
-    match errors with
-    | `Null -> (
-        let pr =
-          json |> member "data" |> member "repository" |> member "pullRequest"
-        in
-        match pr with
-        | `Null -> Error (Json_parse_error "pullRequest not found")
-        | pr ->
+let pr_state_of_pull_request ~owner (pr : pull_request) : Pr_state.t =
+  let status =
+    match pr.state with
+    | "MERGED" -> Pr_state.Merged
+    | "CLOSED" -> Pr_state.Closed
+    | _ -> Pr_state.Open
+  in
+  let merge_state =
+    Option.value_map pr.mergeable ~default:Pr_state.Unknown ~f:parse_merge_state
+  in
+  let merge_ready =
+    match pr.merge_state_status with Some "CLEAN" -> true | _ -> false
+  in
+  let check_status, ci_checks, ci_checks_truncated =
+    match pr.commits.nodes with
+    | [] -> (Pr_state.Pending, [], false)
+    | node :: _ -> (
+        match node.commit.status_check_rollup with
+        | None -> (Pr_state.Pending, [], false)
+        | Some rollup ->
+            let truncated = rollup.contexts.page_info.has_next_page in
+            let checks =
+              List.filter_map rollup.contexts.nodes ~f:ci_check_of_context
+            in
+            (* Derive check_status from individual conclusions; we deliberately
+               do NOT use the GraphQL rollup state (it conflates cancelled runs
+               with real failures). When truncated, downgrade Passing to Pending
+               so we never approve a merge that might fail on page 2+. *)
             let status =
-              match pr |> member "state" |> to_string with
-              | "MERGED" -> Pr_state.Merged
-              | "CLOSED" -> Pr_state.Closed
-              | _ -> Pr_state.Open
+              let base = Pr_state.derive_check_status checks in
+              if truncated && Pr_state.equal_check_status base Pr_state.Passing
+              then Pr_state.Pending
+              else base
             in
-            let merge_state =
-              match pr |> member "mergeable" |> to_string_option with
-              | Some s -> parse_merge_state s
-              | None -> Pr_state.Unknown
-            in
-            let is_draft =
-              pr |> member "isDraft" |> to_bool_option
-              |> Option.value ~default:false
-            in
-            let merge_ready =
-              match pr |> member "mergeStateStatus" |> to_string_option with
-              | Some "CLEAN" -> true
-              | _ -> false
-            in
-            let check_status, ci_checks, ci_checks_truncated =
-              let commits = pr |> member "commits" |> member "nodes" in
-              match commits |> to_list with
-              | [] -> (Pr_state.Pending, [], false)
-              | node :: _ -> (
-                  let rollup =
-                    node |> member "commit" |> member "statusCheckRollup"
-                  in
-                  match rollup with
-                  | `Null -> (Pr_state.Pending, [], false)
-                  | rollup ->
-                      let contexts = rollup |> member "contexts" in
-                      let truncated =
-                        contexts |> member "pageInfo" |> member "hasNextPage"
-                        |> to_bool_option
-                        |> Option.value ~default:false
-                      in
-                      let checks =
-                        contexts |> member "nodes" |> to_list
-                        |> List.filter_map ~f:parse_check_context_node
-                      in
-                      (* Derive check_status from individual conclusions.
-                         We deliberately do NOT use the GraphQL rollup
-                         state — it conflates cancelled runs (e.g.
-                         superseded by a newer commit) with real failures.
-                         See [Pr_state.derive_check_status] for semantics. *)
-                      let status =
-                        let base = Pr_state.derive_check_status checks in
-                        (* Passing is only reliable when we've seen every check.
-                           If the list is truncated, treat as Pending to avoid
-                           approving a merge that might have failures on page 2+. *)
-                        if
-                          truncated
-                          && Pr_state.equal_check_status base Pr_state.Passing
-                        then Pr_state.Pending
-                        else base
-                      in
-                      (status, checks, truncated))
-            in
-            let review_threads =
-              pr |> member "reviewThreads" |> member "nodes" |> to_list
-            in
-            let comments =
-              List.concat_map review_threads ~f:(fun thread ->
-                  if thread |> member "isResolved" |> to_bool then []
-                  else
-                    let thread_id = thread |> member "id" |> to_string_option in
-                    (* [isOutdated] is the authoritative signal from GitHub:
-                       the thread's anchored lines were changed by a later
-                       commit (or the file was deleted). Do not infer this
-                       from [commit] vs [originalCommit] — GitHub advances
-                       [commit] to whatever commit still contains the line,
-                       including commits that touched unrelated files, so
-                       that comparison flags false positives. *)
-                    let outdated =
-                      match thread |> member "isOutdated" with
-                      | `Bool b -> b
-                      | _ -> false
-                    in
-                    thread |> member "comments" |> member "nodes" |> to_list
-                    |> List.map ~f:(parse_comment_node ~thread_id ~outdated))
-            in
-            let unresolved_comment_count =
-              List.count review_threads ~f:(fun thread ->
-                  not (thread |> member "isResolved" |> to_bool))
-            in
-            let head_branch =
-              pr |> member "headRefName" |> to_string_option
-              |> Option.map ~f:Types.Branch.of_string
-            in
-            let head_oid = pr |> member "headRefOid" |> to_string_option in
-            let merge_commit_sha =
-              (* [mergeCommit] is [null] for every open/draft/unmerged PR.
-                 [member "oid"] on [`Null] raises [Type_error], which would
-                 fail the whole poll — guard the null arm explicitly, mirroring
-                 [parse_comment_node]'s [oid_of] helper above. *)
-              match pr |> member "mergeCommit" with
-              | `Null -> None
-              | commit -> commit |> member "oid" |> to_string_option
-            in
-            let base_branch =
-              pr |> member "baseRefName" |> to_string_option
-              |> Option.map ~f:Types.Branch.of_string
-            in
-            let is_fork =
-              match
-                pr
-                |> member "headRepositoryOwner"
-                |> member "login" |> to_string_option
-              with
-              | Some head_owner -> not (String.equal head_owner owner)
-              | None -> false
-            in
-            Ok
-              {
-                Pr_state.status;
-                is_draft;
-                merge_state;
-                merge_ready;
-                check_status;
-                ci_checks;
-                ci_checks_truncated;
-                comments;
-                unresolved_comment_count;
-                findings = [];
-                (* GitHub does not produce review-service findings; the
-                     poller in [bin/main.ml] augments this list from
-                     configured review-service backends. *)
-                head_branch;
-                head_oid;
-                merge_commit_sha;
-                base_branch;
-                is_fork;
-              })
-    | errors ->
-        let msgs =
-          errors |> to_list
-          |> List.map ~f:(fun e -> e |> member "message" |> to_string)
-        in
-        Error (Graphql_error msgs)
-  with Yojson.Safe.Util.Type_error (msg, _) -> Error (Json_parse_error msg)
+            (status, checks, truncated))
+  in
+  let comments =
+    List.concat_map pr.review_threads.nodes ~f:(fun thread ->
+        if thread.is_resolved then []
+        else
+          (* [isOutdated] is the authoritative signal from GitHub: the thread's
+             anchored lines were changed by a later commit. Do not infer it from
+             [commit] vs [originalCommit] — GitHub advances [commit] to whatever
+             commit still contains the line, flagging false positives. *)
+          List.map thread.comments.nodes
+            ~f:(comment_of_node ~thread_id:thread.id ~outdated:thread.is_outdated))
+  in
+  let unresolved_comment_count =
+    List.count pr.review_threads.nodes ~f:(fun thread ->
+        not thread.is_resolved)
+  in
+  let is_fork =
+    match Option.bind pr.head_repository_owner ~f:(fun r -> r.login) with
+    | Some head_owner -> not (String.equal head_owner owner)
+    | None -> false
+  in
+  {
+    Pr_state.status;
+    is_draft = pr.is_draft;
+    merge_state;
+    merge_ready;
+    check_status;
+    ci_checks;
+    ci_checks_truncated;
+    comments;
+    unresolved_comment_count;
+    findings = [];
+    (* GitHub does not produce review-service findings; the poller in
+       [bin/main.ml] augments this list from configured review-service
+       backends. *)
+    head_branch = Option.map pr.head_ref_name ~f:Types.Branch.of_string;
+    head_oid = pr.head_ref_oid;
+    merge_commit_sha = Option.bind pr.merge_commit ~f:(fun o -> o.oid);
+    base_branch = Option.map pr.base_ref_name ~f:Types.Branch.of_string;
+    is_fork;
+  }
+
+let parse_response_json ~owner json =
+  (* [Json.field] is [None] for both a missing and an explicit-null [errors],
+     which is the "no errors" case; a present non-null [errors] is the GraphQL
+     error arm. *)
+  match Json.field "errors" json with
+  | Some errors_json ->
+      let msgs =
+        match Json.list errors_json with
+        | Some es -> List.filter_map es ~f:(Json.string_field "message")
+        | None -> []
+      in
+      Error (Graphql_error msgs)
+  | None -> (
+      (* Decode the whole object: the [response] wrapper turns a null/absent
+         [data]/[repository]/[pullRequest] into [None] rather than raising, so
+         all three funnel to the same "pullRequest not found" as before. *)
+      match Json.try_of_yojson response_of_yojson json with
+      | Error msg -> Error (Json_parse_error msg)
+      | Ok { data = None }
+      | Ok { data = Some { repository = None } }
+      | Ok { data = Some { repository = Some { pull_request = None } } } ->
+          Error (Json_parse_error "pullRequest not found")
+      | Ok { data = Some { repository = Some { pull_request = Some pr } } } ->
+          Ok (pr_state_of_pull_request ~owner pr))
 
 let parse_response ~owner body =
   try parse_response_json ~owner (Yojson.Safe.from_string body)

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -285,7 +285,7 @@ type comment_connection = { nodes : comment_node list [@yojson.default []] }
 
 type review_thread = {
   id : string option; [@yojson.default None]
-  is_resolved : bool; [@key "isResolved"]
+  is_resolved : bool; [@key "isResolved"] [@yojson.default false]
   is_outdated : bool; [@key "isOutdated"] [@yojson.default false]
   comments : comment_connection; [@yojson.default { nodes = [] }]
 }

--- a/lib/persistence.ml
+++ b/lib/persistence.ml
@@ -87,24 +87,55 @@ let overlay_session_id_sidecars ~snapshot_path (snap : Runtime.snapshot) =
   in
   { snap with Runtime.orchestrator }
 
-let string_member key json = Yojson.Safe.Util.(member key json |> to_string)
+(* Decode failure for the *required* accessors below. Replaces the partial
+   accessor exception these helpers used to raise: the two top-level decoders
+   ([orchestrator_of_yojson]/[snapshot_of_yojson]) catch it and produce the same
+   "malformed orchestrator/snapshot: <msg>" Error they did before. *)
+exception Decode_error of string
 
-let string_member_opt key json =
-  Yojson.Safe.Util.(member key json |> to_string_option)
+(* [member key json] mirroring the legacy [member]: absent keys and explicit
+   [`Null] both collapse to [`Null], preserving the [`Null]/[`List] matches and
+   the missing-key semantics of the optional helpers. *)
+let member key json = Option.value (Json.field key json) ~default:`Null
 
-let int_member key json = Yojson.Safe.Util.(member key json |> to_int)
-let bool_member key json = Yojson.Safe.Util.(member key json |> to_bool)
-let list_member key json = Yojson.Safe.Util.(member key json |> to_list)
+let string_member key json =
+  match Json.field key json with
+  | Some (`String s) -> s
+  | _ -> raise (Decode_error (Printf.sprintf "%s: expected a string" key))
+
+let string_member_opt key json = Json.string_field key json
+
+let int_member key json =
+  match Json.field key json with
+  | Some (`Int n) -> n
+  | _ -> raise (Decode_error (Printf.sprintf "%s: expected an int" key))
+
+let bool_member key json =
+  match Json.field key json with
+  | Some (`Bool b) -> b
+  | _ -> raise (Decode_error (Printf.sprintf "%s: expected a bool" key))
+
+let list_member key json =
+  match Json.field key json with
+  | Some (`List l) -> l
+  | None -> raise (Decode_error (Printf.sprintf "%s: expected a list" key))
+  | Some _ -> raise (Decode_error (Printf.sprintf "%s: expected a list" key))
+
+let to_assoc = function
+  | `Assoc kvs -> kvs
+  | _ -> raise (Decode_error "expected an object")
 
 let int_member_opt key json =
-  match Yojson.Safe.Util.member key json with
+  match member key json with
   | `Null -> None
-  | v -> Some (Yojson.Safe.Util.to_int v)
+  | `Int n -> Some n
+  | _ -> raise (Decode_error (Printf.sprintf "%s: expected an int" key))
 
 let bool_member_opt key json =
-  match Yojson.Safe.Util.member key json with
+  match member key json with
   | `Null -> None
-  | v -> Some (Yojson.Safe.Util.to_bool v)
+  | `Bool b -> Some b
+  | _ -> raise (Decode_error (Printf.sprintf "%s: expected a bool" key))
 
 let result_all xs =
   List.fold_right xs ~init:(Ok []) ~f:(fun x acc ->
@@ -112,7 +143,7 @@ let result_all xs =
 
 (** Wrap a raising ppx_yojson_conv deserializer into a Result.t. Delegates to
     {!Onton_core.Json.try_of_yojson} (the sanctioned home for the
-    [Yojson.Safe.Util.Type_error] catch). *)
+    partial-decoder exception catch). *)
 let try_of_yojson = Json.try_of_yojson
 
 (* ---------- Patch_agent ---------- *)
@@ -211,19 +242,17 @@ let patch_agent_of_yojson ~gameplan json =
            try_of_yojson Operation_kind.t_of_yojson_compat j))
   in
   let human_messages =
-    match Yojson.Safe.Util.member "human_messages" json with
-    | `List items ->
-        List.filter_map items ~f:(fun j -> Yojson.Safe.Util.to_string_option j)
+    match member "human_messages" json with
+    | `List items -> List.filter_map items ~f:(fun j -> Json.string j)
     | _ -> []
   in
   let inflight_human_messages =
-    match Yojson.Safe.Util.member "inflight_human_messages" json with
-    | `List items ->
-        List.filter_map items ~f:(fun j -> Yojson.Safe.Util.to_string_option j)
+    match member "inflight_human_messages" json with
+    | `List items -> List.filter_map items ~f:(fun j -> Json.string j)
     | _ -> []
   in
   let* session_fallback =
-    match Yojson.Safe.Util.member "session_fallback" json with
+    match member "session_fallback" json with
     | `Null -> Error "patch_agent: missing session_fallback"
     | v -> try_of_yojson Patch_agent.session_fallback_of_yojson v
   in
@@ -268,7 +297,7 @@ let patch_agent_of_yojson ~gameplan json =
                  | Some p -> Branch.to_string p.Patch.branch
                  | None -> pid)))
        ~pr_status:
-         (match Yojson.Safe.Util.member "pr_status" json with
+         (match member "pr_status" json with
          | `Null -> (
              (* Legacy snapshot: no [pr_status] field. Derive from the legacy
                 [pr_number] field: int -> Present, null -> Absent. Missing
@@ -335,7 +364,7 @@ let patch_agent_of_yojson ~gameplan json =
        ~branch_rebased_onto_sha:
          (string_member_opt "branch_rebased_onto_sha" json)
        ~anchor_history:
-         (match Yojson.Safe.Util.member "anchor_history" json with
+         (match member "anchor_history" json with
          | `Null -> Anchor_history.empty
          | v -> (
              match Anchor_history.of_yojson_opt v with
@@ -354,14 +383,14 @@ let patch_agent_of_yojson ~gameplan json =
              else None)
        ~checks_passing:(bool_member "checks_passing" json)
        ~current_op:
-         (match Yojson.Safe.Util.member "current_op" json with
+         (match member "current_op" json with
          | `Null -> None
          | v -> (
              match try_of_yojson Operation_kind.t_of_yojson_compat v with
              | Ok op -> Some op
              | Error _ -> None))
        ~current_op_state:
-         (match Yojson.Safe.Util.member "current_op_state" json with
+         (match member "current_op_state" json with
          | `Null ->
              (* Field absent in snapshots predating this feature (missing key
                 returns [`Null]) — default to [Queued]. A live agent will be
@@ -385,7 +414,7 @@ let patch_agent_of_yojson ~gameplan json =
             (bool_member_opt "automerge_enabled" json)
             ~default:false)
        ~automerge_deadline:
-         (match Yojson.Safe.Util.member "automerge_deadline" json with
+         (match member "automerge_deadline" json with
          | `Null -> None
          | `Float f -> Some f
          | `Int i -> Some (Float.of_int i)
@@ -412,10 +441,9 @@ let patch_agent_of_yojson ~gameplan json =
             (int_member_opt "automerge_failure_count" json)
             ~default:0)
        ~delivered_ci_run_ids:
-         (match Yojson.Safe.Util.member "delivered_ci_run_ids" json with
+         (match member "delivered_ci_run_ids" json with
          | `List items ->
-             List.filter_map items ~f:(fun j ->
-                 Yojson.Safe.Util.to_int_option j)
+             List.filter_map items ~f:(fun j -> Json.int j)
              |> List.dedup_and_sort ~compare:Int.compare
          | _ -> []))
 
@@ -519,7 +547,7 @@ let action_of_yojson json =
   | "respond" ->
       let* op_kind =
         try_of_yojson Operation_kind.t_of_yojson_compat
-          (Yojson.Safe.Util.member "operation_kind" json)
+          (member "operation_kind" json)
       in
       Ok
         (Orchestrator.Respond
@@ -545,8 +573,7 @@ let orchestrator_of_yojson ~gameplan json =
     let main_branch = Branch.of_string (string_member "main_branch" json) in
     Result.bind
       (result_all
-         (Yojson.Safe.Util.member "agents" json
-         |> Yojson.Safe.Util.to_assoc
+         (member "agents" json |> to_assoc
          |> List.map ~f:(fun (key, value) ->
              Result.bind (patch_agent_of_yojson ~gameplan value)
                ~f:(fun agent ->
@@ -565,8 +592,7 @@ let orchestrator_of_yojson ~gameplan json =
             ~f:(fun acc (k, v) -> Map.set acc ~key:k ~data:v)
         in
         let outbox =
-          Yojson.Safe.Util.member "outbox" json
-          |> Yojson.Safe.Util.to_assoc
+          member "outbox" json |> to_assoc
           |> List.fold
                ~init:(Ok (Map.empty (module Message_id)))
                ~f:(fun acc_result (key, value) ->
@@ -578,9 +604,7 @@ let orchestrator_of_yojson ~gameplan json =
                  let* status =
                    message_status_of_string (string_member "status" value)
                  in
-                 let* action =
-                   action_of_yojson (Yojson.Safe.Util.member "action" value)
-                 in
+                 let* action = action_of_yojson (member "action" value) in
                  let msg_id = Message_id.of_string key in
                  let message =
                    Orchestrator.
@@ -656,8 +680,7 @@ let orchestrator_of_yojson ~gameplan json =
             (Orchestrator.restore ~graph ~agents:agents_map ~outbox ~main_branch
                ()))
   with
-  | Yojson.Safe.Util.Type_error (msg, _) ->
-      Error (Printf.sprintf "malformed orchestrator: %s" msg)
+  | Decode_error msg -> Error (Printf.sprintf "malformed orchestrator: %s" msg)
   | Invalid_argument msg ->
       Error (Printf.sprintf "malformed orchestrator: %s" msg)
 
@@ -673,7 +696,7 @@ let transcripts_of_yojson json =
   (match json with
   | `Assoc fields ->
       List.iter fields ~f:(fun (key, value) ->
-          match Yojson.Safe.Util.to_string_option value with
+          match Json.string value with
           | Some s -> Hashtbl.set t ~key:(Patch_id.of_string key) ~data:s
           | None -> ())
   | _ -> ());
@@ -696,26 +719,22 @@ let snapshot_of_yojson json =
       Error (Printf.sprintf "unsupported version: %d" version)
     else
       Result.bind
-        (try_of_yojson Gameplan.t_of_yojson
-           (Yojson.Safe.Util.member "gameplan" json))
+        (try_of_yojson Gameplan.t_of_yojson (member "gameplan" json))
         ~f:(fun gameplan ->
           Result.bind
-            (orchestrator_of_yojson ~gameplan
-               (Yojson.Safe.Util.member "orchestrator" json))
+            (orchestrator_of_yojson ~gameplan (member "orchestrator" json))
             ~f:(fun orchestrator ->
               Result.map
-                (activity_log_of_yojson
-                   (Yojson.Safe.Util.member "activity_log" json))
+                (activity_log_of_yojson (member "activity_log" json))
                 ~f:(fun activity_log ->
                   let transcripts =
-                    match Yojson.Safe.Util.member "transcripts" json with
+                    match member "transcripts" json with
                     | `Null -> Hashtbl.create (module Patch_id)
                     | j -> transcripts_of_yojson j
                   in
                   { Runtime.orchestrator; activity_log; gameplan; transcripts })))
   with
-  | Yojson.Safe.Util.Type_error (msg, _) ->
-      Error (Printf.sprintf "malformed snapshot: %s" msg)
+  | Decode_error msg -> Error (Printf.sprintf "malformed snapshot: %s" msg)
   | Invalid_argument msg -> Error (Printf.sprintf "malformed snapshot: %s" msg)
 
 (* ---------- File I/O ---------- *)

--- a/lib/session_driver.ml
+++ b/lib/session_driver.ml
@@ -356,10 +356,7 @@ module Make (W : Worktree.S) (Env : ENV) = struct
                         let summary =
                           try
                             let json = Yojson.Safe.from_string input in
-                            let field key =
-                              Yojson.Safe.Util.(
-                                member key json |> to_string_option)
-                            in
+                            let field key = Json.string_field key json in
                             let s =
                               match name with
                               | "Bash" -> field "command"

--- a/lib_core/claude_event_parser.ml
+++ b/lib_core/claude_event_parser.ml
@@ -149,141 +149,143 @@ let find_json_start s =
   | Some n -> String.drop_prefix s n
 
 let session_init_of_json json =
-  let open Yojson.Safe.Util in
-  match member "session_id" json |> to_string_option with
+  match Json.string_field "session_id" json with
   | None -> []
   | Some session_id ->
       [
         Types.Stream_event.Session_init
           {
             session_id;
-            api_key_source = member "apiKeySource" json |> to_string_option;
-            model = member "model" json |> to_string_option;
-            claude_code_version =
-              member "claude_code_version" json |> to_string_option;
-            permission_mode = member "permissionMode" json |> to_string_option;
+            api_key_source = Json.string_field "apiKeySource" json;
+            model = Json.string_field "model" json;
+            claude_code_version = Json.string_field "claude_code_version" json;
+            permission_mode = Json.string_field "permissionMode" json;
           };
       ]
 
 let parse_stream_events (line : string) : Types.Stream_event.t list =
-  try
-    let json = Yojson.Safe.from_string (find_json_start line) in
-    let open Yojson.Safe.Util in
-    let typ = member "type" json |> to_string_option in
-    match typ with
-    | Some "content_block_delta" -> (
-        let delta = member "delta" json in
-        let delta_type = member "type" delta |> to_string_option in
-        match delta_type with
-        | Some "text_delta" ->
-            let text =
-              member "text" delta |> to_string_option
-              |> Option.value ~default:""
-            in
-            [ Types.Stream_event.Text_delta text ]
-        | _ -> [])
-    | Some "content_block_start" -> (
-        let content_block = member "content_block" json in
-        let block_type = member "type" content_block |> to_string_option in
-        match block_type with
-        | Some "tool_use" ->
-            let name =
-              member "name" content_block
-              |> to_string_option |> Option.value ~default:""
-            in
-            [ Types.Stream_event.Tool_use { name; input = ""; status = None } ]
-        | _ -> [])
-    | Some "assistant" ->
-        let content =
-          match member "message" json |> member "content" with
-          | `List l -> l
-          | _ -> []
-        in
-        List.filter_map content ~f:(fun block ->
-            let block_type = member "type" block |> to_string_option in
-            match block_type with
-            | Some "tool_use" ->
-                let name =
-                  member "name" block |> to_string_option
-                  |> Option.value ~default:""
-                in
-                let input =
-                  match member "input" block with
-                  | `Null -> ""
-                  | v -> Yojson.Safe.to_string v
-                in
-                Some
-                  (Types.Stream_event.Tool_use { name; input; status = None })
-            | Some "text" ->
-                let text =
-                  member "text" block |> to_string_option
-                  |> Option.value ~default:""
-                in
-                Some (Types.Stream_event.Text_delta text)
-            | _ -> None)
-    | Some "message_delta" -> (
-        let delta = member "delta" json in
-        let raw_reason =
-          member "stop_reason" delta |> to_string_option
-          |> Option.value ~default:""
-        in
-        match Types.Stop_reason.of_string raw_reason with
-        | None -> []
-        | Some stop_reason ->
-            [ Types.Stream_event.Final_result { text = ""; stop_reason } ])
-    | Some "result" ->
-        let is_error =
-          member "is_error" json |> to_bool_option
-          |> Option.value ~default:false
-        in
-        let session_init = session_init_of_json json in
-        if is_error then
-          let errors =
-            match member "errors" json with
-            | `List items ->
-                List.filter_map items ~f:(fun item -> to_string_option item)
+  match Yojson.Safe.from_string (find_json_start line) with
+  | exception Yojson.Json_error _ -> []
+  | json -> (
+      let typ = Json.string_field "type" json in
+      match typ with
+      | Some "content_block_delta" -> (
+          match
+            Option.bind (Json.field "delta" json) ~f:(Json.string_field "type")
+          with
+          | Some "text_delta" ->
+              let text =
+                Option.bind (Json.field "delta" json)
+                  ~f:(Json.string_field "text")
+                |> Option.value ~default:""
+              in
+              [ Types.Stream_event.Text_delta text ]
+          | Some _ | None -> [])
+      | Some "content_block_start" -> (
+          let content_block = Json.field "content_block" json in
+          let block_type =
+            Option.bind content_block ~f:(Json.string_field "type")
+          in
+          match block_type with
+          | Some "tool_use" ->
+              let name =
+                Option.bind content_block ~f:(Json.string_field "name")
+                |> Option.value ~default:""
+              in
+              [
+                Types.Stream_event.Tool_use { name; input = ""; status = None };
+              ]
+          | Some _ | None -> [])
+      | Some "assistant" ->
+          let content =
+            match
+              Option.bind (Json.field "message" json) ~f:(Json.field "content")
+            with
+            | Some (`List l) -> l
             | _ -> []
           in
-          let result_text =
-            member "result" json |> to_string_option
-            |> Option.map ~f:(fun text -> String.strip text)
-          in
-          let msg =
-            match errors with
-            | _ :: _ as errs -> String.concat ~sep:"; " errs
-            | [] -> (
-                match result_text with
-                | Some text when not (String.is_empty text) -> text
-                | _ -> "unknown error")
-          in
-          session_init @ [ Types.Stream_event.Error msg ]
-        else
-          let text =
-            member "result" json |> to_string_option |> Option.value ~default:""
-          in
+          List.filter_map content ~f:(fun block ->
+              let block_type = Json.string_field "type" block in
+              match block_type with
+              | Some "tool_use" ->
+                  let name =
+                    Json.string_field "name" block |> Option.value ~default:""
+                  in
+                  let input =
+                    match Json.field "input" block with
+                    | None -> ""
+                    | Some v -> Yojson.Safe.to_string v
+                  in
+                  Some
+                    (Types.Stream_event.Tool_use { name; input; status = None })
+              | Some "text" ->
+                  let text =
+                    Json.string_field "text" block |> Option.value ~default:""
+                  in
+                  Some (Types.Stream_event.Text_delta text)
+              | Some _ | None -> None)
+      | Some "message_delta" -> (
           let raw_reason =
-            member "stop_reason" json |> to_string_option
-            |> Option.value ~default:"end_turn"
+            Option.bind (Json.field "delta" json)
+              ~f:(Json.string_field "stop_reason")
+            |> Option.value ~default:""
           in
-          let stop_reason =
-            Types.Stop_reason.of_string raw_reason
-            |> Option.value ~default:Types.Stop_reason.End_turn
+          match Types.Stop_reason.of_string raw_reason with
+          | None -> []
+          | Some stop_reason ->
+              [ Types.Stream_event.Final_result { text = ""; stop_reason } ])
+      | Some "result" ->
+          let is_error =
+            Json.bool_field "is_error" json |> Option.value ~default:false
           in
-          session_init
-          @ [ Types.Stream_event.Final_result { text; stop_reason } ]
-    | Some "error" ->
-        let err =
-          member "error" json |> member "message" |> to_string_option
-          |> Option.value ~default:"unknown error"
-        in
-        [ Types.Stream_event.Error err ]
-    | Some "system" -> (
-        let subtype = member "subtype" json |> to_string_option in
-        match subtype with Some "init" -> session_init_of_json json | _ -> [])
-    | _ -> []
-  with
-  | Yojson.Json_error _ -> []
-  | Yojson.Safe.Util.Type_error _ -> []
+          let session_init = session_init_of_json json in
+          if is_error then
+            let errors =
+              match Option.bind (Json.field "errors" json) ~f:Json.list with
+              | Some items ->
+                  List.filter_map items ~f:(fun item -> Json.string item)
+              | None -> []
+            in
+            let result_text =
+              Json.string_field "result" json
+              |> Option.map ~f:(fun text -> String.strip text)
+            in
+            let msg =
+              match errors with
+              | _ :: _ as errs -> String.concat ~sep:"; " errs
+              | [] -> (
+                  match result_text with
+                  | Some text when not (String.is_empty text) -> text
+                  | _ -> "unknown error")
+            in
+            session_init @ [ Types.Stream_event.Error msg ]
+          else
+            let text =
+              Json.string_field "result" json |> Option.value ~default:""
+            in
+            let raw_reason =
+              Json.string_field "stop_reason" json
+              |> Option.value ~default:"end_turn"
+            in
+            let stop_reason =
+              Types.Stop_reason.of_string raw_reason
+              |> Option.value ~default:Types.Stop_reason.End_turn
+            in
+            session_init
+            @ [ Types.Stream_event.Final_result { text; stop_reason } ]
+      | Some "error" ->
+          let err =
+            Option.bind (Json.field "error" json)
+              ~f:(Json.string_field "message")
+            |> Option.value ~default:"unknown error"
+          in
+          [ Types.Stream_event.Error err ]
+      | Some "system" -> (
+          let subtype = Json.string_field "subtype" json in
+          match subtype with
+          | Some "init" -> session_init_of_json json
+          | Some _ | None -> [])
+      | Some _ | None -> [])
 
 let parse_stream_event (line : string) : Types.Stream_event.t option =
   match parse_stream_events line with [] -> None | e :: _ -> Some e

--- a/lib_core/codex_cost.ml
+++ b/lib_core/codex_cost.ml
@@ -19,10 +19,7 @@ type usage = { input_tokens : int; output_tokens : int; reasoning_tokens : int }
 [@@deriving show, eq, sexp_of, compare]
 
 let zero_usage = { input_tokens = 0; output_tokens = 0; reasoning_tokens = 0 }
-
-let int_member name json =
-  let open Yojson.Safe.Util in
-  match json with `Assoc _ -> member name json |> to_int_option | _ -> None
+let int_member name json = Json.int_field name json
 
 (* Reasoning tokens are reported under three schemas. In priority order:
    1. nested [output_tokens_details.reasoning_tokens] (OpenAI Responses API
@@ -33,11 +30,8 @@ let int_member name json =
    Take the first that decodes as an int; fall through to zero. *)
 let reasoning_tokens_of_usage usage =
   let from_nested =
-    match usage with
-    | `Assoc _ -> (
-        match Yojson.Safe.Util.member "output_tokens_details" usage with
-        | `Assoc _ as details -> int_member "reasoning_tokens" details
-        | _ -> None)
+    match Json.field "output_tokens_details" usage with
+    | Some (`Assoc _ as details) -> int_member "reasoning_tokens" details
     | _ -> None
   in
   let from_flat = int_member "reasoning_tokens" usage in
@@ -135,9 +129,8 @@ let turn_cost_for_payload ~model json =
   match model_pricing model with
   | None -> 0L
   | Some pricing ->
-      let open Yojson.Safe.Util in
       let usage =
-        match json with `Assoc _ -> member "usage" json | _ -> `Null
+        match Json.field "usage" json with Some u -> u | None -> `Null
       in
       cost_of_usage ~pricing (usage_of_yojson usage)
 

--- a/lib_core/codex_event_parser.ml
+++ b/lib_core/codex_event_parser.ml
@@ -9,93 +9,85 @@ open Base
 
 let parse_event_with_cost_tracking ~model ~budget_cap_nano_usd ~cost_state line
     =
-  try
-    match Yojson.Safe.from_string line with
-    | json -> (
-        let open Yojson.Safe.Util in
-        let typ = member "type" json |> to_string_option in
-        match typ with
-        | Some "item.completed" -> (
-            let item = member "item" json in
-            let item_type = member "type" item |> to_string_option in
-            match item_type with
-            | Some "agent_message" ->
-                let text =
-                  match member "text" item |> to_string_option with
-                  | Some t -> t
-                  | None ->
-                      let parts =
-                        match member "content" item with
-                        | `List l ->
-                            List.filter_map l ~f:(fun block ->
-                                match
-                                  member "type" block |> to_string_option
-                                with
-                                | Some "output_text" ->
-                                    member "text" block |> to_string_option
-                                | _ -> None)
-                        | _ -> []
-                      in
-                      String.concat ~sep:"" parts
-                in
-                let events =
-                  if String.is_empty text then []
-                  else [ Types.Stream_event.Text_delta text ]
-                in
-                (events, cost_state)
-            | Some "command_execution" -> ([], cost_state)
-            | _ -> ([], cost_state))
-        | Some "item.started" -> (
-            let item = member "item" json in
-            let item_type = member "type" item |> to_string_option in
-            match item_type with
-            | Some "command_execution" -> (
-                match member "command" item |> to_string_option with
-                | Some cmd when not (String.is_empty cmd) ->
-                    let input =
-                      Yojson.Safe.to_string
-                        (`Assoc [ ("command", `String cmd) ])
+  match Yojson.Safe.from_string line with
+  | exception Yojson.Json_error _ -> ([], cost_state)
+  | json -> (
+      let typ = Json.string_field "type" json in
+      match typ with
+      | Some "item.completed" -> (
+          let item = Json.field "item" json in
+          let item_type = Option.bind item ~f:(Json.string_field "type") in
+          match item_type with
+          | Some "agent_message" ->
+              let text =
+                match Option.bind item ~f:(Json.string_field "text") with
+                | Some t -> t
+                | None ->
+                    let parts =
+                      match Option.bind item ~f:(Json.field "content") with
+                      | Some (`List l) ->
+                          List.filter_map l ~f:(fun block ->
+                              match Json.string_field "type" block with
+                              | Some "output_text" ->
+                                  Json.string_field "text" block
+                              | _ -> None)
+                      | _ -> []
                     in
-                    ( [
-                        Types.Stream_event.Tool_use
-                          { name = "Bash"; input; status = None };
-                      ],
-                      cost_state )
-                | _ -> ([], cost_state))
-            | _ -> ([], cost_state))
-        | Some "thread.started" -> (
-            match member "thread_id" json |> to_string_option with
-            | Some id when not (String.is_empty id) ->
-                ( [
-                    Types.Stream_event.Session_init
-                      {
-                        session_id = id;
-                        api_key_source = None;
-                        model = None;
-                        claude_code_version = None;
-                        permission_mode = None;
-                      };
-                  ],
-                  cost_state )
-            | _ -> ([], cost_state))
-        | Some "turn.started" ->
-            ([ Types.Stream_event.Turn_started ], cost_state)
-        | Some "turn.completed" ->
-            let { Codex_cost.events; state } =
-              Codex_cost.on_turn_completed ~model ~budget_cap_nano_usd
-                ~state:cost_state json
-            in
-            (events, state)
-        | Some "error" ->
-            let msg =
-              member "message" json |> to_string_option
-              |> Option.value ~default:"unknown codex error"
-            in
-            ([ Types.Stream_event.Error msg ], cost_state)
-        | _ -> ([], cost_state))
-  with
-  | Yojson.Json_error _ -> ([], cost_state)
-  | Yojson.Safe.Util.Type_error _ -> ([], cost_state)
+                    String.concat ~sep:"" parts
+              in
+              let events =
+                if String.is_empty text then []
+                else [ Types.Stream_event.Text_delta text ]
+              in
+              (events, cost_state)
+          | Some "command_execution" -> ([], cost_state)
+          | _ -> ([], cost_state))
+      | Some "item.started" -> (
+          let item = Json.field "item" json in
+          let item_type = Option.bind item ~f:(Json.string_field "type") in
+          match item_type with
+          | Some "command_execution" -> (
+              match Option.bind item ~f:(Json.string_field "command") with
+              | Some cmd when not (String.is_empty cmd) ->
+                  let input =
+                    Yojson.Safe.to_string (`Assoc [ ("command", `String cmd) ])
+                  in
+                  ( [
+                      Types.Stream_event.Tool_use
+                        { name = "Bash"; input; status = None };
+                    ],
+                    cost_state )
+              | _ -> ([], cost_state))
+          | _ -> ([], cost_state))
+      | Some "thread.started" -> (
+          match Json.string_field "thread_id" json with
+          | Some id when not (String.is_empty id) ->
+              ( [
+                  Types.Stream_event.Session_init
+                    {
+                      session_id = id;
+                      api_key_source = None;
+                      model = None;
+                      claude_code_version = None;
+                      permission_mode = None;
+                    };
+                ],
+                cost_state )
+          | _ -> ([], cost_state))
+      | Some "turn.started" -> ([ Types.Stream_event.Turn_started ], cost_state)
+      | Some "turn.completed" ->
+          let { Codex_cost.events; state } =
+            Codex_cost.on_turn_completed ~model ~budget_cap_nano_usd
+              ~state:cost_state json
+          in
+          (events, state)
+      | Some "error" ->
+          let msg =
+            Json.string_field "message" json
+            |> Option.value ~default:"unknown codex error"
+          in
+          ([ Types.Stream_event.Error msg ], cost_state)
+      | _ -> ([], cost_state))
 
 let build_args ~model ~cwd_path ~prompt ~resume_session =
   let model_args =

--- a/lib_core/failure_subkind.ml
+++ b/lib_core/failure_subkind.ml
@@ -20,7 +20,6 @@ type init_info = {
 [@@deriving show, eq]
 
 let t_of_yojson json =
-  let open Yojson.Safe.Util in
   match json with
   | `String "Ok" -> (Ok : t)
   | `String "Auth_unavailable" -> Auth_unavailable
@@ -30,11 +29,7 @@ let t_of_yojson json =
   | `String "Empty_response" -> Empty_response
   | `String "Process_error" -> Process_error
   | `Assoc [ ("Api_error", payload) ] ->
-      let status =
-        match payload with
-        | `Assoc _ -> payload |> member "status" |> to_int_option
-        | _ -> None
-      in
+      let status = Json.int_field "status" payload in
       Api_error { status }
   | `Assoc [ ("Other", `String detail) ] -> Other detail
   | _ -> Other "invalid_failure_subkind"
@@ -57,12 +52,7 @@ let yojson_of_t = function
   | Other detail -> `Assoc [ ("Other", `String detail) ]
 
 let init_info_of_yojson json =
-  let open Yojson.Safe.Util in
-  let read_opt_string field =
-    match member field json with
-    | `Null -> None
-    | value -> to_string_option value
-  in
+  let read_opt_string field = Json.string_field field json in
   {
     api_key_source = read_opt_string "api_key_source";
     model = read_opt_string "model";

--- a/lib_core/gameplan_parser.ml
+++ b/lib_core/gameplan_parser.ml
@@ -235,16 +235,35 @@ let patch_id_of_json = function
   | `String s when is_valid_patch_id s -> Some (Types.Patch_id.of_string s)
   | _ -> None
 
+(* Local structural-error exception. Replaces the deliberate partial-accessor
+   exceptions the parser previously used to abort and convert into an [Error];
+   [parse_json_string] catches it at the same boundary and produces the same
+   "JSON structure error" message. *)
+exception Parse_error of string
+
+(* [member key json] with the legacy [member] semantics: absent keys (and
+   explicit [`Null]) collapse to [`Null], so downstream matches on
+   [`Null]/[`List]/[`String] are preserved verbatim. *)
+let member key json = Option.value (Json.field key json) ~default:`Null
+
+(* Required string accessor mirroring the legacy [to_string]: raises on a
+   non-string so the surrounding [try]/[Parse_error] turns it into an [Error]. *)
+let to_string = function
+  | `String s -> s
+  | _ -> raise (Parse_error "expected a string")
+
+let to_list = function
+  | `List items -> items
+  | _ -> raise (Parse_error "expected an array")
+
 let json_string_list json key =
-  let open Yojson.Safe.Util in
-  match json |> member key with
+  match member key json with
   | `List items ->
       List.filter_map items ~f:(function `String s -> Some s | _ -> None)
   | _ -> []
 
 let json_required_string_list json key =
-  let open Yojson.Safe.Util in
-  match json |> member key with
+  match member key json with
   | `Null -> []
   | `List items ->
       List.map items ~f:(fun item ->
@@ -252,15 +271,13 @@ let json_required_string_list json key =
           | `String s -> s
           | _ ->
               raise
-                (Type_error
-                   (Printf.sprintf "%s[] must contain only strings" key, item)))
-  | value ->
-      raise
-        (Type_error (Printf.sprintf "%s must be an array of strings" key, value))
+                (Parse_error
+                   (Printf.sprintf "%s[] must contain only strings" key)))
+  | _ ->
+      raise (Parse_error (Printf.sprintf "%s must be an array of strings" key))
 
 let json_patch_id_list json key =
-  let open Yojson.Safe.Util in
-  match json |> member key with
+  match member key json with
   | `Null -> []
   | `List items ->
       List.map items ~f:(fun item ->
@@ -268,32 +285,28 @@ let json_patch_id_list json key =
           | Some id -> id
           | None ->
               raise
-                (Type_error
-                   (Printf.sprintf "%s[] must contain only patch IDs" key, item)))
-  | value ->
+                (Parse_error
+                   (Printf.sprintf "%s[] must contain only patch IDs" key)))
+  | _ ->
       raise
-        (Type_error
-           (Printf.sprintf "%s must be an array of patch IDs" key, value))
+        (Parse_error (Printf.sprintf "%s must be an array of patch IDs" key))
 
 let json_precedents json =
-  let open Yojson.Safe.Util in
-  match json |> member "precedents" with
+  match member "precedents" json with
   | `List items ->
       List.filter_map items ~f:(fun obj ->
-          match obj |> member "kind" with
+          match member "kind" obj with
           | `String kind when not (String.is_empty kind) ->
               let name =
-                match obj |> member "name" with `String s -> s | _ -> ""
+                match member "name" obj with `String s -> s | _ -> ""
               in
               let url =
-                match obj |> member "url" with
+                match member "url" obj with
                 | `String s when not (String.is_empty s) -> Some s
                 | _ -> None
               in
               let why_applicable =
-                match obj |> member "whyApplicable" with
-                | `String s -> s
-                | _ -> ""
+                match member "whyApplicable" obj with `String s -> s | _ -> ""
               in
               if String.is_empty name then None
               else Some { Types.Precedent.kind; name; url; why_applicable }
@@ -301,21 +314,17 @@ let json_precedents json =
   | _ -> []
 
 let parse_json_string input =
-  match
-    try Ok (Yojson.Safe.from_string input)
-    with Yojson.Json_error msg ->
+  match Yojson.Safe.from_string input with
+  | exception Yojson.Json_error msg ->
       Error (Printf.sprintf "JSON parse error: %s" msg)
-  with
-  | Error msg -> Error msg
-  | Ok json -> (
-      let open Yojson.Safe.Util in
+  | json -> (
       try
-        let project_name = json |> member "projectName" |> to_string in
+        let project_name = member "projectName" json |> to_string in
         let optional_string key =
-          match json |> member key with
+          match member key json with
           | `String s -> Base.String.strip s
           | `Null -> ""
-          | _ -> raise (Type_error (key ^ " must be a string", json))
+          | _ -> raise (Parse_error (key ^ " must be a string"))
         in
         (* [repo_owner] and [repo_name] are forge-agnostic at this layer —
            we only enforce non-empty when present (empty strings are normalised
@@ -374,33 +383,29 @@ let parse_json_string input =
                     | `String s -> s
                     | _ ->
                         raise
-                          (Type_error
-                             ("functionalChanges[].id must be a string", obj))
+                          (Parse_error "functionalChanges[].id must be a string")
                   in
                   let description =
                     match obj |> member "description" with
                     | `String s -> s
                     | _ ->
                         raise
-                          (Type_error
-                             ( "functionalChanges[].description must be a string",
-                               obj ))
+                          (Parse_error
+                             "functionalChanges[].description must be a string")
                   in
                   let owned_by =
                     match patch_id_of_json (obj |> member "ownedBy") with
                     | Some id -> id
                     | None ->
                         raise
-                          (Type_error
-                             ( "functionalChanges[].ownedBy must be an integer \
-                                or alphanumeric patch id",
-                               obj ))
+                          (Parse_error
+                             "functionalChanges[].ownedBy must be an integer \
+                              or alphanumeric patch id")
                   in
                   { Types.Functional_change.id; description; owned_by })
           | _ ->
               raise
-                (Type_error
-                   ("functionalChanges must be an array of objects", json))
+                (Parse_error "functionalChanges must be an array of objects")
         in
         let context_resources =
           match json |> member "contextResources" with
@@ -412,16 +417,15 @@ let parse_json_string input =
                     | `String s -> String.strip s
                     | _ ->
                         raise
-                          (Type_error
-                             ("contextResources[].id must be a string", obj))
+                          (Parse_error "contextResources[].id must be a string")
                   in
                   let kind =
                     match obj |> member "kind" with
                     | `String s -> s
                     | _ ->
                         raise
-                          (Type_error
-                             ("contextResources[].kind must be a string", obj))
+                          (Parse_error
+                             "contextResources[].kind must be a string")
                   in
                   let paths = json_string_list obj "paths" in
                   let why =
@@ -430,9 +434,7 @@ let parse_json_string input =
                   let consumed_by = json_patch_id_list obj "consumedBy" in
                   { Types.Context_resource.id; kind; paths; why; consumed_by })
           | _ ->
-              raise
-                (Type_error
-                   ("contextResources must be an array of objects", json))
+              raise (Parse_error "contextResources must be an array of objects")
         in
         let open_questions =
           match json |> member "openQuestions" with
@@ -443,13 +445,10 @@ let parse_json_string input =
                   | `String s -> s
                   | _ ->
                       raise
-                        (Type_error
-                           ( Printf.sprintf "openQuestions[%d] must be a string"
-                               i,
-                             json )))
-          | _ ->
-              raise
-                (Type_error ("openQuestions must be an array of strings", json))
+                        (Parse_error
+                           (Printf.sprintf "openQuestions[%d] must be a string"
+                              i)))
+          | _ -> raise (Parse_error "openQuestions must be an array of strings")
         in
         (* Dependency graph: {patch, classification, dependsOn[]} format *)
         let dep_graph =
@@ -463,10 +462,9 @@ let parse_json_string input =
                     | Some id -> id
                     | None ->
                         raise
-                          (Type_error
-                             ( "dependencyGraph[].patch must be an integer or \
-                                alphanumeric string",
-                               entry ))
+                          (Parse_error
+                             "dependencyGraph[].patch must be an integer or \
+                              alphanumeric string")
                   in
                   let depends_on =
                     match entry |> member "dependsOn" with
@@ -485,10 +483,9 @@ let parse_json_string input =
                 | Some id -> (id, Types.Patch_id.to_string id)
                 | None ->
                     raise
-                      (Type_error
-                         ( "patches[].number must be an integer or \
-                            alphanumeric string",
-                           p ))
+                      (Parse_error
+                         "patches[].number must be an integer or alphanumeric \
+                          string")
               in
               let title = p |> member "title" |> to_string in
               let changes = json_string_list p "changes" in
@@ -611,7 +608,7 @@ let parse_json_string input =
                               };
                             dependency_graph = dep_graph;
                           })))
-      with Type_error (msg, _) ->
+      with Parse_error msg ->
         Error (Printf.sprintf "JSON structure error: %s" msg))
 
 let read_file path =

--- a/lib_core/gemini_event_parser.ml
+++ b/lib_core/gemini_event_parser.ml
@@ -21,75 +21,69 @@ let build_args ~model ~prompt ~resume_session =
   base @ model_args @ resume_args
 
 let parse_event (line : string) : Types.Stream_event.t list =
-  try
-    match Yojson.Safe.from_string line with
-    | json -> (
-        let open Yojson.Safe.Util in
-        let typ = member "type" json |> to_string_option in
-        match typ with
-        | Some "init" -> (
-            match member "session_id" json |> to_string_option with
-            | Some id when not (String.is_empty id) ->
-                [
-                  Types.Stream_event.Session_init
-                    {
-                      session_id = id;
-                      api_key_source = None;
-                      model = None;
-                      claude_code_version = None;
-                      permission_mode = None;
-                    };
-                ]
-            | _ -> [])
-        | Some "message" -> (
-            let role = member "role" json |> to_string_option in
-            match role with
-            | Some "assistant" ->
-                let text =
-                  member "content" json |> to_string_option
-                  |> Option.value ~default:""
-                in
-                if String.is_empty text then []
-                else [ Types.Stream_event.Text_delta text ]
-            | _ -> [])
-        | Some "tool_use" ->
-            let name =
-              member "tool_name" json |> to_string_option
-              |> Option.value ~default:""
-            in
-            let input =
-              match member "parameters" json with
-              | `Null -> ""
-              | v -> Yojson.Safe.to_string v
-            in
-            [ Types.Stream_event.Tool_use { name; input; status = None } ]
-        | Some "result" -> (
-            let status = member "status" json |> to_string_option in
-            match status with
-            | Some "success" ->
-                [
-                  Types.Stream_event.Final_result
-                    { text = ""; stop_reason = Types.Stop_reason.End_turn };
-                ]
-            | Some other ->
-                let detail =
-                  match member "message" json |> to_string_option with
-                  | Some m when not (String.is_empty m) ->
-                      Printf.sprintf "gemini %s: %s" other m
-                  | _ -> Printf.sprintf "gemini %s" other
-                in
-                [ Types.Stream_event.Error detail ]
-            | None -> [])
-        | Some "error" ->
-            let msg =
-              member "message" json |> to_string_option
-              |> Option.value ~default:"unknown gemini error"
-            in
-            [ Types.Stream_event.Error msg ]
-        | _ -> [])
-  with
-  | Yojson.Json_error _ -> []
-  | Yojson.Safe.Util.Type_error _ -> []
+  match Yojson.Safe.from_string line with
+  | exception Yojson.Json_error _ -> []
+  | json -> (
+      let typ = Json.string_field "type" json in
+      match typ with
+      | Some "init" -> (
+          match Json.string_field "session_id" json with
+          | Some id when not (String.is_empty id) ->
+              [
+                Types.Stream_event.Session_init
+                  {
+                    session_id = id;
+                    api_key_source = None;
+                    model = None;
+                    claude_code_version = None;
+                    permission_mode = None;
+                  };
+              ]
+          | _ -> [])
+      | Some "message" -> (
+          let role = Json.string_field "role" json in
+          match role with
+          | Some "assistant" ->
+              let text =
+                Json.string_field "content" json |> Option.value ~default:""
+              in
+              if String.is_empty text then []
+              else [ Types.Stream_event.Text_delta text ]
+          | _ -> [])
+      | Some "tool_use" ->
+          let name =
+            Json.string_field "tool_name" json |> Option.value ~default:""
+          in
+          let input =
+            match Json.field "parameters" json with
+            | None -> ""
+            | Some v -> Yojson.Safe.to_string v
+          in
+          [ Types.Stream_event.Tool_use { name; input; status = None } ]
+      | Some "result" -> (
+          let status = Json.string_field "status" json in
+          match status with
+          | Some "success" ->
+              [
+                Types.Stream_event.Final_result
+                  { text = ""; stop_reason = Types.Stop_reason.End_turn };
+              ]
+          | Some other ->
+              let detail =
+                match Json.string_field "message" json with
+                | Some m when not (String.is_empty m) ->
+                    Printf.sprintf "gemini %s: %s" other m
+                | _ -> Printf.sprintf "gemini %s" other
+              in
+              [ Types.Stream_event.Error detail ]
+          | None -> [])
+      | Some "error" ->
+          let msg =
+            Json.string_field "message" json
+            |> Option.value ~default:"unknown gemini error"
+          in
+          [ Types.Stream_event.Error msg ]
+      | _ -> [])
 
 let auto_model ~complexity =
   match complexity with

--- a/lib_core/opencode_event_parser.ml
+++ b/lib_core/opencode_event_parser.ml
@@ -46,74 +46,70 @@ let normalize_input_json ~tool (json : Yojson.Safe.t) : Yojson.Safe.t =
   | _ -> json
 
 let parse_event (line : string) : Types.Stream_event.t list =
-  try
-    match Yojson.Safe.from_string line with
-    | json -> (
-        let open Yojson.Safe.Util in
-        let typ = member "type" json |> to_string_option in
-        match typ with
-        | Some "step_start" -> (
-            match member "sessionID" json |> to_string_option with
-            | Some id when not (String.is_empty id) ->
-                [
-                  Types.Stream_event.Turn_started;
-                  Types.Stream_event.Session_init
-                    {
-                      session_id = id;
-                      api_key_source = None;
-                      model = None;
-                      claude_code_version = None;
-                      permission_mode = None;
-                    };
-                ]
-            | _ -> [])
-        | Some "text" ->
-            let part = member "part" json in
-            let text =
-              member "text" part |> to_string_option |> Option.value ~default:""
-            in
-            if String.is_empty text then []
-            else [ Types.Stream_event.Text_delta text ]
-        | Some "tool_use" ->
-            let part = member "part" json in
-            let raw_tool =
-              member "tool" part |> to_string_option |> Option.value ~default:""
-            in
-            let state = member "state" part in
-            let input =
-              match member "input" state with
-              | `Null -> ""
-              | v ->
-                  Yojson.Safe.to_string (normalize_input_json ~tool:raw_tool v)
-            in
-            let status = member "status" state |> to_string_option in
-            [
-              Types.Stream_event.Tool_use
-                { name = normalize_tool_name raw_tool; input; status };
-            ]
-        | Some "step_finish" -> (
-            let part = member "part" json in
-            let reason =
-              member "reason" part |> to_string_option
-              |> Option.value ~default:""
-            in
-            match reason with
-            | "stop" ->
-                [
-                  Types.Stream_event.Final_result
-                    { text = ""; stop_reason = Types.Stop_reason.End_turn };
-                ]
-            | _ -> [])
-        | Some "error" ->
-            let msg =
-              member "message" json |> to_string_option
-              |> Option.value ~default:"unknown opencode error"
-            in
-            [ Types.Stream_event.Error msg ]
-        | _ -> [])
-  with
-  | Yojson.Json_error _ -> []
-  | Yojson.Safe.Util.Type_error _ -> []
+  match Yojson.Safe.from_string line with
+  | exception Yojson.Json_error _ -> []
+  | json -> (
+      let typ = Json.string_field "type" json in
+      match typ with
+      | Some "step_start" -> (
+          match Json.string_field "sessionID" json with
+          | Some id when not (String.is_empty id) ->
+              [
+                Types.Stream_event.Turn_started;
+                Types.Stream_event.Session_init
+                  {
+                    session_id = id;
+                    api_key_source = None;
+                    model = None;
+                    claude_code_version = None;
+                    permission_mode = None;
+                  };
+              ]
+          | _ -> [])
+      | Some "text" ->
+          let text =
+            Option.bind (Json.field "part" json) ~f:(Json.string_field "text")
+            |> Option.value ~default:""
+          in
+          if String.is_empty text then []
+          else [ Types.Stream_event.Text_delta text ]
+      | Some "tool_use" ->
+          let part = Json.field "part" json in
+          let raw_tool =
+            Option.bind part ~f:(Json.string_field "tool")
+            |> Option.value ~default:""
+          in
+          let state = Option.bind part ~f:(Json.field "state") in
+          let input =
+            match Option.bind state ~f:(Json.field "input") with
+            | None -> ""
+            | Some v ->
+                Yojson.Safe.to_string (normalize_input_json ~tool:raw_tool v)
+          in
+          let status = Option.bind state ~f:(Json.string_field "status") in
+          [
+            Types.Stream_event.Tool_use
+              { name = normalize_tool_name raw_tool; input; status };
+          ]
+      | Some "step_finish" -> (
+          let reason =
+            Option.bind (Json.field "part" json) ~f:(Json.string_field "reason")
+            |> Option.value ~default:""
+          in
+          match reason with
+          | "stop" ->
+              [
+                Types.Stream_event.Final_result
+                  { text = ""; stop_reason = Types.Stop_reason.End_turn };
+              ]
+          | _ -> [])
+      | Some "error" ->
+          let msg =
+            Json.string_field "message" json
+            |> Option.value ~default:"unknown opencode error"
+          in
+          [ Types.Stream_event.Error msg ]
+      | _ -> [])
 
 let auto_model ~complexity =
   match complexity with

--- a/lib_core/patch_pr_status.ml
+++ b/lib_core/patch_pr_status.ml
@@ -68,15 +68,9 @@ let yojson_of_t = function
 
 let t_of_yojson_compat (json : Yojson.Safe.t) : (t, string) Result.t =
   let decode_pr_number v =
-    try Ok (Pr_number.t_of_yojson v) with
-    | Ppx_yojson_conv_lib.Yojson_conv.Of_yojson_error (exn, _) ->
-        Error (Stdlib.Printexc.to_string exn)
-    | Yojson.Safe.Util.Type_error (msg, _) ->
-        Error (Printf.sprintf "malformed pr_number: %s" msg)
-    | exn ->
-        Error
-          (Printf.sprintf "malformed pr_number: %s"
-             (Stdlib.Printexc.to_string exn))
+    match Json.try_of_yojson Pr_number.t_of_yojson v with
+    | Ok _ as ok -> ok
+    | Error msg -> Error (Printf.sprintf "malformed pr_number: %s" msg)
   in
   match json with
   | `Null ->

--- a/lib_core/pi_event_parser.ml
+++ b/lib_core/pi_event_parser.ml
@@ -20,45 +20,41 @@ let build_args ~model ~cwd_path ~patch_id ~prompt ~resume_session =
   base @ model_args @ resume_args @ session_args
 
 let parse_event (line : string) : Types.Stream_event.t list =
-  try
-    match Yojson.Safe.from_string line with
-    | json -> (
-        let open Yojson.Safe.Util in
-        let typ = member "type" json |> to_string_option in
-        match typ with
-        | Some "message_update" -> (
-            let evt = member "assistantMessageEvent" json in
-            let evt_type = member "type" evt |> to_string_option in
-            match evt_type with
-            | Some "text_delta" ->
-                let delta =
-                  member "delta" evt |> to_string_option
-                  |> Option.value ~default:""
-                in
-                if String.is_empty delta then []
-                else [ Types.Stream_event.Text_delta delta ]
-            | Some "toolcall_end" ->
-                let tool_call = member "toolCall" evt in
-                let name =
-                  member "name" tool_call |> to_string_option
-                  |> Option.value ~default:""
-                in
-                let input =
-                  match member "arguments" tool_call with
-                  | `Null -> ""
-                  | v -> Yojson.Safe.to_string v
-                in
-                [ Types.Stream_event.Tool_use { name; input; status = None } ]
-            | _ -> [])
-        | Some "agent_end" ->
-            [
-              Types.Stream_event.Final_result
-                { text = ""; stop_reason = Types.Stop_reason.End_turn };
-            ]
-        | _ -> [])
-  with
-  | Yojson.Json_error _ -> []
-  | Yojson.Safe.Util.Type_error _ -> []
+  match Yojson.Safe.from_string line with
+  | exception Yojson.Json_error _ -> []
+  | json -> (
+      let typ = Json.string_field "type" json in
+      match typ with
+      | Some "message_update" -> (
+          let evt = Json.field "assistantMessageEvent" json in
+          let evt_type = Option.bind evt ~f:(Json.string_field "type") in
+          match evt_type with
+          | Some "text_delta" ->
+              let delta =
+                Option.bind evt ~f:(Json.string_field "delta")
+                |> Option.value ~default:""
+              in
+              if String.is_empty delta then []
+              else [ Types.Stream_event.Text_delta delta ]
+          | Some "toolcall_end" ->
+              let tool_call = Option.bind evt ~f:(Json.field "toolCall") in
+              let name =
+                Option.bind tool_call ~f:(Json.string_field "name")
+                |> Option.value ~default:""
+              in
+              let input =
+                match Option.bind tool_call ~f:(Json.field "arguments") with
+                | None -> ""
+                | Some v -> Yojson.Safe.to_string v
+              in
+              [ Types.Stream_event.Tool_use { name; input; status = None } ]
+          | _ -> [])
+      | Some "agent_end" ->
+          [
+            Types.Stream_event.Final_result
+              { text = ""; stop_reason = Types.Stop_reason.End_turn };
+          ]
+      | _ -> [])
 
 let auto_model ~complexity =
   ignore complexity;

--- a/lib_core/repo_config.ml
+++ b/lib_core/repo_config.ml
@@ -21,24 +21,23 @@ let config_path ~config_dir = Stdlib.Filename.concat config_dir "config.json"
 
 let parse_route ~known_backends ~complexity (json : Yojson.Safe.t) :
     (route, string) Result.t =
-  let open Yojson.Safe.Util in
   match json with
   | `Assoc _ ->
       let backend_result =
-        match member "backend" json with
-        | `Null -> Ok None
-        | `String s when String.is_empty (String.strip s) -> Ok None
-        | `String s -> Ok (Some (String.strip s))
-        | _ ->
+        match Json.field "backend" json with
+        | None -> Ok None
+        | Some (`String s) when String.is_empty (String.strip s) -> Ok None
+        | Some (`String s) -> Ok (Some (String.strip s))
+        | Some _ ->
             Error
               (Printf.sprintf "routing.%d.backend must be a string" complexity)
       in
       let model_result =
-        match member "model" json with
-        | `Null -> Ok None
-        | `String s when String.is_empty (String.strip s) -> Ok None
-        | `String s -> Ok (Some (String.strip s))
-        | _ ->
+        match Json.field "model" json with
+        | None -> Ok None
+        | Some (`String s) when String.is_empty (String.strip s) -> Ok None
+        | Some (`String s) -> Ok (Some (String.strip s))
+        | Some _ ->
             Error
               (Printf.sprintf "routing.%d.model must be a string when present"
                  complexity)
@@ -101,15 +100,14 @@ let default_known_review_kinds = [ "review-service" ]
 
 let parse_default ~known_backends (json : Yojson.Safe.t) :
     (string option * string option, string) Result.t =
-  let open Yojson.Safe.Util in
   match json with
   | `Null -> Ok (None, None)
   | `Assoc _ ->
       let backend_result =
-        match member "backend" json with
-        | `Null -> Ok None
-        | `String s when String.is_empty (String.strip s) -> Ok None
-        | `String s ->
+        match Json.field "backend" json with
+        | None -> Ok None
+        | Some (`String s) when String.is_empty (String.strip s) -> Ok None
+        | Some (`String s) ->
             let name = String.strip s in
             if List.mem known_backends name ~equal:String.equal then
               Ok (Some name)
@@ -120,14 +118,14 @@ let parse_default ~known_backends (json : Yojson.Safe.t) :
                     of: %s)"
                    name
                    (String.concat ~sep:", " known_backends))
-        | _ -> Error "default.backend must be a string"
+        | Some _ -> Error "default.backend must be a string"
       in
       let model_result =
-        match member "model" json with
-        | `Null -> Ok None
-        | `String s when String.is_empty (String.strip s) -> Ok None
-        | `String s -> Ok (Some (String.strip s))
-        | _ -> Error "default.model must be a string when present"
+        match Json.field "model" json with
+        | None -> Ok None
+        | Some (`String s) when String.is_empty (String.strip s) -> Ok None
+        | Some (`String s) -> Ok (Some (String.strip s))
+        | Some _ -> Error "default.model must be a string when present"
       in
       Result.bind backend_result ~f:(fun b ->
           Result.map model_result ~f:(fun m -> (b, m)))
@@ -136,18 +134,21 @@ let parse_default ~known_backends (json : Yojson.Safe.t) :
 let parse_string ~known_backends
     ?(known_review_kinds = default_known_review_kinds) (raw : string) :
     (t, string) Result.t =
-  match
-    try Ok (Yojson.Safe.from_string raw)
-    with Yojson.Json_error msg -> Error (Printf.sprintf "config.json: %s" msg)
-  with
-  | Error _ as e -> e
-  | Ok json -> (
-      let open Yojson.Safe.Util in
+  match Yojson.Safe.from_string raw with
+  | exception Yojson.Json_error msg ->
+      Error (Printf.sprintf "config.json: %s" msg)
+  | json -> (
       match json with
       | `Assoc _ ->
-          let default_json = member "default" json in
-          let routing = member "routing" json in
-          let review_backends_json = member "reviewBackends" json in
+          let default_json =
+            Option.value (Json.field "default" json) ~default:`Null
+          in
+          let routing =
+            Option.value (Json.field "routing" json) ~default:`Null
+          in
+          let review_backends_json =
+            Option.value (Json.field "reviewBackends" json) ~default:`Null
+          in
           Result.bind (parse_default ~known_backends default_json)
             ~f:(fun (default_backend, default_model) ->
               Result.bind (parse_routing ~known_backends routing)

--- a/lib_core/review_backend.ml
+++ b/lib_core/review_backend.ml
@@ -10,12 +10,13 @@ type t = { name : string; kind : kind }
 let known_kind_default = [ "review-service" ]
 
 let string_field field json : (string, string) Result.t =
-  let open Yojson.Safe.Util in
-  match json |> member field with
-  | `String s when not (String.is_empty (String.strip s)) -> Ok (String.strip s)
-  | `String _ -> Error (Printf.sprintf "%S must be a non-empty string" field)
-  | `Null -> Error (Printf.sprintf "missing required field %S" field)
-  | _ -> Error (Printf.sprintf "%S must be a string" field)
+  match Json.field field json with
+  | Some (`String s) when not (String.is_empty (String.strip s)) ->
+      Ok (String.strip s)
+  | Some (`String _) ->
+      Error (Printf.sprintf "%S must be a non-empty string" field)
+  | None -> Error (Printf.sprintf "missing required field %S" field)
+  | Some _ -> Error (Printf.sprintf "%S must be a string" field)
 
 let strip_trailing_slashes s =
   let len = String.length s in
@@ -47,7 +48,6 @@ let has_authority base_url =
            ~f:(fun c -> not (Char.equal c ':'))
 
 let parse_review_service_kind json : (kind, string) Result.t =
-  let open Yojson.Safe.Util in
   let ( let* ) = Result.( >>= ) in
   let* base_url = string_field "baseUrl" json in
   let base_url = strip_trailing_slashes base_url in
@@ -60,12 +60,11 @@ let parse_review_service_kind json : (kind, string) Result.t =
       Error "review-service \"baseUrl\" must use https"
     else Ok ()
   in
-  let auth_json = json |> member "auth" in
-  let* () =
-    match auth_json with
-    | `Assoc _ -> Ok ()
-    | `Null -> Error "review-service backend missing required field \"auth\""
-    | _ -> Error "review-service \"auth\" must be an object"
+  let* auth_json =
+    match Json.field "auth" json with
+    | Some (`Assoc _ as auth_json) -> Ok auth_json
+    | None -> Error "review-service backend missing required field \"auth\""
+    | Some _ -> Error "review-service \"auth\" must be an object"
   in
   let* app_id = string_field "appId" auth_json in
   let* private_key_path = string_field "privateKeyPath" auth_json in

--- a/lib_core/review_service.ml
+++ b/lib_core/review_service.ml
@@ -90,65 +90,68 @@ let string_opt = function
   | _ -> None
 
 let int_opt = function `Null -> None | `Int n -> Some n | _ -> None
+let member_opt field json = Json.field field json
 
 let require_string field json =
-  let open Yojson.Safe.Util in
-  match json |> member field with
-  | `String s -> Ok s
-  | `Null -> Error (Printf.sprintf "missing required field %S" field)
-  | _ -> Error (Printf.sprintf "field %S must be a string" field)
+  match member_opt field json with
+  | Some (`String s) -> Ok s
+  | None -> Error (Printf.sprintf "missing required field %S" field)
+  | Some _ -> Error (Printf.sprintf "field %S must be a string" field)
 
 let require_int field json =
-  let open Yojson.Safe.Util in
-  match json |> member field with
-  | `Int n -> Ok n
-  | `Null -> Error (Printf.sprintf "missing required field %S" field)
-  | _ -> Error (Printf.sprintf "field %S must be an integer" field)
+  match member_opt field json with
+  | Some (`Int n) -> Ok n
+  | None -> Error (Printf.sprintf "missing required field %S" field)
+  | Some _ -> Error (Printf.sprintf "field %S must be an integer" field)
+
+let string_field_opt field json =
+  match member_opt field json with Some v -> string_opt v | None -> None
+
+let int_field_opt field json =
+  match member_opt field json with Some v -> int_opt v | None -> None
 
 let parse_last_reply json : last_reply option =
-  let open Yojson.Safe.Util in
   match json with
-  | `Null -> None
   | `Assoc _ ->
-      let author = json |> member "author" |> string_opt in
-      let at = json |> member "at" |> string_opt in
-      let body = json |> member "body" |> string_opt in
+      let author = string_field_opt "author" json in
+      let at = string_field_opt "at" json in
+      let body = string_field_opt "body" json in
       (* All three required for a meaningful reply; any missing means we skip. *)
       Option.map3 author at body ~f:(fun author at body -> { author; at; body })
   | _ -> None
 
 let parse_outcome json : (outcome, string) Result.t =
-  let open Yojson.Safe.Util in
   match json with
   | `Null -> Error "outcome is null"
   | `Assoc _ -> (
-      let kind_str =
-        json |> member "kind" |> string_opt |> Option.value ~default:""
-      in
+      let kind_str = string_field_opt "kind" json |> Option.value ~default:"" in
       match outcome_kind_of_string kind_str with
       | None ->
           Error (Printf.sprintf "outcome.kind is not a known kind: %S" kind_str)
       | Some kind ->
-          let detected_at = json |> member "detectedAt" |> string_opt in
-          let actor = json |> member "actor" |> string_opt in
-          let reason = json |> member "reason" |> string_opt in
-          let last_reply = parse_last_reply (json |> member "lastReply") in
+          let detected_at = string_field_opt "detectedAt" json in
+          let actor = string_field_opt "actor" json in
+          let reason = string_field_opt "reason" json in
+          let last_reply =
+            match Json.field "lastReply" json with
+            | Some lr -> parse_last_reply lr
+            | None -> None
+          in
           Ok { kind; detected_at; actor; reason; last_reply })
   | _ -> Error "outcome must be an object"
 
 let parse_finding json : (finding, string) Result.t =
-  let open Yojson.Safe.Util in
   let ( let* ) = Result.( >>= ) in
   match json with
   | `Assoc _ ->
       let* id = require_string "id" json in
-      let github_comment_id = json |> member "githubCommentId" |> int_opt in
+      let github_comment_id = int_field_opt "githubCommentId" json in
       let* posting_sha = require_string "postingSha" json in
       let* path = require_string "path" json in
       let* start_line = require_int "startLine" json in
       let* end_line = require_int "endLine" json in
       let severity_str =
-        json |> member "severity" |> string_opt |> Option.value ~default:""
+        string_field_opt "severity" json |> Option.value ~default:""
       in
       let* severity =
         match severity_of_string severity_str with
@@ -157,7 +160,9 @@ let parse_finding json : (finding, string) Result.t =
       in
       let* body = require_string "body" json in
       let* created_at = require_string "createdAt" json in
-      let* outcome = parse_outcome (json |> member "outcome") in
+      let* outcome =
+        parse_outcome (Option.value (Json.field "outcome" json) ~default:`Null)
+      in
       Ok
         {
           id;
@@ -174,18 +179,17 @@ let parse_finding json : (finding, string) Result.t =
   | _ -> Error "finding must be an object"
 
 let parse_findings_response json : (findings_response, string) Result.t =
-  let open Yojson.Safe.Util in
   let ( let* ) = Result.( >>= ) in
   match json with
   | `Assoc _ ->
       let* repo_id = require_string "repoId" json in
       let* pull_number = require_int "pullNumber" json in
       let raw_findings =
-        match json |> member "findings" with `List xs -> xs | _ -> []
+        match Json.field "findings" json with Some (`List xs) -> xs | _ -> []
       in
       let count =
-        match json |> member "count" with
-        | `Int n -> n
+        match Json.field "count" json with
+        | Some (`Int n) -> n
         | _ -> List.length raw_findings
       in
       (* Drop entries that fail to parse rather than failing the whole response,
@@ -216,12 +220,13 @@ type resolve_response = { id : string; outcome : outcome }
 [@@deriving show, eq, sexp_of, compare]
 
 let parse_resolve_response json : (resolve_response, string) Result.t =
-  let open Yojson.Safe.Util in
   let ( let* ) = Result.( >>= ) in
   match json with
   | `Assoc _ ->
       let* id = require_string "id" json in
-      let* outcome = parse_outcome (json |> member "outcome") in
+      let* outcome =
+        parse_outcome (Option.value (Json.field "outcome" json) ~default:`Null)
+      in
       Ok { id; outcome }
   | _ -> Error "resolve response must be an object"
 
@@ -278,15 +283,17 @@ let parse_wontfix_artifact body : (wontfix_entry list, string) Result.t =
     | exception Yojson.Json_error msg ->
         Error (Printf.sprintf "wontfix artifact: %s" msg)
     | `List entries ->
+        let field_nonblank field entry =
+          match Json.field field entry with
+          | Some v -> nonblank_string_opt v
+          | None -> None
+        in
         let parsed =
           List.filter_map entries ~f:(fun entry ->
-              let open Yojson.Safe.Util in
               match entry with
               | `Assoc _ ->
-                  let id = entry |> member "id" |> nonblank_string_opt in
-                  let reason =
-                    entry |> member "reason" |> nonblank_string_opt
-                  in
+                  let id = field_nonblank "id" entry in
+                  let reason = field_nonblank "reason" entry in
                   Option.map2 id reason ~f:(fun id reason -> { id; reason })
               | _ -> None)
         in

--- a/scripts/yojson-util-allowlist.txt
+++ b/scripts/yojson-util-allowlist.txt
@@ -11,19 +11,3 @@
 # #-comments are ignored.
 
 lib_core/json.ml
-
-# --- pending migration (remove each line as its module is converted) ---
-lib/persistence.ml
-lib/session_driver.ml
-lib_core/claude_event_parser.ml
-lib_core/codex_cost.ml
-lib_core/codex_event_parser.ml
-lib_core/failure_subkind.ml
-lib_core/gameplan_parser.ml
-lib_core/gemini_event_parser.ml
-lib_core/opencode_event_parser.ml
-lib_core/patch_pr_status.ml
-lib_core/pi_event_parser.ml
-lib_core/repo_config.ml
-lib_core/review_backend.ml
-lib_core/review_service.ml

--- a/scripts/yojson-util-allowlist.txt
+++ b/scripts/yojson-util-allowlist.txt
@@ -13,7 +13,6 @@
 lib_core/json.ml
 
 # --- pending migration (remove each line as its module is converted) ---
-lib/github.ml
 lib/persistence.ml
 lib/session_driver.ml
 lib_core/claude_event_parser.ml


### PR DESCRIPTION
Completes the JSON-hardening plan begun in #334 (which added `Onton_core.Json` + the ratcheting `Yojson.Safe.Util` ban). This PR migrates **every** remaining partial-accessor call site, taking the allowlist down to only `lib_core/json.ml` — so the CI `lint-yojson` job now guarantees no `member`/`to_*` raise can be reintroduced.

Rebased onto `main` after #334 merged.

## A.2 — `lib/github.ml` typed records (the surface that caused #333)

`parse_response_json` is rewritten with `ppx_yojson_conv` record types (`pull_request`, `commits`/`commit_node`, `status_check_rollup`/`contexts`/`context_node`, `review_thread`/`comment_node`, `oid_obj`, `repo_owner`, `repository`/`data`/`response`) decoded via `Json.try_of_yojson`, with pure assembly helpers (`ci_check_of_context`, `comment_of_node`, `pr_state_of_pull_request`). The `mergeCommit` SHA is now `Option.bind pr.merge_commit ~f:(fun o -> o.oid)` — the #333 null-deref is structurally unwriteable.

Key correctness detail: nullable fields use `[@yojson.default None]`, **not** `[@yojson.option]`. `[@yojson.option]` only tolerates an *absent* key, but GraphQL returns nullable fields as *present-null*, and the `__typename` union fragments mix absent keys with present-null values (e.g. an in-progress check's null `conclusion`). `[@yojson.default None]` handles absent→None, null→None, and value→Some uniformly.

The rest of `github.ml` (`extract_github_message`, `response_error_messages`, `parse_rest_pr_list`, `create_pull_request`/`pr_node_id` parsing, `set_draft` GraphQL errors, `interpret_merge_response`) is converted to the total `Json` combinators; dead `Type_error` handlers dropped, `from_string`'s `Json_error` still caught.

## A.3–A.5 — migrate the rest to `Json`

- **Event parsers** (claude/codex/opencode/gemini/pi) + `codex_cost` — swallow-to-`[]` failure mode preserved.
- **review_service / review_backend / repo_config / failure_subkind / patch_pr_status / gameplan_parser** — per-field `Result`/soft-skip semantics preserved; `gameplan_parser` keeps its raise-to-boundary flow via a local `Parse_error`, preserving test-asserted messages.
- **persistence / session_driver** — `persistence` keeps raise-to-boundary via a local `Decode_error`, preserving the `malformed orchestrator/snapshot` errors and the opt-helpers' raise-on-wrong-type behavior.

`Onton_core.Json.try_of_yojson` is the one sanctioned place that references `Yojson.Safe.Util` (the `Type_error` catch); `lib_core/json.ml` is the sole remaining allowlist entry.

## Verification
`dune build` / `dune runtest` / `dune build @fmt` green; `bash scripts/check-no-raw-yojson.sh` OK with the allowlist down to `lib_core/json.ml`; `grep -rn Yojson.Safe.Util lib lib_core` returns only `json.ml`. Existing property/inline suites (persistence, review_service, codex_cost, backend totality, stream parser, github target) stay green, plus `test_github_merge_commit_null`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)