### PR TITLE
[merge-queue-support] Patch 3: Forge enqueue/dequeue operations (uncalled)

### DIFF
--- a/lib/forge.ml
+++ b/lib/forge.ml
@@ -15,6 +15,10 @@ module type S = sig
     | Merge_queued of string
     | Merge_unconfirmed
 
+  type enqueue_result =
+    | Enqueued of Pr_state.merge_queue_entry
+    | Already_enqueued of Pr_state.merge_queue_entry
+
   val pr_state : Types.Pr_number.t -> (Pr_state.t, error) Result.t
 
   val list_prs :
@@ -46,5 +50,9 @@ module type S = sig
       implementation detects the allowed methods (squash/merge/rebase) and picks
       one — callers must not assume squash. *)
 
+  val enqueue_pr :
+    pr_number:Types.Pr_number.t -> (enqueue_result, error) Result.t
+
+  val dequeue_pr : entry_id:string -> (unit, error) Result.t
   val check_repo_access : unit -> (unit, error) Result.t
 end

--- a/lib/forge.mli
+++ b/lib/forge.mli
@@ -15,6 +15,10 @@ module type S = sig
     | Merge_queued of string
     | Merge_unconfirmed
 
+  type enqueue_result =
+    | Enqueued of Pr_state.merge_queue_entry
+    | Already_enqueued of Pr_state.merge_queue_entry
+
   val pr_state : Types.Pr_number.t -> (Pr_state.t, error) Result.t
 
   val list_prs :
@@ -46,5 +50,9 @@ module type S = sig
       implementation detects the allowed methods (squash/merge/rebase) and picks
       one — callers must not assume squash. *)
 
+  val enqueue_pr :
+    pr_number:Types.Pr_number.t -> (enqueue_result, error) Result.t
+
+  val dequeue_pr : entry_id:string -> (unit, error) Result.t
   val check_repo_access : unit -> (unit, error) Result.t
 end

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -142,7 +142,6 @@ let graphql_query =
       headRefName
       headRefOid
       baseRefName
-      mergeQueueEntry { id state position }
       mergeCommit { oid }
       mergeQueueEntry {
         id

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -226,7 +226,8 @@ let parse_merge_queue_entry_state = function
   | "AWAITING_CHECKS" -> Pr_state.Mq_awaiting_checks
   | "MERGEABLE" -> Pr_state.Mq_mergeable
   | "UNMERGEABLE" -> Pr_state.Mq_unmergeable
-  | "LOCKED" | _ -> Pr_state.Mq_locked
+  | "LOCKED" -> Pr_state.Mq_locked
+  | _ -> Pr_state.Mq_queued
 
 (* Typed model of the GraphQL PR response. Every nullable scalar/object is an
    [option] ([@yojson.default None] tolerates both a missing key and an explicit
@@ -324,12 +325,23 @@ type merge_queue = Merge_queue_present
 
 let merge_queue_of_yojson _ = Merge_queue_present
 
-type merge_queue_entry = {
+type merge_queue_entry_node = {
   id : string option; [@yojson.default None]
   state : string option; [@yojson.default None]
   position : int option; [@yojson.default None]
 }
 [@@deriving of_yojson] [@@yojson.allow_extra_fields]
+
+let merge_queue_entry_of_node (node : merge_queue_entry_node) =
+  match node.id with
+  | None -> None
+  | Some id ->
+      let state =
+        Option.value_map node.state ~default:Pr_state.Mq_queued
+          ~f:parse_merge_queue_entry_state
+      in
+      let position = Option.value node.position ~default:0 in
+      Some { Pr_state.id; state; position }
 
 type pull_request = {
   id : string option; [@yojson.default None]
@@ -342,13 +354,13 @@ type pull_request = {
   head_ref_oid : string option; [@key "headRefOid"] [@yojson.default None]
   base_ref_name : string option; [@key "baseRefName"] [@yojson.default None]
   merge_commit : oid_obj option; [@key "mergeCommit"] [@yojson.default None]
-  merge_queue_entry : merge_queue_entry option;
-      [@key "mergeQueueEntry"] [@yojson.default None]
   commits : commits; [@yojson.default { nodes = [] }]
   review_threads : review_threads;
       [@key "reviewThreads"] [@yojson.default { nodes = [] }]
   head_repository_owner : repo_owner option;
       [@key "headRepositoryOwner"] [@yojson.default None]
+  merge_queue_entry : merge_queue_entry_node option;
+      [@key "mergeQueueEntry"] [@yojson.default None]
 }
 [@@deriving of_yojson] [@@yojson.allow_extra_fields]
 
@@ -478,15 +490,7 @@ let pr_state_of_pull_request ~owner ~merge_queue_required (pr : pull_request) :
     | None -> false
   in
   let merge_queue_entry =
-    Option.bind pr.merge_queue_entry ~f:(fun entry ->
-        Option.map entry.id ~f:(fun id ->
-            {
-              Pr_state.id;
-              state =
-                Option.value_map entry.state ~default:Pr_state.Mq_locked
-                  ~f:parse_merge_queue_entry_state;
-              position = Option.value entry.position ~default:0;
-            }))
+    Option.bind pr.merge_queue_entry ~f:merge_queue_entry_of_node
   in
   {
     Pr_state.status;
@@ -544,6 +548,116 @@ let parse_response_json ~owner json =
 let parse_response ~owner body =
   try parse_response_json ~owner (Yojson.Safe.from_string body)
   with Yojson.Json_error msg -> Error (Json_parse_error msg)
+
+let graphql_errors json =
+  match Json.field "errors" json with
+  | None -> None
+  | Some errors_json -> (
+      match Json.list errors_json with
+      | Some [] -> None
+      | Some errors ->
+          Some (List.filter_map errors ~f:(Json.string_field "message"))
+      | None -> Some [])
+
+let merge_queue_entry_field ~context json =
+  match json with
+  | None -> Error (Json_parse_error (context ^ " missing mergeQueueEntry"))
+  | Some entry_json -> (
+      match Json.try_of_yojson merge_queue_entry_node_of_yojson entry_json with
+      | Error msg -> Error (Json_parse_error msg)
+      | Ok entry_node -> (
+          match merge_queue_entry_of_node entry_node with
+          | Some entry -> Ok entry
+          | None ->
+              Error (Json_parse_error (context ^ " mergeQueueEntry missing id"))
+          ))
+
+let parse_enqueue_response_json json =
+  match graphql_errors json with
+  | Some msgs -> Error (Graphql_error msgs)
+  | None ->
+      let entry_json =
+        Json.field "data" json
+        |> Option.bind ~f:(Json.field "enqueuePullRequest")
+        |> Option.bind ~f:(Json.field "mergeQueueEntry")
+      in
+      merge_queue_entry_field ~context:"enqueuePullRequest" entry_json
+
+let parse_enqueue_response body =
+  match Yojson.Safe.from_string body with
+  | exception Yojson.Json_error msg -> Error (Json_parse_error msg)
+  | json -> parse_enqueue_response_json json
+
+let parse_dequeue_response_json json =
+  match graphql_errors json with
+  | Some msgs -> Error (Graphql_error msgs)
+  | None -> (
+      match
+        Json.field "data" json
+        |> Option.bind ~f:(Json.field "dequeuePullRequest")
+      with
+      | Some _ -> Ok ()
+      | None ->
+          Error (Json_parse_error "dequeuePullRequest response missing payload")
+      )
+
+let parse_dequeue_response body =
+  match Yojson.Safe.from_string body with
+  | exception Yojson.Json_error msg -> Error (Json_parse_error msg)
+  | json -> parse_dequeue_response_json json
+
+type enqueue_pr_info_pull_request = {
+  enqueue_info_id : string option; [@key "id"] [@yojson.default None]
+  enqueue_info_head_ref_oid : string option;
+      [@key "headRefOid"] [@yojson.default None]
+  enqueue_info_merge_queue_entry : merge_queue_entry_node option;
+      [@key "mergeQueueEntry"] [@yojson.default None]
+}
+[@@deriving of_yojson] [@@yojson.allow_extra_fields]
+
+type enqueue_pr_info = {
+  node_id : string;
+  head_oid : string;
+  merge_queue_entry : Pr_state.merge_queue_entry option;
+}
+
+let parse_enqueue_pr_info_response body =
+  match Yojson.Safe.from_string body with
+  | exception Yojson.Json_error msg -> Error (Json_parse_error msg)
+  | json -> (
+      match graphql_errors json with
+      | Some msgs -> Error (Graphql_error msgs)
+      | None -> (
+          let pr_json =
+            Json.field "data" json
+            |> Option.bind ~f:(Json.field "repository")
+            |> Option.bind ~f:(Json.field "pullRequest")
+          in
+          match pr_json with
+          | None -> Error (Json_parse_error "pullRequest not found")
+          | Some pr_json -> (
+              match
+                Json.try_of_yojson enqueue_pr_info_pull_request_of_yojson
+                  pr_json
+              with
+              | Error msg -> Error (Json_parse_error msg)
+              | Ok pr -> (
+                  match (pr.enqueue_info_id, pr.enqueue_info_head_ref_oid) with
+                  | Some node_id, Some head_oid ->
+                      Ok
+                        {
+                          node_id;
+                          head_oid;
+                          merge_queue_entry =
+                            Option.bind pr.enqueue_info_merge_queue_entry
+                              ~f:merge_queue_entry_of_node;
+                        }
+                  | None, _ ->
+                      Error (Json_parse_error "pullRequest response missing id")
+                  | _, None ->
+                      Error
+                        (Json_parse_error
+                           "pullRequest response missing headRefOid")))))
 
 let https_config () =
   match Ca_certs.authenticator () with
@@ -654,6 +768,37 @@ let pr_state ~net ~clock ?timeout t pr =
     request ~net ~clock ?timeout t ~meth:`POST ~path:"/graphql" ~body ()
   with
   | Ok resp_str -> parse_response ~owner:t.owner resp_str
+  | Error _ as e -> e
+
+let enqueue_info_query =
+  {|query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
+      id
+      headRefOid
+      mergeQueueEntry { id state position }
+    }
+  }
+}|}
+
+let build_enqueue_info_request_body t (pr : Types.Pr_number.t) =
+  let variables =
+    `Assoc
+      [
+        ("owner", `String t.owner);
+        ("repo", `String t.repo);
+        ("number", `Int (Types.Pr_number.to_int pr));
+      ]
+  in
+  `Assoc [ ("query", `String enqueue_info_query); ("variables", variables) ]
+  |> Yojson.Safe.to_string
+
+let enqueue_pr_info ~net ~clock ?timeout t pr =
+  let body = build_enqueue_info_request_body t pr in
+  match
+    request ~net ~clock ?timeout t ~meth:`POST ~path:"/graphql" ~body ()
+  with
+  | Ok resp_str -> parse_enqueue_pr_info_response resp_str
   | Error _ as e -> e
 
 (** Parse the REST response from [GET /repos/:owner/:repo/pulls]. Returns a list
@@ -832,6 +977,10 @@ type merge_result =
           the patch merged, but also don't count as a failure — the poller will
           observe the real PR state next cycle. *)
 
+type enqueue_result =
+  | Enqueued of Pr_state.merge_queue_entry
+  | Already_enqueued of Pr_state.merge_queue_entry
+
 (** Interpret a 2xx body from [PUT /pulls/:n/merge].
     - Valid JSON with [merged = true] → [Merge_succeeded].
     - Valid JSON with [merged = false] → [Merge_queued msg].
@@ -873,6 +1022,66 @@ let merge_pr ~net ~clock ?timeout t ~pr_number ~merge_method =
   in
   match request ~net ~clock ?timeout t ~meth:`PUT ~path ~body:req_body () with
   | Ok body -> Ok (interpret_merge_response body)
+  | Error _ as e -> e
+
+let enqueue_pull_request_mutation =
+  {|mutation($pullRequestId: ID!, $expectedHeadOid: GitObjectID!) {
+  enqueuePullRequest(input: {
+    pullRequestId: $pullRequestId,
+    expectedHeadOid: $expectedHeadOid
+  }) {
+    mergeQueueEntry { id state position }
+  }
+}|}
+
+let dequeue_pull_request_mutation =
+  {|mutation($id: ID!) {
+  dequeuePullRequest(input: { id: $id }) {
+    clientMutationId
+  }
+}|}
+
+let enqueue_pr ~net ~clock ?timeout t ~pr_number =
+  Result.bind (enqueue_pr_info ~net ~clock ?timeout t pr_number) ~f:(fun info ->
+      match info.merge_queue_entry with
+      | Some entry -> Ok (Already_enqueued entry)
+      | None -> (
+          let req_body =
+            `Assoc
+              [
+                ("query", `String enqueue_pull_request_mutation);
+                ( "variables",
+                  `Assoc
+                    [
+                      ("pullRequestId", `String info.node_id);
+                      ("expectedHeadOid", `String info.head_oid);
+                    ] );
+              ]
+            |> Yojson.Safe.to_string
+          in
+          match
+            request ~net ~clock ?timeout t ~meth:`POST ~path:"/graphql"
+              ~body:req_body ()
+          with
+          | Error _ as e -> e
+          | Ok resp ->
+              Result.map (parse_enqueue_response resp) ~f:(fun entry ->
+                  Enqueued entry)))
+
+let dequeue_pr ~net ~clock ?timeout t ~entry_id =
+  let req_body =
+    `Assoc
+      [
+        ("query", `String dequeue_pull_request_mutation);
+        ("variables", `Assoc [ ("id", `String entry_id) ]);
+      ]
+    |> Yojson.Safe.to_string
+  in
+  match
+    request ~net ~clock ?timeout t ~meth:`POST ~path:"/graphql" ~body:req_body
+      ()
+  with
+  | Ok resp -> parse_dequeue_response resp
   | Error _ as e -> e
 
 (* Which merge methods the repository permits. GitHub rejects a [PUT
@@ -938,6 +1147,13 @@ let get_repo_merge_methods ~net ~clock ?timeout t :
 let is_method_not_allowed = function
   | Http_error { status = 405; body; _ } ->
       response_error_message_contains body ~substring:"not allowed"
+  | Http_error _ | Json_parse_error _ | Graphql_error _ | Timeout _
+  | Transport_error _ ->
+      false
+
+let is_merge_queue_required_error = function
+  | Http_error { status = 405; body; _ } ->
+      response_error_message_contains body ~substring:"merge queue"
   | Http_error _ | Json_parse_error _ | Graphql_error _ | Timeout _
   | Transport_error _ ->
       false
@@ -1177,6 +1393,10 @@ let make ~net ~clock ~token ~owner ~repo ~main_branch :
       | Merge_queued of string
       | Merge_unconfirmed
 
+    type nonrec enqueue_result = enqueue_result =
+      | Enqueued of Pr_state.merge_queue_entry
+      | Already_enqueued of Pr_state.merge_queue_entry
+
     let pr_state pr_number = pr_state ~net ~clock client pr_number
 
     let list_prs ~branch ?base ~state () =
@@ -1198,6 +1418,8 @@ let make ~net ~clock ~token ~owner ~repo ~main_branch :
       set_draft ~net ~clock client ~pr_number ~draft
 
     let merge_pr ~pr_number = merge_pr_choosing ~pr_number
+    let enqueue_pr ~pr_number = enqueue_pr ~net ~clock client ~pr_number
+    let dequeue_pr ~entry_id = dequeue_pr ~net ~clock client ~entry_id
     let check_repo_access () = check_repo_access_internal ~net ~clock client
   end in
   (module M)

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -142,6 +142,7 @@ let graphql_query =
       headRefName
       headRefOid
       baseRefName
+      mergeQueueEntry { id state position }
       mergeCommit { oid }
       mergeQueueEntry {
         id

--- a/lib/github.mli
+++ b/lib/github.mli
@@ -65,6 +65,27 @@ type merge_result =
           as non-authoritative: don't mark merged, don't count as failure — the
           poller will observe the real PR state next cycle. *)
 
+type enqueue_result =
+  | Enqueued of Pr_state.merge_queue_entry
+  | Already_enqueued of Pr_state.merge_queue_entry
+
+val parse_enqueue_response :
+  string -> (Pr_state.merge_queue_entry, error) Result.t
+(** Parse an [enqueuePullRequest] GraphQL response body. Pure helper exposed for
+    regression tests. *)
+
+val parse_dequeue_response : string -> (unit, error) Result.t
+(** Parse a [dequeuePullRequest] GraphQL response body. Pure helper exposed for
+    regression tests. *)
+
+val is_method_not_allowed : error -> bool
+(** True only for the REST 405 response GitHub returns when a merge method is
+    disabled for the repository. *)
+
+val is_merge_queue_required_error : error -> bool
+(** True only for the REST 405 response GitHub returns when the branch requires
+    native merge queue use. *)
+
 val make :
   net:_ Eio.Net.t ->
   clock:_ Eio.Time.clock ->

--- a/test/test_github_merge_commit_null.ml
+++ b/test/test_github_merge_commit_null.ml
@@ -83,12 +83,74 @@ let pending_patch_2_parse_merge_queue_and_entry () =
       Stdlib.exit 1
 
 let pending_patch_3_enqueue_and_dequeue_parsing () =
-  (* PENDING: Patch 3 - enqueue and dequeue mutation response parsing. *)
-  ()
+  let enqueue_body =
+    {|{
+      "data": {
+        "enqueuePullRequest": {
+          "mergeQueueEntry": {
+            "id": "MQE_123",
+            "state": "AWAITING_CHECKS",
+            "position": 7
+          }
+        }
+      }
+    }|}
+  in
+  (match Onton.Github.parse_enqueue_response enqueue_body with
+  | Ok entry ->
+      assert (String.equal entry.Onton_core.Pr_state.id "MQE_123");
+      assert (
+        Onton_core.Pr_state.equal_merge_queue_entry_state
+          entry.Onton_core.Pr_state.state Onton_core.Pr_state.Mq_awaiting_checks);
+      assert (entry.Onton_core.Pr_state.position = 7)
+  | Error e ->
+      Printf.eprintf "  FAIL: enqueue response parse errored: %s\n"
+        (Onton.Github.show_error e);
+      Stdlib.exit 1);
+  (match
+     Onton.Github.parse_enqueue_response
+       {|{"data":{"enqueuePullRequest":{"mergeQueueEntry":{"id":"MQE_999","state":"FUTURE_STATE","position":2}}}}|}
+   with
+  | Ok entry ->
+      assert (
+        Onton_core.Pr_state.equal_merge_queue_entry_state
+          entry.Onton_core.Pr_state.state Onton_core.Pr_state.Mq_queued)
+  | Error e ->
+      Printf.eprintf "  FAIL: future enqueue state parse errored: %s\n"
+        (Onton.Github.show_error e);
+      Stdlib.exit 1);
+  match
+    Onton.Github.parse_dequeue_response
+      {|{"data":{"dequeuePullRequest":{"clientMutationId":null}}}|}
+  with
+  | Ok () -> ()
+  | Error e ->
+      Printf.eprintf "  FAIL: dequeue response parse errored: %s\n"
+        (Onton.Github.show_error e);
+      Stdlib.exit 1
 
 let pending_patch_3_merge_queue_405_detection () =
-  (* PENDING: Patch 3 - is_merge_queue_required_error detects the 405 merge-queue body. *)
-  ()
+  let merge_queue_err =
+    Onton.Github.Http_error
+      {
+        meth = "PUT";
+        path = "/repos/o/r/pulls/1/merge";
+        status = 405;
+        body = {|{"message":"Changes must be made through the merge queue"}|};
+      }
+  in
+  let base_modified_err =
+    Onton.Github.Http_error
+      {
+        meth = "PUT";
+        path = "/repos/o/r/pulls/1/merge";
+        status = 405;
+        body = {|{"message":"Base branch was modified"}|};
+      }
+  in
+  assert (Onton.Github.is_merge_queue_required_error merge_queue_err);
+  assert (not (Onton.Github.is_method_not_allowed merge_queue_err));
+  assert (not (Onton.Github.is_merge_queue_required_error base_modified_err))
 
 let () =
   pending_patch_2_parse_merge_queue_and_entry ();

--- a/test/test_github_merge_commit_null.ml
+++ b/test/test_github_merge_commit_null.ml
@@ -72,7 +72,7 @@ let pending_patch_2_parse_merge_queue_and_entry () =
           assert (String.equal entry.Onton_core.Pr_state.id "MQE_node_456");
           assert (
             Onton_core.Pr_state.equal_merge_queue_entry_state
-              entry.Onton_core.Pr_state.state Onton_core.Pr_state.Mq_locked);
+              entry.Onton_core.Pr_state.state Onton_core.Pr_state.Mq_queued);
           assert (entry.Onton_core.Pr_state.position = 7);
           Stdlib.print_endline
             "  merge queue GraphQL fields: OK (required + entry)"

--- a/test/test_github_merge_commit_null.ml
+++ b/test/test_github_merge_commit_null.ml
@@ -6,12 +6,13 @@
    into [Json_parse_error] — failing the *entire* poll on every cycle and
    blinding the orchestrator to the PR's state. See [lib/github.ml]. *)
 
-let pr_json ~merge_commit =
+let pr_json ?(merge_queue_entry = "null") ~merge_commit () =
   Printf.sprintf
     {|{
       "data": {
         "repository": {
           "pullRequest": {
+            "id": "PR_node_1",
             "state": "OPEN",
             "mergeable": "MERGEABLE",
             "isDraft": true,
@@ -20,6 +21,7 @@ let pr_json ~merge_commit =
             "reviewThreads": { "nodes": [] },
             "headRefName": "feature-branch",
             "headRefOid": "abc123",
+            "mergeQueueEntry": %s,
             "mergeCommit": %s,
             "baseRefName": "main",
             "headRepositoryOwner": { "login": "flowglad" }
@@ -27,7 +29,7 @@ let pr_json ~merge_commit =
         }
       }
     }|}
-    merge_commit
+    merge_queue_entry merge_commit
 
 let parse s =
   Onton.Github.parse_response_json ~owner:"flowglad" (Yojson.Safe.from_string s)
@@ -158,8 +160,13 @@ let () =
   pending_patch_3_merge_queue_405_detection ();
   (* Open PR: mergeCommit is null. Must parse Ok with merge_commit_sha = None,
      not crash the poll. *)
-  (match parse (pr_json ~merge_commit:"null") with
+  (match parse (pr_json ~merge_commit:"null" ()) with
   | Ok st ->
+      assert (
+        match st.Onton_core.Pr_state.node_id with
+        | Some "PR_node_1" -> true
+        | _ -> false);
+      assert (Option.is_none st.Onton_core.Pr_state.merge_queue_entry);
       assert (Option.is_none st.Onton_core.Pr_state.merge_commit_sha);
       Stdlib.print_endline "  open PR (mergeCommit:null): OK (None)"
   | Error e ->
@@ -167,8 +174,35 @@ let () =
         (Onton.Github.show_error e);
       Stdlib.exit 1);
 
+  (* Enqueued PR: mergeQueueEntry should propagate through normal pr_state
+     parsing, not only through the dedicated enqueue-info query. *)
+  (match
+     parse
+       (pr_json ~merge_commit:"null"
+          ~merge_queue_entry:
+            {|{ "id": "MQE_node_1", "state": "MERGEABLE", "position": 3 }|}
+          ())
+   with
+  | Ok st -> (
+      match st.Onton_core.Pr_state.merge_queue_entry with
+      | Some entry ->
+          assert (String.equal entry.Onton_core.Pr_state.id "MQE_node_1");
+          assert (
+            Onton_core.Pr_state.equal_merge_queue_entry_state
+              entry.Onton_core.Pr_state.state Onton_core.Pr_state.Mq_mergeable);
+          assert (entry.Onton_core.Pr_state.position = 3);
+          Stdlib.print_endline
+            "  enqueued PR (mergeQueueEntry): OK (MQE_node_1)"
+      | None ->
+          Printf.eprintf "  FAIL: enqueued PR missing merge_queue_entry\n";
+          Stdlib.exit 1)
+  | Error e ->
+      Printf.eprintf "  FAIL: enqueued PR poll errored: %s\n"
+        (Onton.Github.show_error e);
+      Stdlib.exit 1);
+
   (* Merged PR: mergeCommit present. Must still read the oid through. *)
-  (match parse (pr_json ~merge_commit:{|{ "oid": "deadbeef" }|}) with
+  (match parse (pr_json ~merge_commit:{|{ "oid": "deadbeef" }|} ()) with
   | Ok st ->
       assert (
         match st.Onton_core.Pr_state.merge_commit_sha with


### PR DESCRIPTION
## Patch 3: Forge enqueue/dequeue operations (uncalled)

- Add enqueue_result to Forge.S and github, mirroring the merge_result re-export.
- Implement the enqueuePullRequest mutation (input pullRequestId:ID!, expectedHeadOid) returning Enqueued/Already_enqueued; resolve the PR node id from PullRequest.id.
- Implement the dequeuePullRequest mutation keyed on the MergeQueueEntry id (NOT the PR id).
- Add is_merge_queue_required_error matching the 405 'Changes must be made through the merge queue' body, distinct from is_method_not_allowed and from the 'Base branch was modified' 405.
- No caller yet — reconcile and the executor are unchanged; the operations are dead until Patch 4.
- Implement the enqueue/dequeue response-parse and is_merge_queue_required_error test stubs from Patch 1.

## Changes
- Add enqueue_result to Forge.S and github, mirroring the merge_result re-export.
- Implement the enqueuePullRequest mutation (input pullRequestId:ID!, expectedHeadOid) returning Enqueued/Already_enqueued; resolve the PR node id from PullRequest.id.
- Implement the dequeuePullRequest mutation keyed on the MergeQueueEntry id (NOT the PR id).
- Add is_merge_queue_required_error matching the 405 'Changes must be made through the merge queue' body, distinct from is_method_not_allowed and from the 'Base branch was modified' 405.
- No caller yet — reconcile and the executor are unchanged; the operations are dead until Patch 4.
- Implement the enqueue/dequeue response-parse and is_merge_queue_required_error test stubs from Patch 1.

## Files to Modify
- lib/forge.mli (modify): Add `type enqueue_result = Enqueued of Pr_state.merge_queue_entry | Already_enqueued of Pr_state.merge_queue_entry` and `val enqueue_pr : pr_number:Types.Pr_number.t -> (enqueue_result, error) Result.t` and `val dequeue_pr : entry_id:string -> (unit, error) Result.t` to module type S.
- lib/github.ml (modify): Implement enqueue_pr: resolve the PR node id + head oid (reuse the PR query or a small dedicated query), check the polled mergeQueueEntry for idempotency (return Already_enqueued when present), then run the enqueuePullRequest GraphQL mutation with expectedHeadOid and parse the returned mergeQueueEntry. Implement dequeue_pr via the dequeuePullRequest mutation keyed on entry_id. Add is_merge_queue_required_error (HTTP 405 with body containing 'merge queue'). Wire both into module M (lib/github.ml:1112).
- lib/github.mli (modify): Re-export enqueue_result and the new operations and is_merge_queue_required_error following the merge_result re-export pattern.

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[documentation] GitHub GraphQL API — enqueuePullRequest / dequeuePullRequest mutations** — https://docs.github.com/en/graphql/reference/mutations — Pins the exact mutation names and inputs: enqueuePullRequest takes pullRequestId:ID! (the PullRequest.id node id) plus optional expectedHeadOid; dequeuePullRequest takes id:ID! which is the MergeQueueEntry node id, NOT the PR id — a common and silent mistake the implementer must avoid.

## Gameplan Specification

```
module MERGE_QUEUE_SUPPORT.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> After this gameplan, onton responds correctly to GitHub repos with a
> merge queue: on a queue-governed target branch it adds approved PRs to
> the queue (enqueuePullRequest) instead of direct-merging, tracks the
> queue entry, and removes PRs that lose approval — while repos without a
> merge queue keep the unchanged direct-merge path.

Pr.
MqState.
mq-queued => MqState.
mq-awaiting-checks => MqState.
mq-mergeable => MqState.
mq-unmergeable => MqState.
mq-locked => MqState.
MergeAction.
act-merge => MergeAction.
act-enqueue => MergeAction.
act-dequeue => MergeAction.
act-none => MergeAction.
requires-merge-queue? p: Pr => Bool.
enqueued? p: Pr => Bool.
approved? p: Pr => Bool.
checks-passing? p: Pr => Bool.
merged? p: Pr => Bool.
mq-state p: Pr => MqState.
mq-position p: Pr => Nat0.
action p: Pr => MergeAction.
---
> Detection: an enqueued PR always carries a known queue state.
all p: Pr, enqueued? p | mq-state p = mq-queued or mq-state p = mq-awaiting-checks or mq-state p = mq-mergeable or mq-state p = mq-unmergeable or mq-state p = mq-locked.

> Enqueue an approved, idle, not-yet-queued PR on a queue-governed branch.
all p: Pr, requires-merge-queue? p and approved? p and checks-passing? p and ~(enqueued? p) and ~(merged? p) | action p = act-enqueue.

> Direct merge only where no queue governs the branch.
all p: Pr, action p = act-merge | ~(requires-merge-queue? p).

> Never re-enqueue a PR that is already queued (idempotency).
all p: Pr, action p = act-enqueue | ~(enqueued? p).

> A queued, still-approved, non-unmergeable PR is left to the queue.
all p: Pr, enqueued? p and approved? p and mq-state p ~= mq-unmergeable | action p = act-none.

> A queued PR that lost approval is removed from the queue.
all p: Pr, enqueued? p and ~(approved? p) | action p = act-dequeue.

> An unmergeable entry is never silently waited on (it becomes a failure).
all p: Pr, enqueued? p and mq-state p = mq-unmergeable | action p ~= act-none.

> A merged PR triggers no further action.
all p: Pr, merged? p | action p = act-none.

where

> ══════════════════════════════════════════
> DISPLAY
> ══════════════════════════════════════════
> The TUI shows queue state for enqueued PRs and nothing otherwise.

shown-queued? p: Pr => Bool.
---
all p: Pr, shown-queued? p | enqueued? p.
all p: Pr, enqueued? p | shown-queued? p.
```

## Patch Specification

```
module MERGE_QUEUE_SUPPORT_PATCH_3.

> Patch 3 adds the enqueue/dequeue forge operations. The contract is that
> enqueue is only meaningful on a queue-governed branch and is idempotent.

Pr.
requires-merge-queue? p: Pr => Bool.
enqueued? p: Pr => Bool.
can-enqueue? p: Pr => Bool.
enqueue-idempotent? p: Pr => Bool.
---
> Enqueue applies only where a queue is configured.
all p: Pr, can-enqueue? p | requires-merge-queue? p.
> Enqueuing an already-queued PR is a no-op (Already_enqueued).
all p: Pr, enqueued? p | enqueue-idempotent? p.
```


## Implementation Notes

- `enqueue_pr` uses a small GraphQL PR-info query rather than the full poll query so this dead forge operation can resolve `PullRequest.id`, `headRefOid`, and any existing `mergeQueueEntry` without depending on Patch 2's repository queue detection work.
- Queue-entry parsing maps unknown future `MergeQueueEntryState` strings to `Mq_queued`. That preserves the forward-compatible "wait, do not fail or treat as unmergeable" behavior while still satisfying the known-state invariant with the current Patch 1 type set.
- `dequeue_pr` intentionally accepts `entry_id:string`, not a PR number/node id, to make the `dequeuePullRequest(input:{id})` contract hard to misuse at the Patch 4 call site.
- I exposed the enqueue/dequeue response parsers and the two 405 classifiers from `Github` for direct regression tests; the actual forge operations remain reachable only through `Forge.S` via `Github.make`.

Spec/Evidence Mapping:
- Idempotent enqueue: `lib/github.ml` checks `mergeQueueEntry` before mutation and returns `Already_enqueued`; covered by `dune build` type checking and parser regression coverage in `test/test_github_merge_commit_null.ml`.
- Known queue state: `merge_queue_entry_of_node` normalizes all known GitHub states and defaults unknown states to `Mq_queued`; covered by the future-state parser assertion in `test/test_github_merge_commit_null.ml`.
- Merge-queue 405 split: `is_merge_queue_required_error` matches the `"merge queue"` 405 separately from `is_method_not_allowed` and `"Base branch was modified"`; covered by `test/test_github_merge_commit_null.ml`.
- Required context consulted: existing REST merge/fallback path in `lib/github.ml` and runner automerge handling, plus GitHub's GraphQL mutation reference for `enqueuePullRequest` / `dequeuePullRequest`.
- Verification run: `dune fmt`, `dune build`, and `dune runtest`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds GitHub merge queue enqueue/dequeue to the forge with idempotent enqueue, and updates PR parsing to include the PR node id and queue entry. Wired into `github` but not called yet; behavior change lands in Patch 4.

- New Features
  - Add `enqueue_result` and `enqueue_pr`/`dequeue_pr` to `Forge.S` and `github`; enqueue is idempotent by checking `mergeQueueEntry` first and returning `Already_enqueued`.
  - Implement GraphQL `enqueuePullRequest` (uses PR `id` + `expectedHeadOid`) and `dequeuePullRequest` (by `MergeQueueEntry` id); expose `parse_enqueue_response`/`parse_dequeue_response` for tests.
  - Extend PR polling to fetch `PullRequest.id` and `mergeQueueEntry`; map unknown queue states to `Mq_queued` for forward compatibility.
  - Add `is_merge_queue_required_error` to detect the “merge queue required” 405 separately from `is_method_not_allowed`.

- Bug Fixes
  - Fix merge queue parser test to expect unknown states as queued and verify PR `id`/`mergeQueueEntry` parsing.

<sup>Written for commit c381987262b24ddc5b814d919d840557cf86f2b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/flowglad/onton/pull/349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for GitHub's native merge queue, enabling pull requests to be enqueued for later processing and dequeued by entry ID.
  * Enhanced pull request state tracking to include merge queue entries with position and status information.
  * Improved error detection to identify when merge queue is required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->