### PR TITLE
[codex] Fail fast on supervisor fiber errors

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1040,8 +1040,8 @@ let run_main_loop (setup : runtime_setup) (cap : constructed_capabilities)
             Eio.Fiber.all
               (guard_fiber ~quit_is_normal:true "tui" (fun () ->
                    Fibers.Tui.run ())
-              :: guard_fiber ~quit_is_normal:true "tui-input" (fun () ->
-                  Fibers.Tui.run_input ())
+              :: guard_fiber ~quit_is_normal:true ~return_is_normal:true
+                   "tui-input" (fun () -> Fibers.Tui.run_input ())
               :: guard_fiber "runner" (fun () ->
                   Fibers.Runner.run ~status_msg:tui_state.status_msg ())
               :: common_fibers)

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1002,14 +1002,16 @@ let run_main_loop (setup : runtime_setup) (cap : constructed_capabilities)
     log_event setup.runtime message;
     Printf.eprintf "onton: %s\n%!" message
   in
-  let guard_fiber ?(quit_is_normal = false) name f () =
-    Supervisor_guard.wrap ~quit_is_normal ~name
+  let guard_fiber ?(quit_is_normal = false) ?(return_is_normal = false) name f
+      () =
+    Supervisor_guard.wrap ~quit_is_normal ~return_is_normal ~name
       ~is_normal_quit:(function Fibers.Tui.Quit -> true | _ -> false)
       ~log:log_fatal f ()
   in
   let common_fibers =
     [
-      guard_fiber "startup-reconciler" cap.reconciliation_fiber;
+      guard_fiber ~return_is_normal:true "startup-reconciler"
+        cap.reconciliation_fiber;
       guard_fiber "poller" (fun () -> Fibers.Poller.run cap.startup_reconciler);
       guard_fiber "persistence" (fun () -> Fibers.Persistence.run ());
     ]

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -993,17 +993,36 @@ let run_main_loop (setup : runtime_setup) (cap : constructed_capabilities)
   let module WorktreeClient = (val cap.worktree_client) in
   let module Fibers = Make_fibers (Forge) (WorktreeClient) (Fiber_env) in
   let { Resolved_config.headless; project_name; _ } = setup.config in
+  let save_snapshot () =
+    let snap = Runtime.snapshot_unsync setup.runtime in
+    ignore
+      (Persistence.save ~path:(Project_store.snapshot_path project_name) snap)
+  in
+  let guard_fiber ?(quit_is_normal = false) name f () =
+    try f () with
+    | Fibers.Tui.Quit when quit_is_normal -> raise Fibers.Tui.Quit
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn ->
+        let message =
+          Printf.sprintf "Fatal supervisor fiber error (%s) — %s" name
+            (Printexc.to_string exn)
+        in
+        log_event setup.runtime message;
+        Printf.eprintf "onton: %s\n%!" message;
+        save_snapshot ();
+        Stdlib.exit 1
+  in
   let common_fibers =
     [
-      cap.reconciliation_fiber;
-      (fun () -> Fibers.Poller.run cap.startup_reconciler);
-      (fun () -> Fibers.Persistence.run ());
+      guard_fiber "startup-reconciler" cap.reconciliation_fiber;
+      guard_fiber "poller" (fun () -> Fibers.Poller.run cap.startup_reconciler);
+      guard_fiber "persistence" (fun () -> Fibers.Persistence.run ());
     ]
   in
   if headless then
     Eio.Fiber.all
-      ((fun () -> Fibers.Headless.run ())
-      :: (fun () -> Fibers.Runner.run ())
+      (guard_fiber "headless" (fun () -> Fibers.Headless.run ())
+      :: guard_fiber "runner" (fun () -> Fibers.Runner.run ())
       :: common_fibers)
   else
     let raw_state = Term.Raw.enter () in
@@ -1012,18 +1031,17 @@ let run_main_loop (setup : runtime_setup) (cap : constructed_capabilities)
         Term.Raw.clear_suspend_handlers ();
         Term.Raw.leave raw_state;
         Eio.Flow.copy_string (Tui.exit_tui ()) setup.stdout;
-        let snap = Runtime.snapshot_unsync setup.runtime in
-        ignore
-          (Persistence.save
-             ~path:(Project_store.snapshot_path project_name)
-             snap))
+        save_snapshot ())
       (fun () ->
         Term.Raw.install_suspend_handlers raw_state;
         try
           Eio.Fiber.all
-            ((fun () -> Fibers.Tui.run ())
-            :: (fun () -> Fibers.Tui.run_input ())
-            :: (fun () -> Fibers.Runner.run ~status_msg:tui_state.status_msg ())
+            (guard_fiber ~quit_is_normal:true "tui" (fun () ->
+                 Fibers.Tui.run ())
+            :: guard_fiber ~quit_is_normal:true "tui-input" (fun () ->
+                Fibers.Tui.run_input ())
+            :: guard_fiber "runner" (fun () ->
+                Fibers.Runner.run ~status_msg:tui_state.status_msg ())
             :: common_fibers)
         with Fibers.Tui.Quit -> ())
 

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -998,19 +998,14 @@ let run_main_loop (setup : runtime_setup) (cap : constructed_capabilities)
     ignore
       (Persistence.save ~path:(Project_store.snapshot_path project_name) snap)
   in
+  let log_fatal message =
+    log_event setup.runtime message;
+    Printf.eprintf "onton: %s\n%!" message
+  in
   let guard_fiber ?(quit_is_normal = false) name f () =
-    try f () with
-    | Fibers.Tui.Quit when quit_is_normal -> raise Fibers.Tui.Quit
-    | Eio.Cancel.Cancelled _ as exn -> raise exn
-    | exn ->
-        let message =
-          Printf.sprintf "Fatal supervisor fiber error (%s) — %s" name
-            (Printexc.to_string exn)
-        in
-        log_event setup.runtime message;
-        Printf.eprintf "onton: %s\n%!" message;
-        save_snapshot ();
-        Stdlib.exit 1
+    Supervisor_guard.wrap ~quit_is_normal ~name
+      ~is_normal_quit:(function Fibers.Tui.Quit -> true | _ -> false)
+      ~log:log_fatal f ()
   in
   let common_fibers =
     [
@@ -1019,31 +1014,42 @@ let run_main_loop (setup : runtime_setup) (cap : constructed_capabilities)
       guard_fiber "persistence" (fun () -> Fibers.Persistence.run ());
     ]
   in
-  if headless then
-    Eio.Fiber.all
-      (guard_fiber "headless" (fun () -> Fibers.Headless.run ())
-      :: guard_fiber "runner" (fun () -> Fibers.Runner.run ())
-      :: common_fibers)
+  if headless then (
+    try
+      Eio.Fiber.all
+        (guard_fiber "headless" (fun () -> Fibers.Headless.run ())
+        :: guard_fiber "runner" (fun () -> Fibers.Runner.run ())
+        :: common_fibers)
+    with Supervisor_guard.Fatal_supervisor_error _ ->
+      save_snapshot ();
+      Stdlib.exit 1)
   else
     let raw_state = Term.Raw.enter () in
-    Fun.protect
-      ~finally:(fun () ->
-        Term.Raw.clear_suspend_handlers ();
-        Term.Raw.leave raw_state;
-        Eio.Flow.copy_string (Tui.exit_tui ()) setup.stdout;
-        save_snapshot ())
-      (fun () ->
-        Term.Raw.install_suspend_handlers raw_state;
-        try
-          Eio.Fiber.all
-            (guard_fiber ~quit_is_normal:true "tui" (fun () ->
-                 Fibers.Tui.run ())
-            :: guard_fiber ~quit_is_normal:true "tui-input" (fun () ->
-                Fibers.Tui.run_input ())
-            :: guard_fiber "runner" (fun () ->
-                Fibers.Runner.run ~status_msg:tui_state.status_msg ())
-            :: common_fibers)
-        with Fibers.Tui.Quit -> ())
+    try
+      Fun.protect
+        ~finally:(fun () ->
+          Term.Raw.clear_suspend_handlers ();
+          Term.Raw.leave raw_state;
+          Eio.Flow.copy_string (Tui.exit_tui ()) setup.stdout;
+          save_snapshot ())
+        (fun () ->
+          Term.Raw.install_suspend_handlers raw_state;
+          try
+            Eio.Fiber.all
+              (guard_fiber ~quit_is_normal:true "tui" (fun () ->
+                   Fibers.Tui.run ())
+              :: guard_fiber ~quit_is_normal:true "tui-input" (fun () ->
+                  Fibers.Tui.run_input ())
+              :: guard_fiber "runner" (fun () ->
+                  Fibers.Runner.run ~status_msg:tui_state.status_msg ())
+              :: common_fibers)
+          with Fibers.Tui.Quit -> ())
+    with Supervisor_guard.Fatal_supervisor_error _ -> (
+      match
+        Supervisor_decision.exit_after_fatal Supervisor_decision.Cleanup_done
+      with
+      | Supervisor_decision.Exit_now -> Stdlib.exit 1
+      | Supervisor_decision.Defer_exit_until_cleanup -> assert false)
 
 (** Trailing-positional PR operations parsed from the command line. *)
 type pr_op = Add_pr of Pr_number.t | Remove_pr of Pr_number.t

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1046,12 +1046,10 @@ let run_main_loop (setup : runtime_setup) (cap : constructed_capabilities)
                   Fibers.Runner.run ~status_msg:tui_state.status_msg ())
               :: common_fibers)
           with Fibers.Tui.Quit -> ())
-    with Supervisor_guard.Fatal_supervisor_error _ -> (
-      match
-        Supervisor_decision.exit_after_fatal Supervisor_decision.Cleanup_done
-      with
-      | Supervisor_decision.Exit_now -> Stdlib.exit 1
-      | Supervisor_decision.Defer_exit_until_cleanup -> assert false)
+    with Supervisor_guard.Fatal_supervisor_error _ ->
+      (* Fun.protect's [finally] has already restored the terminal and saved the
+         runtime snapshot. *)
+      Stdlib.exit 1
 
 (** Trailing-positional PR operations parsed from the command line. *)
 type pr_op = Add_pr of Pr_number.t | Remove_pr of Pr_number.t

--- a/lib/activity_log_sink.ml
+++ b/lib/activity_log_sink.ml
@@ -89,7 +89,8 @@ let display_status_of_agent_json ~main_branch json =
     State.Patch_ctx.empty
     |> State.Patch_ctx.set_merged ~patch_id ~value:(bool_member fields "merged")
     |> State.Patch_ctx.set_needs_intervention ~patch_id
-         ~value:(needs_intervention fields)
+         ~value:
+           (needs_intervention fields || bool_member fields "branch_blocked")
     |> State.Patch_ctx.set_approved ~patch_id
          ~value:(bool_member fields "satisfies")
     |> State.Patch_ctx.set_busy ~patch_id ~value:(bool_member fields "busy")
@@ -109,6 +110,22 @@ let display_status_of_agent_json ~main_branch json =
   in
   Display_status.derive ctx ~patch_id ~current_op:(current_op_member fields)
     ~main_branch
+
+let%test "branch_blocked activity-log agent renders needs-help" =
+  let patch_id = "patch-1" in
+  let status =
+    display_status_of_agent_json ~main_branch:(Branch.of_string "main")
+      (`Assoc
+         [
+           ("patch_id", `String patch_id);
+           ("merged", `Bool false);
+           ("branch_blocked", `Bool true);
+           ("busy", `Bool false);
+           ("satisfies", `Bool false);
+           ("queue", `List [ Operation_kind.yojson_of_t Review_comments ]);
+         ])
+  in
+  Display_status.equal status Display_status.Needs_help
 
 let transition_action ~default_kind payload =
   let fields = assoc_fields payload in

--- a/lib/poller_fiber.ml
+++ b/lib/poller_fiber.ml
@@ -458,28 +458,34 @@ struct
       (* Phase 2: Single atomic update — apply all poll results + reconcile.
        This prevents the runner from seeing an intermediate state where
        poll results are applied but the reconciler hasn't run yet. *)
-      let per_patch_sides, reconcile_logs =
+      let poll_events, per_patch_sides, reconcile_logs =
         Runtime.update_orchestrator_returning runtime (fun orch ->
             (* Apply all poll results *)
-            let orch, sides =
-              List.fold observations ~init:(orch, [])
+            let orch, poll_events, sides =
+              List.fold observations ~init:(orch, [], [])
                 ~f:(fun
-                    (orch, sides) (patch_id, obs, failed_ci, ci_truncated) ->
+                    (orch, poll_events, sides)
+                    (patch_id, obs, failed_ci, ci_truncated)
+                  ->
                   match Orchestrator.find_agent orch patch_id with
-                  | None -> (orch, sides)
+                  | None -> (orch, poll_events, sides)
                   | Some agent_before ->
                       let orch, log_entries, newly_blocked =
                         Patch_controller.apply_poll_result orch patch_id obs
                       in
                       let agent_after = Orchestrator.agent orch patch_id in
-                      Event_log.log_poll event_log ~patch_id
-                        ~poll_result:obs.Patch_controller.poll_result
-                        ~agent_before ~agent_after
-                        ~logs:
-                          (List.map log_entries
-                             ~f:(fun (e : Patch_controller.poll_log_entry) ->
-                               e.Patch_controller.message));
+                      let log_messages =
+                        List.map log_entries
+                          ~f:(fun (e : Patch_controller.poll_log_entry) ->
+                            e.Patch_controller.message)
+                      in
                       ( orch,
+                        ( patch_id,
+                          obs.Patch_controller.poll_result,
+                          agent_before,
+                          agent_after,
+                          log_messages )
+                        :: poll_events,
                         ( patch_id,
                           log_entries,
                           newly_blocked,
@@ -594,9 +600,13 @@ struct
                       Orchestrator.enqueue orch pid Operation_kind.Rebase
                   | Reconciler.Start_operation _ -> orch)
             in
-            (orch, (List.rev sides, List.rev !rec_logs)))
+            (orch, (List.rev poll_events, List.rev sides, List.rev !rec_logs)))
       in
       (* Phase 3: Side effects — outside the lock *)
+      List.iter poll_events
+        ~f:(fun (patch_id, poll_result, agent_before, agent_after, logs) ->
+          Event_log.log_poll event_log ~patch_id ~poll_result ~agent_before
+            ~agent_after ~logs);
       List.iter per_patch_sides
         ~f:(fun
             (patch_id, log_entries, newly_blocked, _failed_ci, ci_truncated) ->

--- a/lib/supervisor_guard.ml
+++ b/lib/supervisor_guard.ml
@@ -1,0 +1,34 @@
+(* @archlint.module shell
+   @archlint.domain supervisor *)
+
+open Base
+
+exception
+  Fatal_supervisor_error of {
+    name : string;
+    reason : Supervisor_decision.fatal_reason;
+    message : string;
+  }
+
+let raise_fatal ~log ~name reason =
+  let message = Supervisor_decision.message ~name reason in
+  log message;
+  raise (Fatal_supervisor_error { name; reason; message })
+
+let handle_decision ~log = function
+  | Supervisor_decision.Normal_quit -> ()
+  | Propagate_cancel -> ()
+  | Fatal { name; reason } -> raise_fatal ~log ~name reason
+
+let wrap ?(quit_is_normal = false) ~name ~is_normal_quit ~log f () =
+  match f () with
+  | () ->
+      Supervisor_decision.classify ~name ~quit_is_normal
+        Supervisor_decision.Returned
+      |> handle_decision ~log
+  | exception exn when is_normal_quit exn && quit_is_normal -> raise exn
+  | exception (Eio.Cancel.Cancelled _ as exn) -> raise exn
+  | exception exn ->
+      Supervisor_decision.classify ~name ~quit_is_normal
+        (Supervisor_decision.Raised (Exn.to_string exn))
+      |> handle_decision ~log

--- a/lib/supervisor_guard.ml
+++ b/lib/supervisor_guard.ml
@@ -16,19 +16,24 @@ let raise_fatal ~log ~name reason =
   raise (Fatal_supervisor_error { name; reason; message })
 
 let handle_decision ~log = function
-  | Supervisor_decision.Normal_quit -> ()
+  | Supervisor_decision.Normal_return | Normal_quit -> ()
   | Propagate_cancel -> ()
   | Fatal { name; reason } -> raise_fatal ~log ~name reason
 
-let wrap ?(quit_is_normal = false) ~name ~is_normal_quit ~log f () =
+let wrap ?(quit_is_normal = false) ?(return_is_normal = false) ~name
+    ~is_normal_quit ~log f () =
+  let return_policy =
+    if return_is_normal then Supervisor_decision.Return_is_normal
+    else Return_is_fatal
+  in
   match f () with
   | () ->
-      Supervisor_decision.classify ~name ~quit_is_normal
+      Supervisor_decision.classify ~name ~quit_is_normal ~return_policy
         Supervisor_decision.Returned
       |> handle_decision ~log
   | exception exn when is_normal_quit exn && quit_is_normal -> raise exn
   | exception (Eio.Cancel.Cancelled _ as exn) -> raise exn
   | exception exn ->
-      Supervisor_decision.classify ~name ~quit_is_normal
+      Supervisor_decision.classify ~name ~quit_is_normal ~return_policy
         (Supervisor_decision.Raised (Exn.to_string exn))
       |> handle_decision ~log

--- a/lib/supervisor_guard.mli
+++ b/lib/supervisor_guard.mli
@@ -1,0 +1,23 @@
+(* @archlint.module interface
+   @archlint.domain supervisor *)
+
+(** Effectful guard for long-lived supervisor fibers. *)
+
+exception
+  Fatal_supervisor_error of {
+    name : string;
+    reason : Supervisor_decision.fatal_reason;
+    message : string;
+  }
+
+val wrap :
+  ?quit_is_normal:bool ->
+  name:string ->
+  is_normal_quit:(exn -> bool) ->
+  log:(string -> unit) ->
+  (unit -> unit) ->
+  unit ->
+  unit
+(** Run a long-lived supervisor fiber. Unexpected exceptions and unexpected
+    normal returns become [Fatal_supervisor_error]. Cancellation and explicitly
+    normal quit exceptions are re-raised for the caller's structured cleanup. *)

--- a/lib/supervisor_guard.mli
+++ b/lib/supervisor_guard.mli
@@ -12,12 +12,15 @@ exception
 
 val wrap :
   ?quit_is_normal:bool ->
+  ?return_is_normal:bool ->
   name:string ->
   is_normal_quit:(exn -> bool) ->
   log:(string -> unit) ->
   (unit -> unit) ->
   unit ->
   unit
-(** Run a long-lived supervisor fiber. Unexpected exceptions and unexpected
-    normal returns become [Fatal_supervisor_error]. Cancellation and explicitly
-    normal quit exceptions are re-raised for the caller's structured cleanup. *)
+(** Run a supervisor fiber. Unexpected exceptions become
+    [Fatal_supervisor_error]. Normal returns are fatal by default for long-lived
+    fibers, but can be allowed for one-shot startup fibers. Cancellation and
+    explicitly normal quit exceptions are re-raised for the caller's structured
+    cleanup. *)

--- a/lib/term.ml
+++ b/lib/term.ml
@@ -523,22 +523,34 @@ module Key_io = struct
         try
           let n = Unix.read Unix.stdin buf 0 1 in
           if n = 0 then None else Some (Bytes.get buf 0)
-        with _ -> None)
+        with
+        | Unix.Unix_error (Unix.EINTR, _, _) -> None
+        | _ -> None)
 
   (** Try to read a byte with a short timeout (for escape sequence detection).
       Uses Unix.select with a 50ms timeout. Runs in a systhread so it does not
       block the Eio event loop. *)
   let read_byte_timeout () =
-    Eio_unix.run_in_systhread (fun () ->
-        let ready, _, _ = Unix.select [ Unix.stdin ] [] [] 0.05 in
-        match ready with
-        | [] -> None
-        | _ -> (
-            let buf = Bytes.create 1 in
-            try
-              let n = Unix.read Unix.stdin buf 0 1 in
-              if n = 0 then None else Some (Bytes.get buf 0)
-            with _ -> None))
+    let result =
+      Eio_unix.run_in_systhread (fun () ->
+          try
+            let ready, _, _ = Unix.select [ Unix.stdin ] [] [] 0.05 in
+            match ready with
+            | [] -> None
+            | _ -> (
+                let buf = Bytes.create 1 in
+                try
+                  let n = Unix.read Unix.stdin buf 0 1 in
+                  if n = 0 then None else Some (Bytes.get buf 0)
+                with
+                | Unix.Unix_error (Unix.EINTR, _, _) -> None
+                | _ -> None)
+          with
+          | Unix.Unix_error (Unix.EINTR, _, _) -> None
+          | _ -> None)
+    in
+    Eio.Fiber.yield ();
+    result
 
   (** Poll for the first byte of a key press. Unlike [read_byte], this never
       parks a systhread indefinitely, so TUI input remains cancellable. *)
@@ -552,7 +564,9 @@ module Key_io = struct
               let buf = Bytes.create 1 in
               let n = Unix.read Unix.stdin buf 0 1 in
               if n = 0 then First_byte_eof else First_byte (Bytes.get buf 0)
-        with _ -> First_byte_eof)
+        with
+        | Unix.Unix_error (Unix.EINTR, _, _) -> No_first_byte
+        | _ -> First_byte_eof)
 
   (** Read bracketed paste content until the paste-end CSI sequence
       ([ESC\[201~]). *)
@@ -767,7 +781,10 @@ module Key_io = struct
         else Some (Char c)
 
   (** Poll and parse a single key press. Returns [No_input] when no byte is
-      available yet, giving the caller a cancellation/yield point. *)
+      available yet, giving the caller a cancellation/yield point. Escape
+      sequences may still wait up to 50ms per continuation byte to distinguish a
+      bare Escape key from a longer sequence; each bounded wait yields before
+      the parser tries to read the next byte. *)
   let poll () =
     match poll_first_byte () with
     | No_first_byte -> No_input

--- a/lib/term.ml
+++ b/lib/term.ml
@@ -555,18 +555,22 @@ module Key_io = struct
   (** Poll for the first byte of a key press. Unlike [read_byte], this never
       parks a systhread indefinitely, so TUI input remains cancellable. *)
   let poll_first_byte () =
-    Eio_unix.run_in_systhread (fun () ->
-        try
-          let ready, _, _ = Unix.select [ Unix.stdin ] [] [] 0.05 in
-          match ready with
-          | [] -> No_first_byte
-          | _ ->
-              let buf = Bytes.create 1 in
-              let n = Unix.read Unix.stdin buf 0 1 in
-              if n = 0 then First_byte_eof else First_byte (Bytes.get buf 0)
-        with
-        | Unix.Unix_error (Unix.EINTR, _, _) -> No_first_byte
-        | _ -> First_byte_eof)
+    let result =
+      Eio_unix.run_in_systhread (fun () ->
+          try
+            let ready, _, _ = Unix.select [ Unix.stdin ] [] [] 0.05 in
+            match ready with
+            | [] -> No_first_byte
+            | _ ->
+                let buf = Bytes.create 1 in
+                let n = Unix.read Unix.stdin buf 0 1 in
+                if n = 0 then First_byte_eof else First_byte (Bytes.get buf 0)
+          with
+          | Unix.Unix_error (Unix.EINTR, _, _) -> No_first_byte
+          | _ -> First_byte_eof)
+    in
+    Eio.Fiber.yield ();
+    result
 
   (** Read bracketed paste content until the paste-end CSI sequence
       ([ESC\[201~]). *)

--- a/lib/term.ml
+++ b/lib/term.ml
@@ -512,6 +512,9 @@ module Key_io = struct
 
   [@@@ocaml.warning "-45"] (* scroll_dir.Up/Down vs Key.Up/Down both in scope *)
 
+  type read_result = No_input | Eof | Key of Term_key.t
+  type first_byte = No_first_byte | First_byte_eof | First_byte of char
+
   (** Read a single byte from stdin, returning None on EOF/error. Runs in a
       systhread so it does not block the Eio event loop. *)
   let read_byte () =
@@ -536,6 +539,20 @@ module Key_io = struct
               let n = Unix.read Unix.stdin buf 0 1 in
               if n = 0 then None else Some (Bytes.get buf 0)
             with _ -> None))
+
+  (** Poll for the first byte of a key press. Unlike [read_byte], this never
+      parks a systhread indefinitely, so TUI input remains cancellable. *)
+  let poll_first_byte () =
+    Eio_unix.run_in_systhread (fun () ->
+        try
+          let ready, _, _ = Unix.select [ Unix.stdin ] [] [] 0.05 in
+          match ready with
+          | [] -> No_first_byte
+          | _ ->
+              let buf = Bytes.create 1 in
+              let n = Unix.read Unix.stdin buf 0 1 in
+              if n = 0 then First_byte_eof else First_byte (Bytes.get buf 0)
+        with _ -> First_byte_eof)
 
   (** Read bracketed paste content until the paste-end CSI sequence
       ([ESC\[201~]). *)
@@ -748,6 +765,21 @@ module Key_io = struct
         if code >= 1 && code <= 26 then
           Some (Ctrl (Char.of_int_exn (code + 96)))
         else Some (Char c)
+
+  (** Poll and parse a single key press. Returns [No_input] when no byte is
+      available yet, giving the caller a cancellation/yield point. *)
+  let poll () =
+    match poll_first_byte () with
+    | No_first_byte -> No_input
+    | First_byte_eof -> Eof
+    | First_byte '\027' -> Key (parse_escape ())
+    | First_byte ('\r' | '\n') -> Key Enter
+    | First_byte '\t' -> Key Tab
+    | First_byte ('\127' | '\008') -> Key Backspace
+    | First_byte c ->
+        let code = Char.to_int c in
+        if code >= 1 && code <= 26 then Key (Ctrl (Char.of_int_exn (code + 96)))
+        else Key (Char c)
 end
 
 let%test "enable_mouse is correct" =

--- a/lib/term.mli
+++ b/lib/term.mli
@@ -145,7 +145,13 @@ val disable_mouse : string
 module Key = Term_key
 
 module Key_io : sig
+  type read_result = No_input | Eof | Key of Term_key.t
+
   val read : unit -> Term_key.t option
   (** Read and parse a single key press. Blocks until input is available. Must
       be called while in raw mode. *)
+
+  val poll : unit -> read_result
+  (** Poll and parse a single key press. Returns [No_input] when no byte is
+      available yet. Must be called while in raw mode. *)
 end

--- a/lib/tui.ml
+++ b/lib/tui.ml
@@ -335,48 +335,56 @@ type patch_view = {
    A reason code we don't recognise falls through to the raw code rather than a
    generic message: an unmapped real reason is still more actionable than a
    misleading one, and it flags that a new code needs a phrasing here. *)
+let display_needs_intervention (agent : Patch_agent.t) =
+  Patch_agent.needs_intervention agent || agent.Patch_agent.branch_blocked
+
 let human_intervention_reason (agent : Patch_agent.t) =
-  Option.map (Patch_agent.intervention_reason agent) ~f:(fun code ->
-      match code with
-      | "session_fallback=given_up" ->
-          "Agent gave up after repeated session failures \xe2\x80\x94 needs \
-           manual fix or restart"
-      | "pr_missing" ->
-          "PR is missing from the remote \xe2\x80\x94 recreate it or \
-           investigate why it vanished"
-      | "ci_failure_count>=3" ->
-          Printf.sprintf
-            "CI failed %d times in a row \xe2\x80\x94 fix the failing checks \
-             below"
-            agent.Patch_agent.ci_failure_count
-      | "start_attempts_without_pr>=2" ->
-          Printf.sprintf
-            "Could not open a PR after %d attempts \xe2\x80\x94 open it \
-             manually or check repo access"
-            agent.Patch_agent.start_attempts_without_pr
-      | "conflict_noop_count>=2" ->
-          "Stuck resolving merge conflicts against base \xe2\x80\x94 resolve \
-           them manually"
-      | "no_commits_push_count>=2" ->
-          "Sessions keep producing no commits to push \xe2\x80\x94 the task \
-           may be done or mis-scoped"
-      | "context_exhaustion_count>=2" ->
-          "Context window exhausted repeatedly \xe2\x80\x94 split the patch \
-           into smaller pieces"
-      | "push_failure_count>=3" ->
-          Printf.sprintf
-            "git push failed %d times \xe2\x80\x94 check branch protection or \
-             remote state"
-            agent.Patch_agent.push_failure_count
-      | "rebase_failure_count>=2" ->
-          Printf.sprintf
-            "git rebase failed %d times \xe2\x80\x94 check the activity log \
-             for the fetch or worktree error"
-            agent.Patch_agent.rebase_failure_count
-      | "pr_body_artifact_miss_count>=2" ->
-          "PR body delivery blocked repeatedly \xe2\x80\x94 check the PR \
-           description requirements"
-      | other -> other)
+  if agent.Patch_agent.branch_blocked then
+    Some
+      "Branch is checked out in the repo root - switch the repo root to \
+       another branch before onton can manage this patch"
+  else
+    Option.map (Patch_agent.intervention_reason agent) ~f:(fun code ->
+        match code with
+        | "session_fallback=given_up" ->
+            "Agent gave up after repeated session failures \xe2\x80\x94 needs \
+             manual fix or restart"
+        | "pr_missing" ->
+            "PR is missing from the remote \xe2\x80\x94 recreate it or \
+             investigate why it vanished"
+        | "ci_failure_count>=3" ->
+            Printf.sprintf
+              "CI failed %d times in a row \xe2\x80\x94 fix the failing checks \
+               below"
+              agent.Patch_agent.ci_failure_count
+        | "start_attempts_without_pr>=2" ->
+            Printf.sprintf
+              "Could not open a PR after %d attempts \xe2\x80\x94 open it \
+               manually or check repo access"
+              agent.Patch_agent.start_attempts_without_pr
+        | "conflict_noop_count>=2" ->
+            "Stuck resolving merge conflicts against base \xe2\x80\x94 resolve \
+             them manually"
+        | "no_commits_push_count>=2" ->
+            "Sessions keep producing no commits to push \xe2\x80\x94 the task \
+             may be done or mis-scoped"
+        | "context_exhaustion_count>=2" ->
+            "Context window exhausted repeatedly \xe2\x80\x94 split the patch \
+             into smaller pieces"
+        | "push_failure_count>=3" ->
+            Printf.sprintf
+              "git push failed %d times \xe2\x80\x94 check branch protection \
+               or remote state"
+              agent.Patch_agent.push_failure_count
+        | "rebase_failure_count>=2" ->
+            Printf.sprintf
+              "git rebase failed %d times \xe2\x80\x94 check the activity log \
+               for the fetch or worktree error"
+              agent.Patch_agent.rebase_failure_count
+        | "pr_body_artifact_miss_count>=2" ->
+            "PR body delivery blocked repeatedly \xe2\x80\x94 check the PR \
+             description requirements"
+        | other -> other)
 
 let patch_view_of_agent (agent : Patch_agent.t)
     ~(patches_by_id : Patch.t Map.M(Patch_id).t) ~(graph : Graph.t)
@@ -399,11 +407,12 @@ let patch_view_of_agent (agent : Patch_agent.t)
     | None -> agent.Patch_agent.branch
   in
   let current_op = agent.Patch_agent.current_op in
+  let needs_intervention = display_needs_intervention agent in
   let ctx =
     ( State.Patch_ctx.empty
     |> State.Patch_ctx.set_merged ~patch_id ~value:agent.merged
     |> State.Patch_ctx.set_needs_intervention ~patch_id
-         ~value:(Patch_agent.needs_intervention agent)
+         ~value:needs_intervention
     |> State.Patch_ctx.set_busy ~patch_id ~value:agent.busy
     |> State.Patch_ctx.set_has_pr ~patch_id ~value:(Patch_agent.has_pr agent)
     |> State.Patch_ctx.set_approved ~patch_id
@@ -425,12 +434,15 @@ let patch_view_of_agent (agent : Patch_agent.t)
           match Map.find agents_by_id dep_id with
           | Some dep_agent ->
               let dep_op = dep_agent.Patch_agent.current_op in
+              let dep_needs_intervention =
+                display_needs_intervention dep_agent
+              in
               let dep_ctx =
                 ( State.Patch_ctx.empty
                 |> State.Patch_ctx.set_merged ~patch_id:dep_id
                      ~value:dep_agent.merged
                 |> State.Patch_ctx.set_needs_intervention ~patch_id:dep_id
-                     ~value:(Patch_agent.needs_intervention dep_agent)
+                     ~value:dep_needs_intervention
                 |> State.Patch_ctx.set_busy ~patch_id:dep_id
                      ~value:dep_agent.busy
                 |> State.Patch_ctx.set_has_pr ~patch_id:dep_id
@@ -468,7 +480,7 @@ let patch_view_of_agent (agent : Patch_agent.t)
     dep_ids;
     has_pr = Patch_agent.has_pr agent;
     has_conflict = agent.has_conflict;
-    needs_intervention = Patch_agent.needs_intervention agent;
+    needs_intervention;
     human_messages = List.length agent.human_messages;
     ci_checks = agent.ci_checks;
     recent_stream = [];

--- a/lib/tui.mli
+++ b/lib/tui.mli
@@ -158,11 +158,12 @@ val patch_count : frame -> int
 
 val human_intervention_reason : Onton_core.Patch_agent.t -> string option
 (** The human-facing, actionable banner line for why a patch needs intervention,
-    or [None] when it does not. Translates the authoritative reason code from
-    {!Onton_core.Patch_agent.intervention_reason} (which is driven by the
-    agent's own failure counters) into operator-readable text. This is the
-    source the detail banner trusts first, ahead of any scraped activity-log
-    event. *)
+    or [None] when it does not need operator attention. Translates the
+    authoritative reason code from {!Onton_core.Patch_agent.intervention_reason}
+    (which is driven by the agent's own failure counters) into operator-readable
+    text, and also surfaces worktree branch collisions that intentionally block
+    runner work. This is the source the detail banner trusts first, ahead of any
+    scraped activity-log event. *)
 
 val views_of_orchestrator :
   orchestrator:Orchestrator.t ->

--- a/lib/tui_fiber.ml
+++ b/lib/tui_fiber.ml
@@ -251,8 +251,11 @@ struct
     let last_click_row = ref (-1) in
     let rec loop () =
       sync_input ();
-      match Term.Key_io.read () with
-      | None ->
+      match Term.Key_io.poll () with
+      | No_input ->
+          Eio.Fiber.yield ();
+          loop ()
+      | Eof ->
           eof_count := !eof_count + 1;
           if !eof_count >= 10 then
             log_event Env.runtime
@@ -260,7 +263,7 @@ struct
           else (
             Eio.Fiber.yield ();
             loop ())
-      | Some key -> (
+      | Key key -> (
           eof_count := 0;
           if !show_help then (
             show_help := false;

--- a/lib_core/supervisor_decision.ml
+++ b/lib_core/supervisor_decision.ml
@@ -6,10 +6,13 @@ open Base
 type termination = Returned | Cancelled | Quit | Raised of string
 [@@deriving show, eq]
 
+type return_policy = Return_is_fatal | Return_is_normal [@@deriving show, eq]
+
 type fatal_reason = Returned_unexpectedly | Raised_unexpectedly of string
 [@@deriving show, eq]
 
 type decision =
+  | Normal_return
   | Normal_quit
   | Propagate_cancel
   | Fatal of { name : string; reason : fatal_reason }
@@ -18,14 +21,17 @@ type decision =
 type cleanup_state = Cleanup_pending | Cleanup_done [@@deriving show, eq]
 type exit_decision = Defer_exit_until_cleanup | Exit_now [@@deriving show, eq]
 
-let classify ~name ~quit_is_normal termination =
+let classify ~name ~quit_is_normal ~return_policy termination =
   match termination with
   | Cancelled -> Propagate_cancel
   | Quit when quit_is_normal -> Normal_quit
   | Quit ->
       Fatal
         { name; reason = Raised_unexpectedly "TUI quit escaped non-TUI fiber" }
-  | Returned -> Fatal { name; reason = Returned_unexpectedly }
+  | Returned -> (
+      match return_policy with
+      | Return_is_normal -> Normal_return
+      | Return_is_fatal -> Fatal { name; reason = Returned_unexpectedly })
   | Raised detail -> Fatal { name; reason = Raised_unexpectedly detail }
 
 let message ~name reason =
@@ -44,13 +50,16 @@ let%test_module "supervisor decision" =
   (module struct
     let%test "normal return is fatal" =
       match
-        classify ~name:"poller" ~quit_is_normal:false (Returned : termination)
+        classify ~name:"poller" ~quit_is_normal:false
+          ~return_policy:Return_is_fatal
+          (Returned : termination)
       with
       | Fatal { reason; _ } -> equal_fatal_reason reason Returned_unexpectedly
-      | Normal_quit | Propagate_cancel -> false
+      | Normal_return | Normal_quit | Propagate_cancel -> false
 
     let%test "cancel is propagated" =
       equal_decision
-        (classify ~name:"poller" ~quit_is_normal:false Cancelled)
+        (classify ~name:"poller" ~quit_is_normal:false
+           ~return_policy:Return_is_fatal Cancelled)
         Propagate_cancel
   end)

--- a/lib_core/supervisor_decision.ml
+++ b/lib_core/supervisor_decision.ml
@@ -1,0 +1,56 @@
+(* @archlint.module core
+   @archlint.domain supervisor *)
+
+open Base
+
+type termination = Returned | Cancelled | Quit | Raised of string
+[@@deriving show, eq]
+
+type fatal_reason = Returned_unexpectedly | Raised_unexpectedly of string
+[@@deriving show, eq]
+
+type decision =
+  | Normal_quit
+  | Propagate_cancel
+  | Fatal of { name : string; reason : fatal_reason }
+[@@deriving show, eq]
+
+type cleanup_state = Cleanup_pending | Cleanup_done [@@deriving show, eq]
+type exit_decision = Defer_exit_until_cleanup | Exit_now [@@deriving show, eq]
+
+let classify ~name ~quit_is_normal termination =
+  match termination with
+  | Cancelled -> Propagate_cancel
+  | Quit when quit_is_normal -> Normal_quit
+  | Quit ->
+      Fatal
+        { name; reason = Raised_unexpectedly "TUI quit escaped non-TUI fiber" }
+  | Returned -> Fatal { name; reason = Returned_unexpectedly }
+  | Raised detail -> Fatal { name; reason = Raised_unexpectedly detail }
+
+let message ~name reason =
+  let detail =
+    match reason with
+    | Returned_unexpectedly -> "returned unexpectedly"
+    | Raised_unexpectedly detail -> detail
+  in
+  Printf.sprintf "Fatal supervisor fiber error (%s) — %s" name detail
+
+let exit_after_fatal = function
+  | Cleanup_pending -> Defer_exit_until_cleanup
+  | Cleanup_done -> Exit_now
+
+let%test_module "supervisor decision" =
+  (module struct
+    let%test "normal return is fatal" =
+      match
+        classify ~name:"poller" ~quit_is_normal:false (Returned : termination)
+      with
+      | Fatal { reason; _ } -> equal_fatal_reason reason Returned_unexpectedly
+      | Normal_quit | Propagate_cancel -> false
+
+    let%test "cancel is propagated" =
+      equal_decision
+        (classify ~name:"poller" ~quit_is_normal:false Cancelled)
+        Propagate_cancel
+  end)

--- a/lib_core/supervisor_decision.mli
+++ b/lib_core/supervisor_decision.mli
@@ -1,15 +1,18 @@
 (* @archlint.module interface
    @archlint.domain supervisor *)
 
-(** Pure lifecycle decisions for long-lived supervisor fibers. *)
+(** Pure lifecycle decisions for supervisor fibers. *)
 
 type termination = Returned | Cancelled | Quit | Raised of string
 [@@deriving show, eq]
+
+type return_policy = Return_is_fatal | Return_is_normal [@@deriving show, eq]
 
 type fatal_reason = Returned_unexpectedly | Raised_unexpectedly of string
 [@@deriving show, eq]
 
 type decision =
+  | Normal_return
   | Normal_quit
   | Propagate_cancel
   | Fatal of { name : string; reason : fatal_reason }
@@ -18,10 +21,15 @@ type decision =
 type cleanup_state = Cleanup_pending | Cleanup_done [@@deriving show, eq]
 type exit_decision = Defer_exit_until_cleanup | Exit_now [@@deriving show, eq]
 
-val classify : name:string -> quit_is_normal:bool -> termination -> decision
-(** Classify how a supervised long-lived fiber ended. [Returned] is fatal
-    because these fibers are expected to run until cancellation or intentional
-    TUI quit. *)
+val classify :
+  name:string ->
+  quit_is_normal:bool ->
+  return_policy:return_policy ->
+  termination ->
+  decision
+(** Classify how a supervised long-lived fiber ended. [Returned] is fatal for
+    fibers expected to run until cancellation or intentional TUI quit, and
+    normal for one-shot startup fibers. *)
 
 val message : name:string -> fatal_reason -> string
 (** User-facing fatal supervisor message. *)

--- a/lib_core/supervisor_decision.mli
+++ b/lib_core/supervisor_decision.mli
@@ -1,0 +1,30 @@
+(* @archlint.module interface
+   @archlint.domain supervisor *)
+
+(** Pure lifecycle decisions for long-lived supervisor fibers. *)
+
+type termination = Returned | Cancelled | Quit | Raised of string
+[@@deriving show, eq]
+
+type fatal_reason = Returned_unexpectedly | Raised_unexpectedly of string
+[@@deriving show, eq]
+
+type decision =
+  | Normal_quit
+  | Propagate_cancel
+  | Fatal of { name : string; reason : fatal_reason }
+[@@deriving show, eq]
+
+type cleanup_state = Cleanup_pending | Cleanup_done [@@deriving show, eq]
+type exit_decision = Defer_exit_until_cleanup | Exit_now [@@deriving show, eq]
+
+val classify : name:string -> quit_is_normal:bool -> termination -> decision
+(** Classify how a supervised long-lived fiber ended. [Returned] is fatal
+    because these fibers are expected to run until cancellation or intentional
+    TUI quit. *)
+
+val message : name:string -> fatal_reason -> string
+(** User-facing fatal supervisor message. *)
+
+val exit_after_fatal : cleanup_state -> exit_decision
+(** Fatal supervisor exits are delayed until TUI cleanup has run. *)

--- a/test/dune
+++ b/test/dune
@@ -58,6 +58,20 @@
  (ocamlc_flags (:standard -w -40-42)))
 
 (test
+ (name test_supervisor_decision_properties)
+ (modules test_supervisor_decision_properties)
+ (libraries onton_core qcheck-core qcheck-core.runner)
+ (ocamlopt_flags (:standard -w -40-42))
+ (ocamlc_flags (:standard -w -40-42)))
+
+(test
+ (name test_supervisor_guard)
+ (modules test_supervisor_guard)
+ (libraries onton onton_core eio eio_main)
+ (ocamlopt_flags (:standard -w -40-42))
+ (ocamlc_flags (:standard -w -40-42)))
+
+(test
  (name test_github_target_properties)
  (modules test_github_target_properties)
  (libraries onton_core qcheck-core qcheck-core.runner)

--- a/test/dune
+++ b/test/dune
@@ -72,6 +72,13 @@
  (ocamlc_flags (:standard -w -40-42)))
 
 (test
+ (name test_term_key_io)
+ (modules test_term_key_io)
+ (libraries onton eio_main unix)
+ (ocamlopt_flags (:standard -w -40-42))
+ (ocamlc_flags (:standard -w -40-42)))
+
+(test
  (name test_github_target_properties)
  (modules test_github_target_properties)
  (libraries onton_core qcheck-core qcheck-core.runner)

--- a/test/test_interleaving_properties.ml
+++ b/test/test_interleaving_properties.ml
@@ -1647,6 +1647,87 @@ let () =
   QCheck2.Test.check_exn prop_pi9;
   Stdlib.print_endline "PI-9 passed"
 
+(** PI-9b: Stale/empty CI delivery does not suppress a later failed run.
+
+    Regression for the page-step-authority incident: a CI response can be
+    dispatched for an older failure, then become skip-empty because the branch
+    was force-pushed and fresh checks are still pending. When a later poll sees
+    a different failed CheckRun id, the patch must get [Ci] queued again rather
+    than sitting idle with failing checks. *)
+let () =
+  let prop_pi9b =
+    QCheck2.Test.make
+      ~name:"PI-9b: new failed CI run after skip-empty delivery is re-enqueued"
+      QCheck2.Gen.(
+        let* old_run_id = int_range 1 1_000_000 in
+        let* delta = int_range 1 1_000_000 in
+        return (old_run_id, old_run_id + delta))
+      (fun (old_run_id, new_run_id) ->
+        let patches = mk_patches 1 in
+        match patches with
+        | [] -> true
+        | first :: _ ->
+            let pid = first.Patch.id in
+            let orch = bootstrap patches in
+            let orch =
+              Orchestrator.record_delivered_ci_run_ids orch pid [ old_run_id ]
+            in
+            let orch = Orchestrator.enqueue orch pid Operation_kind.Ci in
+            let orch =
+              Orchestrator.fire orch
+                (Orchestrator.Respond (pid, Operation_kind.Ci))
+            in
+            let orch =
+              Orchestrator.apply_respond_outcome orch pid Operation_kind.Ci
+                Orchestrator.Respond_skip_empty
+            in
+            let skipped = Orchestrator.agent orch pid in
+            let check =
+              Ci_check.
+                {
+                  name = "Lint";
+                  conclusion = "failure";
+                  details_url = None;
+                  description = None;
+                  started_at = None;
+                  id = Some new_run_id;
+                }
+            in
+            let poll_result =
+              {
+                Poller.queue = [ Operation_kind.Ci ];
+                merged = false;
+                closed = false;
+                is_draft = false;
+                merge_state = Pr_state.Mergeable;
+                merge_ready = false;
+                review_decision = None;
+                merge_queue_required = false;
+                merge_queue_entry = None;
+                checks_passing = false;
+                ci_checks = [ check ];
+                merge_commit_sha = None;
+              }
+            in
+            let orch, _logs, _blocked =
+              Patch_controller.apply_poll_result orch pid
+                Patch_controller.
+                  {
+                    poll_result;
+                    base_branch = None;
+                    branch_in_root = false;
+                    worktree_path = None;
+                  }
+            in
+            let agent = Orchestrator.agent orch pid in
+            Int.equal skipped.Patch_agent.ci_failure_count 0
+            && (not skipped.Patch_agent.busy)
+            && List.mem agent.Patch_agent.queue Operation_kind.Ci
+                 ~equal:Operation_kind.equal)
+  in
+  QCheck2.Test.check_exn prop_pi9b;
+  Stdlib.print_endline "PI-9b passed"
+
 (** PI-10: Random interleavings with ad-hoc patches preserve invariants.
     Exercises Add_adhoc/Remove_adhoc commands alongside the standard vocabulary,
     including the case where ad-hoc patches are removed while busy. *)

--- a/test/test_intervention_reason.ml
+++ b/test/test_intervention_reason.ml
@@ -7,9 +7,10 @@
     CI-failure count rendered "runner: pushed after session" — the most recent
     (and innocuous) activity-log line — instead of the actionable reason. The
     fix makes the banner derive from the agent's own failure counters via
-    [Patch_agent.intervention_reason]. These tests pin that: the human reason is
-    present exactly when the agent needs intervention, and a CI-stuck agent
-    reports the CI failure, never a push event. *)
+    [Patch_agent.intervention_reason]. These tests pin that counter-based human
+    reasons stay aligned with raw intervention, branch-blocked agents still get
+    an operator-facing reason, and a CI-stuck agent reports the CI failure,
+    never a push event. *)
 
 open Onton
 open Onton_core
@@ -59,6 +60,17 @@ let () =
       (Patch_agent.needs_intervention a)
       (Option.is_some (Tui.human_intervention_reason a)));
 
+  (* A repo-root branch collision is not a PatchAgent failure-threshold
+     intervention, but it does require operator attention. The TUI must surface
+     it as needs-help instead of leaving the row looking queued and inert. *)
+  let branch_blocked = Patch_agent.set_branch_blocked a in
+  assert (not (Patch_agent.needs_intervention branch_blocked));
+  (match Tui.human_intervention_reason branch_blocked with
+  | None -> assert false
+  | Some msg ->
+      assert (contains msg "repo root");
+      assert (contains msg "branch"));
+
   (* Rebase/worktree failures have their own intervention reason and must not
      be reported as repeated LLM session failures. *)
   let rebase_stuck =
@@ -74,6 +86,75 @@ let () =
       assert (not (contains msg "session")));
 
   print_endline "PASS: human_intervention_reason surfaces the actionable reason"
+
+let make_patch ?(deps = []) ~id ~branch ~title () =
+  Patch.
+    {
+      id;
+      title;
+      description = "";
+      branch;
+      dependencies = deps;
+      spec = "";
+      acceptance_criteria = [];
+      files = [];
+      classification = "";
+      changes = [];
+      test_stubs_introduced = [];
+      test_stubs_implemented = [];
+      complexity = None;
+      precedents = [];
+      required_context = [];
+    }
+
+let make_gameplan patches =
+  Gameplan.
+    {
+      project_name = "test-project";
+      repo_owner = "";
+      repo_name = "";
+      problem_statement = "";
+      solution_summary = "";
+      final_state_spec = "";
+      patches;
+      functional_changes = [];
+      context_resources = [];
+      current_state_analysis = "";
+      explicit_opinions = "";
+      acceptance_criteria = [];
+      open_questions = [];
+    }
+
+let () =
+  let patch_id = Patch_id.of_string "patch-1" in
+  let patch =
+    make_patch ~id:patch_id
+      ~branch:(Branch.of_string "codex/fix")
+      ~title:"fix" ()
+  in
+  let gameplan = make_gameplan [ patch ] in
+  let orchestrator =
+    Orchestrator.create ~patches:gameplan.Gameplan.patches
+      ~main_branch:(Branch.of_string "main")
+    |> fun orchestrator -> Orchestrator.set_branch_blocked orchestrator patch_id
+  in
+  let views =
+    Tui.views_of_orchestrator ~orchestrator ~gameplan ~activity:[]
+      ~resolve_routing:(fun ~complexity:_ ->
+        { Backend_routing.backend = "claude"; model = None })
+      ()
+  in
+  match views with
+  | [ view ] ->
+      assert (Tui.equal_display_status view.Tui.status Tui.Needs_help);
+      assert view.Tui.needs_intervention;
+      (match view.Tui.intervention_reason with
+      | Some msg ->
+          assert (contains msg "repo root");
+          assert (contains msg "branch")
+      | None -> assert false);
+      print_endline "PASS: branch-blocked patches render as needs-help"
+  | _ -> assert false
 
 let assert_raw_fields ~merged ~has_pr ~is_pr_missing ~session_given_up
     ~human_in_queue ~ci_failure_count ~start_attempts_without_pr

--- a/test/test_patch_controller.ml
+++ b/test/test_patch_controller.ml
@@ -790,6 +790,93 @@ let () =
              ~equal:Operation_kind.equal))
   in
 
+  let prop_new_ci_run_after_skip_empty_is_delivered =
+    Test.make
+      ~name:
+        "patch_controller: new failed CI run after skip-empty delivery is \
+         re-enqueued"
+      ~count:200
+      Gen.(
+        let* pid = gen_patch_id in
+        let* branch = gen_branch in
+        let* old_run_id = int_range 1 1_000_000 in
+        let* delta = int_range 1 1_000_000 in
+        return (pid, branch, old_run_id, old_run_id + delta))
+      (fun (pid, branch, old_run_id, new_run_id) ->
+        let patch = make_patch pid branch in
+        let agent =
+          Patch_agent.restore ~patch_id:pid ~branch
+            ~pr_status:(Patch_pr_status.Present (Pr_number.of_int 42))
+            ~has_session:true ~busy:false ~merged:false
+            ~queue:[ Operation_kind.Ci ] ~satisfies:false ~changed:true
+            ~has_conflict:false ~base_branch:(Some main)
+            ~notified_base_branch:(Some main) ~ci_failure_count:0
+            ~session_fallback:Patch_agent.Fresh_available ~human_messages:[]
+            ~inflight_human_messages:[] ~ci_checks:[] ~merge_ready:false
+            ~mergeability_unknown:false ~merge_queue_required:false
+            ~merge_queue_entry:None ~is_draft:false ~pr_body_delivered:true
+            ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr:0
+            ~conflict_noop_count:0 ~no_commits_push_count:0
+            ~context_exhaustion_count:0 ~push_failure_count:0
+            ~rebase_failure_count:0 ~branch_rebased_onto:None
+            ~branch_rebased_onto_sha:None ~merge_commit_sha:None
+            ~base_contains_merged_siblings:true
+            ~anchor_history:Onton_core.Anchor_history.empty
+            ~checks_passing:false ~current_op:None
+            ~current_op_state:Patch_agent.Queued ~current_message_id:None
+            ~generation:0 ~worktree_path:None ~branch_blocked:false
+            ~llm_session_id:None ~automerge_enabled:false
+            ~automerge_deadline:None ~automerge_inflight:false
+            ~automerge_failure_count:0 ~delivered_ci_run_ids:[ old_run_id ]
+        in
+        let orch = make_orch patch agent in
+        let orch =
+          Orchestrator.fire orch (Orchestrator.Respond (pid, Operation_kind.Ci))
+        in
+        let orch =
+          Orchestrator.apply_respond_outcome orch pid Operation_kind.Ci
+            Orchestrator.Respond_skip_empty
+        in
+        let after_skip = Orchestrator.agent orch pid in
+        let check =
+          Ci_check.
+            {
+              name = "Lint";
+              conclusion = "failure";
+              details_url = None;
+              description = None;
+              started_at = None;
+              id = Some new_run_id;
+            }
+        in
+        let poll =
+          Poller.
+            {
+              queue = [ Operation_kind.Ci ];
+              merged = false;
+              closed = false;
+              is_draft = false;
+              merge_state = Pr_state.Mergeable;
+              merge_ready = false;
+              review_decision = None;
+              merge_queue_required = false;
+              merge_queue_entry = None;
+              checks_passing = false;
+              ci_checks = [ check ];
+              merge_commit_sha = None;
+            }
+        in
+        let orch, _logs, _newly_blocked =
+          Patch_controller.apply_poll_result orch pid
+            (make_poll_observation poll)
+        in
+        let agent = Orchestrator.agent orch pid in
+        Int.equal after_skip.Patch_agent.ci_failure_count 0
+        && (not after_skip.Patch_agent.busy)
+        && List.mem agent.Patch_agent.queue Operation_kind.Ci
+             ~equal:Operation_kind.equal)
+  in
+
   let prop_poll_result_persists_world_flags =
     Test.make ~name:"patch_controller: poll result persists checks_passing flag"
       ~count:200
@@ -1599,6 +1686,7 @@ let () =
       prop_poll_ci_failure_never_erases_pr_body_followup;
       prop_idle_ci_failure_count_allows_reenqueue;
       prop_delivered_ci_run_does_not_reenqueue;
+      prop_new_ci_run_after_skip_empty_is_delivered;
       prop_poll_result_persists_world_flags;
       prop_poll_observation_updates_branch_metadata;
       prop_mixed_cycle_converges_for_bootstrap_patch;

--- a/test/test_supervisor_decision_properties.ml
+++ b/test/test_supervisor_decision_properties.ml
@@ -1,0 +1,141 @@
+(* @archlint.module test
+   @archlint.domain supervisor *)
+
+open Base
+open Onton_core
+
+let gen_name =
+  QCheck2.Gen.(
+    map
+      (fun s -> if String.is_empty s then "fiber" else s)
+      (string_size ~gen:printable (int_range 0 24)))
+
+let gen_detail =
+  QCheck2.Gen.(
+    map
+      (fun s -> if String.is_empty s then "Failure" else s)
+      (string_size ~gen:printable (int_range 0 80)))
+
+let gen_termination =
+  let open QCheck2.Gen in
+  oneof
+    [
+      return (Supervisor_decision.Returned : Supervisor_decision.termination);
+      return Supervisor_decision.Cancelled;
+      return Supervisor_decision.Quit;
+      map (fun detail -> Supervisor_decision.Raised detail) gen_detail;
+    ]
+
+let is_fatal = function
+  | Supervisor_decision.Fatal _ -> true
+  | Normal_quit | Propagate_cancel -> false
+
+let () =
+  QCheck2.Test.check_exn
+    (QCheck2.Test.make ~name:"supervisor classify is total" ~count:1_000
+       QCheck2.Gen.(triple gen_name bool gen_termination)
+       (fun (name, quit_is_normal, termination) ->
+         try
+           ignore
+             (Supervisor_decision.classify ~name ~quit_is_normal termination);
+           true
+         with _ -> false));
+
+  QCheck2.Test.check_exn
+    (QCheck2.Test.make ~name:"normal return is always fatal" ~count:300
+       QCheck2.Gen.(pair gen_name bool)
+       (fun (name, quit_is_normal) ->
+         match
+           Supervisor_decision.classify ~name ~quit_is_normal
+             Supervisor_decision.Returned
+         with
+         | Fatal { name = actual; reason } ->
+             String.equal actual name
+             && Supervisor_decision.equal_fatal_reason reason
+                  Returned_unexpectedly
+         | Normal_quit | Propagate_cancel -> false));
+
+  QCheck2.Test.check_exn
+    (QCheck2.Test.make ~name:"unexpected exception is always fatal" ~count:300
+       QCheck2.Gen.(triple gen_name bool gen_detail)
+       (fun (name, quit_is_normal, detail) ->
+         match
+           Supervisor_decision.classify ~name ~quit_is_normal
+             (Supervisor_decision.Raised detail)
+         with
+         | Fatal { name = actual; reason } ->
+             String.equal actual name
+             && Supervisor_decision.equal_fatal_reason reason
+                  (Raised_unexpectedly detail)
+         | Normal_quit | Propagate_cancel -> false));
+
+  QCheck2.Test.check_exn
+    (QCheck2.Test.make ~name:"cancellation is never fatal" ~count:300
+       QCheck2.Gen.(pair gen_name bool)
+       (fun (name, quit_is_normal) ->
+         Supervisor_decision.equal_decision
+           (Supervisor_decision.classify ~name ~quit_is_normal
+              Supervisor_decision.Cancelled)
+           Supervisor_decision.Propagate_cancel));
+
+  QCheck2.Test.check_exn
+    (QCheck2.Test.make ~name:"quit is normal only when allowed" ~count:300
+       QCheck2.Gen.(pair gen_name bool)
+       (fun (name, quit_is_normal) ->
+         match
+           Supervisor_decision.classify ~name ~quit_is_normal
+             Supervisor_decision.Quit
+         with
+         | Normal_quit -> quit_is_normal
+         | Fatal _ -> not quit_is_normal
+         | Propagate_cancel -> false));
+
+  QCheck2.Test.check_exn
+    (QCheck2.Test.make
+       ~name:"fatal exits are deferred until cleanup has completed" ~count:1
+       QCheck2.Gen.unit (fun () ->
+         Supervisor_decision.equal_exit_decision
+           (Supervisor_decision.exit_after_fatal Cleanup_pending)
+           Defer_exit_until_cleanup
+         && Supervisor_decision.equal_exit_decision
+              (Supervisor_decision.exit_after_fatal Cleanup_done)
+              Exit_now));
+
+  QCheck2.Test.check_exn
+    (QCheck2.Test.make
+       ~name:"interleavings cannot stay running after fatal termination"
+       ~count:500
+       QCheck2.Gen.(list_size (int_range 1 30) (pair gen_name gen_termination))
+       (fun events ->
+         let fatal_seen =
+           List.exists events ~f:(fun (name, termination) ->
+               Supervisor_decision.classify ~name ~quit_is_normal:false
+                 termination
+               |> is_fatal)
+         in
+         let final_state_running =
+           List.fold events ~init:true ~f:(fun running (name, termination) ->
+               if not running then false
+               else
+                 match
+                   Supervisor_decision.classify ~name ~quit_is_normal:false
+                     termination
+                 with
+                 | Fatal _ -> false
+                 | Normal_quit | Propagate_cancel -> true)
+         in
+         (not fatal_seen) || not final_state_running));
+
+  QCheck2.Test.check_exn
+    (QCheck2.Test.make ~name:"fatal messages include fiber name and reason"
+       ~count:300
+       QCheck2.Gen.(pair gen_name gen_detail)
+       (fun (name, detail) ->
+         let msg =
+           Supervisor_decision.message ~name
+             (Supervisor_decision.Raised_unexpectedly detail)
+         in
+         String.is_substring msg ~substring:name
+         && String.is_substring msg ~substring:detail));
+
+  Stdlib.print_endline "supervisor_decision properties passed"

--- a/test/test_supervisor_decision_properties.ml
+++ b/test/test_supervisor_decision_properties.ml
@@ -30,6 +30,9 @@ let gen_return_policy =
   QCheck2.Gen.oneof_list
     Supervisor_decision.[ Return_is_fatal; Return_is_normal ]
 
+let gen_cleanup_state =
+  QCheck2.Gen.oneof_list Supervisor_decision.[ Cleanup_pending; Cleanup_done ]
+
 let is_fatal = function
   | Supervisor_decision.Fatal _ -> true
   | Normal_return | Normal_quit | Propagate_cancel -> false
@@ -108,14 +111,17 @@ let () =
 
   QCheck2.Test.check_exn
     (QCheck2.Test.make
-       ~name:"fatal exits are deferred until cleanup has completed" ~count:1
-       QCheck2.Gen.unit (fun () ->
+       ~name:"fatal exits are deferred until cleanup has completed" ~count:100
+       gen_cleanup_state (fun cleanup_state ->
+         let expected =
+           match cleanup_state with
+           | Supervisor_decision.Cleanup_pending ->
+               Supervisor_decision.Defer_exit_until_cleanup
+           | Cleanup_done -> Supervisor_decision.Exit_now
+         in
          Supervisor_decision.equal_exit_decision
-           (Supervisor_decision.exit_after_fatal Cleanup_pending)
-           Defer_exit_until_cleanup
-         && Supervisor_decision.equal_exit_decision
-              (Supervisor_decision.exit_after_fatal Cleanup_done)
-              Exit_now));
+           (Supervisor_decision.exit_after_fatal cleanup_state)
+           expected));
 
   QCheck2.Test.check_exn
     (QCheck2.Test.make

--- a/test/test_supervisor_decision_properties.ml
+++ b/test/test_supervisor_decision_properties.ml
@@ -26,55 +26,71 @@ let gen_termination =
       map (fun detail -> Supervisor_decision.Raised detail) gen_detail;
     ]
 
+let gen_return_policy =
+  QCheck2.Gen.oneof_list
+    Supervisor_decision.[ Return_is_fatal; Return_is_normal ]
+
 let is_fatal = function
   | Supervisor_decision.Fatal _ -> true
-  | Normal_quit | Propagate_cancel -> false
+  | Normal_return | Normal_quit | Propagate_cancel -> false
 
 let () =
   QCheck2.Test.check_exn
     (QCheck2.Test.make ~name:"supervisor classify is total" ~count:1_000
-       QCheck2.Gen.(triple gen_name bool gen_termination)
-       (fun (name, quit_is_normal, termination) ->
+       QCheck2.Gen.(quad gen_name bool gen_return_policy gen_termination)
+       (fun (name, quit_is_normal, return_policy, termination) ->
          try
            ignore
-             (Supervisor_decision.classify ~name ~quit_is_normal termination);
+             (Supervisor_decision.classify ~name ~quit_is_normal ~return_policy
+                termination);
            true
          with _ -> false));
 
   QCheck2.Test.check_exn
-    (QCheck2.Test.make ~name:"normal return is always fatal" ~count:300
+    (QCheck2.Test.make ~name:"normal return is fatal for long-lived fibers"
+       ~count:300
        QCheck2.Gen.(pair gen_name bool)
        (fun (name, quit_is_normal) ->
          match
            Supervisor_decision.classify ~name ~quit_is_normal
-             Supervisor_decision.Returned
+             ~return_policy:Return_is_fatal Supervisor_decision.Returned
          with
          | Fatal { name = actual; reason } ->
              String.equal actual name
              && Supervisor_decision.equal_fatal_reason reason
                   Returned_unexpectedly
-         | Normal_quit | Propagate_cancel -> false));
+         | Normal_return | Normal_quit | Propagate_cancel -> false));
+
+  QCheck2.Test.check_exn
+    (QCheck2.Test.make ~name:"normal return is normal for one-shot fibers"
+       ~count:300
+       QCheck2.Gen.(pair gen_name bool)
+       (fun (name, quit_is_normal) ->
+         Supervisor_decision.equal_decision
+           (Supervisor_decision.classify ~name ~quit_is_normal
+              ~return_policy:Return_is_normal Supervisor_decision.Returned)
+           Supervisor_decision.Normal_return));
 
   QCheck2.Test.check_exn
     (QCheck2.Test.make ~name:"unexpected exception is always fatal" ~count:300
-       QCheck2.Gen.(triple gen_name bool gen_detail)
-       (fun (name, quit_is_normal, detail) ->
+       QCheck2.Gen.(quad gen_name bool gen_return_policy gen_detail)
+       (fun (name, quit_is_normal, return_policy, detail) ->
          match
-           Supervisor_decision.classify ~name ~quit_is_normal
+           Supervisor_decision.classify ~name ~quit_is_normal ~return_policy
              (Supervisor_decision.Raised detail)
          with
          | Fatal { name = actual; reason } ->
              String.equal actual name
              && Supervisor_decision.equal_fatal_reason reason
                   (Raised_unexpectedly detail)
-         | Normal_quit | Propagate_cancel -> false));
+         | Normal_return | Normal_quit | Propagate_cancel -> false));
 
   QCheck2.Test.check_exn
     (QCheck2.Test.make ~name:"cancellation is never fatal" ~count:300
-       QCheck2.Gen.(pair gen_name bool)
-       (fun (name, quit_is_normal) ->
+       QCheck2.Gen.(triple gen_name bool gen_return_policy)
+       (fun (name, quit_is_normal, return_policy) ->
          Supervisor_decision.equal_decision
-           (Supervisor_decision.classify ~name ~quit_is_normal
+           (Supervisor_decision.classify ~name ~quit_is_normal ~return_policy
               Supervisor_decision.Cancelled)
            Supervisor_decision.Propagate_cancel));
 
@@ -84,11 +100,11 @@ let () =
        (fun (name, quit_is_normal) ->
          match
            Supervisor_decision.classify ~name ~quit_is_normal
-             Supervisor_decision.Quit
+             ~return_policy:Return_is_fatal Supervisor_decision.Quit
          with
          | Normal_quit -> quit_is_normal
          | Fatal _ -> not quit_is_normal
-         | Propagate_cancel -> false));
+         | Normal_return | Propagate_cancel -> false));
 
   QCheck2.Test.check_exn
     (QCheck2.Test.make
@@ -110,7 +126,7 @@ let () =
          let fatal_seen =
            List.exists events ~f:(fun (name, termination) ->
                Supervisor_decision.classify ~name ~quit_is_normal:false
-                 termination
+                 ~return_policy:Return_is_fatal termination
                |> is_fatal)
          in
          let final_state_running =
@@ -119,10 +135,10 @@ let () =
                else
                  match
                    Supervisor_decision.classify ~name ~quit_is_normal:false
-                     termination
+                     ~return_policy:Return_is_fatal termination
                  with
                  | Fatal _ -> false
-                 | Normal_quit | Propagate_cancel -> true)
+                 | Normal_return | Normal_quit | Propagate_cancel -> true)
          in
          (not fatal_seen) || not final_state_running));
 

--- a/test/test_supervisor_guard.ml
+++ b/test/test_supervisor_guard.ml
@@ -1,0 +1,78 @@
+(* @archlint.module test
+   @archlint.domain supervisor *)
+
+open Base
+open Onton
+open Onton_core
+
+exception Test_quit
+
+let assert_fatal ?reason name f =
+  let logs = ref [] in
+  match
+    Supervisor_guard.wrap ~name
+      ~is_normal_quit:(function Test_quit -> true | _ -> false)
+      ~log:(fun msg -> logs := msg :: !logs)
+      f ()
+  with
+  | () -> failwith "expected fatal supervisor error"
+  | exception Supervisor_guard.Fatal_supervisor_error fatal ->
+      assert (String.equal fatal.name name);
+      assert (not (List.is_empty !logs));
+      Option.iter reason ~f:(fun expected ->
+          assert (Supervisor_decision.equal_fatal_reason fatal.reason expected))
+
+let assert_fatal_raised_contains name ~substring f =
+  let logs = ref [] in
+  match
+    Supervisor_guard.wrap ~name
+      ~is_normal_quit:(function Test_quit -> true | _ -> false)
+      ~log:(fun msg -> logs := msg :: !logs)
+      f ()
+  with
+  | () -> failwith "expected fatal supervisor error"
+  | exception Supervisor_guard.Fatal_supervisor_error fatal -> (
+      assert (String.equal fatal.name name);
+      assert (not (List.is_empty !logs));
+      match fatal.reason with
+      | Raised_unexpectedly detail ->
+          assert (String.is_substring detail ~substring)
+      | Returned_unexpectedly -> failwith "expected raised fatal reason")
+
+let () =
+  assert_fatal "poller" (fun () -> ());
+  assert_fatal_raised_contains "runner" ~substring:"boom" (fun () ->
+      failwith "boom");
+
+  (match
+     Supervisor_guard.wrap ~quit_is_normal:true ~name:"tui"
+       ~is_normal_quit:(function Test_quit -> true | _ -> false)
+       ~log:(fun _ -> failwith "normal quit should not log")
+       (fun () -> raise Test_quit)
+       ()
+   with
+  | () -> failwith "expected Test_quit to propagate"
+  | exception Test_quit -> ());
+
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  let sibling_cancelled = ref false in
+  (match
+     Eio.Fiber.all
+       [
+         Supervisor_guard.wrap ~name:"returning"
+           ~is_normal_quit:(fun _ -> false)
+           ~log:(fun _ -> ())
+           (fun () -> Eio.Time.sleep clock 0.01);
+         (fun () ->
+           try Eio.Time.sleep clock 60.0
+           with Eio.Cancel.Cancelled _ ->
+             sibling_cancelled := true;
+             raise (Eio.Cancel.Cancelled (Failure "cancelled")));
+       ]
+   with
+  | () -> failwith "expected fatal supervisor error"
+  | exception Supervisor_guard.Fatal_supervisor_error _ -> ());
+  assert !sibling_cancelled;
+
+  Stdlib.print_endline "supervisor_guard passed"

--- a/test/test_supervisor_guard.ml
+++ b/test/test_supervisor_guard.ml
@@ -41,6 +41,15 @@ let assert_fatal_raised_contains name ~substring f =
 
 let () =
   assert_fatal "poller" (fun () -> ());
+  (match
+     Supervisor_guard.wrap ~return_is_normal:true ~name:"startup-reconciler"
+       ~is_normal_quit:(fun _ -> false)
+       ~log:(fun _ -> failwith "normal startup return should not log")
+       (fun () -> ())
+       ()
+   with
+  | () -> ()
+  | exception _ -> failwith "one-shot startup return should be normal");
   assert_fatal_raised_contains "runner" ~substring:"boom" (fun () ->
       failwith "boom");
 

--- a/test/test_term_key_io.ml
+++ b/test/test_term_key_io.ml
@@ -1,0 +1,44 @@
+let with_stdin fd f =
+  let saved = Unix.dup Unix.stdin in
+  Fun.protect
+    ~finally:(fun () ->
+      Unix.dup2 saved Unix.stdin;
+      Unix.close saved)
+    (fun () ->
+      Unix.dup2 fd Unix.stdin;
+      f ())
+
+let with_pipe f =
+  let rd, wr = Unix.pipe () in
+  Fun.protect
+    ~finally:(fun () ->
+      Unix.close rd;
+      Unix.close wr)
+    (fun () -> f ~rd ~wr)
+
+let assert_poll_no_input () =
+  with_pipe (fun ~rd ~wr:_ ->
+      with_stdin rd (fun () ->
+          Eio_main.run @@ fun _env ->
+          match Onton.Term.Key_io.poll () with
+          | Onton.Term.Key_io.No_input -> ()
+          | Eof -> failwith "expected No_input, got Eof"
+          | Key _ -> failwith "expected No_input, got Key"))
+
+let assert_poll_key () =
+  with_pipe (fun ~rd ~wr ->
+      let written = Unix.write_substring wr "q" 0 1 in
+      assert (written = 1);
+      with_stdin rd (fun () ->
+          Eio_main.run @@ fun _env ->
+          match Onton.Term.Key_io.poll () with
+          | Onton.Term.Key_io.Key key ->
+              if not (Onton.Term.Key.equal key (Onton.Term.Key.Char 'q')) then
+                failwith "expected Key(Char q), got different key"
+          | No_input -> failwith "expected Key, got No_input"
+          | Eof -> failwith "expected Key, got Eof"))
+
+let () =
+  assert_poll_no_input ();
+  assert_poll_key ();
+  Printf.printf "term_key_io: passed\n"

--- a/test/test_term_key_io.ml
+++ b/test/test_term_key_io.ml
@@ -1,3 +1,6 @@
+(* @archlint.module test
+   @archlint.domain terminal *)
+
 let with_stdin fd f =
   let saved = Unix.dup Unix.stdin in
   Fun.protect


### PR DESCRIPTION
## Summary

- fail fast when a long-lived supervisor fiber raises unexpectedly, including the poller and runner
- save a snapshot and log a fatal supervisor error before exiting
- add regression property coverage for stale skip-empty CI delivery followed by a new failed check run

## Root Cause

A supervisor fiber could die while the overall process stayed alive, leaving Onton idle and no longer polling or delivering CI failures. In the page-step-authority case, this made Patch 1 appear to await feedback even though the PR had failing checks.

## Validation

- dune build
- dune exec test/test_patch_controller.exe
- dune exec test/test_interleaving_properties.exe
- dune runtest
- pre-commit build/test/format hook

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail fast on supervisor fiber errors to prevent silent stalls in polling and CI delivery. TUI input is now cancellable, yields during escape parsing, and handles EOF gracefully; poll telemetry no longer deadlocks, and branch‑blocked patches clearly show “needs help”.

- **Bug Fixes**
  - Wrapped long‑lived fibers with a supervisor guard that logs a fatal message, saves a snapshot, and exits after cleanup; TUI quit is treated as normal, the `startup-reconciler` may return normally, and TUI input EOF is treated as a normal return.
  - Made TUI input polling non‑blocking via `Term.Key_io.poll`, with EINTR handling, a yield after polling the first byte, and short, yielding waits for escape sequences; returns `No_input` when idle and handles EOF without crashing.
  - Fixed a poll telemetry deadlock by collecting poll events under the orchestrator update and emitting `Event_log.log_poll` outside the lock.
  - Surface branch collisions as operator‑actionable: mark `branch_blocked` as needs‑help in the TUI and activity‑log agent view, with a clear message to switch the repo root branch.
  - Added tests for supervisor decision/guard behavior and TUI key polling, plus properties for CI re‑enqueue after skip‑empty.

<sup>Written for commit 9430044be0c6d119c5fc0b2ba9f41493ae29bc78. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/flowglad/onton/pull/368?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

