### PR TITLE
[merge-queue-support] Patch 5: TUI: show merge-queue state and position

### DIFF
--- a/lib/tui.ml
+++ b/lib/tui.ml
@@ -637,8 +637,8 @@ let render_patch_row ~width ~selected ~now (pv : patch_view) =
   let cursor = if selected then "▸" else " " in
   let row =
     Term.fit_width width
-      (Printf.sprintf "%s%s %s %s%s  %s%s%s%s" cursor patch_label pr_label
-         badge queue_badge pv.title ci_info dep_info am_info)
+      (Printf.sprintf "%s%s %s %s%s  %s%s%s%s" cursor patch_label pr_label badge
+         queue_badge pv.title ci_info dep_info am_info)
   in
   if selected then Term.styled [ Term.Sgr.bold ] row else row
 
@@ -745,8 +745,7 @@ let detail_info_rows (pv : patch_view) ~width ~now =
   let badge = render_status_badge ~queued:(pv_queued pv) pv.status in
   let queue_badge = render_merge_queue_badge pv.merge_queue_entry in
   let status_line =
-    if String.is_empty queue_badge then
-      Printf.sprintf "  Status:      %s" badge
+    if String.is_empty queue_badge then Printf.sprintf "  Status:      %s" badge
     else Printf.sprintf "  Status:      %s %s" badge queue_badge
   in
   let lines =

--- a/lib/tui.ml
+++ b/lib/tui.ml
@@ -310,6 +310,7 @@ type patch_view = {
   ci_checks : Ci_check.t list;
   recent_stream : activity_entry list;
   pr_number : Pr_number.t option;
+  merge_queue_entry : Pr_state.merge_queue_entry option;
   pr_missing : bool;
       (** [true] when [pr_number] is set but the remote no longer has the PR.
           Distinguishes "we lost the PR" from "we have the PR" so the row label
@@ -468,6 +469,7 @@ let patch_view_of_agent (agent : Patch_agent.t)
     ci_checks = agent.ci_checks;
     recent_stream = [];
     pr_number = Patch_agent.pr_number agent;
+    merge_queue_entry = agent.Patch_agent.merge_queue_entry;
     pr_missing = Patch_agent.is_pr_missing agent;
     base_branch = agent.base_branch;
     worktree_path = agent.worktree_path;
@@ -484,11 +486,28 @@ let patch_view_of_agent (agent : Patch_agent.t)
 
 let styled_status status text = Term.styled (status_style status) text
 
+let render_badge ~style ~indicator ~label =
+  Term.styled style (Printf.sprintf "%s %s" indicator label)
+
 let render_status_badge ?(queued = false) status =
-  let ind = status_indicator status in
-  let lbl = label status in
-  let suffix = if queued then " (queued)" else "" in
-  styled_status status (Printf.sprintf "%s %s%s" ind lbl suffix)
+  let lbl = label status ^ if queued then " (queued)" else "" in
+  render_badge ~style:(status_style status) ~indicator:(status_indicator status)
+    ~label:lbl
+
+let merge_queue_badge_state = function
+  | Pr_state.Mq_queued -> (Awaiting_review, "mq-queued")
+  | Mq_awaiting_checks -> (Awaiting_ci, "mq-awaiting-checks")
+  | Mq_mergeable -> (Approved_idle, "mq-mergeable")
+  | Mq_unmergeable -> (Needs_help, "mq-unmergeable")
+  | Mq_locked -> (Ci_queued, "mq-locked")
+
+let render_merge_queue_badge = function
+  | None -> ""
+  | Some (entry : Pr_state.merge_queue_entry) ->
+      let status, state_label = merge_queue_badge_state entry.state in
+      render_badge ~style:(status_style status)
+        ~indicator:(status_indicator status)
+        ~label:(Printf.sprintf "%s #%d" state_label entry.position)
 
 let is_running_status = function
   | Fixing_ci | Addressing_review | Addressing_findings | Resolving_conflict
@@ -576,6 +595,10 @@ let automerge_inline_info ~now (pv : patch_view) =
 
 let render_patch_row ~width ~selected ~now (pv : patch_view) =
   let badge = render_status_badge ~queued:(pv_queued pv) pv.status in
+  let queue_badge = render_merge_queue_badge pv.merge_queue_entry in
+  let queue_badge =
+    if String.is_empty queue_badge then "" else " " ^ queue_badge
+  in
   let patch_label =
     let id_str = Patch_id.to_string pv.patch_id in
     let id_short =
@@ -614,8 +637,8 @@ let render_patch_row ~width ~selected ~now (pv : patch_view) =
   let cursor = if selected then "▸" else " " in
   let row =
     Term.fit_width width
-      (Printf.sprintf "%s%s %s %s  %s%s%s%s" cursor patch_label pr_label badge
-         pv.title ci_info dep_info am_info)
+      (Printf.sprintf "%s%s %s %s%s  %s%s%s%s" cursor patch_label pr_label
+         badge queue_badge pv.title ci_info dep_info am_info)
   in
   if selected then Term.styled [ Term.Sgr.bold ] row else row
 
@@ -720,11 +743,17 @@ let detail_info_rows (pv : patch_view) ~width ~now =
   in
   let rule = Term.hrule width in
   let badge = render_status_badge ~queued:(pv_queued pv) pv.status in
+  let queue_badge = render_merge_queue_badge pv.merge_queue_entry in
+  let status_line =
+    if String.is_empty queue_badge then
+      Printf.sprintf "  Status:      %s" badge
+    else Printf.sprintf "  Status:      %s %s" badge queue_badge
+  in
   let lines =
     [
       header;
       rule;
-      Printf.sprintf "  Status:      %s" badge;
+      status_line;
       fit_value "  Patch ID:    " (Patch_id.to_string pv.patch_id);
       fit_value "  Branch:      " (Branch.to_string pv.branch);
       fit_value "  Base:        "

--- a/lib/tui.ml
+++ b/lib/tui.ml
@@ -496,10 +496,10 @@ let render_status_badge ?(queued = false) status =
 
 let merge_queue_badge_state = function
   | Pr_state.Mq_queued -> (Awaiting_review, "mq-queued")
-  | Mq_awaiting_checks -> (Awaiting_ci, "mq-awaiting-checks")
-  | Mq_mergeable -> (Approved_idle, "mq-mergeable")
-  | Mq_unmergeable -> (Needs_help, "mq-unmergeable")
-  | Mq_locked -> (Ci_queued, "mq-locked")
+  | Pr_state.Mq_awaiting_checks -> (Awaiting_ci, "mq-awaiting-checks")
+  | Pr_state.Mq_mergeable -> (Approved_idle, "mq-mergeable")
+  | Pr_state.Mq_unmergeable -> (Needs_help, "mq-unmergeable")
+  | Pr_state.Mq_locked -> (Ci_queued, "mq-locked")
 
 let render_merge_queue_badge = function
   | None -> ""

--- a/lib/tui.mli
+++ b/lib/tui.mli
@@ -102,6 +102,7 @@ type patch_view = {
   ci_checks : Ci_check.t list;
   recent_stream : activity_entry list;
   pr_number : Pr_number.t option;
+  merge_queue_entry : Pr_state.merge_queue_entry option;
   pr_missing : bool;
       (** [true] when [pr_number] is set but the remote no longer has the PR
           ([pr_status = Missing _]). Distinguishes "we lost it" from "we have

--- a/test/test_tui_render_frame.ml
+++ b/test/test_tui_render_frame.ml
@@ -27,6 +27,7 @@ let make_view ~id ~title =
     ci_checks = [];
     recent_stream = [];
     pr_number = None;
+    merge_queue_entry = None;
     pr_missing = false;
     base_branch = None;
     worktree_path = None;
@@ -189,12 +190,27 @@ let test_patches_render_above_activity () =
   | Some p, Some a -> assert (p < a)
   | _ -> assert false
 
-let pending_patch_5_merge_queue_badge () =
-  (* PENDING: Patch 5 - an enqueued patch renders a merge-queue badge with position. *)
-  ()
+let test_patch_5_merge_queue_badge () =
+  let pv =
+    {
+      (make_view ~id:"1" ~title:"queued patch") with
+      Tui.status = Tui.Approved_idle;
+      Tui.pr_number = Some (Pr_number.of_int 42);
+      Tui.merge_queue_entry =
+        Some
+          {
+            Onton_core.Pr_state.id = "mqe_123";
+            state = Onton_core.Pr_state.Mq_awaiting_checks;
+            position = 3;
+          };
+    }
+  in
+  let frame = render [ pv ] in
+  let lines = plain_lines frame in
+  assert (line_contains lines "mq-awaiting-checks #3")
 
 let () =
-  pending_patch_5_merge_queue_badge ();
+  test_patch_5_merge_queue_badge ();
   test_header_has_project_and_backend ();
   test_header_truncates_when_too_narrow ();
   test_no_summary_row ();


### PR DESCRIPTION
## Patch 5: TUI: show merge-queue state and position

- Render the merge-queue state and position for an enqueued PR using the existing badge style.
- No change for PRs not in a queue (empty render), so non-queue repos look identical.
- Implement the TUI badge test stub from Patch 1.

## Changes
- Render the merge-queue state and position for an enqueued PR using the existing badge style.
- No change for PRs not in a queue (empty render), so non-queue repos look identical.
- Implement the TUI badge test stub from Patch 1.

## Files to Modify
- lib/tui.ml (modify): Add a merge-queue status indication for enqueued PRs (state + position), following the existing status-badge idiom (render_status_badge / the '(queued)' suffix convention). Read the new Patch_agent merge_queue_entry field; render nothing when not enqueued.

## Gameplan Specification

```
module MERGE_QUEUE_SUPPORT.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> After this gameplan, onton responds correctly to GitHub repos with a
> merge queue: on a queue-governed target branch it adds approved PRs to
> the queue (enqueuePullRequest) instead of direct-merging, tracks the
> queue entry, and removes PRs that lose approval — while repos without a
> merge queue keep the unchanged direct-merge path.

Pr.
MqState.
mq-queued => MqState.
mq-awaiting-checks => MqState.
mq-mergeable => MqState.
mq-unmergeable => MqState.
mq-locked => MqState.
MergeAction.
act-merge => MergeAction.
act-enqueue => MergeAction.
act-dequeue => MergeAction.
act-none => MergeAction.
requires-merge-queue? p: Pr => Bool.
enqueued? p: Pr => Bool.
approved? p: Pr => Bool.
checks-passing? p: Pr => Bool.
merged? p: Pr => Bool.
mq-state p: Pr => MqState.
mq-position p: Pr => Nat0.
action p: Pr => MergeAction.
---
> Detection: an enqueued PR always carries a known queue state.
all p: Pr, enqueued? p | mq-state p = mq-queued or mq-state p = mq-awaiting-checks or mq-state p = mq-mergeable or mq-state p = mq-unmergeable or mq-state p = mq-locked.

> Enqueue an approved, idle, not-yet-queued PR on a queue-governed branch.
all p: Pr, requires-merge-queue? p and approved? p and checks-passing? p and ~(enqueued? p) and ~(merged? p) | action p = act-enqueue.

> Direct merge only where no queue governs the branch.
all p: Pr, action p = act-merge | ~(requires-merge-queue? p).

> Never re-enqueue a PR that is already queued (idempotency).
all p: Pr, action p = act-enqueue | ~(enqueued? p).

> A queued, still-approved, non-unmergeable PR is left to the queue.
all p: Pr, enqueued? p and approved? p and mq-state p ~= mq-unmergeable | action p = act-none.

> A queued PR that lost approval is removed from the queue.
all p: Pr, enqueued? p and ~(approved? p) | action p = act-dequeue.

> An unmergeable entry is never silently waited on (it becomes a failure).
all p: Pr, enqueued? p and mq-state p = mq-unmergeable | action p ~= act-none.

> A merged PR triggers no further action.
all p: Pr, merged? p | action p = act-none.

where

> ══════════════════════════════════════════
> DISPLAY
> ══════════════════════════════════════════
> The TUI shows queue state for enqueued PRs and nothing otherwise.

shown-queued? p: Pr => Bool.
---
all p: Pr, shown-queued? p | enqueued? p.
all p: Pr, enqueued? p | shown-queued? p.
```

## Patch Specification

```
module MERGE_QUEUE_SUPPORT_PATCH_5.

> Patch 5 surfaces queue state in the TUI. Display-only.

Pr.
enqueued? p: Pr => Bool.
shown-queued? p: Pr => Bool.
---
> The queue badge is shown exactly when the PR is enqueued.
all p: Pr, shown-queued? p | enqueued? p.
all p: Pr, enqueued? p | shown-queued? p.
```


## Implementation Notes

- I kept the queue display on the existing badge path rather than introducing a separate render branch. `patch_view` now carries `merge_queue_entry`, and both list/detail views call the same `render_merge_queue_badge` helper in [lib/tui.ml](/Users/zax/worktrees/merge-queue-support/patch-5/lib/tui.ml). That keeps badge styling and truncation behavior aligned with the existing status badge implementation from R6.

- The queue state is rendered as a second badge, not folded into the primary status label. The primary badge still reflects the patch's operational state (`approved`, `awaiting-ci`, etc.); the queue badge is additive queue metadata (`mq-awaiting-checks #3`, etc.). This avoids overloading `display_status` with GitHub-specific queue enums and keeps the TUI's existing state derivation untouched.

- Non-enqueued patches remain byte-for-byte unchanged on this path: `render_merge_queue_badge None` returns `""`, and the row/detail format only inserts the extra spacing when a queue badge is present.

- `Mq_*` queue states are mapped onto existing badge styles intentionally, not semantically reclassified in the core model: `mq-awaiting-checks` uses the waiting-CI style, `mq-unmergeable` uses the failure style, and so on. This gives the queue badge the established visual language without inventing new TUI colors/glyphs for a display-only patch.

- No deviation from plan on behavior, but the pending test stub was implemented at the frame-render level in [test/test_tui_render_frame.ml](/Users/zax/worktrees/merge-queue-support/patch-5/test/test_tui_render_frame.ml) rather than as a helper-unit test. That exercises the actual rendered output seen by operators.

- Spec/Evidence Mapping:
  - `shown-queued? p -> enqueued? p`: the queue badge is only emitted from `pv.merge_queue_entry`; `None` renders empty in `render_merge_queue_badge`. Implemented in [lib/tui.ml](/Users/zax/worktrees/merge-queue-support/patch-5/lib/tui.ml). Context consulted: R6 (`lib/tui.ml:20-180`, `487-580`). Evidence: `dune build`, `dune runtest`.
  - `enqueued? p -> shown-queued? p`: any populated `merge_queue_entry` is threaded from `Patch_agent` into `patch_view` and appended in both list and detail status lines. Implemented in [lib/tui.ml](/Users/zax/worktrees/merge-queue-support/patch-5/lib/tui.ml) and [lib/tui.mli](/Users/zax/worktrees/merge-queue-support/patch-5/lib/tui.mli). Evidence: `test_patch_5_merge_queue_badge` in [test/test_tui_render_frame.ml](/Users/zax/worktrees/merge-queue-support/patch-5/test/test_tui_render_frame.ml), plus full `dune runtest`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the merge-queue state and position in the TUI as a second badge next to the main status. Non-queued PRs render unchanged.

- **New Features**
  - Threaded `merge_queue_entry` into `patch_view` and render a queue badge when present (e.g., "mq-awaiting-checks #3"). Uses qualified `Pr_state.Mq_*` variants mapped onto existing badge styles via a shared renderer.
  - Display the queue badge in list rows and the detail "Status" line; omit spacing when not enqueued. Added a frame-level test to assert the correct state and position render.

<sup>Written for commit d2aa5ff2c7dd3e33b6176b18691e79deaa6021ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/flowglad/onton/pull/350?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

