### PR TITLE
[merge-queue-support] Patch 4: Action-aware automerge: enqueue/dequeue on queue-governed branches

### DIFF
--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -607,14 +607,14 @@ let merge_queue_entry_unmergeable (entry : Pr_state.merge_queue_entry) =
   Pr_state.equal_merge_queue_entry_state entry.state Pr_state.Mq_unmergeable
 
 let automerge_action (agent : Patch_agent.t) ~main_branch =
+  let approved = Patch_agent.is_approved agent ~main_branch in
   match (agent.Patch_agent.merge_queue_required, agent.merge_queue_entry) with
   | true, Some entry when merge_queue_entry_unmergeable entry -> None
-  | true, Some entry when not (Patch_agent.is_approved agent ~main_branch) ->
-      Some (Dequeue entry.id)
+  | true, Some entry when not approved -> Some (Dequeue entry.id)
   | true, Some _ -> None
-  | true, None -> Some Enqueue
-  | false, Some entry when not (Patch_agent.is_approved agent ~main_branch) ->
-      Some (Dequeue entry.id)
+  | true, None when approved -> Some Enqueue
+  | true, None -> None
+  | false, Some entry when not approved -> Some (Dequeue entry.id)
   | false, Some _ -> None
   | false, None -> Some Direct_merge
 

--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -573,6 +573,10 @@ let automerge_max_failures = 3
     default prevents a future caller from forgetting the inflight guard. *)
 let is_automerge_candidate ?(ignore_inflight = false) (agent : Patch_agent.t)
     ~main_branch =
+  let enqueued_and_still_approved =
+    Option.is_some agent.Patch_agent.merge_queue_entry
+    && Patch_agent.is_approved agent ~main_branch
+  in
   (ignore_inflight || not agent.Patch_agent.automerge_inflight)
   (* [not merged] looks redundant with [reconcile_automerge]'s early-return
      on [agent.merged], but it is specifically load-bearing for the executor
@@ -584,15 +588,46 @@ let is_automerge_candidate ?(ignore_inflight = false) (agent : Patch_agent.t)
   && (not agent.Patch_agent.merged)
   && agent.Patch_agent.automerge_enabled
   && Patch_agent.is_approved agent ~main_branch
+  && (not enqueued_and_still_approved)
   && agent.Patch_agent.checks_passing
   && List.is_empty agent.Patch_agent.queue
   && agent.Patch_agent.automerge_failure_count < automerge_max_failures
 
+type merge_action = Direct_merge | Enqueue | Dequeue of string
+[@@deriving show, eq, sexp_of]
+
 type automerge_decision = {
   merge_patch_id : Patch_id.t;
   merge_pr_number : Pr_number.t;
+  action : merge_action;
 }
 [@@deriving show, eq, sexp_of]
+
+let merge_queue_entry_unmergeable (entry : Pr_state.merge_queue_entry) =
+  Pr_state.equal_merge_queue_entry_state entry.state Pr_state.Mq_unmergeable
+
+let automerge_action (agent : Patch_agent.t) ~main_branch =
+  match (agent.Patch_agent.merge_queue_required, agent.merge_queue_entry) with
+  | true, Some entry when merge_queue_entry_unmergeable entry -> None
+  | true, Some entry when not (Patch_agent.is_approved agent ~main_branch) ->
+      Some (Dequeue entry.id)
+  | true, Some _ -> None
+  | true, None -> Some Enqueue
+  | false, Some entry when not (Patch_agent.is_approved agent ~main_branch) ->
+      Some (Dequeue entry.id)
+  | false, Some _ -> None
+  | false, None -> Some Direct_merge
+
+let apply_automerge_failure_state t ~now patch_id =
+  let t = Orchestrator.set_automerge_inflight t patch_id false in
+  let t = Orchestrator.increment_automerge_failure_count t patch_id in
+  let agent = Orchestrator.agent t patch_id in
+  if agent.Patch_agent.automerge_failure_count >= automerge_max_failures then
+    Orchestrator.clear_automerge_deadline t patch_id
+  else if not agent.Patch_agent.automerge_enabled then t
+  else
+    Orchestrator.set_automerge_deadline t patch_id
+      (now +. automerge_idle_timeout)
 
 (** Reconcile the automerge deadline for every agent. Returns the updated
     orchestrator and the list of patches whose deadline has now elapsed (the
@@ -647,7 +682,25 @@ let reconcile_automerge t ~now =
            so both guards must stay in sync. *)
         (t, decisions)
       else
-        let candidate = is_automerge_candidate agent ~main_branch in
+        let unmergeable_entry =
+          Option.exists agent.Patch_agent.merge_queue_entry
+            ~f:merge_queue_entry_unmergeable
+        in
+        let approved = Patch_agent.is_approved agent ~main_branch in
+        let cleanup_candidate =
+          Option.is_some agent.Patch_agent.merge_queue_entry && not approved
+        in
+        let candidate =
+          if unmergeable_entry then
+            agent.Patch_agent.automerge_enabled
+            && agent.Patch_agent.automerge_failure_count
+               < automerge_max_failures
+          else if cleanup_candidate then
+            agent.Patch_agent.automerge_enabled
+            && agent.Patch_agent.automerge_failure_count
+               < automerge_max_failures
+          else is_automerge_candidate agent ~main_branch
+        in
         match (candidate, agent.Patch_agent.automerge_deadline) with
         | false, Some _ ->
             (* Feedback arrived, lost approval, CI flipped, or failure cap
@@ -661,11 +714,25 @@ let reconcile_automerge t ~now =
         | true, Some deadline ->
             if Float.( >= ) now deadline then
               match Patch_agent.pr_number agent with
-              | Some pr_number when Patch_agent.is_pr_present agent ->
-                  let t = Orchestrator.set_automerge_inflight t patch_id true in
-                  ( t,
-                    { merge_patch_id = patch_id; merge_pr_number = pr_number }
-                    :: decisions )
+              | Some pr_number when Patch_agent.is_pr_present agent -> (
+                  if unmergeable_entry then
+                    (apply_automerge_failure_state t ~now patch_id, decisions)
+                  else
+                    match automerge_action agent ~main_branch with
+                    | None ->
+                        ( Orchestrator.clear_automerge_deadline t patch_id,
+                          decisions )
+                    | Some action ->
+                        let t =
+                          Orchestrator.set_automerge_inflight t patch_id true
+                        in
+                        ( t,
+                          {
+                            merge_patch_id = patch_id;
+                            merge_pr_number = pr_number;
+                            action;
+                          }
+                          :: decisions ))
               | Some _ | None ->
                   (* Unreachable today because [is_automerge_candidate]
                      requires [is_approved] which requires [has_pr]. Defensive
@@ -697,22 +764,7 @@ let apply_automerge_success t patch_id =
       in flight): writing a deadline would contradict the disabled state and
       stick around until the next tick cleared it. *)
 let apply_automerge_failure t ~now patch_id =
-  let t = Orchestrator.set_automerge_inflight t patch_id false in
-  let t = Orchestrator.increment_automerge_failure_count t patch_id in
-  let agent = Orchestrator.agent t patch_id in
-  if agent.Patch_agent.automerge_failure_count >= automerge_max_failures then
-    (* Clear any existing deadline so the persisted snapshot unambiguously
-       reflects the terminal state; the next reconcile would clear it anyway
-       via the non-candidate path, but leaving it in place between these two
-       events is misleading in traces and on-disk state. *)
-    Orchestrator.clear_automerge_deadline t patch_id
-  else if not agent.Patch_agent.automerge_enabled then
-    (* User disabled automerge while the call was in flight — toggling off
-       already cleared the deadline, so nothing more to do here. *)
-    t
-  else
-    Orchestrator.set_automerge_deadline t patch_id
-      (now +. automerge_idle_timeout)
+  apply_automerge_failure_state t ~now patch_id
 
 let make_orchestrator ~patch_id ~main_branch =
   let patch =

--- a/lib/patch_controller.mli
+++ b/lib/patch_controller.mli
@@ -116,9 +116,13 @@ val automerge_max_failures : int
     which cannot happen once the cap is hit, so the toggle is the only
     recovery). *)
 
+type merge_action = Direct_merge | Enqueue | Dequeue of string
+[@@deriving show, eq, sexp_of]
+
 type automerge_decision = {
   merge_patch_id : Patch_id.t;
   merge_pr_number : Pr_number.t;
+  action : merge_action;
 }
 [@@deriving show, eq, sexp_of]
 

--- a/lib/runner_fiber_impl.ml
+++ b/lib/runner_fiber_impl.ml
@@ -295,7 +295,7 @@ struct
                               queue after approval was lost"
                              (Pr_number.to_int pr_number))
                     | Error err ->
-                        apply_failure ();
+                        push_deadline_and_clear_inflight ();
                         log_event runtime ~patch_id
                           (Printf.sprintf
                              "Automerge dequeue failed for PR #%d — %s"

--- a/lib/runner_fiber_impl.ml
+++ b/lib/runner_fiber_impl.ml
@@ -286,14 +286,14 @@ struct
                 | Patch_controller.Dequeue entry_id -> (
                     match Forge.dequeue_pr ~entry_id with
                     | Ok () ->
-                        clear_inflight_if_needed ();
+                        push_deadline_and_clear_inflight ();
                         log_event runtime ~patch_id
                           (Printf.sprintf
                              "Automerge dequeued PR #%d from GitHub merge \
                               queue after approval was lost"
                              (Pr_number.to_int pr_number))
                     | Error err ->
-                        clear_inflight_if_needed ();
+                        apply_failure ();
                         log_event runtime ~patch_id
                           (Printf.sprintf
                              "Automerge dequeue failed for PR #%d — %s"

--- a/lib/runner_fiber_impl.ml
+++ b/lib/runner_fiber_impl.ml
@@ -146,7 +146,8 @@ struct
      windows, and [automerge_inflight] already prevents double-claiming. *)
     Eio.Fiber.List.iter ~max_fibers:4
       (fun Patch_controller.
-             { merge_patch_id = patch_id; merge_pr_number = pr_number } ->
+             { merge_patch_id = patch_id; merge_pr_number = pr_number; action }
+         ->
         let label =
           Printf.sprintf "automerge PR #%d" (Pr_number.to_int pr_number)
         in
@@ -182,6 +183,36 @@ struct
                 Orchestrator.set_automerge_deadline orch patch_id
                   (now_ts +. Patch_controller.automerge_idle_timeout)))
         in
+        let apply_failure () =
+          inflight_cleared := true;
+          Runtime.update_orchestrator runtime (fun orch ->
+              Patch_controller.apply_automerge_failure orch
+                ~now:(Unix.gettimeofday ()) patch_id)
+        in
+        let handle_enqueue_result result =
+          match result with
+          | Ok (Forge.Enqueued entry) ->
+              push_deadline_and_clear_inflight ();
+              log_event runtime ~patch_id
+                (Printf.sprintf
+                   "Automerge enqueued PR #%d in GitHub merge queue (%s, \
+                    position %d)"
+                   (Pr_number.to_int pr_number)
+                   entry.Pr_state.id entry.Pr_state.position)
+          | Ok (Forge.Already_enqueued entry) ->
+              push_deadline_and_clear_inflight ();
+              log_event runtime ~patch_id
+                (Printf.sprintf
+                   "Automerge PR #%d already in GitHub merge queue (%s, \
+                    position %d)"
+                   (Pr_number.to_int pr_number)
+                   entry.Pr_state.id entry.Pr_state.position)
+          | Error err ->
+              apply_failure ();
+              log_event runtime ~patch_id
+                (Printf.sprintf "Automerge enqueue failed — %s"
+                   (Forge.show_error err))
+        in
         Fun.protect ~finally:clear_inflight_if_needed (fun () ->
             (* Re-read the patch just before hitting GitHub. The original
              decision came from an earlier orchestrator snapshot; between then
@@ -198,7 +229,7 @@ struct
                     Orchestrator.find_agent snap.Runtime.orchestrator patch_id
                   with
                   | None -> false
-                  | Some agent ->
+                  | Some agent -> (
                       let main_branch =
                         Orchestrator.main_branch snap.Runtime.orchestrator
                       in
@@ -215,11 +246,25 @@ struct
                        the inflight short-circuit that the predicate applies
                        by default — necessary here because this re-check runs
                        while we hold the flag. *)
-                      (match Patch_agent.pr_number agent with
+                      let same_pr =
+                        match Patch_agent.pr_number agent with
                         | Some current -> Pr_number.equal current pr_number
-                        | None -> false)
-                      && Patch_controller.is_automerge_candidate
-                           ~ignore_inflight:true agent ~main_branch)
+                        | None -> false
+                      in
+                      same_pr
+                      &&
+                      match action with
+                      | Patch_controller.Direct_merge | Patch_controller.Enqueue
+                        ->
+                          Patch_controller.is_automerge_candidate
+                            ~ignore_inflight:true agent ~main_branch
+                      | Patch_controller.Dequeue entry_id -> (
+                          (not (Patch_agent.is_approved agent ~main_branch))
+                          &&
+                          match agent.Patch_agent.merge_queue_entry with
+                          | Some entry ->
+                              String.equal entry.Pr_state.id entry_id
+                          | None -> false)))
             in
             if not still_candidate then (
               log_event runtime ~patch_id
@@ -235,50 +280,75 @@ struct
               clear_inflight_if_needed ())
             else
               try
-                match Forge.merge_pr ~pr_number with
-                | Ok Forge.Merge_succeeded ->
-                    inflight_cleared := true;
-                    Runtime.update_orchestrator runtime (fun orch ->
-                        Patch_controller.apply_automerge_success orch patch_id);
-                    log_event runtime ~patch_id
-                      (Printf.sprintf "Automerge complete — PR #%d merged"
-                         (Pr_number.to_int pr_number))
-                | Ok (Forge.Merge_queued msg) ->
-                    (* GitHub accepted the request into its native auto-merge
-                     queue. Not a failure — don't bump the counter. Push the
-                     deadline forward (atomically with clearing [inflight]) so
-                     we don't re-fire before the poller observes the eventual
-                     merge. *)
-                    push_deadline_and_clear_inflight ();
-                    log_event runtime ~patch_id
-                      (Printf.sprintf
-                         "Automerge queued by GitHub — awaiting checks (%s)" msg)
-                | Ok Forge.Merge_unconfirmed ->
-                    (* 2xx response with an unexpected shape. Not authoritative
-                     either way — let the poller confirm via PR state rather
-                     than guess. Don't count as failure, but push the
-                     deadline forward (atomic with clearing [inflight]) so we
-                     don't retry every tick. *)
-                    push_deadline_and_clear_inflight ();
-                    log_event runtime ~patch_id
-                      (Printf.sprintf
-                         "%s accepted but merge not confirmed — awaiting poll"
-                         label)
-                | Error err ->
-                    inflight_cleared := true;
-                    Runtime.update_orchestrator runtime (fun orch ->
-                        Patch_controller.apply_automerge_failure orch
-                          ~now:(Unix.gettimeofday ()) patch_id);
-                    log_event runtime ~patch_id
-                      (Printf.sprintf "Automerge failed — %s"
-                         (Forge.show_error err))
+                match action with
+                | Patch_controller.Enqueue ->
+                    handle_enqueue_result (Forge.enqueue_pr ~pr_number)
+                | Patch_controller.Dequeue entry_id -> (
+                    match Forge.dequeue_pr ~entry_id with
+                    | Ok () ->
+                        clear_inflight_if_needed ();
+                        log_event runtime ~patch_id
+                          (Printf.sprintf
+                             "Automerge dequeued PR #%d from GitHub merge \
+                              queue after approval was lost"
+                             (Pr_number.to_int pr_number))
+                    | Error err ->
+                        clear_inflight_if_needed ();
+                        log_event runtime ~patch_id
+                          (Printf.sprintf
+                             "Automerge dequeue failed for PR #%d — %s"
+                             (Pr_number.to_int pr_number)
+                             (Forge.show_error err)))
+                | Patch_controller.Direct_merge -> (
+                    match Forge.merge_pr ~pr_number with
+                    | Ok Forge.Merge_succeeded ->
+                        inflight_cleared := true;
+                        Runtime.update_orchestrator runtime (fun orch ->
+                            Patch_controller.apply_automerge_success orch
+                              patch_id);
+                        log_event runtime ~patch_id
+                          (Printf.sprintf "Automerge complete — PR #%d merged"
+                             (Pr_number.to_int pr_number))
+                    | Ok (Forge.Merge_queued msg) ->
+                        (* GitHub accepted the request into its native auto-merge
+                         queue. Not a failure — don't bump the counter. Push the
+                         deadline forward (atomically with clearing [inflight]) so
+                         we don't re-fire before the poller observes the eventual
+                         merge. *)
+                        push_deadline_and_clear_inflight ();
+                        log_event runtime ~patch_id
+                          (Printf.sprintf
+                             "Automerge queued by GitHub — awaiting checks (%s)"
+                             msg)
+                    | Ok Forge.Merge_unconfirmed ->
+                        (* 2xx response with an unexpected shape. Not authoritative
+                         either way — let the poller confirm via PR state rather
+                         than guess. Don't count as failure, but push the
+                         deadline forward (atomic with clearing [inflight]) so we
+                         don't retry every tick. *)
+                        push_deadline_and_clear_inflight ();
+                        log_event runtime ~patch_id
+                          (Printf.sprintf
+                             "%s accepted but merge not confirmed — awaiting \
+                              poll"
+                             label)
+                    | Error err ->
+                        if Github.is_merge_queue_required_error err then (
+                          log_event runtime ~patch_id
+                            (Printf.sprintf
+                               "Automerge direct merge rejected by GitHub \
+                                merge queue — enqueuing PR #%d"
+                               (Pr_number.to_int pr_number));
+                          handle_enqueue_result (Forge.enqueue_pr ~pr_number))
+                        else (
+                          apply_failure ();
+                          log_event runtime ~patch_id
+                            (Printf.sprintf "Automerge failed — %s"
+                               (Forge.show_error err))))
               with
               | Eio.Cancel.Cancelled _ as exn -> raise exn
               | exn ->
-                  inflight_cleared := true;
-                  Runtime.update_orchestrator runtime (fun orch ->
-                      Patch_controller.apply_automerge_failure orch
-                        ~now:(Unix.gettimeofday ()) patch_id);
+                  apply_failure ();
                   log_event runtime ~patch_id
                     (Printf.sprintf "%s crashed — %s" label
                        (Printexc.to_string exn))))

--- a/lib/runner_fiber_impl.ml
+++ b/lib/runner_fiber_impl.ml
@@ -239,13 +239,7 @@ struct
                        execute, hitting GitHub with the stale [pr_number]
                        would either merge the wrong PR (on the rare chance
                        the old PR is still open) or 405 and bump
-                       [automerge_failure_count] for no reason.
-                       [is_automerge_candidate] gates on everything else (not
-                       merged, automerge enabled, approval, CI, empty queue,
-                       failure cap) and [~ignore_inflight:true] opts out of
-                       the inflight short-circuit that the predicate applies
-                       by default — necessary here because this re-check runs
-                       while we hold the flag. *)
+                       [automerge_failure_count] for no reason. *)
                       let same_pr =
                         match Patch_agent.pr_number agent with
                         | Some current -> Pr_number.equal current pr_number
@@ -254,10 +248,18 @@ struct
                       same_pr
                       &&
                       match action with
-                      | Patch_controller.Direct_merge | Patch_controller.Enqueue
-                        ->
+                      | Patch_controller.Direct_merge ->
                           Patch_controller.is_automerge_candidate
                             ~ignore_inflight:true agent ~main_branch
+                      | Patch_controller.Enqueue ->
+                          agent.Patch_agent.merge_queue_required
+                          && (not agent.Patch_agent.merged)
+                          && agent.Patch_agent.automerge_enabled
+                          && Patch_agent.is_approved agent ~main_branch
+                          && agent.Patch_agent.checks_passing
+                          && List.is_empty agent.Patch_agent.queue
+                          && agent.Patch_agent.automerge_failure_count
+                             < Patch_controller.automerge_max_failures
                       | Patch_controller.Dequeue entry_id -> (
                           (not (Patch_agent.is_approved agent ~main_branch))
                           &&

--- a/test/test_patch_controller.ml
+++ b/test/test_patch_controller.ml
@@ -1369,6 +1369,32 @@ let () =
              (Orchestrator.agent orch pid).Patch_agent.automerge_deadline)
   in
 
+  let pending_patch_4_unapproved_not_enqueued =
+    Test.make
+      ~name:
+        "patch_controller: Patch 4 unapproved queue PR without entry is not \
+         enqueued" QCheck2.Gen.unit (fun () ->
+        let pid = Patch_id.of_string "mq-unapproved-not-enqueued" in
+        let branch = Branch.of_string "feat/mq-unapproved-not-enqueued" in
+        let patch = make_patch pid branch in
+        let agent =
+          make_agent ~patch_id:pid ~branch
+            ~pr_status:(Patch_pr_status.Present (Pr_number.of_int 405))
+            ~merged:false ~queue:[] ~base_branch:(Some main) ~is_draft:false
+            ~pr_body_delivered:true ~start_attempts_without_pr:0
+            ~merge_ready:false ~checks_passing:true ~merge_queue_required:true
+            ~automerge_enabled:true ~automerge_deadline:0.0 ()
+        in
+        let orch = make_orch patch agent in
+        let orch, decisions =
+          Patch_controller.reconcile_automerge orch ~now:1.0
+        in
+        let agent = Orchestrator.agent orch pid in
+        List.is_empty decisions
+        && Option.is_none agent.Patch_agent.automerge_deadline
+        && not agent.Patch_agent.automerge_inflight)
+  in
+
   let pending_patch_4_automerge_dequeue_on_lost_approval =
     Test.make
       ~name:
@@ -1436,6 +1462,7 @@ let () =
     [
       pending_patch_4_automerge_enqueue_action;
       pending_patch_4_automerge_enqueued_idle;
+      pending_patch_4_unapproved_not_enqueued;
       pending_patch_4_automerge_dequeue_on_lost_approval;
       pending_patch_4_unmergeable_counts_as_failure;
       prop_missing_adhoc_does_not_crash_reconcile;

--- a/test/test_patch_controller.ml
+++ b/test/test_patch_controller.ml
@@ -50,25 +50,28 @@ let make_orch patch agent =
     ~outbox:(Map.empty (module Message_id))
     ~main_branch:main ()
 
-let make_agent ~patch_id ~branch ~pr_status ~merged ~queue ~base_branch
-    ~is_draft ~pr_body_delivered ~start_attempts_without_pr =
+let make_agent ?(merge_ready = false) ?(merge_queue_required = false)
+    ?(merge_queue_entry = None) ?(checks_passing = false)
+    ?(automerge_enabled = false) ?automerge_deadline
+    ?(automerge_failure_count = 0) ~patch_id ~branch ~pr_status ~merged ~queue
+    ~base_branch ~is_draft ~pr_body_delivered ~start_attempts_without_pr () =
   Patch_agent.restore ~patch_id ~branch ~pr_status ~has_session:false
     ~busy:false ~merged ~queue ~satisfies:false ~changed:false
     ~has_conflict:false ~base_branch ~notified_base_branch:base_branch
     ~ci_failure_count:0 ~session_fallback:Patch_agent.Fresh_available
-    ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
-    ~merge_ready:false ~merge_queue_required:false ~merge_queue_entry:None
-    ~is_draft ~pr_body_delivered ~pr_body_artifact_miss_count:0
-    ~start_attempts_without_pr ~conflict_noop_count:0 ~no_commits_push_count:0
-    ~context_exhaustion_count:0 ~push_failure_count:0 ~branch_rebased_onto:None
+    ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[] ~merge_ready
+    ~merge_queue_required ~merge_queue_entry ~is_draft ~pr_body_delivered
+    ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr
+    ~conflict_noop_count:0 ~no_commits_push_count:0 ~context_exhaustion_count:0
+    ~push_failure_count:0 ~branch_rebased_onto:None
     ~branch_rebased_onto_sha:None ~merge_commit_sha:None
     ~base_contains_merged_siblings:true
-    ~anchor_history:Onton_core.Anchor_history.empty ~checks_passing:false
+    ~anchor_history:Onton_core.Anchor_history.empty ~checks_passing
     ~current_op:None ~current_op_state:Patch_agent.Queued
     ~current_message_id:None ~generation:0 ~worktree_path:None
-    ~branch_blocked:false ~llm_session_id:None ~automerge_enabled:false
-    ~automerge_deadline:None ~automerge_inflight:false
-    ~automerge_failure_count:0 ~delivered_ci_run_ids:[]
+    ~branch_blocked:false ~llm_session_id:None ~automerge_enabled
+    ~automerge_deadline ~automerge_inflight:false ~automerge_failure_count
+    ~delivered_ci_run_ids:[]
 
 let has_draft_effect effects =
   List.exists effects ~f:(function
@@ -124,7 +127,7 @@ let () =
       let patch = make_patch pid branch in
       let agent =
         make_agent ~patch_id:pid ~branch ~pr_status ~merged ~queue ~base_branch
-          ~is_draft ~pr_body_delivered ~start_attempts_without_pr
+          ~is_draft ~pr_body_delivered ~start_attempts_without_pr ()
       in
       return (patch, make_gameplan patch, make_orch patch agent))
   in
@@ -189,7 +192,7 @@ let () =
           make_agent ~patch_id:pid ~branch
             ~pr_status:(Patch_pr_status.Present (Pr_number.of_int 42))
             ~merged:false ~queue:[] ~base_branch:(Some main) ~is_draft:true
-            ~pr_body_delivered:false ~start_attempts_without_pr:0
+            ~pr_body_delivered:false ~start_attempts_without_pr:0 ()
         in
         let orch = make_orch patch agent in
         let orch1, _effects1 =
@@ -318,7 +321,7 @@ let () =
         let agent =
           make_agent ~patch_id:pid ~branch ~pr_status:Patch_pr_status.Absent
             ~merged:false ~queue:[] ~base_branch:None ~is_draft:false
-            ~pr_body_delivered:false ~start_attempts_without_pr:2
+            ~pr_body_delivered:false ~start_attempts_without_pr:2 ()
         in
         let orch = make_orch patch agent in
         let orch1, effects1 =
@@ -350,7 +353,7 @@ let () =
           make_agent ~patch_id:pid ~branch
             ~pr_status:(Patch_pr_status.Present (Pr_number.of_int 42))
             ~merged:false ~queue:[] ~base_branch:(Some main) ~is_draft:true
-            ~pr_body_delivered:false ~start_attempts_without_pr:0
+            ~pr_body_delivered:false ~start_attempts_without_pr:0 ()
         in
         let orch = make_orch patch agent in
         let orch, effects =
@@ -381,7 +384,7 @@ let () =
         let agent =
           make_agent ~patch_id:pid ~branch ~pr_status:Patch_pr_status.Absent
             ~merged:false ~queue:[] ~base_branch:None ~is_draft:false
-            ~pr_body_delivered:false ~start_attempts_without_pr:2
+            ~pr_body_delivered:false ~start_attempts_without_pr:2 ()
         in
         let orch = make_orch patch agent in
         let orch, effects =
@@ -564,7 +567,7 @@ let () =
           make_agent ~patch_id:pid ~branch
             ~pr_status:(Patch_pr_status.Present (Pr_number.of_int 42))
             ~merged:false ~queue:[] ~base_branch:(Some main) ~is_draft:true
-            ~pr_body_delivered:true ~start_attempts_without_pr:0
+            ~pr_body_delivered:true ~start_attempts_without_pr:0 ()
           |> fun agent -> Patch_agent.set_branch_rebased_onto agent main
         in
         let orch = make_orch patch agent in
@@ -609,7 +612,7 @@ let () =
           make_agent ~patch_id:pid ~branch
             ~pr_status:(Patch_pr_status.Present (Pr_number.of_int 42))
             ~merged:false ~queue:[] ~base_branch:(Some main) ~is_draft:true
-            ~pr_body_delivered:false ~start_attempts_without_pr:0
+            ~pr_body_delivered:false ~start_attempts_without_pr:0 ()
         in
         let orch = make_orch patch agent in
         let poll =
@@ -783,7 +786,7 @@ let () =
           make_agent ~patch_id:pid ~branch
             ~pr_status:(Patch_pr_status.Present (Pr_number.of_int 42))
             ~merged:false ~queue:[] ~base_branch:(Some main) ~is_draft:true
-            ~pr_body_delivered:false ~start_attempts_without_pr:0
+            ~pr_body_delivered:false ~start_attempts_without_pr:0 ()
         in
         let orch = make_orch patch agent in
         let poll =
@@ -825,7 +828,7 @@ let () =
           make_agent ~patch_id:pid ~branch
             ~pr_status:(Patch_pr_status.Present (Pr_number.of_int 42))
             ~merged:false ~queue:[] ~base_branch:None ~is_draft:true
-            ~pr_body_delivered:false ~start_attempts_without_pr:0
+            ~pr_body_delivered:false ~start_attempts_without_pr:0 ()
         in
         let orch = make_orch patch agent in
         let poll =
@@ -967,7 +970,7 @@ let () =
           make_agent ~patch_id:pid ~branch
             ~pr_status:(Patch_pr_status.Present (Pr_number.of_int 42))
             ~merged:false ~queue:[] ~base_branch:(Some branch) ~is_draft:true
-            ~pr_body_delivered:true ~start_attempts_without_pr:0
+            ~pr_body_delivered:true ~start_attempts_without_pr:0 ()
         in
         let orch = make_orch patch agent in
         let _orch', effects =
@@ -997,7 +1000,7 @@ let () =
           make_agent ~patch_id:pid ~branch
             ~pr_status:(Patch_pr_status.Present (Pr_number.of_int 42))
             ~merged:false ~queue:[] ~base_branch:(Some main) ~is_draft:true
-            ~pr_body_delivered:true ~start_attempts_without_pr:0
+            ~pr_body_delivered:true ~start_attempts_without_pr:0 ()
         in
         let orch = make_orch patch agent in
         let _orch', effects =
@@ -1020,7 +1023,7 @@ let () =
           make_agent ~patch_id:pid ~branch
             ~pr_status:(Patch_pr_status.Present (Pr_number.of_int 42))
             ~merged:false ~queue:[] ~base_branch:(Some branch) ~is_draft:true
-            ~pr_body_delivered:true ~start_attempts_without_pr:0
+            ~pr_body_delivered:true ~start_attempts_without_pr:0 ()
         in
         let orch = make_orch patch agent in
         let orch1, effects1 =
@@ -1048,7 +1051,7 @@ let () =
           make_agent ~patch_id:pid ~branch
             ~pr_status:(Patch_pr_status.Present (Pr_number.of_int 42))
             ~merged:false ~queue:[] ~base_branch:(Some branch) ~is_draft:false
-            ~pr_body_delivered:true ~start_attempts_without_pr:0
+            ~pr_body_delivered:true ~start_attempts_without_pr:0 ()
         in
         let orch = make_orch patch agent in
         let obs =
@@ -1306,41 +1309,127 @@ let () =
                | Orchestrator.Respond _ | Orchestrator.Rebase _ -> false)))
   in
 
+  let merge_queue_entry ?(state = Pr_state.Mq_queued) ?(position = 1) id =
+    Pr_state.{ id; state; position }
+  in
+
   let pending_patch_4_automerge_enqueue_action =
     Test.make
       ~name:
-        "patch_controller: PENDING Patch 4 reconcile chooses Enqueue on queue \
-         branch" QCheck2.Gen.unit (fun () ->
-        (* PENDING: Patch 4 - reconcile chooses Enqueue on a queue-governed branch. *)
-        true)
+        "patch_controller: Patch 4 reconcile chooses Enqueue on queue branch"
+      QCheck2.Gen.unit (fun () ->
+        let pid = Patch_id.of_string "mq-enqueue" in
+        let branch = Branch.of_string "feat/mq-enqueue" in
+        let patch = make_patch pid branch in
+        let pr_number = Pr_number.of_int 401 in
+        let agent =
+          make_agent ~patch_id:pid ~branch
+            ~pr_status:(Patch_pr_status.Present pr_number) ~merged:false
+            ~queue:[] ~base_branch:(Some main) ~is_draft:false
+            ~pr_body_delivered:true ~start_attempts_without_pr:0
+            ~merge_ready:true ~checks_passing:true ~merge_queue_required:true
+            ~automerge_enabled:true ~automerge_deadline:0.0 ()
+        in
+        let orch = make_orch patch agent in
+        let orch, decisions =
+          Patch_controller.reconcile_automerge orch ~now:1.0
+        in
+        match decisions with
+        | [ { Patch_controller.merge_patch_id; merge_pr_number; action } ] ->
+            Patch_id.equal merge_patch_id pid
+            && Pr_number.equal merge_pr_number pr_number
+            && Patch_controller.equal_merge_action action
+                 Patch_controller.Enqueue
+            && (Orchestrator.agent orch pid).Patch_agent.automerge_inflight
+        | _ -> false)
   in
 
   let pending_patch_4_automerge_enqueued_idle =
     Test.make
-      ~name:
-        "patch_controller: PENDING Patch 4 enqueued PR yields no merge or \
-         enqueue"
+      ~name:"patch_controller: Patch 4 enqueued PR yields no merge or enqueue"
       QCheck2.Gen.unit (fun () ->
-        (* PENDING: Patch 4 - an enqueued PR yields no new merge or enqueue decision. *)
-        true)
+        let pid = Patch_id.of_string "mq-idle" in
+        let branch = Branch.of_string "feat/mq-idle" in
+        let patch = make_patch pid branch in
+        let agent =
+          make_agent ~patch_id:pid ~branch
+            ~pr_status:(Patch_pr_status.Present (Pr_number.of_int 402))
+            ~merged:false ~queue:[] ~base_branch:(Some main) ~is_draft:false
+            ~pr_body_delivered:true ~start_attempts_without_pr:0
+            ~merge_ready:true ~checks_passing:true ~merge_queue_required:true
+            ~merge_queue_entry:(Some (merge_queue_entry "MQE_idle"))
+            ~automerge_enabled:true ~automerge_deadline:0.0 ()
+        in
+        let orch = make_orch patch agent in
+        let orch, decisions =
+          Patch_controller.reconcile_automerge orch ~now:1.0
+        in
+        List.is_empty decisions
+        && Option.is_none
+             (Orchestrator.agent orch pid).Patch_agent.automerge_deadline)
   in
 
   let pending_patch_4_automerge_dequeue_on_lost_approval =
     Test.make
       ~name:
-        "patch_controller: PENDING Patch 4 enqueued PR that lost approval is \
-         dequeued" QCheck2.Gen.unit (fun () ->
-        (* PENDING: Patch 4 - an enqueued PR that lost approval is dequeued. *)
-        true)
+        "patch_controller: Patch 4 enqueued PR that lost approval is dequeued"
+      QCheck2.Gen.unit (fun () ->
+        let pid = Patch_id.of_string "mq-dequeue" in
+        let branch = Branch.of_string "feat/mq-dequeue" in
+        let patch = make_patch pid branch in
+        let pr_number = Pr_number.of_int 403 in
+        let entry = merge_queue_entry "MQE_dequeue" in
+        let agent =
+          make_agent ~patch_id:pid ~branch
+            ~pr_status:(Patch_pr_status.Present pr_number) ~merged:false
+            ~queue:[ Operation_kind.Review_comments ]
+            ~base_branch:(Some main) ~is_draft:false ~pr_body_delivered:true
+            ~start_attempts_without_pr:0 ~merge_ready:false ~checks_passing:true
+            ~merge_queue_required:true ~merge_queue_entry:(Some entry)
+            ~automerge_enabled:true ~automerge_deadline:0.0 ()
+        in
+        let orch = make_orch patch agent in
+        let orch, decisions =
+          Patch_controller.reconcile_automerge orch ~now:1.0
+        in
+        match decisions with
+        | [ { Patch_controller.merge_patch_id; merge_pr_number; action } ] ->
+            Patch_id.equal merge_patch_id pid
+            && Pr_number.equal merge_pr_number pr_number
+            && Patch_controller.equal_merge_action action
+                 (Patch_controller.Dequeue entry.Pr_state.id)
+            && (Orchestrator.agent orch pid).Patch_agent.automerge_inflight
+        | _ -> false)
   in
 
   let pending_patch_4_unmergeable_counts_as_failure =
     Test.make
-      ~name:
-        "patch_controller: PENDING Patch 4 UNMERGEABLE entry counts as failure"
+      ~name:"patch_controller: Patch 4 UNMERGEABLE entry counts as failure"
       QCheck2.Gen.unit (fun () ->
-        (* PENDING: Patch 4 - an UNMERGEABLE entry counts as an automerge failure. *)
-        true)
+        let pid = Patch_id.of_string "mq-unmergeable" in
+        let branch = Branch.of_string "feat/mq-unmergeable" in
+        let patch = make_patch pid branch in
+        let agent =
+          make_agent ~patch_id:pid ~branch
+            ~pr_status:(Patch_pr_status.Present (Pr_number.of_int 404))
+            ~merged:false ~queue:[] ~base_branch:(Some main) ~is_draft:false
+            ~pr_body_delivered:true ~start_attempts_without_pr:0
+            ~merge_ready:true ~checks_passing:true ~merge_queue_required:true
+            ~merge_queue_entry:
+              (Some
+                 (merge_queue_entry "MQE_unmergeable"
+                    ~state:Pr_state.Mq_unmergeable))
+            ~automerge_enabled:true ~automerge_deadline:0.0 ()
+        in
+        let orch = make_orch patch agent in
+        let orch, decisions =
+          Patch_controller.reconcile_automerge orch ~now:1.0
+        in
+        let agent = Orchestrator.agent orch pid in
+        List.is_empty decisions
+        && agent.Patch_agent.automerge_failure_count = 1
+        && (not agent.Patch_agent.automerge_inflight)
+        && Option.is_some agent.Patch_agent.automerge_deadline)
   in
 
   let suite =

--- a/test/test_rebase_onto.ml
+++ b/test/test_rebase_onto.ml
@@ -801,25 +801,25 @@ let () =
     {!Git_env.clean_env} so tests are unaffected when run inside a git hook
     (which would otherwise leak [GIT_DIR] / [GIT_WORK_TREE]). *)
 let git ~process_mgr ~dir args =
-  Eio.Switch.run @@ fun sw ->
   let stdout_buf = Buffer.create 64 in
   let stderr_buf = Buffer.create 64 in
-  let env = Git_env.clean_env () in
-  let child =
-    Eio.Process.spawn ~sw process_mgr ~env
-      ~stdout:(Eio.Flow.buffer_sink stdout_buf)
-      ~stderr:(Eio.Flow.buffer_sink stderr_buf)
-      ([ "git"; "-C"; dir ] @ args)
-  in
-  (match Eio.Process.await child with
-  | `Exited 0 -> ()
-  | `Exited n ->
-      failwith
-        (Printf.sprintf "git %s failed (exit %d): %s"
-           (String.concat ~sep:" " args)
-           n
-           (Buffer.contents stderr_buf))
-  | `Signaled s -> failwith (Printf.sprintf "git signaled %d" s));
+  Eio.Switch.run (fun sw ->
+      let env = Git_env.clean_env () in
+      let child =
+        Eio.Process.spawn ~sw process_mgr ~env
+          ~stdout:(Eio.Flow.buffer_sink stdout_buf)
+          ~stderr:(Eio.Flow.buffer_sink stderr_buf)
+          ([ "git"; "-C"; dir ] @ args)
+      in
+      match Eio.Process.await child with
+      | `Exited 0 -> ()
+      | `Exited n ->
+          failwith
+            (Printf.sprintf "git %s failed (exit %d): %s"
+               (String.concat ~sep:" " args)
+               n
+               (Buffer.contents stderr_buf))
+      | `Signaled s -> failwith (Printf.sprintf "git signaled %d" s));
   String.strip (Buffer.contents stdout_buf)
 
 (** Create a fresh git repo in a temp dir. No initial commit — callers add their


### PR DESCRIPTION
## Patch 4: Action-aware automerge: enqueue/dequeue on queue-governed branches

- Extend automerge_decision with a merge_action and compute it in reconcile_automerge from merge_queue_required, the entry state, and approval.
- Make is_automerge_candidate exclude an actively-enqueued still-approved PR from re-merge while still allowing a Dequeue decision for an enqueued PR that lost approval.
- Treat an UNMERGEABLE entry as an automerge failure so it advances toward the cap.
- Dispatch the three actions in the runner; treat enqueue success as non-terminal and recover the direct-merge 405 'merge queue' by enqueuing.
- Implement the four Patch-1 reconcile/decision test stubs.

## Changes
- Extend automerge_decision with a merge_action and compute it in reconcile_automerge from merge_queue_required, the entry state, and approval.
- Make is_automerge_candidate exclude an actively-enqueued still-approved PR from re-merge while still allowing a Dequeue decision for an enqueued PR that lost approval.
- Treat an UNMERGEABLE entry as an automerge failure so it advances toward the cap.
- Dispatch the three actions in the runner; treat enqueue success as non-terminal and recover the direct-merge 405 'merge queue' by enqueuing.
- Implement the four Patch-1 reconcile/decision test stubs.

## Files to Modify
- lib/patch_controller.ml (modify): Add `type merge_action = Direct_merge | Enqueue | Dequeue of string` and an `action` field on automerge_decision (lib/patch_controller.ml:584). In reconcile_automerge (line 613) compute the action: when the agent's base requires a merge queue and it is not yet enqueued -> Enqueue; when already enqueued and still approved with a non-UNMERGEABLE state -> emit no decision (wait); when enqueued and approval lost (or head advanced) -> Dequeue entry_id; when enqueued and UNMERGEABLE -> treat as failure (route through apply_automerge_failure semantics); otherwise (no queue) -> Direct_merge. Update is_automerge_candidate (line 567) so an actively-enqueued, still-approved PR is not a re-merge candidate.
- lib/patch_controller.mli (modify): Expose merge_action and the extended automerge_decision.
- lib/runner_fiber_impl.ml (modify): Dispatch on decision.action (lib/runner_fiber_impl.ml:238): Direct_merge -> Forge.merge_pr (existing handling unchanged); Enqueue -> Forge.enqueue_pr, treating Enqueued/Already_enqueued as a non-terminal success (push_deadline_and_clear_inflight, no failure-counter bump, like Merge_queued); Dequeue id -> Forge.dequeue_pr (clear inflight, log, non-fatal on error). On a Direct_merge that returns a Forge error satisfying is_merge_queue_required_error, recover by calling Forge.enqueue_pr instead of apply_automerge_failure.

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[documentation] GitHub merge queue — managing a merge queue (enqueue semantics, expectedHeadOid, 405 body)** — https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue — Defines the queue lifecycle the decision logic mirrors: a queued PR is not yet merged (so enqueue is non-terminal), GitHub auto-dequeues UNMERGEABLE entries (so onton must count them as failures rather than re-enqueue forever), and the direct-merge endpoint returns 405 'Changes must be made through the merge queue' on a governed branch.

## Gameplan Specification

```
module MERGE_QUEUE_SUPPORT.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> After this gameplan, onton responds correctly to GitHub repos with a
> merge queue: on a queue-governed target branch it adds approved PRs to
> the queue (enqueuePullRequest) instead of direct-merging, tracks the
> queue entry, and removes PRs that lose approval — while repos without a
> merge queue keep the unchanged direct-merge path.

Pr.
MqState.
mq-queued => MqState.
mq-awaiting-checks => MqState.
mq-mergeable => MqState.
mq-unmergeable => MqState.
mq-locked => MqState.
MergeAction.
act-merge => MergeAction.
act-enqueue => MergeAction.
act-dequeue => MergeAction.
act-none => MergeAction.
requires-merge-queue? p: Pr => Bool.
enqueued? p: Pr => Bool.
approved? p: Pr => Bool.
checks-passing? p: Pr => Bool.
merged? p: Pr => Bool.
mq-state p: Pr => MqState.
mq-position p: Pr => Nat0.
action p: Pr => MergeAction.
---
> Detection: an enqueued PR always carries a known queue state.
all p: Pr, enqueued? p | mq-state p = mq-queued or mq-state p = mq-awaiting-checks or mq-state p = mq-mergeable or mq-state p = mq-unmergeable or mq-state p = mq-locked.

> Enqueue an approved, idle, not-yet-queued PR on a queue-governed branch.
all p: Pr, requires-merge-queue? p and approved? p and checks-passing? p and ~(enqueued? p) and ~(merged? p) | action p = act-enqueue.

> Direct merge only where no queue governs the branch.
all p: Pr, action p = act-merge | ~(requires-merge-queue? p).

> Never re-enqueue a PR that is already queued (idempotency).
all p: Pr, action p = act-enqueue | ~(enqueued? p).

> A queued, still-approved, non-unmergeable PR is left to the queue.
all p: Pr, enqueued? p and approved? p and mq-state p ~= mq-unmergeable | action p = act-none.

> A queued PR that lost approval is removed from the queue.
all p: Pr, enqueued? p and ~(approved? p) | action p = act-dequeue.

> An unmergeable entry is never silently waited on (it becomes a failure).
all p: Pr, enqueued? p and mq-state p = mq-unmergeable | action p ~= act-none.

> A merged PR triggers no further action.
all p: Pr, merged? p | action p = act-none.

where

> ══════════════════════════════════════════
> DISPLAY
> ══════════════════════════════════════════
> The TUI shows queue state for enqueued PRs and nothing otherwise.

shown-queued? p: Pr => Bool.
---
all p: Pr, shown-queued? p | enqueued? p.
all p: Pr, enqueued? p | shown-queued? p.
```

## Patch Specification

```
module MERGE_QUEUE_SUPPORT_PATCH_4.

> Patch 4 makes onton choose the right merge action per PR. This is the
> behavioral core of the gameplan.

Pr.
MqState.
mq-unmergeable => MqState.
MergeAction.
act-merge => MergeAction.
act-enqueue => MergeAction.
act-dequeue => MergeAction.
act-none => MergeAction.
requires-merge-queue? p: Pr => Bool.
enqueued? p: Pr => Bool.
approved? p: Pr => Bool.
checks-passing? p: Pr => Bool.
merged? p: Pr => Bool.
mq-state p: Pr => MqState.
action p: Pr => MergeAction.
---
> Approved, idle, not-yet-queued PR on a queue-governed branch is enqueued.
all p: Pr, requires-merge-queue? p and approved? p and checks-passing? p and ~(enqueued? p) and ~(merged? p) | action p = act-enqueue.
> Direct merge happens only where no queue governs the branch.
all p: Pr, action p = act-merge | ~(requires-merge-queue? p).
> Enqueue is never issued for a PR already in the queue (idempotency).
all p: Pr, action p = act-enqueue | ~(enqueued? p).
> A queued, still-approved, non-unmergeable PR is left to the queue (wait).
all p: Pr, enqueued? p and approved? p and mq-state p ~= mq-unmergeable | action p = act-none.
> A queued PR that lost approval is removed from the queue.
all p: Pr, enqueued? p and ~(approved? p) | action p = act-dequeue.
> An unmergeable entry is never silently waited on.
all p: Pr, enqueued? p and mq-state p = mq-unmergeable | action p ~= act-none.
> A merged PR triggers no further action.
all p: Pr, merged? p | action p = act-none.
```


## Implementation Notes

- `Dequeue` candidacy intentionally does not require an empty agent work queue. Losing approval is often represented by queued feedback such as `Review_comments`, and the queue entry still needs to be removed before the agent handles that feedback.
- `UNMERGEABLE` entries are handled inside `reconcile_automerge` by applying the same failure-state transition used by failed merge calls. This means no runner decision is emitted for that case; the observable action is the failure counter/deadline update rather than a GitHub call.
- Direct-merge recovery is deliberately narrow: only `Github.is_merge_queue_required_error` triggers enqueue fallback. The existing method fallback and "base branch was modified" retry behavior remain on the old path.
- Unknown `MergeQueueEntryState` values continue to map to the non-actionable waiting state (`Mq_queued`). I aligned the merge-queue parser regression test with that forward-compatible behavior.

Spec/Evidence Mapping:
- Queue-governed approved PR -> enqueue: `Patch_controller.reconcile_automerge` / `automerge_action`; covered by `patch_controller: Patch 4 reconcile chooses Enqueue on queue branch`.
- Already queued approved PR -> wait: `is_automerge_candidate` excludes enqueued approved PRs and `automerge_action` returns no action; covered by `patch_controller: Patch 4 enqueued PR yields no merge or enqueue`.
- Lost approval -> dequeue: cleanup candidacy plus runner `Forge.dequeue_pr`; covered with queued `Review_comments` by `patch_controller: Patch 4 enqueued PR that lost approval is dequeued`.
- Unmergeable -> failure: `merge_queue_entry_unmergeable` path calls `apply_automerge_failure_state`; covered by `patch_controller: Patch 4 UNMERGEABLE entry counts as failure`.
- Static checks run: `dune build`, `dune runtest`, `dune fmt`.