### PR TITLE
Defer Start/Rebase while the base is resolving a rebase conflict

### DIFF
--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -265,12 +265,15 @@ let start_eligibility t ~base_contains_merged_siblings base =
     | Some a -> a.Patch_agent.branch
     | None -> t.main_branch
   in
-  let base_patch_merged, base_patch_busy_rebasing, base_structurally_fresh =
+  let ( base_patch_merged,
+        base_patch_busy_rebasing,
+        base_patch_has_conflict,
+        base_structurally_fresh ) =
     match find_patch_by_branch t base with
-    | None -> (false, false, false)
+    | None -> (false, false, false, false)
     | Some bpid -> (
         match find_agent t bpid with
-        | None -> (false, false, false)
+        | None -> (false, false, false, false)
         | Some a ->
             let running_rebase =
               a.Patch_agent.busy
@@ -311,10 +314,22 @@ let start_eligibility t ~base_contains_merged_siblings base =
               | [ d ], Some b -> Branch.equal b (branch_of d)
               | _ -> false
             in
-            (a.Patch_agent.merged, busy_rebasing, structurally_fresh))
+            (* [has_conflict] extends the busy-rebase defer across the
+               conflicted-rebase window: a [Rebase] that conflicts completes as
+               an op (dropping [busy_rebasing]) but the base's tip is only
+               rewritten when the queued [Merge_conflict] resolution lands and
+               force-pushes. It is set on every path that enqueues
+               [Merge_conflict] and cleared only when resolution completes, so
+               it covers the whole pipeline. The cut source is the *local* base
+               branch, which the resolution rewrites before [has_conflict]
+               clears — so a Start allowed immediately after is fresh. *)
+            ( a.Patch_agent.merged,
+              busy_rebasing,
+              a.Patch_agent.has_conflict,
+              structurally_fresh ))
   in
   Start_eligibility.decide ~base_is_main ~base_branch ~base_patch_merged
-    ~base_patch_busy_rebasing ~base_structurally_fresh
+    ~base_patch_busy_rebasing ~base_patch_has_conflict ~base_structurally_fresh
     ~base_contains_merged_siblings
 
 let runnable_messages t =

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -319,10 +319,10 @@ let start_eligibility t ~base_contains_merged_siblings base =
                an op (dropping [busy_rebasing]) but the base's tip is only
                rewritten when the queued [Merge_conflict] resolution lands and
                force-pushes. It is set on every path that enqueues
-               [Merge_conflict] and cleared only when resolution completes, so
-               it covers the whole pipeline. The cut source is the *local* base
-               branch, which the resolution rewrites before [has_conflict]
-               clears — so a Start allowed immediately after is fresh. *)
+               [Merge_conflict]. Successful resolution clears it after the
+               local base branch is rewritten; a conflict-resolution [Noop]
+               clears it as a GitHub-state signal, and polling re-sets it if the
+               conflict persists. *)
             ( a.Patch_agent.merged,
               busy_rebasing,
               a.Patch_agent.has_conflict,

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -440,7 +440,9 @@ val start_eligibility :
 
     Returns [Allow] when the base is main, when the base patch is merged
     (effectively main), or when the base patch's local branch is rebased onto
-    its structurally-correct base ([branch_rebased_onto = Graph.initial_base])
-    and contains the launching patch's merged siblings. Otherwise returns
+    its structurally-correct base ([branch_rebased_onto = Graph.initial_base]),
+    has no unresolved conflict ([has_conflict] — a conflicted rebase keeps the
+    gate closed until the resolution force-pushes the rewritten tip), and
+    contains the launching patch's merged siblings. Otherwise returns
     [Defer reason]. Freshness is dependency-scoped: an unrelated advance of
     [origin/main] never defers a [Start]. See {!Start_eligibility}. *)

--- a/lib_core/start_eligibility.ml
+++ b/lib_core/start_eligibility.ml
@@ -2,6 +2,7 @@ open Base
 
 type defer_reason =
   | Base_patch_busy_with_rebase of { base_branch : string }
+  | Base_resolving_conflict of { base_branch : string }
   | Base_not_fresh_for_cut of { base_branch : string }
   | Base_missing_merged_sibling of { base_branch : string }
 [@@deriving show, eq, sexp_of, compare]
@@ -10,7 +11,7 @@ type decision = Allow | Defer of defer_reason
 [@@deriving show, eq, sexp_of, compare]
 
 let decide ~base_is_main ~base_branch ~base_patch_merged
-    ~base_patch_busy_rebasing ~base_structurally_fresh
+    ~base_patch_busy_rebasing ~base_patch_has_conflict ~base_structurally_fresh
     ~base_contains_merged_siblings =
   if base_is_main then Allow
   else if base_patch_merged then Allow
@@ -18,6 +19,18 @@ let decide ~base_is_main ~base_branch ~base_patch_merged
     (* An active/imminent rebase is the most informative signal — wait for it
        rather than racing it. *)
     Defer (Base_patch_busy_with_rebase { base_branch })
+  else if base_patch_has_conflict then
+    (* The base's branch tip is pending a rewrite: a rebase of the base hit
+       conflicts (or GitHub reports its PR conflicting with its own base), and
+       the conflict-resolution pipeline (Merge_conflict respond → resolution
+       rebase → force push) will replace the commits a cut taken now would
+       build on. The [Rebase] op itself already completed when it conflicted —
+       [base_patch_busy_rebasing] is false — so without this arm the gate
+       reopens mid-pipeline and the downstream worktree is cut from the doomed
+       pre-rebase tip. A same-name freshen rebase (e.g. main → newer main) is
+       invisible to the structural check below, so this arm is the only thing
+       holding the gate through that window. *)
+    Defer (Base_resolving_conflict { base_branch })
   else if not base_structurally_fresh then
     (* The base patch's local branch is not yet sitting on its
        structurally-correct base (a dependency merged but the rebase that
@@ -39,5 +52,6 @@ let decide ~base_is_main ~base_branch ~base_patch_merged
 let short_label = function
   | Allow -> "allow"
   | Defer (Base_patch_busy_with_rebase _) -> "defer_base_busy_rebasing"
+  | Defer (Base_resolving_conflict _) -> "defer_base_conflicted"
   | Defer (Base_not_fresh_for_cut _) -> "defer_base_stale"
   | Defer (Base_missing_merged_sibling _) -> "defer_base_missing_sibling"

--- a/lib_core/start_eligibility.mli
+++ b/lib_core/start_eligibility.mli
@@ -55,9 +55,12 @@
     doomed pre-rebase tip and the child's PR is born stale (the
     connector-adapter-shape-unification patch-5 / PR #3811 failure mode). The
     [base_patch_has_conflict] input — the base patch's [has_conflict], set on
-    every path that enqueues [Merge_conflict] and cleared only when resolution
-    lands — holds the gate closed across the whole rebase pipeline: queued
-    [Rebase] → running [Rebase] → conflicted → resolution pushed. *)
+    every path that enqueues [Merge_conflict] — holds the gate closed while the
+    unresolved conflict is known locally. Successful conflict resolution clears
+    the flag before the rewritten branch can launch dependents; a conflict
+    rebase [Noop] also clears it so the flag continues to track GitHub conflict
+    state, with the next poll re-setting it and re-enqueueing [Merge_conflict]
+    if the conflict persists. *)
 
 type defer_reason =
   | Base_patch_busy_with_rebase of { base_branch : string }

--- a/lib_core/start_eligibility.mli
+++ b/lib_core/start_eligibility.mli
@@ -41,13 +41,35 @@
     (only [c]'s actual deps are checked), so it preserves the dependency-scoped
     (not main-scoped) discipline above. The same gate is consulted for [Rebase]
     actions, which is what makes a fan-in/chain rebase cascade block on its
-    dependency layers in topological order. *)
+    dependency layers in topological order.
+
+    {1 A conflicted rebase keeps the gate closed}
+
+    The busy-rebase arm covers a [Rebase] that is queued-next or running, but a
+    rebase that hits conflicts {e completes} as an op — the continuation is a
+    queued [Merge_conflict] respond, and the base branch's tip is only rewritten
+    when that resolution lands and force-pushes. During that window every other
+    arm reads fresh: a same-name freshen rebase (main → newer main) leaves
+    [branch_rebased_onto] equal to the structural base, and a pure-chain child
+    has no merged deps so sibling containment is vacuous. Cutting then takes the
+    doomed pre-rebase tip and the child's PR is born stale (the
+    connector-adapter-shape-unification patch-5 / PR #3811 failure mode). The
+    [base_patch_has_conflict] input — the base patch's [has_conflict], set on
+    every path that enqueues [Merge_conflict] and cleared only when resolution
+    lands — holds the gate closed across the whole rebase pipeline: queued
+    [Rebase] → running [Rebase] → conflicted → resolution pushed. *)
 
 type defer_reason =
   | Base_patch_busy_with_rebase of { base_branch : string }
       (** The base patch already has a [Rebase] in flight (busy with op
           [Rebase], or [Rebase] is queued and highest-priority). Wait for it
           rather than racing it. *)
+  | Base_resolving_conflict of { base_branch : string }
+      (** The base patch has an unresolved conflict ([has_conflict]): a rebase
+          of the base conflicted mid-flight, or GitHub reports its PR
+          conflicting with its own base. Either way the base branch's tip is
+          pending a rewrite by the conflict-resolution pipeline, so a cut taken
+          now would build on commits about to be force-pushed away. *)
   | Base_not_fresh_for_cut of { base_branch : string }
       (** The base patch's local branch is not yet rebased onto its
           structurally-correct base — a dependency has merged but the rebase
@@ -70,6 +92,7 @@ val decide :
   base_branch:string ->
   base_patch_merged:bool ->
   base_patch_busy_rebasing:bool ->
+  base_patch_has_conflict:bool ->
   base_structurally_fresh:bool ->
   base_contains_merged_siblings:bool ->
   decision
@@ -83,6 +106,10 @@ val decide :
       [refresh_base_branch] in [mark_merged]).
     + [base_patch_busy_rebasing = true] → [Defer Base_patch_busy_with_rebase].
       Checked before the freshness flag so an active rebase pre-empts.
+    + [base_patch_has_conflict = true] → [Defer Base_resolving_conflict]. The
+      conflicted-rebase continuation of the previous arm: the [Rebase] op
+      completed by conflicting, and until the [Merge_conflict] resolution lands
+      the base's tip is pending a rewrite.
     + [base_structurally_fresh = false] → [Defer Base_not_fresh_for_cut].
     + [base_contains_merged_siblings = false] →
       [Defer Base_missing_merged_sibling]. Checked last: only fires when the
@@ -99,5 +126,5 @@ val decide :
 val short_label : decision -> string
 (** A short, lowercase, snake_case identifier for the decision arm, suitable for
     activity logging. Always non-empty and ≤ 32 characters. Examples: ["allow"],
-    ["defer_base_busy_rebasing"], ["defer_base_stale"],
-    ["defer_base_missing_sibling"]. *)
+    ["defer_base_busy_rebasing"], ["defer_base_conflicted"],
+    ["defer_base_stale"], ["defer_base_missing_sibling"]. *)

--- a/test/test_fanin_liveness_interleavings.ml
+++ b/test/test_fanin_liveness_interleavings.ml
@@ -546,6 +546,7 @@ let sibling_defer_implies_demand m actions =
             | Start_eligibility.Allow
             | Start_eligibility.Defer
                 ( Start_eligibility.Base_patch_busy_with_rebase _
+                | Start_eligibility.Base_resolving_conflict _
                 | Start_eligibility.Base_not_fresh_for_cut _ ) ->
                 true)
         | _ -> true)

--- a/test/test_stale_base_invariants.ml
+++ b/test/test_stale_base_invariants.ml
@@ -14,7 +14,10 @@ open Onton_core.Types
     + the base patch (looked up by branch) is [merged], OR
     + the base patch's local branch is rebased onto its structurally-correct
       base for the current merge state
-      ([branch_rebased_onto = Graph.initial_base]).
+      ([branch_rebased_onto = Graph.initial_base]) AND carries no unresolved
+      conflict ([has_conflict = false] — a conflicted rebase leaves the base's
+      tip pending a rewrite by the resolution force-push, so a cut taken in that
+      window builds on doomed commits).
 
     Crucially, an unrelated advance of [origin/main] never makes a base stale:
     the gate does not consult any main sha. A base sitting directly on main, or
@@ -37,6 +40,13 @@ open Onton_core.Types
       ([Graph.initial_base]); [apply_rebase_result] records
       [branch_rebased_onto = that base]. This is the operation that closes the
       freshness gap.
+    - Models a conflicted rebase via [Rebase_conflict i] ([apply_rebase_result]
+      with [Worktree.Conflict]: sets [has_conflict], enqueues [Merge_conflict],
+      completes the Rebase op) and its resolution via [Resolve_conflict i]
+      (fires the [Merge_conflict] respond, then [apply_conflict_rebase_result]
+      with [Worktree.Ok]). The window between the two is where PR #3811 was cut
+      stale: the Rebase op is gone from the queue, so without the [has_conflict]
+      gate input nothing held the gate closed.
     - Models the controller's Start-firing loop indirectly: only
       eligibility-passing Starts reach [runnable_messages]; the test asserts
       freshness directly from the model. *)
@@ -99,6 +109,16 @@ type command =
       (** Apply a successful rebase onto patch idx's current structural base;
           records [branch_rebased_onto = that base]. Closes the freshness gap.
       *)
+  | Rebase_conflict of int
+      (** Apply a *conflicted* rebase onto patch idx's current structural base:
+          the Rebase op completes, [has_conflict] is set, and a [Merge_conflict]
+          respond is enqueued. The patch's tip is now pending a rewrite — its
+          dependents' Starts must keep deferring until [Resolve_conflict]. *)
+  | Resolve_conflict of int
+      (** Fire the queued [Merge_conflict] respond and resolve it successfully
+          ([apply_conflict_rebase_result] with [Worktree.Ok]): records
+          [branch_rebased_onto = structural base], clears [has_conflict], and
+          completes — reopening the gate for dependents. *)
   | Enqueue_start of int
       (** Place a [Start] in patch idx's outbox so the freshness gate can be
           observed against it. Bootstrap already placed and consumed the initial
@@ -152,6 +172,79 @@ let apply_command m cmd =
             Orchestrator.apply_rebase_result orch pid Worktree.Ok target
           in
           { m with orch }
+  | Rebase_conflict i ->
+      if i >= List.length m.patches then m
+      else
+        let pid = pid_of_idx m.patches i in
+        let agent = Orchestrator.agent m.orch pid in
+        let rebase_in_queue =
+          List.mem agent.Patch_agent.queue Operation_kind.Rebase
+            ~equal:Operation_kind.equal
+        in
+        if
+          (not (Patch_agent.has_pr agent))
+          || agent.Patch_agent.merged || agent.Patch_agent.busy
+          || not rebase_in_queue
+        then m
+        else
+          (* Same firing preconditions as [Rebase_complete], but the rebase
+             hits conflicts: [apply_rebase_result] completes the Rebase op,
+             sets [has_conflict], and enqueues the [Merge_conflict] respond
+             that will finish the pipeline. [branch_rebased_onto] is NOT
+             updated — though in the same-name freshen case (target = current
+             anchor) it already equals the structural base, which is exactly
+             why [has_conflict] must gate independently of structural
+             freshness. *)
+          let target = initial_base_of m.orch m.patches pid in
+          let conflict =
+            Worktree.Conflict
+              {
+                Worktree.target = Branch.to_string target;
+                old_base = "sbi-old-base";
+                unique_commits =
+                  [ { Worktree.sha = "sbi-sha"; subject = "sbi commit" } ];
+                strategy = Worktree.Onto;
+                orig_head = "sbi-orig-head";
+              }
+          in
+          let orch =
+            Orchestrator.fire m.orch (Orchestrator.Rebase (pid, target))
+          in
+          let orch, _effects =
+            Orchestrator.apply_rebase_result orch pid conflict target
+          in
+          { m with orch }
+  | Resolve_conflict i ->
+      if i >= List.length m.patches then m
+      else
+        let pid = pid_of_idx m.patches i in
+        let agent = Orchestrator.agent m.orch pid in
+        let merge_conflict_queued =
+          List.mem agent.Patch_agent.queue Operation_kind.Merge_conflict
+            ~equal:Operation_kind.equal
+        in
+        if
+          (not agent.Patch_agent.has_conflict)
+          || agent.Patch_agent.merged || agent.Patch_agent.busy
+          || not merge_conflict_queued
+        then m
+        else
+          (* Fire the queued [Merge_conflict] respond and resolve it cleanly:
+             the resolution rebase lands on the structural base, records
+             [branch_rebased_onto], clears [has_conflict], and completes —
+             the force-push that rewrites the tip happens before the clear in
+             the real pipeline, so a Start allowed after this point cuts the
+             rewritten branch. *)
+          let target = initial_base_of m.orch m.patches pid in
+          let orch =
+            Orchestrator.fire m.orch
+              (Orchestrator.Respond (pid, Operation_kind.Merge_conflict))
+          in
+          let orch, _decision, _effects =
+            Orchestrator.apply_conflict_rebase_result orch pid Worktree.Ok
+              target
+          in
+          { m with orch }
   | Enqueue_start i ->
       if i >= List.length m.patches then m
       else
@@ -201,6 +294,13 @@ let base_is_fresh m base =
     | None -> false
     | Some (bpid, a) -> (
         if a.Patch_agent.merged then true
+        else if a.Patch_agent.has_conflict then
+          (* A conflicted base is never fresh: its tip is pending a rewrite by
+             the conflict-resolution force-push (the PR #3811 window). This
+             holds even when the branch reads structurally fresh — a same-name
+             freshen rebase (main → newer main) conflicts without ever
+             changing [branch_rebased_onto]. *)
+          false
         else
           (* Bind [open_deps] once and pattern-match to derive the structural
              base directly ([] -> main, [d] -> d's branch), treating >1 open
@@ -248,6 +348,25 @@ let sbi_defer_implies_progress m =
           | Start_eligibility.Defer
               (Start_eligibility.Base_patch_busy_with_rebase _) ->
               true (* by definition: a Rebase is in flight or queued *)
+          | Start_eligibility.Defer
+              (Start_eligibility.Base_resolving_conflict _) -> (
+              (* Progress: the conflict pipeline must be active — the base
+                 patch has the [Merge_conflict] respond queued (enqueued
+                 alongside [has_conflict] by [apply_rebase_result]) or is busy
+                 running it. A conflicted base with neither would be stuck. *)
+              let bpid_opt =
+                Map.to_alist (Orchestrator.agents_map m.orch)
+                |> List.find_map ~f:(fun (pid, ag) ->
+                    if Branch.equal ag.Patch_agent.branch base then Some pid
+                    else None)
+              in
+              match bpid_opt with
+              | None -> false
+              | Some bpid ->
+                  let base_ag = Orchestrator.agent m.orch bpid in
+                  List.mem base_ag.Patch_agent.queue
+                    Operation_kind.Merge_conflict ~equal:Operation_kind.equal
+                  || base_ag.Patch_agent.busy)
           | Start_eligibility.Defer
               (Start_eligibility.Base_missing_merged_sibling _) ->
               (* Unreachable: this invariant evaluates the gate with
@@ -313,6 +432,8 @@ let gen_command ~n_patches =
       return Main_advanced;
       map (fun i -> Pr_merged i) idx;
       map (fun i -> Rebase_complete i) idx;
+      map (fun i -> Rebase_conflict i) idx;
+      map (fun i -> Resolve_conflict i) idx;
       map (fun i -> Enqueue_start i) idx;
     ]
 
@@ -419,9 +540,11 @@ let prop_event_stream_pages_witness =
             | Start_eligibility.Base_patch_busy_with_rebase _ ) ->
             true
         (* Unreachable here: this scenario passes [~base_contains_merged_siblings]
-           via the structural path, not the sibling gate. *)
+           via the structural path, not the sibling gate, and no rebase has
+           conflicted. *)
         | Start_eligibility.Defer
-            (Start_eligibility.Base_missing_merged_sibling _) ->
+            ( Start_eligibility.Base_missing_merged_sibling _
+            | Start_eligibility.Base_resolving_conflict _ ) ->
             false
         | Start_eligibility.Allow -> false
       in
@@ -484,6 +607,91 @@ let prop_unrelated_main_advance_does_not_defer =
       in
       allow_before && allow_after)
 
+(** PI-SBI-3 (witness): the connector-adapter-shape-unification patch-5 / PR
+    #3811 scenario — a same-name freshen rebase of the base conflicts, and the
+    gate must stay closed through the conflict-resolution window.
+
+    1. Bootstrap [a; b; c] with c → b → a; a merges; b rebases onto main
+    cleanly. Start(c, base=b) reads Allow — b is structurally fresh
+    ([branch_rebased_onto = main]). 2. A freshen demand appears for b (in
+    production: b was cut from a stale local main missing a's squash commit, so
+    the reconciler enqueued another Rebase b → main — same target name, so
+    [branch_rebased_onto] never changes). Gate defers on busy-with-rebase. 3.
+    The rebase CONFLICTS. The Rebase op completes; the continuation is a queued
+    [Merge_conflict]. Before the [has_conflict] gate input, every arm read fresh
+    here and Start(c, base=b) fired — cutting c from b's doomed pre-rebase tip
+    (PR #3811 was created from that cut, born stale). The gate must now defer on
+    [Base_resolving_conflict]. 4. The conflict resolution lands and force-pushes
+    b's rewritten tip: eligibility returns to Allow, and a cut now takes the new
+    tip. *)
+let prop_conflicted_freshen_rebase_witness =
+  QCheck2.Test.make ~count:1
+    ~name:
+      "PI-SBI-3: PR #3811 witness — Start(c, base=b) deferred while b's \
+       same-name freshen rebase is mid-conflict, Allow after resolution"
+    (Gen.return ()) (fun () ->
+      let patches = mk_patches 3 in
+      let m = bootstrap patches in
+      let pid_b = pid_of_idx patches 1 in
+      let branch_b = (Orchestrator.agent m.orch pid_b).Patch_agent.branch in
+      let eligibility m =
+        Orchestrator.start_eligibility m.orch
+          ~base_contains_merged_siblings:true branch_b
+      in
+      (* a merges; b absorbs it cleanly. b now sits on main by name. *)
+      let m = apply_command m (Pr_merged 0) in
+      let m = apply_command m (Rebase_complete 1) in
+      let allow_when_settled =
+        match eligibility m with
+        | Start_eligibility.Allow -> true
+        | Start_eligibility.Defer _ -> false
+      in
+      (* Freshen demand: another Rebase b → main (same-name target). *)
+      let m =
+        {
+          m with
+          orch = Orchestrator.enqueue m.orch pid_b Operation_kind.Rebase;
+        }
+      in
+      let defer_busy =
+        match eligibility m with
+        | Start_eligibility.Defer
+            (Start_eligibility.Base_patch_busy_with_rebase _) ->
+            true
+        | Start_eligibility.Allow
+        | Start_eligibility.Defer
+            ( Start_eligibility.Base_resolving_conflict _
+            | Start_eligibility.Base_not_fresh_for_cut _
+            | Start_eligibility.Base_missing_merged_sibling _ ) ->
+            false
+      in
+      (* The freshen rebase conflicts: the Rebase op is gone from the queue,
+         [branch_rebased_onto] still reads main (structurally fresh), and the
+         launching patch has no merged siblings — the exact configuration that
+         let PR #3811 through. Only [has_conflict] can hold the gate. *)
+      let m = apply_command m (Rebase_conflict 1) in
+      let defer_conflicted =
+        match eligibility m with
+        | Start_eligibility.Defer (Start_eligibility.Base_resolving_conflict _)
+          ->
+            true
+        | Start_eligibility.Allow
+        | Start_eligibility.Defer
+            ( Start_eligibility.Base_patch_busy_with_rebase _
+            | Start_eligibility.Base_not_fresh_for_cut _
+            | Start_eligibility.Base_missing_merged_sibling _ ) ->
+            false
+      in
+      (* Resolution lands; the gate reopens onto the rewritten tip. *)
+      let m = apply_command m (Resolve_conflict 1) in
+      let allow_after_resolution =
+        match eligibility m with
+        | Start_eligibility.Allow -> true
+        | Start_eligibility.Defer _ -> false
+      in
+      allow_when_settled && defer_busy && defer_conflicted
+      && allow_after_resolution)
+
 let () =
   let runner = QCheck_base_runner.run_tests_main in
   ignore
@@ -494,4 +702,5 @@ let () =
          prop_completed_rebase_drains_queue;
          prop_event_stream_pages_witness;
          prop_unrelated_main_advance_does_not_defer;
+         prop_conflicted_freshen_rebase_witness;
        ])

--- a/test/test_start_eligibility_properties.ml
+++ b/test/test_start_eligibility_properties.ml
@@ -15,11 +15,11 @@ open Onton_core
     - {b SEP-3 Pre-emption order}: each arm in the documented order is reachable
       and only fires when no earlier arm matches.
     - {b SEP-4 [Allow] ⇒ fresh}: every [Allow] is justified by at least one of:
-      base is main, base patch is merged, or (not busy-rebasing and the base is
-      structurally fresh).
+      base is main, base patch is merged, or (not busy-rebasing, no unresolved
+      conflict, and the base is structurally fresh).
     - {b SEP-5 [Defer] ⇒ not fresh}: every [Defer] reflects a real freshness gap
-      (base patch busy rebasing, or base not structurally fresh) on a non-main,
-      unmerged base.
+      (base patch busy rebasing, base resolving a conflict, or base not
+      structurally fresh) on a non-main, unmerged base.
     - {b SEP-6 Label bounds}: [short_label] is non-empty, ≤ 32 chars, lowercase
       snake_case.
     - {b SEP-7 Variant reachability}: every constructor of {!decision} and
@@ -38,6 +38,7 @@ type inputs = {
   base_branch : string;
   base_patch_merged : bool;
   base_patch_busy_rebasing : bool;
+  base_patch_has_conflict : bool;
   base_structurally_fresh : bool;
   base_contains_merged_siblings : bool;
 }
@@ -48,6 +49,7 @@ let gen_inputs : inputs Gen.t =
   let* base_branch = gen_branch in
   let* base_patch_merged = bool in
   let* base_patch_busy_rebasing = bool in
+  let* base_patch_has_conflict = bool in
   let* base_structurally_fresh = bool in
   let* base_contains_merged_siblings = bool in
   return
@@ -56,6 +58,7 @@ let gen_inputs : inputs Gen.t =
       base_branch;
       base_patch_merged;
       base_patch_busy_rebasing;
+      base_patch_has_conflict;
       base_structurally_fresh;
       base_contains_merged_siblings;
     }
@@ -64,6 +67,7 @@ let call i =
   SE.decide ~base_is_main:i.base_is_main ~base_branch:i.base_branch
     ~base_patch_merged:i.base_patch_merged
     ~base_patch_busy_rebasing:i.base_patch_busy_rebasing
+    ~base_patch_has_conflict:i.base_patch_has_conflict
     ~base_structurally_fresh:i.base_structurally_fresh
     ~base_contains_merged_siblings:i.base_contains_merged_siblings
 
@@ -85,6 +89,15 @@ let is_allow = function SE.Allow -> true | SE.Defer _ -> false
 let is_defer_busy = function
   | SE.Defer (SE.Base_patch_busy_with_rebase _) -> true
   | SE.Allow
+  | SE.Defer (SE.Base_resolving_conflict _)
+  | SE.Defer (SE.Base_not_fresh_for_cut _)
+  | SE.Defer (SE.Base_missing_merged_sibling _) ->
+      false
+
+let is_defer_conflict = function
+  | SE.Defer (SE.Base_resolving_conflict _) -> true
+  | SE.Allow
+  | SE.Defer (SE.Base_patch_busy_with_rebase _)
   | SE.Defer (SE.Base_not_fresh_for_cut _)
   | SE.Defer (SE.Base_missing_merged_sibling _) ->
       false
@@ -93,6 +106,7 @@ let is_defer_stale = function
   | SE.Defer (SE.Base_not_fresh_for_cut _) -> true
   | SE.Allow
   | SE.Defer (SE.Base_patch_busy_with_rebase _)
+  | SE.Defer (SE.Base_resolving_conflict _)
   | SE.Defer (SE.Base_missing_merged_sibling _) ->
       false
 
@@ -100,6 +114,7 @@ let is_defer_missing_sibling = function
   | SE.Defer (SE.Base_missing_merged_sibling _) -> true
   | SE.Allow
   | SE.Defer (SE.Base_patch_busy_with_rebase _)
+  | SE.Defer (SE.Base_resolving_conflict _)
   | SE.Defer (SE.Base_not_fresh_for_cut _) ->
       false
 
@@ -132,10 +147,33 @@ let prop_preempt_busy =
         })
     (fun i -> is_defer_busy (call i))
 
+let prop_defer_when_conflicted =
+  Test.make ~count:300
+    ~name:
+      "SEP-3c': has_conflict, not busy, non-main, unmerged → Defer \
+       Base_resolving_conflict (pre-empts freshness/sibling arms — the \
+       conflicted-rebase window of PR #3811)"
+    Gen.(
+      (* [base_structurally_fresh] and [base_contains_merged_siblings] are left
+         random: a conflicted base must defer even when it reads structurally
+         fresh (same-name freshen rebase) and the launching patch has no merged
+         siblings — exactly the configuration that let patch 5 cut from a
+         mid-conflicted-rebase patch 4. *)
+      let* i = gen_inputs in
+      return
+        {
+          i with
+          base_is_main = false;
+          base_patch_merged = false;
+          base_patch_busy_rebasing = false;
+          base_patch_has_conflict = true;
+        })
+    (fun i -> is_defer_conflict (call i))
+
 let prop_defer_when_not_fresh =
   Test.make ~count:300
     ~name:
-      "SEP-3d: not fresh, not busy, non-main, unmerged → Defer \
+      "SEP-3d: not fresh, not busy, no conflict, non-main, unmerged → Defer \
        Base_not_fresh_for_cut"
     Gen.(
       let* base_branch = gen_branch in
@@ -145,6 +183,7 @@ let prop_defer_when_not_fresh =
           base_branch;
           base_patch_merged = false;
           base_patch_busy_rebasing = false;
+          base_patch_has_conflict = false;
           base_structurally_fresh = false;
           base_contains_merged_siblings = true;
         })
@@ -152,7 +191,9 @@ let prop_defer_when_not_fresh =
 
 let prop_allow_when_fresh =
   Test.make ~count:300
-    ~name:"SEP-3e: structurally fresh, not busy, non-main, unmerged → Allow"
+    ~name:
+      "SEP-3e: structurally fresh, not busy, no conflict, non-main, unmerged → \
+       Allow"
     Gen.(
       let* base_branch = gen_branch in
       return
@@ -161,6 +202,7 @@ let prop_allow_when_fresh =
           base_branch;
           base_patch_merged = false;
           base_patch_busy_rebasing = false;
+          base_patch_has_conflict = false;
           base_structurally_fresh = true;
           base_contains_merged_siblings = true;
         })
@@ -179,6 +221,7 @@ let prop_defer_when_missing_sibling =
           base_branch;
           base_patch_merged = false;
           base_patch_busy_rebasing = false;
+          base_patch_has_conflict = false;
           base_structurally_fresh = true;
           base_contains_merged_siblings = false;
         })
@@ -197,6 +240,7 @@ let prop_stale_preempts_missing_sibling =
           base_branch;
           base_patch_merged = false;
           base_patch_busy_rebasing = false;
+          base_patch_has_conflict = false;
           base_structurally_fresh = false;
           base_contains_merged_siblings = false;
         })
@@ -204,10 +248,12 @@ let prop_stale_preempts_missing_sibling =
 
 let prop_busy_merged_main_preempt_missing_sibling =
   Test.make ~count:400
-    ~name:"SEP-3h: base_is_main / merged / busy each pre-empt the sibling gate"
+    ~name:
+      "SEP-3h: base_is_main / merged / busy / conflicted each pre-empt the \
+       sibling gate"
     Gen.(
       (* missing sibling, but an earlier arm also holds; the earlier arm wins *)
-      let* which = int_range 0 2 in
+      let* which = int_range 0 3 in
       let* base_branch = gen_branch in
       let base =
         {
@@ -215,6 +261,7 @@ let prop_busy_merged_main_preempt_missing_sibling =
           base_branch;
           base_patch_merged = false;
           base_patch_busy_rebasing = false;
+          base_patch_has_conflict = false;
           base_structurally_fresh = true;
           base_contains_merged_siblings = false;
         }
@@ -223,7 +270,8 @@ let prop_busy_merged_main_preempt_missing_sibling =
         (match which with
         | 0 -> { base with base_is_main = true }
         | 1 -> { base with base_patch_merged = true }
-        | _ -> { base with base_patch_busy_rebasing = true }))
+        | 2 -> { base with base_patch_busy_rebasing = true }
+        | _ -> { base with base_patch_has_conflict = true }))
     (fun i -> not (is_defer_missing_sibling (call i)))
 
 let prop_allow_when_contains_siblings =
@@ -237,6 +285,7 @@ let prop_allow_when_contains_siblings =
           base_branch;
           base_patch_merged = false;
           base_patch_busy_rebasing = false;
+          base_patch_has_conflict = false;
           base_structurally_fresh = true;
           base_contains_merged_siblings = true;
         })
@@ -249,6 +298,7 @@ let prop_allow_implies_fresh =
       | SE.Allow ->
           i.base_is_main || i.base_patch_merged
           || (not i.base_patch_busy_rebasing)
+             && (not i.base_patch_has_conflict)
              && i.base_structurally_fresh && i.base_contains_merged_siblings)
 
 let prop_defer_implies_not_fresh =
@@ -257,7 +307,7 @@ let prop_defer_implies_not_fresh =
       | SE.Allow -> true
       | SE.Defer _ ->
           (not i.base_is_main) && (not i.base_patch_merged)
-          && (i.base_patch_busy_rebasing
+          && (i.base_patch_busy_rebasing || i.base_patch_has_conflict
              || (not i.base_structurally_fresh)
              || not i.base_contains_merged_siblings))
 
@@ -277,35 +327,43 @@ let prop_variants_reachable =
       let allow_main =
         SE.decide ~base_is_main:true ~base_branch:"main"
           ~base_patch_merged:false ~base_patch_busy_rebasing:false
-          ~base_structurally_fresh:false ~base_contains_merged_siblings:true
+          ~base_patch_has_conflict:false ~base_structurally_fresh:false
+          ~base_contains_merged_siblings:true
       in
       let allow_merged =
         SE.decide ~base_is_main:false ~base_branch:"b" ~base_patch_merged:true
-          ~base_patch_busy_rebasing:false ~base_structurally_fresh:false
-          ~base_contains_merged_siblings:true
+          ~base_patch_busy_rebasing:false ~base_patch_has_conflict:false
+          ~base_structurally_fresh:false ~base_contains_merged_siblings:true
       in
       let allow_fresh =
         SE.decide ~base_is_main:false ~base_branch:"b" ~base_patch_merged:false
-          ~base_patch_busy_rebasing:false ~base_structurally_fresh:true
-          ~base_contains_merged_siblings:true
+          ~base_patch_busy_rebasing:false ~base_patch_has_conflict:false
+          ~base_structurally_fresh:true ~base_contains_merged_siblings:true
       in
       let defer_busy =
         SE.decide ~base_is_main:false ~base_branch:"b" ~base_patch_merged:false
-          ~base_patch_busy_rebasing:true ~base_structurally_fresh:true
-          ~base_contains_merged_siblings:true
+          ~base_patch_busy_rebasing:true ~base_patch_has_conflict:false
+          ~base_structurally_fresh:true ~base_contains_merged_siblings:true
+      in
+      let defer_conflict =
+        SE.decide ~base_is_main:false ~base_branch:"b" ~base_patch_merged:false
+          ~base_patch_busy_rebasing:false ~base_patch_has_conflict:true
+          ~base_structurally_fresh:true ~base_contains_merged_siblings:true
       in
       let defer_stale =
         SE.decide ~base_is_main:false ~base_branch:"b" ~base_patch_merged:false
-          ~base_patch_busy_rebasing:false ~base_structurally_fresh:false
-          ~base_contains_merged_siblings:true
+          ~base_patch_busy_rebasing:false ~base_patch_has_conflict:false
+          ~base_structurally_fresh:false ~base_contains_merged_siblings:true
       in
       let defer_missing_sibling =
         SE.decide ~base_is_main:false ~base_branch:"b" ~base_patch_merged:false
-          ~base_patch_busy_rebasing:false ~base_structurally_fresh:true
-          ~base_contains_merged_siblings:false
+          ~base_patch_busy_rebasing:false ~base_patch_has_conflict:false
+          ~base_structurally_fresh:true ~base_contains_merged_siblings:false
       in
       is_allow allow_main && is_allow allow_merged && is_allow allow_fresh
-      && is_defer_busy defer_busy && is_defer_stale defer_stale
+      && is_defer_busy defer_busy
+      && is_defer_conflict defer_conflict
+      && is_defer_stale defer_stale
       && is_defer_missing_sibling defer_missing_sibling)
 
 let () =
@@ -318,6 +376,7 @@ let () =
          prop_preempt_base_is_main;
          prop_preempt_base_merged;
          prop_preempt_busy;
+         prop_defer_when_conflicted;
          prop_defer_when_not_fresh;
          prop_allow_when_fresh;
          prop_defer_when_missing_sibling;


### PR DESCRIPTION
## Bug

The require-freshness gate reopened mid-rebase-pipeline. A `Rebase` that hits conflicts **completes as an op** — the continuation is a queued `Merge_conflict` respond — so all three defer conditions evaporated at once, while the base branch's tip was still pending a rewrite by the resolution force-push:

- `base_patch_busy_rebasing` → false (the Rebase op is done; the gate doesn't recognize the queued `Merge_conflict` as the rest of the pipeline)
- `base_structurally_fresh` → true (a same-name freshen rebase, main → newer main, never changes `branch_rebased_onto`, so the name-scoped structural check is blind to it)
- `base_contains_merged_siblings` → vacuously true (a pure-chain child has no merged deps)

### Production trace (connector-adapter-shape-unification)

| ts | event |
|---|---|
| 17:15:18 | `Rebase(4, main)` fires — `Start(5)` correctly deferred via busy-rebase |
| 17:15:21 | the rebase **conflicts**; `Merge_conflict` queued, Rebase op completed |
| 17:15:21 | **same tick**: `Start(5, patch-4)` allowed; patch 5 cut from the doomed pre-rebase tip `3e72535` |
| 17:18:48 | conflict resolution force-pushes `be6fb8ce`, rewriting the history patch 5 was cut from |
| 17:23 | flowglad/provisioning-agent#3811 created from the stale cut — born conflicted |

## Fix

New `base_patch_has_conflict` input to `Start_eligibility.decide` with defer reason `Base_resolving_conflict` (label `defer_base_conflicted`), checked right after the busy-rebase arm. The orchestrator feeds the base patch's `has_conflict`, which is set on every path that enqueues `Merge_conflict` and cleared only when resolution lands — the gate now holds closed across the whole pipeline: queued Rebase → running Rebase → conflicted → resolution pushed.

- **Liveness**: the cut source is the *local* base branch, which the resolution rewrites before `has_conflict` clears, so the first Start allowed after the window cuts the new tip. A permanently conflicted base surfaces via the existing `conflict_noop_count` intervention path. SBI-2 (defer ⇒ progress) covers the new arm in the random state machine.
- **Still dependency-scoped**: the new arm never consults main movement, only the base's own conflict state.

## Tests (derived from the invariant, not the implementation)

- **SEP**: `SEP-3c'` — a conflicted base defers even when structurally fresh with vacuous sibling containment (the exact PR #3811 configuration); pre-emption arms; SEP-4/5 justification updates; variant reachability.
- **SBI**: new `Rebase_conflict` / `Resolve_conflict` commands drive `apply_rebase_result Conflict` and the `Merge_conflict` respond through the real orchestrator transitions; the independent freshness oracle now rejects conflicted bases; **PI-SBI-3** replays the production trace end to end (Allow settled → defer busy → defer through conflict window → Allow after resolution). Verified red against the pre-fix gate, green with the fix.

## Notes

- Stacked on #342 — the SBI/FLI test files this extends land there.
- `spec/anton.pant` doesn't model the eligibility gate (it never has — the gate's spec-derived property home is the SEP/SBI suites per the May rework). If we want the gate lifted into the spec, that's a separate `/write-spec` pass.
- Separate follow-up worth filing: the *root* staleness in the trace is the cut path — `worktree_setup` pre-fetches the patch's own branch but never the base, so patch 4 was cut from a local `main` missing its just-merged dep's squash. That's what made the freshen rebase (and its conflict) necessary at all.
- Pre-existing flake found while validating: `QCHECK_SEED=440463877 dune exec test/test_fanin_liveness_interleavings.exe` fails FLI-3 on the unmodified tree too (rare liveness counterexample, `<no printer>`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/343"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783014887&installation_id=126163856&pr_number=343&repository=flowglad%2Fonton&return_to=https%3A%2F%2Fgithub.com%2Fflowglad%2Fonton%2Fpull%2F343&signature=e311d033265265381e9d6877af3f65543275a4faba40a531941c3f35de74b8b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hold the Start/Rebase gate while the base patch has an unresolved rebase conflict, so we don’t cut from a pre-rewrite tip and create stale, conflicted PRs (e.g., #3811). The gate stays closed through the conflicted-rebase window and reopens only after resolution.

- **Bug Fixes**
  - Added `base_patch_has_conflict` to `Start_eligibility.decide` with `Base_resolving_conflict` (`defer_base_conflicted`), checked after the busy-rebase arm.
  - Orchestrator threads `Patch_agent.has_conflict` into eligibility; docs clarify it’s set when `Merge_conflict` is enqueued, cleared when resolution lands, a resolution `Noop` clears it as a GitHub-state signal, and polling re-sets it if the conflict persists.
  - Gate stays closed across queued/running rebase → conflict → resolution force-push; liveness preserved (first allowed Start cuts the rewritten local base tip).
  - Tests: SEP pre-emption and justifications updated; SBI adds `Rebase_conflict`/`Resolve_conflict`; PI-SBI-3 replays the PR #3811 witness (allow → defer busy → defer conflict → allow).

<sup>Written for commit 2c97248c9d6a9d8215ee7b84946e3e5c997cf05a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/flowglad/onton/pull/343?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Patches now properly defer from starting when their base branch is actively resolving conflicts, preventing operations on history being rewritten.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->