### PR TITLE
Reconcile PR base retarget for ad-hoc agents

### DIFF
--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -272,13 +272,18 @@ let apply_replacement_pr t patch_id ~pr_number ~base_branch ~merged =
   let t = Orchestrator.set_base_branch t patch_id base_branch in
   if merged then Orchestrator.mark_merged t patch_id else t
 
-let reconcile_patch t ~project_name:_ ~gameplan:_ ~(patch : Patch.t) =
-  let patch_id = patch.id in
+(* PR base / draft reconciliation shared by gameplan and ad-hoc agents.
+   [allow_draft_flip] scopes the mark-for-review ratchet to gameplan patches:
+   onton opened those PRs as drafts and owns the draft→ready transition,
+   whereas an ad-hoc PR's draft bit belongs to whoever created the PR. The
+   base retarget applies to every managed agent — a PR left targeting a merged
+   dependency's branch diffs against frozen pre-merge history, so GitHub
+   reports conflicts that no rebase onto main can clear (the local rebase
+   noops, the poller re-reads the stale base, and the two spin forever). *)
+let reconcile_pr_settings t patch_id ~allow_draft_flip =
   let agent = Orchestrator.agent t patch_id in
-  if agent.Patch_agent.merged then (t, [])
-  else
-    let t = enqueue_pr_body_if_needed t patch_id agent in
-    let agent = Orchestrator.agent t patch_id in
+  if agent.Patch_agent.merged then []
+  else begin
     let effects = ref [] in
     (* Gate on [is_pr_present]: emitting Set_pr_draft / Set_pr_base against a
        [Missing] PR would 404 against GitHub. A gameplan patch can in
@@ -326,7 +331,7 @@ let reconcile_patch t ~project_name:_ ~gameplan:_ ~(patch : Patch.t) =
                 && agent.pr_body_delivered && (not agent.has_conflict)
                 && (not rebase_pending) && agent.checks_passing
               in
-              if agent.is_draft && ready_for_review then
+              if allow_draft_flip && agent.is_draft && ready_for_review then
                 effects :=
                   Set_pr_draft { patch_id; pr_number; draft = false }
                   :: !effects;
@@ -337,12 +342,44 @@ let reconcile_patch t ~project_name:_ ~gameplan:_ ~(patch : Patch.t) =
             end
         | None -> ())
     | Some _ | None -> ());
-    (t, List.rev !effects)
+    List.rev !effects
+  end
+
+let reconcile_patch t ~project_name:_ ~gameplan:_ ~(patch : Patch.t) =
+  let patch_id = patch.id in
+  let agent = Orchestrator.agent t patch_id in
+  if agent.Patch_agent.merged then (t, [])
+  else
+    let t = enqueue_pr_body_if_needed t patch_id agent in
+    (t, reconcile_pr_settings t patch_id ~allow_draft_flip:true)
 
 let reconcile_all t ~project_name ~gameplan =
-  List.fold gameplan.Gameplan.patches ~init:(t, []) ~f:(fun (orch, acc) patch ->
-      let orch, effects = reconcile_patch orch ~project_name ~gameplan ~patch in
-      (orch, acc @ effects))
+  let t, gameplan_effects =
+    List.fold gameplan.Gameplan.patches ~init:(t, [])
+      ~f:(fun (orch, acc) patch ->
+        let orch, effects =
+          reconcile_patch orch ~project_name ~gameplan ~patch
+        in
+        (orch, acc @ effects))
+  in
+  (* Ad-hoc agents (tracked but not in the gameplan) get the same base
+     retarget; they never get the draft flip, and no Pr_body demand — the PR
+     body contract is a gameplan artifact. Without this pass an ad-hoc PR
+     whose base branch merged is never retargeted on GitHub, and the
+     stale-base rebase loop above re-fires on every poll. *)
+  let gameplan_pids =
+    Set.of_list
+      (module Patch_id)
+      (List.map gameplan.Gameplan.patches ~f:(fun p -> p.Patch.id))
+  in
+  let adhoc_effects =
+    Orchestrator.all_agents t
+    |> List.filter ~f:(fun (a : Patch_agent.t) ->
+        not (Set.mem gameplan_pids a.Patch_agent.patch_id))
+    |> List.concat_map ~f:(fun (a : Patch_agent.t) ->
+        reconcile_pr_settings t a.Patch_agent.patch_id ~allow_draft_flip:false)
+  in
+  (t, gameplan_effects @ adhoc_effects)
 
 let branch_map_of_patches patches =
   List.fold patches
@@ -1190,6 +1227,101 @@ let%test "reconcile_patch emits no effects for merged agent" =
       ~patch
   in
   List.is_empty effects
+
+(* -- Ad-hoc PR base reconciliation (regression: PR #4347 stale-base loop) -- *)
+
+let empty_gameplan =
+  Gameplan.
+    {
+      project_name = "proj";
+      repo_owner = "";
+      repo_name = "";
+      problem_statement = "";
+      solution_summary = "";
+      final_state_spec = "";
+      patches = [];
+      current_state_analysis = "";
+      explicit_opinions = "";
+      acceptance_criteria = [];
+      open_questions = [];
+      functional_changes = [];
+      context_resources = [];
+    }
+
+let make_adhoc_orchestrator ~base_branch =
+  let t = Orchestrator.create ~patches:[] ~main_branch:main in
+  let t =
+    Orchestrator.add_agent t ~patch_id:pid
+      ~branch:(Branch.of_string "adhoc-branch")
+      ~base_branch ~pr_number:(Pr_number.of_int 47)
+  in
+  (* [add_agent] deliberately does not seed [agent.base_branch]; the poller
+     owns it. Simulate the poll having observed the PR's base on GitHub. *)
+  Orchestrator.set_base_branch t pid base_branch
+
+let%test "reconcile_all retargets a stale ad-hoc PR base and converges" =
+  (* The PR #4347 shape: an ad-hoc PR left targeting a dependency branch that
+     has since merged and is no longer tracked. The structural base is main,
+     so reconcile must emit exactly one Set_pr_base — and once GitHub
+     acknowledges it, the next reconcile must be a fixpoint (no re-emit, no
+     poller/rebase loop). *)
+  let stale = Branch.of_string "merged-dep-branch" in
+  let t = make_adhoc_orchestrator ~base_branch:stale in
+  let t, effects =
+    reconcile_all t ~project_name:"proj" ~gameplan:empty_gameplan
+  in
+  let retarget =
+    Set_pr_base { patch_id = pid; pr_number = Pr_number.of_int 47; base = main }
+  in
+  List.equal equal_github_effect effects [ retarget ]
+  &&
+  let t = apply_github_effect_success t retarget in
+  let _, effects' =
+    reconcile_all t ~project_name:"proj" ~gameplan:empty_gameplan
+  in
+  List.is_empty effects'
+
+let%test "reconcile_all leaves an ad-hoc PR stacked on an open branch alone" =
+  let parent_pid = Patch_id.of_string "p-parent" in
+  let parent_branch = Branch.of_string "parent-branch" in
+  let t = Orchestrator.create ~patches:[] ~main_branch:main in
+  let t =
+    Orchestrator.add_agent t ~patch_id:parent_pid ~branch:parent_branch
+      ~base_branch:main ~pr_number:(Pr_number.of_int 46)
+  in
+  let t = Orchestrator.set_base_branch t parent_pid main in
+  let t =
+    Orchestrator.add_agent t ~patch_id:pid
+      ~branch:(Branch.of_string "adhoc-branch")
+      ~base_branch:parent_branch ~pr_number:(Pr_number.of_int 47)
+  in
+  let t = Orchestrator.set_base_branch t pid parent_branch in
+  let _, effects =
+    reconcile_all t ~project_name:"proj" ~gameplan:empty_gameplan
+  in
+  List.is_empty effects
+
+let%test "reconcile_all never flips an ad-hoc PR's draft bit" =
+  let t = make_adhoc_orchestrator ~base_branch:main in
+  (* Reach the exact fixpoint where a gameplan patch would be marked ready:
+     based on main, rebased onto main, body delivered (ad-hoc default), no
+     conflict, CI green — and currently draft. *)
+  let t = Orchestrator.set_is_draft t pid true in
+  let t = Orchestrator.set_checks_passing t pid true in
+  let t, _ = Orchestrator.apply_rebase_result t pid Worktree.Noop main in
+  let _, effects =
+    reconcile_all t ~project_name:"proj" ~gameplan:empty_gameplan
+  in
+  List.is_empty effects
+  (* Counterfactual: the same state under the gameplan ratchet does flip the
+     draft bit — proving the ad-hoc pass is what suppresses it, not some other
+     unmet precondition. *)
+  && List.equal equal_github_effect
+       (reconcile_pr_settings t pid ~allow_draft_flip:true)
+       [
+         Set_pr_draft
+           { patch_id = pid; pr_number = Pr_number.of_int 47; draft = false };
+       ]
 
 let%test "no merge-conflict re-enqueue after noop" =
   let _patch, t = make_orchestrator ~patch_id:pid ~main_branch:main in

--- a/lib/patch_controller.mli
+++ b/lib/patch_controller.mli
@@ -65,7 +65,14 @@ val reconcile_all :
   project_name:string ->
   gameplan:Gameplan.t ->
   Orchestrator.t * github_effect list
-(** Reconcile all gameplan patches. Ad-hoc patches are ignored. *)
+(** Reconcile all gameplan patches, then every ad-hoc (non-gameplan) agent.
+    Ad-hoc agents receive only the PR base retarget ([Set_pr_base]) — never the
+    draft→ready flip or a Pr_body demand: onton owns the draft lifecycle only
+    for PRs it opened itself, and the PR body contract is a gameplan artifact.
+    The base retarget must cover ad-hoc agents: without it, an ad-hoc PR whose
+    base branch merges is never retargeted on GitHub, GitHub keeps diffing the
+    PR against the frozen pre-merge base (phantom conflicts no rebase can
+    clear), and the poller/rebase pair loops until intervention. *)
 
 val plan_actions :
   Orchestrator.t -> patches:Patch.t list -> Orchestrator.action list


### PR DESCRIPTION
## Problem

`reconcile_all` only iterated `gameplan.Gameplan.patches`, so the `Set_pr_base` GitHub effect was never emitted for ad-hoc agents. When an ad-hoc PR's base branch merged, the PR stayed targeting the frozen pre-merge branch on GitHub, producing a livelock observed on flowglad-provisioning-agent PR #4347:

1. Poll reads the stale `baseRefName` from GitHub and overwrites `agent.base_branch` (`apply_poll_result`).
2. `Reconciler.detect_stale_bases` / `detect_notified_base_drift` see base ≠ main and enqueue a Rebase.
3. The local rebase noops — the branch already contains main — and the Noop arm sets `base_branch := main` **locally only**.
4. Goto 1, every poll tick (~30s).

Because the branch had been rebased onto main and force-pushed while the PR still targeted the frozen base, GitHub diffed it against pre-merge history and reported DIRTY — a phantom conflict no rebase onto main can ever clear. The conflict path then nooped the same way until `conflict_noop_count >= 2` latched `needs_intervention`.

## Fix

Extract the PR base/draft reconciliation from `reconcile_patch` into `reconcile_pr_settings ~allow_draft_flip` and run it over **every tracked agent**, not just gameplan patches:

- **Gameplan patches**: unchanged (Pr_body demand + draft ratchet + base retarget).
- **Ad-hoc agents**: base retarget only. The draft→ready ratchet stays gameplan-scoped — onton owns the draft lifecycle only for PRs it opened itself; an adopted PR's draft bit belongs to whoever created it. Pr_body demand also stays gameplan-scoped (the PR body contract is a gameplan artifact).

Branch-name comparison means this adds no rebase-on-main-advance pressure: once the PR targets main, actual == expected forever.

## Tests

- Stale-base regression: ad-hoc agent based on a vanished merged-dep branch emits exactly one `Set_pr_base → main`, and after `apply_github_effect_success` the next reconcile is a fixpoint (no re-emit loop).
- Stacked ad-hoc PR on an open tracked branch is left alone (structural base is the open parent).
- Ad-hoc draft bit is never flipped, with a counterfactual asserting the same state under `allow_draft_flip:true` would flip it — proving the gate is what suppresses it.

## Follow-up (not in this PR)

The plain-Rebase Noop path (`apply_rebase_result`) has no counter analogous to `conflict_noop_count`; phase 1 of this incident looped ~40 minutes with no escape hatch and was only caught once GitHub flipped to DIRTY. A backstop counter there would catch any future retarget-failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/361"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783782723&installation_id=126163856&pr_number=361&repository=flowglad%2Fonton&return_to=https%3A%2F%2Fgithub.com%2Fflowglad%2Fonton%2Fpull%2F361&signature=5aefe8bdb134df8f84909d977502246c14b8c14116e4bd4c2c7a7033fdfb9862"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retarget ad-hoc PR bases when their dependency branch merges by applying base/draft reconciliation across all agents. This prevents phantom DIRTY conflicts and ends the rebase/poll livelock.

- **Bug Fixes**
  - `reconcile_all` now emits `Set_pr_base` for ad‑hoc agents when their structural base is `main`, stopping endless no-op rebases and conflicts.
  - Stacked ad‑hoc PRs remain on their open parent branch; no unintended retargets.

- **Refactors**
  - Extracted shared `reconcile_pr_settings` and run it for all agents; draft flips are gated via `allow_draft_flip` and stay gameplan-only. Ad‑hoc PRs never get draft flips or PR body demands.
  - Added regression tests for stale-base convergence and the draft gate.

<sup>Written for commit 4668d75bc600341d55a04a54e0443433baeb1c2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/flowglad/onton/pull/361?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

