### PR TITLE
Bound and add scrollable overlay for CI checks in detail view

### DIFF
--- a/lib/tui.ml
+++ b/lib/tui.ml
@@ -1204,6 +1204,7 @@ let render_checks_overlay ~width ~height ~scroll_offset (pv : patch_view) =
   let title =
     let label =
       if total = 0 then " CI Checks"
+      else if vis_count = 0 then Printf.sprintf " CI Checks (– of %d)" total
       else
         Printf.sprintf " CI Checks (%d–%d of %d)" (offset + 1)
           (offset + vis_count) total

--- a/lib/tui.ml
+++ b/lib/tui.ml
@@ -524,6 +524,7 @@ type frame = {
   width : int;
   detail_at_bottom : bool;
   detail_scroll_offset : int;
+  checks_scroll_offset : int;
   patches_start_row : int;
   patches_scroll_offset : int;
   patch_count : int;
@@ -727,6 +728,52 @@ let render_activity (entries : activity_entry list) =
     in
     header :: lines
 
+(** Deduplicate CI checks by name, keeping the most recent result by
+    [started_at]. ISO 8601 timestamps sort lexicographically. Original
+    first-seen order is preserved. Shared between the inline detail info rows
+    and the scrollable checks overlay so both agree on what to show. *)
+let dedup_ci_checks (checks : Ci_check.t list) =
+  let seen = Hashtbl.create (module String) in
+  List.iter checks ~f:(fun (c : Ci_check.t) ->
+      match Hashtbl.find seen c.name with
+      | Some (prev : Ci_check.t) ->
+          let newer =
+            match (c.started_at, prev.started_at) with
+            | Some a, Some b -> String.( >= ) a b
+            | Some _, None -> true
+            | None, Some _ -> false
+            | None, None -> false
+          in
+          if newer then Hashtbl.set seen ~key:c.name ~data:c
+      | None -> Hashtbl.set seen ~key:c.name ~data:c);
+  let emitted = Hashtbl.create (module String) in
+  List.filter_map checks ~f:(fun (c : Ci_check.t) ->
+      if Hashtbl.mem emitted c.name then None
+      else (
+        Hashtbl.set emitted ~key:c.name ~data:();
+        Some (Hashtbl.find_exn seen c.name)))
+
+(** Render a single CI check as an icon + name + conclusion, with [indent]
+    leading spaces. Shared between the inline detail rows and the checks
+    overlay. *)
+let render_ci_check_row ~indent (c : Ci_check.t) =
+  let failure_conclusions = Patch_decision.failure_conclusions in
+  let icon =
+    if String.equal c.conclusion "success" then
+      Term.styled [ Term.Sgr.fg_green ] "✓"
+    else if List.mem failure_conclusions c.conclusion ~equal:String.equal then
+      Term.styled [ Term.Sgr.fg_red ] "✗"
+    else Term.styled [ Term.Sgr.fg_yellow ] "?"
+  in
+  Printf.sprintf "%s%s %s: %s" indent icon c.name c.conclusion
+
+(** Maximum number of CI checks shown inline in the detail info section. Beyond
+    this, an ellipsis row points at the scrollable checks overlay so the checks
+    cannot crowd the transcript and metadata off the screen. Kept a fixed
+    constant (not height-derived) so [detail_info_height] stays a pure function
+    of the check count. *)
+let max_inline_ci_checks = 8
+
 (** Build the info rows for a detail view. Shared between [render_detail] and
     [detail_info_height] to keep them in sync. [~now] is the wall-clock time the
     frame is rendered against — threaded in rather than read from
@@ -844,45 +891,21 @@ let detail_info_rows (pv : patch_view) ~width ~now =
   let ci_section =
     if List.is_empty pv.ci_checks then []
     else
-      let failure_conclusions = Patch_decision.failure_conclusions in
-      (* Deduplicate by name, keeping the most recent result by started_at.
-         ISO 8601 timestamps sort lexicographically. *)
-      let deduped =
-        let seen = Hashtbl.create (module String) in
-        List.iter pv.ci_checks ~f:(fun (c : Ci_check.t) ->
-            match Hashtbl.find seen c.name with
-            | Some (prev : Ci_check.t) ->
-                let newer =
-                  match (c.started_at, prev.started_at) with
-                  | Some a, Some b -> String.( >= ) a b
-                  | Some _, None -> true
-                  | None, Some _ -> false
-                  | None, None -> false
-                in
-                if newer then Hashtbl.set seen ~key:c.name ~data:c
-            | None -> Hashtbl.set seen ~key:c.name ~data:c);
-        (* Preserve original order by filtering to first-seen names *)
-        let emitted = Hashtbl.create (module String) in
-        List.filter_map pv.ci_checks ~f:(fun (c : Ci_check.t) ->
-            if Hashtbl.mem emitted c.name then None
-            else (
-              Hashtbl.set emitted ~key:c.name ~data:();
-              Some (Hashtbl.find_exn seen c.name)))
-      in
+      let deduped = dedup_ci_checks pv.ci_checks in
+      let total = List.length deduped in
+      let shown = List.take deduped max_inline_ci_checks in
       let ci_header = [ ""; Term.styled [ Term.Sgr.bold ] "  CI Checks" ] in
-      let ci_rows =
-        List.map deduped ~f:(fun (c : Ci_check.t) ->
-            let icon =
-              if String.equal c.conclusion "success" then
-                Term.styled [ Term.Sgr.fg_green ] "✓"
-              else if
-                List.mem failure_conclusions c.conclusion ~equal:String.equal
-              then Term.styled [ Term.Sgr.fg_red ] "✗"
-              else Term.styled [ Term.Sgr.fg_yellow ] "?"
-            in
-            Printf.sprintf "    %s %s: %s" icon c.name c.conclusion)
+      let ci_rows = List.map shown ~f:(render_ci_check_row ~indent:"    ") in
+      let overflow =
+        if total > max_inline_ci_checks then
+          [
+            Term.styled [ Term.Sgr.dim ]
+              (Printf.sprintf "    … %d more — press c to view all"
+                 (total - max_inline_ci_checks));
+          ]
+        else []
       in
-      ci_header @ ci_rows
+      ci_header @ ci_rows @ overflow
   in
   lines @ op_line @ intervention @ ci_section
 
@@ -1040,8 +1063,8 @@ let render_footer ~width ~view_mode ?prompt_line () =
                -:remove  m:manage  o:open browser  h:help"
         | Detail_view _ ->
             Term.styled [ Term.Sgr.dim ]
-              " q:quit  esc/backspace:back  enter:message  m:manage  o:open \
-               browser  t:timeline  h:help"
+              " q:quit  esc/backspace:back  enter:message  c:checks  m:manage  \
+               o:open browser  t:timeline  h:help"
         | Timeline_view ->
             Term.styled [ Term.Sgr.dim ]
               " q:quit  esc/backspace:back  ↑/↓:scroll  t:list  h:help"
@@ -1084,6 +1107,7 @@ let render_help_overlay ~width ~height =
           "PgUp      Page up (10 lines)";
           "PgDn      Page down (10 lines)";
           "Enter     Send message";
+          "c         View all CI checks";
           "m         Manage patch";
           "o         Open PR in browser";
           "Esc/Bksp  Back to list";
@@ -1159,6 +1183,58 @@ let render_manage_overlay ~width ~height ~automerge_enabled ~needs_intervention
   let visible = List.sub content ~pos:0 ~len:overlay_h in
   let pad_line line = if width <= 0 then "" else Term.fit_width width line in
   List.map visible ~f:pad_line
+
+(** Full-screen, scrollable list of a patch's CI checks. Opened by hotkey from
+    the detail view when the inline section is capped. Returns the rendered
+    lines and the clamped scroll offset (written back to [checks_scroll] so
+    delta-based input stays in range, mirroring [render_detail]). Only one
+    scroll offset is ever live at a time: while this overlay is up the detail
+    transcript scroll is dormant. *)
+let render_checks_overlay ~width ~height ~scroll_offset (pv : patch_view) =
+  let deduped = dedup_ci_checks pv.ci_checks in
+  let total = List.length deduped in
+  let dismiss = Term.styled [ Term.Sgr.dim ] "(↑/↓ scroll · esc to close)" in
+  (* Reserve the title plus a possible top and bottom indicator. *)
+  let content_visible = Int.max 0 (height - 3) in
+  let max_off =
+    if total > content_visible then total - content_visible else 0
+  in
+  let offset = Int.max 0 (Int.min scroll_offset max_off) in
+  let vis_count = Int.min content_visible (Int.max 0 (total - offset)) in
+  let title =
+    let label =
+      if total = 0 then " CI Checks"
+      else
+        Printf.sprintf " CI Checks (%d–%d of %d)" (offset + 1)
+          (offset + vis_count) total
+    in
+    Term.styled
+      [ Term.Sgr.bold; Term.Sgr.fg_cyan ]
+      (Printf.sprintf "%s  %s" label dismiss)
+  in
+  let top_ind =
+    if offset > 0 then
+      [ Term.styled [ Term.Sgr.dim ] (Printf.sprintf "  ↑ %d above" offset) ]
+    else []
+  in
+  let bot_ind =
+    let below = max_off - offset in
+    if below > 0 then
+      [ Term.styled [ Term.Sgr.dim ] (Printf.sprintf "  ↓ %d below" below) ]
+    else []
+  in
+  let rows =
+    if total = 0 then
+      [ Term.styled [ Term.Sgr.dim ] "  (no CI checks reported)" ]
+    else
+      List.sub deduped ~pos:offset ~len:vis_count
+      |> List.map ~f:(render_ci_check_row ~indent:"  ")
+  in
+  let content = (title :: top_ind) @ rows @ bot_ind in
+  let overlay_h = Int.max 0 (Int.min (List.length content) (height - 1)) in
+  let visible = List.sub content ~pos:0 ~len:overlay_h in
+  let pad_line line = if width <= 0 then "" else Term.fit_width width line in
+  (List.map visible ~f:pad_line, offset)
 
 (** Number of info lines render_detail produces for a patch. Derived from
     [detail_info_rows] so the two cannot drift. Width only affects truncation,
@@ -1238,35 +1314,56 @@ let views_of_orchestrator ~(orchestrator : Orchestrator.t)
 
 let render_frame ~width ~height ~selected ~scroll_offset ~view_mode
     ~(activity : activity_entry list) ~project_name ~backend_name ~show_help
-    ~show_manage ~now ?(transcript = "") ?status_msg ?prompt_line
-    (views : patch_view list) =
+    ~show_checks ~checks_scroll ~show_manage ~now ?(transcript = "") ?status_msg
+    ?prompt_line (views : patch_view list) =
   let no_patches =
     {
       lines = [];
       width;
       detail_at_bottom = false;
       detail_scroll_offset = 0;
+      checks_scroll_offset = checks_scroll;
       patches_start_row = 0;
       patches_scroll_offset = 0;
       patch_count = 0;
     }
   in
+  (* The patch the overlays (manage, checks) act on: the focused patch in detail
+     view, or the selected row in list view. *)
+  let overlay_target_pv () =
+    match view_mode with
+    | Detail_view patch_id ->
+        List.find views ~f:(fun pv -> Patch_id.equal pv.patch_id patch_id)
+    | List_view ->
+        let count = List.length views in
+        if count = 0 then None
+        else
+          let idx = Int.max 0 (Int.min selected (count - 1)) in
+          List.nth views idx
+    | Timeline_view -> None
+  in
   if show_help then
     let overlay = render_help_overlay ~width ~height in
     { no_patches with lines = overlay }
+  else if show_checks then
+    match overlay_target_pv () with
+    | Some pv ->
+        let overlay, clamped =
+          render_checks_overlay ~width ~height ~scroll_offset:checks_scroll pv
+        in
+        { no_patches with lines = overlay; checks_scroll_offset = clamped }
+    | None ->
+        (* No patch in focus — nothing to show. Render a dismissable notice
+           rather than dereferencing an absent patch. *)
+        let line =
+          Term.styled
+            [ Term.Sgr.bold; Term.Sgr.fg_cyan ]
+            " CI Checks  (no patch selected — esc to close)"
+        in
+        let pad = if width <= 0 then "" else Term.fit_width width line in
+        { no_patches with lines = [ pad ] }
   else if show_manage then
-    let target_pv =
-      match view_mode with
-      | Detail_view patch_id ->
-          List.find views ~f:(fun pv -> Patch_id.equal pv.patch_id patch_id)
-      | List_view ->
-          let count = List.length views in
-          if count = 0 then None
-          else
-            let idx = Int.max 0 (Int.min selected (count - 1)) in
-            List.nth views idx
-      | Timeline_view -> None
-    in
+    let target_pv = overlay_target_pv () in
     let automerge_enabled =
       Option.value_map target_pv ~default:false ~f:(fun pv ->
           pv.automerge_enabled)
@@ -1397,6 +1494,7 @@ let render_frame ~width ~height ~selected ~scroll_offset ~view_mode
 let frame_to_string (frame : frame) = String.concat ~sep:"\n" frame.lines ^ "\n"
 let detail_at_bottom frame = frame.detail_at_bottom
 let detail_scroll_offset frame = frame.detail_scroll_offset
+let checks_scroll_offset frame = frame.checks_scroll_offset
 let patches_start_row frame = frame.patches_start_row
 let patches_scroll_offset frame = frame.patches_scroll_offset
 let patch_count frame = frame.patch_count

--- a/lib/tui.mli
+++ b/lib/tui.mli
@@ -139,6 +139,11 @@ val detail_scroll_offset : frame -> int
 (** The actual clamped scroll offset used for the detail view. Written back to
     the detail_scroll ref so delta-based input produces sensible values. *)
 
+val checks_scroll_offset : frame -> int
+(** The actual clamped scroll offset used for the CI checks overlay. Written
+    back to the checks_scroll ref so delta-based input stays in range. When the
+    overlay is not shown this round-trips the input value unchanged. *)
+
 val patches_start_row : frame -> int
 (** 1-indexed terminal row where the first patch line is rendered in list view.
     Returns 0 for non-list views. *)
@@ -177,6 +182,15 @@ val render_manage_overlay :
   needs_intervention:bool ->
   string list
 
+val render_checks_overlay :
+  width:int ->
+  height:int ->
+  scroll_offset:int ->
+  patch_view ->
+  string list * int
+(** Full-screen scrollable list of a patch's CI checks. Returns the rendered
+    lines and the clamped scroll offset. *)
+
 type prompt_info = { prompt_text : string; cursor_col : int }
 
 val render_frame :
@@ -189,6 +203,8 @@ val render_frame :
   project_name:string ->
   backend_name:string ->
   show_help:bool ->
+  show_checks:bool ->
+  checks_scroll:int ->
   show_manage:bool ->
   now:float ->
   ?transcript:string ->

--- a/lib/tui_fiber.ml
+++ b/lib/tui_fiber.ml
@@ -113,6 +113,8 @@ struct
       input_mode;
       prompt_line;
       show_help;
+      show_checks;
+      checks_scroll;
       status_msg;
       patches_start_row;
       patches_scroll_offset;
@@ -175,12 +177,14 @@ struct
         Tui.render_frame ~width ~height ~selected:!list_selected ~scroll_offset
           ~view_mode:!view_mode ~activity ~project_name:Env.project_name
           ~backend_name:Env.backend_name ~show_help:!show_help
+          ~show_checks:!show_checks ~checks_scroll:!checks_scroll
           ~show_manage:
             (Tui_input.equal_input_mode !input_mode Tui_input.Manage_patch)
           ~now ~transcript ?status_msg:!status_msg ?prompt_line:!prompt_line
           views
       in
       detail_scroll := Tui.detail_scroll_offset frame;
+      checks_scroll := Tui.checks_scroll_offset frame;
       if Tui.detail_at_bottom frame then detail_follow := true;
       patches_start_row := Tui.patches_start_row frame;
       patches_scroll_offset := Tui.patches_scroll_offset frame;
@@ -205,6 +209,8 @@ struct
       input_mode;
       prompt_line;
       show_help;
+      show_checks;
+      checks_scroll;
       status_msg;
       patches_start_row;
       patches_scroll_offset;
@@ -258,6 +264,34 @@ struct
           eof_count := 0;
           if !show_help then (
             show_help := false;
+            loop ())
+          else if !show_checks then (
+            (* Dedicated, self-contained scroll region. The detail transcript
+               scroll stays dormant while this is up, preserving the "one live
+               scroll offset" invariant. Render clamps [checks_scroll]. *)
+            (match key with
+            | Term.Key.Escape | Term.Key.Char ('q' | 'c') ->
+                show_checks := false
+            | Term.Key.Up | Term.Key.Char 'k' ->
+                checks_scroll := Int.max 0 (!checks_scroll - 1)
+            | Term.Key.Down | Term.Key.Char 'j' ->
+                checks_scroll := Int.max 0 (!checks_scroll + 1)
+            | Term.Key.Page_up ->
+                checks_scroll := Int.max 0 (!checks_scroll - 10)
+            | Term.Key.Page_down ->
+                checks_scroll := Int.max 0 (!checks_scroll + 10)
+            | Term.Key.Mouse (Term_key.Scroll { dir; _ }) ->
+                let delta =
+                  match dir with Term_key.Up -> -3 | Term_key.Down -> 3
+                in
+                checks_scroll := Int.max 0 (!checks_scroll + delta)
+            | Term.Key.Char _ | Term.Key.Enter | Term.Key.Tab | Term.Key.Paste _
+            | Term.Key.Backspace | Term.Key.Left | Term.Key.Right
+            | Term.Key.Home | Term.Key.End | Term.Key.Delete | Term.Key.F _
+            | Term.Key.Ctrl _
+            | Term.Key.Mouse (Term_key.Click _)
+            | Term.Key.Unknown _ ->
+                ());
             loop ())
           else if Tui_input.equal_input_mode !input_mode Tui_input.Manage_patch
           then (
@@ -842,6 +876,14 @@ struct
                    | Tui.List_view -> Option.is_some (selected_pid ())
                    | Tui.Timeline_view -> false ->
                 input_mode := Tui_input.Manage_patch;
+                loop ()
+            | Term.Key.Char 'c'
+              when match !view_mode with
+                   | Tui.Detail_view _ -> true
+                   | Tui.List_view -> Option.is_some (selected_pid ())
+                   | Tui.Timeline_view -> false ->
+                show_checks := true;
+                checks_scroll := 0;
                 loop ()
             | Term.Key.Char _ | Term.Key.Enter | Term.Key.Tab
             | Term.Key.Backspace | Term.Key.Escape | Term.Key.Up | Term.Key.Down

--- a/lib/tui_state.ml
+++ b/lib/tui_state.ml
@@ -11,6 +11,8 @@ type t = {
   input_mode : Tui_input.input_mode ref;
   prompt_line : Tui.prompt_info option ref;
   show_help : bool ref;
+  show_checks : bool ref;
+  checks_scroll : int ref;
   status_msg : Tui.status_msg option ref;
   patches_start_row : int ref;
   patches_scroll_offset : int ref;
@@ -29,6 +31,8 @@ let create () =
     input_mode = ref Tui_input.Normal;
     prompt_line = ref None;
     show_help = ref false;
+    show_checks = ref false;
+    checks_scroll = ref 0;
     status_msg = ref None;
     patches_start_row = ref 0;
     patches_scroll_offset = ref 0;

--- a/lib/tui_state.mli
+++ b/lib/tui_state.mli
@@ -11,6 +11,8 @@ type t = {
   input_mode : Tui_input.input_mode ref;
   prompt_line : Tui.prompt_info option ref;
   show_help : bool ref;
+  show_checks : bool ref;
+  checks_scroll : int ref;
   status_msg : Tui.status_msg option ref;
   patches_start_row : int ref;
   patches_scroll_offset : int ref;

--- a/lib_test/git_env.ml
+++ b/lib_test/git_env.ml
@@ -239,7 +239,9 @@ let init_repo dir =
   run_git ~cwd:dir [ "init"; "-q"; "-b"; "main" ];
   run_git ~cwd:dir [ "config"; "user.email"; "test@example.com" ];
   run_git ~cwd:dir [ "config"; "user.name"; "test" ];
-  run_git ~cwd:dir [ "config"; "commit.gpgsign"; "false" ]
+  run_git ~cwd:dir [ "config"; "commit.gpgsign"; "false" ];
+  run_git ~cwd:dir [ "config"; "rerere.enabled"; "false" ];
+  run_git ~cwd:dir [ "config"; "rerere.autoupdate"; "false" ]
 
 let rm_rf dir =
   let cmd = Printf.sprintf "rm -rf %s" (Stdlib.Filename.quote dir) in

--- a/test/test_rebase_onto.ml
+++ b/test/test_rebase_onto.ml
@@ -858,8 +858,12 @@ let assert_rebase_noop label = function
 
 let assert_rebase_conflict label = function
   | Worktree.Conflict _ -> ()
-  | Worktree.Ok | Worktree.Noop | Worktree.Error _ ->
-      failwith (Printf.sprintf "%s: expected Conflict" label)
+  | Worktree.Ok ->
+      failwith (Printf.sprintf "%s: expected Conflict, got Ok" label)
+  | Worktree.Noop ->
+      failwith (Printf.sprintf "%s: expected Conflict, got Noop" label)
+  | Worktree.Error msg ->
+      failwith (Printf.sprintf "%s: expected Conflict, got Error: %s" label msg)
 
 (** Simulate squash-merge of [branch] into main: checkout main, create a single
     new commit with the same tree diff, then delete [branch]. *)

--- a/test/test_tui_render_frame.ml
+++ b/test/test_tui_render_frame.ml
@@ -265,6 +265,19 @@ let test_checks_overlay_clamps_offset () =
   assert (clamped > 0);
   assert (clamped <= 40)
 
+(* When no check rows can fit, the title should not report an inverted range. *)
+let test_checks_overlay_zero_visible_range () =
+  let pv =
+    { (make_view ~id:"1" ~title:"overlay") with Tui.ci_checks = make_checks 40 }
+  in
+  let lines, clamped =
+    Tui.render_checks_overlay ~width:80 ~height:3 ~scroll_offset:0 pv
+  in
+  let lines = List.map lines ~f:Onton.Term.strip_ansi in
+  assert (clamped = 0);
+  assert (line_contains lines "CI Checks (– of 40)");
+  assert (not (line_contains lines "CI Checks (1–0 of 40)"))
+
 let test_patch_5_merge_queue_badge () =
   let pv =
     {
@@ -299,6 +312,7 @@ let () =
   test_detail_inline_ci_checks_under_cap ();
   test_checks_overlay_lists_all ();
   test_checks_overlay_clamps_offset ();
+  test_checks_overlay_zero_visible_range ();
   test_timeline_view_no_summary ();
   test_patches_render_above_activity ();
   QCheck2.Test.check_exn

--- a/test/test_tui_render_frame.ml
+++ b/test/test_tui_render_frame.ml
@@ -50,8 +50,8 @@ let plain_lines frame =
 let render ?(width = 80) ?(height = 24) ?(view_mode = Tui.List_view)
     ?(activity = []) ?(project_name = "demo") ?(backend_name = "claude") views =
   Tui.render_frame ~width ~height ~selected:0 ~scroll_offset:0 ~view_mode
-    ~activity ~project_name ~backend_name ~show_help:false ~show_manage:false
-    ~now:0.0 views
+    ~activity ~project_name ~backend_name ~show_help:false ~show_checks:false
+    ~checks_scroll:0 ~show_manage:false ~now:0.0 views
 
 let one_view = [ make_view ~id:"1" ~title:"first patch" ]
 
@@ -193,6 +193,78 @@ let test_patches_render_above_activity () =
   | Some p, Some a -> assert (p < a)
   | _ -> assert false
 
+let make_checks n =
+  List.init n ~f:(fun i ->
+      {
+        Ci_check.name = Printf.sprintf "check-%d" i;
+        conclusion = (if i = 0 then "failure" else "pending");
+        details_url = None;
+        description = None;
+        started_at = None;
+        id = None;
+      })
+
+let count_check_rows lines =
+  List.count lines ~f:(fun line -> String.is_substring line ~substring:"check-")
+
+(* Inline detail section: with more than the cap, only the cap is shown plus an
+   ellipsis pointing at the overlay; metadata and footer survive. *)
+let test_detail_inline_ci_checks_capped () =
+  let pv =
+    {
+      (make_view ~id:"1" ~title:"many checks") with
+      Tui.ci_checks = make_checks 40;
+    }
+  in
+  let frame =
+    render ~height:60 ~view_mode:(Tui.Detail_view pv.Tui.patch_id) [ pv ]
+  in
+  let lines = plain_lines frame in
+  assert (count_check_rows lines = 8);
+  assert (line_contains lines "32 more");
+  assert (line_contains lines "press c to view all");
+  (* Metadata and footer are not crowded out. *)
+  assert (line_contains lines "Patch ID:");
+  assert (line_contains lines "h:help")
+
+(* At or below the cap, every check is shown inline and there is no ellipsis. *)
+let test_detail_inline_ci_checks_under_cap () =
+  let pv =
+    {
+      (make_view ~id:"1" ~title:"few checks") with
+      Tui.ci_checks = make_checks 5;
+    }
+  in
+  let frame =
+    render ~height:60 ~view_mode:(Tui.Detail_view pv.Tui.patch_id) [ pv ]
+  in
+  let lines = plain_lines frame in
+  assert (count_check_rows lines = 5);
+  assert (not (line_contains lines "more — press c"))
+
+(* The overlay lists more than the inline cap and reports the total. *)
+let test_checks_overlay_lists_all () =
+  let pv =
+    { (make_view ~id:"1" ~title:"overlay") with Tui.ci_checks = make_checks 40 }
+  in
+  let lines, _ =
+    Tui.render_checks_overlay ~width:80 ~height:50 ~scroll_offset:0 pv
+  in
+  let lines = List.map lines ~f:Onton.Term.strip_ansi in
+  assert (count_check_rows lines > 8);
+  assert (line_contains lines "of 40")
+
+(* A large scroll offset clamps to the last page. *)
+let test_checks_overlay_clamps_offset () =
+  let pv =
+    { (make_view ~id:"1" ~title:"overlay") with Tui.ci_checks = make_checks 40 }
+  in
+  let _, clamped =
+    Tui.render_checks_overlay ~width:80 ~height:20 ~scroll_offset:9999 pv
+  in
+  assert (clamped > 0);
+  assert (clamped <= 40)
+
 let test_patch_5_merge_queue_badge () =
   let pv =
     {
@@ -223,6 +295,10 @@ let () =
   test_list_view_activity_squeezed_partial ();
   test_frame_anchored_at_top ();
   test_detail_view_no_summary ();
+  test_detail_inline_ci_checks_capped ();
+  test_detail_inline_ci_checks_under_cap ();
+  test_checks_overlay_lists_all ();
+  test_checks_overlay_clamps_offset ();
   test_timeline_view_no_summary ();
   test_patches_render_above_activity ();
   QCheck2.Test.check_exn


### PR DESCRIPTION
## Problem

A patch with many CI checks rendered its checks list **unbounded** in the detail info section. Since `paint_frame` writes every line from row 1 with no clipping, a long list native-scrolled the terminal and pushed the metadata and transcript off the top — the checks crowded out everything else (see the ~90-check screenshot that motivated this).

## Approach

Two changes, keeping the "one live scroll offset" invariant:

1. **Cap the inline checks** at a fixed default (`max_inline_ci_checks = 8`). Beyond that, a dimmed ellipsis row appears: `… N more — press c to view all`. Metadata and transcript are no longer crowded out.
2. **A dedicated scrollable checks overlay** opened with `c` (from the detail view or a selected list row), dismissed with `esc`/`q`/`c`. It lists every check with `↑`/`↓`/`j`/`k`/PgUp/PgDn/wheel scrolling and `↑N above`/`↓N below` indicators. The overlay has its own clamped scroll offset; the transcript scroll stays dormant while it's up, so exactly one scroll offset is ever active.

The inline cap is a fixed constant rather than height-derived, so `detail_info_height` stays a pure function of the check count.

## Changes

- `lib/tui.ml`: extracted shared `dedup_ci_checks` + `render_ci_check_row`; capped the inline `ci_section` with the ellipsis; added `render_checks_overlay` (returns lines + clamped offset, mirroring `render_detail`); added `checks_scroll_offset` to the frame; wired `~show_checks`/`~checks_scroll` into `render_frame` via a shared `overlay_target_pv` resolver; added `c:checks` to the detail footer and a help-overlay entry.
- `lib/tui.mli`: exported the new overlay function, accessor, and `render_frame` labels.
- `lib/tui_state.{ml,mli}`: added `show_checks` and `checks_scroll` refs.
- `lib/tui_fiber.ml`: bound/threaded the refs, wrote back the clamped offset, added the `c` open key and an overlay input branch (scroll/close) next to the help dismiss.
- `test/test_tui_render_frame.ml`: 4 new tests — inline cap shows exactly 8 + ellipsis with metadata/footer surviving; under-cap shows all with no ellipsis; overlay lists all 40 with an "of 40" header; overlay clamps an out-of-range offset.

## Testing

`dune build` clean; full `dune runtest` (including the new tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds the CI checks in the detail view (cap at 8) and adds a full-screen, scrollable checks overlay to keep metadata/transcript visible and maintain a single active scroll state. Also stabilizes rebase conflict tests and fixes the overlay header when no rows fit.

- New Features
  - Press c to open the CI checks overlay; esc/q/c to close.
  - Scroll with ↑/↓/j/k/PgUp/PgDn or mouse; shows “↑N above/↓N below”.
  - Overlay has its own clamped `checks_scroll_offset`; transcript scroll pauses.
  - Shared `dedup_ci_checks` and `render_ci_check_row` for consistent rows.
  - Added c:checks to the detail footer and help.

- Bug Fixes
  - Inline CI checks capped at 8 with dimmed “… N more — press c to view all”; prevents native terminal scrolling; metadata/footer stay visible.
  - Overlay title handles empty visible ranges (“CI Checks (– of N)”) to avoid inverted counts.
  - Tests cover inline cap, under-cap, overlay totals, offset clamping, and zero-visible-range.
  - Stabilizes rebase conflict tests by disabling Git `rerere` and tightening conflict assertions.

<sup>Written for commit e2d896f543c4f128ac49d24534dca1802efb2a67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/flowglad/onton/pull/366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

