### PR TITLE
Broadcast to all agents with a session, including needs-intervention

### DIFF
--- a/lib/tui_fiber.ml
+++ b/lib/tui_fiber.ml
@@ -440,37 +440,31 @@ struct
                       | Tui.List_view | Tui.Timeline_view -> ())
                 | Tui_input.Prompt_broadcast ->
                     if not (String.is_empty line) then begin
-                      let views =
+                      (* Broadcast goes to every agent that has a live session,
+                         including ones parked in needs-intervention — a human
+                         broadcast resets their intervention state and gives
+                         them direction. Agents that never started a session
+                         (Pending, etc.) have nothing to receive it, and merged
+                         agents are terminal, so both are skipped via the
+                         [has_session]/[merged] predicate rather than by display
+                         status. *)
+                      let targets =
                         Runtime.read Env.runtime (fun snap ->
-                            Tui.views_of_orchestrator
-                              ~orchestrator:snap.Runtime.orchestrator
-                              ~gameplan:snap.Runtime.gameplan ~activity:[]
-                              ~resolve_routing:Env.resolve_routing ())
+                            Orchestrator.all_agents snap.Runtime.orchestrator
+                            |> List.filter ~f:(fun (a : Patch_agent.t) ->
+                                a.Patch_agent.has_session
+                                && not a.Patch_agent.merged)
+                            |> List.map ~f:(fun (a : Patch_agent.t) ->
+                                a.Patch_agent.patch_id))
                       in
-                      let active =
-                        List.filter views ~f:(fun (pv : Tui.patch_view) ->
-                            (not
-                               (Tui.equal_display_status pv.Tui.status
-                                  Tui.Merged))
-                            && (not
-                                  (Tui.equal_display_status pv.Tui.status
-                                     Tui.Pending))
-                            && (not
-                                  (Tui.equal_display_status pv.Tui.status
-                                     Tui.Needs_help))
-                            && not
-                                 (Tui.equal_display_status pv.Tui.status
-                                    Tui.Blocked_by_dep))
-                      in
-                      let count = List.length active in
-                      List.iter active ~f:(fun (pv : Tui.patch_view) ->
+                      let count = List.length targets in
+                      List.iter targets ~f:(fun patch_id ->
                           Runtime.update_orchestrator Env.runtime (fun orch ->
-                              Orchestrator.send_human_message orch
-                                pv.Tui.patch_id line));
+                              Orchestrator.send_human_message orch patch_id line));
                       log_event Env.runtime
                         (Printf.sprintf "Broadcast to %s — %s"
-                           (pluralize count "active patch"
-                              ~plural:"active patches")
+                           (pluralize count "patch with a session"
+                              ~plural:"patches with a session")
                            line)
                     end
                 | Tui_input.Prompt_pr -> (


### PR DESCRIPTION
## What

The `*` broadcast command sent a human message to patch agents selected by *display status*, explicitly excluding `Merged`, `Pending`, `Needs_help`, and `Blocked_by_dep`. Since `Needs_help` is the rendering of needs-intervention, agents parked in intervention never received broadcasts — even though a human broadcast is exactly what unblocks them.

## Change

`lib/tui_fiber.ml` — the `Prompt_broadcast` handler now gates on the agent's own session/merge state via `Orchestrator.all_agents`, targeting every agent where `has_session && not merged`:

- **Needs-intervention agents now receive it.** `send_human_message` already calls `reset_intervention_state`, so the broadcast both unblocks them and gives direction.
- **Never-started agents (Pending, etc.) are skipped** — `has_session = false`, so there's nothing to receive the message.
- **Merged agents stay excluded** — terminal; `has_session` remains `true` after merge, so the explicit `not merged` guard preserves the prior exclusion.

This drops the dependency on `views_of_orchestrator` / `resolve_routing` for this path, gating on agent state directly. Log line now reads "Broadcast to N patches with a session".

## Notes

Merged agents are deliberately kept excluded — taking "all agents with a session" literally would re-include them, but it'd only enqueue a no-op Human op on a terminal agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Broadcast now sends to all agents with a live session (excluding merged), including those in needs-intervention, so they get unblocked. Agents that never started a session are skipped.

- **Bug Fixes**
  - Include needs-intervention agents in `*` broadcasts; `send_human_message` clears intervention state.
  - Skip agents without a session (e.g., Pending); keep merged excluded.
  - Update log: "Broadcast to N patches with a session".

- **Refactors**
  - Gate on agent state via `Orchestrator.all_agents` (`has_session && not merged`) instead of display status and `views_of_orchestrator`/`resolve_routing`.

<sup>Written for commit dbda15926585b2f828152067f026073be177f8a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/flowglad/onton/pull/367?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected broadcast message targeting to deliver to agents with active sessions that haven't been merged, improving message distribution accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->