### PR TITLE
Merge activity feed before truncating for uniform density

### DIFF
--- a/lib/tui_fiber.ml
+++ b/lib/tui_fiber.ml
@@ -7,41 +7,29 @@ open Types
 let log_event runtime ?patch_id msg =
   Runtime_logging.log_event runtime ?patch_id msg
 
-let merged_log_entries ~(log : Activity_log.t) ~limit ~compare
-    ~(map_event : Activity_log.Event.t -> 'a)
-    ~(map_transition : Activity_log.Transition_entry.t -> 'a) =
-  let events =
-    List.map (Activity_log.recent_events log ~limit) ~f:(fun e ->
-        (e.Activity_log.Event.timestamp, map_event e))
-  in
-  let transitions =
-    List.map (Activity_log.recent_transitions log ~limit) ~f:(fun t ->
-        (t.Activity_log.Transition_entry.timestamp, map_transition t))
-  in
-  List.sort (events @ transitions) ~compare
-
 let activity_entries_of_log ?(limit = 10) (log : Activity_log.t) =
-  merged_log_entries ~log ~limit
-    ~compare:(fun (t1, _) (t2, _) -> Float.descending t1 t2)
-    ~map_event:(fun (e : Activity_log.Event.t) ->
-      Tui.Event
-        {
-          patch_id =
-            Option.map e.Activity_log.Event.patch_id ~f:Patch_id.to_string;
-          message = e.Activity_log.Event.message;
-          timestamp = e.Activity_log.Event.timestamp;
-        })
-    ~map_transition:(fun (t : Activity_log.Transition_entry.t) ->
-      Tui.Transition
-        {
-          patch_id = Patch_id.to_string t.Activity_log.Transition_entry.patch_id;
-          from_label = Tui.label t.Activity_log.Transition_entry.from_status;
-          to_status = t.Activity_log.Transition_entry.to_status;
-          to_label = Tui.label t.Activity_log.Transition_entry.to_status;
-          action = t.Activity_log.Transition_entry.action;
-          timestamp = t.Activity_log.Transition_entry.timestamp;
-        })
-  |> List.map ~f:snd
+  Activity_log.merged_recent log ~limit
+  |> List.map ~f:(function
+    | Activity_log.Merged_entry.Event (e : Activity_log.Event.t) ->
+        Tui.Event
+          {
+            patch_id =
+              Option.map e.Activity_log.Event.patch_id ~f:Patch_id.to_string;
+            message = e.Activity_log.Event.message;
+            timestamp = e.Activity_log.Event.timestamp;
+          }
+    | Activity_log.Merged_entry.Transition (t : Activity_log.Transition_entry.t)
+      ->
+        Tui.Transition
+          {
+            patch_id =
+              Patch_id.to_string t.Activity_log.Transition_entry.patch_id;
+            from_label = Tui.label t.Activity_log.Transition_entry.from_status;
+            to_status = t.Activity_log.Transition_entry.to_status;
+            to_label = Tui.label t.Activity_log.Transition_entry.to_status;
+            action = t.Activity_log.Transition_entry.action;
+            timestamp = t.Activity_log.Transition_entry.timestamp;
+          })
 
 let pluralize ?plural n singular =
   let many = match plural with Some p -> p | None -> singular ^ "s" in

--- a/lib_core/activity_log.ml
+++ b/lib_core/activity_log.ml
@@ -43,6 +43,19 @@ module Stream_entry = struct
   let create ~timestamp ~patch_id ~kind = { timestamp; patch_id; kind }
 end
 
+(* A single row of the user-facing activity feed: either a status transition or
+   a free-form event, carrying its own timestamp so the two streams can be
+   interleaved chronologically. Stream entries are deliberately excluded — they
+   are replay diagnostics, not feed rows (see [stream_kind_of_raw]). *)
+module Merged_entry = struct
+  type t = Transition of Transition_entry.t | Event of Event.t
+  [@@deriving show, eq, sexp_of, compare]
+
+  let timestamp = function
+    | Transition t -> t.Transition_entry.timestamp
+    | Event e -> e.Event.timestamp
+end
+
 type t = {
   transitions : Transition_entry.t list;
   events : Event.t list;
@@ -90,6 +103,24 @@ let stream_kind_of_raw ~channel:_ raw =
 let recent_transitions t ~limit = List.take t.transitions limit
 let recent_events t ~limit = List.take t.events limit
 let recent_stream_entries t ~limit = List.take t.stream_entries limit
+
+let merged_recent t ~limit =
+  (* Merge *then* truncate. Truncating each source to [limit] before merging
+     would hand the union a non-uniform density: a high-rate source (events)
+     floods the recent window while a low-rate source (transitions) stretches
+     far into the past, so the feed reads dense at the top and sparse at the
+     bottom. Capping each source at [limit] first is still a sound upper bound —
+     the [limit] newest of the union can draw at most [limit] from either
+     source — so we keep only the [limit] newest of the merged, sorted result. *)
+  let entries =
+    List.map (recent_events t ~limit) ~f:(fun e -> Merged_entry.Event e)
+    @ List.map (recent_transitions t ~limit) ~f:(fun tr ->
+        Merged_entry.Transition tr)
+  in
+  List.take
+    (List.stable_sort entries ~compare:(fun a b ->
+         Float.descending (Merged_entry.timestamp a) (Merged_entry.timestamp b)))
+    limit
 
 let trim t ~max =
   {

--- a/lib_core/activity_log.mli
+++ b/lib_core/activity_log.mli
@@ -56,6 +56,14 @@ module Stream_entry : sig
   val create : timestamp:float -> patch_id:Types.Patch_id.t -> kind:kind -> t
 end
 
+module Merged_entry : sig
+  type t = Transition of Transition_entry.t | Event of Event.t
+  [@@deriving show, eq, sexp_of, compare]
+
+  val timestamp : t -> float
+  (** The entry's timestamp, regardless of which stream it came from. *)
+end
+
 type t [@@deriving show, eq, sexp_of, compare]
 
 val empty : t
@@ -76,6 +84,18 @@ val recent_events : t -> limit:int -> Event.t list
 (** Return the most recent [limit] events (newest first). Returns an empty list
     if [limit <= 0]. Returns all events if [limit] exceeds the number of
     entries. *)
+
+val merged_recent : t -> limit:int -> Merged_entry.t list
+(** The [limit] most recent transitions and events, interleaved into a single
+    timestamp-descending feed (newest first). Returns an empty list if
+    [limit <= 0], and at most [limit] entries otherwise.
+
+    The two streams are merged *before* truncation, not after: this is the
+    [limit] newest rows of their union, so the feed's density is uniform over
+    time rather than dense-at-top/sparse-at-bottom (which is what taking [limit]
+    from each stream and concatenating would produce when the streams have
+    different rates). Stream entries are excluded — they are replay diagnostics,
+    not user-facing feed rows. *)
 
 val add_stream_entry : t -> Stream_entry.t -> t
 (** Prepend a stream entry to the log. *)

--- a/test/test_activity_log_properties.ml
+++ b/test/test_activity_log_properties.ml
@@ -235,6 +235,102 @@ let prop_trim_large_max_unchanged =
       let trimmed = Activity_log.trim log ~max:10_000 in
       Activity_log.equal log trimmed)
 
+(* ─────────────────────────────────────────────────────────────────────────
+   merged_recent: the user-facing feed = the [limit] newest of the union of
+   transitions and events, interleaved by timestamp. Spec derived from the .mli.
+   ───────────────────────────────────────────────────────────────────────── *)
+
+let timestamp_descending a b =
+  Float.descending
+    (Activity_log.Merged_entry.timestamp a)
+    (Activity_log.Merged_entry.timestamp b)
+
+let prop_merged_length_bound =
+  QCheck2.Test.make ~name:"merged_recent returns at most ~limit entries"
+    ~count:300
+    QCheck2.Gen.(pair gen_log (int_range (-5) 50))
+    (fun (log, limit) ->
+      List.length (Activity_log.merged_recent log ~limit) <= Int.max 0 limit)
+
+let prop_merged_descending =
+  QCheck2.Test.make ~name:"merged_recent is sorted newest-first by timestamp"
+    ~count:300
+    QCheck2.Gen.(pair gen_log (int_range 0 50))
+    (fun (log, limit) ->
+      let entries = Activity_log.merged_recent log ~limit in
+      List.is_sorted entries ~compare:timestamp_descending)
+
+(* A log whose insertion order is strictly increasing, distinct timestamps —
+   mirroring production, where entries are appended as time advances. Under this
+   ordering [recent_*] returns exactly the newest-by-timestamp entries, so
+   [merged_recent] must equal the globally newest [limit] rows of the union. The
+   random-timestamp [gen_log] above deliberately does not hold that coincidence,
+   so it can't express this property. *)
+type payload =
+  | P_event of Types.Patch_id.t option * string
+  | P_transition of
+      Types.Patch_id.t * Display_status.t * Display_status.t * string
+
+let gen_payload =
+  let open QCheck2.Gen in
+  oneof
+    [
+      map2
+        (fun pid msg -> P_event (pid, msg))
+        (option gen_patch_id)
+        (string_size (int_range 0 32));
+      (let* pid = gen_patch_id in
+       let* from_status = gen_status in
+       let* to_status = gen_status in
+       let* action = string_size (int_range 0 16) in
+       pure (P_transition (pid, from_status, to_status, action)));
+    ]
+
+let build_ordered_log payloads =
+  List.foldi payloads ~init:Activity_log.empty ~f:(fun i log p ->
+      let timestamp = Float.of_int (i + 1) in
+      match p with
+      | P_event (patch_id, message) ->
+          Activity_log.add_event log
+            (Activity_log.Event.create ~timestamp ?patch_id message)
+      | P_transition (patch_id, from_status, to_status, action) ->
+          Activity_log.add_transition log
+            (Activity_log.Transition_entry.create ~timestamp ~patch_id
+               ~from_status ~to_status ~action))
+
+let gen_ordered_log =
+  QCheck2.Gen.(map build_ordered_log (list_size (int_range 0 32) gen_payload))
+
+let prop_merged_matches_union_take =
+  (* The defining property: merging before truncating must yield exactly the
+     [limit] newest rows of the *whole* union — never a per-source slice. This
+     is what keeps the feed's density uniform rather than dense-at-top. The old
+     take-per-source-then-merge implementation returned up to 2*limit rows and
+     fails this on length. *)
+  QCheck2.Test.make
+    ~name:"merged_recent = newest limit of the union (time-ordered log)"
+    ~count:300
+    QCheck2.Gen.(pair gen_ordered_log (int_range 0 50))
+    (fun (log, limit) ->
+      let big = 10_000 in
+      let union =
+        List.map (Activity_log.recent_events log ~limit:big) ~f:(fun e ->
+            Activity_log.Merged_entry.Event e)
+        @ List.map (Activity_log.recent_transitions log ~limit:big) ~f:(fun t ->
+            Activity_log.Merged_entry.Transition t)
+      in
+      let expected =
+        List.take (List.stable_sort union ~compare:timestamp_descending) limit
+      in
+      List.equal Activity_log.Merged_entry.equal
+        (Activity_log.merged_recent log ~limit)
+        expected)
+
+let prop_merged_negative_limit_empty =
+  QCheck2.Test.make ~name:"merged_recent with limit <= 0 returns []" ~count:200
+    QCheck2.Gen.(pair gen_log (int_range (-20) 0))
+    (fun (log, limit) -> List.is_empty (Activity_log.merged_recent log ~limit))
+
 let prop_stream_kind_of_raw_total =
   QCheck2.Test.make ~name:"stream_kind_of_raw is total" ~count:200
     QCheck2.Gen.string_small (fun raw ->
@@ -255,6 +351,10 @@ let () =
       prop_trim_idempotent;
       prop_trim_zero_empty;
       prop_trim_large_max_unchanged;
+      prop_merged_length_bound;
+      prop_merged_descending;
+      prop_merged_matches_union_take;
+      prop_merged_negative_limit_empty;
       prop_stream_kind_of_raw_total;
     ]
   in


### PR DESCRIPTION
## Problem

The TUI activity feed read dense at the top and sparse at the bottom — the "top half has more detail than the bottom" effect. The cause: `merged_log_entries` took `limit` rows from each log (`events` and `transitions`) **independently**, then merged and sorted by timestamp **without truncating the union**.

With two streams of different rates, the high-rate `events` stream floods the recent window while the low-rate `transitions` stream stretches far into the past. After merge-sort the recent region is densely interleaved (both streams) and the older region is only transitions — and the call returned up to `2 × limit` rows.

## Fix

Lower the merge into the pure core module as `Activity_log.merged_recent`, which **merges then truncates**: interleave the two streams by timestamp and keep only the `limit` newest of the *union*. Capping each source at `limit` first is still a sound upper bound (the `limit` newest of the union can draw at most `limit` from either source), so no correct row is dropped — the result is uniform-density and exactly `limit` rows.

- `lib_core/activity_log.ml` + `.mli` — new `Merged_entry` type and `merged_recent`, contract documented in the `.mli`.
- `lib/tui_fiber.ml` — `activity_entries_of_log` now calls `merged_recent`; the old private `merged_log_entries` is gone.
- `lib/headless_fiber.ml` — **left untouched**. Its merge is a different beast (ascending, deduped via `seen`, no truncation — a streaming printer where truncation would drop log lines).

## Tests

Four new QCheck2 properties in `test_activity_log_properties.ml`:
- length ≤ `limit`
- newest-first ordering
- `limit ≤ 0 ⇒ []`
- **equivalence**: against a time-ordered log generator, `merged_recent` equals the newest `limit` of the full union. This is the regression guard — the old take-per-source-then-merge code returned >`limit` rows and fails it on length.

All 16 properties pass; `dune build` and full `dune runtest` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)