### PR TITLE
Restore x86_64 macOS release build on macos-15-intel (#316)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,15 @@ jobs:
         include:
           - arch: arm64
             runner: macos-14
-          # x86_64 dropped: GitHub retired the free macos-13 Intel runner and
-          # the paid macos-13-large runner also never provisions for this org,
-          # so the Intel build hung indefinitely. Tracked in #316 — restore the
-          # entry once an x86_64 macOS runner is available again.
+          - arch: x86_64
+            # macos-15-intel is GitHub's free, standard Intel/x86_64 image
+            # (shipped 2025-09-19) — the supported replacement for the retired
+            # macos-13. Unlike the paid macos-13-large larger runner (which
+            # needs a >$0 Actions spending limit and otherwise queues forever),
+            # this standard image provisions on public repos with no billing
+            # setup. It's the last x86_64 macOS image GitHub offers; Intel
+            # support ends when macOS 15 retires (~Fall 2027). Tracked in #316.
+            runner: macos-15-intel
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -81,7 +86,8 @@ jobs:
             --repo "$GITHUB_REPOSITORY" \
             --title "$GITHUB_REF_NAME" \
             --generate-notes \
-            onton-arm64-apple-darwin.tar.gz
+            onton-arm64-apple-darwin.tar.gz \
+            onton-x86_64-apple-darwin.tar.gz
 
   homebrew:
     name: Update Homebrew Formula
@@ -96,6 +102,7 @@ jobs:
         id: sha
         run: |
           echo "arm64=$(shasum -a 256 onton-arm64-apple-darwin.tar.gz | cut -d ' ' -f 1)" >> "$GITHUB_OUTPUT"
+          echo "x86_64=$(shasum -a 256 onton-x86_64-apple-darwin.tar.gz | cut -d ' ' -f 1)" >> "$GITHUB_OUTPUT"
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -106,6 +113,7 @@ jobs:
           VERSION="${GITHUB_REF_NAME#v}"
           sed -e "s/VERSION/$VERSION/g" \
               -e "s/SHA256_ARM64/${{ steps.sha.outputs.arm64 }}/g" \
+              -e "s/SHA256_X86_64/${{ steps.sha.outputs.x86_64 }}/g" \
               Formula/onton.rb.template > Formula/onton.rb
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/Formula/onton.rb.template
+++ b/Formula/onton.rb.template
@@ -7,13 +7,14 @@ class Onton < Formula
   version "VERSION"
   license "MIT"
 
-  # x86_64/Intel build temporarily dropped — no x86_64 macOS CI runner is
-  # available (GitHub retired macos-13). Tracked in #316. Without an on_intel
-  # block, `brew install` fails cleanly on Intel rather than installing an
-  # unrunnable ARM64 binary.
   on_arm do
     url "https://github.com/flowglad/onton/releases/download/vVERSION/onton-arm64-apple-darwin.tar.gz"
     sha256 "SHA256_ARM64"
+  end
+
+  on_intel do
+    url "https://github.com/flowglad/onton/releases/download/vVERSION/onton-x86_64-apple-darwin.tar.gz"
+    sha256 "SHA256_X86_64"
   end
 
   depends_on "gmp"


### PR DESCRIPTION
Fixes #316. Re-adds the Intel/x86_64 release build that #328 dropped, this time on the right runner label.

## Why the earlier attempts hung
Both prior tries queued forever at "waiting for a runner":

- **#324** pinned `macos-13` — GitHub retired the free Intel image (deprecation began 2025-09-22, removed 2025-12-04), so the label maps to no runner.
- **#327** pinned `macos-13-large` — a *larger* runner, which bills per-minute even on public repos and needs an Actions spending limit > $0. With the org's default $0 limit it never provisions. Confirmed from the stuck run's logs: the `Build (x86_64)` job had an empty `runner` field and zero steps.

## The fix
`macos-15-intel` (shipped 2025-09-19) is the **free, standard** Intel/x86_64 image that replaced `macos-13`. It provisions on public repos with no billing setup, and is the last x86_64 macOS image GitHub offers (Intel support ends ~Fall 2027).

Changes are the exact inverse of #328 with the corrected runner:
- `release.yml` — restore the `x86_64` matrix entry (`runner: macos-15-intel`), the second release asset, the x86_64 SHA computation, and the `SHA256_X86_64` sed substitution.
- `Formula/onton.rb.template` — restore the `on_intel` block.
- README already advertises both arches, so no change there.

## Verification (done)
Pushed a throwaway `v0.0.0-intel-test` tag against this branch. `macos-15-intel` got a runner immediately and the x86_64 build went green (~19 min). The full pipeline ran end-to-end: the resulting release shipped **both** `onton-arm64-apple-darwin.tar.gz` and `onton-x86_64-apple-darwin.tar.gz`.

> The Release workflow only runs on a `v*` tag, so it can't be exercised by this PR's checks — Intel ships on the next real release tag after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/337"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782507048&installation_id=126163856&pr_number=337&repository=flowglad%2Fonton&return_to=https%3A%2F%2Fgithub.com%2Fflowglad%2Fonton%2Fpull%2F337&signature=9506fca512cdd6ed058cdadc7d339b23d025f8013777b9b03ada34423f2ce363"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore the x86_64 macOS release build by switching the Intel job to the free `macos-15-intel` runner. This unblocks Intel binaries and fixes Homebrew installs on Intel Macs.

- **Bug Fixes**
  - Re-add x86_64 matrix entry on `macos-15-intel` (replaces retired `macos-13` and avoids paid `macos-13-large`).
  - Include the x86_64 tarball in release uploads and compute its SHA256.
  - Restore the `on_intel` block in the Homebrew formula.

<sup>Written for commit e7e65129e6d1b8a95cebb0c1436307b6f0478c1e. Summary will update on new commits. <a href="https://cubic.dev/pr/flowglad/onton/pull/337?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

