### PR TITLE
Show the actionable reason in the needs-intervention banner

### DIFF
--- a/lib/tui.ml
+++ b/lib/tui.ml
@@ -326,6 +326,53 @@ type patch_view = {
 }
 [@@warning "-69"]
 
+(* Translate the authoritative [Patch_agent.intervention_reason] code into a
+   human-facing, actionable banner line. The codes are the single source of
+   truth for *why* a patch is stuck (see patch_agent.ml); this function is the
+   single source of truth for how to *phrase* that to an operator. Returns
+   [None] exactly when the agent does not need intervention.
+
+   A reason code we don't recognise falls through to the raw code rather than a
+   generic message: an unmapped real reason is still more actionable than a
+   misleading one, and it flags that a new code needs a phrasing here. *)
+let human_intervention_reason (agent : Patch_agent.t) =
+  Option.map (Patch_agent.intervention_reason agent) ~f:(fun code ->
+      match code with
+      | "session_fallback=given_up" ->
+          "Agent gave up after repeated session failures \xe2\x80\x94 needs \
+           manual fix or restart"
+      | "pr_missing" ->
+          "PR is missing from the remote \xe2\x80\x94 recreate it or \
+           investigate why it vanished"
+      | "ci_failure_count>=3" ->
+          Printf.sprintf
+            "CI failed %d times in a row \xe2\x80\x94 fix the failing checks \
+             below"
+            agent.Patch_agent.ci_failure_count
+      | "start_attempts_without_pr>=2" ->
+          Printf.sprintf
+            "Could not open a PR after %d attempts \xe2\x80\x94 open it \
+             manually or check repo access"
+            agent.Patch_agent.start_attempts_without_pr
+      | "conflict_noop_count>=2" ->
+          "Stuck resolving merge conflicts against base \xe2\x80\x94 resolve \
+           them manually"
+      | "no_commits_push_count>=2" ->
+          "Sessions keep producing no commits to push \xe2\x80\x94 the task \
+           may be done or mis-scoped"
+      | "context_exhaustion_count>=2" ->
+          "Context window exhausted repeatedly \xe2\x80\x94 split the patch \
+           into smaller pieces"
+      | "push_failure_count>=3" ->
+          Printf.sprintf
+            "git push failed %d times \xe2\x80\x94 check branch protection or \
+             remote state"
+            agent.Patch_agent.push_failure_count
+      | "pr_body_artifact_miss_count>=2" ->
+          "PR body delivery blocked repeatedly \xe2\x80\x94 check the PR \
+           description requirements"
+      | other -> other)
+
 let patch_view_of_agent (agent : Patch_agent.t)
     ~(patches_by_id : Patch.t Map.M(Patch_id).t) ~(graph : Graph.t)
     ~(main_branch : Branch.t) ~(agents_by_id : Patch_agent.t Map.M(Patch_id).t)
@@ -424,7 +471,7 @@ let patch_view_of_agent (agent : Patch_agent.t)
     pr_missing = Patch_agent.is_pr_missing agent;
     base_branch = agent.base_branch;
     worktree_path = agent.worktree_path;
-    intervention_reason = None;
+    intervention_reason = human_intervention_reason agent;
     automerge_enabled = agent.automerge_enabled;
     automerge_deadline = agent.automerge_deadline;
     automerge_failure_count = agent.automerge_failure_count;
@@ -1135,12 +1182,20 @@ let views_of_orchestrator ~(orchestrator : Orchestrator.t)
         in
         let intervention_reason =
           if pv.needs_intervention then
-            match Map.Poly.find intervention_reasons pv.patch_id with
+            (* Prefer the authoritative reason derived from the agent's own
+               failure counters (set in [patch_view_of_agent]). The activity-log
+               map and recent stream are only deep fallbacks: scraping the most
+               recent event surfaces whatever happened last (e.g. "pushed after
+               session"), which is rarely the reason the patch is stuck. *)
+            match pv.intervention_reason with
             | Some _ as r -> r
-            | None ->
-                List.find_map filtered ~f:(function
-                  | Event { message; _ } -> Some message
-                  | Transition _ -> None)
+            | None -> (
+                match Map.Poly.find intervention_reasons pv.patch_id with
+                | Some _ as r -> r
+                | None ->
+                    List.find_map filtered ~f:(function
+                      | Event { message; _ } -> Some message
+                      | Transition _ -> None))
           else None
         in
         { pv with recent_stream = List.take filtered 10; intervention_reason })

--- a/lib/tui.mli
+++ b/lib/tui.mli
@@ -148,6 +148,14 @@ val patch_count : frame -> int
 (** Number of actually rendered patch rows in the visible window (not total
     patches). Only meaningful in list view; 0 otherwise. *)
 
+val human_intervention_reason : Onton_core.Patch_agent.t -> string option
+(** The human-facing, actionable banner line for why a patch needs intervention,
+    or [None] when it does not. Translates the authoritative reason code from
+    {!Onton_core.Patch_agent.intervention_reason} (which is driven by the
+    agent's own failure counters) into operator-readable text. This is the
+    source the detail banner trusts first, ahead of any scraped activity-log
+    event. *)
+
 val views_of_orchestrator :
   orchestrator:Orchestrator.t ->
   gameplan:Gameplan.t ->

--- a/test/dune
+++ b/test/dune
@@ -178,6 +178,11 @@
  (libraries onton onton_core base))
 
 (test
+ (name test_intervention_reason)
+ (modules test_intervention_reason)
+ (libraries onton onton_core))
+
+(test
  (name test_stream_parser)
  (modules test_stream_parser)
  (libraries onton onton_core qcheck-core))

--- a/test/test_intervention_reason.ml
+++ b/test/test_intervention_reason.ml
@@ -1,0 +1,59 @@
+(** Regression tests for [Tui.human_intervention_reason].
+
+    The misleading-banner bug: a patch pushed into needs-intervention by a high
+    CI-failure count rendered "runner: pushed after session" — the most recent
+    (and innocuous) activity-log line — instead of the actionable reason. The
+    fix makes the banner derive from the agent's own failure counters via
+    [Patch_agent.intervention_reason]. These tests pin that: the human reason is
+    present exactly when the agent needs intervention, and a CI-stuck agent
+    reports the CI failure, never a push event. *)
+
+open Onton
+open Onton_core
+open Onton_core.Types
+
+let agent () =
+  Patch_agent.create ~branch:(Branch.of_string "b")
+    (Patch_id.of_string "patch-1")
+
+let rec apply n f x = if n <= 0 then x else apply (n - 1) f (f x)
+
+let contains s sub =
+  let s = String.lowercase_ascii s and sub = String.lowercase_ascii sub in
+  let n = String.length s and m = String.length sub in
+  let rec go i =
+    i + m <= n && (String.equal (String.sub s i m) sub || go (i + 1))
+  in
+  m = 0 || go 0
+
+let () =
+  (* A healthy agent needs no intervention and has no banner reason. *)
+  let a = agent () in
+  assert (not (Patch_agent.needs_intervention a));
+  assert (Option.is_none (Tui.human_intervention_reason a));
+
+  (* Three CI failures is the documented threshold for intervention. *)
+  let stuck = apply 3 Patch_agent.increment_ci_failure_count a in
+  assert (Patch_agent.needs_intervention stuck);
+  (match Tui.human_intervention_reason stuck with
+  | None -> assert false
+  | Some msg ->
+      (* The reason names the CI failure and its count... *)
+      assert (contains msg "ci");
+      assert (contains msg "3");
+      (* ...and never the innocuous push event that triggered the bug. *)
+      assert (not (contains msg "pushed")));
+
+  (* The human reason is present exactly when intervention is needed: the two
+     stay in lockstep with the authoritative predicate, so the banner can't
+     show a reason for a healthy patch (or hide one for a stuck patch). *)
+  assert (
+    Bool.equal
+      (Patch_agent.needs_intervention stuck)
+      (Option.is_some (Tui.human_intervention_reason stuck)));
+  assert (
+    Bool.equal
+      (Patch_agent.needs_intervention a)
+      (Option.is_some (Tui.human_intervention_reason a)));
+
+  print_endline "PASS: human_intervention_reason surfaces the actionable reason"


### PR DESCRIPTION
## Problem

The patch-detail **"Needs attention"** banner displayed the *most recent activity-log event* for a patch rather than *why it actually needs intervention*. In the reported case, a patch stuck on CI failures that had just been pushed showed:

> ⚠ Needs attention: runner: pushed after session

— innocuous and unactionable — even though `Patch_agent.intervention_reason` (the documented single source of truth) already knew the real reason was `ci_failure_count>=3`.

The TUI ignored that authoritative reason and instead scraped the last log line via `intervention_reasons_of_log`, surfacing whatever happened most recently.

## Fix

- New `human_intervention_reason` (lib/tui.ml) translates each authoritative reason code (`ci_failure_count>=3`, `pr_missing`, `session_fallback=given_up`, …) into an operator-readable, actionable line with the real counts interpolated — e.g. *"CI failed 3 times in a row — fix the failing checks below"*. An unmapped code falls through to the raw code (still the real reason, and a signal that a new code needs phrasing) rather than a generic message.
- `patch_view_of_agent` now populates `intervention_reason` from this function.
- `views_of_orchestrator` prefers the authoritative reason; the scraped activity-log event and recent stream are demoted to deep fallbacks.

Net effect: the banner now names the actual blocking condition instead of the last thing that happened.

## Test

`test/test_intervention_reason.ml` builds an agent through the public API, drives it to 3 CI failures, and asserts the banner reason names the CI failure and its count — and **never** "pushed" — plus that the human reason is present exactly when `Patch_agent.needs_intervention` is true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the real, actionable reason in the Needs attention banner by using `Patch_agent.intervention_reason` instead of the last activity-log event. Stuck patches now display the actual blocking condition (e.g., repeated CI failures), not innocuous recent events.

- Bug Fixes
  - Added `human_intervention_reason` to translate reason codes to clear text; unmapped codes fall back to the raw code.
  - `patch_view_of_agent` now sets `intervention_reason` from this source; `views_of_orchestrator` prefers it and only falls back to scraped log events.
  - Added `test/test_intervention_reason.ml` to pin CI-failure messaging and ensure the reason appears exactly when `needs_intervention` is true.

<sup>Written for commit a5e136e65634c720ff8c8ff501e4c193ddf4b8d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/flowglad/onton/pull/340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

