### PR TITLE
Heal stale open chains under fan-in patches: frontier demand + rewrite cascade

### DIFF
--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -166,12 +166,21 @@ let mark_merged t patch_id =
              snapshot. (Today [refresh_base_branch] mutates only [base_branch],
              but re-reading keeps this correct if that ever changes.) The
              [merged] guard is not dead: a dependent can already be merged when
-             this fires, and a merged dep must not be handed a [Rebase]. *)
+             this fires, and a merged dep must not be handed a [Rebase].
+
+             The [has_pr] guard mirrors [detect_rebases]: a PR-less dependent
+             has no branch to absorb into — its eventual Start cuts from the
+             freshly-resolved base, so a queued [Rebase] would sit inert
+             through the cut and then fire against an already-fresh branch:
+             pure waste, and an unnecessary rewrite + CI cycle whenever main
+             moved in between (caught by NUR-3 in
+             [test_fanin_liveness_interleavings.ml]). *)
           match find_agent t dep_id with
           | None -> t
           | Some dep_agent ->
               if
                 dep_agent.Patch_agent.merged
+                || (not (Patch_agent.has_pr dep_agent))
                 || List.mem dep_agent.Patch_agent.queue Operation_kind.Rebase
                      ~equal:Operation_kind.equal
               then t

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -177,6 +177,55 @@ let mark_merged t patch_id =
               then t
               else enqueue t dep_id Operation_kind.Rebase))
 
+(** Eagerly enqueue a [Rebase] for every dependent whose local branch physically
+    sits on [patch_id]'s just-rewritten branch. The dual of [mark_merged]'s
+    eager enqueue: that one creates rebase demand when a dependency {e merges};
+    this one creates it when a dependency's branch is {e rewritten} (a completed
+    rebase / conflict resolution force-replaces its commits). A stacked child's
+    history then references commits that no longer exist — but every name-based
+    detector reads it as fresh ([branch_rebased_onto] still names the base,
+    [base_branch] agrees, and [detect_sibling_stale_bases] only ever targets the
+    fan-in patch's sole open dep, one layer up). Without this cascade a chain
+    under a fan-in patch livelocks: the sibling detector re-enqueues the
+    top-of-chain rebase every tick, the rebase lands on a base that still lacks
+    the merged sibling's squash, and the fan-in patch never becomes startable
+    (the seed-440463877 FLI-3 counterexample; in production the churn is a
+    pointless force-push per poll tick, healed only if GitHub happens to report
+    a textual conflict).
+
+    Each cascaded rebase that completes re-fires this, so the wave walks the
+    open stack one layer per round in topological order, gated at every step by
+    [Start_eligibility] (a child's rebase defers while its base is itself
+    mid-rebase or conflicted). Guards mirror [mark_merged]'s ([merged], rebase
+    already queued) plus:
+
+    - [has_pr]: an unstarted dependent has no branch yet or will cut from the
+      post-rewrite local ref — no demand needed (and
+      [detect_sibling_stale_bases] covers the unstarted-fan-in case).
+    - [branch_rebased_onto = patch_id's branch]: only children physically on the
+      rewritten branch are stranded; a fan-in dependent based on a different
+      open dep is untouched by this rewrite. *)
+let enqueue_rebase_for_stranded_dependents t patch_id =
+  match find_agent t patch_id with
+  | None -> t
+  | Some rebased ->
+      let rebased_branch = rebased.Patch_agent.branch in
+      Graph.dependents t.graph patch_id
+      |> List.fold ~init:t ~f:(fun t dep_id ->
+          match find_agent t dep_id with
+          | None -> t
+          | Some d ->
+              if
+                d.Patch_agent.merged
+                || (not (Patch_agent.has_pr d))
+                || List.mem d.Patch_agent.queue Operation_kind.Rebase
+                     ~equal:Operation_kind.equal
+                || not
+                     (Option.equal Branch.equal
+                        d.Patch_agent.branch_rebased_onto (Some rebased_branch))
+              then t
+              else enqueue t dep_id Operation_kind.Rebase)
+
 let remove_agent t patch_id =
   {
     t with
@@ -621,6 +670,10 @@ let apply_rebase_result t patch_id rebase_result new_base =
       in
       let t = clear_has_conflict t patch_id in
       let t = reset_conflict_noop_count t patch_id in
+      (* The rebase rewrote this branch's commits; stacked children are now on
+         dead history. [Noop] below deliberately does not cascade — the branch
+         was not rewritten. *)
+      let t = enqueue_rebase_for_stranded_dependents t patch_id in
       (complete t patch_id, [ Push_branch ])
   | Worktree.Noop ->
       let t = set_base_branch t patch_id new_base in
@@ -699,6 +752,10 @@ let apply_conflict_rebase_result t patch_id rebase_result new_base =
       in
       let t = clear_has_conflict t patch_id in
       let t = reset_conflict_noop_count t patch_id in
+      (* Conflict resolution rewrote this branch's commits just like a clean
+         rebase — cascade demand to stacked children. The [Noop] arm below does
+         not cascade: the branch already contained the target. *)
+      let t = enqueue_rebase_for_stranded_dependents t patch_id in
       let t = complete t patch_id in
       (t, Conflict_resolved, [ Push_branch ])
   | Worktree.Noop ->

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -312,10 +312,20 @@ val apply_rebase_result :
   Branch.t ->
   t * rebase_effect list
 (** Apply a rebase outcome to the orchestrator state. Pure function. [Ok] ->
-    set_base_branch + clear_has_conflict + reset_conflict_noop_count + complete
-    \+ [[Push_branch]]. [Noop] -> set_base_branch + complete + [[]]. [Conflict]
-    -> set_base_branch + set_has_conflict + enqueue Merge_conflict + complete.
-    [Error _] -> set_session_failed + set_tried_fresh + complete. *)
+    set_base_branch + clear_has_conflict + reset_conflict_noop_count + rewrite
+    cascade + complete + [[Push_branch]]. [Noop] -> set_base_branch + complete
+    \+ [[]]. [Conflict] -> set_base_branch + set_has_conflict + enqueue
+    Merge_conflict + complete. [Error _] -> set_session_failed + set_tried_fresh
+    \+ complete.
+
+    The {e rewrite cascade} on [Ok] is the dual of [mark_merged]'s eager
+    enqueue: a completed rebase force-replaces the branch's commits, leaving
+    stacked children (open dependents with PRs whose [branch_rebased_onto] names
+    this branch) on dead history that every name-based detector reads as fresh.
+    Each such child gets a [Rebase] enqueued; each child's own [Ok] re-fires the
+    cascade, so the wave walks an open stack one layer per round, serialized
+    bottom-up by the eligibility gate. [Noop] deliberately does not cascade —
+    the branch was not rewritten. *)
 
 val apply_rebase_with_anchor :
   t ->
@@ -363,11 +373,13 @@ val apply_conflict_rebase_result :
   Branch.t ->
   t * conflict_rebase_decision * rebase_effect list
 (** Apply a rebase outcome during merge-conflict resolution. Pure function. [Ok]
-    -> clear_has_conflict + reset_conflict_noop_count + complete +
-    [Conflict_resolved] + [[Push_branch]]. [Noop] -> clear_has_conflict +
-    increment_conflict_noop_count + complete + [Conflict_resolved] +
-    [[Push_branch]] (local is correct; has_conflict cleared so it purely tracks
-    GitHub state — the poller will re-set and re-enqueue if conflict persists).
+    -> clear_has_conflict + reset_conflict_noop_count + rewrite cascade (see
+    {!apply_rebase_result} — conflict resolution rewrites the branch just like a
+    clean rebase) + complete + [Conflict_resolved] + [[Push_branch]]. [Noop] ->
+    clear_has_conflict + increment_conflict_noop_count + complete +
+    [Conflict_resolved] + [[Push_branch]] (local is correct; has_conflict
+    cleared so it purely tracks GitHub state — the poller will re-set and
+    re-enqueue if conflict persists; no cascade — the branch was not rewritten).
     [Conflict] -> set_has_conflict + [Deliver_to_agent] + [[]]. [Error _] ->
     set_session_failed + complete + [Conflict_failed]. *)
 

--- a/lib/poller_fiber.ml
+++ b/lib/poller_fiber.ml
@@ -501,6 +501,17 @@ struct
             let agents = Orchestrator.all_agents orch in
             let patch_views =
               List.map agents ~f:(fun (a : Patch_agent.t) ->
+                  (* The frontier is only meaningful (and only worth the extra
+                     [is_ancestor] probes) when containment just computed
+                     false; everywhere else the detector ignores it. Same
+                     oracle and inputs as the containment fold above. *)
+                  let sibling_rebase_target =
+                    if a.Patch_agent.base_contains_merged_siblings then None
+                    else
+                      Base_containment.stale_chain_rebase_target ~graph
+                        ~patch_id:a.Patch_agent.patch_id ~has_merged ~merge_sha
+                        ~branch_of ~main ~ancestor_oracle
+                  in
                   Reconciler.
                     {
                       id = a.Patch_agent.patch_id;
@@ -515,6 +526,7 @@ struct
                       branch_rebased_onto = a.Patch_agent.branch_rebased_onto;
                       base_contains_merged_siblings =
                         a.Patch_agent.base_contains_merged_siblings;
+                      sibling_rebase_target;
                     })
             in
             let merged_patches =

--- a/lib_core/base_containment.ml
+++ b/lib_core/base_containment.ml
@@ -24,3 +24,59 @@ let contains_merged_siblings ~graph ~patch_id ~has_merged ~merge_sha ~branch_of
             | None -> false (* fail-closed until the merge SHA is known *)
             | Some sha ->
                 ancestor_oracle sha ~descendant:(Types.Branch.to_string base))
+
+(* [main] is unused: a layer whose open deps are all merged resolves to main
+   structurally, which is detected via [open_pr_deps = []] — the branch name
+   itself is never compared. Kept in the signature for symmetry with
+   [contains_merged_siblings] (callers thread the same inputs to both). *)
+let stale_chain_rebase_target ~graph ~patch_id ~has_merged ~merge_sha ~branch_of
+    ~main:_ ~ancestor_oracle =
+  match Graph.open_pr_deps graph patch_id ~has_merged with
+  | [] | _ :: _ :: _ ->
+      (* No open dep (base is main — nothing to freshen) or not at the
+         last-but-one-merge edge (the patch defers on dependency satisfaction;
+         [sole_open_dep] is undefined). *)
+      None
+  | [ b ] -> (
+      let merged_dep_shas =
+        Graph.deps graph patch_id |> List.filter ~f:has_merged
+        |> List.map ~f:merge_sha
+      in
+      if
+        List.is_empty merged_dep_shas
+        || List.exists merged_dep_shas ~f:Option.is_none
+      then
+        (* No merged siblings to absorb, or a merge SHA is not yet known —
+           fail closed and create no demand; the cache recompute on a later
+           tick re-derives the target once the SHA lands. *)
+        None
+      else
+        let shas = List.filter_opt merged_dep_shas in
+        let contains pid =
+          let branch_s = Types.Branch.to_string (branch_of pid) in
+          List.for_all shas ~f:(fun sha ->
+              ancestor_oracle sha ~descendant:branch_s)
+        in
+        (* Walk [b]'s sole-open-dep chain downward. The frontier is the
+           deepest stale layer whose own structural base already contains the
+           SHAs — main contains every merged squash by definition, and a layer
+           above a fresh layer rebases onto that fresh branch. The three-way
+           result keeps "deeper layer is fresh" (the layer above it is the
+           frontier) distinct from "chain blocked" (a fan-in layer with
+           several open deps: the squash cannot flow past it until its own
+           merges land, so NO layer above it is a useful target — rebasing one
+           would absorb a base that still lacks the squash, the churn this
+           function exists to prevent). *)
+        let rec frontier c =
+          if contains c then `Fresh
+          else
+            match Graph.open_pr_deps graph c ~has_merged with
+            | [] -> `Target c (* base is main: the content source *)
+            | [ d ] -> (
+                match frontier d with
+                | `Target _ as deeper -> deeper
+                | `Fresh -> `Target c (* [d] is fresh — [c] is the frontier *)
+                | `Blocked -> `Blocked)
+            | _ :: _ :: _ -> `Blocked
+        in
+        match frontier b with `Target c -> Some c | `Fresh | `Blocked -> None)

--- a/lib_core/base_containment.mli
+++ b/lib_core/base_containment.mli
@@ -38,3 +38,45 @@ val contains_merged_siblings :
 
     Only the patch's own dependencies are consulted, so an unrelated advance of
     main never flips this to [false]. *)
+
+val stale_chain_rebase_target :
+  graph:Graph.t ->
+  patch_id:Types.Patch_id.t ->
+  has_merged:(Types.Patch_id.t -> bool) ->
+  merge_sha:(Types.Patch_id.t -> string option) ->
+  branch_of:(Types.Patch_id.t -> Types.Branch.t) ->
+  main:Types.Branch.t ->
+  ancestor_oracle:(string -> descendant:string -> bool) ->
+  Types.Patch_id.t option
+(** Which patch in [patch_id]'s base chain should be rebased next so that the
+    base branch absorbs [patch_id]'s merged siblings — the demand target for
+    [Reconciler.detect_sibling_stale_bases].
+
+    When [contains_merged_siblings] is false for a fan-in patch [P] whose sole
+    open dep is [B], the missing squash commits live on main and can only enter
+    [B]'s branch by flowing {e up} [B]'s chain of still-open ancestors, each
+    layer rebasing onto its structural base, bottom-up. Rebasing [B] alone is
+    not enough — when [B] is itself stacked, its rebase target lacks the squash
+    just like [B]'s branch does, so the rebase completes without absorbing
+    anything and the demand re-fires forever (the FLI-3 seed-440463877/seed-7
+    livelocks; in production, a pointless force-push per poll tick). Conversely,
+    demanding every chain layer each tick starves the upper layers: the freshly
+    re-queued lower rebase keeps the layer above it deferred on
+    [Base_patch_busy_with_rebase].
+
+    This returns the {e frontier}: the deepest stale layer of [B]'s chain whose
+    own structural base already contains every merged-dep squash of [P] (main
+    contains all of them by definition; a layer above a fresh layer rebases onto
+    that fresh branch). Healing the frontier moves it up one layer; once [B]
+    itself absorbs the squashes, [contains_merged_siblings] flips true and the
+    demand stops. Exactly one rebase per stale layer, no starvation, no
+    redundant rebase of already-fresh layers.
+
+    Returns [None] when: [patch_id] is not at the last-but-one-merge edge (no
+    open dep, or more than one); there are no merged deps; a merged dep's
+    [merge_sha] is unknown (fail-closed); the whole chain already contains the
+    squashes; or the chain is interrupted by a layer with more than one open dep
+    (the squash cannot flow past that fan-in until its own merges land —
+    fail-closed, re-derived on a later tick). Whether the returned target is
+    actually rebasable (holds a PR, no [Rebase] already queued) is the caller's
+    concern ([base_rebasable] in the detector). *)

--- a/lib_core/reconciler.ml
+++ b/lib_core/reconciler.ml
@@ -20,6 +20,15 @@ type patch_view = {
           deps merged into main) or the base branch already carries the merged
           siblings. Drives [detect_sibling_stale_bases] and the Start/Rebase
           gate. *)
+  sibling_rebase_target : Patch_id.t option;
+      (** When [base_contains_merged_siblings] is [false]: the patch in this
+          patch's base chain whose rebase actually moves the missing squash
+          commits one layer closer — the frontier computed by
+          {!Base_containment.stale_chain_rebase_target} (effectfully, by the
+          same caller and oracle as the containment flag). [None] when
+          containment holds or the frontier is undefined (unknown merge SHA,
+          chain interrupted by a multi-open-dep layer). Consumed by
+          [detect_sibling_stale_bases]. *)
 }
 [@@deriving sexp_of]
 
@@ -127,23 +136,40 @@ let detect_stale_bases graph views ~has_merged ~branch_of ~main =
     commits. The other rebase detectors never fix this: [B] is not a dependent
     of the merged sibling, so none of [detect_rebases] / [detect_stale_bases] /
     [detect_notified_base_drift] enqueues [B]'s rebase. This detector creates
-    that demand — it enqueues a [Rebase] of [B] (the dependency), which on its
-    next run rebases onto [Graph.initial_base B] (= main once [B]'s own deps are
-    merged) and thereby absorbs [P]'s merged siblings. [P]'s own
-    [Start]/[Rebase] stays deferred by the eligibility gate
-    ([Base_missing_merged_sibling]) until [B] is fresh.
+    that demand. [P]'s own [Start]/[Rebase] stays deferred by the eligibility
+    gate ([Base_missing_merged_sibling]) until [B] is fresh.
+
+    {b The demand targets the chain frontier, not [B] itself.} The missing
+    sibling's squash commit lives on main; it can only enter [B]'s branch by
+    flowing up the chain of still-open ancestors under [B] — each layer rebasing
+    onto its structural base, bottom-up. Rebasing [B] alone is not enough: when
+    [B] is itself stacked ([B] ← [C] ← … ← main), [B]'s rebase target is [C]'s
+    branch, which lacks the squash just like [B]'s — the rebase completes
+    without absorbing anything, the containment flag stays false, and the
+    detector re-fires forever (the seed-440463877 / seed-7 FLI-3 livelocks; in
+    production, a pointless force-push per poll tick). Demanding the {e whole}
+    chain each tick is also wrong — the re-queued lower rebases keep every layer
+    above deferred on [Base_patch_busy_with_rebase], starving the wave. The
+    per-view [sibling_rebase_target]
+    ({!Base_containment.stale_chain_rebase_target}) is the resolution: the
+    deepest stale layer whose own base already contains the squashes. Healing it
+    moves the frontier up one layer per tick until [B] absorbs the content and
+    the containment flag flips true. (A completed rebase additionally cascades
+    demand to its stacked children eagerly — [Orchestrator.apply_rebase_result]
+    — so in practice the wave often runs ahead of this detector's tick-by-tick
+    re-derivation.)
 
     [P] is considered whether or not it has a PR. An *unstarted* [P] (no PR yet)
     is the case that needs this detector most: its pending [Start (P, base = B)]
     sits deferred on [Base_missing_merged_sibling], and with no PR of its own no
     other detector will ever act on [P]'s behalf — without the demand created
     here the Start would defer until [B] merges, defeating stacked starts. Only
-    [~merged] is required of [P]; rebasability is [B]'s concern
-    ([base_rebasable] below).
+    [~merged] is required of [P]; rebasability is the target layer's concern
+    ([base_rebasable] below — an unstarted target is skipped: it cuts fresh from
+    its base when it starts, healing its layer without a rebase).
 
-    The [open_pr_deps = 1] guard keeps [sole_open_dep] total and pins this to
-    the "last-but-one dependency merged" edge, where a single rebase of [B]
-    realizes containment for [P]. *)
+    The [open_pr_deps = 1] guard pins this to the "last-but-one dependency
+    merged" edge, where healing [B]'s chain realizes containment for [P]. *)
 let detect_sibling_stale_bases graph views ~has_merged =
   let view_by_id =
     List.fold views
@@ -180,8 +206,9 @@ let detect_sibling_stale_bases graph views ~has_merged =
         && List.length (Graph.open_pr_deps graph v.id ~has_merged) = 1
         && not v.base_contains_merged_siblings
       then
-        let b = Graph.sole_open_dep graph v.id ~has_merged in
-        if base_rebasable b then Some (Enqueue_rebase b) else None
+        match v.sibling_rebase_target with
+        | Some target when base_rebasable target -> Some (Enqueue_rebase target)
+        | Some _ | None -> None
       else None)
 
 let plan_operations views ~has_merged ~branch_of ~graph ~main =

--- a/lib_core/reconciler.mli
+++ b/lib_core/reconciler.mli
@@ -33,6 +33,15 @@ type patch_view = {
           [false] when a SHA is not yet known. [true] when the base is main or
           the base branch already carries the merged siblings. Drives
           [detect_sibling_stale_bases] and the Start/Rebase eligibility gate. *)
+  sibling_rebase_target : Types.Patch_id.t option;
+      (** When [base_contains_merged_siblings] is [false]: the patch in this
+          patch's base chain whose rebase actually moves the missing squash
+          commits one layer closer — the frontier computed by
+          {!Base_containment.stale_chain_rebase_target} (effectfully, by the
+          same caller and oracle as the containment flag). [None] when
+          containment holds or the frontier is undefined (no merged deps,
+          unknown merge SHA, chain interrupted by a multi-open-dep layer).
+          Consumed by [detect_sibling_stale_bases]. *)
 }
 [@@deriving sexp_of]
 (** Observable state of a single patch, projected for reconciliation. *)
@@ -93,18 +102,20 @@ val detect_sibling_stale_bases :
   has_merged:(Types.Patch_id.t -> bool) ->
   action list
 (** [detect_sibling_stale_bases graph views ~has_merged] returns
-    [Enqueue_rebase B] for the sole open dependency [B] of every fan-in patch
-    [P] that is not merged, has exactly one open dependency, and whose base does
-    not yet contain its merged siblings
-    ([base_contains_merged_siblings = false]). [P] need not have a PR: an
-    unstarted fan-in patch's deferred [Start (P, base = B)]
-    ([Base_missing_merged_sibling]) relies on exactly this demand to ever become
-    runnable. [B] is enqueued (not [P]); [P]'s own start/rebase is gated
-    separately by [Start_eligibility]. Skips when [B] has no PR yet or already
-    has a [Rebase] queued, so queued/unstarted dependencies are never
-    rebase-enqueued by this detector. This is the demand that the other three
-    detectors miss, because [B] is a *sibling* of [P]'s merged deps, not a
-    dependent of them. *)
+    [Enqueue_rebase] for the [sibling_rebase_target] of every fan-in patch [P]
+    that is not merged, has exactly one open dependency, and whose base does not
+    yet contain its merged siblings ([base_contains_merged_siblings = false]).
+    The target is the {e frontier} of [P]'s base chain — the deepest stale layer
+    whose own base already contains the missing squash commits (see
+    {!Base_containment.stale_chain_rebase_target}); for an unstacked base [B] it
+    is [B] itself. [P] need not have a PR: an unstarted fan-in patch's deferred
+    [Start (P, base = B)] ([Base_missing_merged_sibling]) relies on exactly this
+    demand to ever become runnable. The target is enqueued (not [P]); [P]'s own
+    start/rebase is gated separately by [Start_eligibility]. Skips when the
+    target has no PR yet or already has a [Rebase] queued, so queued/unstarted
+    dependencies are never rebase-enqueued by this detector. This is the demand
+    that the other three detectors miss, because the chain layers are *siblings*
+    of [P]'s merged deps, not dependents of them. *)
 
 val plan_operations :
   patch_view list ->

--- a/lib_test/test_generators.ml
+++ b/lib_test/test_generators.ml
@@ -482,6 +482,8 @@ let gen_patch_view =
                generator. *)
             branch_rebased_onto = Some base_branch;
             base_contains_merged_siblings = true;
+            (* Containment holds above, so there is no frontier to heal. *)
+            sibling_rebase_target = None;
           })
       (pair gen_patch_id gen_branch)
       (quad bool bool bool bool)
@@ -762,6 +764,8 @@ let apply_reconcile_actions orch ~main ~branch_of =
               Option.value a.Onton_core.Patch_agent.base_branch ~default:main;
             branch_rebased_onto = a.Onton_core.Patch_agent.branch_rebased_onto;
             base_contains_merged_siblings = true;
+            (* Containment held to [true] above, so no frontier exists. *)
+            sibling_rebase_target = None;
           })
   in
   let merged_patches =

--- a/test/test_base_containment.ml
+++ b/test/test_base_containment.ml
@@ -170,6 +170,130 @@ let prop_iff_all_merged_in_contained =
       in
       Bool.equal (contains ~merged ~contained ()) expected)
 
+(* ---------- stale_chain_rebase_target (the frontier) ---------- *)
+
+(* P fans in on a merged sibling [s] and the top of an open chain
+   c3 ← c2 ← c1 (c1's deps all merged → its structural base is main, the
+   content source). [s]'s squash lives on main only; the frontier must walk it
+   up the chain one layer at a time — the FLI-3 seed-440463877 / seed-7
+   livelock shape. The oracle here is per-branch: [healed] is the set of
+   branch names treated as containing [s]'s squash. *)
+let chain_graph =
+  Graph.of_patches
+    [
+      mk_patch ~id:"p" ~deps:[ "s"; "c3" ];
+      mk_patch ~id:"s" ~deps:[];
+      mk_patch ~id:"c3" ~deps:[ "c2" ];
+      mk_patch ~id:"c2" ~deps:[ "c1" ];
+      mk_patch ~id:"c1" ~deps:[];
+    ]
+
+let frontier ?(graph = chain_graph) ?(merged = [ pid "s" ])
+    ?(merge_sha = merge_sha) ~healed () =
+  let ancestor_oracle ancestor ~descendant =
+    String.equal ancestor (sha_of "s")
+    && List.mem healed descendant ~equal:String.equal
+  in
+  BC.stale_chain_rebase_target ~graph ~patch_id:(pid "p")
+    ~has_merged:(fun d -> List.mem merged d ~equal:Types.Patch_id.equal)
+    ~merge_sha ~branch_of ~main ~ancestor_oracle
+
+let eq_target = Option.equal Types.Patch_id.equal
+
+let prop_frontier_starts_at_chain_bottom =
+  Test.make
+    ~name:"BCF-1: nothing healed → frontier is the deepest layer (base main)"
+    ~count:1 (Gen.return ()) (fun () ->
+      eq_target (frontier ~healed:[] ()) (Some (pid "c1")))
+
+let prop_frontier_moves_up_one_layer_per_heal =
+  Test.make ~name:"BCF-2: healing the frontier moves it up exactly one layer"
+    ~count:1 (Gen.return ()) (fun () ->
+      eq_target (frontier ~healed:[ "c1" ] ()) (Some (pid "c2"))
+      && eq_target (frontier ~healed:[ "c1"; "c2" ] ()) (Some (pid "c3"))
+      && eq_target (frontier ~healed:[ "c1"; "c2"; "c3" ] ()) None)
+
+let prop_frontier_skips_stale_layers_below_fresh =
+  Test.make
+    ~name:
+      "BCF-3: a stale layer below a fresh one is irrelevant — the target's own \
+       base supplies the content" ~count:1 (Gen.return ()) (fun () ->
+      (* c2 healed, c1 not: c3 rebases onto fresh branch-c2 directly. *)
+      eq_target (frontier ~healed:[ "c2" ] ()) (Some (pid "c3")))
+
+let prop_frontier_none_without_merged_deps =
+  Test.make ~name:"BCF-4: no merged deps → None" ~count:1 (Gen.return ())
+    (fun () -> eq_target (frontier ~merged:[] ~healed:[] ()) None)
+
+let prop_frontier_fail_closed_missing_sha =
+  Test.make
+    ~name:"BCF-5: merged dep with unknown merge_sha → None (fail-closed)"
+    ~count:1 (Gen.return ()) (fun () ->
+      let merge_sha p =
+        if Types.Patch_id.equal p (pid "s") then None else merge_sha p
+      in
+      eq_target (frontier ~merge_sha ~healed:[] ()) None)
+
+let prop_frontier_none_off_the_edge =
+  Test.make ~name:"BCF-6: >1 open dep (not at the edge) → None" ~count:1
+    (Gen.return ()) (fun () ->
+      (* s not merged → P has two open deps. *)
+      eq_target (frontier ~merged:[ pid "c1" ] ~healed:[] ()) None)
+
+let prop_frontier_fail_closed_on_interrupted_chain =
+  Test.make ~name:"BCF-7: chain interrupted by a multi-open-dep layer → None"
+    ~count:1 (Gen.return ()) (fun () ->
+      (* c2 itself fans in on two open deps: the squash cannot flow past it
+         until its own merges land. *)
+      let graph =
+        Graph.of_patches
+          [
+            mk_patch ~id:"p" ~deps:[ "s"; "c3" ];
+            mk_patch ~id:"s" ~deps:[];
+            mk_patch ~id:"c3" ~deps:[ "c2" ];
+            mk_patch ~id:"c2" ~deps:[ "c1"; "x" ];
+            mk_patch ~id:"c1" ~deps:[];
+            mk_patch ~id:"x" ~deps:[];
+          ]
+      in
+      eq_target (frontier ~graph ~healed:[] ()) None)
+
+(* Spec property over arbitrary heal subsets: whenever a target exists, it is
+   stale itself, its structural base already contains the squash (main always
+   does), and every layer above it back up to B is stale too (otherwise a
+   shallower fresh layer would have stopped the walk earlier and containment
+   would flip sooner). *)
+let prop_frontier_target_is_stale_with_fresh_base =
+  Test.make
+    ~name:
+      "BCF-8: target is a stale layer whose own base is fresh (random heal \
+       subsets)"
+    ~count:200
+    Gen.(
+      let* c1 = bool in
+      let* c2 = bool in
+      let* c3 = bool in
+      return (c1, c2, c3))
+    (fun (c1, c2, c3) ->
+      let healed =
+        List.filter_map
+          [ ("c1", c1); ("c2", c2); ("c3", c3) ]
+          ~f:(fun (b, h) -> if h then Some b else None)
+      in
+      let fresh b = List.mem healed b ~equal:String.equal in
+      match frontier ~healed () with
+      | None -> fresh "c3" (* only when B itself already has the content *)
+      | Some t ->
+          let t = Types.Patch_id.to_string t in
+          let base_fresh =
+            match t with
+            | "c3" -> fresh "c2"
+            | "c2" -> fresh "c1"
+            | "c1" -> true (* base is main, the content source *)
+            | _ -> false
+          in
+          (not (fresh t)) && base_fresh)
+
 let () =
   let runner = QCheck_base_runner.run_tests_main in
   ignore
@@ -184,4 +308,12 @@ let () =
          prop_fail_closed_missing_sha;
          prop_only_own_deps_consulted;
          prop_iff_all_merged_in_contained;
+         prop_frontier_starts_at_chain_bottom;
+         prop_frontier_moves_up_one_layer_per_heal;
+         prop_frontier_skips_stale_layers_below_fresh;
+         prop_frontier_none_without_merged_deps;
+         prop_frontier_fail_closed_missing_sha;
+         prop_frontier_none_off_the_edge;
+         prop_frontier_fail_closed_on_interrupted_chain;
+         prop_frontier_target_is_stale_with_fresh_base;
        ])

--- a/test/test_fanin_liveness_interleavings.ml
+++ b/test/test_fanin_liveness_interleavings.ml
@@ -35,7 +35,20 @@ open Onton_core.Types
     Liveness oracle: after a bounded fair quiescence loop (tick + fire every
     runnable Start/Rebase, repeatedly), no patch may remain unstarted while
     [Graph.deps_satisfied] holds for it — a startable-but-never-started patch at
-    the fixpoint is exactly the liveness violation. *)
+    the fixpoint is exactly the liveness violation.
+
+    The NUR properties (no unnecessary rebases) are the {e inverse}: freshness
+    must be available at the transitions where it matters (FLI), and {e only}
+    there (NUR). The historical failure mode they pin down is the
+    rebase-on-every-main-advance herd (main-SHA-scoped freshness force-pushed
+    and re-ran CI on every open PR each time main moved): NUR-1 asserts the
+    quiescence fixpoint is rebase-silent, NUR-2 asserts main advances from work
+    outside the gameplan are completely inert, and NUR-3 asserts every emitted
+    rebase demand and every rewriting rebase is justified by dependency-scoped
+    need — a missing relevant squash (own merged lineage or a fan-in consumer's
+    merged sibling), a structural misplacement, or un-stranding from a rewritten
+    patch-branch base. Together the two suites bracket the scheduler: rebases
+    happen exactly when freshness demands them. *)
 
 let main = Branch.of_string "main"
 let main_s = Branch.to_string main
@@ -129,20 +142,69 @@ let do_start m pid base =
     let orch = Orchestrator.complete orch pid in
     absorb { m with orch } ~branch:agent.Patch_agent.branch ~from:base
 
-(** Complete a rebase of [pid] onto [base]: the branch re-cuts onto the target,
-    absorbing its current merge SHAs. *)
-let do_rebase m pid base =
+type fired_rebase = {
+  fired_pid : Patch_id.t;
+  fired_outcome : [ `Ok | `Noop ];
+  fired_delta : Set.M(String).t;
+      (** Merge SHAs newly absorbed — empty for [`Noop]. *)
+  fired_anchor_before : Branch.t option;
+  fired_target : Branch.t;
+}
+(** One executed rebase, as observed by the no-unnecessary-rebase (NUR)
+    properties: which patch fired, whether it rewrote anything, the merge SHAs
+    it absorbed, where its branch sat beforehand, and the target. *)
+
+(** Complete a rebase of [pid] onto [base], mirroring production's
+    [Worktree.rebase_onto] outcome split: when the branch already contains
+    everything the target has (production:
+    [merge-base --is-ancestor target HEAD]; model: the target's absorbed SHA set
+    is a subset of the branch's), the result is [Noop] — the anchor is still
+    recorded but nothing is rewritten and the rewrite cascade does not fire.
+    Otherwise [Ok]: the branch re-cuts onto the target, absorbing its current
+    merge SHAs, and stacked children are cascade-enqueued. The Ok/Noop fidelity
+    is what makes the NUR (parsimony) properties meaningful: a redundant queued
+    rebase on an already-fresh branch must register as no-work, exactly as in
+    production. Returns the {!fired_rebase} observation alongside the new model.
+*)
+let do_rebase_traced m pid base =
   let agent = Orchestrator.agent m.orch pid in
   if
     (not (Patch_agent.has_pr agent))
     || agent.Patch_agent.merged || agent.Patch_agent.busy
-  then m
+  then (m, None)
   else
+    let base_set = absorbed_of m (Branch.to_string base) in
+    let own_set = absorbed_of m (Branch.to_string agent.Patch_agent.branch) in
+    let anchor_before = agent.Patch_agent.branch_rebased_onto in
     let orch = Orchestrator.fire m.orch (Orchestrator.Rebase (pid, base)) in
-    let orch, _effects =
-      Orchestrator.apply_rebase_result orch pid Worktree.Ok base
-    in
-    absorb { m with orch } ~branch:agent.Patch_agent.branch ~from:base
+    if Set.is_subset base_set ~of_:own_set then
+      let orch, _effects =
+        Orchestrator.apply_rebase_result orch pid Worktree.Noop base
+      in
+      ( { m with orch },
+        Some
+          {
+            fired_pid = pid;
+            fired_outcome = `Noop;
+            fired_delta = Set.empty (module String);
+            fired_anchor_before = anchor_before;
+            fired_target = base;
+          } )
+    else
+      let orch, _effects =
+        Orchestrator.apply_rebase_result orch pid Worktree.Ok base
+      in
+      ( absorb { m with orch } ~branch:agent.Patch_agent.branch ~from:base,
+        Some
+          {
+            fired_pid = pid;
+            fired_outcome = `Ok;
+            fired_delta = Set.diff base_set own_set;
+            fired_anchor_before = anchor_before;
+            fired_target = base;
+          } )
+
+let do_rebase m pid base = fst (do_rebase_traced m pid base)
 
 (** Bootstrap a model where the first [started] patches (in dependency order;
     [gen_patch_dag]/[mk_linear_patches] only depend backwards, so a prefix is
@@ -187,9 +249,24 @@ type command =
       (** Fire the patch's Start if (and only if) the gated planner surfaces a
           runnable Start for it right now — the production path. Keeps every
           reachable model state production-reachable. *)
+  | Unrelated_main_advance of int
+      (** Main absorbs a merge SHA that is no gameplan patch's squash — a human
+          merging unrelated work. Freshness is dependency-scoped, so this must
+          never create rebase demand or defer anything (the historical failure
+          mode was rebasing every open patch on every main advance). The NUR
+          properties assert exactly that; the liveness properties assert it
+          never breaks convergence either. *)
 
 let apply_command m cmd =
   match cmd with
+  | Unrelated_main_advance i ->
+      {
+        m with
+        absorbed =
+          Map.set m.absorbed ~key:main_s
+            ~data:
+              (Set.add (absorbed_of m main_s) (Printf.sprintf "unrelated-%d" i));
+      }
   | Pr_merged i ->
       if i >= List.length m.patches then m
       else
@@ -331,20 +408,27 @@ let tick m =
   ({ m with orch }, actions)
 
 (** Fire every Start/Rebase the gated planner surfaces as runnable right now — a
-    fair runner draining one planning round. *)
-let fire_runnable m =
+    fair runner draining one planning round. Returns the rebases that actually
+    executed so the NUR properties can audit them. *)
+let fire_runnable_traced m =
   let msgs = Patch_controller.plan_messages m.orch ~patches:m.patches in
-  List.fold msgs ~init:m ~f:(fun m msg ->
+  List.fold msgs ~init:(m, []) ~f:(fun (m, fired) msg ->
       match Orchestrator.message_action msg with
-      | Orchestrator.Start (pid, base) -> do_start m pid base
-      | Orchestrator.Rebase (pid, base) ->
+      | Orchestrator.Start (pid, base) -> (do_start m pid base, fired)
+      | Orchestrator.Rebase (pid, base) -> (
           let open_deps =
             Graph.open_pr_deps
               (Orchestrator.graph m.orch)
               pid ~has_merged:(has_merged_in m.orch)
           in
-          if List.length open_deps > 1 then m else do_rebase m pid base
-      | Orchestrator.Respond _ -> m)
+          if List.length open_deps > 1 then (m, fired)
+          else
+            match do_rebase_traced m pid base with
+            | m, Some f -> (m, f :: fired)
+            | m, None -> (m, fired))
+      | Orchestrator.Respond _ -> (m, fired))
+
+let fire_runnable m = fst (fire_runnable_traced m)
 
 (** Fair quiescence: with external events stopped, run [n] rounds of tick +
     fire-runnable. A correct system converges well within [2 * n_patches + 3]
@@ -352,6 +436,20 @@ let fire_runnable m =
     slack for the final containment recompute). *)
 let quiesce m ~rounds =
   Fn.apply_n_times ~n:rounds (fun m -> fire_runnable (fst (tick m))) m
+
+(** [b]'s sole-open-dep chain, [b] included, down to the main-based layer.
+    Mirrors the frontier walk's domain; a multi-open-dep layer ends it. *)
+let open_chain_of m b =
+  let rec go acc pid =
+    match
+      Graph.open_pr_deps
+        (Orchestrator.graph m.orch)
+        pid ~has_merged:(has_merged_in m.orch)
+    with
+    | [ d ] -> go (d :: acc) d
+    | [] | _ :: _ :: _ -> acc
+  in
+  go [ b ] b
 
 (* -- Liveness oracle -- *)
 
@@ -493,6 +591,7 @@ let gen_command ~n_patches =
       map (fun i -> Pr_merged i) idx;
       map (fun i -> Rebase_complete i) idx;
       map (fun i -> Start_via_gate i) idx;
+      map (fun i -> Unrelated_main_advance i) idx;
     ]
 
 let gen_scenario =
@@ -517,6 +616,7 @@ let show_command = function
   | Pr_merged i -> Printf.sprintf "Pr_merged %d" i
   | Rebase_complete i -> Printf.sprintf "Rebase_complete %d" i
   | Start_via_gate i -> Printf.sprintf "Start_via_gate %d" i
+  | Unrelated_main_advance i -> Printf.sprintf "Unrelated_main_advance %d" i
 
 let show_scenario (patches, started, cmds) =
   let patch_s (p : Patch.t) =
@@ -564,20 +664,6 @@ let prop_random_dag_liveness =
     [base_structurally_fresh] first — which in this model implies B has Started
     and holds a PR.) *)
 let sibling_defer_implies_demand m actions =
-  let open_chain_of b =
-    (* B's sole-open-dep chain, B included, down to the main-based layer.
-       Mirrors the frontier walk's domain; a multi-open-dep layer ends it. *)
-    let rec go acc pid =
-      match
-        Graph.open_pr_deps
-          (Orchestrator.graph m.orch)
-          pid ~has_merged:(has_merged_in m.orch)
-      with
-      | [ d ] -> go (d :: acc) d
-      | [] | _ :: _ :: _ -> acc
-    in
-    go [ b ] b
-  in
   List.for_all m.patches ~f:(fun (p : Patch.t) ->
       let agent = Orchestrator.agent m.orch p.Patch.id in
       if Patch_agent.has_pr agent || agent.Patch_agent.merged then true
@@ -598,7 +684,7 @@ let sibling_defer_implies_demand m actions =
             with
             | Start_eligibility.Defer
                 (Start_eligibility.Base_missing_merged_sibling _) ->
-                List.exists (open_chain_of b) ~f:(fun c ->
+                List.exists (open_chain_of m b) ~f:(fun c ->
                     let c_agent = Orchestrator.agent m.orch c in
                     (not (Patch_agent.has_pr c_agent))
                     || List.mem c_agent.Patch_agent.queue Operation_kind.Rebase
@@ -697,6 +783,279 @@ let prop_chain_fanin_merge_witness =
       let m = quiesce m ~rounds:((2 * List.length patches) + 3) in
       no_startable_unstarted m && started_everywhere m)
 
+(* -- NUR (no unnecessary rebases): the inverse of the liveness suite -- *)
+
+(** The merge SHAs whose absence from [pid]'s branch would justify rebasing it,
+    derived from the dependency-scoped freshness spec:
+
+    - squashes of [pid]'s own merged {e transitive} ancestors (its branch must
+      carry its lineage's merged form — covers direct dep merges and the
+      rewrite-stranding case, where the content a stranded child re-absorbs is
+      its rewritten ancestor's merged deps);
+    - squashes of the merged deps of any fan-in patch [P] whose open base chain
+      runs through [pid] (the frontier consumers: [pid] must carry the sibling
+      content so [P] can eventually cut from a complete base).
+
+    Everything else — in particular a main advance from work outside these sets
+    — is noise that must never produce rebase demand. *)
+let relevant_shas m pid =
+  let graph = Orchestrator.graph m.orch in
+  let has_merged = has_merged_in m.orch in
+  let own_lineage =
+    Graph.transitive_ancestors graph pid
+    |> List.filter ~f:has_merged |> List.map ~f:merge_sha_of
+  in
+  let consumer_siblings =
+    List.concat_map m.patches ~f:(fun (p : Patch.t) ->
+        let consumer = p.Patch.id in
+        if Patch_id.equal consumer pid then []
+        else
+          match Graph.open_pr_deps graph consumer ~has_merged with
+          | [ b ] when List.mem (open_chain_of m b) pid ~equal:Patch_id.equal ->
+              Graph.deps graph consumer |> List.filter ~f:has_merged
+              |> List.map ~f:merge_sha_of
+          | [] | [ _ ] | _ :: _ :: _ -> [])
+  in
+  Set.of_list (module String) (own_lineage @ consumer_siblings)
+
+(** Is rebase demand for [pid] justified right now? Either the branch is
+    structurally misplaced (its recorded anchor is not its structural base — the
+    dep-merge / retarget cases), or a relevant squash is missing from the
+    branch. An unstarted patch (no anchor) is exempt: an inert queued rebase
+    cannot waste work, and its eventual Start cuts fresh. *)
+let rebase_demand_justified m pid =
+  let agent = Orchestrator.agent m.orch pid in
+  match agent.Patch_agent.branch_rebased_onto with
+  | None -> true
+  | Some anchor ->
+      let structurally_misplaced =
+        match
+          Graph.open_pr_deps
+            (Orchestrator.graph m.orch)
+            pid ~has_merged:(has_merged_in m.orch)
+        with
+        | [] | [ _ ] -> not (Branch.equal anchor (initial_base_of m pid))
+        | _ :: _ :: _ -> false
+      in
+      let own_set = absorbed_of m (Branch.to_string agent.Patch_agent.branch) in
+      let missing_relevant =
+        Set.exists (relevant_shas m pid) ~f:(fun sha ->
+            not (Set.mem own_set sha))
+      in
+      structurally_misplaced || missing_relevant
+
+let enqueued_rebases actions =
+  List.filter_map actions ~f:(function
+    | Reconciler.Enqueue_rebase pid -> Some pid
+    | Reconciler.Mark_merged _ | Reconciler.Start_operation _ -> None)
+
+(** NUR-1 (fixpoint rebase-silence): once a scenario quiesces, further fair
+    rounds plan no Start/Rebase, the reconciler emits no rebase demand, and no
+    rebase executes — not even a [`Noop]. The frontier livelock this suite
+    started from manifested as exactly this kind of perpetual churn (an endless
+    force-push per tick); so would the historical rebase-on-every-main-advance
+    regime. *)
+let prop_fixpoint_rebase_silence =
+  QCheck2.Test.make ~count:200 ~print:show_scenario
+    ~name:
+      "NUR-1: at the quiescence fixpoint, no rebase is demanded, planned, or \
+       executed" gen_scenario (fun (patches, started, cmds) ->
+      try
+        let m = bootstrap patches ~started in
+        let m =
+          List.fold cmds ~init:m ~f:(fun m cmd ->
+              fst (tick (apply_command m cmd)))
+        in
+        let m = quiesce m ~rounds:((2 * List.length patches) + 3) in
+        let _m, ok =
+          Fn.apply_n_times ~n:3
+            (fun (m, ok) ->
+              let m, actions = tick m in
+              let no_demand = List.is_empty (enqueued_rebases actions) in
+              let no_plan =
+                Patch_controller.plan_messages m.orch ~patches:m.patches
+                |> List.for_all ~f:(fun msg ->
+                    match Orchestrator.message_action msg with
+                    | Orchestrator.Start _ | Orchestrator.Rebase _ -> false
+                    | Orchestrator.Respond _ -> true)
+              in
+              let m, fired = fire_runnable_traced m in
+              (m, ok && no_demand && no_plan && List.is_empty fired))
+            (m, true)
+        in
+        ok
+      with exn ->
+        Stdlib.Printf.eprintf "NUR-1 raised: %s\n%!" (Exn.to_string exn);
+        false)
+
+(** NUR-2 (unrelated main advances are inert): from a quiesced state, main
+    absorbing squashes of work outside the gameplan must not move anything — no
+    rebase demand, nothing planned, nothing executed. This is the exact
+    historical failure mode (main-SHA-scoped freshness rebased every open patch
+    on every main advance) pinned as a regression test. *)
+let prop_unrelated_main_advance_inert =
+  QCheck2.Test.make ~count:200 ~print:show_scenario
+    ~name:
+      "NUR-2: unrelated main advances at the fixpoint demand, plan, and \
+       execute no rebases" gen_scenario (fun (patches, started, cmds) ->
+      try
+        let m = bootstrap patches ~started in
+        let m =
+          List.fold cmds ~init:m ~f:(fun m cmd ->
+              fst (tick (apply_command m cmd)))
+        in
+        let m = quiesce m ~rounds:((2 * List.length patches) + 3) in
+        let _m, ok =
+          List.fold [ 1000; 1001; 1002 ] ~init:(m, true) ~f:(fun (m, ok) i ->
+              let m = apply_command m (Unrelated_main_advance i) in
+              let m, actions = tick m in
+              let no_demand = List.is_empty (enqueued_rebases actions) in
+              let m, fired = fire_runnable_traced m in
+              (m, ok && no_demand && List.is_empty fired))
+        in
+        ok
+      with exn ->
+        Stdlib.Printf.eprintf "NUR-2 raised: %s\n%!" (Exn.to_string exn);
+        false)
+
+(** NUR-3 (all rebase work is justified): at every step of a random scenario —
+    command ticks and quiescence rounds alike —
+
+    + every [Enqueue_rebase] the reconciler emits targets a patch whose rebase
+      demand is justified ({!rebase_demand_justified}); and
+    + every rebase that actually {e rewrites} ([`Ok]) is necessary:
+
+    - onto {e main}: it absorbed at least one relevant squash or fixed a
+      structural misplacement (its anchor moved). This is where the historical
+      herd lived — main is append-only, so an Ok rebase onto it absorbing only
+      unrelated content is pure waste.
+    - onto a {e patch branch}: always necessary. In this model a patch branch
+      only ever changes by rewrite (cut/rebase snapshots), so [`Ok] means the
+      child's history references commits the base force-replaced — the
+      un-stranding rebase the cascade exists for. (Its absorbed delta can be
+      entirely sibling content relevant to a fan-in consumer elsewhere, e.g. a
+      child hanging off a frontier-healed mid-chain layer, so SHA-relevance is
+      the wrong oracle here.)
+
+    [`Noop] executions are tolerated mid-convergence (a queued demand can be
+    healed from elsewhere before it fires — e.g. a fresh cut absorbed the
+    content first); they rewrite nothing and push no new commits, and NUR-1
+    asserts they die out at the fixpoint.
+
+    Together with the liveness suite this brackets the scheduler from both
+    sides: rebases happen exactly when freshness demands them. *)
+let prop_all_rebase_work_justified =
+  QCheck2.Test.make ~count:200 ~print:show_scenario
+    ~name:
+      "NUR-3: every emitted rebase demand and every rewriting rebase is \
+       justified" gen_scenario (fun (patches, started, cmds) ->
+      try
+        let step (m, ok) pre =
+          let m = pre m in
+          (* Demand justification is evaluated on the pre-tick model state:
+             [tick] both emits the demand and (for [Mark_merged]) updates the
+             state the demand was derived from. *)
+          let demand_justified_in m_before actions =
+            List.for_all (enqueued_rebases actions) ~f:(fun pid ->
+                rebase_demand_justified m_before pid)
+          in
+          let m_before = m in
+          let m, actions = tick m in
+          let demand_ok = demand_justified_in m_before actions in
+          let m_pre_fire = m in
+          let m, fired = fire_runnable_traced m in
+          let fired_ok =
+            List.for_all fired ~f:(fun f ->
+                match f.fired_outcome with
+                | `Noop -> true
+                | `Ok when not (Branch.equal f.fired_target main) ->
+                    (* Un-stranding: patch branches only move by rewrite, so
+                       an Ok rebase onto one means the base was force-replaced
+                       under this child. *)
+                    true
+                | `Ok ->
+                    let relevant = relevant_shas m_pre_fire f.fired_pid in
+                    (not (Set.is_empty (Set.inter f.fired_delta relevant)))
+                    || not
+                         (Option.equal Branch.equal f.fired_anchor_before
+                            (Some f.fired_target)))
+          in
+          (m, ok && demand_ok && fired_ok)
+        in
+        let acc =
+          List.fold cmds
+            ~init:(bootstrap patches ~started, true)
+            ~f:(fun acc cmd -> step acc (fun m -> apply_command m cmd))
+        in
+        let _m, ok =
+          Fn.apply_n_times
+            ~n:((2 * List.length patches) + 3)
+            (fun acc -> step acc Fn.id)
+            acc
+        in
+        ok
+      with exn ->
+        Stdlib.Printf.eprintf "NUR-3 raised: %s\n%!" (Exn.to_string exn);
+        false)
+
+(** NUR-4 (witness): the stale-eager-enqueue waste NUR-3 first caught.
+    [mark_merged] used to enqueue a [Rebase] on PR-less dependents; the demand
+    sat inert through the patch's (fresh) cut and then fired anyway — and if
+    main had absorbed unrelated work in between, the rebase was an [`Ok] rewrite
+    (force-push + CI re-run) whose entire delta was content nobody needed. The
+    [has_pr] guard on the eager enqueue (mirroring [detect_rebases]) removes the
+    demand; this witness replays the shrunk counterexample and asserts no
+    unjustified rewrite ever fires.
+
+    NOTE the ordering dependency this guard assumes: a PR-less dependent's
+    eventual cut must itself be fresh (the base-fetch fix for main-based cuts).
+    Before that, the inert queued rebase was accidentally load-bearing — it
+    healed stale cuts shortly after Start (the connector-adapter patch-4 trace).
+*)
+let prop_stale_eager_enqueue_witness =
+  QCheck2.Test.make ~count:1
+    ~name:
+      "NUR-4: a dep merge while the dependent is PR-less creates no rebase \
+       demand that later fires as an unrelated-content rewrite"
+    (QCheck2.Gen.return ()) (fun () ->
+      let patches =
+        [ mk_patch ~id:"p0" ~deps:[]; mk_patch ~id:"p1" ~deps:[ "p0" ] ]
+      in
+      let step (m, ok) pre =
+        let m = pre m in
+        let m_before = m in
+        let m, actions = tick m in
+        let demand_ok =
+          List.for_all (enqueued_rebases actions) ~f:(fun pid ->
+              rebase_demand_justified m_before pid)
+        in
+        let m_pre_fire = m in
+        let m, fired = fire_runnable_traced m in
+        let fired_ok =
+          List.for_all fired ~f:(fun f ->
+              match f.fired_outcome with
+              | `Noop -> true
+              | `Ok when not (Branch.equal f.fired_target main) -> true
+              | `Ok ->
+                  let relevant = relevant_shas m_pre_fire f.fired_pid in
+                  (not (Set.is_empty (Set.inter f.fired_delta relevant)))
+                  || not
+                       (Option.equal Branch.equal f.fired_anchor_before
+                          (Some f.fired_target)))
+        in
+        (m, ok && demand_ok && fired_ok)
+      in
+      (* p0 starts; p0 merges while p1 is still PR-less; p1 starts (fresh
+         cut); main then absorbs unrelated work. Nothing may rebase p1. *)
+      let acc =
+        List.fold
+          [ Pr_merged 0; Pr_merged 0; Unrelated_main_advance 0 ]
+          ~init:(bootstrap patches ~started:0, true)
+          ~f:(fun acc cmd -> step acc (fun m -> apply_command m cmd))
+      in
+      let _m, ok = Fn.apply_n_times ~n:7 (fun acc -> step acc Fn.id) acc in
+      ok)
+
 let () =
   let runner = QCheck_base_runner.run_tests_main in
   ignore
@@ -708,4 +1067,8 @@ let () =
          prop_sibling_defer_implies_demand;
          prop_chain_fanin_rewrite_witness;
          prop_chain_fanin_merge_witness;
+         prop_fixpoint_rebase_silence;
+         prop_unrelated_main_advance_inert;
+         prop_all_rebase_work_justified;
+         prop_stale_eager_enqueue_witness;
        ])

--- a/test/test_fanin_liveness_interleavings.ml
+++ b/test/test_fanin_liveness_interleavings.ml
@@ -107,9 +107,14 @@ let deps_satisfied m pid =
 (** Start [pid] from [base]: PR appears, implementation notes are delivered, and
     the session completes, mirroring the SBI bootstrap plus the deps-notes-ready
     contract (fire Start → set_pr_number → Pr_body delivered → complete). The
-    branch absorbs its base's current merge SHAs (the cut). No-op when already
-    started or when dependencies are not satisfied (cannot cut a worktree off a
-    missing base). *)
+    notes step matters: the deps-notes-ready Start gate
+    ([Patch_controller.plan_action_for_patch]) defers a child's Start until
+    every open dep has [pr_body_delivered] — these tests target rebase
+    freshness liveness, so the model publishes notes promptly; the notes
+    gate's own liveness has its own properties
+    ([test_interleaving_properties.ml]). The branch absorbs its base's current
+    merge SHAs (the cut). No-op when already started or when dependencies are
+    not satisfied (cannot cut a worktree off a missing base). *)
 let do_start m pid base =
   let agent = Orchestrator.agent m.orch pid in
   if Patch_agent.has_pr agent || agent.Patch_agent.merged then m
@@ -250,7 +255,8 @@ let apply_command m cmd =
 
 (* -- Tick: the poller's reconcile phase over the pure model -- *)
 
-let view_of_agent (a : Patch_agent.t) : Reconciler.patch_view =
+let view_of_agent ~sibling_rebase_target (a : Patch_agent.t) :
+    Reconciler.patch_view =
   {
     Reconciler.id = a.Patch_agent.patch_id;
     has_pr = Patch_agent.has_pr a;
@@ -262,6 +268,7 @@ let view_of_agent (a : Patch_agent.t) : Reconciler.patch_view =
     base_branch = Option.value a.Patch_agent.base_branch ~default:main;
     branch_rebased_onto = a.Patch_agent.branch_rebased_onto;
     base_contains_merged_siblings = a.Patch_agent.base_contains_merged_siblings;
+    sibling_rebase_target;
   }
 
 (** One reconcile tick, mirroring [poller_fiber]'s reconcile phase: containment
@@ -291,7 +298,19 @@ let tick m =
           a.Patch_agent.patch_id contains)
   in
   let m = { m with orch } in
-  let views = List.map (Orchestrator.all_agents m.orch) ~f:view_of_agent in
+  let views =
+    List.map (Orchestrator.all_agents m.orch) ~f:(fun (a : Patch_agent.t) ->
+        (* Mirror [poller_fiber]: the frontier is computed (same oracle as the
+           containment fold) only when containment just read false. *)
+        let sibling_rebase_target =
+          if a.Patch_agent.base_contains_merged_siblings then None
+          else
+            Base_containment.stale_chain_rebase_target ~graph
+              ~patch_id:a.Patch_agent.patch_id ~has_merged ~merge_sha ~branch_of
+              ~main ~ancestor_oracle
+        in
+        view_of_agent ~sibling_rebase_target a)
+  in
   let merged_patches =
     List.filter_map (Orchestrator.all_agents m.orch)
       ~f:(fun (a : Patch_agent.t) ->
@@ -494,8 +513,25 @@ let gen_scenario =
 
 (* -- FLI-3 (random interleavings): liveness under fair quiescence -- *)
 
+let show_command = function
+  | Pr_merged i -> Printf.sprintf "Pr_merged %d" i
+  | Rebase_complete i -> Printf.sprintf "Rebase_complete %d" i
+  | Start_via_gate i -> Printf.sprintf "Start_via_gate %d" i
+
+let show_scenario (patches, started, cmds) =
+  let patch_s (p : Patch.t) =
+    Printf.sprintf "%s<-[%s]"
+      (Patch_id.to_string p.Patch.id)
+      (String.concat ~sep:","
+         (List.map p.Patch.dependencies ~f:Patch_id.to_string))
+  in
+  Printf.sprintf "patches=[%s] started=%d cmds=[%s]"
+    (String.concat ~sep:"; " (List.map patches ~f:patch_s))
+    started
+    (String.concat ~sep:"; " (List.map cmds ~f:show_command))
+
 let prop_random_dag_liveness =
-  QCheck2.Test.make ~count:300
+  QCheck2.Test.make ~count:300 ~print:show_scenario
     ~name:
       "FLI-3: random DAG interleavings quiesce with no startable-but-unstarted \
        patch" gen_scenario (fun (patches, started, cmds) ->
@@ -507,21 +543,41 @@ let prop_random_dag_liveness =
         in
         let m = quiesce m ~rounds:((2 * List.length patches) + 3) in
         no_startable_unstarted m
-      with _ -> false)
+      with exn ->
+        Stdlib.Printf.eprintf "FLI-3 raised: %s\n%!" (Exn.to_string exn);
+        false)
 
 (* -- FLI-4 (safety at every step): sibling-Defer implies demand -- *)
 
 (** The precise property the [has_pr] guard violated: whenever an unstarted
     patch P's hypothetical Start is deferred on [Base_missing_merged_sibling],
-    the freshening demand must already exist — its sole open dep B either has a
-    [Rebase] queued or this very reconcile round emitted [Enqueue_rebase B].
+    the freshening demand must already exist {e somewhere on B's open chain} —
+    the missing squash flows up from main one layer at a time
+    ([Base_containment.stale_chain_rebase_target]), so the demand may
+    legitimately sit on a layer below B (the frontier) rather than on B itself.
+    Demand means: some chain layer has a [Rebase] queued, or this very reconcile
+    round emitted [Enqueue_rebase] for one, or a chain layer has no PR yet (its
+    future Start cuts fresh from its base, healing that layer without a rebase).
     Checked after every command's tick.
 
     (A Defer on this arm presupposes B is structurally fresh — [decide] checks
     [base_structurally_fresh] first — which in this model implies B has Started
-    and holds a PR, so [base_rebasable]'s B-side guard cannot be the blocker.)
-*)
+    and holds a PR.) *)
 let sibling_defer_implies_demand m actions =
+  let open_chain_of b =
+    (* B's sole-open-dep chain, B included, down to the main-based layer.
+       Mirrors the frontier walk's domain; a multi-open-dep layer ends it. *)
+    let rec go acc pid =
+      match
+        Graph.open_pr_deps
+          (Orchestrator.graph m.orch)
+          pid ~has_merged:(has_merged_in m.orch)
+      with
+      | [ d ] -> go (d :: acc) d
+      | [] | _ :: _ :: _ -> acc
+    in
+    go [ b ] b
+  in
   List.for_all m.patches ~f:(fun (p : Patch.t) ->
       let agent = Orchestrator.agent m.orch p.Patch.id in
       if Patch_agent.has_pr agent || agent.Patch_agent.merged then true
@@ -542,9 +598,12 @@ let sibling_defer_implies_demand m actions =
             with
             | Start_eligibility.Defer
                 (Start_eligibility.Base_missing_merged_sibling _) ->
-                List.mem b_agent.Patch_agent.queue Operation_kind.Rebase
-                  ~equal:Operation_kind.equal
-                || enqueues_rebase_of actions b
+                List.exists (open_chain_of b) ~f:(fun c ->
+                    let c_agent = Orchestrator.agent m.orch c in
+                    (not (Patch_agent.has_pr c_agent))
+                    || List.mem c_agent.Patch_agent.queue Operation_kind.Rebase
+                         ~equal:Operation_kind.equal
+                    || enqueues_rebase_of actions c)
             | Start_eligibility.Allow
             | Start_eligibility.Defer
                 ( Start_eligibility.Base_patch_busy_with_rebase _
@@ -570,6 +629,74 @@ let prop_sibling_defer_implies_demand =
         ok
       with _ -> false)
 
+(* -- FLI-5 / FLI-6 (witnesses): the two chain-under-fan-in livelocks FLI-3
+   found at seeds 440463877 and 7 -- *)
+
+let started_everywhere m =
+  List.for_all m.patches ~f:(fun (p : Patch.t) ->
+      let a = Orchestrator.agent m.orch p.Patch.id in
+      Patch_agent.has_pr a || a.Patch_agent.merged)
+
+(** Seed-440463877 shape — {e rewrite stranding}. p4 fans in on the merged root
+    p0 and the top of an open chain p3 ← p2 ← p1 ← p0. When p0 merges, p1's
+    freshening rebase onto main rewrites branch-p1, stranding p2 (and
+    transitively p3) on dead history that lacks p0's squash: every name-based
+    detector reads p2 as fresh, and the sibling detector used to rebase only p3
+    — onto a branch-p2 that still lacked the squash — re-firing forever while p4
+    never became startable. The rewrite cascade
+    ([Orchestrator.apply_rebase_result] → stranded dependents) plus the
+    frontier-targeted sibling demand drive the squash up the chain one layer per
+    round; p4 then starts. *)
+let prop_chain_fanin_rewrite_witness =
+  QCheck2.Test.make ~count:1
+    ~name:
+      "FLI-5: rewrite-stranded chain under a fan-in patch heals \
+       (seed-440463877 witness)" (QCheck2.Gen.return ()) (fun () ->
+      let patches =
+        [
+          mk_patch ~id:"p0" ~deps:[];
+          mk_patch ~id:"p1" ~deps:[ "p0" ];
+          mk_patch ~id:"p2" ~deps:[ "p1" ];
+          mk_patch ~id:"p3" ~deps:[ "p2" ];
+          mk_patch ~id:"p4" ~deps:[ "p0"; "p3" ];
+          mk_patch ~id:"p5" ~deps:[ "p0" ];
+        ]
+      in
+      let m = bootstrap patches ~started:3 in
+      let m = fst (tick (apply_command m (Pr_merged 0))) in
+      let m = quiesce m ~rounds:((2 * List.length patches) + 3) in
+      no_startable_unstarted m && started_everywhere m)
+
+(** Seed-7 shape — {e merged-sibling content deep in the chain}. p5 fans in on
+    p1 and p3, with p3 ← p2 ← p0 and p1 merging straight to main (its squash
+    never enters p2's lineage — p1 is not a dependency of p2, so no detector
+    ever saw a reason to rebase p2). The squash can only reach branch-p3 by p2
+    first rebasing onto main; rebasing p3 alone re-fires forever. The frontier
+    ([Base_containment.stale_chain_rebase_target]) targets p2 first, then p3,
+    and p5 starts. *)
+let prop_chain_fanin_merge_witness =
+  QCheck2.Test.make ~count:1
+    ~name:
+      "FLI-6: merged-sibling squash flows up the open chain under a fan-in \
+       patch (seed-7 witness)" (QCheck2.Gen.return ()) (fun () ->
+      let patches =
+        [
+          mk_patch ~id:"p0" ~deps:[];
+          mk_patch ~id:"p1" ~deps:[ "p0" ];
+          mk_patch ~id:"p2" ~deps:[ "p0" ];
+          mk_patch ~id:"p3" ~deps:[ "p2" ];
+          mk_patch ~id:"p4" ~deps:[ "p0" ];
+          mk_patch ~id:"p5" ~deps:[ "p1"; "p3" ];
+        ]
+      in
+      let m = bootstrap patches ~started:3 in
+      let m = fst (tick (apply_command m (Pr_merged 0))) in
+      let m = fst (tick (apply_command m (Rebase_complete 1))) in
+      let m = fst (tick (apply_command m (Rebase_complete 2))) in
+      let m = fst (tick (apply_command m (Pr_merged 1))) in
+      let m = quiesce m ~rounds:((2 * List.length patches) + 3) in
+      no_startable_unstarted m && started_everywhere m)
+
 let () =
   let runner = QCheck_base_runner.run_tests_main in
   ignore
@@ -579,4 +706,6 @@ let () =
          prop_diamond_exhaustive;
          prop_random_dag_liveness;
          prop_sibling_defer_implies_demand;
+         prop_chain_fanin_rewrite_witness;
+         prop_chain_fanin_merge_witness;
        ])

--- a/test/test_fanin_liveness_interleavings.ml
+++ b/test/test_fanin_liveness_interleavings.ml
@@ -910,8 +910,15 @@ let prop_unrelated_main_advance_inert =
               let m = apply_command m (Unrelated_main_advance i) in
               let m, actions = tick m in
               let no_demand = List.is_empty (enqueued_rebases actions) in
+              let no_plan =
+                Patch_controller.plan_messages m.orch ~patches:m.patches
+                |> List.for_all ~f:(fun msg ->
+                    match Orchestrator.message_action msg with
+                    | Orchestrator.Start _ | Orchestrator.Rebase _ -> false
+                    | Orchestrator.Respond _ -> true)
+              in
               let m, fired = fire_runnable_traced m in
-              (m, ok && no_demand && List.is_empty fired))
+              (m, ok && no_demand && no_plan && List.is_empty fired))
         in
         ok
       with exn ->

--- a/test/test_fanin_liveness_interleavings.ml
+++ b/test/test_fanin_liveness_interleavings.ml
@@ -122,12 +122,12 @@ let deps_satisfied m pid =
     contract (fire Start → set_pr_number → Pr_body delivered → complete). The
     notes step matters: the deps-notes-ready Start gate
     ([Patch_controller.plan_action_for_patch]) defers a child's Start until
-    every open dep has [pr_body_delivered] — these tests target rebase
-    freshness liveness, so the model publishes notes promptly; the notes
-    gate's own liveness has its own properties
-    ([test_interleaving_properties.ml]). The branch absorbs its base's current
-    merge SHAs (the cut). No-op when already started or when dependencies are
-    not satisfied (cannot cut a worktree off a missing base). *)
+    every open dep has [pr_body_delivered] — these tests target rebase freshness
+    liveness, so the model publishes notes promptly; the notes gate's own
+    liveness has its own properties ([test_interleaving_properties.ml]). The
+    branch absorbs its base's current merge SHAs (the cut). No-op when already
+    started or when dependencies are not satisfied (cannot cut a worktree off a
+    missing base). *)
 let do_start m pid base =
   let agent = Orchestrator.agent m.orch pid in
   if Patch_agent.has_pr agent || agent.Patch_agent.merged then m

--- a/test/test_interleaving_properties.ml
+++ b/test/test_interleaving_properties.ml
@@ -2099,6 +2099,7 @@ let () =
                     Option.value ag.Patch_agent.base_branch ~default:main;
                   branch_rebased_onto = ag.Patch_agent.branch_rebased_onto;
                   base_contains_merged_siblings = true;
+                  sibling_rebase_target = None;
                 })
         in
         let merged_patches =
@@ -2746,6 +2747,7 @@ let reconcile_views_of orch =
           base_branch = Option.value ag.Patch_agent.base_branch ~default:main;
           branch_rebased_onto = ag.Patch_agent.branch_rebased_onto;
           base_contains_merged_siblings = true;
+          sibling_rebase_target = None;
         })
 
 let () =

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -434,7 +434,8 @@ let () =
   let main = Types.Branch.of_string "main" in
   let mk_view ?(has_pr = true) ?(merged = false) ?(busy = false)
       ?(needs_intervention = false) ?(branch_blocked = false) ?(queue = [])
-      ?(base_contains_merged_siblings = true) id =
+      ?(base_contains_merged_siblings = true) ?(sibling_rebase_target = None) id
+      =
     Reconciler.
       {
         id;
@@ -447,6 +448,7 @@ let () =
         base_branch = main;
         branch_rebased_onto = Some main;
         base_contains_merged_siblings;
+        sibling_rebase_target;
       }
   in
   let mk_patch id =

--- a/test/test_reconciler_properties.ml
+++ b/test/test_reconciler_properties.ml
@@ -94,6 +94,7 @@ let gen_rebase_scenario =
                   base_branch = main;
                   branch_rebased_onto = Some main;
                   base_contains_merged_siblings = true;
+                  sibling_rebase_target = None;
                 })
         in
         (graph, views, newly_merged))
@@ -157,6 +158,7 @@ let prop_detect_rebases_skips_already_queued =
                 base_branch = main;
                 branch_rebased_onto = Some main;
                 base_contains_merged_siblings = true;
+                sibling_rebase_target = None;
               })
       in
       return (graph, views, ids))
@@ -195,6 +197,7 @@ let gen_plan_scenario =
                   base_branch = main;
                   branch_rebased_onto = Some main;
                   base_contains_merged_siblings = true;
+                  sibling_rebase_target = None;
                 }))))
 
 let prop_plan_skips_busy =
@@ -363,6 +366,7 @@ let gen_reconcile_scenario =
                   base_branch = main;
                   branch_rebased_onto = Some main;
                   base_contains_merged_siblings = true;
+                  sibling_rebase_target = None;
                 }))))
 
 let prop_reconcile_merges_subset =
@@ -423,7 +427,7 @@ let other_br = Types.Branch.of_string "other"
 
 let mk_view ~id ?(has_pr = true) ?(merged = false) ?(queue = [])
     ?(base_branch = main_br) ?(branch_rebased_onto = Some main_br)
-    ?(base_contains_merged_siblings = true) () =
+    ?(base_contains_merged_siblings = true) ?(sibling_rebase_target = None) () =
   Reconciler.
     {
       id;
@@ -436,6 +440,7 @@ let mk_view ~id ?(has_pr = true) ?(merged = false) ?(queue = [])
       base_branch;
       branch_rebased_onto;
       base_contains_merged_siblings;
+      sibling_rebase_target;
     }
 
 let pid s = Types.Patch_id.of_string s
@@ -670,8 +675,15 @@ let fanin_views ~merged ~contains =
         ~f:(fun d -> not (merged_in merged d))
     in
     let base = match open_deps with [ d ] -> branch_of d | _ -> main_br in
+    (* The frontier the poller would compute: in this flat fan-in every open
+       dep's own deps are merged or main-based (its structural base already
+       holds the content), so the frontier is the sole open dep itself when
+       the base is stale. *)
+    let sibling_rebase_target =
+      match (contains, open_deps) with false, [ d ] -> Some d | _ -> None
+    in
     mk_view ~id:(pid "p") ~base_branch:base ~branch_rebased_onto:(Some base)
-      ~base_contains_merged_siblings:contains ()
+      ~base_contains_merged_siblings:contains ~sibling_rebase_target ()
   in
   [
     p_view;
@@ -803,9 +815,14 @@ let prop_fanin_unstarted_p_enqueues_base_rebase =
       let merged = [ pid "d1"; pid "d3" ] in
       let views =
         [
-          (* P is unstarted: no PR, no base recorded yet. *)
+          (* P is unstarted: no PR, no base recorded yet. The frontier the
+             poller would compute is the sole open dep d2 itself (d2's own dep
+             d1 is merged, so d2's structural base is main — the content
+             source). *)
           mk_view ~id:(pid "p") ~has_pr:false ~branch_rebased_onto:None
-            ~base_contains_merged_siblings:false ();
+            ~base_contains_merged_siblings:false
+            ~sibling_rebase_target:(Some (pid "d2"))
+            ();
           mk_view ~id:(pid "d2") ();
         ]
       in

--- a/test/test_stale_base_invariants.ml
+++ b/test/test_stale_base_invariants.ml
@@ -219,14 +219,21 @@ let apply_command m cmd =
       else
         let pid = pid_of_idx m.patches i in
         let agent = Orchestrator.agent m.orch pid in
-        let merge_conflict_queued =
-          List.mem agent.Patch_agent.queue Operation_kind.Merge_conflict
-            ~equal:Operation_kind.equal
+        (* Mirror the production planner: a respond only fires when it is the
+           highest-priority queued op ([Patch_agent.respond] raises
+           otherwise). The rewrite cascade can legitimately queue a [Rebase]
+           (priority 0) onto a conflicted patch — e.g. its base completed a
+           rebase — and production then runs that rebase first; this command
+           is infeasible until the queue's head is [Merge_conflict] again. *)
+        let merge_conflict_is_next =
+          Option.equal Operation_kind.equal
+            (Patch_agent.highest_priority agent)
+            (Some Operation_kind.Merge_conflict)
         in
         if
           (not agent.Patch_agent.has_conflict)
           || agent.Patch_agent.merged || agent.Patch_agent.busy
-          || not merge_conflict_queued
+          || not merge_conflict_is_next
         then m
         else
           (* Fire the queued [Merge_conflict] respond and resolve it cleanly:
@@ -397,28 +404,48 @@ let sbi_defer_implies_progress m =
 
 (** SBI-3 (rebase drains the queue): the freshness gate's
     [Base_patch_busy_with_rebase] arm only stays sound if a completed rebase
-    actually removes [Rebase] from the agent's queue — otherwise
+    actually removes [Rebase] from {e the rebased agent's own} queue — otherwise
     [runnable_rebase] would latch [true] forever and a just-rebased base would
-    keep deferring. Assert the postcondition directly: any idle (not [busy])
-    agent that is structurally fresh (its local branch sits on its current
-    structural base) must carry no queued [Rebase]. [Patch_agent.complete] after
-    a successful rebase enforces this; this locks it in so a regression in
-    [fire]/[apply_rebase_result]/[complete] would be caught here rather than
-    hidden behind a vacuous liveness pass. *)
-let sbi_completed_rebase_drains_queue m =
-  List.for_all
-    (Map.to_alist (Orchestrator.agents_map m.orch))
-    ~f:(fun (pid, a) ->
-      let structurally_fresh =
-        match a.Patch_agent.branch_rebased_onto with
-        | Some b -> Branch.equal b (initial_base_of m.orch m.patches pid)
-        | None -> false
-      in
-      if (not a.Patch_agent.busy) && structurally_fresh then
-        not
-          (List.mem a.Patch_agent.queue Operation_kind.Rebase
-             ~equal:Operation_kind.equal)
-      else true)
+    keep deferring. Assert the postcondition directly: immediately after a
+    [Rebase_complete i] that actually applied, agent [i] carries no queued
+    [Rebase]. [Patch_agent.complete] after a successful rebase enforces this;
+    locking it in catches a regression in
+    [fire]/[apply_rebase_result]/[complete] rather than hiding it behind a
+    vacuous liveness pass.
+
+    Deliberately scoped to the rebased agent, not to every idle
+    structurally-fresh agent: a completed rebase {e rewrites} its branch, and
+    [Orchestrator.apply_rebase_result] eagerly enqueues a [Rebase] for stacked
+    children sitting on the rewritten branch — children that read structurally
+    fresh by name ([branch_rebased_onto] still names the base) while their
+    history is dead. A queued [Rebase] on such an agent is the rewrite cascade
+    working as designed, not a latch: it does not latch because this very
+    postcondition re-asserts draining when that child's own rebase completes. *)
+let sbi_completed_rebase_drains_queue m pid =
+  let a = Orchestrator.agent m.orch pid in
+  not
+    (List.mem a.Patch_agent.queue Operation_kind.Rebase
+       ~equal:Operation_kind.equal)
+
+(** Whether [Rebase_complete i] would actually apply right now — mirrors
+    [apply_command]'s feasibility guard, so SBI-3 only asserts after a rebase
+    that genuinely ran (infeasible commands are no-ops and prove nothing about
+    queue draining). *)
+let rebase_complete_applies m i =
+  i < List.length m.patches
+  &&
+  let pid = pid_of_idx m.patches i in
+  let agent = Orchestrator.agent m.orch pid in
+  Patch_agent.has_pr agent
+  && (not agent.Patch_agent.merged)
+  && (not agent.Patch_agent.busy)
+  && List.mem agent.Patch_agent.queue Operation_kind.Rebase
+       ~equal:Operation_kind.equal
+  && List.length
+       (Graph.open_pr_deps (Orchestrator.graph m.orch) pid
+          ~has_merged:(fun dep ->
+            (Orchestrator.agent m.orch dep).Patch_agent.merged))
+     <= 1
 
 (* -- Generators -- *)
 
@@ -489,8 +516,34 @@ let prop_completed_rebase_drains_queue =
       let m = bootstrap (mk_patches n_patches) in
       let _final, ok =
         List.fold cmds ~init:(m, true) ~f:(fun (m, ok) cmd ->
+            (* Capture feasibility on the pre-command state: the command's own
+               application consumes the queued Rebase we are asserting about. *)
+            let applied =
+              match cmd with
+              | Rebase_complete i | Rebase_conflict i ->
+                  (* A conflicted rebase also completes as an op
+                     ([apply_rebase_result Conflict] drains [Rebase] and
+                     enqueues [Merge_conflict]) — the drain postcondition
+                     holds for it too. *)
+                  rebase_complete_applies m i
+              | Main_advanced | Pr_merged _ | Resolve_conflict _
+              | Enqueue_start _ ->
+                  false
+            in
             let m = apply_command m cmd in
-            (m, ok && sbi_completed_rebase_drains_queue m))
+            let ok =
+              ok
+              &&
+              match (cmd, applied) with
+              | (Rebase_complete i | Rebase_conflict i), true ->
+                  sbi_completed_rebase_drains_queue m (pid_of_idx m.patches i)
+              | (Rebase_complete _ | Rebase_conflict _), false
+              | ( ( Main_advanced | Pr_merged _ | Resolve_conflict _
+                  | Enqueue_start _ ),
+                  _ ) ->
+                  true
+            in
+            (m, ok))
       in
       ok)
 


### PR DESCRIPTION
## The flake

`QCHECK_SEED=440463877` failed FLI-3 ("random DAG interleavings quiesce with no startable-but-unstarted patch") with `<no printer>`. Adding a scenario printer shrank it to a six-patch DAG; fixing that exposed a second livelock at seed 7. Both share one root: **the sibling-stale-base demand only ever reaches one layer, but the missing squash commit can sit arbitrarily deep in the fan-in patch's open base chain.**

### Livelock 1 — rewrite stranding (seed 440463877)

`p4 ← {p0, p3}`, chain `p3 ← p2 ← p1 ← p0`. p0 merges → p1's freshen rebase onto main **rewrites** `branch-p1`, stranding p2 (and transitively p3) on dead history lacking p0's squash. Every name-based detector reads p2 as fresh (`branch_rebased_onto` still names `branch-p1`). `detect_sibling_stale_bases` re-enqueued `Rebase(p3)` — onto a `branch-p2` that still lacked the squash — **every tick, forever**. In production: a pointless force-push of the top-of-chain branch per poll tick, healed only if GitHub happens to report a textual conflict.

### Livelock 2 — merged-sibling content deep in the chain (seed 7)

`p5 ← {p1, p3}`, `p3 ← p2 ← p0`, `p1 ← p0`. p1 merges straight to main; its squash never enters p2's lineage (p1 isn't a dep of p2, so no detector ever rebases p2) — yet `branch-p3` can't absorb it until p2 rebases onto main first.

## Fix — two composing mechanisms

1. **Frontier-targeted sibling demand.** The poller now computes, alongside the containment cache, `Base_containment.stale_chain_rebase_target`: the *deepest stale layer whose own structural base already contains the missing squashes* (main is always a source). It rides a new `patch_view.sibling_rebase_target` field; `detect_sibling_stale_bases` enqueues exactly that layer. Healing the frontier moves it up one layer per tick until containment flips. One rebase per stale layer, no churn, no starvation — I tried "enqueue the whole chain" first and it starves: the re-queued lower rebases keep every layer above deferred on `Base_patch_busy_with_rebase` forever. The walk also distinguishes "deeper layer is fresh" from "chain blocked by a multi-open-dep layer" (fail-closed) — conflating them re-creates the churn (caught by BCF-7 during development).
2. **Rewrite cascade** — the dual of `mark_merged`'s eager enqueue. `apply_rebase_result Ok` (and conflict-resolution `Ok`) now eagerly enqueues a `Rebase` for open dependents with PRs whose `branch_rebased_onto` names the rewritten branch. Each child's completion re-fires it, so the wave walks an open stack one layer per round, serialized bottom-up by the eligibility gate (including #343's conflicted-base arm). `Noop` arms don't cascade (no rewrite). Production today heals stranded children only via GitHub conflict detection (the connector-adapter trace shows patches 2/3 thrashing through `Merge_conflict` LLM sessions after each of patch 1's rebases) — the cascade does it proactively with cheap orchestrator rebases, and covers the textually-clean case where GitHub may never flag anything and child PRs silently carry their base's pre-rewrite commits.

## ⚠️ Also fixes main's currently-red FLI suite

#341 (deps-notes-ready Start gate) and #342 (FLI tests) merged independently — neither CI run saw the combination (no merge-time currency requirement) — leaving **FLI-1/2/3 failing on `origin/main` right now** (verified on a pristine checkout): the FLI model never published notes, so every stacked Start deferred forever. The model's `do_start` now mirrors the production lifecycle (`complete → Pr_body`); the notes gate keeps its own properties from #341.

## Tests

- FLI-3 passes at both livelock seeds and 45 swept seeds; the shrunk counterexamples are locked in as deterministic witnesses **FLI-5** and **FLI-6**. FLI-3/4 gained a scenario printer + exception logging.
- **FLI-4** generalized to frontier semantics: a sibling-arm Defer implies demand *somewhere on the base's open chain*.
- **BCF-1..8** (`test_base_containment.ml`): frontier properties derived from the `.mli` contract, including a randomized invariant (any target is itself stale while its own base is fresh).
- **SBI-3** reworked to its documented purpose: a completed rebase (clean or conflicted) drains the `Rebase` from *the rebased agent's own* queue, asserted as a postcondition per applied command. The old blanket "no idle structurally-fresh agent carries a queued Rebase" is precisely what the cascade now legitimately violates for stranded children — name-freshness was the blind spot all along.
- SBI's `Resolve_conflict` command gained the production planner's highest-priority guard (the cascade can queue a `Rebase` onto a conflicted patch; production runs it before the `Merge_conflict` respond).

Full `dune runtest` green via the commit hook (it is red on main today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/345"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783018664&installation_id=126163856&pr_number=345&repository=flowglad%2Fonton&return_to=https%3A%2F%2Fgithub.com%2Fflowglad%2Fonton%2Fpull%2F345&signature=9bf0f08ea5b7ac06cff8f5fa4c63ee8dd984015dc1acde7b53902c2ee5de1cfb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix livelocks when a fan‑in patch’s base sits on a stale open chain by targeting the chain frontier and cascading rewrites to stacked children. This removes rebase churn, makes fan‑in patches startable, and brings FLI‑1/2/3 back to green on `main`.

- **Bug Fixes**
  - Frontier‑targeted sibling demand: new `Base_containment.stale_chain_rebase_target`; poller populates `patch_view.sibling_rebase_target` only when containment is false; `detect_sibling_stale_bases` enqueues that frontier so the chain heals one layer per tick (fail‑closed on missing SHA or interrupted chains).
  - Rewrite cascade: on `apply_rebase_result Ok` and conflict‑resolution `Ok`, enqueue `Rebase` for open dependents whose `branch_rebased_onto` names the rewritten branch; `Noop` does not cascade.
  - Eager enqueue guard: `mark_merged` now requires `has_pr` before enqueueing a dependent `Rebase`, preventing wasteful post‑Start rewrites (NUR‑4).

- **Tests**
  - NUR‑1..4: prove rebases happen only on true demand — model mirrors production Ok/Noop, traces fired rebases and absorbed deltas, adds `Unrelated_main_advance`, and now asserts planner silence in NUR‑2 (no demand, no plan, no execute on unrelated main advances).
  - FLI: model publishes notes on Start; added witnesses FLI‑5/6; generalized FLI‑4 to frontier semantics; minor formatting fixes in fan‑in liveness tests.
  - SBI/BCF: `Resolve_conflict` respects planner priority; SBI‑3 asserts drain on the rebased agent only; added BCF‑1..8 frontier properties.

<sup>Written for commit d667c613c94b2845f218a17c68eddbbaf6291046. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/flowglad/onton/pull/345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

