### PR TITLE
[codex] Handle merge queue ejection as CI feedback

### DIFF
--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -94,7 +94,7 @@ let apply_poll_result t patch_id
       poll_observation) =
   let logs = ref [] in
   let log message = logs := { message; patch_id } :: !logs in
-  let poll_result, merge_queue_ejected =
+  let poll_result, merge_queue_failure =
     let agent = Orchestrator.agent t patch_id in
     let application =
       Merge_queue_decision.apply ~previous_entry:agent.merge_queue_entry
@@ -102,7 +102,10 @@ let apply_poll_result t patch_id
     in
     if application.merge_queue_ejected then
       log "Merge queue removed PR after checks failed — treating as CI failure";
-    (application.poll_result, application.merge_queue_ejected)
+    if application.merge_queue_unmergeable then
+      log "Merge queue marked PR unmergeable — treating as CI failure";
+    ( application.poll_result,
+      application.merge_queue_ejected || application.merge_queue_unmergeable )
   in
   (* If the agent was [Missing] and we have a successful poll observation,
      lift it back to [Present] before applying any world-state updates. The
@@ -227,8 +230,9 @@ let apply_poll_result t patch_id
     Orchestrator.set_checks_passing t patch_id poll_result.checks_passing
   in
   let t =
-    if merge_queue_ejected then
-      Orchestrator.increment_automerge_failure_count t patch_id
+    if merge_queue_failure then
+      let t = Orchestrator.increment_automerge_failure_count t patch_id in
+      Orchestrator.clear_automerge_deadline t patch_id
     else t
   in
   let t =
@@ -820,10 +824,7 @@ let reconcile_automerge t ~now =
           Option.is_some agent.Patch_agent.merge_queue_entry && not approved
         in
         let candidate =
-          if unmergeable_entry then
-            agent.Patch_agent.automerge_enabled
-            && agent.Patch_agent.automerge_failure_count
-               < automerge_max_failures
+          if unmergeable_entry then false
           else if cleanup_candidate then
             agent.Patch_agent.automerge_enabled
             && agent.Patch_agent.automerge_failure_count
@@ -853,24 +854,21 @@ let reconcile_automerge t ~now =
             if Float.( >= ) now deadline then
               match Patch_agent.pr_number agent with
               | Some pr_number when Patch_agent.is_pr_present agent -> (
-                  if unmergeable_entry then
-                    (apply_automerge_failure_state t ~now patch_id, decisions)
-                  else
-                    match automerge_action agent ~main_branch with
-                    | None ->
-                        ( Orchestrator.clear_automerge_deadline t patch_id,
-                          decisions )
-                    | Some action ->
-                        let t =
-                          Orchestrator.set_automerge_inflight t patch_id true
-                        in
-                        ( t,
-                          {
-                            merge_patch_id = patch_id;
-                            merge_pr_number = pr_number;
-                            action;
-                          }
-                          :: decisions ))
+                  match automerge_action agent ~main_branch with
+                  | None ->
+                      ( Orchestrator.clear_automerge_deadline t patch_id,
+                        decisions )
+                  | Some action ->
+                      let t =
+                        Orchestrator.set_automerge_inflight t patch_id true
+                      in
+                      ( t,
+                        {
+                          merge_patch_id = patch_id;
+                          merge_pr_number = pr_number;
+                          action;
+                        }
+                        :: decisions ))
               | Some _ | None ->
                   (* Unreachable today because [is_automerge_candidate]
                      requires [is_approved] which requires [has_pr]. Defensive
@@ -1443,6 +1441,7 @@ let make_approved_agent t =
 let%test "apply_poll_result turns merge queue ejection into CI feedback" =
   let _patch, t = make_orchestrator ~patch_id:pid ~main_branch:main in
   let t = make_approved_agent t in
+  let t = Orchestrator.set_automerge_deadline t pid 1.0 in
   let t = Orchestrator.set_merge_queue_required t pid true in
   let t =
     Orchestrator.set_merge_queue_entry t pid
@@ -1478,9 +1477,53 @@ let%test "apply_poll_result turns merge queue ejection into CI feedback" =
   List.mem agent.queue Operation_kind.Ci ~equal:Operation_kind.equal
   && (not agent.checks_passing) && (not agent.merge_ready)
   && agent.automerge_failure_count = 1
+  && Option.is_none agent.automerge_deadline
   && List.exists agent.ci_checks ~f:Ci_check.is_merge_queue_failure
   && List.exists logs ~f:(fun { message; _ } ->
       String.is_substring message ~substring:"Merge queue removed PR")
+
+let%test
+    "apply_poll_result turns unmergeable merge queue entry into CI feedback" =
+  let _patch, t = make_orchestrator ~patch_id:pid ~main_branch:main in
+  let t = make_approved_agent t in
+  let t = Orchestrator.set_automerge_deadline t pid 1.0 in
+  let poll_result =
+    Poller.
+      {
+        queue = [];
+        merged = false;
+        closed = false;
+        is_draft = false;
+        merge_state = Pr_state.Mergeable;
+        merge_ready = true;
+        review_decision = Some "APPROVED";
+        merge_queue_required = true;
+        merge_queue_entry =
+          Some Pr_state.{ id = "MQE_2"; state = Mq_unmergeable; position = 4 };
+        checks_passing = true;
+        ci_checks = [];
+        merge_commit_sha = None;
+      }
+  in
+  let t, logs, _ =
+    apply_poll_result t pid
+      {
+        poll_result;
+        base_branch = Some main;
+        branch_in_root = false;
+        worktree_path = None;
+      }
+  in
+  let agent = Orchestrator.agent t pid in
+  List.mem agent.queue Operation_kind.Ci ~equal:Operation_kind.equal
+  && (not agent.checks_passing) && (not agent.merge_ready)
+  && Option.exists agent.merge_queue_entry ~f:(fun entry ->
+      Pr_state.equal_merge_queue_entry_state entry.state Pr_state.Mq_unmergeable)
+  && agent.automerge_failure_count = 1
+  && Option.is_none agent.automerge_deadline
+  && List.exists agent.ci_checks ~f:Ci_check.is_merge_queue_failure
+  && List.exists logs ~f:(fun { message; _ } ->
+      String.is_substring message ~substring:"marked PR unmergeable")
 
 let%test "reconcile_automerge clears deadline on merged agent" =
   let _patch, t = make_orchestrator ~patch_id:pid ~main_branch:main in

--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -94,6 +94,16 @@ let apply_poll_result t patch_id
       poll_observation) =
   let logs = ref [] in
   let log message = logs := { message; patch_id } :: !logs in
+  let poll_result, merge_queue_ejected =
+    let agent = Orchestrator.agent t patch_id in
+    let application =
+      Merge_queue_decision.apply ~previous_entry:agent.merge_queue_entry
+        poll_result
+    in
+    if application.merge_queue_ejected then
+      log "Merge queue removed PR after checks failed — treating as CI failure";
+    (application.poll_result, application.merge_queue_ejected)
+  in
   (* If the agent was [Missing] and we have a successful poll observation,
      lift it back to [Present] before applying any world-state updates. The
      pure classifier is total; the effectful dispatch is a flat match.
@@ -215,6 +225,11 @@ let apply_poll_result t patch_id
   in
   let t =
     Orchestrator.set_checks_passing t patch_id poll_result.checks_passing
+  in
+  let t =
+    if merge_queue_ejected then
+      Orchestrator.increment_automerge_failure_count t patch_id
+    else t
   in
   let t =
     let agent = Orchestrator.agent t patch_id in
@@ -1424,6 +1439,48 @@ let make_approved_agent t =
   let t = Orchestrator.set_checks_passing t pid true in
   let t = Orchestrator.set_pr_body_delivered t pid true in
   Orchestrator.set_automerge_enabled t pid true
+
+let%test "apply_poll_result turns merge queue ejection into CI feedback" =
+  let _patch, t = make_orchestrator ~patch_id:pid ~main_branch:main in
+  let t = make_approved_agent t in
+  let t = Orchestrator.set_merge_queue_required t pid true in
+  let t =
+    Orchestrator.set_merge_queue_entry t pid
+      (Some Pr_state.{ id = "MQE_1"; state = Mq_awaiting_checks; position = 1 })
+  in
+  let poll_result =
+    Poller.
+      {
+        queue = [];
+        merged = false;
+        closed = false;
+        is_draft = false;
+        merge_state = Pr_state.Mergeable;
+        merge_ready = true;
+        review_decision = Some "APPROVED";
+        merge_queue_required = true;
+        merge_queue_entry = None;
+        checks_passing = true;
+        ci_checks = [];
+        merge_commit_sha = None;
+      }
+  in
+  let t, logs, _ =
+    apply_poll_result t pid
+      {
+        poll_result;
+        base_branch = Some main;
+        branch_in_root = false;
+        worktree_path = None;
+      }
+  in
+  let agent = Orchestrator.agent t pid in
+  List.mem agent.queue Operation_kind.Ci ~equal:Operation_kind.equal
+  && (not agent.checks_passing) && (not agent.merge_ready)
+  && agent.automerge_failure_count = 1
+  && List.exists agent.ci_checks ~f:Ci_check.is_merge_queue_failure
+  && List.exists logs ~f:(fun { message; _ } ->
+      String.is_substring message ~substring:"Merge queue removed PR")
 
 let%test "reconcile_automerge clears deadline on merged agent" =
   let _patch, t = make_orchestrator ~patch_id:pid ~main_branch:main in

--- a/lib/runner_fiber_impl.ml
+++ b/lib/runner_fiber_impl.ml
@@ -1231,9 +1231,18 @@ struct
                         | None, _ -> Some "no PR number"
                         | Some _, None -> Some "fetch failed"
                         | Some _, Some pr_state ->
+                            let agent_has_merge_queue_failure =
+                              Runtime.read runtime (fun snap ->
+                                  Orchestrator.agent snap.Runtime.orchestrator
+                                    patch_id)
+                              |> fun agent ->
+                              Base.List.exists agent.Patch_agent.ci_checks
+                                ~f:Ci_check.is_merge_queue_failure
+                            in
                             if
                               Base.List.exists pr_state.Pr_state.ci_checks
                                 ~f:Ci_check.is_failure
+                              || agent_has_merge_queue_failure
                             then None
                             else (
                               log_event runtime ~patch_id
@@ -1265,7 +1274,10 @@ struct
                                    [agent.ci_checks] reflects the fresh
                                    list. *)
                                   (match (is_ci, fresh_pr_state) with
-                                  | true, Some pr_state ->
+                                  | true, Some pr_state
+                                    when Base.List.exists
+                                           pr_state.Pr_state.ci_checks
+                                           ~f:Ci_check.is_failure ->
                                       Runtime.update_orchestrator runtime
                                         (fun orch ->
                                           Orchestrator.set_ci_checks orch

--- a/lib/runner_fiber_impl.ml
+++ b/lib/runner_fiber_impl.ml
@@ -1274,14 +1274,24 @@ struct
                                    [agent.ci_checks] reflects the fresh
                                    list. *)
                                   (match (is_ci, fresh_pr_state) with
-                                  | true, Some pr_state
-                                    when Base.List.exists
-                                           pr_state.Pr_state.ci_checks
-                                           ~f:Ci_check.is_failure ->
+                                  | true, Some pr_state ->
+                                      let synthetic_checks =
+                                        Runtime.read runtime (fun snap ->
+                                            Orchestrator.agent
+                                              snap.Runtime.orchestrator patch_id)
+                                        |> fun agent ->
+                                        Base.List.filter
+                                          agent.Patch_agent.ci_checks
+                                          ~f:Ci_check.is_merge_queue_failure
+                                      in
+                                      let ci_checks =
+                                        pr_state.Pr_state.ci_checks
+                                        @ synthetic_checks
+                                      in
                                       Runtime.update_orchestrator runtime
                                         (fun orch ->
                                           Orchestrator.set_ci_checks orch
-                                            patch_id pr_state.Pr_state.ci_checks)
+                                            patch_id ci_checks)
                                   | _ -> ());
                                   let agent =
                                     Runtime.read runtime (fun snap ->

--- a/lib_core/merge_queue_decision.ml
+++ b/lib_core/merge_queue_decision.ml
@@ -4,32 +4,61 @@
 open Base
 open Types
 
-type application = { poll_result : Poller.t; merge_queue_ejected : bool }
+type application = {
+  poll_result : Poller.t;
+  merge_queue_ejected : bool;
+  merge_queue_unmergeable : bool;
+}
 [@@deriving show, eq]
+
+let has_current_failure (poll_result : Poller.t) =
+  List.exists poll_result.ci_checks ~f:Ci_check.is_failure
 
 let should_treat_ejection_as_ci_failure ~previous_entry (poll_result : Poller.t)
     =
   let had_merge_queue_entry = Option.is_some previous_entry in
-  let current_failures =
-    List.exists poll_result.ci_checks ~f:Ci_check.is_failure
-  in
   had_merge_queue_entry && poll_result.merge_queue_required
   && Option.is_none poll_result.merge_queue_entry
   && (not poll_result.merged) && (not poll_result.closed)
   && poll_result.merge_ready && poll_result.checks_passing
-  && not current_failures
+  && not (has_current_failure poll_result)
+
+let should_treat_unmergeable_as_ci_failure (poll_result : Poller.t) =
+  let merge_queue_unmergeable =
+    Option.exists poll_result.merge_queue_entry ~f:(fun entry ->
+        Pr_state.equal_merge_queue_entry_state entry.state
+          Pr_state.Mq_unmergeable)
+  in
+  poll_result.merge_queue_required && merge_queue_unmergeable
+  && (not poll_result.merged) && (not poll_result.closed)
+  && poll_result.checks_passing
+  && not (has_current_failure poll_result)
+
+let apply_failure (poll_result : Poller.t) =
+  {
+    poll_result with
+    queue = Operation_kind.Ci :: poll_result.queue;
+    merge_ready = false;
+    checks_passing = false;
+    ci_checks = Ci_check.merge_queue_failure () :: poll_result.ci_checks;
+  }
 
 let apply ~previous_entry poll_result =
   if should_treat_ejection_as_ci_failure ~previous_entry poll_result then
     {
-      poll_result =
-        {
-          poll_result with
-          queue = Operation_kind.Ci :: poll_result.queue;
-          merge_ready = false;
-          checks_passing = false;
-          ci_checks = Ci_check.merge_queue_failure () :: poll_result.ci_checks;
-        };
+      poll_result = apply_failure poll_result;
       merge_queue_ejected = true;
+      merge_queue_unmergeable = false;
     }
-  else { poll_result; merge_queue_ejected = false }
+  else if should_treat_unmergeable_as_ci_failure poll_result then
+    {
+      poll_result = apply_failure poll_result;
+      merge_queue_ejected = false;
+      merge_queue_unmergeable = true;
+    }
+  else
+    {
+      poll_result;
+      merge_queue_ejected = false;
+      merge_queue_unmergeable = false;
+    }

--- a/lib_core/merge_queue_decision.ml
+++ b/lib_core/merge_queue_decision.ml
@@ -1,0 +1,35 @@
+(* @archlint.module core
+   @archlint.domain merge-queue-decision *)
+
+open Base
+open Types
+
+type application = { poll_result : Poller.t; merge_queue_ejected : bool }
+[@@deriving show, eq]
+
+let should_treat_ejection_as_ci_failure ~previous_entry (poll_result : Poller.t)
+    =
+  let had_merge_queue_entry = Option.is_some previous_entry in
+  let current_failures =
+    List.exists poll_result.ci_checks ~f:Ci_check.is_failure
+  in
+  had_merge_queue_entry && poll_result.merge_queue_required
+  && Option.is_none poll_result.merge_queue_entry
+  && (not poll_result.merged) && (not poll_result.closed)
+  && poll_result.merge_ready && poll_result.checks_passing
+  && not current_failures
+
+let apply ~previous_entry poll_result =
+  if should_treat_ejection_as_ci_failure ~previous_entry poll_result then
+    {
+      poll_result =
+        {
+          poll_result with
+          queue = Operation_kind.Ci :: poll_result.queue;
+          merge_ready = false;
+          checks_passing = false;
+          ci_checks = Ci_check.merge_queue_failure () :: poll_result.ci_checks;
+        };
+      merge_queue_ejected = true;
+    }
+  else { poll_result; merge_queue_ejected = false }

--- a/lib_core/merge_queue_decision.mli
+++ b/lib_core/merge_queue_decision.mli
@@ -1,11 +1,17 @@
 (* @archlint.module interface
    @archlint.domain merge-queue-decision *)
 
-type application = { poll_result : Poller.t; merge_queue_ejected : bool }
+type application = {
+  poll_result : Poller.t;
+  merge_queue_ejected : bool;
+  merge_queue_unmergeable : bool;
+}
 [@@deriving show, eq]
 
 val should_treat_ejection_as_ci_failure :
   previous_entry:Pr_state.merge_queue_entry option -> Poller.t -> bool
+
+val should_treat_unmergeable_as_ci_failure : Poller.t -> bool
 
 val apply :
   previous_entry:Pr_state.merge_queue_entry option -> Poller.t -> application

--- a/lib_core/merge_queue_decision.mli
+++ b/lib_core/merge_queue_decision.mli
@@ -1,0 +1,8 @@
+type application = { poll_result : Poller.t; merge_queue_ejected : bool }
+[@@deriving show, eq]
+
+val should_treat_ejection_as_ci_failure :
+  previous_entry:Pr_state.merge_queue_entry option -> Poller.t -> bool
+
+val apply :
+  previous_entry:Pr_state.merge_queue_entry option -> Poller.t -> application

--- a/lib_core/merge_queue_decision.mli
+++ b/lib_core/merge_queue_decision.mli
@@ -1,3 +1,6 @@
+(* @archlint.module interface
+   @archlint.domain merge-queue-decision *)
+
 type application = { poll_result : Poller.t; merge_queue_ejected : bool }
 [@@deriving show, eq]
 

--- a/lib_core/types.ml
+++ b/lib_core/types.ml
@@ -217,9 +217,9 @@ module Ci_check = struct
       details_url = None;
       description =
         Some
-          "GitHub removed this PR from the merge queue after merge queue \
-           checks failed. Inspect the merge queue or Actions history for the \
-           failing synthetic queue run.";
+          "GitHub reported a merge queue failure for this PR. It may have been \
+           removed after queue checks failed, or marked unmergeable while \
+           still in the queue.";
       started_at = None;
       id = None;
     }

--- a/lib_core/types.ml
+++ b/lib_core/types.ml
@@ -207,6 +207,25 @@ module Ci_check = struct
 
   let is_success (c : t) =
     List.mem success_conclusions c.conclusion ~equal:String.equal
+
+  let merge_queue_failure_name = "GitHub merge queue"
+
+  let merge_queue_failure () =
+    {
+      name = merge_queue_failure_name;
+      conclusion = "failure";
+      details_url = None;
+      description =
+        Some
+          "GitHub removed this PR from the merge queue after merge queue \
+           checks failed. Inspect the merge queue or Actions history for the \
+           failing synthetic queue run.";
+      started_at = None;
+      id = None;
+    }
+
+  let is_merge_queue_failure (c : t) =
+    String.equal c.name merge_queue_failure_name && is_failure c
 end
 
 module Pr_url = struct

--- a/lib_core/types.mli
+++ b/lib_core/types.mli
@@ -203,6 +203,8 @@ module Ci_check : sig
 
   val is_failure : t -> bool
   val is_success : t -> bool
+  val merge_queue_failure : unit -> t
+  val is_merge_queue_failure : t -> bool
 end
 
 module Pr_url : sig

--- a/test/dune
+++ b/test/dune
@@ -86,6 +86,13 @@
  (ocamlc_flags (:standard -w -40-42)))
 
 (test
+ (name test_merge_queue_decision_properties)
+ (modules test_merge_queue_decision_properties)
+ (libraries onton_core qcheck-core qcheck-core.runner)
+ (ocamlopt_flags (:standard -w -40-42))
+ (ocamlc_flags (:standard -w -40-42)))
+
+(test
  (name test_push_reject_classify_properties)
  (modules test_push_reject_classify_properties)
  (libraries onton_core qcheck-core qcheck-core.runner)

--- a/test/test_merge_queue_decision_properties.ml
+++ b/test/test_merge_queue_decision_properties.ml
@@ -1,0 +1,242 @@
+(* @archlint.module test
+   @archlint.domain merge-queue-decision *)
+
+open Base
+open Onton_core
+open Onton_core.Types
+
+let gen_string =
+  QCheck2.Gen.(string_size ~gen:(char_range 'a' 'z') (int_range 1 16))
+
+let gen_operation_kind =
+  QCheck2.Gen.oneof_list
+    Operation_kind.
+      [ Human; Ci; Review_comments; Findings; Pr_body; Merge_conflict; Rebase ]
+
+let gen_queue = QCheck2.Gen.(list_size (int_range 0 5) gen_operation_kind)
+
+let gen_ci_check =
+  let open QCheck2.Gen in
+  let conclusions =
+    Ci_check.failure_conclusions @ Ci_check.success_conclusions
+    @ [ "cancelled"; "queued"; "in_progress"; "unknown" ]
+  in
+  map5
+    (fun name conclusion details_url description id ->
+      Ci_check.
+        { name; conclusion; details_url; description; started_at = None; id })
+    gen_string (oneof_list conclusions) (option gen_string) (option gen_string)
+    (option (int_range 1 999_999))
+
+let gen_ci_checks = QCheck2.Gen.(list_size (int_range 0 8) gen_ci_check)
+
+let gen_merge_queue_entry =
+  let open QCheck2.Gen in
+  let states =
+    Pr_state.
+      [ Mq_queued; Mq_awaiting_checks; Mq_mergeable; Mq_unmergeable; Mq_locked ]
+  in
+  map3
+    (fun id state position -> Pr_state.{ id; state; position })
+    gen_string (oneof_list states) (int_range 0 99)
+
+let gen_previous_entry = QCheck2.Gen.option gen_merge_queue_entry
+
+let gen_poll_result =
+  let open QCheck2.Gen in
+  let* queue = gen_queue in
+  let* merged = bool in
+  let* closed = bool in
+  let* is_draft = bool in
+  let* merge_ready = bool in
+  let* merge_queue_required = bool in
+  let* merge_queue_entry = gen_previous_entry in
+  let* checks_passing = bool in
+  let* ci_checks = gen_ci_checks in
+  let merge_state =
+    if merge_ready then Pr_state.Mergeable else Pr_state.Unknown
+  in
+  return
+    Poller.
+      {
+        queue;
+        merged;
+        closed;
+        is_draft;
+        merge_state;
+        merge_ready;
+        review_decision = None;
+        merge_queue_required;
+        merge_queue_entry;
+        checks_passing;
+        ci_checks;
+        merge_commit_sha = None;
+      }
+
+let failing_check =
+  Ci_check.
+    {
+      name = "failing";
+      conclusion = "failure";
+      details_url = None;
+      description = None;
+      started_at = None;
+      id = Some 1;
+    }
+
+let base_ejection_poll =
+  Poller.
+    {
+      queue = [];
+      merged = false;
+      closed = false;
+      is_draft = false;
+      merge_state = Pr_state.Mergeable;
+      merge_ready = true;
+      review_decision = Some "APPROVED";
+      merge_queue_required = true;
+      merge_queue_entry = None;
+      checks_passing = true;
+      ci_checks = [];
+      merge_commit_sha = None;
+    }
+
+let previous_entry =
+  Pr_state.{ id = "MQE_1"; state = Mq_awaiting_checks; position = 1 }
+
+let expected_ejection ~previous_entry (poll : Poller.t) =
+  Option.is_some previous_entry
+  && poll.merge_queue_required
+  && Option.is_none poll.merge_queue_entry
+  && (not poll.merged) && (not poll.closed) && poll.merge_ready
+  && poll.checks_passing
+  && not (List.exists poll.ci_checks ~f:Ci_check.is_failure)
+
+let prop_totality =
+  QCheck2.Test.make ~name:"MQD total over arbitrary prior entry + poll"
+    ~count:2000
+    QCheck2.Gen.(pair gen_previous_entry gen_poll_result)
+    (fun (previous_entry, poll) ->
+      try
+        let _ = Merge_queue_decision.apply ~previous_entry poll in
+        true
+      with _ -> false)
+
+let prop_exact_predicate =
+  QCheck2.Test.make ~name:"MQD ejection iff every predicate term holds"
+    ~count:2000
+    QCheck2.Gen.(pair gen_previous_entry gen_poll_result)
+    (fun (previous_entry, poll) ->
+      Bool.equal
+        (Merge_queue_decision.should_treat_ejection_as_ci_failure
+           ~previous_entry poll)
+        (expected_ejection ~previous_entry poll))
+
+let boundary_cases =
+  [
+    ("no previous entry", None, base_ejection_poll, false);
+    ( "queue not required",
+      Some previous_entry,
+      { base_ejection_poll with merge_queue_required = false },
+      false );
+    ( "still enqueued",
+      Some previous_entry,
+      { base_ejection_poll with merge_queue_entry = Some previous_entry },
+      false );
+    ( "merged",
+      Some previous_entry,
+      { base_ejection_poll with merged = true },
+      false );
+    ( "closed",
+      Some previous_entry,
+      { base_ejection_poll with closed = true },
+      false );
+    ( "not merge-ready",
+      Some previous_entry,
+      { base_ejection_poll with merge_ready = false },
+      false );
+    ( "checks not passing",
+      Some previous_entry,
+      { base_ejection_poll with checks_passing = false },
+      false );
+    ( "current failure already visible",
+      Some previous_entry,
+      { base_ejection_poll with ci_checks = [ failing_check ] },
+      false );
+    ("ejected", Some previous_entry, base_ejection_poll, true);
+  ]
+
+let prop_boundary_cases =
+  QCheck2.Test.make ~name:"MQD boundary guard matrix" ~count:1 QCheck2.Gen.unit
+    (fun () ->
+      List.for_all boundary_cases
+        ~f:(fun (_name, previous_entry, poll, expected) ->
+          Bool.equal
+            (Merge_queue_decision.should_treat_ejection_as_ci_failure
+               ~previous_entry poll)
+            expected))
+
+let prop_apply_shape =
+  QCheck2.Test.make ~name:"MQD apply rewrites only ejection cases" ~count:2000
+    QCheck2.Gen.(pair gen_previous_entry gen_poll_result)
+    (fun (previous_entry, poll) ->
+      let result = Merge_queue_decision.apply ~previous_entry poll in
+      if expected_ejection ~previous_entry poll then
+        result.merge_queue_ejected
+        && List.exists result.poll_result.queue ~f:(Operation_kind.equal Ci)
+        && (not result.poll_result.merge_ready)
+        && (not result.poll_result.checks_passing)
+        && List.exists result.poll_result.ci_checks
+             ~f:Ci_check.is_merge_queue_failure
+      else
+        (not result.merge_queue_ejected) && Poller.equal result.poll_result poll)
+
+let prop_idempotent =
+  QCheck2.Test.make ~name:"MQD apply is idempotent for a fixed prior entry"
+    ~count:1000
+    QCheck2.Gen.(pair gen_previous_entry gen_poll_result)
+    (fun (previous_entry, poll) ->
+      let first = Merge_queue_decision.apply ~previous_entry poll in
+      let second =
+        Merge_queue_decision.apply ~previous_entry first.poll_result
+      in
+      (not second.merge_queue_ejected)
+      && Poller.equal second.poll_result first.poll_result)
+
+let prop_interleaving_threaded_prior_state =
+  QCheck2.Test.make
+    ~name:
+      "MQD interleaving: threaded merge-queue entry produces exactly local \
+       ejection decisions"
+    ~count:1000
+    QCheck2.Gen.(
+      pair gen_previous_entry (list_size (int_range 0 20) gen_poll_result))
+    (fun (initial_previous_entry, polls) ->
+      let _last_previous, ok =
+        List.fold polls ~init:(initial_previous_entry, true)
+          ~f:(fun (previous_entry, ok) poll ->
+            let result = Merge_queue_decision.apply ~previous_entry poll in
+            let expected = expected_ejection ~previous_entry poll in
+            let local_ok =
+              Bool.equal result.merge_queue_ejected expected
+              &&
+              if result.merge_queue_ejected then
+                Option.is_none result.poll_result.merge_queue_entry
+                && List.exists result.poll_result.ci_checks
+                     ~f:Ci_check.is_merge_queue_failure
+              else true
+            in
+            (result.poll_result.merge_queue_entry, ok && local_ok))
+      in
+      ok)
+
+let () =
+  List.iter
+    [
+      prop_totality;
+      prop_exact_predicate;
+      prop_boundary_cases;
+      prop_apply_shape;
+      prop_idempotent;
+      prop_interleaving_threaded_prior_state;
+    ] ~f:(fun test -> QCheck2.Test.check_exn test)

--- a/test/test_merge_queue_decision_properties.ml
+++ b/test/test_merge_queue_decision_properties.ml
@@ -104,13 +104,26 @@ let base_ejection_poll =
 let previous_entry =
   Pr_state.{ id = "MQE_1"; state = Mq_awaiting_checks; position = 1 }
 
+let visible_failure (poll : Poller.t) =
+  List.exists poll.ci_checks ~f:Ci_check.is_failure
+
 let expected_ejection ~previous_entry (poll : Poller.t) =
   Option.is_some previous_entry
   && poll.merge_queue_required
   && Option.is_none poll.merge_queue_entry
   && (not poll.merged) && (not poll.closed) && poll.merge_ready
   && poll.checks_passing
-  && not (List.exists poll.ci_checks ~f:Ci_check.is_failure)
+  && not (visible_failure poll)
+
+let expected_unmergeable (poll : Poller.t) =
+  let has_unmergeable_entry =
+    Option.exists poll.merge_queue_entry ~f:(fun entry ->
+        Pr_state.equal_merge_queue_entry_state entry.state
+          Pr_state.Mq_unmergeable)
+  in
+  poll.merge_queue_required && has_unmergeable_entry && (not poll.merged)
+  && (not poll.closed) && poll.checks_passing
+  && not (visible_failure poll)
 
 let prop_totality =
   QCheck2.Test.make ~name:"MQD total over arbitrary prior entry + poll"
@@ -131,6 +144,13 @@ let prop_exact_predicate =
         (Merge_queue_decision.should_treat_ejection_as_ci_failure
            ~previous_entry poll)
         (expected_ejection ~previous_entry poll))
+
+let prop_exact_unmergeable_predicate =
+  QCheck2.Test.make ~name:"MQD unmergeable iff every predicate term holds"
+    ~count:2000 gen_poll_result (fun poll ->
+      Bool.equal
+        (Merge_queue_decision.should_treat_unmergeable_as_ci_failure poll)
+        (expected_unmergeable poll))
 
 let boundary_cases =
   [
@@ -166,6 +186,29 @@ let boundary_cases =
     ("ejected", Some previous_entry, base_ejection_poll, true);
   ]
 
+let unmergeable_poll =
+  {
+    base_ejection_poll with
+    Poller.merge_queue_entry =
+      Some Pr_state.{ id = "MQE_2"; state = Mq_unmergeable; position = 4 };
+  }
+
+let unmergeable_boundary_cases =
+  [
+    ( "queue not required",
+      { unmergeable_poll with merge_queue_required = false },
+      false );
+    ("merged", { unmergeable_poll with merged = true }, false);
+    ("closed", { unmergeable_poll with closed = true }, false);
+    ( "checks not passing",
+      { unmergeable_poll with checks_passing = false },
+      false );
+    ( "current failure already visible",
+      { unmergeable_poll with ci_checks = [ failing_check ] },
+      false );
+    ("unmergeable", unmergeable_poll, true);
+  ]
+
 let prop_boundary_cases =
   QCheck2.Test.make ~name:"MQD boundary guard matrix" ~count:1 QCheck2.Gen.unit
     (fun () ->
@@ -176,20 +219,34 @@ let prop_boundary_cases =
                ~previous_entry poll)
             expected))
 
+let prop_unmergeable_boundary_cases =
+  QCheck2.Test.make ~name:"MQD unmergeable boundary guard matrix" ~count:1
+    QCheck2.Gen.unit (fun () ->
+      List.for_all unmergeable_boundary_cases ~f:(fun (_name, poll, expected) ->
+          Bool.equal
+            (Merge_queue_decision.should_treat_unmergeable_as_ci_failure poll)
+            expected))
+
 let prop_apply_shape =
-  QCheck2.Test.make ~name:"MQD apply rewrites only ejection cases" ~count:2000
+  QCheck2.Test.make ~name:"MQD apply rewrites only merge-queue failure cases"
+    ~count:2000
     QCheck2.Gen.(pair gen_previous_entry gen_poll_result)
     (fun (previous_entry, poll) ->
       let result = Merge_queue_decision.apply ~previous_entry poll in
-      if expected_ejection ~previous_entry poll then
-        result.merge_queue_ejected
+      if expected_ejection ~previous_entry poll || expected_unmergeable poll
+      then
+        Bool.equal result.merge_queue_ejected
+          (expected_ejection ~previous_entry poll)
+        && Bool.equal result.merge_queue_unmergeable (expected_unmergeable poll)
         && List.exists result.poll_result.queue ~f:(Operation_kind.equal Ci)
         && (not result.poll_result.merge_ready)
         && (not result.poll_result.checks_passing)
         && List.exists result.poll_result.ci_checks
              ~f:Ci_check.is_merge_queue_failure
       else
-        (not result.merge_queue_ejected) && Poller.equal result.poll_result poll)
+        (not result.merge_queue_ejected)
+        && (not result.merge_queue_unmergeable)
+        && Poller.equal result.poll_result poll)
 
 let prop_idempotent =
   QCheck2.Test.make ~name:"MQD apply is idempotent for a fixed prior entry"
@@ -201,6 +258,7 @@ let prop_idempotent =
         Merge_queue_decision.apply ~previous_entry first.poll_result
       in
       (not second.merge_queue_ejected)
+      && (not second.merge_queue_unmergeable)
       && Poller.equal second.poll_result first.poll_result)
 
 let prop_interleaving_threaded_prior_state =
@@ -216,14 +274,25 @@ let prop_interleaving_threaded_prior_state =
         List.fold polls ~init:(initial_previous_entry, true)
           ~f:(fun (previous_entry, ok) poll ->
             let result = Merge_queue_decision.apply ~previous_entry poll in
-            let expected = expected_ejection ~previous_entry poll in
+            let expected =
+              expected_ejection ~previous_entry poll
+              || expected_unmergeable poll
+            in
             let local_ok =
-              Bool.equal result.merge_queue_ejected expected
+              let synthetic_failure =
+                List.exists result.poll_result.ci_checks
+                  ~f:Ci_check.is_merge_queue_failure
+              in
+              Bool.equal
+                (result.merge_queue_ejected || result.merge_queue_unmergeable)
+                expected
               &&
-              if result.merge_queue_ejected then
-                Option.is_none result.poll_result.merge_queue_entry
-                && List.exists result.poll_result.ci_checks
-                     ~f:Ci_check.is_merge_queue_failure
+              if result.merge_queue_ejected || result.merge_queue_unmergeable
+              then
+                synthetic_failure
+                && (not result.poll_result.checks_passing)
+                && List.exists result.poll_result.queue
+                     ~f:(Operation_kind.equal Ci)
               else true
             in
             (result.poll_result.merge_queue_entry, ok && local_ok))
@@ -235,7 +304,9 @@ let () =
     [
       prop_totality;
       prop_exact_predicate;
+      prop_exact_unmergeable_predicate;
       prop_boundary_cases;
+      prop_unmergeable_boundary_cases;
       prop_apply_shape;
       prop_idempotent;
       prop_interleaving_threaded_prior_state;

--- a/test/test_patch_controller.ml
+++ b/test/test_patch_controller.ml
@@ -1536,9 +1536,10 @@ let () =
         | _ -> false)
   in
 
-  let pending_patch_4_unmergeable_counts_as_failure =
+  let pending_patch_4_unmergeable_clears_automerge_deadline =
     Test.make
-      ~name:"patch_controller: Patch 4 UNMERGEABLE entry counts as failure"
+      ~name:
+        "patch_controller: Patch 4 UNMERGEABLE entry clears automerge deadline"
       QCheck2.Gen.unit (fun () ->
         let pid = Patch_id.of_string "mq-unmergeable" in
         let branch = Branch.of_string "feat/mq-unmergeable" in
@@ -1561,9 +1562,9 @@ let () =
         in
         let agent = Orchestrator.agent orch pid in
         List.is_empty decisions
-        && agent.Patch_agent.automerge_failure_count = 1
+        && agent.Patch_agent.automerge_failure_count = 0
         && (not agent.Patch_agent.automerge_inflight)
-        && Option.is_some agent.Patch_agent.automerge_deadline)
+        && Option.is_none agent.Patch_agent.automerge_deadline)
   in
 
   (* A direct-merge patch that is approval-ready in every respect but reads
@@ -1667,7 +1668,7 @@ let () =
       pending_patch_4_automerge_enqueued_idle;
       pending_patch_4_unapproved_not_enqueued;
       pending_patch_4_automerge_dequeue_on_lost_approval;
-      pending_patch_4_unmergeable_counts_as_failure;
+      pending_patch_4_unmergeable_clears_automerge_deadline;
       prop_missing_adhoc_does_not_crash_reconcile;
       prop_apply_poll_lifts_missing_to_present;
       prop_child_of_missing_parent_not_startable;


### PR DESCRIPTION
## Summary

This teaches onton to recognize when GitHub removes an approved PR from the merge queue after merge-queue checks fail. Instead of treating the PR as freshly approved and restarting the automerge timer, the poll application now turns that ejection into CI feedback so the normal CI repair path runs.

## Changes

- Added a pure `Merge_queue_decision` module in `lib_core` for the ejection classification and poll-result rewrite.
- Added a synthetic `GitHub merge queue` CI failure check so the agent receives actionable CI feedback even after GitHub stops exposing the failed synthetic queue run on the PR.
- Preserved that synthetic failure through the pre-session CI refresh in the effectful runner.
- Added pure-only QCheck coverage for totality, exact predicate boundaries, idempotence, and threaded interleavings over changing merge-queue state.

## Validation

- `dune build`
- `dune exec test/test_merge_queue_decision_properties.exe`
- `dune runtest`
- pre-commit hook: build, runtest, format check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/369"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784224459&installation_id=126163856&pr_number=369&repository=flowglad%2Fonton&return_to=https%3A%2F%2Fgithub.com%2Fflowglad%2Fonton%2Fpull%2F369&signature=dec3d3754a01eebf9f6126d7019441d4137ae45ced5283e2d353d6d0df08ebe8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat merge-queue ejection and unmergeable queue entries as CI feedback so affected PRs follow the normal CI repair path instead of restarting automerge. Adds a persistent synthetic “GitHub merge queue” failure that the runner respects.

- **New Features**
  - Detects merge-queue ejection or `Mq_unmergeable` and rewrites the poll to queue `Ci`, clear `merge_ready`, and set `checks_passing = false`.
  - Adds a synthetic “GitHub merge queue” CI failure and preserves it through CI refresh; the runner treats it as failing even if GitHub hides or omits the run.
  - Introduces pure `Merge_queue_decision` with property tests; increments `automerge_failure_count` and clears the automerge deadline when the poll reports ejection or unmergeable.

- **Bug Fixes**
  - During reconcile, stops counting unmergeable queue entries as automerge failures; skips automerge and clears the deadline instead.

<sup>Written for commit 00546c8b319530cc971e1f5d87abbb3888c495fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/flowglad/onton/pull/369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Merge queue ejections are now properly treated as CI failures, with improved failure count tracking and system responses.
  * Enhanced CI failure detection to better account for merge queue-related scenarios during pull request evaluation.
  * Fixed automerge failure history tracking to ensure accurate counts across all failure types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->