### PR TITLE
Fetch the base and cut from origin's SHA for main-based worktree cuts

### DIFF
--- a/lib/worktree_setup.ml
+++ b/lib/worktree_setup.ml
@@ -144,12 +144,63 @@ module Make (W : Worktree.S) (Env : ENV) : S = struct
             | Fetch_branch_error msg ->
                 log_event runtime ~patch_id
                   (Printf.sprintf "Pre-create fetch failed (continuing): %s" msg));
+            (* When the base is the main branch, also refresh
+               [refs/remotes/origin/<main>] and cut from its resolved SHA. The
+               orchestrator never advances the local main ref, so cutting from
+               it right after a dependency's squash-merge starts the branch on
+               yesterday's main, missing that dependency's commits — the
+               connector-adapter-shape-unification patch-4 stale cut that
+               forced an immediate freshen rebase (which then conflicted). For
+               a dependency-branch base the local ref is authoritative (its
+               worktree writes locally first; origin lags until push), so no
+               fetch is attempted: {!Start_point_plan.base_start_point} encodes
+               the asymmetry, and on fetch/resolve failure it falls back
+               fail-open to the local ref with the freshen-rebase detectors as
+               the backstop, exactly the pre-fetch behavior. *)
+            let base_is_main =
+              Runtime.read runtime (fun snap ->
+                  Types.Branch.equal
+                    (Orchestrator.main_branch snap.Runtime.orchestrator)
+                    (Types.Branch.of_string base))
+            in
+            let fetched_remote_sha =
+              if not base_is_main then None
+              else
+                match W.fetch_origin_branch ~fetch_lock ~branch:base with
+                | Fetch_branch_ok ->
+                    W.read_branch_sha ~path:(W.resolve_main_root ())
+                      ~ref_name:("refs/remotes/origin/" ^ base)
+                | Fetch_branch_no_remote_ref ->
+                    log_event runtime ~patch_id
+                      (Printf.sprintf
+                         "No remote ref for base %s — cutting from the local \
+                          ref"
+                         base);
+                    None
+                | Fetch_branch_error msg ->
+                    log_event runtime ~patch_id
+                      (Printf.sprintf
+                         "Base fetch failed (continuing with possibly-stale \
+                          local %s): %s"
+                         base msg);
+                    None
+            in
+            let start_point =
+              Start_point_plan.base_start_point ~base_branch:base ~base_is_main
+                ~fetched_remote_sha
+            in
+            log_event runtime ~patch_id
+              (Printf.sprintf "Worktree base start point: %s (%s)"
+                 (Start_point_plan.base_start_point_short_label start_point)
+                 (Start_point_plan.base_start_point_ref start_point));
             log_event runtime ~patch_id
               (Printf.sprintf "Creating worktree at %s" path);
             let create_outcome =
               match
                 Eio.Mutex.use_ro worktree_mutex (fun () ->
-                    W.create ~project_name ~patch_id ~branch:br ~base_ref:base)
+                    W.create ~project_name ~patch_id ~branch:br
+                      ~base_ref:
+                        (Start_point_plan.base_start_point_ref start_point))
               with
               | Ok _ -> `Created
               | Error refusal -> `Refused refusal

--- a/lib/worktree_setup.ml
+++ b/lib/worktree_setup.ml
@@ -156,7 +156,13 @@ module Make (W : Worktree.S) (Env : ENV) : S = struct
                fetch is attempted: {!Start_point_plan.base_start_point} encodes
                the asymmetry, and on fetch/resolve failure it falls back
                fail-open to the local ref with the freshen-rebase detectors as
-               the backstop, exactly the pre-fetch behavior. *)
+               the backstop, exactly the pre-fetch behavior.
+
+               This deliberately shares [Env.fetch_mutex] with the branch fetch
+               above (and the rest of the runtime's fetch traffic). Git updates
+               refs in the same managed clone, so serializing both fetches keeps
+               ref observation ordered at the cost of one more locked network
+               round trip during main-base worktree creation. *)
             let base_is_main =
               Runtime.read runtime (fun snap ->
                   Types.Branch.equal

--- a/lib_core/start_point_plan.ml
+++ b/lib_core/start_point_plan.ml
@@ -58,3 +58,24 @@ let short_label = function
   | Refuse (Local_has_unpushed_commits _) -> "refuse_local_ahead"
   | Refuse Branch_checked_out_in_main_root -> "refuse_main_checkout"
   | Refuse (Worktree_already_registered _) -> "refuse_wt_registered"
+
+type base_start_point =
+  | Base_at_fetched_remote_sha of { sha : sha }
+  | Base_at_local_ref of { base_branch : string }
+[@@deriving show, eq, sexp_of, compare]
+
+let base_start_point ~base_branch ~base_is_main ~fetched_remote_sha =
+  match (base_is_main, fetched_remote_sha) with
+  | true, Some sha -> Base_at_fetched_remote_sha { sha }
+  (* A non-main base never cuts from a remote SHA, even when one is supplied:
+     the dep's worktree writes the local branch first and origin lags until
+     the post-session push, so preferring origin could travel backwards. *)
+  | true, None | false, _ -> Base_at_local_ref { base_branch }
+
+let base_start_point_ref = function
+  | Base_at_fetched_remote_sha { sha } -> sha
+  | Base_at_local_ref { base_branch } -> base_branch
+
+let base_start_point_short_label = function
+  | Base_at_fetched_remote_sha _ -> "base_at_origin_sha"
+  | Base_at_local_ref _ -> "base_at_local_ref"

--- a/lib_core/start_point_plan.mli
+++ b/lib_core/start_point_plan.mli
@@ -109,7 +109,10 @@ val plan :
     dependency-scoped and enforced by the orchestrator's scheduling gate (see
     {!Start_eligibility}). A stacked dependent cut from its base's tip contains
     everything in that base; main integration cascades at merge boundaries, so a
-    base lagging main for unrelated reasons must not block the cut. *)
+    base lagging main for unrelated reasons must not block the cut. Which
+    {e ref} the base is read from (freshly-fetched remote SHA vs local branch)
+    is the separate {!base_start_point} decision below, supplied by the caller
+    as [base_branch]. *)
 
 val short_label : decision -> string
 (** A short, lowercase, snake_case identifier for the planner arm that fired,
@@ -117,3 +120,66 @@ val short_label : decision -> string
     Examples: ["reset_to_remote"], ["use_local_unchanged"],
     ["create_from_base"], ["refuse_local_diverged"], ["refuse_local_ahead"],
     ["refuse_main_checkout"], ["refuse_wt_registered"]. *)
+
+(** {1 Base start point for the brand-new-branch cut}
+
+    Which ref should [Create_new_branch_from_base] actually cut from? The answer
+    is asymmetric, because authority differs by base kind:
+
+    - {b Base is the main branch}: the {e remote} is authoritative. The
+      orchestrator never advances the managed clone's local [<main>] — it only
+      observes merges via the API — so the local ref lags origin by however long
+      since the last incidental fetch. Cutting from it right after a
+      dependency's squash-merge produces a branch missing that dependency's
+      commits (the connector-adapter-shape-unification patch-4 stale cut: local
+      [main] was fetched seconds {e before} the dep's squash landed, and the
+      branch was born needing a freshen rebase that then conflicted). The caller
+      fetches [origin/<main>] and cuts from the {e resolved SHA} — a SHA rather
+      than the [origin/<main>] name so the cut is pinned to exactly what was
+      fetched and the new branch picks up no upstream tracking.
+    - {b Base is a dependency patch's branch}: the {e local} ref is
+      authoritative. The dep's worktree shares the managed repo's ref store, so
+      its commits land on the local branch first and origin lags until the
+      post-session push — fetching and preferring origin here could travel
+      {e backwards}. The scheduling gate ({!Start_eligibility}) already
+      guarantees the dep is settled (not mid-rebase, not mid-conflict) when the
+      cut fires.
+
+    Cutting a new branch from the freshest main is {e not} a main-currency gate:
+    nothing is rebased or re-validated on main movement, and an open PR behind
+    main still merges directly. It only stops a brand-new branch from being born
+    on yesterday's main. *)
+
+type base_start_point =
+  | Base_at_fetched_remote_sha of { sha : sha }
+      (** Cut from [sha], the just-fetched tip of [origin/<base>]. Chosen only
+          for a main-branch base whose remote tip was successfully fetched and
+          resolved. *)
+  | Base_at_local_ref of { base_branch : string }
+      (** Cut from the local [base_branch] ref — the dependency-base case, and
+          the fail-open fallback when fetching/resolving the main base's remote
+          tip failed (the freshen-rebase detectors remain the backstop, exactly
+          as before this decision existed). *)
+[@@deriving show, eq, sexp_of, compare]
+
+val base_start_point :
+  base_branch:string ->
+  base_is_main:bool ->
+  fetched_remote_sha:sha option ->
+  base_start_point
+(** [base_start_point] is total and deterministic:
+
+    + [base_is_main = true] and [fetched_remote_sha = Some sha] →
+      [Base_at_fetched_remote_sha { sha }].
+    + Otherwise → [Base_at_local_ref { base_branch }]. A non-main base never
+      cuts from a remote SHA, even if the caller supplies one — local is
+      authoritative for dependency branches. *)
+
+val base_start_point_ref : base_start_point -> string
+(** The string to hand to [git worktree add -b <branch> <path> <start-point>]:
+    the SHA for [Base_at_fetched_remote_sha], the branch name for
+    [Base_at_local_ref]. *)
+
+val base_start_point_short_label : base_start_point -> string
+(** Activity-log identifier for the chosen arm. Non-empty, ≤ 32 characters,
+    lowercase snake_case: ["base_at_origin_sha"] / ["base_at_local_ref"]. *)

--- a/test/dune
+++ b/test/dune
@@ -271,6 +271,13 @@
  (ocamlc_flags (:standard -w -40-42)))
 
 (test
+ (name test_worktree_setup_base_fetch_integration)
+ (modules test_worktree_setup_base_fetch_integration)
+ (libraries onton onton_core onton_test_support eio eio_main eio.unix unix)
+ (ocamlopt_flags (:standard -w -40-42))
+ (ocamlc_flags (:standard -w -40-42)))
+
+(test
  (name test_push_plan_integration)
  (modules test_push_plan_integration)
  (libraries onton onton_core onton_test_support eio eio_main eio.unix unix)

--- a/test/test_fanin_liveness_interleavings.ml
+++ b/test/test_fanin_liveness_interleavings.ml
@@ -104,11 +104,12 @@ let deps_satisfied m pid =
     pid ~has_merged:(has_merged_in m.orch) ~has_pr:(fun dep ->
       Patch_agent.is_pr_present (Orchestrator.agent m.orch dep))
 
-(** Start [pid] from [base]: PR appears and the session completes, mirroring the
-    SBI bootstrap (fire Start → set_pr_number → complete). The branch absorbs
-    its base's current merge SHAs (the cut). No-op when already started or when
-    dependencies are not satisfied (cannot cut a worktree off a missing base).
-*)
+(** Start [pid] from [base]: PR appears, implementation notes are delivered, and
+    the session completes, mirroring the SBI bootstrap plus the deps-notes-ready
+    contract (fire Start → set_pr_number → Pr_body delivered → complete). The
+    branch absorbs its base's current merge SHAs (the cut). No-op when already
+    started or when dependencies are not satisfied (cannot cut a worktree off a
+    missing base). *)
 let do_start m pid base =
   let agent = Orchestrator.agent m.orch pid in
   if Patch_agent.has_pr agent || agent.Patch_agent.merged then m
@@ -119,6 +120,7 @@ let do_start m pid base =
       Orchestrator.set_pr_number orch pid
         (Pr_number.of_int (idx_of_pid m.patches pid + 1))
     in
+    let orch = Orchestrator.set_pr_body_delivered orch pid true in
     let orch = Orchestrator.complete orch pid in
     absorb { m with orch } ~branch:agent.Patch_agent.branch ~from:base
 

--- a/test/test_start_point_plan_properties.ml
+++ b/test/test_start_point_plan_properties.ml
@@ -298,6 +298,93 @@ let prop_remote_wins_over_local =
       in
       not (is_use_local d))
 
+(* ---------- base_start_point (BSP) ----------
+
+   The brand-new-branch cut's base ref. Invariants, derived from the authority
+   rules (remote canonical for main — the orchestrator never advances local
+   main; local canonical for dependency branches — the dep's worktree writes
+   locally first and origin lags until push):
+
+   - BSP-1 totality/determinism over all inputs.
+   - BSP-2 main base + fetched SHA → cut pinned to that SHA.
+   - BSP-3 a non-main base NEVER cuts from a remote SHA, even if supplied.
+   - BSP-4 main base without a fetched SHA falls back (fail-open) to the local
+     ref — pre-fetch behavior, freshen-rebase detectors as backstop.
+   - BSP-5 the rendered ref is exactly the SHA / the base branch name.
+   - BSP-6 label bounds. *)
+
+type bsp_inputs = {
+  bsp_base_branch : string;
+  bsp_base_is_main : bool;
+  bsp_fetched_remote_sha : string option;
+}
+
+let gen_bsp_inputs : bsp_inputs Gen.t =
+  let open Gen in
+  let* bsp_base_branch = gen_branch_name in
+  let* bsp_base_is_main = bool in
+  let* bsp_fetched_remote_sha = gen_sha_option in
+  return { bsp_base_branch; bsp_base_is_main; bsp_fetched_remote_sha }
+
+let call_bsp i =
+  SP.base_start_point ~base_branch:i.bsp_base_branch
+    ~base_is_main:i.bsp_base_is_main
+    ~fetched_remote_sha:i.bsp_fetched_remote_sha
+
+let prop_bsp_total_deterministic =
+  Test.make ~count:500 ~name:"BSP-1: base_start_point total + deterministic"
+    gen_bsp_inputs (fun i ->
+      try SP.equal_base_start_point (call_bsp i) (call_bsp i) with _ -> false)
+
+let prop_bsp_main_uses_fetched_sha =
+  Test.make ~count:500
+    ~name:"BSP-2: main base + fetched SHA → Base_at_fetched_remote_sha"
+    Gen.(
+      let* base_branch = gen_branch_name in
+      let* sha = gen_sha in
+      return (base_branch, sha))
+    (fun (base_branch, sha) ->
+      SP.equal_base_start_point
+        (SP.base_start_point ~base_branch ~base_is_main:true
+           ~fetched_remote_sha:(Some sha))
+        (SP.Base_at_fetched_remote_sha { sha }))
+
+let prop_bsp_non_main_never_remote =
+  Test.make ~count:500 ~name:"BSP-3: non-main base never cuts from a remote SHA"
+    gen_bsp_inputs (fun i ->
+      SP.equal_base_start_point
+        (call_bsp { i with bsp_base_is_main = false })
+        (SP.Base_at_local_ref { base_branch = i.bsp_base_branch }))
+
+let prop_bsp_main_no_sha_falls_back =
+  Test.make ~count:500
+    ~name:"BSP-4: main base without fetched SHA falls back to the local ref"
+    gen_branch_name (fun base_branch ->
+      SP.equal_base_start_point
+        (SP.base_start_point ~base_branch ~base_is_main:true
+           ~fetched_remote_sha:None)
+        (SP.Base_at_local_ref { base_branch }))
+
+let prop_bsp_ref_rendering =
+  Test.make ~count:500
+    ~name:"BSP-5: base_start_point_ref renders the SHA / the base branch"
+    gen_bsp_inputs (fun i ->
+      let sp = call_bsp i in
+      let rendered = SP.base_start_point_ref sp in
+      match sp with
+      | SP.Base_at_fetched_remote_sha { sha } -> String.equal rendered sha
+      | SP.Base_at_local_ref { base_branch } ->
+          String.equal rendered base_branch)
+
+let prop_bsp_label_bounds =
+  Test.make ~count:500
+    ~name:"BSP-6: base_start_point_short_label non-empty, ≤32, snake_case"
+    gen_bsp_inputs (fun i ->
+      let lbl = SP.base_start_point_short_label (call_bsp i) in
+      (not (String.is_empty lbl))
+      && String.length lbl <= 32
+      && Re.execp label_re lbl)
+
 let () =
   let runner = QCheck_base_runner.run_tests_main in
   ignore
@@ -313,4 +400,10 @@ let () =
          prop_label_bounds;
          prop_variants_reachable;
          prop_remote_wins_over_local;
+         prop_bsp_total_deterministic;
+         prop_bsp_main_uses_fetched_sha;
+         prop_bsp_non_main_never_remote;
+         prop_bsp_main_no_sha_falls_back;
+         prop_bsp_ref_rendering;
+         prop_bsp_label_bounds;
        ])

--- a/test/test_worktree_setup_base_fetch_integration.ml
+++ b/test/test_worktree_setup_base_fetch_integration.ml
@@ -42,18 +42,19 @@ let with_temp_dir f =
   Unix.mkdir dir 0o755;
   (* Worktree paths derive from $HOME (see [Worktree.worktree_dir]); redirect
      HOME into the temp dir so the worktree lives inside our sandbox. Restored
-     (and the sandbox wiped) at exit. *)
+     (and the sandbox wiped) before the next scenario runs. *)
   let prior_home = Stdlib.Sys.getenv_opt "HOME" in
   Unix.putenv "HOME" dir;
-  Stdlib.at_exit (fun () ->
+  Stdlib.Fun.protect
+    ~finally:(fun () ->
       (match prior_home with
       | Some h -> Unix.putenv "HOME" h
       | None -> Unix.putenv "HOME" (Stdlib.Filename.get_temp_dir_name ()));
       try
         Git_env.sh ~dir:"/"
           (Printf.sprintf "rm -rf %s" (Stdlib.Filename.quote dir))
-      with _ -> ());
-  f dir
+      with _ -> ())
+    (fun () -> f dir)
 
 let setup_origin_with_main ~origin_dir =
   Unix.mkdir origin_dir 0o755;
@@ -164,9 +165,8 @@ let scenario_stale_local_main env =
   sh ~dir:origin_dir "git add dep.txt";
   sh ~dir:origin_dir "git commit -q -m 'dep squash'";
   let origin_tip = git_capture ~dir:origin_dir [ "rev-parse"; "main" ] in
-  assert_string "precondition: local main is stale"
-    (git_capture ~dir:managed_dir [ "rev-parse"; "main" ])
-    clone_time_main;
+  assert_string "precondition: local main is stale" clone_time_main
+    (git_capture ~dir:managed_dir [ "rev-parse"; "main" ]);
   let wt =
     run_ensure env ~managed_dir ~project_name:"stale-main"
       ~pid:(Types.Patch_id.of_string "1")

--- a/test/test_worktree_setup_base_fetch_integration.ml
+++ b/test/test_worktree_setup_base_fetch_integration.ml
@@ -120,11 +120,11 @@ let empty_gameplan =
 let run_ensure env ~managed_dir ~project_name ~pid ~branch ~base_ref =
   let process_mgr = Eio.Stdenv.process_mgr env in
   let module W = (val Worktree.make ~process_mgr ~repo_root:managed_dir) in
+  let patch = mk_patch ~pid ~branch in
+  let gameplan = { empty_gameplan with Types.Gameplan.patches = [ patch ] } in
   let module Env : Worktree_setup.ENV = struct
     let runtime =
-      Runtime.create ~gameplan:empty_gameplan
-        ~main_branch:(Types.Branch.of_string "main")
-        ()
+      Runtime.create ~gameplan ~main_branch:(Types.Branch.of_string "main") ()
 
     let clock = Eio.Stdenv.clock env
     let fs = Eio.Stdenv.fs env
@@ -135,12 +135,10 @@ let run_ensure env ~managed_dir ~project_name ~pid ~branch ~base_ref =
     let user_config = { User_config.on_worktree_create = None }
   end in
   let module WS = Worktree_setup.Make (W) (Env) in
-  let patch = mk_patch ~pid ~branch in
-  let orch =
-    Orchestrator.create ~patches:[ patch ]
-      ~main_branch:(Types.Branch.of_string "main")
+  let agent =
+    Runtime.read Env.runtime (fun snap ->
+        Orchestrator.agent snap.Runtime.orchestrator pid)
   in
-  let agent = Orchestrator.agent orch pid in
   match
     WS.ensure_worktree ~patch_id:pid ~agent
       ~branch:(Types.Branch.of_string branch)

--- a/test/test_worktree_setup_base_fetch_integration.ml
+++ b/test/test_worktree_setup_base_fetch_integration.ml
@@ -1,0 +1,237 @@
+open Base
+open Onton
+open Onton_core
+module Git_env = Onton_test_support.Git_env
+
+(** Integration test: drive the real [Worktree_setup.ensure_worktree] against
+    real git fixtures to verify which ref a brand-new branch is cut from
+    ({!Start_point_plan.base_start_point} wiring).
+
+    The production bug this locks out (connector-adapter-shape-unification patch
+    4 / PR #3809): the orchestrator never advances the managed clone's local
+    main ref, so a Start that fired right after a dependency's squash-merge cut
+    the new branch from yesterday's main — missing the dependency's commits and
+    forcing an immediate freshen rebase that then conflicted. [ensure_worktree]
+    must fetch [origin/<main>] and cut from its resolved SHA.
+
+    Scenarios:
+
+    - "stale local main" — origin's main advances after the clone; local [main]
+      and the remote-tracking ref both lag. Cutting with [base_ref = "main"]
+      must land on origin's {e current} tip, not the clone-time tip. (Red before
+      the base-fetch fix.)
+    - "dep branch base is local-canonical" — the base is a dependency patch's
+      branch whose local ref is ahead of [origin/<dep>] (the dep's worktree
+      writes locally first; origin lags until push). The cut must use the local
+      tip — never the remote.
+    - "fetch failure falls back to local main" — origin is unreachable. The cut
+      proceeds fail-open from the local main ref (pre-fix behavior; the
+      freshen-rebase detectors remain the backstop).
+
+    Every git command runs against the real binary; no mocks. *)
+
+let sh ?(dir = ".") cmd = Git_env.sh ~dir cmd
+let git_capture ?(dir = ".") args = Git_env.git_capture ~cwd:dir args
+
+let with_temp_dir f =
+  let dir =
+    Stdlib.Filename.concat
+      (Stdlib.Filename.get_temp_dir_name ())
+      (Printf.sprintf "onton-base-fetch-%d-%d" (Unix.getpid ()) (Random.bits ()))
+  in
+  Unix.mkdir dir 0o755;
+  (* Worktree paths derive from $HOME (see [Worktree.worktree_dir]); redirect
+     HOME into the temp dir so the worktree lives inside our sandbox. Restored
+     (and the sandbox wiped) at exit. *)
+  let prior_home = Stdlib.Sys.getenv_opt "HOME" in
+  Unix.putenv "HOME" dir;
+  Stdlib.at_exit (fun () ->
+      (match prior_home with
+      | Some h -> Unix.putenv "HOME" h
+      | None -> Unix.putenv "HOME" (Stdlib.Filename.get_temp_dir_name ()));
+      try
+        Git_env.sh ~dir:"/"
+          (Printf.sprintf "rm -rf %s" (Stdlib.Filename.quote dir))
+      with _ -> ());
+  f dir
+
+let setup_origin_with_main ~origin_dir =
+  Unix.mkdir origin_dir 0o755;
+  sh ~dir:origin_dir "git init -q --initial-branch=main";
+  sh ~dir:origin_dir "git config user.email 'test@example.com'";
+  sh ~dir:origin_dir "git config user.name 'Test'";
+  sh ~dir:origin_dir "echo base > README.md";
+  sh ~dir:origin_dir "git add README.md";
+  sh ~dir:origin_dir "git commit -q -m 'base'"
+
+let clone_into ~origin_dir ~managed_dir =
+  sh
+    (Printf.sprintf "git clone -q %s %s"
+       (Stdlib.Filename.quote origin_dir)
+       (Stdlib.Filename.quote managed_dir));
+  sh ~dir:managed_dir "git config user.email 'test@example.com'";
+  sh ~dir:managed_dir "git config user.name 'Test'"
+
+let assert_string label want got =
+  if not (String.equal want got) then
+    failwith (Printf.sprintf "%s: expected %S got %S" label want got)
+
+let mk_patch ~pid ~branch =
+  Types.Patch.
+    {
+      id = pid;
+      title = "P";
+      description = "";
+      branch = Types.Branch.of_string branch;
+      dependencies = [];
+      spec = "";
+      acceptance_criteria = [];
+      files = [];
+      classification = "";
+      changes = [];
+      test_stubs_introduced = [];
+      test_stubs_implemented = [];
+      complexity = None;
+      precedents = [];
+      required_context = [];
+    }
+
+let empty_gameplan =
+  {
+    Types.Gameplan.project_name = "";
+    repo_owner = "";
+    repo_name = "";
+    problem_statement = "";
+    solution_summary = "";
+    final_state_spec = "";
+    patches = [];
+    current_state_analysis = "";
+    explicit_opinions = "";
+    acceptance_criteria = [];
+    open_questions = [];
+    functional_changes = [];
+    context_resources = [];
+  }
+
+(** Instantiate the real [Worktree_setup.Make] over a real git-backed [W] for
+    [managed_dir], then run [ensure_worktree] for a brand-new [branch] cut from
+    [base_ref]. Returns the worktree path. *)
+let run_ensure env ~managed_dir ~project_name ~pid ~branch ~base_ref =
+  let process_mgr = Eio.Stdenv.process_mgr env in
+  let module W = (val Worktree.make ~process_mgr ~repo_root:managed_dir) in
+  let module Env : Worktree_setup.ENV = struct
+    let runtime =
+      Runtime.create ~gameplan:empty_gameplan
+        ~main_branch:(Types.Branch.of_string "main")
+        ()
+
+    let clock = Eio.Stdenv.clock env
+    let fs = Eio.Stdenv.fs env
+    let worktree_mutex = Eio.Mutex.create ()
+    let hook_mutex = Eio.Mutex.create ()
+    let fetch_mutex = Eio.Mutex.create ()
+    let project_name = project_name
+    let user_config = { User_config.on_worktree_create = None }
+  end in
+  let module WS = Worktree_setup.Make (W) (Env) in
+  let patch = mk_patch ~pid ~branch in
+  let orch =
+    Orchestrator.create ~patches:[ patch ]
+      ~main_branch:(Types.Branch.of_string "main")
+  in
+  let agent = Orchestrator.agent orch pid in
+  match
+    WS.ensure_worktree ~patch_id:pid ~agent
+      ~branch:(Types.Branch.of_string branch)
+      ~base_ref ()
+  with
+  | Worktree_setup.Path p -> p
+  | Worktree_setup.Missing -> failwith "ensure_worktree: Missing"
+  | Worktree_setup.Refused -> failwith "ensure_worktree: Refused"
+
+(** Origin's main advances after the clone; both the local [main] ref and the
+    clone-time remote-tracking ref lag. The cut must land on origin's current
+    tip. *)
+let scenario_stale_local_main env =
+  with_temp_dir @@ fun root ->
+  let origin_dir = Stdlib.Filename.concat root "origin" in
+  let managed_dir = Stdlib.Filename.concat root "managed" in
+  setup_origin_with_main ~origin_dir;
+  clone_into ~origin_dir ~managed_dir;
+  let clone_time_main = git_capture ~dir:managed_dir [ "rev-parse"; "main" ] in
+  (* The dependency's squash-merge lands on origin main AFTER the clone. *)
+  sh ~dir:origin_dir "echo dep-squash > dep.txt";
+  sh ~dir:origin_dir "git add dep.txt";
+  sh ~dir:origin_dir "git commit -q -m 'dep squash'";
+  let origin_tip = git_capture ~dir:origin_dir [ "rev-parse"; "main" ] in
+  assert_string "precondition: local main is stale"
+    (git_capture ~dir:managed_dir [ "rev-parse"; "main" ])
+    clone_time_main;
+  let wt =
+    run_ensure env ~managed_dir ~project_name:"stale-main"
+      ~pid:(Types.Patch_id.of_string "1")
+      ~branch:"stale-main/patch-1" ~base_ref:"main"
+  in
+  let head = git_capture ~dir:wt [ "rev-parse"; "HEAD" ] in
+  assert_string "stale_local_main: worktree HEAD == origin's current main tip"
+    origin_tip head;
+  Stdlib.print_endline "  stale_local_main: OK"
+
+(** The base is a dependency patch's branch whose local ref is ahead of
+    [origin/<dep>] — the cut must use the local tip (local-canonical), never the
+    remote one. *)
+let scenario_dep_base_local_canonical env =
+  with_temp_dir @@ fun root ->
+  let origin_dir = Stdlib.Filename.concat root "origin" in
+  let managed_dir = Stdlib.Filename.concat root "managed" in
+  setup_origin_with_main ~origin_dir;
+  (* Origin has the dep branch at the base commit. *)
+  sh ~dir:origin_dir "git branch dep";
+  clone_into ~origin_dir ~managed_dir;
+  (* The dep's worktree advanced the local branch; origin lags (unpushed). *)
+  sh ~dir:managed_dir "git checkout -q -b dep origin/dep";
+  sh ~dir:managed_dir "echo dep-work > work.txt";
+  sh ~dir:managed_dir "git add work.txt";
+  sh ~dir:managed_dir "git commit -q -m 'dep work'";
+  let local_dep_tip = git_capture ~dir:managed_dir [ "rev-parse"; "dep" ] in
+  sh ~dir:managed_dir "git checkout -q main";
+  let wt =
+    run_ensure env ~managed_dir ~project_name:"dep-base"
+      ~pid:(Types.Patch_id.of_string "2")
+      ~branch:"dep-base/patch-2" ~base_ref:"dep"
+  in
+  let head = git_capture ~dir:wt [ "rev-parse"; "HEAD" ] in
+  assert_string "dep_base: worktree HEAD == local dep tip (not origin/dep)"
+    local_dep_tip head;
+  Stdlib.print_endline "  dep_base_local_canonical: OK"
+
+(** Origin is unreachable: the main-base fetch fails and the cut proceeds
+    fail-open from the local main ref (the pre-fetch behavior, with the
+    freshen-rebase detectors as backstop). *)
+let scenario_fetch_failure_falls_back env =
+  with_temp_dir @@ fun root ->
+  let origin_dir = Stdlib.Filename.concat root "origin" in
+  let managed_dir = Stdlib.Filename.concat root "managed" in
+  setup_origin_with_main ~origin_dir;
+  clone_into ~origin_dir ~managed_dir;
+  let local_main = git_capture ~dir:managed_dir [ "rev-parse"; "main" ] in
+  sh ~dir:managed_dir
+    (Printf.sprintf "git remote set-url origin %s"
+       (Stdlib.Filename.quote (Stdlib.Filename.concat root "gone")));
+  let wt =
+    run_ensure env ~managed_dir ~project_name:"fetch-fail"
+      ~pid:(Types.Patch_id.of_string "3")
+      ~branch:"fetch-fail/patch-3" ~base_ref:"main"
+  in
+  let head = git_capture ~dir:wt [ "rev-parse"; "HEAD" ] in
+  assert_string "fetch_failure: worktree HEAD == local main (fail-open)"
+    local_main head;
+  Stdlib.print_endline "  fetch_failure_falls_back: OK"
+
+let () =
+  Eio_main.run @@ fun env ->
+  Stdlib.print_endline "worktree_setup base-fetch integration:";
+  scenario_stale_local_main env;
+  scenario_dep_base_local_canonical env;
+  scenario_fetch_failure_falls_back env;
+  Stdlib.print_endline "all base-fetch integration scenarios passed"


### PR DESCRIPTION
## Bug

A brand-new patch branch is cut from the managed clone's **local** base ref (`git worktree add -b <branch> <path> <base>`). For a main-based cut, that local ref is whatever the last incidental fetch left behind — the orchestrator never advances local main — so a `Start` firing right after a dependency's squash-merge cuts the branch from yesterday's main, missing that dependency's commits. The pre-create fetch in `ensure_worktree` refreshes the *patch's own* branch, never the base, and `refresh_base_branch` is a pure state-field update (no git).

### Production trace (connector-adapter-shape-unification)

- 17:11:26 — patch 2 squash-merges; `Start(4, main)` fires within the same second
- the cut uses local `main@a62f1cbe`, fetched *before* the squash landed → patch 4 born missing its dep's commits
- the freshen `Rebase(4, main)` this forced then **conflicted** — the conflict window that let PR #3811 cut stale (gated separately in #343) — and flowglad/provisioning-agent#3809 paid a full rebase + conflict-resolution cycle a fresh cut would have avoided
- the recorded anchor (`main@cce7e6a9`, resolved from origin *after* the cut) never matched the actual cut base

## Fix

Asymmetric by base kind, encoded in a new pure decision `Start_point_plan.base_start_point`:

- **Main-branch base — remote is authoritative.** `ensure_worktree` now fetches `origin/<main>` alongside the existing pre-create fetch and cuts from the **resolved SHA** (a SHA, not the `origin/<main>` name, so the cut is pinned to exactly what was fetched and the new branch picks up no upstream tracking). Fetch/resolve failure falls back fail-open to the local ref — the pre-fix behavior, with the freshen-rebase detectors as backstop.
- **Dependency-branch base — local is authoritative.** The dep's worktree shares the repo's ref store: commits land locally first, origin lags until the post-session push. Preferring origin here could travel *backwards*, so the local ref is kept unconditionally. (The Start-eligibility gate already guarantees the dep is settled when the cut fires.)

**This is not a main-currency gate** — nothing is rebased or re-validated on main movement, and an open PR behind main still merges directly (the dependency-scoped freshness discipline is untouched). It only stops a brand-new branch from being born on yesterday's main.

## Tests

- **BSP-1..6** (`test_start_point_plan_properties.ml`): totality/determinism; main+SHA pins the SHA; a non-main base **never** cuts from a remote SHA even when one is supplied; main-without-SHA falls back to local; ref rendering; label bounds.
- **`test_worktree_setup_base_fetch_integration.ml`** — real git fixtures driving the real `Worktree_setup.Make(W)(Env).ensure_worktree`:
  - *stale local main*: origin advances post-clone; the cut must land on origin's current tip — **verified red before the fix** (cut landed on the clone-time tip), green with it
  - *dep branch base is local-canonical*: local `dep` ahead of `origin/dep`; the cut uses the local tip
  - *fetch failure*: unreachable origin; the cut proceeds fail-open from local main

Related: #343 (gate fix for the conflicted-rebase window this stale cut triggered). The two compose: this PR prevents the stale cut at the source; #343 keeps children from cutting mid-recovery when a freshen rebase is needed for any other reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale main-based worktree cuts by fetching `origin/<main>` and cutting from its resolved SHA, so new branches include just-merged dependency commits. Dependency-based cuts keep using the local base to avoid regressing to an older remote.

- **Bug Fixes**
  - Main base: fetch `origin/<main>` under the shared `fetch_mutex` and cut from its resolved SHA; no upstream tracking; on fetch/resolve failure, fall back to local `main`.
  - Dependency base: always cut from the local base ref.
  - Added `Start_point_plan.base_start_point` (plus `base_start_point_ref` and `base_start_point_short_label`) to choose the start ref and log a short label; this is not a main-currency gate.
  - Tests: BSP-1..6 property tests; real-git integration for stale-local-main, dep-base-local-canonical, and fetch-failure fallback (now wired through the runtime orchestrator); updated fan-in liveness test to set PR body delivered in the start flow. Related: #343.

<sup>Written for commit 521f66762301fc4b3319c762f1809baa8bf3ac40. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/flowglad/onton/pull/344?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

