### PR TITLE
write-gameplan: don't assume a new feature flag

### DIFF
--- a/skills/write-gameplan/SKILL.md
+++ b/skills/write-gameplan/SKILL.md
@@ -300,18 +300,32 @@ Attach precedents at the **patch** level, on the specific patches the precedent 
 
 ### Feature Flagging
 
-If the gameplan introduces new behavior that should be gated:
+When a gameplan introduces new behavior, there are **three** possible gating strategies — and which one is right is a decision for the programmer, not an assumption for you to make:
+
+1. **Create a new feature flag** and gate the new behavior behind it.
+2. **Gate behind an existing feature flag** the project already defines.
+3. **Don't gate at all** — ship the behavior directly (appropriate for pure refactors with no observable change, low-risk additions, or work that is itself enabling a flag that already exists).
+
+**Do not default to "create a new flag."** Creating a new flag is one option among three, not the presumed answer. Reflexively minting a new flag for every gameplan litters the codebase with dead toggles, fragments rollouts that should share a flag, and gates changes that never needed gating.
+
+**Before deciding, investigate and clarify:**
+
+- **Search the codebase for existing flag infrastructure and flags.** Find how this project gates behavior (a flag service, a database-backed flag table, environment variables, build constants) and enumerate the flags that already exist. A new feature frequently belongs under an existing flag that already gates the surrounding surface or an in-progress rollout.
+- **Decide whether gating is warranted at all.** If the change is a pure refactor with no observable behavior change, or is otherwise safe to ship unconditionally, option 3 is correct — record *why* no flag is needed.
+- **If the user has not already specified which strategy to use and the answer is not unambiguous from the codebase, do not guess — surface it.** Add an entry to `openQuestions` (e.g. "Gate behind a new flag, reuse existing flag `X`, or ship ungated?") so it is resolved with the programmer during [Resolving Open Questions](#resolving-open-questions), presenting the three options with the tradeoffs you found. Only treat the decision as settled when the user has stated it or the codebase makes it unambiguous.
+
+Once the strategy is decided, implement the mechanics:
 
 **Runtime flag service** (percentage rollout / allowlist):
 - Use your project's feature flag infrastructure (e.g., LaunchDarkly, Unleash, a database-backed flag table, or a custom service)
-- Declare the flag, gate new behavior behind it, and document the rollout strategy
+- Declare the flag (or reference the existing one), gate new behavior behind it, and document the rollout strategy
 - Use this for gradual rollouts or per-user gating
 
 **Configuration flag** (global on/off, simple cases only):
 - Pattern: an environment variable, config file entry, or build-time constant
 - Use only when a runtime flag service is overkill (e.g., dev-only toggles)
 
-Document the flag in the `featureFlagStrategy` field.
+Record the chosen strategy in the `featureFlagStrategy` field — naming whether the flag is new or reused, or stating plainly why no flag is needed — and populate `featureFlags` accordingly (an empty array when ungated).
 
 ### Patch Ordering
 


### PR DESCRIPTION
## Summary

The `write-gameplan` skill nudged the agent toward minting a **new** feature flag for every gameplan. This reframes the Feature Flagging guidance so the agent collaborates with the programmer on the gating strategy instead of assuming.

## Changes

The **Feature Flagging** subsection now:

- States the **three** strategies up front — create a new flag, gate behind an existing flag, or don't gate at all.
- Explicitly forbids defaulting to "create a new flag," with the rationale (dead toggles, fragmented rollouts, needlessly gated changes).
- Requires investigating the codebase for existing flag infrastructure and enumerating existing flags before deciding.
- Routes an undecided choice into the existing `openQuestions` dialogue (the established [Resolving Open Questions](#resolving-open-questions) step) rather than guessing — presenting all three options with tradeoffs.
- Clarifies recording the chosen strategy in `featureFlagStrategy` and populating `featureFlags` accordingly (empty array when ungated).

No schema change needed — the schema already permits an empty `featureFlags` array and a free-text `featureFlagStrategy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/339"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782664397&installation_id=126163856&pr_number=339&repository=flowglad%2Fonton&return_to=https%3A%2F%2Fgithub.com%2Fflowglad%2Fonton%2Fpull%2F339&signature=4ef957228c25e978d28d28a621f20a26a2ee34637cca48f28fa43bedca25c18e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->