### PR TITLE
Resolve GitHub token at runtime; stop persisting it in project config

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1481,7 +1481,8 @@ let main_cmd ~pr_ops =
       Stdlib.exit
         ( Eio_main.run @@ fun env ->
           Prune_runner.run_prune ~net:(Eio.Stdenv.net env)
-            ~clock:(Eio.Stdenv.clock env) ~refresh:(not no_refresh) () )
+            ~clock:(Eio.Stdenv.clock env) ~github_token
+            ~refresh:(not no_refresh) () )
     else if upload_debug then (
       match project with
       | None ->

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -312,8 +312,8 @@ let finalize_run ~project_name ~repo_coords ~run_knobs ~backend_inputs
     resolve_backend_model ~cli_backend ~cli_model ~stored_backend ~stored_model
       ~repo_config
   in
-  Project_store.save_config ~project_name ~github_token ~github_owner
-    ~github_repo ~backend ~model
+  Project_store.save_config ~project_name ~github_owner ~github_repo ~backend
+    ~model
     ~main_branch:(Branch.to_string main_branch)
     ~poll_interval ~repo_root ~max_concurrency
     ~url_scheme:(Option.map Managed_repo.string_of_url_scheme url_scheme)
@@ -542,14 +542,6 @@ let resolve_config ~project ~gameplan_path ~github_token ~backend ~model
               | Ok stored ->
                   (* CLI flags override stored config; stored config overrides
                      git-remote inference *)
-                  let merge_cli_stored cli stored_val =
-                    let c = Base.String.strip cli in
-                    if Base.String.is_empty c then stored_val else c
-                  in
-                  let token_from_stored =
-                    merge_cli_stored github_token
-                      stored.Project_store.github_token
-                  in
                   (* Always route through [Repo_root.normalize] — including
                      the stored value — so legacy configs that persisted a
                      worktree path (or a trailing [/.]) self-heal on load. *)
@@ -558,9 +550,15 @@ let resolve_config ~project ~gameplan_path ~github_token ~backend ~model
                     | Some rr -> Repo_root.normalize rr
                     | None -> Repo_root.normalize stored.Project_store.repo_root
                   in
+                  (* The GitHub token is resolved fresh on every run from the
+                     CLI flag / [GITHUB_TOKEN] / [gh auth token] — it is never
+                     persisted. Passing the raw CLI flag (empty when absent)
+                     lets [resolve_github_credentials] fall through to
+                     [gh auth token], so a token rotated after project creation
+                     takes effect on resume instead of a stale stored value
+                     winning. *)
                   let token, inferred_owner, inferred_repo =
-                    resolve_github_credentials ~github_token:token_from_stored
-                      ~repo_root
+                    resolve_github_credentials ~github_token ~repo_root
                   in
                   (* Precedence on resume: gameplan > stored config > inferred
                      from git remote. Gameplan-authored sessions have non-empty
@@ -1335,7 +1333,11 @@ let github_token_arg =
   let open Cmdliner in
   Arg.(
     value & opt string ""
-    & info [ "token" ] ~docv:"TOKEN" ~doc:"GitHub API token."
+    & info [ "token" ] ~docv:"TOKEN"
+        ~doc:
+          "GitHub API token. Resolved fresh on every run (falls back to \
+           GITHUB_TOKEN, then `gh auth token`) and never persisted to the \
+           project config."
         ~env:(Cmd.Env.info "GITHUB_TOKEN"))
 
 let backend_arg =
@@ -1457,7 +1459,7 @@ let no_refresh_arg =
         ~doc:
           "When pruning, skip the forge reconciliation step and rely solely on \
            the [merged] flag stored in each project's snapshot. Useful offline \
-           or when forge tokens have been rotated.")
+           or when `gh` is not authenticated.")
 
 let auto_merge_arg =
   let open Cmdliner in

--- a/lib/project_store.ml
+++ b/lib/project_store.ml
@@ -83,7 +83,6 @@ let ensure_dir path =
 
 type stored_config = {
   project_name : string;
-  github_token : string;
   github_owner : string;
   github_repo : string;
   backend : string;
@@ -100,15 +99,14 @@ type stored_config = {
 }
 [@@deriving yojson]
 
-let save_config ~project_name ~github_token ~github_owner ~github_repo ~backend
-    ~model ~main_branch ~poll_interval ~repo_root ~max_concurrency
+let save_config ~project_name ~github_owner ~github_repo ~backend ~model
+    ~main_branch ~poll_interval ~repo_root ~max_concurrency
     ?(url_scheme : string option = None) () =
   let dir = project_dir project_name in
   ensure_dir dir;
   let config =
     {
       project_name;
-      github_token;
       github_owner;
       github_repo;
       backend;
@@ -157,6 +155,14 @@ let migrate_backend_model fields =
   in
   ("backend", `String backend) :: ("model", `String model) :: without
 
+(* Drop fields that were persisted by older versions but are no longer part of
+   [stored_config]. [stored_config_of_yojson] is strict (no
+   [allow_extra_fields]), so a legacy [github_token] key would otherwise fail to
+   parse. The token is now resolved per run (env / [gh auth token]) and never
+   persisted; see [Managed_repo.infer_github_token]. *)
+let drop_legacy_fields fields =
+  List.filter fields ~f:(fun (k, _) -> not (String.equal k "github_token"))
+
 let load_config ~project_name =
   let path = config_path project_name in
   try
@@ -169,7 +175,9 @@ let load_config ~project_name =
     let json = Yojson.Safe.from_string content in
     match json with
     | `Assoc fields ->
-        Ok (stored_config_of_yojson (`Assoc (migrate_backend_model fields)))
+        Ok
+          (stored_config_of_yojson
+             (`Assoc (drop_legacy_fields (migrate_backend_model fields))))
     | _ -> Ok (stored_config_of_yojson json)
   with exn -> Error (Stdlib.Printexc.to_string exn)
 
@@ -300,3 +308,39 @@ let%test "publish_gameplan_artifact is a no-op without a stored gameplan" =
       let project_name = "publish-test-empty" in
       publish_gameplan_artifact ~project_name;
       not (Stdlib.Sys.file_exists (gameplan_artifact_path project_name)))
+
+(* A config written by an older version still carries a [github_token] key.
+   [stored_config_of_yojson] is strict, so [load_config] must drop the legacy
+   key (via [drop_legacy_fields]) rather than fail to parse. *)
+let%test "load_config tolerates a legacy persisted github_token" =
+  with_temp_data_dir (fun () ->
+      let project_name = "legacy-token" in
+      ensure_dir (project_dir project_name);
+      let legacy =
+        {|{"project_name":"legacy-token","github_token":"ghp_stale","github_owner":"o","github_repo":"r","backend":"claude","model":"sonnet","main_branch":"main","poll_interval":5.0,"repo_root":"/tmp/r","max_concurrency":4}|}
+      in
+      let oc = Stdlib.open_out_bin (config_path project_name) in
+      Stdlib.output_string oc legacy;
+      Stdlib.close_out oc;
+      match load_config ~project_name with
+      | Ok cfg ->
+          String.equal cfg.github_owner "o" && String.equal cfg.github_repo "r"
+      | Error _ -> false)
+
+(* The token is no longer persisted: [save_config] must not write a
+   [github_token] key, and the config it writes must round-trip through
+   [load_config]. *)
+let%test "save_config persists no github_token and round-trips" =
+  with_temp_data_dir (fun () ->
+      let project_name = "no-token" in
+      save_config ~project_name ~github_owner:"o" ~github_repo:"r"
+        ~backend:"claude" ~model:"sonnet" ~main_branch:"main" ~poll_interval:5.0
+        ~repo_root:"/tmp/r" ~max_concurrency:4 ();
+      let raw = read_file_for_test (config_path project_name) in
+      (not (String.is_substring raw ~substring:"github_token"))
+      &&
+      match load_config ~project_name with
+      | Ok cfg ->
+          String.equal cfg.project_name project_name
+          && String.equal cfg.github_owner "o"
+      | Error _ -> false)

--- a/lib/project_store.mli
+++ b/lib/project_store.mli
@@ -35,7 +35,6 @@ val ensure_dir : string -> unit
 
 type stored_config = {
   project_name : string;
-  github_token : string;
   github_owner : string;
   github_repo : string;
   backend : string;
@@ -54,7 +53,6 @@ type stored_config = {
 
 val save_config :
   project_name:string ->
-  github_token:string ->
   github_owner:string ->
   github_repo:string ->
   backend:string ->

--- a/lib/prune_runner.ml
+++ b/lib/prune_runner.ml
@@ -87,8 +87,8 @@ let refresh_agents_from_forge
             errors = 0;
             skipped_reason =
               Some
-                "no GitHub token available (set GITHUB_TOKEN or log in with \
-                 `gh`)";
+                "no GitHub token available (pass --token, set GITHUB_TOKEN, or \
+                 log in with `gh`)";
           } )
     | Some forge ->
         let module Forge = (val forge) in
@@ -213,20 +213,26 @@ let kept_reason ~base ~refresh_summary =
   | None -> base
   | Some note -> Stdlib.Printf.sprintf "%s (%s)" base note
 
-let run_prune ~net ~clock ~refresh () =
+let run_prune ~net ~clock ~github_token ~refresh () =
   let slugs = Project_store.list_projects () in
   if List.is_empty slugs then (
     Stdlib.Printf.printf "No stored projects to consider.\n";
     0)
   else
-    (* Resolve the GitHub token once for the whole prune run from
-       GITHUB_TOKEN / [gh auth token] — it is no longer persisted per project.
-       Skipped under [--no-refresh] since no forge queries happen. [make_forge]
-       closes over the run-wide [net]/[clock]/[token] so per-project
-       classification only supplies the owner/repo/branch that actually vary,
-       and yields [None] when no token is available so the refresh is reported
-       as skipped rather than failing. *)
-    let token = if refresh then Managed_repo.infer_github_token () else "" in
+    (* Resolve the GitHub token once for the whole prune run. Prefer the
+       explicit CLI/env value, then fall back to [gh auth token]; tokens are no
+       longer persisted per project. Skipped under [--no-refresh] since no forge
+       queries happen. [make_forge] closes over the run-wide [net]/[clock]/
+       [token] so per-project classification only supplies the
+       owner/repo/branch that actually vary, and yields [None] when no token is
+       available so the refresh is reported as skipped rather than failing. *)
+    let token =
+      if not refresh then ""
+      else
+        let explicit = String.strip github_token in
+        if String.is_empty explicit then Managed_repo.infer_github_token ()
+        else explicit
+    in
     let make_forge ~owner ~repo ~main_branch =
       if String.is_empty token then None
       else Some (Github.make ~net ~clock ~token ~owner ~repo ~main_branch)

--- a/lib/prune_runner.ml
+++ b/lib/prune_runner.ml
@@ -62,65 +62,74 @@ let refresh_candidates (agents : Patch_agent.t Map.M(Patch_id).t) =
     recorded PR number. Returns the (possibly updated) agents map and a
     [refresh_summary]. Forge errors are tolerated — the corresponding agent is
     left untouched, classification proceeds with its stored [merged] flag. *)
-let refresh_agents_from_forge ~net ~clock ~(cfg : Project_store.stored_config)
+let refresh_agents_from_forge
+    ~(make_forge :
+       owner:string ->
+       repo:string ->
+       main_branch:Branch.t ->
+       (module Forge.S with type error = Github.error) option)
+    ~(cfg : Project_store.stored_config)
     ~(agents : Patch_agent.t Map.M(Patch_id).t) =
   let candidates = refresh_candidates agents in
   if List.is_empty candidates then
     ( agents,
       { attempted = 0; newly_merged = 0; errors = 0; skipped_reason = None } )
   else
-    let token = String.strip cfg.Project_store.github_token in
-    if String.is_empty token then
-      ( agents,
-        {
-          attempted = 0;
-          newly_merged = 0;
-          errors = 0;
-          skipped_reason = Some "no GitHub token in stored config";
-        } )
-    else
-      let module Forge =
-        (val Github.make ~net ~clock ~token ~owner:cfg.github_owner
-               ~repo:cfg.github_repo
-               ~main_branch:(Types.Branch.of_string cfg.main_branch))
-      in
-      let results =
-        Eio.Fiber.List.map ~max_fibers:16
-          (fun (patch_id, pr_number) ->
-            let result =
-              try
-                Result.map_error (Forge.pr_state pr_number) ~f:(fun _ -> ())
-              with
-              | Eio.Cancel.Cancelled _ as exn -> raise exn
-              | _ -> Error ()
-            in
-            (patch_id, pr_number, result))
-          candidates
-      in
-      let attempted = List.length results in
-      let agents, newly_merged, errors =
-        List.fold results ~init:(agents, 0, 0)
-          ~f:(fun (agents, merged_count, errs) (patch_id, _pr_number, result) ->
-            match result with
-            | Error _ -> (agents, merged_count, errs + 1)
-            | Ok pr_state ->
-                if Pr_state.merged pr_state then
-                  let agents =
-                    Map.change agents patch_id ~f:(function
-                      | None -> None
-                      | Some agent ->
-                          (* Record the merge-commit SHA we already have in
+    match
+      make_forge ~owner:cfg.github_owner ~repo:cfg.github_repo
+        ~main_branch:(Types.Branch.of_string cfg.main_branch)
+    with
+    | None ->
+        ( agents,
+          {
+            attempted = 0;
+            newly_merged = 0;
+            errors = 0;
+            skipped_reason =
+              Some
+                "no GitHub token available (set GITHUB_TOKEN or log in with \
+                 `gh`)";
+          } )
+    | Some forge ->
+        let module Forge = (val forge) in
+        let results =
+          Eio.Fiber.List.map ~max_fibers:16
+            (fun (patch_id, pr_number) ->
+              let result =
+                try
+                  Result.map_error (Forge.pr_state pr_number) ~f:(fun _ -> ())
+                with
+                | Eio.Cancel.Cancelled _ as exn -> raise exn
+                | _ -> Error ()
+              in
+              (patch_id, pr_number, result))
+            candidates
+        in
+        let attempted = List.length results in
+        let agents, newly_merged, errors =
+          List.fold results ~init:(agents, 0, 0)
+            ~f:(fun
+                (agents, merged_count, errs) (patch_id, _pr_number, result) ->
+              match result with
+              | Error _ -> (agents, merged_count, errs + 1)
+              | Ok pr_state ->
+                  if Pr_state.merged pr_state then
+                    let agents =
+                      Map.change agents patch_id ~f:(function
+                        | None -> None
+                        | Some agent ->
+                            (* Record the merge-commit SHA we already have in
                              hand so dependents' base-containment gate can
                              ancestry-check it without waiting for a re-poll. *)
-                          Some
-                            (Patch_agent.set_merge_commit_sha
-                               (Patch_agent.mark_merged agent)
-                               pr_state.Pr_state.merge_commit_sha))
-                  in
-                  (agents, merged_count + 1, errs)
-                else (agents, merged_count, errs))
-      in
-      (agents, { attempted; newly_merged; errors; skipped_reason = None })
+                            Some
+                              (Patch_agent.set_merge_commit_sha
+                                 (Patch_agent.mark_merged agent)
+                                 pr_state.Pr_state.merge_commit_sha))
+                    in
+                    (agents, merged_count + 1, errs)
+                  else (agents, merged_count, errs))
+        in
+        (agents, { attempted; newly_merged; errors; skipped_reason = None })
 
 let format_refresh_summary (s : refresh_summary) =
   let pr_word n = if n = 1 then "PR" else "PRs" in
@@ -147,7 +156,7 @@ let format_refresh_summary (s : refresh_summary) =
         in
         Some (String.concat ~sep:", " parts)
 
-let classify_project ~net ~clock ~refresh ~slug =
+let classify_project ~make_forge ~refresh ~slug =
   let snap_path = Project_store.snapshot_path slug in
   if not (Stdlib.Sys.file_exists snap_path) then (No_snapshot, None)
   else
@@ -171,7 +180,7 @@ let classify_project ~net ~clock ~refresh ~slug =
                     } )
             | Ok cfg ->
                 let agents, summary =
-                  refresh_agents_from_forge ~net ~clock ~cfg ~agents
+                  refresh_agents_from_forge ~make_forge ~cfg ~agents
                 in
                 (agents, Some summary)
         in
@@ -210,6 +219,18 @@ let run_prune ~net ~clock ~refresh () =
     Stdlib.Printf.printf "No stored projects to consider.\n";
     0)
   else
+    (* Resolve the GitHub token once for the whole prune run from
+       GITHUB_TOKEN / [gh auth token] — it is no longer persisted per project.
+       Skipped under [--no-refresh] since no forge queries happen. [make_forge]
+       closes over the run-wide [net]/[clock]/[token] so per-project
+       classification only supplies the owner/repo/branch that actually vary,
+       and yields [None] when no token is available so the refresh is reported
+       as skipped rather than failing. *)
+    let token = if refresh then Managed_repo.infer_github_token () else "" in
+    let make_forge ~owner ~repo ~main_branch =
+      if String.is_empty token then None
+      else Some (Github.make ~net ~clock ~token ~owner ~repo ~main_branch)
+    in
     let removed = ref [] in
     let kept = ref [] in
     let errors = ref [] in
@@ -245,7 +266,7 @@ let run_prune ~net ~clock ~refresh () =
                      ~finally:(fun () -> Project_lock.release lock)
                      (fun () ->
                        let status, refresh_summary =
-                         classify_project ~net ~clock ~refresh ~slug
+                         classify_project ~make_forge ~refresh ~slug
                        in
                        (match status with
                        | All_merged -> remove_path project_dir

--- a/lib/prune_runner.mli
+++ b/lib/prune_runner.mli
@@ -2,7 +2,12 @@
    @archlint.domain prune-runner *)
 
 val run_prune :
-  net:_ Eio.Net.t -> clock:_ Eio.Time.clock -> refresh:bool -> unit -> int
+  net:_ Eio.Net.t ->
+  clock:_ Eio.Time.clock ->
+  github_token:string ->
+  refresh:bool ->
+  unit ->
+  int
 (** Remove stored projects whose gameplan patches are all merged.
 
     When [refresh] is [true], every project with at least one non-terminal patch
@@ -13,6 +18,9 @@ val run_prune :
     the supervisor stopped polling. Refresh is conservative — any forge error
     leaves the stored [merged] flag untouched so the project is kept, not
     accidentally deleted.
+
+    [github_token] is the explicit CLI/env token value. When it is empty, prune
+    falls back to inferring a token from the environment or [gh auth token].
 
     Returns [0] on success and [1] when one or more projects report prune errors
     (for example lock, snapshot-load, or prune-time filesystem errors).


### PR DESCRIPTION
## Summary

Fixes #360. Resuming an older project could fail GitHub API calls with `HTTP 401: Requires authentication` even when `gh auth status` was healthy. On resume the code merged the CLI token with the token persisted in the project config and — because the stored token was non-empty — never fell through to the `gh auth token` fallback. A token rotated after project creation lost to the stale stored value forever.

This removes the `github_token` field from the persisted project config entirely (option 1 from the issue). The token is now resolved fresh on every run (`--token` → `GITHUB_TOKEN` → `gh auth token`) and never written to disk, which also retires the plaintext bearer tokens that accumulated in `~/.local/share/onton/<project>/config.json` (the issue author found 15 stale ones).

## Changes

- **`bin/main.ml`** — the actual fix: the resume path passes the raw CLI flag (empty when `--token`/`GITHUB_TOKEN` are absent) straight to `resolve_github_credentials`, so it falls through to `gh auth token`. Dropped the dead `token_from_stored`/`merge_cli_stored` plumbing, removed the token from `save_config`, and noted non-persistence in the `--token` help.
- **`lib/project_store.{ml,mli}`** — dropped `github_token` from `stored_config` and `save_config`. Added `drop_legacy_fields` to `load_config` so existing configs that still carry the key parse under the strict deriver. Since `finalize_run` rewrites `config.json` every run, the first resume scrubs the old plaintext token off disk.
- **`lib/prune_runner.ml`** — `run_prune` resolves the token once per run and closes over the run-wide `net`/`clock`/`token` in a `make_forge` factory, dropping all three from `classify_project` and `refresh_agents_from_forge`. Returns `None` (reported as "refresh skipped") when no token is available. Updated the `--no-refresh` doc (rotated tokens are no longer a reason to skip).
- **Tests** — two inline `let%test`s in `project_store.ml` cover legacy-key drop and no-token round-trip. The existing `debug_upload` redaction test now doubles as legacy-config coverage (it reads the raw file, so a token in an old config is still redacted).

## Trade-off

`--token` is no longer sticky across resumes — a project resumes under current `gh auth` rather than an earlier explicit per-project token. This is the intended behavior per the issue, but is a user-visible change for anyone who relied on a bot token differing from their `gh` identity.

## Test plan

- `dune build && dune test` green (incl. new inline tests + format check via pre-commit hook).
- Manual repro from the issue: write a `config.json` with a bogus `github_token`, unset `GITHUB_TOKEN`, resume — GraphQL calls now succeed via `gh auth token` instead of 401ing, and the rewritten config no longer contains the key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/362"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783876252&installation_id=126163856&pr_number=362&repository=flowglad%2Fonton&return_to=https%3A%2F%2Fgithub.com%2Fflowglad%2Fonton%2Fpull%2F362&signature=86108045dc759e80d08bec493bacb422d0af706a36ed666a1f16bada290bbd7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve the GitHub token at runtime instead of storing it in project configs, fixing resume-time 401s and removing plaintext tokens from disk. Also fixes prune refresh to honor the CLI/env token and skip cleanly when unauthenticated. Fixes #360.

- **Bug Fixes**
  - Resume now uses current auth (`--token` → `GITHUB_TOKEN` → `gh auth token`), avoiding stale-token 401s.
  - Prune refresh resolves the token once per run, honors `--token`/env, and reports "skipped" when no token is available.

- **Refactors**
  - Removed `github_token` from stored config; loader drops the legacy key and the first rewrite scrubs it from disk.
  - Updated `save_config` and public types; `--token` help notes it is not persisted; `--no-refresh` help clarifies `gh` auth requirement.
  - Routed forge access through a run-scoped `make_forge` factory.

<sup>Written for commit a10ed93ac200e7756dc2224138f2fcd829417123. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/flowglad/onton/pull/362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

