### PR TITLE
Move Linux CI to Blacksmith runners; stickydisk the opam switch

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - blacksmith-4vcpu-ubuntu-2404

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   build-and-test:
     name: Build & Test
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     # Pin to bash so `${PIPESTATUS[0]}` (a bash-only array) in the Build and
     # Run tests steps is guaranteed — GitHub Actions defaults to bash on Linux
     # in practice, but making it explicit avoids silent breakage if the
@@ -21,23 +21,51 @@ jobs:
     defaults:
       run:
         shell: bash
+    env:
+      # Single source for the compiler version: setup-ocaml's switch and the
+      # self-heal rebuild in Install dependencies must agree.
+      OCAML_COMPILER: '5.4.1'
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v4 (Blacksmith fork)
 
-      # We deliberately do NOT cache [_opam/] here. setup-ocaml@v3 caches its
-      # own opam-root state at [~/.opam/] (compiler + repo metadata) keyed
-      # separately from anything we'd cache for [_opam/]. Caching the local
-      # switch alongside means the two can drift: a stale [~/.opam/] without
-      # the switch registered makes opam treat [_opam/] as a fresh switch and
-      # try to reinstall packages whose files still exist on disk — the
-      # classic "zarith ... META already exists" symptom we kept hitting
-      # whenever a cancel-in-progress run saved a half-consistent [_opam/].
-      # [dune-cache: true] handles the much larger speed win (avoiding
-      # recompilation), and the opam.ocaml.org archive mirror keeps the
-      # `opam install` step under ~90s by serving precompiled binaries.
+      # Persist the local switch across runs on a Blacksmith sticky disk.
+      # actions/cache was unusable for [_opam/]: it freezes the first entry
+      # per key, so one half-consistent save (e.g. from a cancel-in-progress
+      # run) poisoned every later run ("zarith ... META already exists") until
+      # manually evicted. A sticky disk is mutable, last-write-wins storage:
+      # a bad state is overwritten by the next good run, and the guard steps
+      # below wipe stale state in ways that also persist — self-healing
+      # instead of self-poisoning.
+      - name: Mount opam switch cache
+        uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88 # v1
+        with:
+          path: ${{ github.workspace }}/_opam
+          # Stable key (no *.opam hash): stickydisk has no restore-keys, so a
+          # hashed key would go cold on every dependency bump. opam reconciles
+          # the switch against *.opam on install, fetching only what changed.
+          key: ${{ github.repository }}-opam-build-${{ runner.os }}
+
+      # Guard 1: half-written switch. The marker is deleted here and recreated
+      # only after a successful install, so a run interrupted anywhere in
+      # between — including inside setup-ocaml's switch creation — leaves no
+      # marker, and the next run starts from an empty switch instead of
+      # letting setup-ocaml trip over partial files.
+      - name: Reset switch cache unless last run completed
+        run: |
+          if [ ! -f _opam/.ci-switch-ok ]; then
+            echo "No completion marker — clearing cached switch"
+            find _opam -mindepth 1 -delete
+          fi
+          rm -f _opam/.ci-switch-ok
+
+      # setup-ocaml still caches its opam-root state at [~/.opam/] (compiler
+      # + repo metadata) via actions/cache, keyed separately from the sticky
+      # disk — Guard 2 below handles the two drifting apart. [dune-cache:
+      # true] covers recompilation, and the opam.ocaml.org archive mirror
+      # keeps source fetches fast.
       - uses: ocaml/setup-ocaml@e32b06a3e831ff2fbc6f08cf35be2085e3918014 # v3.6.1
         with:
-          ocaml-compiler: '5.4.1'
+          ocaml-compiler: ${{ env.OCAML_COMPILER }}
           dune-cache: true
 
       - name: Use opam.ocaml.org archive cache
@@ -47,7 +75,22 @@ jobs:
         run: opam option 'archive-mirrors=["https://opam.ocaml.org/cache"]'
 
       - name: Install dependencies
-        run: opam install . --deps-only --with-test -y
+        # Guard 2: switch/root drift. A cached [_opam/] paired with a fresh
+        # [~/.opam/] (setup-ocaml cache miss) makes opam treat the switch as
+        # new and reinstall packages over files that already exist on disk —
+        # the historical "zarith ... META already exists" failure. On any
+        # install failure, rebuild the switch from scratch and retry once; the
+        # wipe lands on the sticky disk, so the heal persists. `find -delete`
+        # (not `rm -rf _opam`) because _opam is the mount point itself.
+        run: |
+          if ! opam install . --deps-only --with-test -y; then
+            echo "::warning::opam install failed — wiping cached _opam and rebuilding the switch"
+            opam switch remove "$PWD" -y || true
+            find _opam -mindepth 1 -delete
+            opam switch create . "$OCAML_COMPILER" --no-install -y
+            opam install . --deps-only --with-test -y
+          fi
+          touch _opam/.ci-switch-ok
 
       - name: Build
         id: build
@@ -97,15 +140,18 @@ jobs:
 
   format:
     name: Format Check
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v4 (Blacksmith fork)
 
-      # Same reasoning as build-and-test above: do NOT cache [_opam/]. The
-      # manual switch cache drifts from setup-ocaml's [~/.opam/] state and, via
-      # actions/cache's frozen-first-entry behavior, a single half-consistent
-      # [_opam/] poisons every later run ("zarith ... META already exists").
-      # [dune-cache: true] plus the archive mirror cover the speed win.
+      # No sticky disk for [_opam/] here, unlike build-and-test: this job's
+      # switch install happens inside the lint-fmt action (a `uses:` step we
+      # can't wrap in a wipe-and-retry guard), so a stale cached switch would
+      # wedge CI red until someone manually cleared the disk — the same
+      # poisoning failure mode ("zarith ... META already exists") that got
+      # [_opam/] caching removed in the first place. The switch here is tiny
+      # (ocamlformat only); [dune-cache: true] plus the archive mirror cover
+      # the speed win.
       - uses: ocaml/setup-ocaml@e32b06a3e831ff2fbc6f08cf35be2085e3918014 # v3.6.1
         with:
           ocaml-compiler: '5.4.1'
@@ -118,13 +164,13 @@ jobs:
 
   shell-lint:
     name: Shell Lint & Format
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
       SHFMT_VERSION: v3.13.1
       # 2-space indent + case-item indent matches the existing scripts/ style.
       SHFMT_FLAGS: "-i 2 -ci"
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v4 (Blacksmith fork)
 
       - name: Discover shell scripts
         id: discover
@@ -191,9 +237,9 @@ jobs:
 
   lint-yojson:
     name: No raw Yojson.Safe.Util
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v4 (Blacksmith fork)
         with:
           persist-credentials: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,36 +33,31 @@ jobs:
       # per key, so one half-consistent save (e.g. from a cancel-in-progress
       # run) poisoned every later run ("zarith ... META already exists") until
       # manually evicted. A sticky disk is mutable, last-write-wins storage:
-      # a bad state is overwritten by the next good run, and the guard steps
-      # below wipe stale state in ways that also persist — self-healing
-      # instead of self-poisoning.
+      # a bad state is overwritten by the next good run — self-healing instead
+      # of self-poisoning.
+      #
+      # The disk mounts at a side path, NOT at [_opam/]: `opam switch create`
+      # refuses a pre-existing [_opam] directory — even an empty mount point —
+      # so setup-ocaml must see no [_opam] at all. The cached switch is
+      # rsync'd in after setup-ocaml runs and back out after a successful
+      # install.
       - name: Mount opam switch cache
         uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88 # v1
         with:
-          path: ${{ github.workspace }}/_opam
-          # Stable key (no *.opam hash): stickydisk has no restore-keys, so a
-          # hashed key would go cold on every dependency bump. opam reconciles
+          path: ~/.opam-switch-disk
+          # No *.opam hash in the key: stickydisk has no restore-keys, so a
+          # hashed key would go cold on every dependency bump; opam reconciles
           # the switch against *.opam on install, fetching only what changed.
-          key: ${{ github.repository }}-opam-build-${{ runner.os }}
+          # The compiler version IS in the key: a restored switch silently
+          # keeps its old compiler (`opam install` never upgrades the switch
+          # base), so a version bump must start from an empty disk.
+          key: ${{ github.repository }}-opam-build-${{ runner.os }}-${{ env.OCAML_COMPILER }}
 
-      # Guard 1: half-written switch. The marker is deleted here and recreated
-      # only after a successful install, so a run interrupted anywhere in
-      # between — including inside setup-ocaml's switch creation — leaves no
-      # marker, and the next run starts from an empty switch instead of
-      # letting setup-ocaml trip over partial files.
-      - name: Reset switch cache unless last run completed
-        run: |
-          if [ ! -f _opam/.ci-switch-ok ]; then
-            echo "No completion marker — clearing cached switch"
-            find _opam -mindepth 1 -delete
-          fi
-          rm -f _opam/.ci-switch-ok
-
-      # setup-ocaml still caches its opam-root state at [~/.opam/] (compiler
-      # + repo metadata) via actions/cache, keyed separately from the sticky
-      # disk — Guard 2 below handles the two drifting apart. [dune-cache:
-      # true] covers recompilation, and the opam.ocaml.org archive mirror
-      # keeps source fetches fast.
+      # setup-ocaml caches its opam-root state at [~/.opam/] (compiler + repo
+      # metadata) via actions/cache, keyed separately from the sticky disk —
+      # Guard 2 in Install dependencies handles the two drifting apart.
+      # [dune-cache: true] covers recompilation, and the opam.ocaml.org
+      # archive mirror keeps source fetches fast.
       - uses: ocaml/setup-ocaml@e32b06a3e831ff2fbc6f08cf35be2085e3918014 # v3.6.1
         with:
           ocaml-compiler: ${{ env.OCAML_COMPILER }}
@@ -74,23 +69,40 @@ jobs:
         # archives behind a CDN, so opam only falls back to upstream on a miss.
         run: opam option 'archive-mirrors=["https://opam.ocaml.org/cache"]'
 
+      - name: Restore cached switch
+        # Guard 1: half-written copy. The marker is dropped before the disk
+        # copy is updated and recreated only after it completes (see Install
+        # dependencies), so a job cancelled mid-sync leaves no marker and the
+        # next run simply starts cold instead of restoring partial files —
+        # the historical half-consistent-[_opam/] poisoning scenario.
+        run: |
+          if [ -f "$HOME/.opam-switch-disk/.ci-switch-ok" ]; then
+            echo "Restoring cached switch from sticky disk"
+            rsync -a --delete "$HOME/.opam-switch-disk/_opam/" _opam/
+          else
+            echo "No completion marker on sticky disk — starting cold"
+          fi
+
       - name: Install dependencies
-        # Guard 2: switch/root drift. A cached [_opam/] paired with a fresh
-        # [~/.opam/] (setup-ocaml cache miss) makes opam treat the switch as
-        # new and reinstall packages over files that already exist on disk —
-        # the historical "zarith ... META already exists" failure. On any
-        # install failure, rebuild the switch from scratch and retry once; the
-        # wipe lands on the sticky disk, so the heal persists. `find -delete`
-        # (not `rm -rf _opam`) because _opam is the mount point itself.
+        # Guard 2: switch/root drift. A restored [_opam/] paired with opam
+        # root state it wasn't built against can make opam reinstall packages
+        # over files that already exist on disk — the historical "zarith ...
+        # META already exists" failure. On any install failure, rebuild the
+        # switch from scratch and retry once.
+        #
+        # On success, refresh the disk copy under the Guard 1 marker protocol:
+        # drop marker -> sync -> recreate marker.
         run: |
           if ! opam install . --deps-only --with-test -y; then
-            echo "::warning::opam install failed — wiping cached _opam and rebuilding the switch"
+            echo "::warning::opam install failed — rebuilding the switch from scratch"
             opam switch remove "$PWD" -y || true
-            find _opam -mindepth 1 -delete
+            rm -rf _opam
             opam switch create . "$OCAML_COMPILER" --no-install -y
             opam install . --deps-only --with-test -y
           fi
-          touch _opam/.ci-switch-ok
+          rm -f "$HOME/.opam-switch-disk/.ci-switch-ok"
+          rsync -a --delete _opam/ "$HOME/.opam-switch-disk/_opam/"
+          touch "$HOME/.opam-switch-disk/.ci-switch-ok"
 
       - name: Build
         id: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,9 @@ jobs:
             # support ends when macOS 15 retires (~Fall 2027). Tracked in #316.
             runner: macos-15-intel
     steps:
+      # Plain actions/checkout here: this job runs on GitHub-hosted macOS
+      # (Blacksmith is Linux-only), where the Blacksmith checkout fork's git
+      # mirror has nothing to talk to.
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       # We deliberately do NOT cache [_opam/]. setup-ocaml@v3 caches its own
@@ -36,9 +39,10 @@ jobs:
       # still exist on disk (the "zarith ... META already exists" failure). Worse
       # here: actions/cache freezes the first entry for a given `*.opam` hash, so
       # one half-consistent [_opam/] (e.g. from a cancelled run) poisons every
-      # later run until the cache is manually evicted. See the build-and-test job
-      # in ci.yml for the full rationale. [dune-cache: true] plus the
-      # opam.ocaml.org archive mirror keep `opam install` fast without it.
+      # later run until the cache is manually evicted. CI's build-and-test job
+      # sidesteps this with a Blacksmith sticky disk, but Blacksmith is
+      # Linux-only — no such option on these macOS runners. [dune-cache: true]
+      # plus the opam.ocaml.org archive mirror keep `opam install` fast without it.
       - uses: ocaml/setup-ocaml@e32b06a3e831ff2fbc6f08cf35be2085e3918014 # v3.6.1
         with:
           ocaml-compiler: '5.4.1'
@@ -72,7 +76,7 @@ jobs:
   release:
     name: Create Release
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
@@ -92,7 +96,7 @@ jobs:
   homebrew:
     name: Update Homebrew Formula
     needs: release
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
@@ -104,7 +108,7 @@ jobs:
           echo "arm64=$(shasum -a 256 onton-arm64-apple-darwin.tar.gz | cut -d ' ' -f 1)" >> "$GITHUB_OUTPUT"
           echo "x86_64=$(shasum -a 256 onton-x86_64-apple-darwin.tar.gz | cut -d ' ' -f 1)" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v4 (Blacksmith fork)
         with:
           ref: main
 


### PR DESCRIPTION
## What

Mirrors provisioning-agent's Blacksmith setup:

- All Linux jobs in `ci.yml` and `release.yml`: `ubuntu-latest` → `blacksmith-4vcpu-ubuntu-2404`, `actions/checkout` → `useblacksmith/checkout` (same SHA pins as provisioning-agent)
- New `.github/actionlint.yaml` registering the runner label
- The release build matrix stays on GitHub-hosted macOS — Blacksmith is Linux-only

## Why stickydisk for `_opam` is safe now

`Install dependencies` was ~2m45s of a ~4m45s CI job. The repo previously removed `_opam/` caching because `actions/cache` freezes the first entry per key — one half-consistent save from a cancel-in-progress run poisoned every later run ("zarith ... META already exists") until manual eviction.

A Blacksmith sticky disk is mutable, last-write-wins storage, so the same hazard is self-healing instead of self-poisoning, enforced by two guards in `build-and-test`:

1. **Completion marker** (`_opam/.ci-switch-ok`): deleted at job start, recreated only after a successful install. An interrupted run leaves no marker → the next run starts from an empty switch instead of letting setup-ocaml trip over partial files.
2. **Wipe-and-retry**: if `opam install` fails (cached `_opam` drifted from setup-ocaml's separately-cached `~/.opam`), wipe the disk, rebuild the switch, retry once. The wipe persists to the disk, so the heal sticks.

The **format job deliberately gets no sticky disk**: its switch install happens inside `lint-fmt` (a `uses:` step), so a stale disk can't be wrapped in a self-heal retry and would wedge CI red — the exact failure mode that got `_opam` caching removed.

## Expected effect

Warm runs: `Install dependencies` drops from ~2m45s to a near-noop re-resolve. First run / dependency bumps pay only the delta.

## Watch on first run

- Blacksmith app must cover this repo (installed for the flowglad org via provisioning-agent — if it was per-repo scoped, the first job queues until onton is added)
- First run is a cold disk: timings should match today's, with savings from the second run on

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/346"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783024415&installation_id=126163856&pr_number=346&repository=flowglad%2Fonton&return_to=https%3A%2F%2Fgithub.com%2Fflowglad%2Fonton%2Fpull%2F346&signature=47cabfc1b9f9b9d9ed0dea8cecc5b8874bcc4c963810ec2c4e974e4a0dd8015a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move all Linux CI and release jobs to Blacksmith runners and persist the local opam switch on a Blacksmith sticky disk for faster, more reliable builds. The switch is rsynced in/out of a side-mounted disk, making warm installs near-noop and self-healing.

- **Refactors**
  - Linux jobs in `ci.yml` and the `release`/`homebrew` jobs in `release.yml`: `ubuntu-latest` → `blacksmith-4vcpu-ubuntu-2404`; use `useblacksmith/checkout` (macOS build matrix stays on GitHub-hosted runners with `actions/checkout`).
  - Persist `_opam` via `useblacksmith/stickydisk` mounted at `~/.opam-switch-disk`; rsync the switch in after `ocaml/setup-ocaml` and back out on success.
  - Tighten the completion marker protocol (drop before sync, recreate after) and keep the wipe-and-retry on `opam install` failure; disk key includes `OCAML_COMPILER`, and `OCAML_COMPILER` is set once so all steps agree.
  - Add `.github/actionlint.yaml` to register the Blacksmith runner label.

<sup>Written for commit 2384ba2bfd0590e2e42d4c9235cc1d692315686d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/flowglad/onton/pull/346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

