### PR TITLE
[codex] Guard automerge timers for merge queue entries

### DIFF
--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -577,6 +577,10 @@ let set_merge_queue_entry t patch_id entry =
   update_agent t patch_id ~f:(fun a ->
       Patch_agent.set_merge_queue_entry a entry)
 
+let observe_merge_queue t patch_id ~required ~entry =
+  update_agent t patch_id ~f:(fun a ->
+      Automerge_state.observe_merge_queue a ~required ~entry)
+
 let set_merge_commit_sha t patch_id sha =
   update_agent t patch_id ~f:(fun a -> Patch_agent.set_merge_commit_sha a sha)
 
@@ -628,8 +632,7 @@ let set_automerge_enabled t patch_id v =
   update_agent t patch_id ~f:(fun a -> Patch_agent.set_automerge_enabled a v)
 
 let set_automerge_deadline t patch_id deadline =
-  update_agent t patch_id ~f:(fun a ->
-      Patch_agent.set_automerge_deadline a deadline)
+  update_agent t patch_id ~f:(fun a -> Automerge_state.arm_deadline a deadline)
 
 let clear_automerge_deadline t patch_id =
   update_agent t patch_id ~f:Patch_agent.clear_automerge_deadline
@@ -642,6 +645,14 @@ let increment_automerge_failure_count t patch_id =
 
 let reset_automerge_failure_count t patch_id =
   update_agent t patch_id ~f:Patch_agent.reset_automerge_failure_count
+
+let entered_merge_queue t patch_id entry =
+  update_agent t patch_id ~f:(fun a ->
+      Automerge_state.entered_merge_queue a entry)
+
+let apply_automerge_failure_state t patch_id ~retry_deadline ~max_failures =
+  update_agent t patch_id ~f:(fun a ->
+      Automerge_state.merge_call_failed a ~retry_deadline ~max_failures)
 
 (** {2 Queries} *)
 

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -124,6 +124,16 @@ val set_merge_queue_required : t -> Patch_id.t -> bool -> t
 val set_merge_queue_entry :
   t -> Patch_id.t -> Pr_state.merge_queue_entry option -> t
 
+val observe_merge_queue :
+  t ->
+  Patch_id.t ->
+  required:bool ->
+  entry:Pr_state.merge_queue_entry option ->
+  t
+(** Apply a poll observation of merge-queue state. Delegates the agent-level
+    state rule to {!Automerge_state.observe_merge_queue}, including clearing any
+    stale automerge deadline once a queue entry is present. *)
+
 val set_merge_commit_sha : t -> Patch_id.t -> string option -> t
 val set_base_contains_merged_siblings : t -> Patch_id.t -> bool -> t
 val set_is_draft : t -> Patch_id.t -> bool -> t
@@ -149,11 +159,26 @@ val mark_inflight_human_messages_delivered : t -> Patch_id.t -> t
     {!Patch_agent.mark_inflight_human_messages_delivered}. *)
 
 val set_automerge_enabled : t -> Patch_id.t -> bool -> t
+
 val set_automerge_deadline : t -> Patch_id.t -> float -> t
+(** Arm an automerge deadline via {!Automerge_state.arm_deadline}. If the patch
+    is already known to be in the merge queue, this clears the deadline instead
+    of recording an incoherent timer. *)
+
 val clear_automerge_deadline : t -> Patch_id.t -> t
 val set_automerge_inflight : t -> Patch_id.t -> bool -> t
 val increment_automerge_failure_count : t -> Patch_id.t -> t
 val reset_automerge_failure_count : t -> Patch_id.t -> t
+
+val entered_merge_queue : t -> Patch_id.t -> Pr_state.merge_queue_entry -> t
+(** Record that the PR is now in GitHub's merge queue, regardless of whether
+    that was learned from an automerge enqueue response, manual enqueue, or
+    polling. Delegates to {!Automerge_state.entered_merge_queue}. *)
+
+val apply_automerge_failure_state :
+  t -> Patch_id.t -> retry_deadline:float -> max_failures:int -> t
+(** Apply the pure automerge failure/backoff transition from
+    {!Automerge_state.merge_call_failed}. *)
 
 (** {2 Queries} *)
 

--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -212,11 +212,9 @@ let apply_poll_result t patch_id
       (Poller.mergeability_unknown poll_result)
   in
   let t =
-    Orchestrator.set_merge_queue_required t patch_id
-      poll_result.merge_queue_required
-  in
-  let t =
-    Orchestrator.set_merge_queue_entry t patch_id poll_result.merge_queue_entry
+    Orchestrator.observe_merge_queue t patch_id
+      ~required:poll_result.merge_queue_required
+      ~entry:poll_result.merge_queue_entry
   in
   let t =
     let was_draft = (Orchestrator.agent t patch_id).Patch_agent.is_draft in
@@ -752,15 +750,9 @@ let automerge_action (agent : Patch_agent.t) ~main_branch =
   | false, None -> Some Direct_merge
 
 let apply_automerge_failure_state t ~now patch_id =
-  let t = Orchestrator.set_automerge_inflight t patch_id false in
-  let t = Orchestrator.increment_automerge_failure_count t patch_id in
-  let agent = Orchestrator.agent t patch_id in
-  if agent.Patch_agent.automerge_failure_count >= automerge_max_failures then
-    Orchestrator.clear_automerge_deadline t patch_id
-  else if not agent.Patch_agent.automerge_enabled then t
-  else
-    Orchestrator.set_automerge_deadline t patch_id
-      (now +. automerge_idle_timeout)
+  Orchestrator.apply_automerge_failure_state t patch_id
+    ~retry_deadline:(now +. automerge_idle_timeout)
+    ~max_failures:automerge_max_failures
 
 (** Reconcile the automerge deadline for every agent. Returns the updated
     orchestrator and the list of patches whose deadline has now elapsed (the
@@ -884,6 +876,9 @@ let apply_automerge_success t patch_id =
   let t = Orchestrator.clear_automerge_deadline t patch_id in
   let t = Orchestrator.set_automerge_inflight t patch_id false in
   Orchestrator.reset_automerge_failure_count t patch_id
+
+let apply_merge_queue_entered t patch_id entry =
+  Orchestrator.entered_merge_queue t patch_id entry
 
 (** Apply the durable state change that follows a failed merge call. Clears the
     inflight flag and increments the failure counter. Pushes the deadline out by

--- a/lib/patch_controller.mli
+++ b/lib/patch_controller.mli
@@ -193,6 +193,14 @@ val apply_automerge_success : Orchestrator.t -> Patch_id.t -> Orchestrator.t
 (** Mark the patch as merged, clear the automerge deadline, clear the inflight
     flag, and reset the failure counter. *)
 
+val apply_merge_queue_entered :
+  Orchestrator.t -> Patch_id.t -> Pr_state.merge_queue_entry -> Orchestrator.t
+(** Record that the PR is in GitHub's merge queue, regardless of whether that
+    was learned from an automerge enqueue response, manual enqueue, or polling.
+    Being in the merge queue is terminal for the automerge timer: the next
+    useful transition comes from polling GitHub's queue state, not from another
+    automerge fire. *)
+
 val apply_automerge_failure :
   Orchestrator.t -> now:float -> Patch_id.t -> Orchestrator.t
 (** Record a failed merge call: clear the inflight flag and increment the

--- a/lib/runner_fiber_impl.ml
+++ b/lib/runner_fiber_impl.ml
@@ -192,10 +192,16 @@ struct
               Patch_controller.apply_automerge_failure orch
                 ~now:(Unix.gettimeofday ()) patch_id)
         in
+        let record_enqueued_and_clear_inflight entry =
+          if not !inflight_cleared then (
+            inflight_cleared := true;
+            Runtime.update_orchestrator runtime (fun orch ->
+                Patch_controller.apply_merge_queue_entered orch patch_id entry))
+        in
         let handle_enqueue_result result =
           match result with
           | Ok (Forge.Enqueued entry) ->
-              push_deadline_and_clear_inflight ();
+              record_enqueued_and_clear_inflight entry;
               log_event runtime ~patch_id
                 (Printf.sprintf
                    "Automerge enqueued PR #%d in GitHub merge queue (%s, \
@@ -203,7 +209,7 @@ struct
                    (Pr_number.to_int pr_number)
                    entry.Pr_state.id entry.Pr_state.position)
           | Ok (Forge.Already_enqueued entry) ->
-              push_deadline_and_clear_inflight ();
+              record_enqueued_and_clear_inflight entry;
               log_event runtime ~patch_id
                 (Printf.sprintf
                    "Automerge PR #%d already in GitHub merge queue (%s, \

--- a/lib_core/automerge_state.ml
+++ b/lib_core/automerge_state.ml
@@ -1,0 +1,43 @@
+(* @archlint.module core
+   @archlint.domain automerge-state *)
+
+open Base
+
+let merge_queue_timer_invariant (agent : Patch_agent.t) =
+  Option.is_none agent.merge_queue_entry
+  || Option.is_none agent.automerge_deadline
+
+let clear_deadline_if_enqueued agent =
+  if Option.is_some agent.Patch_agent.merge_queue_entry then
+    Patch_agent.clear_automerge_deadline agent
+  else agent
+
+let entered_merge_queue agent entry =
+  let agent = Patch_agent.set_merge_queue_required agent true in
+  let agent = Patch_agent.set_merge_queue_entry agent (Some entry) in
+  let agent = Patch_agent.clear_automerge_deadline agent in
+  let agent = Patch_agent.set_automerge_inflight agent false in
+  Patch_agent.reset_automerge_failure_count agent
+
+let observe_merge_queue agent ~required ~entry =
+  match entry with
+  | Some entry -> entered_merge_queue agent entry
+  | None ->
+      let agent = Patch_agent.set_merge_queue_required agent required in
+      let agent = Patch_agent.set_merge_queue_entry agent None in
+      clear_deadline_if_enqueued agent
+
+let arm_deadline agent deadline =
+  if Option.is_some agent.Patch_agent.merge_queue_entry then
+    Patch_agent.clear_automerge_deadline agent
+  else Patch_agent.set_automerge_deadline agent deadline
+
+let merge_call_failed agent ~retry_deadline ~max_failures =
+  let agent = Patch_agent.set_automerge_inflight agent false in
+  let agent = Patch_agent.increment_automerge_failure_count agent in
+  if Option.is_some agent.Patch_agent.merge_queue_entry then
+    Patch_agent.clear_automerge_deadline agent
+  else if agent.Patch_agent.automerge_failure_count >= max_failures then
+    Patch_agent.clear_automerge_deadline agent
+  else if not agent.Patch_agent.automerge_enabled then agent
+  else arm_deadline agent retry_deadline

--- a/lib_core/automerge_state.ml
+++ b/lib_core/automerge_state.ml
@@ -24,8 +24,8 @@ let observe_merge_queue agent ~required ~entry =
   | Some entry -> entered_merge_queue agent entry
   | None ->
       let agent = Patch_agent.set_merge_queue_required agent required in
-      let agent = Patch_agent.set_merge_queue_entry agent None in
-      clear_deadline_if_enqueued agent
+      let agent = clear_deadline_if_enqueued agent in
+      Patch_agent.set_merge_queue_entry agent None
 
 let arm_deadline agent deadline =
   if Option.is_some agent.Patch_agent.merge_queue_entry then

--- a/lib_core/automerge_state.mli
+++ b/lib_core/automerge_state.mli
@@ -28,7 +28,8 @@ val arm_deadline : Patch_agent.t -> float -> Patch_agent.t
 
 val merge_call_failed :
   Patch_agent.t -> retry_deadline:float -> max_failures:int -> Patch_agent.t
-(** Apply a failed merge/enqueue/dequeue call. Clears inflight, increments the
+(** Apply a failed merge or enqueue call. Clears inflight, increments the
     failure counter, and arms [retry_deadline] only if automerge remains
     enabled, the failure cap has not been reached, and the PR is not already
-    known to be in the merge queue. *)
+    known to be in the merge queue. Dequeue failures are handled separately by
+    the runner and do not increment the automerge failure count. *)

--- a/lib_core/automerge_state.mli
+++ b/lib_core/automerge_state.mli
@@ -1,0 +1,34 @@
+(* @archlint.module interface
+   @archlint.domain automerge-state *)
+
+val merge_queue_timer_invariant : Patch_agent.t -> bool
+(** [true] when an agent is not simultaneously known to be in GitHub's merge
+    queue and carrying an armed automerge deadline. Once a PR has a merge-queue
+    entry, the automerge timer has no useful action left to take. *)
+
+val entered_merge_queue :
+  Patch_agent.t -> Pr_state.merge_queue_entry -> Patch_agent.t
+(** Apply the semantic fact that this PR is now in GitHub's merge queue,
+    regardless of how that happened: automerge enqueue response, manual enqueue,
+    or a later poll observation. Records the entry, clears the automerge
+    deadline and inflight flag, and resets the consecutive failure count. *)
+
+val observe_merge_queue :
+  Patch_agent.t ->
+  required:bool ->
+  entry:Pr_state.merge_queue_entry option ->
+  Patch_agent.t
+(** Apply a poll observation of GitHub merge-queue state. A present queue entry
+    uses {!entered_merge_queue}; future queue movement is learned by polling,
+    not by another automerge timer fire. *)
+
+val arm_deadline : Patch_agent.t -> float -> Patch_agent.t
+(** Arm an automerge deadline only when the agent is not already known to be in
+    the merge queue. If it is already enqueued, clear the deadline instead. *)
+
+val merge_call_failed :
+  Patch_agent.t -> retry_deadline:float -> max_failures:int -> Patch_agent.t
+(** Apply a failed merge/enqueue/dequeue call. Clears inflight, increments the
+    failure counter, and arms [retry_deadline] only if automerge remains
+    enabled, the failure cap has not been reached, and the PR is not already
+    known to be in the merge queue. *)

--- a/test/dune
+++ b/test/dune
@@ -93,6 +93,13 @@
  (ocamlc_flags (:standard -w -40-42)))
 
 (test
+ (name test_automerge_state_properties)
+ (modules test_automerge_state_properties)
+ (libraries onton_core qcheck-core qcheck-core.runner)
+ (ocamlopt_flags (:standard -w -40-42))
+ (ocamlc_flags (:standard -w -40-42)))
+
+(test
  (name test_push_reject_classify_properties)
  (modules test_push_reject_classify_properties)
  (libraries onton_core qcheck-core qcheck-core.runner)

--- a/test/test_action_outcome_properties.ml
+++ b/test/test_action_outcome_properties.ml
@@ -15,6 +15,17 @@ let mk_patches = Onton_test_support.Test_generators.mk_linear_patches
 let make_gameplan = Onton_test_support.Test_generators.make_test_gameplan
 let pid_of_idx = Onton_test_support.Test_generators.pid_of_idx
 
+let gen_merge_queue_entry =
+  let open QCheck2.Gen in
+  let states =
+    Pr_state.
+      [ Mq_queued; Mq_awaiting_checks; Mq_mergeable; Mq_unmergeable; Mq_locked ]
+  in
+  map3
+    (fun id state position -> Pr_state.{ id; state; position })
+    (string_size ~gen:(char_range 'a' 'z') (int_range 1 16))
+    (oneof_list states) (int_range 0 99)
+
 (** Bootstrap a single-patch orchestrator with an idle agent that has a PR. *)
 let bootstrap_one () =
   let patches = mk_patches 1 in
@@ -567,3 +578,79 @@ let () =
          | [] -> ());
          List.length (Orchestrator.all_messages orch) >= 0));
   Stdlib.print_endline "orchestrator public surface linked"
+
+(* AO-MQ: merge-queue/automerge failure wrappers preserve the shared
+   agent-level automerge invariants when reached through the orchestrator and
+   patch-controller public surfaces. *)
+let () =
+  QCheck2.Test.check_exn
+    (QCheck2.Test.make
+       ~name:"AO-MQ: merge queue wrappers clear stale automerge timers"
+       ~count:200
+       QCheck2.Gen.(triple bool gen_merge_queue_entry gen_merge_queue_entry)
+       (fun (required, observed_entry, entered_entry) ->
+         try
+           let orch, _patches, _gameplan, pid = bootstrap_one () in
+           let orch = Orchestrator.set_automerge_enabled orch pid true in
+           let orch = Orchestrator.set_automerge_inflight orch pid true in
+           let orch = Orchestrator.set_automerge_deadline orch pid 10.0 in
+           let orch =
+             Orchestrator.apply_automerge_failure_state orch pid
+               ~retry_deadline:20.0 ~max_failures:3
+           in
+           let after_failure = Orchestrator.agent orch pid in
+           if after_failure.Patch_agent.automerge_inflight then
+             QCheck2.Test.fail_reportf
+               "apply_automerge_failure_state left inflight=true";
+           if after_failure.Patch_agent.automerge_failure_count <> 1 then
+             QCheck2.Test.fail_reportf
+               "apply_automerge_failure_state did not increment failures";
+           let orch =
+             Orchestrator.observe_merge_queue orch pid ~required
+               ~entry:(Some observed_entry)
+           in
+           let after_observe = Orchestrator.agent orch pid in
+           if not after_observe.Patch_agent.merge_queue_required then
+             QCheck2.Test.fail_reportf
+               "observe_merge_queue with entry did not require merge queue";
+           if
+             not
+               (Option.equal Pr_state.equal_merge_queue_entry
+                  after_observe.Patch_agent.merge_queue_entry
+                  (Some observed_entry))
+           then
+             QCheck2.Test.fail_reportf
+               "observe_merge_queue did not record observed entry";
+           if Option.is_some after_observe.Patch_agent.automerge_deadline then
+             QCheck2.Test.fail_reportf
+               "observe_merge_queue left a stale automerge deadline";
+           let orch = Orchestrator.entered_merge_queue orch pid entered_entry in
+           let after_entered = Orchestrator.agent orch pid in
+           if
+             not
+               (Option.equal Pr_state.equal_merge_queue_entry
+                  after_entered.Patch_agent.merge_queue_entry
+                  (Some entered_entry))
+           then
+             QCheck2.Test.fail_reportf
+               "entered_merge_queue did not replace queue entry";
+           let orch =
+             Orchestrator.set_automerge_inflight orch pid true |> fun orch ->
+             Orchestrator.set_automerge_deadline orch pid 30.0 |> fun orch ->
+             Orchestrator.increment_automerge_failure_count orch pid
+           in
+           let orch =
+             Patch_controller.apply_merge_queue_entered orch pid observed_entry
+           in
+           let after_controller = Orchestrator.agent orch pid in
+           Option.equal Pr_state.equal_merge_queue_entry
+             after_controller.Patch_agent.merge_queue_entry
+             (Some observed_entry)
+           && after_controller.Patch_agent.merge_queue_required
+           && Option.is_none after_controller.Patch_agent.automerge_deadline
+           && (not after_controller.Patch_agent.automerge_inflight)
+           && after_controller.Patch_agent.automerge_failure_count = 0
+         with
+         | QCheck2.Test.Test_fail _ as exn -> raise exn
+         | _ -> false));
+  Stdlib.print_endline "AO-MQ passed"

--- a/test/test_automerge_state_properties.ml
+++ b/test/test_automerge_state_properties.ml
@@ -1,0 +1,145 @@
+(* @archlint.module test
+   @archlint.domain automerge-state *)
+
+open Base
+open Onton_core
+open Onton_core.Types
+
+let pid = Patch_id.of_string "am-state"
+let branch = Branch.of_string "feat/am-state"
+let retry_deadline = 600.0
+let max_failures = 3
+
+let gen_string =
+  QCheck2.Gen.(string_size ~gen:(char_range 'a' 'z') (int_range 1 16))
+
+let gen_merge_queue_entry =
+  let open QCheck2.Gen in
+  let states =
+    Pr_state.
+      [ Mq_queued; Mq_awaiting_checks; Mq_mergeable; Mq_unmergeable; Mq_locked ]
+  in
+  map3
+    (fun id state position -> Pr_state.{ id; state; position })
+    gen_string (oneof_list states) (int_range 0 99)
+
+type op =
+  | Enable of bool
+  | Arm of float
+  | Set_inflight of bool
+  | Entered of Pr_state.merge_queue_entry
+  | Observe_none of bool
+  | Observe_some of Pr_state.merge_queue_entry
+  | Merge_failure
+  | Reset_failure
+  | Clear_deadline
+
+let gen_op =
+  let open QCheck2.Gen in
+  oneof
+    [
+      map (fun v -> Enable v) bool;
+      map (fun n -> Arm (Float.of_int n)) (int_range 0 10_000);
+      map (fun v -> Set_inflight v) bool;
+      map (fun entry -> Entered entry) gen_merge_queue_entry;
+      map (fun required -> Observe_none required) bool;
+      map (fun entry -> Observe_some entry) gen_merge_queue_entry;
+      pure Merge_failure;
+      pure Reset_failure;
+      pure Clear_deadline;
+    ]
+
+let apply_op agent = function
+  | Enable v -> Patch_agent.set_automerge_enabled agent v
+  | Arm deadline -> Automerge_state.arm_deadline agent deadline
+  | Set_inflight v -> Patch_agent.set_automerge_inflight agent v
+  | Entered entry -> Automerge_state.entered_merge_queue agent entry
+  | Observe_none required ->
+      Automerge_state.observe_merge_queue agent ~required ~entry:None
+  | Observe_some entry ->
+      Automerge_state.observe_merge_queue agent ~required:false
+        ~entry:(Some entry)
+  | Merge_failure ->
+      Automerge_state.merge_call_failed agent ~retry_deadline ~max_failures
+  | Reset_failure -> Patch_agent.reset_automerge_failure_count agent
+  | Clear_deadline -> Patch_agent.clear_automerge_deadline agent
+
+let base_agent () =
+  Patch_agent.create ~branch pid |> fun agent ->
+  Patch_agent.set_automerge_enabled agent true
+
+let prop_entered_merge_queue_shape =
+  QCheck2.Test.make
+    ~name:
+      "automerge_state MQ-IN: entering merge queue clears \
+       timer/inflight/failures"
+    ~count:1000
+    QCheck2.Gen.(pair (list_size (int_range 0 30) gen_op) gen_merge_queue_entry)
+    (fun (ops, entry) ->
+      let agent = List.fold ops ~init:(base_agent ()) ~f:apply_op in
+      let agent = Automerge_state.entered_merge_queue agent entry in
+      agent.Patch_agent.merge_queue_required
+      && Option.equal Pr_state.equal_merge_queue_entry agent.merge_queue_entry
+           (Some entry)
+      && Option.is_none agent.automerge_deadline
+      && (not agent.automerge_inflight)
+      && agent.automerge_failure_count = 0
+      && Automerge_state.merge_queue_timer_invariant agent)
+
+let prop_observe_entry_is_entered_merge_queue =
+  QCheck2.Test.make
+    ~name:
+      "automerge_state MQ-OBS: observing an entry has entered-queue semantics"
+    ~count:1000
+    QCheck2.Gen.(pair (list_size (int_range 0 30) gen_op) gen_merge_queue_entry)
+    (fun (ops, entry) ->
+      let agent = List.fold ops ~init:(base_agent ()) ~f:apply_op in
+      let observed =
+        Automerge_state.observe_merge_queue agent ~required:false
+          ~entry:(Some entry)
+      in
+      let entered = Automerge_state.entered_merge_queue agent entry in
+      Patch_agent.equal observed entered)
+
+let prop_failure_does_not_rearm_when_already_enqueued =
+  QCheck2.Test.make
+    ~name:"automerge_state MQ-FAIL: failure cannot re-arm an enqueued patch"
+    ~count:1000
+    QCheck2.Gen.(pair (list_size (int_range 0 30) gen_op) gen_merge_queue_entry)
+    (fun (ops, entry) ->
+      let agent = List.fold ops ~init:(base_agent ()) ~f:apply_op in
+      let agent =
+        Automerge_state.entered_merge_queue agent entry |> fun agent ->
+        Patch_agent.set_automerge_inflight agent true |> fun agent ->
+        Automerge_state.arm_deadline agent 1.0 |> fun agent ->
+        Automerge_state.merge_call_failed agent ~retry_deadline ~max_failures
+      in
+      Option.is_none agent.Patch_agent.automerge_deadline
+      && Automerge_state.merge_queue_timer_invariant agent)
+
+let prop_interleavings_preserve_invariant =
+  QCheck2.Test.make
+    ~name:
+      "automerge_state MQ-INT: transition interleavings never leave entry+timer"
+    ~count:2000
+    QCheck2.Gen.(list_size (int_range 0 80) gen_op)
+    (fun ops ->
+      let _agent, ok =
+        List.fold ops
+          ~init:(base_agent (), true)
+          ~f:(fun (agent, ok) op ->
+            try
+              let agent = apply_op agent op in
+              (agent, ok && Automerge_state.merge_queue_timer_invariant agent)
+            with _ -> (agent, false))
+      in
+      ok)
+
+let () =
+  List.iter
+    [
+      prop_entered_merge_queue_shape;
+      prop_observe_entry_is_entered_merge_queue;
+      prop_failure_does_not_rearm_when_already_enqueued;
+      prop_interleavings_preserve_invariant;
+    ] ~f:(fun test -> QCheck2.Test.check_exn test)

--- a/test/test_automerge_state_properties.ml
+++ b/test/test_automerge_state_properties.ml
@@ -101,6 +101,27 @@ let prop_observe_entry_is_entered_merge_queue =
       let entered = Automerge_state.entered_merge_queue agent entry in
       Patch_agent.equal observed entered)
 
+let prop_observe_none_ejection_clears_stale_deadline =
+  QCheck2.Test.make
+    ~name:
+      "automerge_state MQ-EJECT: observing no entry clears stale queue timer"
+    ~count:1000
+    QCheck2.Gen.(triple bool gen_merge_queue_entry (int_range 0 10_000))
+    (fun (required, entry, deadline) ->
+      let agent =
+        base_agent () |> fun agent ->
+        Patch_agent.set_merge_queue_required agent true |> fun agent ->
+        Patch_agent.set_merge_queue_entry agent (Some entry) |> fun agent ->
+        Patch_agent.set_automerge_deadline agent (Float.of_int deadline)
+      in
+      let agent =
+        Automerge_state.observe_merge_queue agent ~required ~entry:None
+      in
+      Bool.equal agent.Patch_agent.merge_queue_required required
+      && Option.is_none agent.Patch_agent.merge_queue_entry
+      && Option.is_none agent.Patch_agent.automerge_deadline
+      && Automerge_state.merge_queue_timer_invariant agent)
+
 let prop_failure_does_not_rearm_when_already_enqueued =
   QCheck2.Test.make
     ~name:"automerge_state MQ-FAIL: failure cannot re-arm an enqueued patch"
@@ -140,6 +161,7 @@ let () =
     [
       prop_entered_merge_queue_shape;
       prop_observe_entry_is_entered_merge_queue;
+      prop_observe_none_ejection_clears_stale_deadline;
       prop_failure_does_not_rearm_when_already_enqueued;
       prop_interleavings_preserve_invariant;
     ] ~f:(fun test -> QCheck2.Test.check_exn test)

--- a/test/test_patch_controller.ml
+++ b/test/test_patch_controller.ml
@@ -1477,6 +1477,36 @@ let () =
              (Orchestrator.agent orch pid).Patch_agent.automerge_deadline)
   in
 
+  let pending_patch_4_merge_queue_entered_clears_timer =
+    Test.make
+      ~name:
+        "patch_controller: Patch 4 entering merge queue records entry and \
+         clears automerge timer" QCheck2.Gen.unit (fun () ->
+        let pid = Patch_id.of_string "mq-enqueue-success" in
+        let branch = Branch.of_string "feat/mq-enqueue-success" in
+        let patch = make_patch pid branch in
+        let entry = merge_queue_entry "MQE_enqueue_success" in
+        let agent =
+          make_agent ~patch_id:pid ~branch
+            ~pr_status:(Patch_pr_status.Present (Pr_number.of_int 406))
+            ~merged:false ~queue:[] ~base_branch:(Some main) ~is_draft:false
+            ~pr_body_delivered:true ~start_attempts_without_pr:0
+            ~merge_ready:true ~checks_passing:true ~merge_queue_required:true
+            ~automerge_enabled:true ~automerge_deadline:0.0
+            ~automerge_failure_count:1 ()
+        in
+        let orch = make_orch patch agent in
+        let orch = Orchestrator.set_automerge_inflight orch pid true in
+        let orch = Patch_controller.apply_merge_queue_entered orch pid entry in
+        let agent = Orchestrator.agent orch pid in
+        Option.equal Pr_state.equal_merge_queue_entry agent.merge_queue_entry
+          (Some entry)
+        && agent.merge_queue_required
+        && Option.is_none agent.automerge_deadline
+        && (not agent.automerge_inflight)
+        && agent.automerge_failure_count = 0)
+  in
+
   let pending_patch_4_unapproved_not_enqueued =
     Test.make
       ~name:
@@ -1666,6 +1696,7 @@ let () =
       pending_automerge_blocked_clears_deadline;
       pending_patch_4_automerge_enqueue_action;
       pending_patch_4_automerge_enqueued_idle;
+      pending_patch_4_merge_queue_entered_clears_timer;
       pending_patch_4_unapproved_not_enqueued;
       pending_patch_4_automerge_dequeue_on_lost_approval;
       pending_patch_4_unmergeable_clears_automerge_deadline;


### PR DESCRIPTION
## Summary

- Add pure `Automerge_state` transitions for entering the merge queue, observing merge-queue state, arming deadlines, and merge-call failure backoff.
- Route poll observations, automerge enqueue responses, and failure backoff through those transitions.
- Add `onton_core`-only property tests with random interleavings to guarantee a patch cannot be both in the merge queue and have an armed automerge timer.

## Root Cause

Automerge enqueue success was treated as a non-terminal response and pushed the deadline forward. That could leave a patch visibly in the GitHub merge queue while still carrying an armed automerge timer. Manual queue entry observed via polling should have the same semantics as automerge enqueue: once a PR is known to be in the queue, the timer has no useful action left.

## Validation

- `dune build`
- `dune exec test/test_automerge_state_properties.exe`
- `dune exec test/test_patch_controller.exe`
- `dune runtest`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/370"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784228206&installation_id=126163856&pr_number=370&repository=flowglad%2Fonton&return_to=https%3A%2F%2Fgithub.com%2Fflowglad%2Fonton%2Fpull%2F370&signature=1980c51555b51123b8b279817f8c9b4aeb51b7bda9f40d7e179bba9b2e670249"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents automerge timers from running for PRs in GitHub’s merge queue and clears stale timers when a PR is ejected. Centralizes state transitions and adds tests to ensure a patch can never be both queued and timed.

- **Bug Fixes**
  - Clear automerge deadline and inflight, and reset failures when a queue entry is recorded (enqueue, manual, or poll) via `entered_merge_queue`/`observe_merge_queue`.
  - On queue ejection observed via poll (entry becomes `None`), clear any existing automerge deadline before dropping the entry.
  - Do not re-arm deadlines on merge-call failure when already queued; only re-arm when automerge is enabled and under the failure cap.
  - On enqueue results (`Enqueued`/`Already_enqueued`), record the queue entry and clear inflight instead of pushing the deadline.

- **Refactors**
  - Introduced `lib_core/automerge_state` with pure transitions (`observe_merge_queue`, `entered_merge_queue`, `arm_deadline`, `merge_call_failed`), and routed `Orchestrator`, `Patch_controller`, and `Runner` through them. Added `Orchestrator.observe_merge_queue`/`entered_merge_queue`/`apply_automerge_failure_state` and `Patch_controller.apply_merge_queue_entered`.
  - Added `test/test_automerge_state_properties.ml`; extended `test/test_action_outcome_properties.ml` and controller tests to cover the wrapper APIs and the queue+timer invariant.
  - Clarified failure/backoff docs: dequeue failures do not increment automerge failure count.

<sup>Written for commit 6f282efdb3e99fa1669315a4ae6681fb577adeb5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/flowglad/onton/pull/370?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

