### PR TITLE
[merge-queue-support] Patch 2: Populate merge-queue state from GitHub (unconsumed)

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -757,7 +757,7 @@ let construct_capabilities ~net (setup : runtime_setup) =
   in
   let forge =
     Github.make ~net ~clock:setup.clock ~token:github_token ~owner:github_owner
-      ~repo:github_repo
+      ~repo:github_repo ~main_branch
   in
   let module Forge = (val forge) in
   let worktree_client =

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -117,14 +117,24 @@ let show_error = function
   | Graphql_error msgs ->
       Printf.sprintf "GitHub GraphQL error: %s" (String.concat ~sep:"; " msgs)
 
-type t = { token : string; owner : string; repo : string }
+type t = {
+  token : string;
+  owner : string;
+  repo : string;
+  main_branch : Types.Branch.t;
+}
 
-let create ~token ~owner ~repo = { token; owner; repo }
+let create ~token ~owner ~repo ~main_branch =
+  { token; owner; repo; main_branch }
 
 let graphql_query =
-  {|query($owner: String!, $repo: String!, $number: Int!) {
+  {|query($owner: String!, $repo: String!, $number: Int!, $mergeQueueBranch: String) {
   repository(owner: $owner, name: $repo) {
+    mergeQueue(branch: $mergeQueueBranch) {
+      id
+    }
     pullRequest(number: $number) {
+      id
       state
       isDraft
       mergeable
@@ -133,6 +143,11 @@ let graphql_query =
       headRefOid
       baseRefName
       mergeCommit { oid }
+      mergeQueueEntry {
+        id
+        state
+        position
+      }
       headRepositoryOwner { login }
       commits(last: 1) {
         nodes {
@@ -195,6 +210,7 @@ let build_request_body t (pr : Types.Pr_number.t) =
         ("owner", `String t.owner);
         ("repo", `String t.repo);
         ("number", `Int (Types.Pr_number.to_int pr));
+        ("mergeQueueBranch", `String (Types.Branch.to_string t.main_branch));
       ]
   in
   `Assoc [ ("query", `String graphql_query); ("variables", variables) ]
@@ -204,6 +220,13 @@ let parse_merge_state = function
   | "MERGEABLE" -> Pr_state.Mergeable
   | "CONFLICTING" -> Pr_state.Conflicting
   | _ -> Pr_state.Unknown
+
+let parse_merge_queue_entry_state = function
+  | "QUEUED" -> Pr_state.Mq_queued
+  | "AWAITING_CHECKS" -> Pr_state.Mq_awaiting_checks
+  | "MERGEABLE" -> Pr_state.Mq_mergeable
+  | "UNMERGEABLE" -> Pr_state.Mq_unmergeable
+  | "LOCKED" | _ -> Pr_state.Mq_locked
 
 (* Typed model of the GraphQL PR response. Every nullable scalar/object is an
    [option] ([@yojson.default None] tolerates both a missing key and an explicit
@@ -297,7 +320,19 @@ type review_threads = { nodes : review_thread list [@yojson.default []] }
 type repo_owner = { login : string option [@yojson.default None] }
 [@@deriving of_yojson] [@@yojson.allow_extra_fields]
 
+type merge_queue = Merge_queue_present
+
+let merge_queue_of_yojson _ = Merge_queue_present
+
+type merge_queue_entry = {
+  id : string option; [@yojson.default None]
+  state : string option; [@yojson.default None]
+  position : int option; [@yojson.default None]
+}
+[@@deriving of_yojson] [@@yojson.allow_extra_fields]
+
 type pull_request = {
+  id : string option; [@yojson.default None]
   state : string;
   mergeable : string option; [@yojson.default None]
   is_draft : bool; [@key "isDraft"] [@yojson.default false]
@@ -307,6 +342,8 @@ type pull_request = {
   head_ref_oid : string option; [@key "headRefOid"] [@yojson.default None]
   base_ref_name : string option; [@key "baseRefName"] [@yojson.default None]
   merge_commit : oid_obj option; [@key "mergeCommit"] [@yojson.default None]
+  merge_queue_entry : merge_queue_entry option;
+      [@key "mergeQueueEntry"] [@yojson.default None]
   commits : commits; [@yojson.default { nodes = [] }]
   review_threads : review_threads;
       [@key "reviewThreads"] [@yojson.default { nodes = [] }]
@@ -316,6 +353,7 @@ type pull_request = {
 [@@deriving of_yojson] [@@yojson.allow_extra_fields]
 
 type repository = {
+  merge_queue : merge_queue option; [@key "mergeQueue"] [@yojson.default None]
   pull_request : pull_request option; [@key "pullRequest"] [@yojson.default None]
 }
 [@@deriving of_yojson] [@@yojson.allow_extra_fields]
@@ -382,7 +420,8 @@ let comment_of_node ~thread_id ~outdated (n : comment_node) : Types.Comment.t =
     outdated;
   }
 
-let pr_state_of_pull_request ~owner (pr : pull_request) : Pr_state.t =
+let pr_state_of_pull_request ~owner ~merge_queue_required (pr : pull_request) :
+    Pr_state.t =
   let status =
     match pr.state with
     | "MERGED" -> Pr_state.Merged
@@ -438,6 +477,17 @@ let pr_state_of_pull_request ~owner (pr : pull_request) : Pr_state.t =
     | Some head_owner -> not (String.equal head_owner owner)
     | None -> false
   in
+  let merge_queue_entry =
+    Option.bind pr.merge_queue_entry ~f:(fun entry ->
+        Option.map entry.id ~f:(fun id ->
+            {
+              Pr_state.id;
+              state =
+                Option.value_map entry.state ~default:Pr_state.Mq_locked
+                  ~f:parse_merge_queue_entry_state;
+              position = Option.value entry.position ~default:0;
+            }))
+  in
   {
     Pr_state.status;
     is_draft = pr.is_draft;
@@ -452,9 +502,9 @@ let pr_state_of_pull_request ~owner (pr : pull_request) : Pr_state.t =
     (* GitHub does not produce review-service findings; the poller in
        [bin/main.ml] augments this list from configured review-service
        backends. *)
-    node_id = None;
-    merge_queue_required = false;
-    merge_queue_entry = None;
+    node_id = pr.id;
+    merge_queue_required;
+    merge_queue_entry;
     head_branch = Option.map pr.head_ref_name ~f:Types.Branch.of_string;
     head_oid = pr.head_ref_oid;
     merge_commit_sha = Option.bind pr.merge_commit ~f:(fun o -> o.oid);
@@ -482,10 +532,14 @@ let parse_response_json ~owner json =
       | Error msg -> Error (Json_parse_error msg)
       | Ok { data = None }
       | Ok { data = Some { repository = None } }
-      | Ok { data = Some { repository = Some { pull_request = None } } } ->
+      | Ok { data = Some { repository = Some { pull_request = None; _ } } } ->
           Error (Json_parse_error "pullRequest not found")
-      | Ok { data = Some { repository = Some { pull_request = Some pr } } } ->
-          Ok (pr_state_of_pull_request ~owner pr))
+      | Ok { data = Some { repository = Some repo } } -> (
+          let merge_queue_required = Option.is_some repo.merge_queue in
+          match repo.pull_request with
+          | None -> Error (Json_parse_error "pullRequest not found")
+          | Some pr ->
+              Ok (pr_state_of_pull_request ~owner ~merge_queue_required pr)))
 
 let parse_response ~owner body =
   try parse_response_json ~owner (Yojson.Safe.from_string body)
@@ -1065,9 +1119,9 @@ let%expect_test "show_error transport error includes endpoint" =
   Stdlib.print_endline (show_error err);
   [%expect {| GitHub API POST /graphql → transport error: connection refused |}]
 
-let make ~net ~clock ~token ~owner ~repo :
+let make ~net ~clock ~token ~owner ~repo ~main_branch :
     (module Forge.S with type error = error) =
-  let client = create ~token ~owner ~repo in
+  let client = create ~token ~owner ~repo ~main_branch in
   (* Cache the repo's allowed merge methods across calls; populated lazily on
      the first merge and narrowed if a 405 later reveals a method is disabled. *)
   let merge_methods_cache = ref None in

--- a/lib/github.mli
+++ b/lib/github.mli
@@ -71,7 +71,8 @@ val make :
   token:string ->
   owner:string ->
   repo:string ->
+  main_branch:Types.Branch.t ->
   (module Forge.S with type error = error)
-(** [make ~net ~clock ~token ~owner ~repo] packages a GitHub-backed forge module
-    that closes over the network and time capabilities plus client
+(** [make ~net ~clock ~token ~owner ~repo ~main_branch] packages a GitHub-backed
+    forge module that closes over the network and time capabilities plus client
     configuration. *)

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -564,6 +564,13 @@ let set_checks_passing t patch_id v =
 let set_merge_ready t patch_id v =
   update_agent t patch_id ~f:(fun a -> Patch_agent.set_merge_ready a v)
 
+let set_merge_queue_required t patch_id v =
+  update_agent t patch_id ~f:(fun a -> Patch_agent.set_merge_queue_required a v)
+
+let set_merge_queue_entry t patch_id entry =
+  update_agent t patch_id ~f:(fun a ->
+      Patch_agent.set_merge_queue_entry a entry)
+
 let set_merge_commit_sha t patch_id sha =
   update_agent t patch_id ~f:(fun a -> Patch_agent.set_merge_commit_sha a sha)
 

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -115,6 +115,11 @@ val record_delivered_ci_run_ids : t -> Patch_id.t -> int list -> t
 
 val set_checks_passing : t -> Patch_id.t -> bool -> t
 val set_merge_ready : t -> Patch_id.t -> bool -> t
+val set_merge_queue_required : t -> Patch_id.t -> bool -> t
+
+val set_merge_queue_entry :
+  t -> Patch_id.t -> Pr_state.merge_queue_entry option -> t
+
 val set_merge_commit_sha : t -> Patch_id.t -> string option -> t
 val set_base_contains_merged_siblings : t -> Patch_id.t -> bool -> t
 val set_is_draft : t -> Patch_id.t -> bool -> t

--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -192,6 +192,13 @@ let apply_poll_result t patch_id
   in
   let t = Orchestrator.set_merge_ready t patch_id poll_result.merge_ready in
   let t =
+    Orchestrator.set_merge_queue_required t patch_id
+      poll_result.merge_queue_required
+  in
+  let t =
+    Orchestrator.set_merge_queue_entry t patch_id poll_result.merge_queue_entry
+  in
+  let t =
     let was_draft = (Orchestrator.agent t patch_id).Patch_agent.is_draft in
     let t = Orchestrator.set_is_draft t patch_id poll_result.is_draft in
     if (not was_draft) && poll_result.is_draft then log "Marked as draft"

--- a/lib/prune_runner.ml
+++ b/lib/prune_runner.ml
@@ -78,7 +78,8 @@ let refresh_agents_from_forge ~net ~clock ~(cfg : Project_store.stored_config)
     else
       let module Forge =
         (val Github.make ~net ~clock ~token ~owner:cfg.github_owner
-               ~repo:cfg.github_repo)
+               ~repo:cfg.github_repo
+               ~main_branch:(Types.Branch.of_string cfg.main_branch))
       in
       let results =
         Eio.Fiber.List.map ~max_fibers:16

--- a/test/test_github_merge_commit_null.ml
+++ b/test/test_github_merge_commit_null.ml
@@ -33,8 +33,54 @@ let parse s =
   Onton.Github.parse_response_json ~owner:"flowglad" (Yojson.Safe.from_string s)
 
 let pending_patch_2_parse_merge_queue_and_entry () =
-  (* PENDING: Patch 2 - parse mergeQueue and mergeQueueEntry from GraphQL PR query. *)
-  ()
+  let body =
+    {|{
+      "data": {
+        "repository": {
+          "mergeQueue": { "id": "MQ_main" },
+          "pullRequest": {
+            "id": "PR_node_123",
+            "state": "OPEN",
+            "mergeable": "MERGEABLE",
+            "isDraft": false,
+            "mergeStateStatus": "CLEAN",
+            "commits": { "nodes": [] },
+            "reviewThreads": { "nodes": [] },
+            "headRefName": "feature-branch",
+            "headRefOid": "abc123",
+            "baseRefName": "main",
+            "mergeCommit": null,
+            "mergeQueueEntry": {
+              "id": "MQE_node_456",
+              "state": "SOME_FUTURE_STATE",
+              "position": 7
+            },
+            "headRepositoryOwner": { "login": "flowglad" }
+          }
+        }
+      }
+    }|}
+  in
+  match parse body with
+  | Ok st -> (
+      assert (st.Onton_core.Pr_state.node_id = Some "PR_node_123");
+      assert st.Onton_core.Pr_state.merge_queue_required;
+      match st.Onton_core.Pr_state.merge_queue_entry with
+      | Some entry ->
+          assert (String.equal entry.Onton_core.Pr_state.id "MQE_node_456");
+          assert (
+            Onton_core.Pr_state.equal_merge_queue_entry_state
+              entry.Onton_core.Pr_state.state Onton_core.Pr_state.Mq_locked);
+          assert (entry.Onton_core.Pr_state.position = 7);
+          Stdlib.print_endline
+            "  merge queue GraphQL fields: OK (required + entry)"
+      | None ->
+          Stdlib.print_endline "  FAIL: missing parsed merge queue entry";
+          Stdlib.exit 1)
+  | Error e ->
+      Printf.eprintf "  FAIL: merge queue fixture errored: %s\n"
+        (Onton.Github.show_error e);
+      Stdlib.exit 1
 
 let pending_patch_3_enqueue_and_dequeue_parsing () =
   (* PENDING: Patch 3 - enqueue and dequeue mutation response parsing. *)


### PR DESCRIPTION
## Patch 2: Populate merge-queue state from GitHub (unconsumed)

- Add the merge-queue fields to the GraphQL query and the pull_request record; thread main_branch from config to the query variable via the client.
- Parse mergeQueue presence, pullRequest.id, and mergeQueueEntry{id,state,position} into the Pr_state fields; map unknown state strings to a non-actionable value.
- Carry the fields through Poller.poll, patch_controller apply, and the new Orchestrator setters so Patch_agent reflects queue state.
- Nothing consumes these fields yet — is_automerge_candidate and the executor are unchanged, so behavior is identical.
- Implement the GraphQL-parse test stub from Patch 1 with a fixture JSON body.

## Changes
- Add the merge-queue fields to the GraphQL query and the pull_request record; thread main_branch from config to the query variable via the client.
- Parse mergeQueue presence, pullRequest.id, and mergeQueueEntry{id,state,position} into the Pr_state fields; map unknown state strings to a non-actionable value.
- Carry the fields through Poller.poll, patch_controller apply, and the new Orchestrator setters so Patch_agent reflects queue state.
- Nothing consumes these fields yet — is_automerge_candidate and the executor are unchanged, so behavior is identical.
- Implement the GraphQL-parse test stub from Patch 1 with a fixture JSON body.

## Files to Modify
- lib/github.ml (modify): Extend the GraphQL PR query (lib/github.ml:124): add a $mergeQueueBranch:String variable, repository.mergeQueue(branch:$mergeQueueBranch){id}, pullRequest.id, and pullRequest.mergeQueueEntry{id state position}. Add corresponding fields to the pull_request record (lib/github.ml:300). In pr_state_of_pull_request (lib/github.ml:385) set merge_queue_required = (mergeQueue present), node_id = pullRequest.id, and parse mergeQueueEntry into merge_queue_entry (mapping the state string to merge_queue_entry_state, unknown->Mq_locked). Store main_branch on the client and pass it as the mergeQueueBranch variable in pr_state.
- lib/github.mli (modify): Update the make signature to take ~main_branch.
- lib/forge.mli (modify): No interface change here (pr_state signature unchanged); main_branch is captured at construction. (Edit only if a doc comment needs updating.)
- lib_core/poller.ml (modify): Populate Poller.t.merge_queue_required and merge_queue_entry from the Pr_state in poll (replace the inert defaults from Patch 1).
- lib/patch_controller.ml (modify): In the apply step (~lib/patch_controller.ml:193), push poll_result.merge_queue_required and merge_queue_entry into the orchestrator via new Orchestrator setters (set_merge_queue_required / set_merge_queue_entry).
- lib/orchestrator.ml (modify): Add set_merge_queue_required / set_merge_queue_entry wrappers delegating to the Patch_agent setters.
- lib/orchestrator.mli (modify): Expose the two new setters.
- bin/main.ml (modify): Pass ~main_branch into Github.make at the construction site.

## Gameplan Specification

```
module MERGE_QUEUE_SUPPORT.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> After this gameplan, onton responds correctly to GitHub repos with a
> merge queue: on a queue-governed target branch it adds approved PRs to
> the queue (enqueuePullRequest) instead of direct-merging, tracks the
> queue entry, and removes PRs that lose approval — while repos without a
> merge queue keep the unchanged direct-merge path.

Pr.
MqState.
mq-queued => MqState.
mq-awaiting-checks => MqState.
mq-mergeable => MqState.
mq-unmergeable => MqState.
mq-locked => MqState.
MergeAction.
act-merge => MergeAction.
act-enqueue => MergeAction.
act-dequeue => MergeAction.
act-none => MergeAction.
requires-merge-queue? p: Pr => Bool.
enqueued? p: Pr => Bool.
approved? p: Pr => Bool.
checks-passing? p: Pr => Bool.
merged? p: Pr => Bool.
mq-state p: Pr => MqState.
mq-position p: Pr => Nat0.
action p: Pr => MergeAction.
---
> Detection: an enqueued PR always carries a known queue state.
all p: Pr, enqueued? p | mq-state p = mq-queued or mq-state p = mq-awaiting-checks or mq-state p = mq-mergeable or mq-state p = mq-unmergeable or mq-state p = mq-locked.

> Enqueue an approved, idle, not-yet-queued PR on a queue-governed branch.
all p: Pr, requires-merge-queue? p and approved? p and checks-passing? p and ~(enqueued? p) and ~(merged? p) | action p = act-enqueue.

> Direct merge only where no queue governs the branch.
all p: Pr, action p = act-merge | ~(requires-merge-queue? p).

> Never re-enqueue a PR that is already queued (idempotency).
all p: Pr, action p = act-enqueue | ~(enqueued? p).

> A queued, still-approved, non-unmergeable PR is left to the queue.
all p: Pr, enqueued? p and approved? p and mq-state p ~= mq-unmergeable | action p = act-none.

> A queued PR that lost approval is removed from the queue.
all p: Pr, enqueued? p and ~(approved? p) | action p = act-dequeue.

> An unmergeable entry is never silently waited on (it becomes a failure).
all p: Pr, enqueued? p and mq-state p = mq-unmergeable | action p ~= act-none.

> A merged PR triggers no further action.
all p: Pr, merged? p | action p = act-none.

where

> ══════════════════════════════════════════
> DISPLAY
> ══════════════════════════════════════════
> The TUI shows queue state for enqueued PRs and nothing otherwise.

shown-queued? p: Pr => Bool.
---
all p: Pr, shown-queued? p | enqueued? p.
all p: Pr, enqueued? p | shown-queued? p.
```

## Patch Specification

```
module MERGE_QUEUE_SUPPORT_PATCH_2.

> Patch 2 populates the polled snapshot from GitHub. The invariant is
> that an enqueued PR always carries a well-formed queue state.

Pr.
MqState.
mq-queued => MqState.
mq-awaiting-checks => MqState.
mq-mergeable => MqState.
mq-unmergeable => MqState.
mq-locked => MqState.
enqueued? p: Pr => Bool.
requires-merge-queue? p: Pr => Bool.
mq-state p: Pr => MqState.
---
> Detection and entry-state are populated; an enqueued PR has one of the
> five known states (unknown strings collapse to mq-locked).
all p: Pr, enqueued? p | mq-state p = mq-queued or mq-state p = mq-awaiting-checks or mq-state p = mq-mergeable or mq-state p = mq-unmergeable or mq-state p = mq-locked.
```


## Implementation Notes

- `Github.make` now captures `main_branch` because merge-queue detection is repository/branch-scoped. The only extra call-site beyond the main runtime was `Prune_runner`, which constructs a forge for refreshes from stored config.
- `Repository.mergeQueue` is decoded as a presence marker only. The query still selects `id` because GraphQL requires a sub-selection, but the OCaml code intentionally uses only null-vs-non-null for this patch.
- `mergeQueueEntry.position` defaults to `0` if GitHub omits it, preserving the `Nat0` invariant without making the whole poll fail on a partial queue-entry object. Entries without an `id` are ignored, so `enqueued?` only becomes true when the dequeue-capable node id is available for later patches.
- Unknown `MergeQueueEntryState` strings map to `Mq_locked`, which is the planned non-actionable waiting fallback. This was covered with a fixture using `SOME_FUTURE_STATE`.
- Spec/Evidence Mapping: the Patch 2 invariant that every enqueued PR has one of the five modeled states is implemented in `Github.parse_merge_queue_entry_state` and the `Pr_state.merge_queue_entry` construction path, carried through `Poller.poll` and `Patch_controller.apply_poll_result` into `Patch_agent`; evidence is `test_github_merge_commit_null`’s merge-queue fixture plus `dune build` and `dune runtest`.