### PR TITLE
Publish a read-only gameplan copy for patch agents to consult on demand

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -315,6 +315,10 @@ let finalize_run ~project_name ~repo_coords ~run_knobs ~backend_inputs
     ~poll_interval ~repo_root ~max_concurrency
     ~url_scheme:(Option.map Managed_repo.string_of_url_scheme url_scheme)
     ();
+  (* Refresh the agent-readable gameplan copy under artifacts/ so patch
+     agents can consult the full gameplan on demand (the gameplan layer of
+     every patch prompt points at this path). *)
+  Project_store.publish_gameplan_artifact ~project_name;
   let config =
     {
       Resolved_config.project = Some project_name;

--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -351,12 +351,25 @@ let plan_action_for_patch t ~branch_map patch_id =
        is_pr_present rather than has_pr (which is true for [Missing] too). *)
     Patch_agent.is_pr_present (Orchestrator.agent t pid)
   in
+  let notes_delivered pid =
+    (* deps-notes-ready (spec): the child's prompt points at each ancestor's
+       implementation notes ([artifacts/<id>/pr-body.md]), so Start waits for
+       every unmerged dep to finish its Pr_body step. Merged deps are exempt —
+       a merged patch can never deliver notes ([enqueue_pr_body_if_needed]
+       skips merged agents), so waiting on one would deadlock; its artifact
+       persists on disk if it was delivered while open. [pr_body_delivered]
+       is monotone (never reset), so gating at plan time is race-free. *)
+    (Orchestrator.agent t pid).Patch_agent.pr_body_delivered
+  in
   if
     (not (Patch_agent.has_pr agent))
     && (not agent.Patch_agent.busy)
     && (not agent.Patch_agent.merged)
     && (not (Patch_agent.needs_intervention agent))
     && Graph.deps_satisfied (Orchestrator.graph t) patch_id ~has_merged ~has_pr
+    && List.for_all
+         (Graph.open_pr_deps (Orchestrator.graph t) patch_id ~has_merged)
+         ~f:notes_delivered
   then
     let branch_of pid =
       match Map.find branch_map pid with
@@ -977,6 +990,64 @@ let%test
       | Set_pr_draft { patch_id; draft = false; _ } ->
           Patch_id.equal patch_id child_id
       | Set_pr_draft _ | Set_pr_base _ -> false))
+
+(* Shared fixture for the deps-notes-ready Start gate tests: a parent with an
+   open PR and a child depending on it. *)
+let make_notes_gate_fixture () =
+  let parent_id = Patch_id.of_string "parent" in
+  let child_id = Patch_id.of_string "child" in
+  let mk_patch id branch deps =
+    {
+      Patch.id;
+      title = "test";
+      description = "test";
+      branch;
+      dependencies = deps;
+      spec = "";
+      acceptance_criteria = [];
+      changes = [];
+      files = [];
+      classification = "";
+      test_stubs_introduced = [];
+      test_stubs_implemented = [];
+      complexity = None;
+      precedents = [];
+      required_context = [];
+    }
+  in
+  let parent_patch = mk_patch parent_id (Branch.of_string "parent-branch") [] in
+  let child_patch =
+    mk_patch child_id (Branch.of_string "child-branch") [ parent_id ]
+  in
+  let patches = [ parent_patch; child_patch ] in
+  let t = Orchestrator.create ~patches ~main_branch:main in
+  let t = Orchestrator.fire t (Orchestrator.Start (parent_id, main)) in
+  let t = Orchestrator.set_pr_number t parent_id (Pr_number.of_int 41) in
+  let t = Orchestrator.complete t parent_id in
+  (parent_id, child_id, patches, t)
+
+let plans_child_start ~child_id ~patches t =
+  List.exists (plan_actions t ~patches) ~f:(function
+    | Orchestrator.Start (p, _) -> Patch_id.equal p child_id
+    | Orchestrator.Respond _ | Orchestrator.Rebase _ -> false)
+
+let%test "plan_actions defers child Start until open dep's notes are delivered"
+    =
+  let parent_id, child_id, patches, t = make_notes_gate_fixture () in
+  (* Parent's PR is open but its Pr_body step has not completed
+     (deps-notes-ready is false), so the child must not start yet. *)
+  (not (plans_child_start ~child_id ~patches t))
+  (* Once the notes are delivered the child becomes startable. *)
+  && plans_child_start ~child_id ~patches
+       (Orchestrator.set_pr_body_delivered t parent_id true)
+
+let%test "plan_actions does not gate child Start on a merged dep's notes" =
+  let parent_id, child_id, patches, t = make_notes_gate_fixture () in
+  (* Parent merges without ever delivering notes (e.g. merged by a human
+     before the Pr_body step ran). A merged dep can never deliver, so the
+     gate must exempt it rather than deadlock the child. *)
+  let t = Orchestrator.mark_merged t parent_id in
+  plans_child_start ~child_id ~patches t
 
 let%test "reconcile_patch emits no effects for merged agent" =
   let patch, t = make_orchestrator ~patch_id:pid ~main_branch:main in

--- a/lib/project_store.ml
+++ b/lib/project_store.ml
@@ -3,8 +3,8 @@ open Ppx_yojson_conv_lib.Yojson_conv.Primitives
 
 let data_dir () =
   match Stdlib.Sys.getenv_opt "ONTON_DATA_DIR" with
-  | Some d -> d
-  | None -> (
+  | Some d when not (String.is_empty d) -> d
+  | Some _ | None -> (
       match Stdlib.Sys.getenv_opt "XDG_DATA_HOME" with
       | Some xdg -> Stdlib.Filename.concat xdg "onton"
       | None ->
@@ -206,7 +206,7 @@ let publish_gameplan_artifact ~project_name =
     ensure_dir (Stdlib.Filename.dirname dest);
     let oc = Stdlib.open_out_bin dest in
     Stdlib.Fun.protect
-      ~finally:(fun () -> Stdlib.close_out oc)
+      ~finally:(fun () -> Stdlib.close_out_noerr oc)
       (fun () ->
         Stdlib.output_string oc content;
         Stdlib.flush oc))
@@ -238,21 +238,7 @@ let with_temp_data_dir f =
     ~finally:(fun () ->
       (match old with
       | Some value -> Unix.putenv "ONTON_DATA_DIR" value
-      | None ->
-          (* Tests do not have an unsetenv binding. Restore the resolved
-             default data root so later tests never inherit a deleted temp
-             directory through ONTON_DATA_DIR. *)
-          let default =
-            match Stdlib.Sys.getenv_opt "XDG_DATA_HOME" with
-            | Some xdg -> Stdlib.Filename.concat xdg "onton"
-            | None ->
-                Stdlib.Filename.concat
-                  (Stdlib.Filename.concat (Stdlib.Sys.getenv "HOME")
-                     ".local/share")
-                  "onton"
-          in
-          ensure_dir default;
-          Unix.putenv "ONTON_DATA_DIR" default);
+      | None -> Unix.putenv "ONTON_DATA_DIR" "");
       try
         ignore
           (Stdlib.Sys.command

--- a/lib/project_store.ml
+++ b/lib/project_store.ml
@@ -47,9 +47,16 @@ let stored_gameplan_path project_name =
   let md = gameplan_path project_name in
   if Stdlib.Sys.file_exists md then md else gameplan_json_path project_name
 
+let artifacts_root project_name =
+  Stdlib.Filename.concat (project_dir project_name) "artifacts"
+
 let artifact_dir ~project_name ~patch_id =
-  Stdlib.Filename.concat (project_dir project_name)
-    (Stdlib.Filename.concat "artifacts" (Types.Patch_id.to_string patch_id))
+  Stdlib.Filename.concat
+    (artifacts_root project_name)
+    (Types.Patch_id.to_string patch_id)
+
+let gameplan_artifact_path project_name =
+  Stdlib.Filename.concat (artifacts_root project_name) "gameplan.json"
 
 let pr_body_artifact_path ~project_name ~patch_id =
   Stdlib.Filename.concat (artifact_dir ~project_name ~patch_id) "pr-body.md"
@@ -186,6 +193,24 @@ let save_gameplan_source ~project_name ~source_path =
   if Stdlib.Sys.file_exists stale then
     try Stdlib.Sys.remove stale with Sys_error _ -> ()
 
+let publish_gameplan_artifact ~project_name =
+  let source = stored_gameplan_path project_name in
+  if Stdlib.Sys.file_exists source then (
+    let ic = Stdlib.open_in_bin source in
+    let content =
+      Stdlib.Fun.protect
+        ~finally:(fun () -> Stdlib.close_in_noerr ic)
+        (fun () -> Stdlib.In_channel.input_all ic)
+    in
+    let dest = gameplan_artifact_path project_name in
+    ensure_dir (Stdlib.Filename.dirname dest);
+    let oc = Stdlib.open_out_bin dest in
+    Stdlib.Fun.protect
+      ~finally:(fun () -> Stdlib.close_out oc)
+      (fun () ->
+        Stdlib.output_string oc content;
+        Stdlib.flush oc))
+
 let project_exists project_name =
   Stdlib.Sys.file_exists (config_path project_name)
 
@@ -200,3 +225,79 @@ let list_projects () =
                 (Stdlib.Filename.concat dir name)
                 "config.json"))
   else []
+
+(* === Inline tests === *)
+
+(* Mirrors [Session_artifacts]'s test helper: point ONTON_DATA_DIR at a
+   fresh temp dir for the duration of [f], then restore. *)
+let with_temp_data_dir f =
+  let old = Stdlib.Sys.getenv_opt "ONTON_DATA_DIR" in
+  let dir = Stdlib.Filename.temp_dir "onton-project-store-" "" in
+  Unix.putenv "ONTON_DATA_DIR" dir;
+  Stdlib.Fun.protect
+    ~finally:(fun () ->
+      (match old with
+      | Some value -> Unix.putenv "ONTON_DATA_DIR" value
+      | None ->
+          (* Tests do not have an unsetenv binding. Restore the resolved
+             default data root so later tests never inherit a deleted temp
+             directory through ONTON_DATA_DIR. *)
+          let default =
+            match Stdlib.Sys.getenv_opt "XDG_DATA_HOME" with
+            | Some xdg -> Stdlib.Filename.concat xdg "onton"
+            | None ->
+                Stdlib.Filename.concat
+                  (Stdlib.Filename.concat (Stdlib.Sys.getenv "HOME")
+                     ".local/share")
+                  "onton"
+          in
+          ensure_dir default;
+          Unix.putenv "ONTON_DATA_DIR" default);
+      try
+        ignore
+          (Stdlib.Sys.command
+             (Printf.sprintf "rm -rf %s" (Stdlib.Filename.quote dir)))
+      with _ -> ())
+    (fun () -> f ())
+
+let read_file_for_test path =
+  let ic = Stdlib.open_in_bin path in
+  Stdlib.Fun.protect
+    ~finally:(fun () -> Stdlib.close_in_noerr ic)
+    (fun () -> Stdlib.In_channel.input_all ic)
+
+let%test "publish_gameplan_artifact copies the stored gameplan for agents" =
+  with_temp_data_dir (fun () ->
+      let project_name = "publish-test" in
+      ensure_dir (project_dir project_name);
+      let content = "{\"project_name\": \"publish-test\", \"patches\": []}" in
+      let oc = Stdlib.open_out_bin (gameplan_json_path project_name) in
+      Stdlib.output_string oc content;
+      Stdlib.close_out oc;
+      publish_gameplan_artifact ~project_name;
+      let dest = gameplan_artifact_path project_name in
+      Stdlib.Sys.file_exists dest
+      && String.equal (read_file_for_test dest) content)
+
+let%test "publish_gameplan_artifact refreshes a stale copy" =
+  with_temp_data_dir (fun () ->
+      let project_name = "publish-test-refresh" in
+      ensure_dir (project_dir project_name);
+      let write path content =
+        let oc = Stdlib.open_out_bin path in
+        Stdlib.output_string oc content;
+        Stdlib.close_out oc
+      in
+      write (gameplan_json_path project_name) "{\"v\": 1}";
+      publish_gameplan_artifact ~project_name;
+      write (gameplan_json_path project_name) "{\"v\": 2}";
+      publish_gameplan_artifact ~project_name;
+      String.equal
+        (read_file_for_test (gameplan_artifact_path project_name))
+        "{\"v\": 2}")
+
+let%test "publish_gameplan_artifact is a no-op without a stored gameplan" =
+  with_temp_data_dir (fun () ->
+      let project_name = "publish-test-empty" in
+      publish_gameplan_artifact ~project_name;
+      not (Stdlib.Sys.file_exists (gameplan_artifact_path project_name)))

--- a/lib/project_store.ml
+++ b/lib/project_store.ml
@@ -194,7 +194,7 @@ let save_gameplan_source ~project_name ~source_path =
     try Stdlib.Sys.remove stale with Sys_error _ -> ()
 
 let publish_gameplan_artifact ~project_name =
-  let source = stored_gameplan_path project_name in
+  let source = gameplan_json_path project_name in
   if Stdlib.Sys.file_exists source then (
     let ic = Stdlib.open_in_bin source in
     let content =
@@ -281,6 +281,16 @@ let%test "publish_gameplan_artifact refreshes a stale copy" =
       String.equal
         (read_file_for_test (gameplan_artifact_path project_name))
         "{\"v\": 2}")
+
+let%test "publish_gameplan_artifact does not publish markdown as JSON" =
+  with_temp_data_dir (fun () ->
+      let project_name = "publish-test-markdown" in
+      ensure_dir (project_dir project_name);
+      let oc = Stdlib.open_out_bin (gameplan_path project_name) in
+      Stdlib.output_string oc "# Markdown gameplan";
+      Stdlib.close_out oc;
+      publish_gameplan_artifact ~project_name;
+      not (Stdlib.Sys.file_exists (gameplan_artifact_path project_name)))
 
 let%test "publish_gameplan_artifact is a no-op without a stored gameplan" =
   with_temp_data_dir (fun () ->

--- a/lib/project_store.mli
+++ b/lib/project_store.mli
@@ -86,6 +86,21 @@ val stored_gameplan_path : string -> string
 val sessions_dir : string -> string
 (** Path to the per-session artifact directory root ([sessions/]). *)
 
+val gameplan_artifact_path : string -> string
+(** Absolute path of the agent-readable gameplan copy
+    ([artifacts/gameplan.json]). Lives in the agent-facing [artifacts/] subtree
+    (alongside the per-patch artifact dirs) so patch agents can consult the full
+    gameplan on demand without being pointed at the project-dir root, which
+    holds [config.json] and its token. A pure function of the project name —
+    prompt layers embed it without touching the filesystem. *)
+
+val publish_gameplan_artifact : project_name:string -> unit
+(** Copy the stored gameplan ({!stored_gameplan_path}) to
+    {!gameplan_artifact_path} for patch agents to read. No-op when no stored
+    gameplan exists (ad-hoc sessions). Called once at startup, after
+    {!save_gameplan_source} / resume validation, so the copy matches the
+    gameplan the run was parsed from. *)
+
 val pr_body_artifact_path :
   project_name:string -> patch_id:Types.Patch_id.t -> string
 (** Absolute path the agent writes the LLM-authored PR body to. Lives under the

--- a/lib/project_store.mli
+++ b/lib/project_store.mli
@@ -95,9 +95,9 @@ val gameplan_artifact_path : string -> string
     prompt layers embed it without touching the filesystem. *)
 
 val publish_gameplan_artifact : project_name:string -> unit
-(** Copy the stored gameplan ({!stored_gameplan_path}) to
+(** Copy the stored JSON gameplan ({!gameplan_json_path}) to
     {!gameplan_artifact_path} for patch agents to read. No-op when no stored
-    gameplan exists (ad-hoc sessions). Called once at startup, after
+    JSON gameplan exists (ad-hoc sessions). Called once at startup, after
     {!save_gameplan_source} / resume validation, so the copy matches the
     gameplan the run was parsed from. *)
 

--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -177,6 +177,25 @@ let agents_md_section = function
    [prompts/review.md], [prompts/ci_failure.md], etc.) are no longer
    honoured. *)
 
+(* The gameplan-reference section points agents at the read-only copy
+   published by [Project_store.publish_gameplan_artifact] at startup. The
+   path is a pure function of the project name (no filesystem probe here),
+   so the rendered gameplan layer stays byte-identical across the run. *)
+let gameplan_reference_section ~(project_name : string) : string =
+  Printf.sprintf
+    "\n\
+     ## Full Gameplan Reference\n\n\
+     A read-only copy of the complete gameplan JSON — every patch's full \
+     description, spec, acceptance criteria, and the functional-change \
+     ownership map — is saved at:\n\n\
+     `%s`\n\n\
+     Everything your patch needs is already in this prompt, so most sessions \
+     never read it. Consult it only when you genuinely need cross-patch \
+     context — for example, to check a sibling patch's scope before deciding \
+     whether a change belongs to you. Do not edit the file, and do not take on \
+     work owned by sibling patches.\n"
+    (Project_store.gameplan_artifact_path project_name)
+
 let render_gameplan_layer ~(project_name : string) (gameplan : Gameplan.t) :
     string =
   let patches_list =
@@ -201,6 +220,7 @@ let render_gameplan_layer ~(project_name : string) (gameplan : Gameplan.t) :
         optional_section ~header:"Current State Analysis"
           gameplan.Gameplan.current_state_analysis );
       ("patches_list", patches_list);
+      ("gameplan_reference_section", gameplan_reference_section ~project_name);
     ]
   in
   render_with_override ~project_name ~name:"gameplan" ~vars ~default:(fun () ->
@@ -215,7 +235,7 @@ let render_gameplan_layer ~(project_name : string) (gameplan : Gameplan.t) :
 {{final_state_spec_section}}{{explicit_opinions_section}}{{current_state_section}}
 ## Patches in Gameplan
 {{patches_list}}
-
+{{gameplan_reference_section}}
 |}
         vars)
 
@@ -1546,6 +1566,16 @@ let%test "gameplan_layer is the prefix of render_patch_prompt for both patches"
   in
   String.is_prefix prompt_a ~prefix:g_layer
   && String.is_prefix prompt_b ~prefix:g_layer
+
+let%test "gameplan layer points at the published gameplan artifact copy" =
+  let _, _, gameplan = make_layer_test_fixture () in
+  let g_layer = render_gameplan_layer ~project_name:"onton" gameplan in
+  String.is_substring g_layer ~substring:"## Full Gameplan Reference"
+  && String.is_substring g_layer
+       ~substring:("`" ^ Project_store.gameplan_artifact_path "onton" ^ "`")
+  (* The pointer is lazy-disclosure only: the layer must keep withholding
+     sibling patch detail itself (titles only, per the patches list). *)
+  && not (String.is_substring g_layer ~substring:"Pass patch + gameplan")
 
 let%test
     "gameplan + patch layers are the prefix of every layered prompt for one \

--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -469,6 +469,19 @@ let ancestor_patches (gameplan : Gameplan.t) (patch : Patch.t) : Patch.t list =
       List.find gameplan.Gameplan.patches ~f:(fun (p : Patch.t) ->
           Patch_id.equal p.Patch.id id))
 
+(* The single source of truth for deriving the patch layer's gameplan-scoped
+   inputs (owned functional changes, required context resources, ancestor
+   notes). Every caller that renders a patch layer for a gameplan patch must
+   go through this — hand-assembling the inputs at a call site is how the
+   long-lived session's cached layer drifts from the composed prompt. *)
+let render_patch_layer_of_gameplan ~project_name ?pr_number (patch : Patch.t)
+    (gameplan : Gameplan.t) ~base_branch =
+  render_patch_layer ~project_name patch ?pr_number
+    ~functional_changes:(owned_functional_changes gameplan patch)
+    ~context_resources:(required_context_resources gameplan patch)
+    ~ancestors:(ancestor_patches gameplan patch)
+    ~base_branch ()
+
 (* When all of [patch], [gameplan], [base_branch] are supplied, returns
    the gameplan+patch prefix; otherwise returns the empty string. Used by
    the layered turn-prompt composers to support callers that don't have a
@@ -477,15 +490,12 @@ let layered_prefix ~project_name ?pr_number ?patch ?gameplan ?base_branch
     ?agents_md () =
   match (patch, gameplan, base_branch) with
   | Some p, Some g, Some b ->
-      let functional_changes = owned_functional_changes g p in
-      let context_resources = required_context_resources g p in
-      let ancestors = ancestor_patches g p in
       render_gameplan_layer ~project_name g
       ^ (match agents_md with
         | Some content -> agents_md_section (Some content)
         | None -> "")
-      ^ render_patch_layer ~project_name p ?pr_number ~functional_changes
-          ~context_resources ~ancestors ~base_branch:b ()
+      ^ render_patch_layer_of_gameplan ~project_name ?pr_number p g
+          ~base_branch:b
   | _ -> ""
 
 let render_turn_layer_start ~(project_name : string) : string =
@@ -495,13 +505,10 @@ let render_turn_layer_start ~(project_name : string) : string =
 
 let render_patch_prompt ~(project_name : string) ?agents_md ?pr_number
     (patch : Patch.t) (gameplan : Gameplan.t) ~(base_branch : string) =
-  let functional_changes = owned_functional_changes gameplan patch in
-  let context_resources = required_context_resources gameplan patch in
-  let ancestors = ancestor_patches gameplan patch in
   render_gameplan_layer ~project_name gameplan
   ^ agents_md_section agents_md
-  ^ render_patch_layer ~project_name patch ?pr_number ~functional_changes
-      ~context_resources ~ancestors ~base_branch ()
+  ^ render_patch_layer_of_gameplan ~project_name ?pr_number patch gameplan
+      ~base_branch
   ^ render_turn_layer_start ~project_name
 
 let render_spec_suffix (patch : Patch.t) (gameplan : Gameplan.t) : string =
@@ -1676,6 +1683,41 @@ let%test "dependency notes cover transitive ancestors, not just direct deps" =
   && String.is_substring prompt_c ~substring:(path_of patch_a)
   && String.is_substring prompt_c ~substring:(path_of patch_b)
 
+let%test "gameplan-derived patch layer carries required context resources" =
+  let patch_a, patch_b, gameplan = make_layer_test_fixture () in
+  let resource =
+    Context_resource.
+      {
+        id = "CR-1";
+        kind = "doc";
+        paths = [ "docs/layers.md" ];
+        why = "Defines the layer contract.";
+        consumed_by = [];
+      }
+  in
+  let patch_b = { patch_b with Patch.required_context = [ "CR-1" ] } in
+  let gameplan =
+    {
+      gameplan with
+      Gameplan.patches = [ patch_a; patch_b ];
+      context_resources = [ resource ];
+    }
+  in
+  let layer =
+    render_patch_layer_of_gameplan ~project_name:"onton" patch_b gameplan
+      ~base_branch:"feat/patch-1"
+  in
+  let prompt =
+    render_patch_prompt ~project_name:"onton" patch_b gameplan
+      ~base_branch:"feat/patch-1"
+  in
+  (* The layer is byte-identically embedded in the composed prompt... *)
+  String.is_substring prompt ~substring:layer
+  (* ...and carries the gameplan-derived context resources — the input the
+     runner's hand-assembled call sites used to drop. *)
+  && String.is_substring layer ~substring:"## Required Context Before Editing"
+  && String.is_substring layer ~substring:"CR-1"
+
 let%test "pr body prompt tells the author about dependent patch readers" =
   let rendered =
     render_pr_body_prompt ~project_name:"onton" ~pr_number:(Pr_number.of_int 7)
@@ -1689,10 +1731,9 @@ let%test
   let patch_a, _, gameplan = make_layer_test_fixture () in
   let pr_number = Pr_number.of_int 7 in
   let g_layer = render_gameplan_layer ~project_name:"onton" gameplan in
-  let functional_changes = owned_functional_changes gameplan patch_a in
   let p_layer =
-    render_patch_layer ~project_name:"onton" patch_a ~pr_number
-      ~functional_changes ~base_branch:"main" ()
+    render_patch_layer_of_gameplan ~project_name:"onton" ~pr_number patch_a
+      gameplan ~base_branch:"main"
   in
   let agents_md = "Follow AGENTS.md.\nNever use *_exn." in
   let prefix = g_layer ^ agents_md_section (Some agents_md) ^ p_layer in

--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -256,9 +256,45 @@ let format_functional_changes_section (fcs : Functional_change.t list) : string
      exhaustive and each change is owned by exactly one patch, so if a change \
      appears here, no sibling patch will pick it up.\n\n" ^ body ^ "\n"
 
+(* The dependency-notes section points the agent at the implementation notes
+   each ancestor patch's agent records via its Pr_body session
+   ([Project_store.pr_body_artifact_path]). Start is gated on every unmerged
+   dep having delivered its notes (deps-notes-ready in the spec, enforced by
+   [Patch_controller.plan_action_for_patch]), so the files exist by the time
+   this layer is first read — except for an ancestor that merged before its
+   notes step ran. Paths are pure functions of the project name and patch id —
+   no filesystem probe here — so the rendered patch layer stays byte-identical
+   across a patch's sessions. *)
+let dependency_notes_section ~(project_name : string) (ancestors : Patch.t list)
+    : string =
+  if List.is_empty ancestors then ""
+  else
+    let entries =
+      List.map ancestors ~f:(fun (p : Patch.t) ->
+          Printf.sprintf "- Patch %s: %s — `%s`"
+            (Patch_id.to_string p.Patch.id)
+            p.Patch.title
+            (Project_store.pr_body_artifact_path ~project_name
+               ~patch_id:p.Patch.id))
+      |> String.concat ~sep:"\n"
+    in
+    Printf.sprintf
+      "\n\
+       ## Dependency Implementation Notes\n\n\
+       Your worktree already contains the changes from these ancestor patches. \
+       Each patch's agent records implementation notes — key decisions, \
+       deviations from plan, gotchas — at:\n\n\
+       %s\n\n\
+       Like the gameplan reference, these are read-only, on-demand context: \
+       consult a file only when you need to understand a decision your patch \
+       builds on. Each ancestor's notes are recorded before a dependent patch \
+       starts; in the rare case a file is missing, that ancestor merged before \
+       its notes step ran. Do not edit these files.\n"
+      entries
+
 let render_patch_layer ~(project_name : string) (patch : Patch.t) ?pr_number
-    ?(functional_changes = []) ?(context_resources = []) ~(base_branch : string)
-    () : string =
+    ?(functional_changes = []) ?(context_resources = []) ?(ancestors = [])
+    ~(base_branch : string) () : string =
   let patch_id = Patch_id.to_string patch.Patch.id in
   let deps =
     match patch.Patch.dependencies with
@@ -334,6 +370,8 @@ The supervisor opens the draft PR after your first commit lands on the remote, w
       ( "functional_changes_section",
         format_functional_changes_section functional_changes );
       ("context_resources_section", format_context_resources context_resources);
+      ( "dependency_notes_section",
+        dependency_notes_section ~project_name ancestors );
       ("changes_section", optional_list_section ~header:"Changes" patch.changes);
       ( "spec_section",
         if String.is_empty patch.spec then ""
@@ -398,7 +436,7 @@ The supervisor opens the draft PR after your first commit lands on the remote, w
 
 ## Dependencies
 {{dependencies}}
-
+{{dependency_notes_section}}
 ## Your Task
 
 {{base_branch_note}}{{description}}
@@ -424,6 +462,13 @@ let required_context_resources (gameplan : Gameplan.t) (patch : Patch.t) :
     ~f:(fun (r : Context_resource.t) ->
       List.mem patch.Patch.required_context r.id ~equal:String.equal)
 
+let ancestor_patches (gameplan : Gameplan.t) (patch : Patch.t) : Patch.t list =
+  let graph = Graph.of_patches gameplan.Gameplan.patches in
+  Graph.transitive_ancestors graph patch.Patch.id
+  |> List.filter_map ~f:(fun id ->
+      List.find gameplan.Gameplan.patches ~f:(fun (p : Patch.t) ->
+          Patch_id.equal p.Patch.id id))
+
 (* When all of [patch], [gameplan], [base_branch] are supplied, returns
    the gameplan+patch prefix; otherwise returns the empty string. Used by
    the layered turn-prompt composers to support callers that don't have a
@@ -434,12 +479,13 @@ let layered_prefix ~project_name ?pr_number ?patch ?gameplan ?base_branch
   | Some p, Some g, Some b ->
       let functional_changes = owned_functional_changes g p in
       let context_resources = required_context_resources g p in
+      let ancestors = ancestor_patches g p in
       render_gameplan_layer ~project_name g
       ^ (match agents_md with
         | Some content -> agents_md_section (Some content)
         | None -> "")
       ^ render_patch_layer ~project_name p ?pr_number ~functional_changes
-          ~context_resources ~base_branch:b ()
+          ~context_resources ~ancestors ~base_branch:b ()
   | _ -> ""
 
 let render_turn_layer_start ~(project_name : string) : string =
@@ -451,10 +497,11 @@ let render_patch_prompt ~(project_name : string) ?agents_md ?pr_number
     (patch : Patch.t) (gameplan : Gameplan.t) ~(base_branch : string) =
   let functional_changes = owned_functional_changes gameplan patch in
   let context_resources = required_context_resources gameplan patch in
+  let ancestors = ancestor_patches gameplan patch in
   render_gameplan_layer ~project_name gameplan
   ^ agents_md_section agents_md
   ^ render_patch_layer ~project_name patch ?pr_number ~functional_changes
-      ~context_resources ~base_branch ()
+      ~context_resources ~ancestors ~base_branch ()
   ^ render_turn_layer_start ~project_name
 
 let render_spec_suffix (patch : Patch.t) (gameplan : Gameplan.t) : string =
@@ -698,7 +745,7 @@ The current PR body is:
 {{pr_body}}
 ---
 {{spec_context}}
-The supervisor will keep this description and specs on the PR. Your job is to write **additional notes** — anything a reviewer needs beyond the gameplan description. The supervisor will append your notes to the PR body under an `## Implementation Notes` header.
+The supervisor will keep this description and specs on the PR. Your job is to write **additional notes** — anything a reviewer needs beyond the gameplan description. The supervisor will append your notes to the PR body under an `## Implementation Notes` header. Agents implementing patches that depend on this one are also pointed at these notes, so they double as a handoff to the work built on top of your changes.
 
 **Write just the notes content (no header) to `{{artifact_path}}`.** This is an absolute path outside the worktree — write it with the Write tool. Do NOT run `gh`, `git`, or any forge command; the supervisor reads the file and PATCHes the PR.
 
@@ -708,6 +755,7 @@ What to include:
 - Anything surprising or non-obvious about the approach.
 - Deviations from the original plan (if any).
 - Important details a reviewer should know.
+- Anything an agent building a dependent patch on top of yours should know: renames, new invariants, API changes, gotchas.
 - A short `Spec/Evidence Mapping` when applicable: spec clause or acceptance criterion satisfied, code path implementing it, required context resource consulted, and test/static check proving it if available.
 
 Do not repeat information already in the description or specs above — add only what's new.
@@ -1576,6 +1624,64 @@ let%test "gameplan layer points at the published gameplan artifact copy" =
   (* The pointer is lazy-disclosure only: the layer must keep withholding
      sibling patch detail itself (titles only, per the patches list). *)
   && not (String.is_substring g_layer ~substring:"Pass patch + gameplan")
+
+let%test "patch layer lists ancestor implementation notes for dependents" =
+  let patch_a, patch_b, gameplan = make_layer_test_fixture () in
+  let prompt_a =
+    render_patch_prompt ~project_name:"onton" patch_a gameplan
+      ~base_branch:"main"
+  in
+  let prompt_b =
+    render_patch_prompt ~project_name:"onton" patch_b gameplan
+      ~base_branch:"feat/patch-1"
+  in
+  let expected_entry =
+    Printf.sprintf "- Patch 1: Add layer helpers — `%s`"
+      (Project_store.pr_body_artifact_path ~project_name:"onton"
+         ~patch_id:patch_a.Patch.id)
+  in
+  String.is_substring prompt_b ~substring:"## Dependency Implementation Notes"
+  && String.is_substring prompt_b ~substring:expected_entry
+  (* A patch with no ancestors gets no section at all. *)
+  && not
+       (String.is_substring prompt_a
+          ~substring:"## Dependency Implementation Notes")
+
+let%test "dependency notes cover transitive ancestors, not just direct deps" =
+  let patch_a, patch_b, gameplan = make_layer_test_fixture () in
+  let patch_c =
+    {
+      patch_b with
+      Patch.id = Patch_id.of_string "3";
+      title = "Stack further";
+      branch = Branch.of_string "feat/patch-3";
+      dependencies = [ Patch_id.of_string "2" ];
+    }
+  in
+  let gameplan =
+    { gameplan with Gameplan.patches = [ patch_a; patch_b; patch_c ] }
+  in
+  let ancestors = ancestor_patches gameplan patch_c in
+  let prompt_c =
+    render_patch_prompt ~project_name:"onton" patch_c gameplan
+      ~base_branch:"feat/patch-2"
+  in
+  let path_of p =
+    Project_store.pr_body_artifact_path ~project_name:"onton"
+      ~patch_id:p.Patch.id
+  in
+  List.equal String.equal
+    (List.map ancestors ~f:(fun p -> Patch_id.to_string p.Patch.id))
+    [ "1"; "2" ]
+  && String.is_substring prompt_c ~substring:(path_of patch_a)
+  && String.is_substring prompt_c ~substring:(path_of patch_b)
+
+let%test "pr body prompt tells the author about dependent patch readers" =
+  let rendered =
+    render_pr_body_prompt ~project_name:"onton" ~pr_number:(Pr_number.of_int 7)
+      ~pr_body:"body" ~spec_suffix:"" ~artifact_path:"/tmp/pr-body.md"
+  in
+  String.is_substring rendered ~substring:"patches that depend on this one"
 
 let%test
     "gameplan + patch layers are the prefix of every layered prompt for one \

--- a/lib/prompt.mli
+++ b/lib/prompt.mli
@@ -11,16 +11,18 @@ val substitute_variables : string -> (string * string) list -> string
     Every layered prompt is composed as
 
     {[
-      render_gameplan_layer ^ render_patch_layer ^ render_turn_layer_<kind>
+      render_gameplan_layer
+      ^ render_patch_layer_of_gameplan
+      ^ render_turn_layer_<kind>
     ]}
 
     so prefix-cache hits accumulate at the layer boundaries:
 
     - {!render_gameplan_layer} is byte-identical across every layered prompt in
       a single gameplan run.
-    - {!render_patch_layer} is byte-identical across every layered prompt for
-      one patch agent during a period where [pr_number] and [base_branch] are
-      stable.
+    - {!render_patch_layer_of_gameplan} is byte-identical across every layered
+      prompt for one patch agent during a period where [pr_number] and
+      [base_branch] are stable.
     - The per-kind [render_turn_layer_*] helpers are strictly turn-dynamic.
 
     Project-level overrides are now per-layer: [prompts/gameplan.md],
@@ -38,47 +40,32 @@ val render_gameplan_layer : project_name:string -> Gameplan.t -> string
     so the layer stays byte-identical across the run. Ends with a trailing blank
     line. *)
 
-val render_patch_layer :
+val render_patch_layer_of_gameplan :
   project_name:string ->
-  Patch.t ->
   ?pr_number:Pr_number.t ->
-  ?functional_changes:Functional_change.t list ->
-  ?context_resources:Context_resource.t list ->
-  ?ancestors:Patch.t list ->
+  Patch.t ->
+  Gameplan.t ->
   base_branch:string ->
-  unit ->
   string
 (** Patch-stable middle. Contains the patch heading, dependencies, a pointer to
-    each ancestor patch's implementation notes (when [ancestors] is non-empty),
+    each ancestor patch's implementation notes (when the patch has ancestors),
     base-branch note, description, the functional changes the patch owns (if
-    any), changes, files, test stubs, specification (with Pantagruel guide),
-    acceptance criteria, git identifiers, and PR instructions. Ends with a
-    trailing blank line. [functional_changes] should contain only the entries
-    from [Gameplan.t.functional_changes] whose [owned_by] equals [Patch.t.id].
-    [context_resources] should contain only resources whose IDs appear in this
-    patch's [required_context]. [ancestors] should be
-    {!ancestor_patches}[ gameplan patch] — the note pointers are pure functions
-    of the project name and ancestor ids ({!Project_store.pr_body_artifact_path}
-    — no filesystem probe), so the layer stays byte-identical across a patch's
-    sessions. Start is gated on every unmerged dep having delivered its notes
-    (deps-notes-ready, enforced by [Patch_controller.plan_action_for_patch]), so
-    the files exist by the time the layer is first read. *)
+    any), the required context resources, changes, files, test stubs,
+    specification (with Pantagruel guide), acceptance criteria, git identifiers,
+    and PR instructions. Ends with a trailing blank line.
 
-val owned_functional_changes : Gameplan.t -> Patch.t -> Functional_change.t list
-(** Returns the functional changes in the gameplan owned by this patch. Use this
-    when constructing patch layers directly, so composed and manually layered
-    prompts carry the same patch-stable content. *)
+    The functional changes, context resources, and ancestor list are all derived
+    from the gameplan here — this is deliberately the only exported way to
+    render a patch layer, so a call site cannot hand-assemble the inputs and
+    silently diverge from the composed prompt (the bug class that broke the
+    byte-identical prefix contract for long-lived session layers).
 
-val required_context_resources :
-  Gameplan.t -> Patch.t -> Context_resource.t list
-(** Returns the authoritative context resources required by this patch. *)
-
-val ancestor_patches : Gameplan.t -> Patch.t -> Patch.t list
-(** Returns the transitive ancestor patches of this patch (every patch reachable
-    by walking [dependencies], excluding the patch itself), in ascending
-    patch-id order. Use this when constructing patch layers directly, so
-    composed and manually layered prompts carry the same patch-stable content.
-*)
+    The ancestor note pointers are pure functions of the project name and
+    ancestor ids ([Project_store.pr_body_artifact_path] — no filesystem probe),
+    so the layer stays byte-identical across a patch's sessions. Start is gated
+    on every unmerged dep having delivered its notes (deps-notes-ready, enforced
+    by [Patch_controller.plan_action_for_patch]), so the files exist by the time
+    the layer is first read. *)
 
 val render_turn_layer_start : project_name:string -> string
 

--- a/lib/prompt.mli
+++ b/lib/prompt.mli
@@ -44,17 +44,25 @@ val render_patch_layer :
   ?pr_number:Pr_number.t ->
   ?functional_changes:Functional_change.t list ->
   ?context_resources:Context_resource.t list ->
+  ?ancestors:Patch.t list ->
   base_branch:string ->
   unit ->
   string
-(** Patch-stable middle. Contains the patch heading, dependencies, base-branch
-    note, description, the functional changes the patch owns (if any), changes,
-    files, test stubs, specification (with Pantagruel guide), acceptance
-    criteria, git identifiers, and PR instructions. Ends with a trailing blank
-    line. [functional_changes] should contain only the entries from
-    [Gameplan.t.functional_changes] whose [owned_by] equals [Patch.t.id].
+(** Patch-stable middle. Contains the patch heading, dependencies, a pointer to
+    each ancestor patch's implementation notes (when [ancestors] is non-empty),
+    base-branch note, description, the functional changes the patch owns (if
+    any), changes, files, test stubs, specification (with Pantagruel guide),
+    acceptance criteria, git identifiers, and PR instructions. Ends with a
+    trailing blank line. [functional_changes] should contain only the entries
+    from [Gameplan.t.functional_changes] whose [owned_by] equals [Patch.t.id].
     [context_resources] should contain only resources whose IDs appear in this
-    patch's [required_context]. *)
+    patch's [required_context]. [ancestors] should be
+    {!ancestor_patches}[ gameplan patch] — the note pointers are pure functions
+    of the project name and ancestor ids ({!Project_store.pr_body_artifact_path}
+    — no filesystem probe), so the layer stays byte-identical across a patch's
+    sessions. Start is gated on every unmerged dep having delivered its notes
+    (deps-notes-ready, enforced by [Patch_controller.plan_action_for_patch]), so
+    the files exist by the time the layer is first read. *)
 
 val owned_functional_changes : Gameplan.t -> Patch.t -> Functional_change.t list
 (** Returns the functional changes in the gameplan owned by this patch. Use this
@@ -64,6 +72,13 @@ val owned_functional_changes : Gameplan.t -> Patch.t -> Functional_change.t list
 val required_context_resources :
   Gameplan.t -> Patch.t -> Context_resource.t list
 (** Returns the authoritative context resources required by this patch. *)
+
+val ancestor_patches : Gameplan.t -> Patch.t -> Patch.t list
+(** Returns the transitive ancestor patches of this patch (every patch reachable
+    by walking [dependencies], excluding the patch itself), in ascending
+    patch-id order. Use this when constructing patch layers directly, so
+    composed and manually layered prompts carry the same patch-stable content.
+*)
 
 val render_turn_layer_start : project_name:string -> string
 

--- a/lib/prompt.mli
+++ b/lib/prompt.mli
@@ -31,7 +31,12 @@ val substitute_variables : string -> (string * string) list -> string
 val render_gameplan_layer : project_name:string -> Gameplan.t -> string
 (** Gameplan-stable prefix. Contains the project heading, problem statement,
     solution summary, optional final state spec / explicit opinions / current
-    state analysis, and the patches list. Ends with a trailing blank line. *)
+    state analysis, the patches list, and a pointer to the read-only gameplan
+    copy at [Project_store.gameplan_artifact_path] (published once at startup by
+    {!Project_store.publish_gameplan_artifact}) for agents that need cross-patch
+    context on demand. The pointer path is a pure function of the project name,
+    so the layer stays byte-identical across the run. Ends with a trailing blank
+    line. *)
 
 val render_patch_layer :
   project_name:string ->

--- a/lib/runner_fiber_impl.ml
+++ b/lib/runner_fiber_impl.ml
@@ -739,12 +739,15 @@ struct
                                           Prompt.owned_functional_changes
                                             gameplan patch
                                         in
+                                        let ancestors =
+                                          Prompt.ancestor_patches gameplan patch
+                                        in
                                         let patch_prompt =
                                           Prompt.render_patch_layer
                                             ~project_name patch
                                             ?pr_number:
                                               (Patch_agent.pr_number agent)
-                                            ~functional_changes
+                                            ~functional_changes ~ancestors
                                             ~base_branch:
                                               (Branch.to_string base_branch)
                                             ()
@@ -1330,9 +1333,13 @@ struct
                                                 Prompt.owned_functional_changes
                                                   gameplan p
                                               in
+                                              let ancestors =
+                                                Prompt.ancestor_patches gameplan
+                                                  p
+                                              in
                                               Prompt.render_patch_layer
                                                 ~project_name p ?pr_number
-                                                ~functional_changes
+                                                ~functional_changes ~ancestors
                                                 ~base_branch:base ()
                                           | None -> ""
                                         in
@@ -1897,9 +1904,13 @@ struct
                                                 Prompt.owned_functional_changes
                                                   gameplan p
                                               in
+                                              let ancestors =
+                                                Prompt.ancestor_patches gameplan
+                                                  p
+                                              in
                                               Prompt.render_patch_layer
                                                 ~project_name p ?pr_number
-                                                ~functional_changes
+                                                ~functional_changes ~ancestors
                                                 ~base_branch:
                                                   base_branch_for_layer ()
                                           | None -> ""

--- a/lib/runner_fiber_impl.ml
+++ b/lib/runner_fiber_impl.ml
@@ -735,22 +735,14 @@ struct
                                           Prompt.render_gameplan_layer
                                             ~project_name gameplan
                                         in
-                                        let functional_changes =
-                                          Prompt.owned_functional_changes
-                                            gameplan patch
-                                        in
-                                        let ancestors =
-                                          Prompt.ancestor_patches gameplan patch
-                                        in
                                         let patch_prompt =
-                                          Prompt.render_patch_layer
-                                            ~project_name patch
+                                          Prompt.render_patch_layer_of_gameplan
+                                            ~project_name
                                             ?pr_number:
                                               (Patch_agent.pr_number agent)
-                                            ~functional_changes ~ancestors
+                                            patch gameplan
                                             ~base_branch:
                                               (Branch.to_string base_branch)
-                                            ()
                                         in
                                         let r, _tool_failures =
                                           run_llm_session ~sw ~gameplan_prompt
@@ -1329,18 +1321,10 @@ struct
                                         let patch_prompt =
                                           match patch with
                                           | Some p ->
-                                              let functional_changes =
-                                                Prompt.owned_functional_changes
-                                                  gameplan p
-                                              in
-                                              let ancestors =
-                                                Prompt.ancestor_patches gameplan
-                                                  p
-                                              in
-                                              Prompt.render_patch_layer
-                                                ~project_name p ?pr_number
-                                                ~functional_changes ~ancestors
-                                                ~base_branch:base ()
+                                              Prompt
+                                              .render_patch_layer_of_gameplan
+                                                ~project_name ?pr_number p
+                                                gameplan ~base_branch:base
                                           | None -> ""
                                         in
                                         let result, _tool_failures =
@@ -1900,19 +1884,12 @@ struct
                                         let patch_prompt =
                                           match patch_for_layer with
                                           | Some p ->
-                                              let functional_changes =
-                                                Prompt.owned_functional_changes
-                                                  gameplan p
-                                              in
-                                              let ancestors =
-                                                Prompt.ancestor_patches gameplan
-                                                  p
-                                              in
-                                              Prompt.render_patch_layer
-                                                ~project_name p ?pr_number
-                                                ~functional_changes ~ancestors
+                                              Prompt
+                                              .render_patch_layer_of_gameplan
+                                                ~project_name ?pr_number p
+                                                gameplan
                                                 ~base_branch:
-                                                  base_branch_for_layer ()
+                                                  base_branch_for_layer
                                           | None -> ""
                                         in
                                         let result, tool_failures =

--- a/spec/anton.pant
+++ b/spec/anton.pant
@@ -103,8 +103,10 @@ where
 main => Branch.
 merge-target b: Branch => Branch.
 deps-satisfied p: Patch => Bool.
+notes-delivered p: Patch => Bool.
+deps-notes-ready p: Patch => Bool.
 
-PatchCtx ~> Start @ p: Patch, in-gameplan p, deps-satisfied p, ~has-pr p.
+PatchCtx ~> Start @ p: Patch, in-gameplan p, deps-satisfied p, deps-notes-ready p, ~has-pr p.
 ---
 has-pr' p.
 has-session' p.
@@ -113,7 +115,7 @@ satisfies' p.
 base-branch' p = initial-base p.
 
 > Start's preconditions guarantee its postconditions.
-all p: Patch | in-gameplan p and deps-satisfied p and ~has-pr p ->
+all p: Patch | in-gameplan p and deps-satisfied p and deps-notes-ready p and ~has-pr p ->
     has-pr' p and satisfies' p.
 
 where
@@ -239,6 +241,15 @@ is-feedback review-comments.
 > Definition (not invariant):
 >   deps-satisfied p  <->  #(open-pr-deps p) <= 1,
 >                          all deps merged or have PR
+
+> Definition (not invariant):
+>   deps-notes-ready p  <->  all d: deps p | merged d or notes-delivered d
+> notes-delivered d means d's Pr_body step completed: its implementation
+> notes were written to the per-patch artifact and PATCHed onto the PR.
+> Dependent patch prompts point at those notes, so Start waits for them.
+> Merged deps are exempt: a merged patch can never deliver notes after
+> merging, so waiting on it would deadlock; its notes artifact persists
+> on disk if it was delivered while the PR was open.
 
 > Added patches have no deps.
 all p: Patch | ~in-gameplan p -> #(deps p) = 0.

--- a/test/test_interleaving_properties.ml
+++ b/test/test_interleaving_properties.ml
@@ -3064,23 +3064,23 @@ let () =
     QCheck2.Test.make
       ~name:"NG-1: notes gate is deadlock-free under fair scheduling" ~count:50
       (QCheck2.Gen.return ()) (fun () ->
-        let orch = Orchestrator.create ~patches ~main_branch:main in
-        let pr_counter = ref 0 in
-        let started_and_delivered o =
-          List.for_all patches ~f:(fun (p : Patch.t) ->
-              match Orchestrator.find_agent o p.Patch.id with
-              | None -> false
-              | Some a ->
-                  Patch_agent.has_pr a && a.Patch_agent.pr_body_delivered)
-        in
-        let rec loop o iter =
-          if started_and_delivered o then true
-          else if iter >= 12 then
-            failwith
-              "NG-1: chain did not fully start within the fair-scheduling bound"
-          else loop (happy_tick o patches ~pr_counter) (iter + 1)
-        in
-        loop orch 0)
+        try
+          let orch = Orchestrator.create ~patches ~main_branch:main in
+          let pr_counter = ref 0 in
+          let started_and_delivered o =
+            List.for_all patches ~f:(fun (p : Patch.t) ->
+                match Orchestrator.find_agent o p.Patch.id with
+                | None -> false
+                | Some a ->
+                    Patch_agent.has_pr a && a.Patch_agent.pr_body_delivered)
+          in
+          let rec loop o iter =
+            if started_and_delivered o then true
+            else if iter >= 12 then false
+            else loop (happy_tick o patches ~pr_counter) (iter + 1)
+          in
+          loop orch 0
+        with _ -> false)
   in
   QCheck2.Test.check_exn prop_ng1;
   Stdlib.print_endline "NG-1 passed"
@@ -3094,24 +3094,25 @@ let () =
     QCheck2.Test.make
       ~name:"NG-2: early merge without notes does not deadlock the child"
       ~count:50 (QCheck2.Gen.return ()) (fun () ->
-        let parent = pid_of_idx patches 0 in
-        let child = pid_of_idx patches 1 in
-        let orch = Orchestrator.create ~patches ~main_branch:main in
-        let pr_counter = ref 1 in
-        (* Parent starts and lands a PR... *)
-        let orch = happy_tick orch patches ~pr_counter in
-        (* ...then merges before any Pr_body session completes. *)
-        let a = Orchestrator.agent orch parent in
-        if a.Patch_agent.pr_body_delivered then
-          failwith "NG-2: parent notes should not be delivered yet";
-        let orch = Orchestrator.mark_merged orch parent in
-        let rec loop o iter =
-          if Patch_agent.has_pr (Orchestrator.agent o child) then true
-          else if iter >= 6 then
-            failwith "NG-2: child deadlocked behind a merged dep's notes"
-          else loop (happy_tick o patches ~pr_counter) (iter + 1)
-        in
-        loop orch 0)
+        try
+          let parent = pid_of_idx patches 0 in
+          let child = pid_of_idx patches 1 in
+          let orch = Orchestrator.create ~patches ~main_branch:main in
+          let pr_counter = ref 1 in
+          (* Parent starts and lands a PR... *)
+          let orch = happy_tick orch patches ~pr_counter in
+          (* ...then merges before any Pr_body session completes. *)
+          let a = Orchestrator.agent orch parent in
+          if a.Patch_agent.pr_body_delivered then false
+          else
+            let orch = Orchestrator.mark_merged orch parent in
+            let rec loop o iter =
+              if Patch_agent.has_pr (Orchestrator.agent o child) then true
+              else if iter >= 6 then false
+              else loop (happy_tick o patches ~pr_counter) (iter + 1)
+            in
+            loop orch 0
+        with _ -> false)
   in
   QCheck2.Test.check_exn prop_ng2;
   Stdlib.print_endline "NG-2 passed"
@@ -3127,60 +3128,66 @@ let () =
     QCheck2.Test.make
       ~name:"NG-3: persistent Pr_body miss escalates visibly and is recoverable"
       ~count:50 (QCheck2.Gen.return ()) (fun () ->
-        let parent = pid_of_idx patches 0 in
-        let child = pid_of_idx patches 1 in
-        let gameplan = make_gameplan patches in
-        let tick o =
-          let o, _effects, _actions =
-            Patch_controller.tick o ~project_name:"test-project" ~gameplan
+        try
+          let parent = pid_of_idx patches 0 in
+          let child = pid_of_idx patches 1 in
+          let gameplan = make_gameplan patches in
+          let tick o =
+            let o, _effects, _actions =
+              Patch_controller.tick o ~project_name:"test-project" ~gameplan
+            in
+            o
           in
-          o
-        in
-        (* Parent starts and lands a PR. *)
-        let orch = Orchestrator.create ~patches ~main_branch:main in
-        let orch = tick orch in
-        let orch =
-          Orchestrator.set_pr_number orch parent (Pr_number.of_int 1)
-        in
-        let orch = Orchestrator.complete orch parent in
-        (* Two consecutive Pr_body sessions that fail to deliver the artifact. *)
-        let miss o =
-          let o = tick o in
-          let a = Orchestrator.agent o parent in
-          if
-            not
-              (Option.equal Operation_kind.equal a.Patch_agent.current_op
-                 (Some Operation_kind.Pr_body))
-          then failwith "NG-3: expected tick to fire Respond(Pr_body)";
-          let o =
-            Orchestrator.apply_session_result o parent Orchestrator.Session_ok
+          (* Parent starts and lands a PR. *)
+          let orch = Orchestrator.create ~patches ~main_branch:main in
+          let orch = tick orch in
+          let orch =
+            Orchestrator.set_pr_number orch parent (Pr_number.of_int 1)
           in
-          Orchestrator.apply_respond_outcome o parent Operation_kind.Pr_body
-            Orchestrator.Respond_pr_body_miss
-        in
-        let orch = miss orch in
-        let orch = miss orch in
-        let a = Orchestrator.agent orch parent in
-        if not (Patch_agent.needs_intervention a) then
-          failwith "NG-3: miss cap should surface needs_intervention";
-        if Patch_agent.has_pr (Orchestrator.agent orch child) then
-          failwith "NG-3: child must stay gated while notes are undelivered";
-        (* The block is not a silent deadlock: an operator reset plus one
-           successful delivery lets the child through. *)
-        let orch = Orchestrator.reset_intervention_state orch parent in
-        let orch = tick orch in
-        let orch =
-          Orchestrator.apply_session_result orch parent Orchestrator.Session_ok
-        in
-        let orch =
-          Orchestrator.apply_respond_outcome orch parent Operation_kind.Pr_body
-            Orchestrator.Respond_ok
-        in
-        let orch = tick orch in
-        let child_agent = Orchestrator.agent orch child in
-        if not child_agent.Patch_agent.busy then
-          failwith "NG-3: child should start once notes are delivered";
-        true)
+          let orch = Orchestrator.complete orch parent in
+          (* Two consecutive Pr_body sessions that fail to deliver the
+             artifact. *)
+          let miss o =
+            let o = tick o in
+            let a = Orchestrator.agent o parent in
+            if
+              not
+                (Option.equal Operation_kind.equal a.Patch_agent.current_op
+                   (Some Operation_kind.Pr_body))
+            then None
+            else
+              let o =
+                Orchestrator.apply_session_result o parent
+                  Orchestrator.Session_ok
+              in
+              Some
+                (Orchestrator.apply_respond_outcome o parent
+                   Operation_kind.Pr_body Orchestrator.Respond_pr_body_miss)
+          in
+          match Option.bind (miss orch) ~f:miss with
+          | None -> false
+          | Some orch ->
+              let a = Orchestrator.agent orch parent in
+              if not (Patch_agent.needs_intervention a) then false
+              else if Patch_agent.has_pr (Orchestrator.agent orch child) then
+                false
+              else
+                (* The block is not a silent deadlock: an operator reset plus
+                   one successful Pr_body delivery lets the child through. *)
+                let orch = Orchestrator.reset_intervention_state orch parent in
+                let orch = tick orch in
+                let orch =
+                  Orchestrator.apply_session_result orch parent
+                    Orchestrator.Session_ok
+                in
+                let orch =
+                  Orchestrator.apply_respond_outcome orch parent
+                    Operation_kind.Pr_body Orchestrator.Respond_ok
+                in
+                let orch = tick orch in
+                let child_agent = Orchestrator.agent orch child in
+                child_agent.Patch_agent.busy
+        with _ -> false)
   in
   QCheck2.Test.check_exn prop_ng3;
   Stdlib.print_endline "NG-3 passed"

--- a/test/test_interleaving_properties.ml
+++ b/test/test_interleaving_properties.ml
@@ -3011,3 +3011,176 @@ let () =
   in
   QCheck2.Test.check_exn prop;
   Stdlib.print_endline "PI-AH-9 passed"
+
+(* ========== Notes-gate (deps-notes-ready) deadlock-freedom properties ==========
+
+   The Start gate added for deps-notes-ready defers a child's Start until every
+   unmerged dep has [pr_body_delivered]. Because the gate lives in pure
+   decision logic ([Patch_controller.plan_action_for_patch]) and Pr_body
+   completion is a pure transition ([Orchestrator.apply_respond_outcome]),
+   these properties can drive the full loop without any effectful handler and
+   prove the gate cannot deadlock: under fair scheduling every blocked child is
+   eventually unblocked, and the only blocking terminal state is the visible
+   (and recoverable) [needs_intervention] escalation. *)
+
+(** One fair-scheduling step: tick (reconcile + plan + fire), then complete
+    every busy agent along the happy path — Respond sessions succeed
+    ([Session_ok] + [Respond_ok]), Start sessions land a PR and complete. *)
+let happy_tick orch patches ~pr_counter =
+  let gameplan = make_gameplan patches in
+  let orch, _effects, _actions =
+    Patch_controller.tick orch ~project_name:"test-project" ~gameplan
+  in
+  List.fold (Orchestrator.all_agents orch) ~init:orch
+    ~f:(fun o (a : Patch_agent.t) ->
+      if not a.Patch_agent.busy then o
+      else
+        let pid = a.Patch_agent.patch_id in
+        match a.Patch_agent.current_op with
+        | Some kind ->
+            let o =
+              Orchestrator.apply_session_result o pid Orchestrator.Session_ok
+            in
+            Orchestrator.apply_respond_outcome o pid kind
+              Orchestrator.Respond_ok
+        | None ->
+            let o =
+              if Patch_agent.has_pr a then o
+              else (
+                pr_counter := !pr_counter + 1;
+                Orchestrator.set_pr_number o pid (Pr_number.of_int !pr_counter))
+            in
+            Orchestrator.complete o pid)
+
+(** NG-1: The notes gate is deadlock-free under fair scheduling. On a fresh
+    linear chain, fair happy-path scheduling starts every patch and delivers
+    every patch's notes within a bounded number of ticks. If the gate were
+    stated over a condition the system never makes true, this property would
+    stall at the iteration bound. *)
+let () =
+  let n = 3 in
+  let patches = mk_patches n in
+  let prop_ng1 =
+    QCheck2.Test.make
+      ~name:"NG-1: notes gate is deadlock-free under fair scheduling" ~count:50
+      (QCheck2.Gen.return ()) (fun () ->
+        let orch = Orchestrator.create ~patches ~main_branch:main in
+        let pr_counter = ref 0 in
+        let started_and_delivered o =
+          List.for_all patches ~f:(fun (p : Patch.t) ->
+              match Orchestrator.find_agent o p.Patch.id with
+              | None -> false
+              | Some a ->
+                  Patch_agent.has_pr a && a.Patch_agent.pr_body_delivered)
+        in
+        let rec loop o iter =
+          if started_and_delivered o then true
+          else if iter >= 12 then
+            failwith
+              "NG-1: chain did not fully start within the fair-scheduling bound"
+          else loop (happy_tick o patches ~pr_counter) (iter + 1)
+        in
+        loop orch 0)
+  in
+  QCheck2.Test.check_exn prop_ng1;
+  Stdlib.print_endline "NG-1 passed"
+
+(** NG-2: A dep that merges without ever delivering notes (e.g. a human merges
+    the PR before the Pr_body step ran) does not deadlock its child — the gate
+    exempts merged deps because they can never deliver. *)
+let () =
+  let patches = mk_patches 2 in
+  let prop_ng2 =
+    QCheck2.Test.make
+      ~name:"NG-2: early merge without notes does not deadlock the child"
+      ~count:50 (QCheck2.Gen.return ()) (fun () ->
+        let parent = pid_of_idx patches 0 in
+        let child = pid_of_idx patches 1 in
+        let orch = Orchestrator.create ~patches ~main_branch:main in
+        let pr_counter = ref 1 in
+        (* Parent starts and lands a PR... *)
+        let orch = happy_tick orch patches ~pr_counter in
+        (* ...then merges before any Pr_body session completes. *)
+        let a = Orchestrator.agent orch parent in
+        if a.Patch_agent.pr_body_delivered then
+          failwith "NG-2: parent notes should not be delivered yet";
+        let orch = Orchestrator.mark_merged orch parent in
+        let rec loop o iter =
+          if Patch_agent.has_pr (Orchestrator.agent o child) then true
+          else if iter >= 6 then
+            failwith "NG-2: child deadlocked behind a merged dep's notes"
+          else loop (happy_tick o patches ~pr_counter) (iter + 1)
+        in
+        loop orch 0)
+  in
+  QCheck2.Test.check_exn prop_ng2;
+  Stdlib.print_endline "NG-2 passed"
+
+(** NG-3: Persistent Pr_body misses do not deadlock silently — the parent
+    surfaces via [needs_intervention] at the miss cap (the child stays gated,
+    which is the intended visible block), and the block is recoverable:
+    [reset_intervention_state] plus one successful Pr_body delivery unblocks the
+    child. *)
+let () =
+  let patches = mk_patches 2 in
+  let prop_ng3 =
+    QCheck2.Test.make
+      ~name:"NG-3: persistent Pr_body miss escalates visibly and is recoverable"
+      ~count:50 (QCheck2.Gen.return ()) (fun () ->
+        let parent = pid_of_idx patches 0 in
+        let child = pid_of_idx patches 1 in
+        let gameplan = make_gameplan patches in
+        let tick o =
+          let o, _effects, _actions =
+            Patch_controller.tick o ~project_name:"test-project" ~gameplan
+          in
+          o
+        in
+        (* Parent starts and lands a PR. *)
+        let orch = Orchestrator.create ~patches ~main_branch:main in
+        let orch = tick orch in
+        let orch =
+          Orchestrator.set_pr_number orch parent (Pr_number.of_int 1)
+        in
+        let orch = Orchestrator.complete orch parent in
+        (* Two consecutive Pr_body sessions that fail to deliver the artifact. *)
+        let miss o =
+          let o = tick o in
+          let a = Orchestrator.agent o parent in
+          if
+            not
+              (Option.equal Operation_kind.equal a.Patch_agent.current_op
+                 (Some Operation_kind.Pr_body))
+          then failwith "NG-3: expected tick to fire Respond(Pr_body)";
+          let o =
+            Orchestrator.apply_session_result o parent Orchestrator.Session_ok
+          in
+          Orchestrator.apply_respond_outcome o parent Operation_kind.Pr_body
+            Orchestrator.Respond_pr_body_miss
+        in
+        let orch = miss orch in
+        let orch = miss orch in
+        let a = Orchestrator.agent orch parent in
+        if not (Patch_agent.needs_intervention a) then
+          failwith "NG-3: miss cap should surface needs_intervention";
+        if Patch_agent.has_pr (Orchestrator.agent orch child) then
+          failwith "NG-3: child must stay gated while notes are undelivered";
+        (* The block is not a silent deadlock: an operator reset plus one
+           successful delivery lets the child through. *)
+        let orch = Orchestrator.reset_intervention_state orch parent in
+        let orch = tick orch in
+        let orch =
+          Orchestrator.apply_session_result orch parent Orchestrator.Session_ok
+        in
+        let orch =
+          Orchestrator.apply_respond_outcome orch parent Operation_kind.Pr_body
+            Orchestrator.Respond_ok
+        in
+        let orch = tick orch in
+        let child_agent = Orchestrator.agent orch child in
+        if not child_agent.Patch_agent.busy then
+          failwith "NG-3: child should start once notes are delivered";
+        true)
+  in
+  QCheck2.Test.check_exn prop_ng3;
+  Stdlib.print_endline "NG-3 passed"

--- a/test/test_spawn_logic.ml
+++ b/test/test_spawn_logic.ml
@@ -7,8 +7,9 @@ open Onton_core.Types
 
     These properties verify from the spec that: 1. Only non-busy, non-merged,
     non-intervention agents with queued operations produce actions. 2. Start
-    only for patches without PRs where deps are satisfied. 3. Respond only for
-    patches with PRs, respecting priority. *)
+    only for patches without PRs where deps are satisfied and every unmerged dep
+    has delivered its implementation notes (deps-notes-ready). 3. Respond only
+    for patches with PRs, respecting priority. *)
 
 let main = Branch.of_string "main"
 
@@ -170,6 +171,35 @@ let () =
         with _ -> false)
   in
 
+  (* deps-notes-ready (spec): every Start target's unmerged deps have
+     delivered their implementation notes. Half the patches get delivered
+     notes so the generator exercises both gate outcomes. *)
+  let prop_start_deps_notes_ready =
+    Test.make
+      ~name:"plan_spawns: Start only when unmerged deps' notes delivered"
+      gen_patch_list_unique (fun patches ->
+        try
+          let orch = Orchestrator.create ~patches ~main_branch:main in
+          let orch = prepare_with_prs orch patches in
+          let orch =
+            List.foldi patches ~init:orch ~f:(fun i o (p : Patch.t) ->
+                if i % 2 = 0 then
+                  Orchestrator.set_pr_body_delivered o p.Patch.id true
+                else o)
+          in
+          let graph = Orchestrator.graph orch in
+          let has_merged p = (Orchestrator.agent orch p).Patch_agent.merged in
+          let spawns = Onton.Spawn_logic.plan_spawns orch ~patches in
+          List.for_all spawns ~f:(fun s ->
+              match Onton.Spawn_logic.classify s with
+              | `Start pid ->
+                  List.for_all (Graph.open_pr_deps graph pid ~has_merged)
+                    ~f:(fun d ->
+                      (Orchestrator.agent orch d).Patch_agent.pr_body_delivered)
+              | `Respond _ | `Rebase _ -> true)
+        with _ -> false)
+  in
+
   (* All patches whose Start preconditions hold do get started (liveness) *)
   let prop_all_startable_started =
     Test.make ~name:"plan_spawns: all startable patches get Start"
@@ -184,16 +214,51 @@ let () =
                 | `Respond _ | `Rebase _ -> None)
           in
           let graph = Orchestrator.graph orch in
+          let has_merged p = (Orchestrator.agent orch p).Patch_agent.merged in
           List.for_all (Graph.all_patch_ids graph) ~f:(fun pid ->
               let a = Orchestrator.agent orch pid in
               if
                 (not (Patch_agent.has_pr a))
                 && (not a.Patch_agent.busy) && (not a.Patch_agent.merged)
-                && Graph.deps_satisfied graph pid
-                     ~has_merged:(fun p ->
-                       (Orchestrator.agent orch p).Patch_agent.merged)
-                     ~has_pr:(fun p ->
-                       Patch_agent.has_pr (Orchestrator.agent orch p))
+                && Graph.deps_satisfied graph pid ~has_merged ~has_pr:(fun p ->
+                    Patch_agent.has_pr (Orchestrator.agent orch p))
+                && List.for_all (Graph.open_pr_deps graph pid ~has_merged)
+                     ~f:(fun d ->
+                       (Orchestrator.agent orch d).Patch_agent.pr_body_delivered)
+              then List.mem started_ids pid ~equal:Patch_id.equal
+              else true)
+        with _ -> false)
+  in
+
+  (* Liveness through the notes gate: once every dep's notes step has
+     completed, every otherwise-startable patch gets its Start. *)
+  let prop_startable_with_notes_started =
+    Test.make
+      ~name:"plan_spawns: startable patches start once dep notes delivered"
+      gen_patch_list_unique (fun patches ->
+        try
+          let orch = Orchestrator.create ~patches ~main_branch:main in
+          let orch = prepare_with_prs orch patches in
+          let orch =
+            List.fold patches ~init:orch ~f:(fun o (p : Patch.t) ->
+                Orchestrator.set_pr_body_delivered o p.Patch.id true)
+          in
+          let graph = Orchestrator.graph orch in
+          let has_merged p = (Orchestrator.agent orch p).Patch_agent.merged in
+          let spawns = Onton.Spawn_logic.plan_spawns orch ~patches in
+          let started_ids =
+            List.filter_map spawns ~f:(fun s ->
+                match Onton.Spawn_logic.classify s with
+                | `Start pid -> Some pid
+                | `Respond _ | `Rebase _ -> None)
+          in
+          List.for_all (Graph.all_patch_ids graph) ~f:(fun pid ->
+              let a = Orchestrator.agent orch pid in
+              if
+                (not (Patch_agent.has_pr a))
+                && (not a.Patch_agent.busy) && (not a.Patch_agent.merged)
+                && Graph.deps_satisfied graph pid ~has_merged ~has_pr:(fun p ->
+                    Patch_agent.has_pr (Orchestrator.agent orch p))
               then List.mem started_ids pid ~equal:Patch_id.equal
               else true)
         with _ -> false)
@@ -300,7 +365,9 @@ let () =
       prop_intervention_blocks;
       prop_start_no_pr;
       prop_start_deps_satisfied;
+      prop_start_deps_notes_ready;
       prop_all_startable_started;
+      prop_startable_with_notes_started;
       prop_respond_has_pr;
       prop_respond_priority;
       prop_respond_not_rebase;


### PR DESCRIPTION
## Problem

Patch agents see the full gameplan narrative but only their own patch in detail — sibling patches appear in the prompt as titles only. That boundary is right for prompt size and ownership, but it leaves an agent no way to check cross-patch context (e.g. a sibling patch's scope before deciding whether a change belongs to it) when it genuinely needs to.

## Approach

Save a read-only copy of the gameplan where every patch agent can reach it, and point at it from the prompt — lazy disclosure instead of prompt inflation.

- **`Project_store.publish_gameplan_artifact`** copies the stored gameplan to `artifacts/gameplan.json` — inside the agent-facing `artifacts/` subtree alongside the existing per-patch carve-outs (`pr-body.md`, `findings_wontfix.json`), and away from the project-dir root where `config.json` holds the GitHub token. No-op for ad-hoc sessions with no stored gameplan.
- **Published once at startup** in `finalize_run`, the chokepoint both fresh `--gameplan` and resume paths converge on, so the copy always matches the gameplan the run was parsed from (and refreshes when a project is restarted with an updated gameplan).
- **The gameplan layer ends with a "Full Gameplan Reference" section** pointing at the path, framed as read-only, exceptional-use context with an explicit reminder not to take on sibling-owned work. The path is a pure function of the project name — no filesystem probe at render time — so the layer's byte-identity guarantee and prefix-cache behavior are unchanged. The section is exposed to project-level `prompts/gameplan.md` overrides as `{{gameplan_reference_section}}`.

The artifact is always JSON: `Gameplan_parser.parse_file` is JSON-only, so every runnable gameplan is JSON regardless of the stored filename.

## Tests

- `lib/project_store.ml`: three inline tests under a temp `ONTON_DATA_DIR` (copy content matches the stored gameplan byte-for-byte, re-publish refreshes a stale copy, no-op without a stored gameplan).
- `lib/prompt.ml`: the gameplan layer contains the section header and the exact artifact path while still withholding sibling patch prose; the existing layer-invariant tests re-verify the section lands in the cache-stable prefix for all five turn kinds.
- `dune build` + full `dune runtest` + format check green (enforced by the pre-commit hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publish a read-only gameplan at `artifacts/gameplan.json` and add an on-demand “Dependency Implementation Notes” section so agents can consult cross-patch context without inflating prompts. Start is gated on unmerged deps delivering notes, and patch-layer rendering is centralized to keep prompts byte-identical across sessions.

- **New Features**
  - Publish at startup via `Project_store.publish_gameplan_artifact` to `artifacts/gameplan.json`; the gameplan layer ends with “Full Gameplan Reference” pointing to `Project_store.gameplan_artifact_path` and is exposed as `{{gameplan_reference_section}}` (prefix-cache stable).
  - Add a “Dependency Implementation Notes” section listing every transitive ancestor as “Patch N: Title — `artifacts/<id>/pr-body.md`”; expose `Prompt.ancestor_patches`, compose the same bytes in long-lived sessions, and update the PR-body prompt to note these also serve dependents.
  - Gate Start on `deps-notes-ready`: `Patch_controller.plan_action_for_patch` waits until each unmerged dep’s `pr_body_delivered` is true; merged deps are exempt to avoid deadlocks. Spec updated in `spec/anton.pant`; property tests (NG-1..3) and spawn-logic properties cover deadlock-freedom and liveness.
  - Make the gameplan-derived patch layer the only exported renderer: `render_patch_layer_of_gameplan` derives functional changes, required context, and ancestors from the gameplan; all runner call sites now use it, restoring byte-identical patch layers and fixing missing `required_context` in long-lived sessions.

- **Bug Fixes**
  - Treat empty `ONTON_DATA_DIR` as unset and restore it after temp-dir tests to avoid bad paths and ensure safe artifact cleanup.
  - Notes-gate property tests now falsify cleanly to catch regressions.

<sup>Written for commit 06209a9dd3e03a6eaa4ee7dbecf99d7892a8d4a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/flowglad/onton/pull/341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Gameplan is now published as a readable artifact, enabling agent access without direct project directory access.
  * Prompts include a reference pointer to the published gameplan artifact.

* **Bug Fixes**
  * Fixed environment variable handling when `ONTON_DATA_DIR` is present but empty; now properly falls back to standard data directory logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->