### PR TITLE
Detect allowed merge methods; stop assuming squash

### DIFF
--- a/lib/forge.ml
+++ b/lib/forge.ml
@@ -41,10 +41,10 @@ module type S = sig
   val set_draft :
     pr_number:Types.Pr_number.t -> draft:bool -> (unit, error) Result.t
 
-  val merge_pr :
-    pr_number:Types.Pr_number.t ->
-    merge_method:[ `Merge | `Squash | `Rebase ] ->
-    (merge_result, error) Result.t
+  val merge_pr : pr_number:Types.Pr_number.t -> (merge_result, error) Result.t
+  (** Merge the PR, choosing a merge method the repository actually permits. The
+      implementation detects the allowed methods (squash/merge/rebase) and picks
+      one — callers must not assume squash. *)
 
   val check_repo_access : unit -> (unit, error) Result.t
 end

--- a/lib/forge.mli
+++ b/lib/forge.mli
@@ -41,10 +41,10 @@ module type S = sig
   val set_draft :
     pr_number:Types.Pr_number.t -> draft:bool -> (unit, error) Result.t
 
-  val merge_pr :
-    pr_number:Types.Pr_number.t ->
-    merge_method:[ `Merge | `Squash | `Rebase ] ->
-    (merge_result, error) Result.t
+  val merge_pr : pr_number:Types.Pr_number.t -> (merge_result, error) Result.t
+  (** Merge the PR, choosing a merge method the repository actually permits. The
+      implementation detects the allowed methods (squash/merge/rebase) and picks
+      one — callers must not assume squash. *)
 
   val check_repo_access : unit -> (unit, error) Result.t
 end

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -1058,12 +1058,15 @@ let make ~net ~clock ~token ~owner ~repo :
           (* unreachable: order is always non-empty per the guard above *)
       | m :: rest -> (
           match merge_pr ~net ~clock client ~pr_number ~merge_method:m with
-          | Error e when is_method_not_allowed e && not (List.is_empty rest) ->
-              (* Stale allow-set: drop this method and try the next. *)
+          | Error e when is_method_not_allowed e ->
+              (* Stale allow-set: narrow the cache so future merges skip this
+                 method, then try the next candidate. Disabling happens even
+                 when [m] is the last candidate, so a repeat 405 isn't retried
+                 on the next call. *)
               merge_methods_cache :=
                 Option.map !merge_methods_cache ~f:(fun mm ->
                     disable_method mm m);
-              attempt rest
+              if List.is_empty rest then Error e else attempt rest
           | (Ok _ | Error _) as other -> other)
     in
     attempt order

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -782,6 +782,71 @@ let merge_pr ~net ~clock ?timeout t ~pr_number ~merge_method =
   | Ok body -> Ok (interpret_merge_response body)
   | Error _ as e -> e
 
+(* Which merge methods the repository permits. GitHub rejects a [PUT
+   /pulls/:n/merge] whose [merge_method] is disabled with HTTP 405 ("Squash
+   merges are not allowed on this repository", etc.), so onton must not assume
+   any particular method is available — it detects and chooses one. *)
+type repo_merge_methods = { squash : bool; merge : bool; rebase : bool }
+
+let method_allowed (m : repo_merge_methods) = function
+  | `Squash -> m.squash
+  | `Merge -> m.merge
+  | `Rebase -> m.rebase
+
+let disable_method (m : repo_merge_methods) = function
+  | `Squash -> { m with squash = false }
+  | `Merge -> { m with merge = false }
+  | `Rebase -> { m with rebase = false }
+
+(* Preference order, most → least preferred. Squash first preserves onton's
+   historical default on repos that allow it; the choice is method-agnostic
+   downstream — rebase anchoring keys off the actual [mergeCommit.oid] and the
+   dependency's pre-merge tip, not on the merge having been a squash. *)
+let merge_method_preference = [ `Squash; `Merge; `Rebase ]
+
+let allowed_methods_in_preference (m : repo_merge_methods) =
+  List.filter merge_method_preference ~f:(method_allowed m)
+
+(* Parse the [allow_*_merge] booleans from a [GET /repos/:owner/:repo] body. An
+   absent field defaults to [true]: older GitHub Enterprise omits them, and the
+   worst case of a wrong [true] is a 405 that [merge_pr]'s fallback recovers
+   from. Returns [None] only when the body is not parseable JSON. *)
+let parse_repo_merge_methods body : repo_merge_methods option =
+  match Yojson.Safe.from_string body with
+  | exception Yojson.Json_error _ -> None
+  | json ->
+      let open Yojson.Safe.Util in
+      let allowed field =
+        match member field json with `Bool v -> v | _ -> true
+      in
+      Some
+        {
+          squash = allowed "allow_squash_merge";
+          merge = allowed "allow_merge_commit";
+          rebase = allowed "allow_rebase_merge";
+        }
+
+let get_repo_merge_methods ~net ~clock ?timeout t :
+    (repo_merge_methods, error) Result.t =
+  let path = Printf.sprintf "/repos/%s/%s" t.owner t.repo in
+  match request ~net ~clock ?timeout t ~meth:`GET ~path () with
+  | Ok body -> (
+      match parse_repo_merge_methods body with
+      | Some m -> Ok m
+      | None ->
+          Error (Json_parse_error "could not parse repo merge-method settings"))
+  | Error _ as e -> e
+
+(* A non-2xx response meaning "this merge method is disabled on the repo"
+   (GitHub 405 "… merges are not allowed on this repository"), as distinct from
+   a transient/auth/conflict failure that must not trigger method fallback. *)
+let is_method_not_allowed = function
+  | Http_error { status = 405; body; _ } ->
+      response_error_message_contains body ~substring:"not allowed"
+  | Http_error _ | Json_parse_error _ | Graphql_error _ | Timeout _
+  | Transport_error _ ->
+      false
+
 (* ── Inline tests ── *)
 
 let%test "parse_rest_pr_list open PR" =
@@ -849,6 +914,72 @@ let%test "interpret_merge_response non-json body -> Merge_unconfirmed" =
   | Merge_unconfirmed -> true
   | Merge_succeeded | Merge_queued _ -> false
 
+let%test "parse_repo_merge_methods: all flags honored" =
+  match
+    parse_repo_merge_methods
+      {|{"allow_squash_merge":false,"allow_merge_commit":true,"allow_rebase_merge":false}|}
+  with
+  | Some { squash = false; merge = true; rebase = false } -> true
+  | _ -> false
+
+let%test "parse_repo_merge_methods: absent fields default to allowed" =
+  match parse_repo_merge_methods {|{"name":"repo"}|} with
+  | Some { squash = true; merge = true; rebase = true } -> true
+  | _ -> false
+
+let%test "parse_repo_merge_methods: non-json -> None" =
+  Option.is_none (parse_repo_merge_methods "not json")
+
+let%test "allowed_methods_in_preference: squash-disabled repo picks merge first"
+    =
+  match
+    allowed_methods_in_preference
+      { squash = false; merge = true; rebase = true }
+  with
+  | [ `Merge; `Rebase ] -> true
+  | _ -> false
+
+let%test "allowed_methods_in_preference: squash preferred when allowed" =
+  match
+    allowed_methods_in_preference
+      { squash = true; merge = true; rebase = false }
+  with
+  | [ `Squash; `Merge ] -> true
+  | _ -> false
+
+let%test "allowed_methods_in_preference: none allowed -> empty" =
+  List.is_empty
+    (allowed_methods_in_preference
+       { squash = false; merge = false; rebase = false })
+
+let%test "is_method_not_allowed: 405 'not allowed' -> true" =
+  is_method_not_allowed
+    (Http_error
+       {
+         meth = "PUT";
+         path = "/merge";
+         status = 405;
+         body =
+           {|{"message":"Squash merges are not allowed on this repository"}|};
+       })
+
+let%test "is_method_not_allowed: 405 without the phrase -> false" =
+  not
+    (is_method_not_allowed
+       (Http_error
+          {
+            meth = "PUT";
+            path = "/merge";
+            status = 405;
+            body = {|{"message":"Pull Request is not mergeable"}|};
+          }))
+
+let%test "is_method_not_allowed: 409 conflict -> false" =
+  not
+    (is_method_not_allowed
+       (Http_error
+          { meth = "PUT"; path = "/merge"; status = 409; body = "conflict" }))
+
 let%expect_test "show_error includes endpoint + permission hint on 403" =
   let err =
     Http_error
@@ -896,6 +1027,45 @@ let%expect_test "show_error transport error includes endpoint" =
 let make ~net ~clock ~token ~owner ~repo :
     (module Forge.S with type error = error) =
   let client = create ~token ~owner ~repo in
+  (* Cache the repo's allowed merge methods across calls; populated lazily on
+     the first merge and narrowed if a 405 later reveals a method is disabled. *)
+  let merge_methods_cache = ref None in
+  let resolve_allowed_methods () =
+    match !merge_methods_cache with
+    | Some m -> Some m
+    | None -> (
+        match get_repo_merge_methods ~net ~clock client with
+        | Ok m ->
+            merge_methods_cache := Some m;
+            Some m
+        | Error _ -> None)
+  in
+  let merge_pr_choosing ~pr_number =
+    (* Candidate methods, preferred first: the detected allowed set when we
+       could read it, otherwise the full preference list (a failed detect must
+       not block merges — the 405 fallback below still protects us). *)
+    let order =
+      match resolve_allowed_methods () with
+      | Some m -> allowed_methods_in_preference m
+      | None -> merge_method_preference
+    in
+    let order =
+      if List.is_empty order then merge_method_preference else order
+    in
+    let rec attempt = function
+      | [] -> merge_pr ~net ~clock client ~pr_number ~merge_method:`Merge
+      | m :: rest -> (
+          match merge_pr ~net ~clock client ~pr_number ~merge_method:m with
+          | Error e when is_method_not_allowed e && not (List.is_empty rest) ->
+              (* Stale allow-set: drop this method and try the next. *)
+              merge_methods_cache :=
+                Option.map !merge_methods_cache ~f:(fun mm ->
+                    disable_method mm m);
+              attempt rest
+          | (Ok _ | Error _) as other -> other)
+    in
+    attempt order
+  in
   let module M = struct
     type nonrec error = error
 
@@ -927,9 +1097,7 @@ let make ~net ~clock ~token ~owner ~repo :
     let set_draft ~pr_number ~draft =
       set_draft ~net ~clock client ~pr_number ~draft
 
-    let merge_pr ~pr_number ~merge_method =
-      merge_pr ~net ~clock client ~pr_number ~merge_method
-
+    let merge_pr ~pr_number = merge_pr_choosing ~pr_number
     let check_repo_access () = check_repo_access_internal ~net ~clock client
   end in
   (module M)

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -1053,7 +1053,9 @@ let make ~net ~clock ~token ~owner ~repo :
       if List.is_empty order then merge_method_preference else order
     in
     let rec attempt = function
-      | [] -> merge_pr ~net ~clock client ~pr_number ~merge_method:`Merge
+      | [] ->
+          assert false
+          (* unreachable: order is always non-empty per the guard above *)
       | m :: rest -> (
           match merge_pr ~net ~clock client ~pr_number ~merge_method:m with
           | Error e when is_method_not_allowed e && not (List.is_empty rest) ->

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -658,9 +658,11 @@ let apply_rebase_push_result t patch_id
   | Some Worktree.Push_no_commits
   | Some (Worktree.Push_error _)
   | Some Worktree.Push_worktree_missing ->
-      (* Push_no_commits after rebase means every commit squashed away — treat
-         as an infrastructure error and retry the rebase. Push_worktree_missing
-         lands here because the next Rebase invocation re-runs through
+      (* Push_no_commits after rebase means the rebase produced no commits —
+         the patch's work is already present on the new base (e.g. it landed
+         via the dependency's merge), so there is nothing to push. Treat as an
+         infrastructure error and retry the rebase. Push_worktree_missing lands
+         here because the next Rebase invocation re-runs through
          [ensure_worktree], which reconstructs the missing worktree before
          retrying. *)
       let t = enqueue t patch_id Operation_kind.Rebase in

--- a/lib/poller_fiber.ml
+++ b/lib/poller_fiber.ml
@@ -444,7 +444,8 @@ struct
                         :: sides ))
             in
             (* Recompute the base-containment cache for every agent: does each
-               patch's resolved base branch already contain the squash commit of
+               patch's resolved base branch already contain the merge commit
+               ([mergeCommit.oid], whatever the repo's merge method produced) of
                every *merged* dependency of that patch? This is the only git I/O
                of the reconcile phase; it is skipped (trivially [true]) for
                patches based on main or with no merged deps, so the [is_ancestor]

--- a/lib/runner_fiber_impl.ml
+++ b/lib/runner_fiber_impl.ml
@@ -235,7 +235,7 @@ struct
               clear_inflight_if_needed ())
             else
               try
-                match Forge.merge_pr ~pr_number ~merge_method:`Squash with
+                match Forge.merge_pr ~pr_number with
                 | Ok Forge.Merge_succeeded ->
                     inflight_cleared := true;
                     Runtime.update_orchestrator runtime (fun orch ->

--- a/lib_core/rebase_decision.mli
+++ b/lib_core/rebase_decision.mli
@@ -11,21 +11,26 @@
     (a HEAD SHA, an [is-ancestor] oracle) and the resolved-remote SHA captured
     before the rebase.
 
-    {2 Why anchors matter — the squash-merge trap}
+    {2 Why anchors matter — the history-rewriting-merge trap}
 
     A patch agent branched off a dependency's tip and never rebased before that
-    dependency's PR squash-merged to [main] will, on its first rebase, try to
-    replay the dep's pre-squash commits on top of the post-squash version of
-    [main] — every file the dep added produces a "both added" conflict. Today
+    dependency's PR merged to [main] will, on its first rebase, try to replay
+    the dep's pre-merge commits on top of the post-merge version of [main] —
+    every file the dep added produces a "both added" conflict. This bites
+    whenever the merge rewrote the dep's history so its original commit SHAs are
+    not ancestors of [main]: a {b squash} merge (one new commit) or a {b rebase}
+    merge (cherry-picked commits with fresh SHAs). (A plain merge {e commit}
+    keeps the original SHAs as ancestors, so a 2-arg rebase is a no-op there —
+    but anchors are still correct, so the same path handles all three.) Today
     the orchestrator records an anchor SHA only after a successful rebase, so
     such a patch has no anchor at first-rebase time and falls back to the legacy
     2-arg rebase, which is the failure mode.
 
     With anchors recorded at every base transition (Start, Noop, Conflict-
     resolved, base retarget), {!plan} returns an [Onto] invocation whose
-    [<upstream>] is the dep's pre-squash tip — git's 3-arg rebase then replays
+    [<upstream>] is the dep's pre-merge tip — git's 3-arg rebase then replays
     exactly the patch's own commits, the dep's commits stay on [main] untouched,
-    and no conflict arises. *)
+    and no conflict arises, regardless of the merge method. *)
 
 (** {2 Structured plan + reasoning} *)
 


### PR DESCRIPTION
## Problem

Onton hardcoded `~merge_method:`Squash` on every automerge (`runner_fiber_impl.ml`). On a repo with squash merges disabled, every attempt failed and the patch retried forever:

```
Automerge failed — GitHub API PUT /repos/flowglad/provisioning-agent/pulls/3504/merge
  → HTTP 405: Squash merges are not allowed on this repository.
```

## Fix

**(1) Don't try a disallowed method.** The github client detects the repo's allowed merge methods from `GET /repos/:owner/:repo` (`allow_squash_merge` / `allow_merge_commit` / `allow_rebase_merge`), caches them, and picks the preferred *allowed* one — preference `squash > merge > rebase` (squash preserves the historical default where it's available). `Forge.merge_pr` drops its `~merge_method` argument; method selection is now an internal detail of the forge. As belt-and-suspenders for a stale cache or a failed detection, a `405 "… not allowed"` response drops that method from the candidate set and retries the next allowed one (and remembers it).

**(2) Don't assume merges are squashes elsewhere.** Audited the SHA-driven logic and confirmed it's already method-agnostic:
- **base-containment** keys off `mergeCommit.oid` — whatever commit the merge produced, for any method — so "does the base contain the merged dep" works regardless of squash/merge/rebase.
- **rebase anchoring** keys off the dependency's *pre-merge tip* + 3-arg `git rebase --onto <base> <anchor>`, which replays only the patch's own commits for any history-rewriting merge (squash or rebase) and is a harmless no-op for a plain merge commit.

Reworded the comments/docs that asserted squash as the only outcome: `orchestrator.ml` Push_no_commits, `poller_fiber.ml` base-containment, and `rebase_decision.mli`'s trap section (now "history-rewriting-merge trap", covering squash *and* rebase merges and noting merge-commits are the easy case).

## Tests

Inline `let%test`s in `github.ml`:
- `parse_repo_merge_methods` — flags honored, absent fields default to allowed, non-json → `None`
- `allowed_methods_in_preference` — squash-disabled repo picks `[Merge; Rebase]`, squash preferred when allowed, none-allowed → empty
- `is_method_not_allowed` — 405 "not allowed" → true, other 405 → false, 409 conflict → false

`dune build` / `dune runtest` / `dune build @fmt` all green (pre-commit hook + CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automerge now detects each repo’s allowed merge methods and picks one (squash > merge > rebase) instead of always using squash. This avoids 405 errors, ends infinite retries, and remembers disallowed methods so we don’t try them again.

- **Bug Fixes**
  - Detect allowed methods via `GET /repos/:owner/:repo`, cache them, and choose the first allowed in preference order.
  - On a 405 “not allowed”, disable that method in the cache even if it was the last/only candidate; retry the next when available.
  - Updated logic/comments to be method-agnostic (base-containment uses `mergeCommit.oid`; rebase anchoring uses pre-merge tip with 3-arg rebase).
  - Made the unreachable empty-candidate case explicit (`assert false`) to surface a clean failure if the invariant ever regresses.

- **Migration**
  - `Forge.merge_pr` no longer takes `~merge_method`; remove that argument in callers.
  - Do not assume merges are squashes in downstream logic.

<sup>Written for commit 45aec4a2013eb07f7f0e0919c037862f6f9200f6. Summary will update on new commits. <a href="https://cubic.dev/pr/flowglad/onton/pull/336?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

