### PR TITLE
Update archlint exemption annotations

### DIFF
--- a/bin/setsid_exec/main.ml
+++ b/bin/setsid_exec/main.ml
@@ -1,5 +1,5 @@
 (* @archlint.module exempt
-   @archlint.exempt-reason framework-boundary *)
+   @archlint.exempt-reason effect-boundary *)
 
 (* Tiny launcher shim. Calls setsid(2) so the exec'd process becomes the
    leader of a new session and process group, then execvp's its argv. Onton

--- a/lib/findings_registry.ml
+++ b/lib/findings_registry.ml
@@ -1,5 +1,5 @@
 (* @archlint.module exempt
-   @archlint.exempt-reason framework-boundary *)
+   @archlint.exempt-reason effect-boundary *)
 
 type entry = {
   backend_name : string;

--- a/lib/git_env.ml
+++ b/lib/git_env.ml
@@ -1,5 +1,5 @@
 (* @archlint.module exempt
-   @archlint.exempt-reason framework-boundary *)
+   @archlint.exempt-reason effect-boundary *)
 
 open Base
 

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -1,5 +1,5 @@
 (* @archlint.module exempt
-   @archlint.exempt-reason framework-boundary *)
+   @archlint.exempt-reason effect-boundary *)
 
 open Base
 open Ppx_yojson_conv_lib.Yojson_conv.Primitives

--- a/lib/llm_backend.ml
+++ b/lib/llm_backend.ml
@@ -1,5 +1,5 @@
 (* @archlint.module exempt
-   @archlint.exempt-reason framework-boundary *)
+   @archlint.exempt-reason effect-boundary *)
 
 open Base
 

--- a/lib/patch_agent_backend.ml
+++ b/lib/patch_agent_backend.ml
@@ -1,5 +1,5 @@
 (* @archlint.module exempt
-   @archlint.exempt-reason framework-boundary *)
+   @archlint.exempt-reason effect-boundary *)
 
 open Base
 module Long_lived = Llm_backend_long_lived

--- a/lib/session_artifacts.ml
+++ b/lib/session_artifacts.ml
@@ -1,5 +1,5 @@
 (* @archlint.module exempt
-   @archlint.exempt-reason framework-boundary *)
+   @archlint.exempt-reason effect-boundary *)
 
 open Base
 

--- a/lib/term.ml
+++ b/lib/term.ml
@@ -1,5 +1,5 @@
 (* @archlint.module exempt
-   @archlint.exempt-reason framework-boundary *)
+   @archlint.exempt-reason effect-boundary *)
 
 open Base
 


### PR DESCRIPTION
## Summary
- rename OCaml archlint exemption annotations from framework-boundary to effect-boundary
- keep the affected modules marked exempt under the simplified archlint vocabulary

## Verification
- dune build
- dune runtest
- format check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/357"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783456711&installation_id=126163856&pr_number=357&repository=flowglad%2Fonton&return_to=https%3A%2F%2Fgithub.com%2Fflowglad%2Fonton%2Fpull%2F357&signature=ad6fc455a70b9540bb2067699b7b10726422f12bad3e63eb4db60319759bc817"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rename OCaml archlint exemption annotations from framework-boundary to effect-boundary to align with the simplified archlint vocabulary. All previously exempt modules remain exempt; no behavior changes.

<sup>Written for commit a53d7ed8c5bb2bd0e0d46c89b071864893c79aff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/flowglad/onton/pull/357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code organization annotations across multiple modules. No functional changes or user-visible impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->