### PR TITLE
[codex] Update activity stream transitions

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -930,7 +930,7 @@ let construct_capabilities ~net (setup : runtime_setup) =
   in
   Telemetry_dispatch.register_sink (Event_log.sink event_log);
   Telemetry_dispatch.register_sink
-    (Activity_log_sink.sink
+    (Activity_log_sink.sink ~main_branch
        ~update:(Runtime.update_activity_log setup.runtime)
        ());
   let review_clients =

--- a/lib/activity_log_sink.ml
+++ b/lib/activity_log_sink.ml
@@ -53,32 +53,29 @@ let session_given_up fields =
   | Some _ | None -> false
 
 let needs_intervention fields =
-  if bool_member fields "merged" then false
-  else
-    let queue = operation_list_member fields "queue" in
-    let human_in_queue =
-      List.mem queue Operation_kind.Human ~equal:Operation_kind.equal
-    in
-    if session_given_up fields then true
-    else if is_pr_missing fields then true
-    else if human_in_queue then false
-    else
-      Option.value (int_member fields "ci_failure_count") ~default:0 >= 3
-      || (not (has_pr fields))
-         && Option.value
-              (int_member fields "start_attempts_without_pr")
-              ~default:0
-            >= 2
-      || Option.value (int_member fields "conflict_noop_count") ~default:0 >= 2
-      || Option.value (int_member fields "no_commits_push_count") ~default:0
-         >= 2
-      || Option.value (int_member fields "context_exhaustion_count") ~default:0
-         >= 2
-      || Option.value (int_member fields "push_failure_count") ~default:0 >= 3
-      || Option.value
-           (int_member fields "pr_body_artifact_miss_count")
-           ~default:0
-         >= 2
+  let queue = operation_list_member fields "queue" in
+  Patch_agent.needs_intervention_of_fields
+    ~merged:(bool_member fields "merged")
+    ~has_pr:(has_pr fields) ~is_pr_missing:(is_pr_missing fields)
+    ~session_given_up:(session_given_up fields)
+    ~human_in_queue:
+      (List.mem queue Operation_kind.Human ~equal:Operation_kind.equal)
+    ~ci_failure_count:
+      (Option.value (int_member fields "ci_failure_count") ~default:0)
+    ~start_attempts_without_pr:
+      (Option.value (int_member fields "start_attempts_without_pr") ~default:0)
+    ~conflict_noop_count:
+      (Option.value (int_member fields "conflict_noop_count") ~default:0)
+    ~no_commits_push_count:
+      (Option.value (int_member fields "no_commits_push_count") ~default:0)
+    ~context_exhaustion_count:
+      (Option.value (int_member fields "context_exhaustion_count") ~default:0)
+    ~push_failure_count:
+      (Option.value (int_member fields "push_failure_count") ~default:0)
+    ~pr_body_artifact_miss_count:
+      (Option.value
+         (int_member fields "pr_body_artifact_miss_count")
+         ~default:0)
 
 let display_status_of_agent_json ~main_branch json =
   let fields = assoc_fields json in

--- a/lib/activity_log_sink.ml
+++ b/lib/activity_log_sink.ml
@@ -1,7 +1,144 @@
 (* @archlint.module shell
    @archlint.domain activity-log *)
 
-let sink ~update () =
+open Base
+open Types
+
+let assoc_fields = function `Assoc fields -> fields | _ -> []
+let member fields name = List.Assoc.find fields ~equal:String.equal name
+
+let bool_member fields name =
+  match member fields name with Some (`Bool value) -> value | _ -> false
+
+let int_member fields name =
+  match member fields name with Some (`Int value) -> Some value | _ -> None
+
+let string_member fields name =
+  match member fields name with Some (`String value) -> Some value | _ -> None
+
+let operation_kind_of_json json =
+  match Json.try_of_yojson Operation_kind.t_of_yojson_compat json with
+  | Ok op -> Some op
+  | Error _ -> None
+
+let operation_list_member fields name =
+  match member fields name with
+  | Some (`List values) -> List.filter_map values ~f:operation_kind_of_json
+  | _ -> []
+
+let current_op_member fields =
+  match member fields "current_op" with
+  | Some `Null | None -> None
+  | Some json -> operation_kind_of_json json
+
+let has_pr fields =
+  match member fields "pr_status" with
+  | Some (`Assoc pr_fields) -> (
+      match string_member pr_fields "kind" with
+      | Some ("present" | "missing") -> true
+      | Some "absent" | Some _ | None -> false)
+  | _ -> Option.is_some (int_member fields "pr_number")
+
+let is_pr_missing fields =
+  match member fields "pr_status" with
+  | Some (`Assoc pr_fields) -> (
+      match string_member pr_fields "kind" with
+      | Some "missing" -> true
+      | Some _ | None -> false)
+  | _ -> false
+
+let session_given_up fields =
+  match member fields "session_fallback" with
+  | Some (`String "Given_up") | Some (`List [ `String "Given_up" ]) -> true
+  | Some _ | None -> false
+
+let needs_intervention fields =
+  if bool_member fields "merged" then false
+  else
+    let queue = operation_list_member fields "queue" in
+    let human_in_queue =
+      List.mem queue Operation_kind.Human ~equal:Operation_kind.equal
+    in
+    if session_given_up fields then true
+    else if is_pr_missing fields then true
+    else if human_in_queue then false
+    else
+      Option.value (int_member fields "ci_failure_count") ~default:0 >= 3
+      || (not (has_pr fields))
+         && Option.value
+              (int_member fields "start_attempts_without_pr")
+              ~default:0
+            >= 2
+      || Option.value (int_member fields "conflict_noop_count") ~default:0 >= 2
+      || Option.value (int_member fields "no_commits_push_count") ~default:0
+         >= 2
+      || Option.value (int_member fields "context_exhaustion_count") ~default:0
+         >= 2
+      || Option.value (int_member fields "push_failure_count") ~default:0 >= 3
+      || Option.value
+           (int_member fields "pr_body_artifact_miss_count")
+           ~default:0
+         >= 2
+
+let display_status_of_agent_json ~main_branch json =
+  let fields = assoc_fields json in
+  let patch_id =
+    Option.value (string_member fields "patch_id") ~default:""
+    |> Patch_id.of_string
+  in
+  let ctx =
+    State.Patch_ctx.empty
+    |> State.Patch_ctx.set_merged ~patch_id ~value:(bool_member fields "merged")
+    |> State.Patch_ctx.set_needs_intervention ~patch_id
+         ~value:(needs_intervention fields)
+    |> State.Patch_ctx.set_approved ~patch_id
+         ~value:(bool_member fields "satisfies")
+    |> State.Patch_ctx.set_busy ~patch_id ~value:(bool_member fields "busy")
+    |> State.Patch_ctx.set_has_pr ~patch_id ~value:(has_pr fields)
+  in
+  let ctx =
+    match string_member fields "base_branch" with
+    | Some branch ->
+        State.Patch_ctx.set_base_branch ctx ~patch_id
+          ~branch:(Branch.of_string branch)
+    | None -> ctx
+  in
+  let ctx =
+    List.fold (operation_list_member fields "queue") ~init:ctx
+      ~f:(fun ctx kind ->
+        State.Patch_ctx.set_queued ctx ~patch_id ~kind ~value:true)
+  in
+  Display_status.derive ctx ~patch_id ~current_op:(current_op_member fields)
+    ~main_branch
+
+let transition_action ~default_kind payload =
+  let fields = assoc_fields payload in
+  match string_member fields "event_log_kind" with
+  | Some kind -> kind
+  | None -> (
+      match string_member fields "action" with
+      | Some action -> action
+      | None -> (
+          match string_member fields "result" with
+          | Some result -> default_kind ^ ": " ^ result
+          | None -> default_kind))
+
+let transition_of_payload ~main_branch ~timestamp ~patch_id ~default_kind
+    payload =
+  let fields = assoc_fields payload in
+  match (member fields "agent_before", member fields "agent_after") with
+  | Some before_json, Some after_json ->
+      let from_status = display_status_of_agent_json ~main_branch before_json in
+      let to_status = display_status_of_agent_json ~main_branch after_json in
+      if Display_status.equal from_status to_status then None
+      else
+        Some
+          (Activity_log.Transition_entry.create ~timestamp ~patch_id
+             ~from_status ~to_status
+             ~action:(transition_action ~default_kind payload))
+  | _ -> None
+
+let sink ~main_branch ~update () =
   let consume = function
     | Telemetry.Event.Free_form { patch_id; message; _ } ->
         let timestamp = Unix.gettimeofday () in
@@ -17,14 +154,34 @@ let sink ~update () =
                 Activity_log.add_stream_entry log
                   (Activity_log.Stream_entry.create ~timestamp ~patch_id ~kind))
         )
-    | Poll _ | Action _ | Complete _ | Spawn_started _ | Spawn_finalized _ -> ()
+    | Poll { patch_id; payload } ->
+        let timestamp = Unix.gettimeofday () in
+        Option.iter
+          (transition_of_payload ~main_branch ~timestamp ~patch_id
+             ~default_kind:"poll" payload) ~f:(fun transition ->
+            update (fun log -> Activity_log.add_transition log transition))
+    | Action { patch_id; payload; _ } ->
+        let timestamp = Unix.gettimeofday () in
+        Option.iter
+          (transition_of_payload ~main_branch ~timestamp ~patch_id
+             ~default_kind:"action" payload) ~f:(fun transition ->
+            update (fun log -> Activity_log.add_transition log transition))
+    | Complete { patch_id; payload; _ } ->
+        let timestamp = Unix.gettimeofday () in
+        Option.iter
+          (transition_of_payload ~main_branch ~timestamp ~patch_id
+             ~default_kind:"complete" payload) ~f:(fun transition ->
+            update (fun log -> Activity_log.add_transition log transition))
+    | Spawn_started _ | Spawn_finalized _ -> ()
   in
   {
     Telemetry.Sink.name = "activity_log";
     interested_in =
       (function
-      | Telemetry.Event.Free_form _ | Telemetry.Event.Stream _ -> true
-      | Poll _ | Action _ | Complete _ | Spawn_started _ | Spawn_finalized _ ->
-          false);
+      | Telemetry.Event.Free_form _ | Telemetry.Event.Stream _
+      | Telemetry.Event.Poll _ | Telemetry.Event.Action _
+      | Telemetry.Event.Complete _ ->
+          true
+      | Spawn_started _ | Spawn_finalized _ -> false);
     consume;
   }

--- a/lib/activity_log_sink.mli
+++ b/lib/activity_log_sink.mli
@@ -2,8 +2,10 @@
    @archlint.domain activity-log-sink *)
 
 val sink :
+  main_branch:Types.Branch.t ->
   update:((Activity_log.t -> Activity_log.t) -> unit) ->
   unit ->
   Telemetry.Sink.t
-(** Telemetry sink that appends free-form events and stream entries through
-    [update]. The callback should apply its function to the current live log. *)
+(** Telemetry sink that appends free-form events, status transitions, and stream
+    entries through [update]. The callback should apply its function to the
+    current live log. *)

--- a/lib/headless_fiber.ml
+++ b/lib/headless_fiber.ml
@@ -6,8 +6,7 @@ open Types
 
 let merged_log_entries ~(log : Activity_log.t) ~limit ~compare
     ~(map_event : Activity_log.Event.t -> 'a)
-    ~(map_transition : Activity_log.Transition_entry.t -> 'a)
-    ~(map_stream : Activity_log.Stream_entry.t -> 'a) =
+    ~(map_transition : Activity_log.Transition_entry.t -> 'a) =
   let events =
     List.map (Activity_log.recent_events log ~limit) ~f:(fun e ->
         (e.Activity_log.Event.timestamp, map_event e))
@@ -16,22 +15,7 @@ let merged_log_entries ~(log : Activity_log.t) ~limit ~compare
     List.map (Activity_log.recent_transitions log ~limit) ~f:(fun t ->
         (t.Activity_log.Transition_entry.timestamp, map_transition t))
   in
-  let stream =
-    List.map (Activity_log.recent_stream_entries log ~limit) ~f:(fun s ->
-        (s.Activity_log.Stream_entry.timestamp, map_stream s))
-  in
-  List.sort (events @ transitions @ stream) ~compare
-
-let format_stream_kind (kind : Activity_log.Stream_entry.kind) =
-  match kind with
-  | Activity_log.Stream_entry.Tool_use (name, input) ->
-      if String.length input > 0 then Printf.sprintf "Tool %s — %s" name input
-      else Printf.sprintf "Tool %s" name
-  | Activity_log.Stream_entry.Text_chunk text -> text
-  | Activity_log.Stream_entry.Finished reason ->
-      Printf.sprintf "Finished — %s" reason
-  | Activity_log.Stream_entry.Stream_error msg ->
-      Printf.sprintf "Stream error — %s" msg
+  List.sort (events @ transitions) ~compare
 
 let format_time ts =
   let t = Unix.localtime ts in
@@ -71,11 +55,7 @@ struct
         Runtime.read Env.runtime (fun snap ->
             merged_log_entries ~log:snap.Runtime.activity_log ~limit:500
               ~compare:(fun (t1, _) (t2, _) -> Float.ascending t1 t2)
-              ~map_event:format_event ~map_transition:format_transition
-              ~map_stream:(fun (s : Activity_log.Stream_entry.t) ->
-                Printf.sprintf "[%s] %s"
-                  (Patch_id.to_string s.Activity_log.Stream_entry.patch_id)
-                  (format_stream_kind s.Activity_log.Stream_entry.kind)))
+              ~map_event:format_event ~map_transition:format_transition)
       in
       List.iter entries ~f:(fun (ts, msg) ->
           let key = (ts, msg) in

--- a/lib/tui_fiber.ml
+++ b/lib/tui_fiber.ml
@@ -9,8 +9,7 @@ let log_event runtime ?patch_id msg =
 
 let merged_log_entries ~(log : Activity_log.t) ~limit ~compare
     ~(map_event : Activity_log.Event.t -> 'a)
-    ~(map_transition : Activity_log.Transition_entry.t -> 'a)
-    ~(map_stream : Activity_log.Stream_entry.t -> 'a) =
+    ~(map_transition : Activity_log.Transition_entry.t -> 'a) =
   let events =
     List.map (Activity_log.recent_events log ~limit) ~f:(fun e ->
         (e.Activity_log.Event.timestamp, map_event e))
@@ -19,22 +18,7 @@ let merged_log_entries ~(log : Activity_log.t) ~limit ~compare
     List.map (Activity_log.recent_transitions log ~limit) ~f:(fun t ->
         (t.Activity_log.Transition_entry.timestamp, map_transition t))
   in
-  let stream =
-    List.map (Activity_log.recent_stream_entries log ~limit) ~f:(fun s ->
-        (s.Activity_log.Stream_entry.timestamp, map_stream s))
-  in
-  List.sort (events @ transitions @ stream) ~compare
-
-let format_stream_kind (kind : Activity_log.Stream_entry.kind) =
-  match kind with
-  | Activity_log.Stream_entry.Tool_use (name, input) ->
-      if String.length input > 0 then Printf.sprintf "Tool %s — %s" name input
-      else Printf.sprintf "Tool %s" name
-  | Activity_log.Stream_entry.Text_chunk text -> text
-  | Activity_log.Stream_entry.Finished reason ->
-      Printf.sprintf "Finished — %s" reason
-  | Activity_log.Stream_entry.Stream_error msg ->
-      Printf.sprintf "Stream error — %s" msg
+  List.sort (events @ transitions) ~compare
 
 let activity_entries_of_log ?(limit = 10) (log : Activity_log.t) =
   merged_log_entries ~log ~limit
@@ -56,14 +40,6 @@ let activity_entries_of_log ?(limit = 10) (log : Activity_log.t) =
           to_label = Tui.label t.Activity_log.Transition_entry.to_status;
           action = t.Activity_log.Transition_entry.action;
           timestamp = t.Activity_log.Transition_entry.timestamp;
-        })
-    ~map_stream:(fun (s : Activity_log.Stream_entry.t) ->
-      Tui.Event
-        {
-          patch_id =
-            Some (Patch_id.to_string s.Activity_log.Stream_entry.patch_id);
-          message = format_stream_kind s.Activity_log.Stream_entry.kind;
-          timestamp = s.Activity_log.Stream_entry.timestamp;
         })
   |> List.map ~f:snd
 

--- a/lib_core/patch_agent.ml
+++ b/lib_core/patch_agent.ml
@@ -132,16 +132,14 @@ let pr_number t = Patch_pr_status.pr_number t.pr_status
    drift. The label strings are stable and intended to land verbatim in the
    event log so operators can grep for "why is this patch stuck?" by
    reason. *)
-let intervention_reason t =
-  if t.merged then None
-  else
-    let human_in_queue =
-      List.mem t.queue Operation_kind.Human ~equal:Operation_kind.equal
-    in
-    let given_up = equal_session_fallback t.session_fallback Given_up in
-    if given_up then Some "session_fallback=given_up"
-    else if is_pr_missing t then Some "pr_missing"
-      (* The Human exemption lets a newly-arrived human message be delivered
+let intervention_reason_of_fields ~merged ~has_pr ~is_pr_missing
+    ~session_given_up ~human_in_queue ~ci_failure_count
+    ~start_attempts_without_pr ~conflict_noop_count ~no_commits_push_count
+    ~context_exhaustion_count ~push_failure_count ~pr_body_artifact_miss_count =
+  if merged then None
+  else if session_given_up then Some "session_fallback=given_up"
+  else if is_pr_missing then Some "pr_missing"
+    (* The Human exemption lets a newly-arrived human message be delivered
        even to an agent with a high ci_failure_count or other failure state.
        However, the exemption does NOT apply when session_fallback = Given_up:
        a Given_up agent cannot start any session, so the delivery attempt
@@ -153,20 +151,44 @@ let intervention_reason t =
        [merged] is terminal — a merged agent never needs intervention, so
        short-circuit on it to keep the predicate self-consistent even for
        callers that don't pre-filter by [merged]. *)
-    else if human_in_queue then None
-    else if t.ci_failure_count >= 3 then Some "ci_failure_count>=3"
-    else if (not (has_pr t)) && t.start_attempts_without_pr >= 2 then
-      Some "start_attempts_without_pr>=2"
-    else if t.conflict_noop_count >= 2 then Some "conflict_noop_count>=2"
-    else if t.no_commits_push_count >= 2 then Some "no_commits_push_count>=2"
-    else if t.context_exhaustion_count >= 2 then
-      Some "context_exhaustion_count>=2"
-    else if t.push_failure_count >= 3 then Some "push_failure_count>=3"
-    else if t.pr_body_artifact_miss_count >= 2 then
-      Some "pr_body_artifact_miss_count>=2"
-    else None
+  else if human_in_queue then None
+  else if ci_failure_count >= 3 then Some "ci_failure_count>=3"
+  else if (not has_pr) && start_attempts_without_pr >= 2 then
+    Some "start_attempts_without_pr>=2"
+  else if conflict_noop_count >= 2 then Some "conflict_noop_count>=2"
+  else if no_commits_push_count >= 2 then Some "no_commits_push_count>=2"
+  else if context_exhaustion_count >= 2 then Some "context_exhaustion_count>=2"
+  else if push_failure_count >= 3 then Some "push_failure_count>=3"
+  else if pr_body_artifact_miss_count >= 2 then
+    Some "pr_body_artifact_miss_count>=2"
+  else None
+
+let intervention_reason t =
+  intervention_reason_of_fields ~merged:t.merged ~has_pr:(has_pr t)
+    ~is_pr_missing:(is_pr_missing t)
+    ~session_given_up:(equal_session_fallback t.session_fallback Given_up)
+    ~human_in_queue:
+      (List.mem t.queue Operation_kind.Human ~equal:Operation_kind.equal)
+    ~ci_failure_count:t.ci_failure_count
+    ~start_attempts_without_pr:t.start_attempts_without_pr
+    ~conflict_noop_count:t.conflict_noop_count
+    ~no_commits_push_count:t.no_commits_push_count
+    ~context_exhaustion_count:t.context_exhaustion_count
+    ~push_failure_count:t.push_failure_count
+    ~pr_body_artifact_miss_count:t.pr_body_artifact_miss_count
 
 let needs_intervention t = Option.is_some (intervention_reason t)
+
+let needs_intervention_of_fields ~merged ~has_pr ~is_pr_missing
+    ~session_given_up ~human_in_queue ~ci_failure_count
+    ~start_attempts_without_pr ~conflict_noop_count ~no_commits_push_count
+    ~context_exhaustion_count ~push_failure_count ~pr_body_artifact_miss_count =
+  Option.is_some
+    (intervention_reason_of_fields ~merged ~has_pr ~is_pr_missing
+       ~session_given_up ~human_in_queue ~ci_failure_count
+       ~start_attempts_without_pr ~conflict_noop_count ~no_commits_push_count
+       ~context_exhaustion_count ~push_failure_count
+       ~pr_body_artifact_miss_count)
 
 let create ~branch patch_id =
   {

--- a/lib_core/patch_agent.mli
+++ b/lib_core/patch_agent.mli
@@ -176,6 +176,24 @@ val intervention_reason : t -> string option
     in the event log so operators can grep "why is this patch stuck?" by reason.
 *)
 
+val intervention_reason_of_fields :
+  merged:bool ->
+  has_pr:bool ->
+  is_pr_missing:bool ->
+  session_given_up:bool ->
+  human_in_queue:bool ->
+  ci_failure_count:int ->
+  start_attempts_without_pr:int ->
+  conflict_noop_count:int ->
+  no_commits_push_count:int ->
+  context_exhaustion_count:int ->
+  push_failure_count:int ->
+  pr_body_artifact_miss_count:int ->
+  string option
+(** Raw-field form of {!intervention_reason}. This is the canonical pure
+    decision for callers that reconstruct agent status from persisted telemetry
+    instead of holding a {!t}. *)
+
 val needs_intervention : t -> bool
 (** [Option.is_some (intervention_reason t)]. Derived predicate. True iff the
     agent is not [merged] AND any of:
@@ -188,6 +206,22 @@ val needs_intervention : t -> bool
       [conflict_noop_count >= 2], [no_commits_push_count >= 2],
       [context_exhaustion_count >= 2], [push_failure_count >= 3],
       [pr_body_artifact_miss_count >= 2]. *)
+
+val needs_intervention_of_fields :
+  merged:bool ->
+  has_pr:bool ->
+  is_pr_missing:bool ->
+  session_given_up:bool ->
+  human_in_queue:bool ->
+  ci_failure_count:int ->
+  start_attempts_without_pr:int ->
+  conflict_noop_count:int ->
+  no_commits_push_count:int ->
+  context_exhaustion_count:int ->
+  push_failure_count:int ->
+  pr_body_artifact_miss_count:int ->
+  bool
+(** [Option.is_some (intervention_reason_of_fields ...)]. *)
 
 (** {2 Spec actions} *)
 

--- a/test/test_telemetry_migration.ml
+++ b/test/test_telemetry_migration.ml
@@ -88,7 +88,11 @@ let test_activity_log_free_form () =
   let update f = log := f !log in
   let patch_id = Types.Patch_id.of_string "patch-5" in
   Onton.Telemetry_dispatch.with_sink
-    ~sink:(Onton.Activity_log_sink.sink ~update ()) (fun () ->
+    ~sink:
+      (Onton.Activity_log_sink.sink
+         ~main_branch:(Types.Branch.of_string "main")
+         ~update ())
+    (fun () ->
       Onton.Telemetry_dispatch.emit
         (Telemetry.Event.Free_form
            {
@@ -113,7 +117,11 @@ let test_activity_log_stream_drops_untagged () =
   let update f = log := f !log in
   let patch_id = Types.Patch_id.of_string "patch-5" in
   Onton.Telemetry_dispatch.with_sink
-    ~sink:(Onton.Activity_log_sink.sink ~update ()) (fun () ->
+    ~sink:
+      (Onton.Activity_log_sink.sink
+         ~main_branch:(Types.Branch.of_string "main")
+         ~update ())
+    (fun () ->
       Onton.Telemetry_dispatch.emit
         (Telemetry.Event.Stream
            {
@@ -150,7 +158,11 @@ let test_activity_log_stream_accepts_tagged () =
          ])
   in
   Onton.Telemetry_dispatch.with_sink
-    ~sink:(Onton.Activity_log_sink.sink ~update ()) (fun () ->
+    ~sink:
+      (Onton.Activity_log_sink.sink
+         ~main_branch:(Types.Branch.of_string "main")
+         ~update ())
+    (fun () ->
       Onton.Telemetry_dispatch.emit
         (Telemetry.Event.Stream
            {
@@ -174,6 +186,72 @@ let test_activity_log_stream_accepts_tagged () =
       fail
         (Printf.sprintf "expected one stream entry, got %d"
            (List.length entries))
+
+let agent_json ?(busy = false) patch_id =
+  `Assoc
+    [
+      ("patch_id", Types.Patch_id.yojson_of_t patch_id);
+      ("pr_status", `Assoc [ ("kind", `String "absent") ]);
+      ("pr_number", `Null);
+      ("busy", `Bool busy);
+      ("merged", `Bool false);
+      ("satisfies", `Bool false);
+      ("base_branch", `Null);
+      ("queue", `List []);
+      ("current_op", `Null);
+      ("session_fallback", `String "Fresh_available");
+      ("ci_failure_count", `Int 0);
+      ("start_attempts_without_pr", `Int 0);
+      ("conflict_noop_count", `Int 0);
+      ("no_commits_push_count", `Int 0);
+      ("context_exhaustion_count", `Int 0);
+      ("push_failure_count", `Int 0);
+      ("pr_body_artifact_miss_count", `Int 0);
+    ]
+
+let test_activity_log_records_status_transition () =
+  let log = ref Activity_log.empty in
+  let update f = log := f !log in
+  let patch_id = Types.Patch_id.of_string "patch-5" in
+  Onton.Telemetry_dispatch.with_sink
+    ~sink:
+      (Onton.Activity_log_sink.sink
+         ~main_branch:(Types.Branch.of_string "main")
+         ~update ())
+    (fun () ->
+      Onton.Telemetry_dispatch.emit
+        (Telemetry.Event.Action
+           {
+             patch_id;
+             session_uuid = None;
+             payload =
+               `Assoc
+                 [
+                   ("action", `String "Start");
+                   ("agent_before", agent_json patch_id);
+                   ("agent_after", agent_json ~busy:true patch_id);
+                 ];
+           }));
+  match Activity_log.recent_transitions !log ~limit:1 with
+  | [ transition ] ->
+      if
+        not
+          (Display_status.equal
+             transition.Activity_log.Transition_entry.from_status
+             Display_status.Pending)
+      then fail "expected transition from pending";
+      if
+        not
+          (Display_status.equal
+             transition.Activity_log.Transition_entry.to_status
+             Display_status.Starting)
+      then fail "expected transition to starting";
+      expect_equal_string ~name:"action" "Start"
+        transition.Activity_log.Transition_entry.action
+  | transitions ->
+      fail
+        (Printf.sprintf "expected one transition, got %d"
+           (List.length transitions))
 
 let test_pre_migration_events_jsonl_loads () =
   let line =
@@ -224,4 +302,5 @@ let () =
   test_activity_log_free_form ();
   test_activity_log_stream_drops_untagged ();
   test_activity_log_stream_accepts_tagged ();
+  test_activity_log_records_status_transition ();
   test_pre_migration_events_jsonl_loads ()


### PR DESCRIPTION
## Summary

- stop showing patch-agent stream entries like tool calls in the overview Activity stream and headless activity output
- record display-status transitions from structured poll/action/complete telemetry using `agent_before` and `agent_after`
- add a regression test covering Activity-log transition recording

## Why

The overview Activity stream was mixing high-level operational activity with low-level patch-agent stream events, which made tool calls dominate the pane. The Activity stream now focuses on user-visible events and patch state transitions while preserving stream entries in the log data for diagnostics.

## Validation

- `dune fmt`
- `dune build`
- `dune runtest`
- pre-commit hook also ran build, tests, and format check during commit

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/363"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784134189&installation_id=126163856&pr_number=363&repository=flowglad%2Fonton&return_to=https%3A%2F%2Fgithub.com%2Fflowglad%2Fonton%2Fpull%2F363&signature=a9a0224f14b6b290472ab7040633699e5b53be567f1a826b07af55dd62f8014a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the Activity stream by hiding low-level patch-agent stream events and adding clear status transitions derived from telemetry. Headless and TUI now show only user-visible events and transitions; stream entries stay in logs for diagnostics.

- **New Features**
  - Record display-status transitions from `Poll`, `Action`, and `Complete` telemetry using `agent_before`/`agent_after` and `main_branch`.
  - Remove tool calls and other stream chunks from the overview Activity and headless output; still persisted as stream entries.
  - Share “needs intervention” logic via new field-based helpers, and add a regression test for transition recording.

- **Migration**
  - `Activity_log_sink.sink` now requires `~main_branch`. Pass the repository’s main branch when registering the sink.

<sup>Written for commit 226fb0e06a1b0ede5d0d2de5ad13640ce6e93dad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/flowglad/onton/pull/363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

