### PR TITLE
Handle context-window exhaustion with bounded fresh-restart

### DIFF
--- a/Formula/onton.rb
+++ b/Formula/onton.rb
@@ -4,16 +4,17 @@
 class Onton < Formula
   desc "OCaml orchestrator for parallel Claude Code agents executing gameplan patches"
   homepage "https://github.com/flowglad/onton"
-  version "0.0.0-intel-test"
+  version "0.38.0"
   license "MIT"
 
-  # x86_64/Intel build temporarily dropped — no x86_64 macOS CI runner is
-  # available (GitHub retired macos-13). Tracked in #316. Without an on_intel
-  # block, `brew install` fails cleanly on Intel rather than installing an
-  # unrunnable ARM64 binary.
   on_arm do
-    url "https://github.com/flowglad/onton/releases/download/v0.0.0-intel-test/onton-arm64-apple-darwin.tar.gz"
-    sha256 "1db62f838ae8abdb2b10642ce5afbe537387c2ee0763089febc13c06c18b8d9f"
+    url "https://github.com/flowglad/onton/releases/download/v0.38.0/onton-arm64-apple-darwin.tar.gz"
+    sha256 "fe77cc36f15116f525a413e3d7375d7094ef9b19bc4f9eed31c8b14bccd63623"
+  end
+
+  on_intel do
+    url "https://github.com/flowglad/onton/releases/download/v0.38.0/onton-x86_64-apple-darwin.tar.gz"
+    sha256 "b36b5c736b6ec394abf899fbd4929466696b712b2c28d270028ad0f3bcd90fe0"
   end
 
   depends_on "gmp"

--- a/lib/event_log.ml
+++ b/lib/event_log.ml
@@ -127,6 +127,7 @@ let failure_subkind_of_session_result (result : Orchestrator.session_result) =
   | Session_worktree_missing -> Failure_subkind.Process_error
   | Session_push_failed _ -> Failure_subkind.Process_error
   | Session_no_commits -> Failure_subkind.Other "session_no_commits"
+  | Session_context_exhausted -> Failure_subkind.Context_exhausted
 
 let sink t =
   {

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -761,6 +761,12 @@ type session_result =
           branch-protection, lease, hook, …). [None] reflects a transport/local
           [git push] error (no server message available). *)
   | Session_no_commits
+  | Session_context_exhausted
+      (** The session exhausted the model's context window
+          ([Run_classification.Context_exhausted]). Clears [llm_session_id] so
+          the next session starts fresh (resuming the overflowed thread would
+          re-overflow) and bumps [context_exhaustion_count]; at [>= 2] the agent
+          surfaces for intervention. *)
 [@@deriving show, eq, sexp_of]
 
 (** Complete a failed session, restoring only still-inflight human messages to
@@ -825,6 +831,9 @@ let apply_session_result t patch_id result =
          push-failure counters. *)
       let t =
         update_agent t patch_id ~f:Patch_agent.reset_no_commits_push_count
+      in
+      let t =
+        update_agent t patch_id ~f:Patch_agent.reset_context_exhaustion_count
       in
       update_agent t patch_id ~f:Patch_agent.reset_push_failure_count
   | Session_process_error { is_fresh; _ } ->
@@ -897,6 +906,16 @@ let apply_session_result t patch_id result =
          [apply_respond_outcome] via [Respond_retry_push]. *)
       let t = clear_session_fallback t patch_id in
       update_agent t patch_id ~f:Patch_agent.increment_no_commits_push_count
+  | Session_context_exhausted ->
+      (* The session overflowed the model's context window. [on_context_exhausted]
+         bumps [context_exhaustion_count] and clears [llm_session_id] so the next
+         session starts Fresh — resuming the overflowed thread would re-overflow
+         immediately. At [>= 2] the agent surfaces for intervention: a fresh
+         session that still overflows means the task does not fit one context
+         window. The session never finished its turn, so route through
+         [complete_failed] to restore any still-inflight human messages. *)
+      let t = update_agent t patch_id ~f:Patch_agent.on_context_exhausted in
+      complete_failed t patch_id
 
 let combine_session_and_push ~(session : session_result)
     ~(push : Worktree.push_result) : session_result =
@@ -922,7 +941,7 @@ let combine_session_and_push ~(session : session_result)
               (* unreachable — outer match catches this *))
       | Session_process_error _ | Session_no_resume | Session_failed _
       | Session_give_up | Session_worktree_missing | Session_push_failed _
-      | Session_no_commits ->
+      | Session_no_commits | Session_context_exhausted ->
           session)
 
 type start_outcome = Start_ok | Start_failed | Start_stale

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -193,6 +193,11 @@ type session_result =
       (** [Some r] carries a classified server-side rejection; [None] reflects a
           transport / local [git push] failure ([Push_error]). *)
   | Session_no_commits
+  | Session_context_exhausted
+      (** The session exhausted the model's context window. Clears
+          [llm_session_id] so the next session starts fresh and bumps
+          [context_exhaustion_count]; at [>= 2] the agent surfaces for
+          intervention. *)
 [@@deriving show, eq, sexp_of]
 
 val apply_session_result : t -> Patch_id.t -> session_result -> t

--- a/lib/persistence.ml
+++ b/lib/persistence.ml
@@ -194,6 +194,7 @@ let patch_agent_to_yojson (a : Patch_agent.t) =
       ("start_attempts_without_pr", `Int a.start_attempts_without_pr);
       ("conflict_noop_count", `Int a.conflict_noop_count);
       ("no_commits_push_count", `Int a.no_commits_push_count);
+      ("context_exhaustion_count", `Int a.context_exhaustion_count);
       ("push_failure_count", `Int a.push_failure_count);
       ( "branch_rebased_onto",
         match a.branch_rebased_onto with
@@ -359,6 +360,10 @@ let patch_agent_of_yojson ~gameplan json =
          (Option.value (int_member_opt "conflict_noop_count" json) ~default:0)
        ~no_commits_push_count:
          (Option.value (int_member_opt "no_commits_push_count" json) ~default:0)
+       ~context_exhaustion_count:
+         (Option.value
+            (int_member_opt "context_exhaustion_count" json)
+            ~default:0)
        ~push_failure_count:
          (Option.value (int_member_opt "push_failure_count" json) ~default:0)
        ~branch_rebased_onto_sha:
@@ -827,14 +832,15 @@ let%test_module "session_id_sidecars" =
           ~base_contains_merged_siblings:true ~is_draft:false
           ~pr_body_delivered:true ~pr_body_artifact_miss_count:0
           ~start_attempts_without_pr:0 ~conflict_noop_count:0
-          ~no_commits_push_count:0 ~push_failure_count:0
-          ~branch_rebased_onto:None ~branch_rebased_onto_sha:None
-          ~anchor_history:Anchor_history.empty ~checks_passing:false
-          ~current_op:None ~current_op_state:Patch_agent.Queued
-          ~current_message_id:None ~generation:0 ~worktree_path:None
-          ~branch_blocked:false ~llm_session_id ~automerge_enabled:false
-          ~automerge_deadline:None ~automerge_inflight:false
-          ~automerge_failure_count:0 ~delivered_ci_run_ids:[]
+          ~no_commits_push_count:0 ~context_exhaustion_count:0
+          ~push_failure_count:0 ~branch_rebased_onto:None
+          ~branch_rebased_onto_sha:None ~anchor_history:Anchor_history.empty
+          ~checks_passing:false ~current_op:None
+          ~current_op_state:Patch_agent.Queued ~current_message_id:None
+          ~generation:0 ~worktree_path:None ~branch_blocked:false
+          ~llm_session_id ~automerge_enabled:false ~automerge_deadline:None
+          ~automerge_inflight:false ~automerge_failure_count:0
+          ~delivered_ci_run_ids:[]
       in
       let orch =
         Orchestrator.restore

--- a/lib/session_driver.ml
+++ b/lib/session_driver.ml
@@ -551,6 +551,19 @@ module Make (W : Worktree.S) (Env : ENV) = struct
                       ( Orchestrator.Session_failed
                           { is_fresh; detail = Some detail },
                         `Failed )
+                  | Context_exhausted { stream_errors } ->
+                      (* The model's context window overflowed (e.g. Codex "ran
+                   out of room"). Resuming this thread would re-overflow, so
+                   [Session_context_exhausted] clears the session id and the
+                   next run starts fresh. The dedicated counter surfaces the
+                   agent for intervention if a fresh session overflows too. *)
+                      log_event runtime ~patch_id
+                        (Printf.sprintf
+                           "Session exited (%s) — context window exhausted; \
+                            clearing session, next run starts fresh — %s"
+                           backend_name
+                           (truncate stream_errors 500));
+                      (Orchestrator.Session_context_exhausted, `Failed)
                   | Success { stream_errors } ->
                       (match (resume_session, result) with
                       | Some _, Ok r when not r.Llm_backend.got_events ->
@@ -794,7 +807,8 @@ module Make (W : Worktree.S) (Env : ENV) = struct
                   | Orchestrator.Session_no_resume
                   | Orchestrator.Session_failed _ | Orchestrator.Session_give_up
                   | Orchestrator.Session_worktree_missing
-                  | Orchestrator.Session_push_failed _ ->
+                  | Orchestrator.Session_push_failed _
+                  | Orchestrator.Session_context_exhausted ->
                       combined
                 in
                 let final_user_result =
@@ -812,7 +826,8 @@ module Make (W : Worktree.S) (Env : ENV) = struct
                   | Orchestrator.Session_process_error _
                   | Orchestrator.Session_no_resume
                   | Orchestrator.Session_failed _ | Orchestrator.Session_give_up
-                  | Orchestrator.Session_worktree_missing ->
+                  | Orchestrator.Session_worktree_missing
+                  | Orchestrator.Session_context_exhausted ->
                       `Failed
                 in
                 let _, push_agent_after =

--- a/lib_core/codex_event_parser.ml
+++ b/lib_core/codex_event_parser.ml
@@ -87,6 +87,18 @@ let parse_event_with_cost_tracking ~model ~budget_cap_nano_usd ~cost_state line
             |> Option.value ~default:"unknown codex error"
           in
           ([ Types.Stream_event.Error msg ], cost_state)
+      | Some "turn.failed" ->
+          (* A failed turn carries its reason under [error.message] (e.g. the
+             "ran out of room in the model's context window" overflow). Without
+             this arm the failure is silently dropped — no stream error, no log
+             — and an overflow looks like a clean exit. Surface it as an Error
+             so the driver records it and the classifier can detect overflow. *)
+          let msg =
+            Json.field "error" json
+            |> Option.bind ~f:(Json.string_field "message")
+            |> Option.value ~default:"codex turn failed"
+          in
+          ([ Types.Stream_event.Error msg ], cost_state)
       | _ -> ([], cost_state))
 
 let build_args ~model ~cwd_path ~prompt ~resume_session =
@@ -300,6 +312,22 @@ let%test "parse_event error" =
   let line = {|{"type":"error","message":"rate limited"}|} in
   List.equal Types.Stream_event.equal (parse_event line)
     [ Types.Stream_event.Error "rate limited" ]
+
+let%test "parse_event turn.failed surfaces error.message as Error" =
+  let line =
+    {|{"type":"turn.failed","error":{"message":"Codex ran out of room in the model's context window. Start a new thread or clear earlier history before retrying."}}|}
+  in
+  List.equal Types.Stream_event.equal (parse_event line)
+    [
+      Types.Stream_event.Error
+        "Codex ran out of room in the model's context window. Start a new \
+         thread or clear earlier history before retrying.";
+    ]
+
+let%test "parse_event turn.failed without error.message falls back" =
+  let line = {|{"type":"turn.failed"}|} in
+  List.equal Types.Stream_event.equal (parse_event line)
+    [ Types.Stream_event.Error "codex turn failed" ]
 
 let%test "parse_event invalid json" =
   List.is_empty (parse_event "not json at all")

--- a/lib_core/failure_subkind.ml
+++ b/lib_core/failure_subkind.ml
@@ -6,6 +6,7 @@ type t =
   | Api_error of { status : int option }
   | Network_error
   | Timed_out
+  | Context_exhausted
   | No_session_to_resume
   | Empty_response
   | Process_error
@@ -25,6 +26,7 @@ let t_of_yojson json =
   | `String "Auth_unavailable" -> Auth_unavailable
   | `String "Network_error" -> Network_error
   | `String "Timed_out" -> Timed_out
+  | `String "Context_exhausted" -> Context_exhausted
   | `String "No_session_to_resume" -> No_session_to_resume
   | `String "Empty_response" -> Empty_response
   | `String "Process_error" -> Process_error
@@ -46,6 +48,7 @@ let yojson_of_t = function
       `Assoc [ ("Api_error", `Assoc fields) ]
   | Network_error -> `String "Network_error"
   | Timed_out -> `String "Timed_out"
+  | Context_exhausted -> `String "Context_exhausted"
   | No_session_to_resume -> `String "No_session_to_resume"
   | Empty_response -> `String "Empty_response"
   | Process_error -> `String "Process_error"
@@ -110,6 +113,7 @@ let classify ~classification ~init ~text_tail ~stderr_tail =
   | Run_classification.Process_error _ -> Process_error
   | No_session_to_resume -> No_session_to_resume
   | Timed_out -> Timed_out
+  | Run_classification.Context_exhausted _ -> Context_exhausted
   | Success _ -> Ok
   | Session_failed { detail; _ } ->
       classify_session_failed ~init ~text_tail ~stderr_tail ~detail
@@ -121,6 +125,7 @@ let to_string = function
   | Api_error { status = None } -> "api_error"
   | Network_error -> "network_error"
   | Timed_out -> "timed_out"
+  | Context_exhausted -> "context_exhausted"
   | No_session_to_resume -> "no_session_to_resume"
   | Empty_response -> "empty_response"
   | Process_error -> "process_error"

--- a/lib_core/failure_subkind.mli
+++ b/lib_core/failure_subkind.mli
@@ -6,6 +6,7 @@ type t =
   | Api_error of { status : int option }
   | Network_error
   | Timed_out
+  | Context_exhausted
   | No_session_to_resume
   | Empty_response
   | Process_error

--- a/lib_core/patch_agent.ml
+++ b/lib_core/patch_agent.ml
@@ -48,6 +48,14 @@ type t = {
   start_attempts_without_pr : int;
   conflict_noop_count : int;
   no_commits_push_count : int;
+  context_exhaustion_count : int;
+      (** Consecutive sessions that ended by exhausting the model's context
+          window ([Run_classification.Context_exhausted]). Each one clears
+          [llm_session_id] so the next session starts fresh (resuming the
+          overflowed thread would re-overflow). At [>= 2] contributes to
+          [needs_intervention]: a *fresh* session that still overflows means the
+          task does not fit one context window and needs a human. Reset on a
+          successful session. *)
   push_failure_count : int;
   branch_rebased_onto : Branch.t option;
   branch_rebased_onto_sha : string option;
@@ -136,6 +144,8 @@ let intervention_reason t =
       Some "start_attempts_without_pr>=2"
     else if t.conflict_noop_count >= 2 then Some "conflict_noop_count>=2"
     else if t.no_commits_push_count >= 2 then Some "no_commits_push_count>=2"
+    else if t.context_exhaustion_count >= 2 then
+      Some "context_exhaustion_count>=2"
     else if t.push_failure_count >= 3 then Some "push_failure_count>=3"
     else if t.pr_body_artifact_miss_count >= 2 then
       Some "pr_body_artifact_miss_count>=2"
@@ -174,6 +184,7 @@ let create ~branch patch_id =
     start_attempts_without_pr = 0;
     conflict_noop_count = 0;
     no_commits_push_count = 0;
+    context_exhaustion_count = 0;
     push_failure_count = 0;
     branch_rebased_onto = None;
     branch_rebased_onto_sha = None;
@@ -224,6 +235,7 @@ let create_adhoc ~patch_id ~branch ~pr_number =
     start_attempts_without_pr = 0;
     conflict_noop_count = 0;
     no_commits_push_count = 0;
+    context_exhaustion_count = 0;
     push_failure_count = 0;
     branch_rebased_onto = None;
     branch_rebased_onto_sha = None;
@@ -294,6 +306,20 @@ let increment_no_commits_push_count t =
   { t with no_commits_push_count = t.no_commits_push_count + 1 }
 
 let reset_no_commits_push_count t = { t with no_commits_push_count = 0 }
+
+(* Context-window exhaustion: bump the counter and drop [llm_session_id] so the
+   next session starts fresh — resuming the overflowed thread would re-overflow
+   immediately. Deliberately leaves [session_fallback] untouched: exhaustion has
+   its own intervention budget (the counter), orthogonal to the resume/fresh
+   fallback ladder. *)
+let on_context_exhausted t =
+  {
+    t with
+    context_exhaustion_count = t.context_exhaustion_count + 1;
+    llm_session_id = None;
+  }
+
+let reset_context_exhaustion_count t = { t with context_exhaustion_count = 0 }
 
 let increment_push_failure_count t =
   { t with push_failure_count = t.push_failure_count + 1 }
@@ -427,6 +453,7 @@ let reset_intervention_state t =
     start_attempts_without_pr = 0;
     conflict_noop_count = 0;
     no_commits_push_count = 0;
+    context_exhaustion_count = 0;
     push_failure_count = 0;
     pr_body_artifact_miss_count = 0;
   }
@@ -439,11 +466,11 @@ let restore ~patch_id ~branch ~pr_status ~has_session ~busy ~merged ~queue
     ~ci_checks ~merge_ready ~merge_commit_sha ~base_contains_merged_siblings
     ~is_draft ~pr_body_delivered ~pr_body_artifact_miss_count
     ~start_attempts_without_pr ~conflict_noop_count ~no_commits_push_count
-    ~push_failure_count ~branch_rebased_onto ~branch_rebased_onto_sha
-    ~anchor_history ~checks_passing ~current_op ~current_op_state
-    ~current_message_id ~generation ~worktree_path ~branch_blocked
-    ~llm_session_id ~automerge_enabled ~automerge_deadline ~automerge_inflight
-    ~automerge_failure_count ~delivered_ci_run_ids =
+    ~context_exhaustion_count ~push_failure_count ~branch_rebased_onto
+    ~branch_rebased_onto_sha ~anchor_history ~checks_passing ~current_op
+    ~current_op_state ~current_message_id ~generation ~worktree_path
+    ~branch_blocked ~llm_session_id ~automerge_enabled ~automerge_deadline
+    ~automerge_inflight ~automerge_failure_count ~delivered_ci_run_ids =
   {
     patch_id;
     branch;
@@ -471,6 +498,7 @@ let restore ~patch_id ~branch ~pr_status ~has_session ~busy ~merged ~queue
     start_attempts_without_pr;
     conflict_noop_count;
     no_commits_push_count;
+    context_exhaustion_count;
     push_failure_count;
     branch_rebased_onto;
     branch_rebased_onto_sha;

--- a/lib_core/patch_agent.mli
+++ b/lib_core/patch_agent.mli
@@ -57,6 +57,15 @@ type t = private {
   start_attempts_without_pr : int;
   conflict_noop_count : int;
   no_commits_push_count : int;
+  context_exhaustion_count : int;
+      (** Consecutive sessions that ended by exhausting the model's context
+          window ([Run_classification.Context_exhausted]).
+          [on_context_exhausted] bumps this and clears [llm_session_id] so the
+          next session starts fresh (resuming the overflowed thread would
+          re-overflow). At [>= 2] contributes to [needs_intervention] — a fresh
+          session that still overflows means the task does not fit one context
+          window. Reset on a successful session and by
+          [reset_intervention_state]. *)
   push_failure_count : int;
       (** Consecutive [Session_push_failed] outcomes (Session_ok or session
           retry with [Push_rejected]/[Push_error]) since the last successful
@@ -162,7 +171,8 @@ val needs_intervention : t -> bool
     - [Human] not in queue AND any of: [ci_failure_count >= 3],
       [(not has_pr) && start_attempts_without_pr >= 2],
       [conflict_noop_count >= 2], [no_commits_push_count >= 2],
-      [push_failure_count >= 3], [pr_body_artifact_miss_count >= 2]. *)
+      [context_exhaustion_count >= 2], [push_failure_count >= 3],
+      [pr_body_artifact_miss_count >= 2]. *)
 
 (** {2 Spec actions} *)
 
@@ -308,6 +318,16 @@ val reset_no_commits_push_count : t -> t
 (** Reset [no_commits_push_count] to 0. Called on [Session_ok] with a successful
     push, because the agent has demonstrated it can commit. *)
 
+val on_context_exhausted : t -> t
+(** Record a session that exhausted the model's context window. Bumps
+    [context_exhaustion_count] and clears [llm_session_id] so the next session
+    starts fresh — resuming the overflowed thread would re-overflow. Leaves
+    [session_fallback] untouched; exhaustion's intervention budget is the
+    counter, not the resume/fresh ladder. *)
+
+val reset_context_exhaustion_count : t -> t
+(** Reset [context_exhaustion_count] to 0. Called on a successful session. *)
+
 val increment_push_failure_count : t -> t
 (** Record a [Session_push_failed] outcome. At [>= 3], [needs_intervention]
     triggers — the push has been refused by the remote three sessions in a row
@@ -358,9 +378,10 @@ val reset_ci_failure_count : t -> t
 val reset_intervention_state : t -> t
 (** Reset [session_fallback] to [Fresh_available], [ci_failure_count] to 0,
     [start_attempts_without_pr] to 0, [conflict_noop_count] to 0,
-    [no_commits_push_count] to 0, [push_failure_count] to 0, and
-    [pr_body_artifact_miss_count] to 0. Used after manual resolution (e.g.,
-    sending a human message) to give the patch a fresh start. *)
+    [no_commits_push_count] to 0, [context_exhaustion_count] to 0,
+    [push_failure_count] to 0, and [pr_body_artifact_miss_count] to 0. Used
+    after manual resolution (e.g., sending a human message) to give the patch a
+    fresh start. *)
 
 val set_branch_blocked : t -> t
 (** Set the branch-blocked flag (branch is checked out in repo root). *)
@@ -518,6 +539,7 @@ val restore :
   start_attempts_without_pr:int ->
   conflict_noop_count:int ->
   no_commits_push_count:int ->
+  context_exhaustion_count:int ->
   push_failure_count:int ->
   branch_rebased_onto:Types.Branch.t option ->
   branch_rebased_onto_sha:string option ->

--- a/lib_core/run_classification.ml
+++ b/lib_core/run_classification.ml
@@ -19,16 +19,33 @@ type classification =
   | Process_error of string
   | No_session_to_resume
   | Timed_out
+  | Context_exhausted of { stream_errors : string }
   | Success of { stream_errors : string }
   | Session_failed of { exit_code : int; detail : string }
 [@@deriving show, eq]
 
 let truncate s n = if String.length s <= n then s else String.prefix s n ^ "..."
 
+(* The model's context window overflowed. Matched on the error stream only
+   (never agent text), so legitimate output mentioning these phrases cannot
+   trip it. Codex surfaces this as an [error]/[turn.failed] event carrying
+   "Codex ran out of room in the model's context window..."; Claude's
+   [model_context_window_exceeded] / "prompt is too long" land here too when
+   its own auto-compaction fails. The phrasing is intentionally broad to cover
+   both backends' wording and the OpenAI [context_length_exceeded] code. *)
+let is_context_exhausted stream_errors =
+  let h = String.lowercase stream_errors in
+  let contains needle = String.is_substring h ~substring:needle in
+  contains "ran out of room" || contains "context window"
+  || contains "context_length_exceeded"
+  || contains "model_context_window_exceeded"
+
 let classify ~is_resume result =
   match result with
   | Error msg -> Process_error msg
   | Ok r when r.timed_out -> Timed_out
+  | Ok r when is_context_exhausted r.stream_errors ->
+      Context_exhausted { stream_errors = r.stream_errors }
   | Ok r when r.saw_final_result -> Success { stream_errors = r.stream_errors }
   | Ok r when r.exit_code = 0 -> Success { stream_errors = r.stream_errors }
   | Ok r when (not r.got_events) && is_resume -> No_session_to_resume
@@ -42,3 +59,69 @@ let classify ~is_resume result =
         | s, e -> s ^ " | stream: " ^ e
       in
       Session_failed { exit_code = r.exit_code; detail = truncate detail 500 }
+
+let%test_module "context exhaustion classification" =
+  (module struct
+    let outcome ?(exit_code = 0) ?(saw_final_result = false)
+        ?(timed_out = false) stream_errors =
+      {
+        exit_code;
+        got_events = true;
+        saw_final_result;
+        stderr = "";
+        stream_errors;
+        timed_out;
+      }
+
+    let is_ctx = function
+      | Context_exhausted _ -> true
+      | Process_error _ | No_session_to_resume | Timed_out | Success _
+      | Session_failed _ ->
+          false
+
+    let is_success = function
+      | Success _ -> true
+      | Process_error _ | No_session_to_resume | Timed_out | Context_exhausted _
+      | Session_failed _ ->
+          false
+
+    (* Spec: an outcome whose error stream reports context overflow is
+       Context_exhausted regardless of exit code or a final-result event. *)
+    let%test "codex overflow phrase, exit 0 -> Context_exhausted" =
+      is_ctx
+        (classify ~is_resume:true
+           (Ok
+              (outcome
+                 "Codex ran out of room in the model's context window. Start a \
+                  new thread or clear earlier history before retrying.")))
+
+    let%test "overflow + saw_final_result -> Context_exhausted (precedence)" =
+      is_ctx
+        (classify ~is_resume:false
+           (Ok (outcome ~saw_final_result:true "model_context_window_exceeded")))
+
+    let%test "openai context_length_exceeded -> Context_exhausted" =
+      is_ctx
+        (classify ~is_resume:false (Ok (outcome "context_length_exceeded")))
+
+    (* Timeout still wins: a timed-out session is Timed_out even if its partial
+       error stream happens to mention the context window. *)
+    let%test "timed_out + overflow phrase -> Timed_out" =
+      match
+        classify ~is_resume:true
+          (Ok (outcome ~timed_out:true "ran out of room in the context window"))
+      with
+      | Timed_out -> true
+      | Process_error _ | No_session_to_resume | Context_exhausted _ | Success _
+      | Session_failed _ ->
+          false
+
+    (* No false positive: a benign error stream with exit 0 stays Success. *)
+    let%test "benign stream error, exit 0 -> Success" =
+      is_success
+        (classify ~is_resume:false
+           (Ok (outcome "tool execution failed: ENOENT")))
+
+    let%test "is_context_exhausted negative on empty" =
+      not (is_context_exhausted "")
+  end)

--- a/lib_core/run_classification.mli
+++ b/lib_core/run_classification.mli
@@ -19,11 +19,20 @@ type classification =
   | Process_error of string
   | No_session_to_resume
   | Timed_out
+  | Context_exhausted of { stream_errors : string }
   | Success of { stream_errors : string }
   | Session_failed of { exit_code : int; detail : string }
 [@@deriving show, eq]
 
+val is_context_exhausted : string -> bool
+(** [true] when the error stream reports a context-window overflow ("ran out of
+    room", "context window", "context_length_exceeded",
+    "model_context_window_exceeded"). Matched on the error stream only, so
+    legitimate agent output mentioning these phrases cannot trip it. *)
+
 val classify :
   is_resume:bool -> (run_outcome, string) Result.t -> classification
 (** Classify an LLM runner result into a pure decision value. [is_resume]
-    indicates whether this was a --resume session (explicit session ID). *)
+    indicates whether this was a --resume session (explicit session ID).
+    [Context_exhausted] takes precedence over [Success] (it can be reported on
+    an otherwise-clean exit-0 stream) but not over [Timed_out]. *)

--- a/lib_test/test_generators.ml
+++ b/lib_test/test_generators.ml
@@ -416,6 +416,7 @@ let gen_patch_agent_fully_populated =
     let* raw_llm_session_id =
       option (string_size ~gen:printable (int_range 8 36))
     in
+    let* context_exhaustion_count = int_range 0 3 in
     let a = Onton_core.Patch_agent.create ~branch pid in
     let a = Onton_core.Patch_agent.start a ~base_branch:branch in
     let a =
@@ -429,6 +430,13 @@ let gen_patch_agent_fully_populated =
           Onton_core.Patch_agent.set_tried_fresh a
       | Onton_core.Patch_agent.Given_up ->
           Onton_core.Patch_agent.set_session_failed a
+    in
+    (* Exercise context_exhaustion_count in the round-trip. Applied before
+       llm_session_id is set below, since on_context_exhausted also clears the
+       session id (the generator's intended id wins by being set last). *)
+    let a =
+      Fn.apply_n_times ~n:context_exhaustion_count
+        Onton_core.Patch_agent.on_context_exhausted a
     in
     (* When session_fallback is Tried_fresh or Given_up, llm_session_id must
        be None (escalation clears it). Only Fresh_available may have a value. *)

--- a/test/test_interleaving_properties.ml
+++ b/test/test_interleaving_properties.ml
@@ -2295,7 +2295,8 @@ let respond_outcome_of session_result =
       Orchestrator.Respond_retry_push
   | Orchestrator.Session_process_error _ | Orchestrator.Session_no_resume
   | Orchestrator.Session_failed _ | Orchestrator.Session_give_up
-  | Orchestrator.Session_worktree_missing ->
+  | Orchestrator.Session_worktree_missing
+  | Orchestrator.Session_context_exhausted ->
       Orchestrator.Respond_failed
 
 (** Given the current agent state, produce the session_result that a persistent
@@ -2598,7 +2599,8 @@ let () =
               true
           | Orchestrator.Session_failed _ | Orchestrator.Session_process_error _
           | Orchestrator.Session_no_resume | Orchestrator.Session_give_up
-          | Orchestrator.Session_worktree_missing ->
+          | Orchestrator.Session_worktree_missing
+          | Orchestrator.Session_context_exhausted ->
               false
         in
         let rec loop orch iter =

--- a/test/test_patch_agent.ml
+++ b/test/test_patch_agent.ml
@@ -726,9 +726,9 @@ let () =
               ~merge_ready:false ~is_draft:false ~pr_body_delivered:false
               ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
               ~conflict_noop_count:0 ~no_commits_push_count:0
-              ~push_failure_count:0 ~branch_rebased_onto:None
-              ~branch_rebased_onto_sha:None ~merge_commit_sha:None
-              ~base_contains_merged_siblings:true
+              ~context_exhaustion_count:0 ~push_failure_count:0
+              ~branch_rebased_onto:None ~branch_rebased_onto_sha:None
+              ~merge_commit_sha:None ~base_contains_merged_siblings:true
               ~anchor_history:Onton_core.Anchor_history.empty
               ~checks_passing:false ~current_op:None
               ~current_op_state:Onton_core.Patch_agent.Queued
@@ -812,9 +812,9 @@ let () =
               ~merge_ready:false ~is_draft:false ~pr_body_delivered:false
               ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
               ~conflict_noop_count:0 ~no_commits_push_count:0
-              ~push_failure_count:0 ~branch_rebased_onto:None
-              ~branch_rebased_onto_sha:None ~merge_commit_sha:None
-              ~base_contains_merged_siblings:true
+              ~context_exhaustion_count:0 ~push_failure_count:0
+              ~branch_rebased_onto:None ~branch_rebased_onto_sha:None
+              ~merge_commit_sha:None ~base_contains_merged_siblings:true
               ~anchor_history:Onton_core.Anchor_history.empty
               ~checks_passing:false ~current_op:None
               ~current_op_state:Onton_core.Patch_agent.Queued

--- a/test/test_patch_controller.ml
+++ b/test/test_patch_controller.ml
@@ -59,9 +59,10 @@ let make_agent ~patch_id ~branch ~pr_status ~merged ~queue ~base_branch
     ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
     ~merge_ready:false ~is_draft ~pr_body_delivered
     ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr
-    ~conflict_noop_count:0 ~no_commits_push_count:0 ~push_failure_count:0
-    ~branch_rebased_onto:None ~branch_rebased_onto_sha:None
-    ~merge_commit_sha:None ~base_contains_merged_siblings:true
+    ~conflict_noop_count:0 ~no_commits_push_count:0 ~context_exhaustion_count:0
+    ~push_failure_count:0 ~branch_rebased_onto:None
+    ~branch_rebased_onto_sha:None ~merge_commit_sha:None
+    ~base_contains_merged_siblings:true
     ~anchor_history:Onton_core.Anchor_history.empty ~checks_passing:false
     ~current_op:None ~current_op_state:Patch_agent.Queued
     ~current_message_id:None ~generation:0 ~worktree_path:None
@@ -235,9 +236,9 @@ let () =
             ~merge_ready:false ~is_draft:true ~pr_body_delivered:true
             ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
             ~conflict_noop_count:0 ~no_commits_push_count:0
-            ~push_failure_count:0 ~branch_rebased_onto:(Some main)
-            ~branch_rebased_onto_sha:None ~merge_commit_sha:None
-            ~base_contains_merged_siblings:true
+            ~context_exhaustion_count:0 ~push_failure_count:0
+            ~branch_rebased_onto:(Some main) ~branch_rebased_onto_sha:None
+            ~merge_commit_sha:None ~base_contains_merged_siblings:true
             ~anchor_history:Onton_core.Anchor_history.empty ~checks_passing:true
             ~current_op:None ~current_op_state:Patch_agent.Queued
             ~current_message_id:None ~generation:0 ~worktree_path:None
@@ -285,9 +286,9 @@ let () =
             ~merge_ready:false ~is_draft:true ~pr_body_delivered:true
             ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
             ~conflict_noop_count:0 ~no_commits_push_count:0
-            ~push_failure_count:0 ~branch_rebased_onto:None
-            ~branch_rebased_onto_sha:None ~merge_commit_sha:None
-            ~base_contains_merged_siblings:true
+            ~context_exhaustion_count:0 ~push_failure_count:0
+            ~branch_rebased_onto:None ~branch_rebased_onto_sha:None
+            ~merge_commit_sha:None ~base_contains_merged_siblings:true
             ~anchor_history:Onton_core.Anchor_history.empty ~checks_passing:true
             ~current_op:None ~current_op_state:Patch_agent.Queued
             ~current_message_id:None ~generation:0 ~worktree_path:None
@@ -424,9 +425,9 @@ let () =
             ~is_draft:false ~pr_body_delivered:true
             ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
             ~conflict_noop_count:0 ~no_commits_push_count:0
-            ~push_failure_count:0 ~branch_rebased_onto:None
-            ~branch_rebased_onto_sha:None ~merge_commit_sha:None
-            ~base_contains_merged_siblings:true
+            ~context_exhaustion_count:0 ~push_failure_count:0
+            ~branch_rebased_onto:None ~branch_rebased_onto_sha:None
+            ~merge_commit_sha:None ~base_contains_merged_siblings:true
             ~anchor_history:Onton_core.Anchor_history.empty
             ~checks_passing:false ~current_op:None
             ~current_op_state:Patch_agent.Queued ~current_message_id:None
@@ -469,9 +470,9 @@ let () =
             ~is_draft:false ~pr_body_delivered:true
             ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
             ~conflict_noop_count:0 ~no_commits_push_count:0
-            ~push_failure_count:0 ~branch_rebased_onto:None
-            ~branch_rebased_onto_sha:None ~merge_commit_sha:None
-            ~base_contains_merged_siblings:true
+            ~context_exhaustion_count:0 ~push_failure_count:0
+            ~branch_rebased_onto:None ~branch_rebased_onto_sha:None
+            ~merge_commit_sha:None ~base_contains_merged_siblings:true
             ~anchor_history:Onton_core.Anchor_history.empty
             ~checks_passing:false ~current_op:None
             ~current_op_state:Patch_agent.Queued ~current_message_id:None
@@ -514,9 +515,9 @@ let () =
             ~merge_ready:false ~is_draft:true ~pr_body_delivered:false
             ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
             ~conflict_noop_count:0 ~no_commits_push_count:0
-            ~push_failure_count:0 ~branch_rebased_onto:None
-            ~branch_rebased_onto_sha:None ~merge_commit_sha:None
-            ~base_contains_merged_siblings:true
+            ~context_exhaustion_count:0 ~push_failure_count:0
+            ~branch_rebased_onto:None ~branch_rebased_onto_sha:None
+            ~merge_commit_sha:None ~base_contains_merged_siblings:true
             ~anchor_history:Onton_core.Anchor_history.empty
             ~checks_passing:false ~current_op:None
             ~current_op_state:Patch_agent.Queued ~current_message_id:None
@@ -655,9 +656,9 @@ let () =
             ~merge_ready:false ~is_draft:false ~pr_body_delivered:true
             ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
             ~conflict_noop_count:0 ~no_commits_push_count:0
-            ~push_failure_count:0 ~branch_rebased_onto:None
-            ~branch_rebased_onto_sha:None ~merge_commit_sha:None
-            ~base_contains_merged_siblings:true
+            ~context_exhaustion_count:0 ~push_failure_count:0
+            ~branch_rebased_onto:None ~branch_rebased_onto_sha:None
+            ~merge_commit_sha:None ~base_contains_merged_siblings:true
             ~anchor_history:Onton_core.Anchor_history.empty
             ~checks_passing:false ~current_op:None
             ~current_op_state:Patch_agent.Queued ~current_message_id:None
@@ -721,9 +722,9 @@ let () =
             ~merge_ready:false ~is_draft:false ~pr_body_delivered:true
             ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
             ~conflict_noop_count:0 ~no_commits_push_count:0
-            ~push_failure_count:0 ~branch_rebased_onto:None
-            ~branch_rebased_onto_sha:None ~merge_commit_sha:None
-            ~base_contains_merged_siblings:true
+            ~context_exhaustion_count:0 ~push_failure_count:0
+            ~branch_rebased_onto:None ~branch_rebased_onto_sha:None
+            ~merge_commit_sha:None ~base_contains_merged_siblings:true
             ~anchor_history:Onton_core.Anchor_history.empty
             ~checks_passing:false ~current_op:None
             ~current_op_state:Patch_agent.Queued ~current_message_id:None
@@ -868,9 +869,9 @@ let () =
             ~merge_ready:false ~is_draft:true ~pr_body_delivered:false
             ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
             ~conflict_noop_count:0 ~no_commits_push_count:0
-            ~push_failure_count:0 ~branch_rebased_onto:(Some main)
-            ~branch_rebased_onto_sha:None ~merge_commit_sha:None
-            ~base_contains_merged_siblings:true
+            ~context_exhaustion_count:0 ~push_failure_count:0
+            ~branch_rebased_onto:(Some main) ~branch_rebased_onto_sha:None
+            ~merge_commit_sha:None ~base_contains_merged_siblings:true
             ~anchor_history:Onton_core.Anchor_history.empty
             ~checks_passing:false ~current_op:None
             ~current_op_state:Patch_agent.Queued ~current_message_id:None
@@ -1080,9 +1081,9 @@ let () =
             ~merge_ready:false ~is_draft:false ~pr_body_delivered:true
             ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
             ~conflict_noop_count:0 ~no_commits_push_count:0
-            ~push_failure_count:0 ~branch_rebased_onto:None
-            ~branch_rebased_onto_sha:None ~merge_commit_sha:None
-            ~base_contains_merged_siblings:true
+            ~context_exhaustion_count:0 ~push_failure_count:0
+            ~branch_rebased_onto:None ~branch_rebased_onto_sha:None
+            ~merge_commit_sha:None ~base_contains_merged_siblings:true
             ~anchor_history:Onton_core.Anchor_history.empty
             ~checks_passing:false ~current_op:None
             ~current_op_state:Patch_agent.Queued ~current_message_id:None
@@ -1125,9 +1126,9 @@ let () =
             ~merge_ready:false ~is_draft:false ~pr_body_delivered:true
             ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
             ~conflict_noop_count:0 ~no_commits_push_count:0
-            ~push_failure_count:0 ~branch_rebased_onto:None
-            ~branch_rebased_onto_sha:None ~merge_commit_sha:None
-            ~base_contains_merged_siblings:true
+            ~context_exhaustion_count:0 ~push_failure_count:0
+            ~branch_rebased_onto:None ~branch_rebased_onto_sha:None
+            ~merge_commit_sha:None ~base_contains_merged_siblings:true
             ~anchor_history:Onton_core.Anchor_history.empty
             ~checks_passing:false ~current_op:None
             ~current_op_state:Patch_agent.Queued ~current_message_id:None

--- a/test/test_poll_log_properties.ml
+++ b/test/test_poll_log_properties.ml
@@ -52,9 +52,10 @@ let make_agent ~patch_id ~branch ~has_conflict ~ci_failure_count ~current_op
     ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
     ~merge_ready:false ~is_draft ~pr_body_delivered:true
     ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
-    ~conflict_noop_count:0 ~no_commits_push_count:0 ~push_failure_count:0
-    ~branch_rebased_onto:None ~branch_rebased_onto_sha:None
-    ~merge_commit_sha:None ~base_contains_merged_siblings:true
+    ~conflict_noop_count:0 ~no_commits_push_count:0 ~context_exhaustion_count:0
+    ~push_failure_count:0 ~branch_rebased_onto:None
+    ~branch_rebased_onto_sha:None ~merge_commit_sha:None
+    ~base_contains_merged_siblings:true
     ~anchor_history:Onton_core.Anchor_history.empty ~checks_passing ~current_op
     ~current_op_state:(if busy then Patch_agent.Running else Patch_agent.Queued)
     ~current_message_id:None ~generation:0 ~worktree_path ~branch_blocked

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -732,7 +732,8 @@ let () =
             a.Patch_agent.busy
         | Orchestrator.Session_process_error _ | Orchestrator.Session_no_resume
         | Orchestrator.Session_failed _ | Orchestrator.Session_give_up
-        | Orchestrator.Session_worktree_missing ->
+        | Orchestrator.Session_worktree_missing
+        | Orchestrator.Session_context_exhausted ->
             not a.Patch_agent.busy)
   in
   (* Property: Session_give_up sets needs_intervention *)
@@ -1366,6 +1367,78 @@ let () =
         && Int.equal a_before.Patch_agent.ci_failure_count
              a_after.Patch_agent.ci_failure_count)
   in
+  (* context_exhaustion_count property tests (PCE-N) mirror PNC-N: bump the
+     counter, clear llm_session_id (so the next session starts fresh rather
+     than resuming the overflowed thread), trigger needs_intervention at >= 2,
+     and reset on Session_ok / reset_intervention_state. *)
+  let prop_pce1_increments_counter =
+    Test.make ~name:"PCE-1: on_context_exhausted bumps the counter by exactly 1"
+      (Gen.int_range 0 5) (fun n ->
+        let a =
+          List.fold (List.range 0 n) ~init:(fresh_agent ()) ~f:(fun a _ ->
+              Patch_agent.on_context_exhausted a)
+        in
+        Int.equal a.Patch_agent.context_exhaustion_count n)
+  in
+  let prop_pce2_intervention_threshold =
+    Test.make
+      ~name:"PCE-2: context_exhaustion_count >= 2 flips needs_intervention"
+      (Gen.int_range 0 4) (fun n ->
+        let a =
+          List.fold (List.range 0 n) ~init:(fresh_agent ()) ~f:(fun a _ ->
+              Patch_agent.on_context_exhausted a)
+        in
+        Bool.equal (Patch_agent.needs_intervention a) (n >= 2))
+  in
+  let prop_pce3_clears_session_id =
+    Test.make ~name:"PCE-3: on_context_exhausted clears llm_session_id"
+      (Gen.return ()) (fun () ->
+        let a =
+          Patch_agent.set_llm_session_id (fresh_agent ()) (Some "overflowed")
+        in
+        let a = Patch_agent.on_context_exhausted a in
+        Option.is_none a.Patch_agent.llm_session_id)
+  in
+  let prop_pce4_reset_intervention_clears_counter =
+    Test.make ~name:"PCE-4: reset_intervention_state zeros context_exhaustion"
+      (Gen.int_range 0 5) (fun n ->
+        let a =
+          List.fold (List.range 0 n) ~init:(fresh_agent ()) ~f:(fun a _ ->
+              Patch_agent.on_context_exhausted a)
+        in
+        let a = Patch_agent.reset_intervention_state a in
+        Int.equal a.Patch_agent.context_exhaustion_count 0
+        && not (Patch_agent.needs_intervention a))
+  in
+  let prop_pce5_apply_bumps_and_clears =
+    Test.make
+      ~name:
+        "PCE-5: apply_session_result Session_context_exhausted bumps counter, \
+         clears session, completes" (Gen.return ()) (fun () ->
+        let orch, pid = mk_busy_orch () in
+        let orch =
+          Orchestrator.set_llm_session_id orch pid (Some "overflowed")
+        in
+        let orch =
+          Orchestrator.apply_session_result orch pid Session_context_exhausted
+        in
+        let a = Orchestrator.agent orch pid in
+        Int.equal a.Patch_agent.context_exhaustion_count 1
+        && Option.is_none a.Patch_agent.llm_session_id
+        && not a.Patch_agent.busy)
+  in
+  let prop_pce6_session_ok_resets =
+    Test.make ~name:"PCE-6: Session_ok resets context_exhaustion_count"
+      (Gen.int_range 1 4) (fun n ->
+        let orch, pid = mk_busy_orch () in
+        let orch =
+          List.fold (List.range 0 n) ~init:orch ~f:(fun o _ ->
+              Orchestrator.apply_session_result o pid Session_context_exhausted)
+        in
+        let orch = Orchestrator.apply_session_result orch pid Session_ok in
+        let a = Orchestrator.agent orch pid in
+        Int.equal a.Patch_agent.context_exhaustion_count 0)
+  in
   (* Pure push-gate tests — verify the two pure decision helpers in
      [Worktree] that drive [force_push_with_lease]. *)
   let prop_gate_zero_skips =
@@ -1514,6 +1587,12 @@ let () =
       prop_pnc6_apply_bumps_counter;
       prop_pnc7_apply_completes_failed;
       prop_pnc8_apply_preserves_other_counters;
+      prop_pce1_increments_counter;
+      prop_pce2_intervention_threshold;
+      prop_pce3_clears_session_id;
+      prop_pce4_reset_intervention_clears_counter;
+      prop_pce5_apply_bumps_and_clears;
+      prop_pce6_session_ok_resets;
       prop_gate_zero_skips;
       prop_gate_positive_proceeds;
       prop_gate_unknown_proceeds;

--- a/test/test_run_classification.ml
+++ b/test/test_run_classification.ml
@@ -14,7 +14,8 @@ let () =
       (fun msg ->
         match classify ~is_resume:false (Error msg) with
         | Process_error m -> String.equal m msg
-        | No_session_to_resume | Timed_out | Success _ | Session_failed _ ->
+        | No_session_to_resume | Timed_out | Context_exhausted _ | Success _
+        | Session_failed _ ->
             false)
   in
 
@@ -25,8 +26,8 @@ let () =
         let r = { r with timed_out = true } in
         match classify ~is_resume:false (Ok r) with
         | Timed_out -> true
-        | Process_error _ | No_session_to_resume | Success _ | Session_failed _
-          ->
+        | Process_error _ | No_session_to_resume | Context_exhausted _
+        | Success _ | Session_failed _ ->
             false)
   in
 
@@ -50,7 +51,9 @@ let () =
         in
         match classify ~is_resume:true (Ok r) with
         | No_session_to_resume -> true
-        | Process_error _ | Timed_out | Success _ | Session_failed _ -> false)
+        | Process_error _ | Timed_out | Context_exhausted _ | Success _
+        | Session_failed _ ->
+            false)
   in
 
   (* Ok with no events + resume + exit_code=0 -> Success *)
@@ -68,8 +71,8 @@ let () =
         in
         match classify ~is_resume:true (Ok r) with
         | Success _ -> true
-        | Process_error _ | No_session_to_resume | Timed_out | Session_failed _
-          ->
+        | Process_error _ | No_session_to_resume | Timed_out
+        | Context_exhausted _ | Session_failed _ ->
             false)
   in
 
@@ -82,8 +85,8 @@ let () =
         in
         match classify ~is_resume:false (Ok r) with
         | Success _ -> true
-        | Process_error _ | No_session_to_resume | Timed_out | Session_failed _
-          ->
+        | Process_error _ | No_session_to_resume | Timed_out
+        | Context_exhausted _ | Session_failed _ ->
             false)
   in
 
@@ -102,7 +105,8 @@ let () =
         in
         match classify ~is_resume:false (Ok r) with
         | Session_failed _ -> true
-        | Process_error _ | No_session_to_resume | Timed_out | Success _ ->
+        | Process_error _ | No_session_to_resume | Timed_out
+        | Context_exhausted _ | Success _ ->
             false)
   in
 
@@ -121,7 +125,8 @@ let () =
         in
         match classify ~is_resume:false (Ok r) with
         | Session_failed { detail; _ } -> String.length detail <= 503
-        | Process_error _ | No_session_to_resume | Timed_out | Success _ ->
+        | Process_error _ | No_session_to_resume | Timed_out
+        | Context_exhausted _ | Success _ ->
             false)
   in
 
@@ -138,8 +143,8 @@ let () =
         let r = { r with saw_final_result = true; timed_out = false } in
         match classify ~is_resume (Ok r) with
         | Success _ -> true
-        | Process_error _ | No_session_to_resume | Timed_out | Session_failed _
-          ->
+        | Process_error _ | No_session_to_resume | Timed_out
+        | Context_exhausted _ | Session_failed _ ->
             false)
   in
 
@@ -150,8 +155,8 @@ let () =
         let r = { r with saw_final_result = true; timed_out = true } in
         match classify ~is_resume:false (Ok r) with
         | Timed_out -> true
-        | Process_error _ | No_session_to_resume | Success _ | Session_failed _
-          ->
+        | Process_error _ | No_session_to_resume | Context_exhausted _
+        | Success _ | Session_failed _ ->
             false)
   in
 
@@ -162,7 +167,50 @@ let () =
         let r = { r with got_events = false; timed_out = false } in
         match classify ~is_resume:false (Ok r) with
         | No_session_to_resume -> false (* should not happen without continue *)
-        | Process_error _ | Timed_out | Success _ | Session_failed _ -> true)
+        | Process_error _ | Timed_out | Context_exhausted _ | Success _
+        | Session_failed _ ->
+            true)
+  in
+
+  (* An error stream that reports a context-window overflow classifies as
+     Context_exhausted regardless of exit code or saw_final_result (but after
+     timed_out). Spec: an overflowed thread is poisoned and must be restarted
+     fresh, not resumed — see [Patch_agent.on_context_exhausted]. *)
+  let prop_context_exhausted =
+    Test.make ~name:"classify: overflow error stream -> Context_exhausted"
+      ~count:500
+      Gen.(
+        pair gen_run_outcome
+          (oneof_list
+             [
+               "Codex ran out of room in the model's context window. Start a \
+                new thread or clear earlier history before retrying.";
+               "model_context_window_exceeded";
+               "Your input exceeds the context window of this model \
+                (context_length_exceeded)";
+             ]))
+      (fun (r, overflow) ->
+        let r = { r with stream_errors = overflow; timed_out = false } in
+        match classify ~is_resume:true (Ok r) with
+        | Context_exhausted { stream_errors } ->
+            String.equal stream_errors overflow
+        | Process_error _ | No_session_to_resume | Timed_out | Success _
+        | Session_failed _ ->
+            false)
+  in
+
+  (* Timeout still wins over a context-overflow error stream. *)
+  let prop_timeout_beats_context_exhausted =
+    Test.make ~name:"classify: timed_out overrides context overflow" ~count:500
+      gen_run_outcome (fun r ->
+        let r =
+          { r with stream_errors = "ran out of room"; timed_out = true }
+        in
+        match classify ~is_resume:false (Ok r) with
+        | Timed_out -> true
+        | Process_error _ | No_session_to_resume | Context_exhausted _
+        | Success _ | Session_failed _ ->
+            false)
   in
 
   let suite =
@@ -177,6 +225,8 @@ let () =
       prop_saw_final_is_success;
       prop_timeout_beats_saw_final;
       prop_no_continue_uses_exit_code;
+      prop_context_exhausted;
+      prop_timeout_beats_context_exhausted;
     ]
   in
   let errcode = QCheck_base_runner.run_tests ~verbose:true suite in


### PR DESCRIPTION
## Problem

A Codex session that overflows the model's context window exits `0` with `"ran out of room in the model's context window"` in its error stream. `Run_classification.classify` previously treated any exit-0 outcome as `Success`, so:

1. `llm_session_id` was **retained**, and the next operation resumed the *same overflowed thread* → instant re-overflow → another silent "success" → **infinite no-progress loop**.
2. The failure ladder never advanced (it only escalates on classified *failures*), so the agent never surfaced for intervention. Stuck but invisible.

## Fix

Detect context exhaustion as a distinct outcome and recover by **starting fresh**:

- **Detection** (`run_classification`): new `is_context_exhausted` predicate (matched on the error stream only — never agent text) + a `Context_exhausted` variant, classified **after `Timed_out`, before `Success`** (so it wins over a misleading exit-0, but a real timeout still wins).
- **Parser robustness** (`codex_event_parser`): surface `turn.failed`'s `error.message` as a stream `Error` (previously silently dropped), so overflow is detected whichever event carries it.
- **Recovery** (`patch_agent`): new `context_exhaustion_count` + `on_context_exhausted` — bumps the counter and clears `llm_session_id` so the next session starts fresh (the prompt rebuilds context from the working tree + PR diff). Leaves the resume/fresh `session_fallback` ladder untouched; exhaustion has its own intervention budget. At `>= 2` the agent surfaces for intervention: a *fresh* session that still overflows means the task doesn't fit one context window.
- **Wiring**: `Session_context_exhausted` through `orchestrator` / `session_driver`; `Context_exhausted` telemetry subkind in `failure_subkind` / `event_log`; `persistence` serialize + deserialize-with-default for old snapshots.

Detection is backend-agnostic: Claude auto-compacts in headless mode so it's normally unaffected, but its rare compaction-failure now also fresh-restarts rather than looping.

## Tests

- `test_run_classification`: overflow → `Context_exhausted`, precedence over success, timeout beats overflow, no false positives.
- `test_properties`: `PCE-1..6` (counter increments, `>=2` flips intervention, clears `llm_session_id`, `Session_ok` / `reset_intervention_state` reset).
- `codex_event_parser`: inline tests for `turn.failed`.
- `test_generators`: round-trip generator now exercises the new field.

Full suite + ocamlformat check pass (verified by the pre-push hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/338"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782510680&installation_id=126163856&pr_number=338&repository=flowglad%2Fonton&return_to=https%3A%2F%2Fgithub.com%2Fflowglad%2Fonton%2Fpull%2F338&signature=8fc7d7d8e76ffefaac541c399801708ef0fac84624fe2755946e85ecf8a790ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detects model context-window exhaustion and restarts with a fresh session to prevent infinite resume loops. Adds a small, bounded restart budget and surfaces for intervention after two overflows.

- **Bug Fixes**
  - Detection: new `Context_exhausted` in `run_classification` via `is_context_exhausted`; takes precedence over success, but not over timeout. Parser now surfaces Codex `turn.failed` `error.message` as stream `Error` for reliable detection (backend-agnostic: covers Codex and Claude).
  - Recovery: `patch_agent.on_context_exhausted` increments `context_exhaustion_count` and clears `llm_session_id` so the next run starts fresh; intervention triggers at `>= 2`; resets on successful sessions and `reset_intervention_state`.
  - Wiring/telemetry: handled as `Session_context_exhausted` in `orchestrator`/`session_driver`; `failure_subkind` gains `Context_exhausted`.
  - Persistence/tests: added `context_exhaustion_count` with default on deserialize; comprehensive tests cover classification precedence, parser behavior, state updates, and property checks.
  - Packaging: Homebrew formula updated to `v0.38.0`, re-enables Intel build.

<sup>Written for commit ddd8906ec326639aeef29d118362e20de863e0f7. Summary will update on new commits. <a href="https://cubic.dev/pr/flowglad/onton/pull/338?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

