### PR TITLE
[request-review-before-merge] Patch 2: Add optional review_team to repo_config

### DIFF
--- a/lib/worktree.ml
+++ b/lib/worktree.ml
@@ -538,6 +538,13 @@ let oldest_non_ancestor_commit = Worktree_parser.oldest_non_ancestor_commit
     the upstream as [old_base], not [onto]. *)
 let parse_rebase_merge_state = Worktree_parser.parse_rebase_merge_state
 
+type onto_anchor = Worktree_parser.onto_anchor =
+  | Anchor of string
+  | No_anchor of string
+[@@deriving show, eq, sexp_of, compare]
+
+let classify_onto_anchor = Worktree_parser.classify_onto_anchor
+
 (** Find the old base commit for [--onto] rebase by identifying which commits on
     our branch are unique (not in target). Uses patch-id matching via
     [git log --cherry-pick], and additionally strips commits whose subject
@@ -571,16 +578,20 @@ let find_old_base ~process_mgr ~path ~target ~project_name ~ancestor_ids =
   else
     match classify_unique_commits ~project_name ~ancestor_ids stdout with
     | Result.Error msg -> Result.Error msg
-    | Result.Ok (commits, oldest_sha) ->
+    | Result.Ok (commits, oldest_sha) -> (
         let code, stdout, stderr =
           run_git_exit_code ~process_mgr
             [ "git"; "-C"; path; "rev-parse"; Printf.sprintf "%s~1" oldest_sha ]
         in
-        if code <> 0 then
-          Result.Error
-            (Printf.sprintf "rev-parse oldest~1 failed (exit %d): %s" code
-               (String.strip stderr))
-        else Result.Ok (String.strip stdout, commits)
+        (* An empty anchor (oldest is a root commit, or the running git resolves
+           [<root>~1] to "" with exit 0) must NOT reach [git rebase --onto] — it
+           aborts there with "invalid upstream ''". Route both the failed and
+           blank cases to [Error] so [rebase_onto] takes the plain/upstream
+           fallback. See [Worktree_parser.classify_onto_anchor]. *)
+        match Worktree_parser.classify_onto_anchor ~code ~stdout with
+        | Worktree_parser.Anchor old_base -> Result.Ok (old_base, commits)
+        | Worktree_parser.No_anchor reason ->
+            Result.Error (Printf.sprintf "%s: %s" reason (String.strip stderr)))
 
 let classify_fetch_result = Worktree_parser.classify_fetch_result
 

--- a/lib/worktree.ml
+++ b/lib/worktree.ml
@@ -314,6 +314,86 @@ let execute_start_point_action ~process_mgr ~repo_root ~path ~branch_str
           add_worktree_for_existing_branch ~process_mgr ~repo_root ~path
             ~branch_str)
 
+(* The effectful operations [create] performs, factored into an injectable
+   record so the wiring — short-circuit, ref reads, ancestry, decision, action
+   dispatch — can be exercised with in-memory fakes instead of a live git
+   repository. {!create} supplies the git-backed implementation via {!git_io};
+   tests supply scripted ref states. Mirrors the pure/effectful split already
+   used for [classify_push_result], [push_gate_from_count], etc. *)
+type create_io = {
+  worktree_exists : path:string -> bool;
+      (** The [Sys.file_exists path] short-circuit: when [true], [create] trusts
+          the existing worktree and skips every git operation below. *)
+  check_ref_collision : branch_str:string -> unit;
+      (** Case-insensitive ref-collision guard; raises to abort creation. *)
+  read_ref : ref_name:string -> string option;
+      (** Resolve a ref to its SHA, or [None] when the ref is absent. *)
+  ancestry : local:string -> remote:string -> Start_point_plan.ancestry;
+      (** Two-way ancestry between an existing local and remote SHA. *)
+  execute_action :
+    path:string -> branch_str:string -> Start_point_plan.action -> unit;
+      (** Run the git commands realising the planner's chosen action. *)
+}
+
+(* Wiring of [create], parameterised over its effects. Given [io], it reads the
+   local/remote refs, computes ancestry only when both sides exist, consults the
+   pure {!Start_point_plan.plan}, and either executes the action or surfaces the
+   refusal. [create] is exactly this with the git-backed [io]; the split exists
+   so the control flow (including the short-circuit and the refusal mapping) can
+   be unit-tested without spawning git.
+
+   [branch_checked_out_in_main_root] and [existing_worktree_path] are checked by
+   [Worktree_setup.ensure_worktree] before this point — we pass [false]/[None]
+   so the planner's totality contract is preserved without redoing the work. *)
+let create_with_io ~io ~project_name ~patch_id ~branch ~base_ref :
+    (t, Start_point_plan.refusal) Result.t =
+  let path = worktree_dir ~project_name ~patch_id in
+  let branch_str = Types.Branch.to_string branch in
+  if io.worktree_exists ~path then Result.Ok { patch_id; branch; path }
+  else (
+    io.check_ref_collision ~branch_str;
+    let local_ref = io.read_ref ~ref_name:("refs/heads/" ^ branch_str) in
+    let remote_ref =
+      io.read_ref ~ref_name:("refs/remotes/origin/" ^ branch_str)
+    in
+    let ancestry =
+      match (local_ref, remote_ref) with
+      | Some l, Some r -> io.ancestry ~local:l ~remote:r
+      | _ -> Start_point_plan.Unknown
+    in
+    let decision =
+      Start_point_plan.plan ~local_ref ~remote_ref ~ancestry
+        ~base_branch:base_ref ~branch_checked_out_in_main_root:false
+        ~existing_worktree_path:None
+    in
+    match decision with
+    | Refuse refusal -> Result.Error refusal
+    | Plan action ->
+        io.execute_action ~path ~branch_str action;
+        Result.Ok { patch_id; branch; path })
+
+(* The production [create_io]: every operation backed by a real git invocation
+   against [repo_root]. The [worktree_exists] short-circuit is keyed only on
+   [$HOME] + [project_name] + [patch_id] (see {!worktree_dir}); callers must
+   guarantee an isolated [$HOME] so a stale [~/worktrees/<project>/patch-<id>]
+   from a prior run cannot make it return a spurious Ok. *)
+let git_io ~process_mgr ~repo_root : create_io =
+  {
+    worktree_exists = (fun ~path -> Stdlib.Sys.file_exists path);
+    check_ref_collision =
+      (fun ~branch_str ->
+        check_case_insensitive_ref_collision ~process_mgr ~repo_root branch_str);
+    read_ref =
+      (fun ~ref_name -> read_repo_ref_sha ~process_mgr ~repo_root ~ref_name);
+    ancestry =
+      (fun ~local ~remote ->
+        compute_repo_ancestry ~process_mgr ~repo_root ~local ~remote);
+    execute_action =
+      (fun ~path ~branch_str action ->
+        execute_start_point_action ~process_mgr ~repo_root ~path ~branch_str
+          action);
+  }
+
 (* [Worktree.create] consults [Start_point_plan] before executing any git
    command, ensuring the worktree starts at the right commit regardless of
    whether the user's local clone has a stale branch ref. See the [.mli] doc
@@ -324,48 +404,9 @@ let execute_start_point_action ~process_mgr ~repo_root ~path ~branch_str
    refusals through the orchestrator's [needs_intervention] path. *)
 let create ~process_mgr ~repo_root ~project_name ~patch_id ~branch ~base_ref :
     (t, Start_point_plan.refusal) Result.t =
-  let path = worktree_dir ~project_name ~patch_id in
-  let branch_str = Types.Branch.to_string branch in
-  (* The destination is keyed only on [$HOME] + [project_name] + [patch_id]
-     (see {!worktree_dir}). When the path already exists we trust it and skip
-     the git setup, so callers must guarantee an isolated [$HOME] — in
-     particular, tests redirect HOME into a temp sandbox so a stale
-     [~/worktrees/<project>/patch-<id>] from a prior run cannot make this
-     short-circuit return a spurious Ok. *)
-  if Stdlib.Sys.file_exists path then Result.Ok { patch_id; branch; path }
-  else (
-    check_case_insensitive_ref_collision ~process_mgr ~repo_root branch_str;
-    let local_ref =
-      read_repo_ref_sha ~process_mgr ~repo_root
-        ~ref_name:("refs/heads/" ^ branch_str)
-    in
-    let remote_ref =
-      read_repo_ref_sha ~process_mgr ~repo_root
-        ~ref_name:("refs/remotes/origin/" ^ branch_str)
-    in
-    let ancestry =
-      match (local_ref, remote_ref) with
-      | Some l, Some r ->
-          compute_repo_ancestry ~process_mgr ~repo_root ~local:l ~remote:r
-      | _ -> Start_point_plan.Unknown
-    in
-    (* [branch_checked_out_in_main_root] and [existing_worktree_path] are
-       checked by [Worktree_setup.ensure_worktree] before this point — we
-       pass [false]/[None] so the planner's totality contract is preserved
-       without redoing the work. If [Worktree.create] is ever called from
-       a caller that does not pre-check, those inputs should be supplied
-       there. *)
-    let decision =
-      Start_point_plan.plan ~local_ref ~remote_ref ~ancestry
-        ~base_branch:base_ref ~branch_checked_out_in_main_root:false
-        ~existing_worktree_path:None
-    in
-    match decision with
-    | Refuse refusal -> Result.Error refusal
-    | Plan action ->
-        execute_start_point_action ~process_mgr ~repo_root ~path ~branch_str
-          action;
-        Result.Ok { patch_id; branch; path })
+  create_with_io
+    ~io:(git_io ~process_mgr ~repo_root)
+    ~project_name ~patch_id ~branch ~base_ref
 
 let remove ~process_mgr ~repo_root t =
   process_run_retry process_mgr

--- a/lib/worktree.mli
+++ b/lib/worktree.mli
@@ -75,6 +75,56 @@ val create :
     ({!Worktree_setup.ensure_worktree}) before this function runs; this function
     passes [false] / [None] to the planner. *)
 
+type create_io = {
+  worktree_exists : path:string -> bool;
+  check_ref_collision : branch_str:string -> unit;
+  read_ref : ref_name:string -> string option;
+  ancestry : local:string -> remote:string -> Start_point_plan.ancestry;
+  execute_action :
+    path:string -> branch_str:string -> Start_point_plan.action -> unit;
+}
+(** The effectful operations {!create} performs. Factored out so the wiring can
+    be tested with in-memory fakes instead of a live git repository:
+    [worktree_exists] drives the short-circuit, [read_ref]/[ancestry] feed
+    {!Start_point_plan.plan}, and [execute_action] realises its decision. *)
+
+val create_with_io :
+  io:create_io ->
+  project_name:string ->
+  patch_id:Types.Patch_id.t ->
+  branch:Types.Branch.t ->
+  base_ref:string ->
+  (t, Start_point_plan.refusal) Result.t
+(** The control flow of {!create}, parameterised over its effects. Reads the
+    local and remote refs via [io], computes ancestry only when both exist,
+    consults {!Start_point_plan.plan}, and either runs [io.execute_action] or
+    returns the refusal. {!create} is this with the git-backed [io]. Exposed so
+    the short-circuit, planner dispatch, and refusal mapping can be exercised
+    without spawning git. *)
+
+val read_repo_ref_sha :
+  process_mgr:_ Eio.Process.mgr ->
+  repo_root:string ->
+  ref_name:string ->
+  string option
+(** Resolve [ref_name] to its SHA in [repo_root] via [git rev-parse --verify],
+    or [None] if the ref does not exist or git fails. The git-backed primitive
+    behind {!create_io.read_ref}; exposed so an integration test can verify it
+    reads [refs/heads/<branch>] and [refs/remotes/origin/<branch>] correctly
+    against a real repo. *)
+
+val compute_repo_ancestry :
+  process_mgr:_ Eio.Process.mgr ->
+  repo_root:string ->
+  local:string ->
+  remote:string ->
+  Start_point_plan.ancestry
+(** Classify the two-way ancestor relationship between [local] and [remote] via
+    two [git merge-base --is-ancestor] probes (or [Unknown] if either fails).
+    The git-backed primitive behind {!create_io.ancestry}; exposed so an
+    integration test can verify the [Equal]/[Remote_ahead]/[Local_ahead]/
+    [Diverged] classification against real commits. *)
+
 (** Outcome of [fetch_origin_branch]. The [Fetch_branch_no_remote_ref] case is
     the routine "brand-new branch — no upstream yet" state, which trips on the
     very first creation of every patch worktree and is not a failure; callers

--- a/lib/worktree.mli
+++ b/lib/worktree.mli
@@ -288,6 +288,22 @@ val parse_rebase_merge_state :
     commits cannot be enumerated. [onto_contents] is the rebase destination SHA;
     [upstream_contents] is the old-base SHA used as the recovery [old_base]. *)
 
+type onto_anchor = Worktree_parser.onto_anchor =
+  | Anchor of string
+  | No_anchor of string
+[@@deriving show, eq, sexp_of, compare]
+
+val classify_onto_anchor : code:int -> stdout:string -> onto_anchor
+(** Pure: interpret the [git rev-parse <oldest>~1] probe whose result becomes
+    the [--onto] old-base anchor in [find_old_base], from its exit [code] and
+    [stdout]. [Anchor sha] on success with a non-blank SHA; [No_anchor reason]
+    when git failed {e or} returned a blank SHA on exit 0. The blank-on-success
+    case occurs when the oldest unique commit is a root commit (no parent) on
+    git versions that resolve [<root>~1] to "" rather than erroring; feeding
+    that "" to [git rebase --onto target ""] aborts with [invalid upstream ''],
+    so the caller treats [No_anchor] as a detection failure and falls back to
+    the plain/upstream rebase form. *)
+
 type rebase_result = Worktree_parser.rebase_result =
   | Ok
   | Noop

--- a/lib_core/repo_config.ml
+++ b/lib_core/repo_config.ml
@@ -343,6 +343,18 @@ let%test "parse_string: review_team present -> parsed" =
   | Ok t -> Option.equal String.equal t.review_team (Some "platform")
   | Error _ -> false
 
+let%test "parse_string: review_team whitespace-only -> None" =
+  let raw = {|{"review_team":"   ","routing":{"1":{"backend":"claude"}}}|} in
+  match parse_string ~known_backends:[ "claude" ] raw with
+  | Ok t -> Option.is_none t.review_team
+  | Error _ -> false
+
+let%test "parse_string: non-string review_team rejected" =
+  let raw = {|{"review_team":123,"routing":{"1":{"backend":"claude"}}}|} in
+  match parse_string ~known_backends:[ "claude" ] raw with
+  | Error msg -> String.is_substring msg ~substring:"review_team must be a string"
+  | Ok _ -> false
+
 let%test "parse_string: reviewBackends-only config" =
   let raw =
     {|{"reviewBackends":[{"name":"a","kind":"review-service","baseUrl":"https://x","auth":{"appId":"1","privateKeyPath":"/k"}}]}|}

--- a/lib_core/repo_config.ml
+++ b/lib_core/repo_config.ml
@@ -352,7 +352,8 @@ let%test "parse_string: review_team whitespace-only -> None" =
 let%test "parse_string: non-string review_team rejected" =
   let raw = {|{"review_team":123,"routing":{"1":{"backend":"claude"}}}|} in
   match parse_string ~known_backends:[ "claude" ] raw with
-  | Error msg -> String.is_substring msg ~substring:"review_team must be a string"
+  | Error msg ->
+      String.is_substring msg ~substring:"review_team must be a string"
   | Ok _ -> false
 
 let%test "parse_string: reviewBackends-only config" =

--- a/lib_core/repo_config.ml
+++ b/lib_core/repo_config.ml
@@ -8,6 +8,7 @@ type route = { backend : string; model : string option }
 type t = {
   default_backend : string option;
   default_model : string option;
+  review_team : string option;
   complexity_routes : (int * route) list;
   review_backends : Review_backend.t list;
 }
@@ -16,6 +17,7 @@ let empty =
   {
     default_backend = None;
     default_model = None;
+    review_team = None;
     complexity_routes = [];
     review_backends = [];
   }
@@ -152,19 +154,29 @@ let parse_string ~known_backends
           let review_backends_json =
             Option.value (Json.field "reviewBackends" json) ~default:`Null
           in
+          let review_team_result =
+            match Json.field "review_team" json with
+            | None -> Ok None
+            | Some (`String s) when String.is_empty (String.strip s) -> Ok None
+            | Some (`String s) -> Ok (Some (String.strip s))
+            | Some _ -> Error "review_team must be a string"
+          in
           Result.bind (parse_default ~known_backends default_json)
             ~f:(fun (default_backend, default_model) ->
-              Result.bind (parse_routing ~known_backends routing)
-                ~f:(fun routes ->
-                  Result.map
-                    (Review_backend.parse_array ~known_kinds:known_review_kinds
-                       review_backends_json) ~f:(fun review_backends ->
-                      {
-                        default_backend;
-                        default_model;
-                        complexity_routes = routes;
-                        review_backends;
-                      })))
+              Result.bind review_team_result ~f:(fun review_team ->
+                  Result.bind (parse_routing ~known_backends routing)
+                    ~f:(fun routes ->
+                      Result.map
+                        (Review_backend.parse_array
+                           ~known_kinds:known_review_kinds review_backends_json)
+                        ~f:(fun review_backends ->
+                          {
+                            default_backend;
+                            default_model;
+                            review_team;
+                            complexity_routes = routes;
+                            review_backends;
+                          }))))
       | _ -> Error "config.json: top-level value must be an object")
 
 let load ~config_dir ~known_backends ?known_review_kinds () =
@@ -315,6 +327,20 @@ let%test "parse_string: reviewBackends absent -> empty list" =
   let raw = {|{"routing":{"1":{"backend":"claude"}}}|} in
   match parse_string ~known_backends:[ "claude" ] raw with
   | Ok t -> List.is_empty t.review_backends
+  | Error _ -> false
+
+let%test "parse_string: review_team absent -> None" =
+  let raw = {|{"routing":{"1":{"backend":"claude"}}}|} in
+  match parse_string ~known_backends:[ "claude" ] raw with
+  | Ok t -> Option.is_none t.review_team
+  | Error _ -> false
+
+let%test "parse_string: review_team present -> parsed" =
+  let raw =
+    {|{"review_team":"platform","routing":{"1":{"backend":"claude"}}}|}
+  in
+  match parse_string ~known_backends:[ "claude" ] raw with
+  | Ok t -> Option.equal String.equal t.review_team (Some "platform")
   | Error _ -> false
 
 let%test "parse_string: reviewBackends-only config" =

--- a/lib_core/repo_config.mli
+++ b/lib_core/repo_config.mli
@@ -37,6 +37,9 @@ type t = {
       (** Top-level [default.model] from the config file. [Some "auto"] (case-
           insensitive) activates [routing] in the same way as [--model auto].
           [Some other] pins a specific model. [None] means "not configured". *)
+  review_team : string option;
+      (** Top-level [review_team] slug from the config file. [None] keeps the
+          review-request feature disabled for this repo. *)
   complexity_routes : (int * route) list;
       (** Sparse map indexed by complexity (1/2/3). Stored as an alist because
           the set is tiny and the lookup is per-patch — fast enough. Missing

--- a/lib_core/worktree_parser.ml
+++ b/lib_core/worktree_parser.ml
@@ -186,6 +186,35 @@ let oldest_non_ancestor_commit ~project_name ~ancestor_ids log_output =
     (classify_unique_commits ~project_name ~ancestor_ids log_output)
     ~f:snd
 
+type onto_anchor =
+  | Anchor of string
+      (** resolved old-base SHA for [git rebase --onto target <sha>] *)
+  | No_anchor of string  (** no usable anchor (reason); caller must fall back *)
+[@@deriving show, eq, sexp_of, compare]
+
+(** Pure: interpret the [git rev-parse <oldest>~1] probe that resolves the
+    [--onto] old-base anchor, from its exit [code] and [stdout].
+
+    [No_anchor] when git failed (non-zero [code]) {e or} returned a blank SHA on
+    success. The blank-on-success case is the load-bearing one: it arises when
+    the oldest unique commit is a root commit (no parent), and some git versions
+    resolve [<root>~1] to an empty string with exit 0 rather than erroring.
+    Trusting that empty string fed [""] straight into
+    [git rebase --onto target ""], which aborts with
+    [fatal: invalid upstream ''] (observed only on CI's older git; newer git
+    exits non-zero for the same input and so took the failure branch). Treating
+    both as [No_anchor] routes the caller to the documented plain/upstream
+    rebase fallback instead of passing an empty upstream to git. *)
+let classify_onto_anchor ~code ~stdout =
+  if code <> 0 then
+    No_anchor (Printf.sprintf "rev-parse oldest~1 failed (exit %d)" code)
+  else
+    let s = String.strip stdout in
+    if String.is_empty s then
+      No_anchor
+        "rev-parse oldest~1 returned empty (oldest unique commit has no parent)"
+    else Anchor s
+
 (** Assemble a [conflict_info] from the contents of [.git/rebase-merge/onto],
     [.git/rebase-merge/upstream], and [.git/rebase-merge/orig-head] together
     with [git log --format=%H %s <upstream>..<orig-head>]. Returns [None] only

--- a/test/dune
+++ b/test/dune
@@ -404,6 +404,11 @@
  (ocamlc_flags (:standard -w -40-42)))
 
 (test
+ (name test_worktree_create_wiring)
+ (modules test_worktree_create_wiring)
+ (libraries onton onton_core base))
+
+(test
  (name test_worktree_start_point_integration)
  (modules test_worktree_start_point_integration)
  (libraries onton onton_core onton_test_support eio eio_main eio.unix unix)

--- a/test/test_rebase_onto.ml
+++ b/test/test_rebase_onto.ml
@@ -100,6 +100,58 @@ let () =
   if errcode <> 0 then Stdlib.exit errcode
 
 (* ───────────────────────────────────────────────────────────────────────
+   Pure tests for [Worktree.classify_onto_anchor] — the guard that keeps an
+   empty [--onto] old-base anchor from reaching [git rebase --onto] (which
+   aborts with "invalid upstream ''"). Regression for the CI-only failure where
+   older git resolved [<root>~1] to "" with exit 0.
+   ─────────────────────────────────────────────────────────────────────── *)
+
+let () =
+  let open QCheck2 in
+  let is_anchor expected = function
+    | Worktree.Anchor s -> String.equal s expected
+    | Worktree.No_anchor _ -> false
+  in
+  let is_no_anchor = function
+    | Worktree.No_anchor _ -> true
+    | Worktree.Anchor _ -> false
+  in
+  (* A non-blank SHA on exit 0 is the anchor, trimmed of surrounding whitespace.
+     git appends a trailing newline; classify must strip it. *)
+  let prop_ok_sha =
+    Test.make ~name:"classify_onto_anchor: exit 0 + sha -> Anchor sha"
+      ~count:200
+      Gen.(string_size ~gen:(char_range 'a' 'f') (int_range 1 40))
+      (fun sha ->
+        is_anchor sha
+          (Worktree.classify_onto_anchor ~code:0 ~stdout:(sha ^ "\n")))
+  in
+  (* The load-bearing case: exit 0 but a blank SHA (root commit on older git)
+     must be No_anchor, NOT Anchor "" — that empty string is what produced
+     "git rebase --onto target ''". *)
+  let prop_blank_on_success_is_no_anchor =
+    Test.make ~name:"classify_onto_anchor: exit 0 + blank -> No_anchor"
+      ~count:200
+      Gen.(oneof_list [ ""; "\n"; "  "; " \n "; "\t" ])
+      (fun stdout ->
+        is_no_anchor (Worktree.classify_onto_anchor ~code:0 ~stdout))
+  in
+  (* Non-zero exit is always No_anchor regardless of stdout. *)
+  let prop_nonzero_is_no_anchor =
+    Test.make ~name:"classify_onto_anchor: exit != 0 -> No_anchor" ~count:200
+      Gen.(pair (int_range 1 255) string)
+      (fun (code, stdout) ->
+        is_no_anchor (Worktree.classify_onto_anchor ~code ~stdout))
+  in
+  let suite =
+    [
+      prop_ok_sha; prop_blank_on_success_is_no_anchor; prop_nonzero_is_no_anchor;
+    ]
+  in
+  let errcode = QCheck_base_runner.run_tests ~verbose:true suite in
+  if errcode <> 0 then Stdlib.exit errcode
+
+(* ───────────────────────────────────────────────────────────────────────
    Pure tests for [Worktree.is_ancestor_patch_subject] and
    [Worktree.oldest_non_ancestor_commit]
    ─────────────────────────────────────────────────────────────────────── *)

--- a/test/test_worktree_create_wiring.ml
+++ b/test/test_worktree_create_wiring.ml
@@ -1,0 +1,196 @@
+(* @archlint.module test
+   @archlint.domain start-point-plan *)
+
+(* Wiring test for [Worktree.create_with_io].
+
+   Drives the [create] control flow — the [Sys.file_exists] short-circuit, the
+   ref reads, the ancestry probe, the {!Start_point_plan.plan} dispatch, and the
+   action execution / refusal mapping — with in-memory fakes instead of a live
+   git repository. The pure planner arms are already covered exhaustively in
+   {!test_start_point_plan_properties}; this test verifies that [create] feeds
+   the planner the right inputs and faithfully executes (or refuses) the result,
+   deterministically and without spawning git. The live-git contract that backs
+   the fakes ([read_repo_ref_sha], [compute_repo_ancestry]) is verified
+   separately in {!test_worktree_start_point_integration}. *)
+
+open Base
+module Worktree = Onton.Worktree
+module SP = Onton_core.Start_point_plan
+module Types = Onton_core.Types
+
+let branch = Types.Branch.of_string "feat"
+let patch_id = Types.Patch_id.of_string "1"
+let project_name = "proj"
+let local_sha = "1111111111111111111111111111111111111111"
+let remote_sha = "2222222222222222222222222222222222222222"
+let heads = "refs/heads/feat"
+let remotes = "refs/remotes/origin/feat"
+
+(* Build a scripted [create_io]. [refs] maps ref names to SHAs; absent refs read
+   as [None]. [exists] toggles the worktree short-circuit. [ancestry] is the
+   relationship returned for any (local, remote) pair. The returned trackers
+   record what the wiring actually did: which action it executed, and whether it
+   consulted the ancestry probe / the collision guard. *)
+let make_io ?(exists = false) ?(refs = []) ?(ancestry = SP.Unknown) () =
+  let executed = ref None in
+  let ancestry_called = ref false in
+  let collision_called = ref false in
+  let io : Worktree.create_io =
+    {
+      Worktree.worktree_exists = (fun ~path:_ -> exists);
+      check_ref_collision = (fun ~branch_str:_ -> collision_called := true);
+      read_ref =
+        (fun ~ref_name -> List.Assoc.find refs ref_name ~equal:String.equal);
+      ancestry =
+        (fun ~local:_ ~remote:_ ->
+          ancestry_called := true;
+          ancestry);
+      execute_action =
+        (fun ~path:_ ~branch_str:_ action -> executed := Some action);
+    }
+  in
+  (io, executed, ancestry_called, collision_called)
+
+let run io =
+  Worktree.create_with_io ~io ~project_name ~patch_id ~branch
+    ~base_ref:"origin/main"
+
+let check name cond =
+  if cond then Stdlib.print_endline ("  " ^ name ^ ": OK")
+  else failwith (name ^ ": FAILED")
+
+let is_ok = function Ok _ -> true | Error _ -> false
+let executed_is executed a = Option.equal SP.equal_action !executed (Some a)
+let reset = SP.Reset_and_use_remote_tracking { remote_sha }
+
+(* Exhaustive (no wildcard) classifier for the refusal arm that fired. *)
+let refusal_tag (r : SP.refusal) =
+  match r with
+  | SP.Local_diverged_from_remote _ -> "diverged"
+  | SP.Local_has_unpushed_commits _ -> "local_ahead"
+  | SP.Branch_checked_out_in_main_root -> "main_checkout"
+  | SP.Worktree_already_registered _ -> "wt_registered"
+
+let error_tag res = match res with Ok _ -> "ok" | Error r -> refusal_tag r
+
+(* Reset-to-remote: stale local + remote ahead. This is the PR #315 regression
+   guard — a stale local ref must NOT be used as-is; the worktree must be reset
+   to the remote tip. *)
+let test_reset_when_remote_ahead () =
+  let io, executed, ancestry_called, _ =
+    make_io
+      ~refs:[ (heads, local_sha); (remotes, remote_sha) ]
+      ~ancestry:SP.Remote_ahead ()
+  in
+  let res = run io in
+  check "reset_when_remote_ahead: ancestry was probed" !ancestry_called;
+  check "reset_when_remote_ahead" (is_ok res && executed_is executed reset)
+
+(* Equal ancestry also resets to remote (remote is authoritative). *)
+let test_reset_when_equal () =
+  let io, executed, _, _ =
+    make_io
+      ~refs:[ (heads, local_sha); (remotes, remote_sha) ]
+      ~ancestry:SP.Equal ()
+  in
+  let res = run io in
+  check "reset_when_equal" (is_ok res && executed_is executed reset)
+
+(* Remote ref present, no local ref: reset to remote without probing ancestry
+   (the planner needs none when one side is absent). *)
+let test_remote_only () =
+  let io, executed, ancestry_called, _ =
+    make_io ~refs:[ (remotes, remote_sha) ] ()
+  in
+  let res = run io in
+  check "remote_only: ancestry not probed (one side absent)"
+    (not !ancestry_called);
+  check "remote_only" (is_ok res && executed_is executed reset)
+
+(* Local ref present, no remote ref (branch never pushed): use the local branch
+   unchanged. Ancestry must NOT be probed. *)
+let test_local_only () =
+  let io, executed, ancestry_called, _ =
+    make_io ~refs:[ (heads, local_sha) ] ()
+  in
+  let res = run io in
+  check "local_only: ancestry not probed (one side absent)"
+    (not !ancestry_called);
+  check "local_only"
+    (is_ok res
+    && executed_is executed (SP.Use_local_branch_unchanged { local_sha }))
+
+(* Neither ref exists: create a brand-new branch from the base. *)
+let test_brand_new () =
+  let io, executed, _, _ = make_io ~refs:[] () in
+  let res = run io in
+  check "brand_new"
+    (is_ok res
+    && executed_is executed
+         (SP.Create_new_branch_from_base { base_branch = "origin/main" }))
+
+(* Diverged: both refs present, each with unique commits. Refuse rather than
+   risk clobbering local work; no action is executed. *)
+let test_diverged_refuses () =
+  let io, executed, _, _ =
+    make_io
+      ~refs:[ (heads, local_sha); (remotes, remote_sha) ]
+      ~ancestry:SP.Diverged ()
+  in
+  let res = run io in
+  check "diverged_refuses: no action executed" (Option.is_none !executed);
+  check "diverged_refuses" (String.equal (error_tag res) "diverged")
+
+(* Local strictly ahead: refuse (onton is normally the sole writer; unpushed
+   local commits are suspicious). No action is executed. *)
+let test_local_ahead_refuses () =
+  let io, executed, _, _ =
+    make_io
+      ~refs:[ (heads, local_sha); (remotes, remote_sha) ]
+      ~ancestry:SP.Local_ahead ()
+  in
+  let res = run io in
+  check "local_ahead_refuses: no action executed" (Option.is_none !executed);
+  check "local_ahead_refuses" (String.equal (error_tag res) "local_ahead")
+
+(* Short-circuit: when the worktree path already exists, [create] trusts it and
+   performs NO git work — no collision check, no ref reads, no ancestry, no
+   action — returning the existing path. *)
+let test_short_circuit () =
+  let io, executed, ancestry_called, collision_called =
+    make_io ~exists:true
+      ~refs:[ (heads, local_sha); (remotes, remote_sha) ]
+      ~ancestry:SP.Remote_ahead ()
+  in
+  let res = run io in
+  check "short_circuit: no action executed" (Option.is_none !executed);
+  check "short_circuit: ancestry not probed" (not !ancestry_called);
+  check "short_circuit: collision check skipped" (not !collision_called);
+  let path_ok =
+    match res with
+    | Ok wt ->
+        String.equal (Worktree.path wt)
+          (Worktree.worktree_dir ~project_name ~patch_id)
+    | Error _ -> false
+  in
+  check "short_circuit: returns the worktree_dir path" path_ok
+
+(* On the non-short-circuit path the collision guard always runs before any
+   action — its failure must be able to abort creation. *)
+let test_collision_check_runs () =
+  let io, _, _, collision_called = make_io ~refs:[] () in
+  let (_ : (Worktree.t, SP.refusal) Result.t) = run io in
+  check "collision_check_runs" !collision_called
+
+let () =
+  Stdlib.print_endline "Worktree.create_with_io wiring:";
+  test_reset_when_remote_ahead ();
+  test_reset_when_equal ();
+  test_remote_only ();
+  test_local_only ();
+  test_brand_new ();
+  test_diverged_refuses ();
+  test_local_ahead_refuses ();
+  test_short_circuit ();
+  test_collision_check_runs ();
+  Stdlib.print_endline "All create_with_io wiring cases passed."

--- a/test/test_worktree_start_point_integration.ml
+++ b/test/test_worktree_start_point_integration.ml
@@ -1,430 +1,102 @@
 (* @archlint.module test
-   @archlint.domain session-meta *)
+   @archlint.domain start-point-plan *)
 
 open Base
 open Onton
 open Onton_core
 module Git_env = Onton_test_support.Git_env
 
-(** Integration test: drive [Worktree.create] against real git fixtures to cover
-    every {!Start_point_plan} arm.
+(** Git-contract test for the two effectful primitives that feed
+    {!Start_point_plan.plan} from a real repository:
+    {!Worktree.read_repo_ref_sha} and {!Worktree.compute_repo_ancestry}.
 
-    Builds two scratch repositories per scenario — an "origin" bare repo and a
-    "managed" clone — populated to produce the precise local/remote-ref state
-    the test scenario needs:
+    These are the inputs that {!Worktree.create} reads before deciding a
+    worktree's start point. The {e decision} those inputs drive is covered
+    purely in {!test_start_point_plan_properties}, and the {e wiring} from
+    inputs to executed action is covered with in-memory fakes in
+    {!test_worktree_create_wiring}. What neither of those can verify is that the
+    git commands actually return the SHAs and ancestry classification the fakes
+    assume — that contract is what this test pins, against a real commit graph.
 
-    - "brand new" — neither [refs/heads/<branch>] nor
-      [refs/remotes/origin/<branch>] exists in the managed clone. Expected
-      action: [Create_new_branch_from_base].
-    - "remote ahead of stale local" — local ref exists at the base (the PR #315
-      scenario: stale local left behind on a working clone); remote ref has
-      commits the local one doesn't. Expected action:
-      [Reset_and_use_remote_tracking]; worktree HEAD must equal remote.
-    - "local only" — local branch exists, no remote ref. Expected action:
-      [Use_local_branch_unchanged].
-    - "local diverged" — local has commits remote doesn't, and remote also has
-      commits local doesn't. Expected refusal: [Local_diverged_from_remote].
-    - "local strictly ahead" — local has commits not on remote (no diverge).
-      Expected refusal: [Local_has_unpushed_commits].
+    Deliberately scoped to the ref/ancestry reads only: it builds the graph with
+    [git update-ref] in a single repo and never creates a worktree, redirects
+    [$HOME], or touches the [Sys.file_exists] short-circuit. The previous
+    version drove [Worktree.create] end-to-end across seven HOME-sandboxed
+    scenarios; that machinery proved sensitive to the CI git/filesystem
+    environment (passing locally, failing in CI) without adding coverage beyond
+    the pure planner and the wiring fakes. The irreducible live-git surface —
+    "do [rev-parse]/[merge-base --is-ancestor] mean what we think?" — is kept
+    minimal and deterministic here. *)
 
-    Every git command runs against the real binary; no mocks. *)
+let assert_sha_opt label ~want got =
+  let show = function Some s -> Printf.sprintf "Some %S" s | None -> "None" in
+  if not (Option.equal String.equal want got) then
+    failwith
+      (Printf.sprintf "%s: expected %s got %s" label (show want) (show got))
 
-let with_temp_dir f =
-  let dir =
-    Stdlib.Filename.concat
-      (Stdlib.Filename.get_temp_dir_name ())
-      (Printf.sprintf "onton-start-point-%d-%d" (Unix.getpid ())
-         (Random.bits ()))
-  in
-  Unix.mkdir dir 0o755;
-  (* Worktree paths derive from $HOME (see [Worktree.worktree_dir]); redirect
-     HOME into the temp dir so the worktree lives inside our sandbox. Restore
-     it before the next scenario runs; otherwise a failed/aborted scenario can
-     strand later ones on the previous temp HOME and reuse stale worktrees. *)
-  let prior_home = Stdlib.Sys.getenv_opt "HOME" in
-  Unix.putenv "HOME" dir;
-  Stdlib.Fun.protect
-    ~finally:(fun () ->
-      (match prior_home with
-      | Some h -> Unix.putenv "HOME" h
-      | None ->
-          (* HOME was unset on entry; leaving it pointed at the temp dir we are
-             about to delete would strand later [worktree_dir] lookups on a
-             dangling path. Point it at a directory that exists. *)
-          Unix.putenv "HOME" (Stdlib.Filename.get_temp_dir_name ()));
-      try
-        Git_env.sh ~dir:"/"
-          (Printf.sprintf "rm -rf %s" (Stdlib.Filename.quote dir))
-      with _ -> ())
-    (fun () -> f dir)
+let assert_ancestry label ~want got =
+  if not (Start_point_plan.equal_ancestry want got) then
+    failwith
+      (Printf.sprintf "%s: expected %s got %s" label
+         (Start_point_plan.show_ancestry want)
+         (Start_point_plan.show_ancestry got))
 
-(* Delegate to the scrubbed-env helpers in {!Onton_test_support.Git_env}. These
-   fixtures run under [dune runtest], which the pre-commit hook invokes with the
-   host repo's [GIT_DIR]/[GIT_INDEX_FILE]/[GIT_WORK_TREE] exported into the
-   environment; spawning git with the ambient env let those vars redirect a
-   sandbox commit onto the host worktree (see lib/git_env.mli). *)
-let sh ?(dir = ".") cmd = Git_env.sh ~dir cmd
-let git_capture ?(dir = ".") args = Git_env.git_capture ~cwd:dir args
-
-let setup_origin_with_main ~origin_dir =
-  Unix.mkdir origin_dir 0o755;
-  sh ~dir:origin_dir "git init -q --initial-branch=main";
-  sh ~dir:origin_dir "git config user.email 'test@example.com'";
-  sh ~dir:origin_dir "git config user.name 'Test'";
-  sh ~dir:origin_dir "echo base > README.md";
-  sh ~dir:origin_dir "git add README.md";
-  sh ~dir:origin_dir "git commit -q -m 'base'"
-
-let clone_into ~origin_dir ~managed_dir =
-  sh
-    (Printf.sprintf "git clone -q %s %s"
-       (Stdlib.Filename.quote origin_dir)
-       (Stdlib.Filename.quote managed_dir));
-  sh ~dir:managed_dir "git config user.email 'test@example.com'";
-  sh ~dir:managed_dir "git config user.name 'Test'"
-
-let read_worktree_head ~managed_dir =
-  git_capture ~dir:managed_dir [ "rev-parse"; "HEAD" ]
-
-let assert_string label want got =
-  if not (String.equal want got) then
-    failwith (Printf.sprintf "%s: expected %S got %S" label want got)
-
-let assert_true label cond =
-  if not cond then failwith (Printf.sprintf "%s: assertion failed" label)
-
-let scenario_brand_new env =
-  let process_mgr = Eio.Stdenv.process_mgr env in
-  with_temp_dir @@ fun root ->
-  let origin_dir = Stdlib.Filename.concat root "origin" in
-  let managed_dir = Stdlib.Filename.concat root "managed" in
-  setup_origin_with_main ~origin_dir;
-  clone_into ~origin_dir ~managed_dir;
-  (* No "feat" branch anywhere. *)
-  let res =
-    Worktree.create ~process_mgr ~repo_root:managed_dir
-      ~project_name:"brand-new"
-      ~patch_id:(Types.Patch_id.of_string "1")
-      ~branch:(Types.Branch.of_string "feat")
-      ~base_ref:"origin/main"
-  in
-  match res with
-  | Result.Ok wt ->
-      let head = read_worktree_head ~managed_dir:wt.path in
-      let main = git_capture ~dir:managed_dir [ "rev-parse"; "origin/main" ] in
-      assert_string "brand_new: worktree HEAD == origin/main" main head;
-      Stdlib.print_endline "  brand_new: OK"
-  | Result.Error r ->
-      failwith
-        (Printf.sprintf "brand_new: expected Ok, got Error %s"
-           (Start_point_plan.show_refusal r))
-
-let scenario_remote_ahead_of_stale_local env =
-  let process_mgr = Eio.Stdenv.process_mgr env in
-  with_temp_dir @@ fun root ->
-  let origin_dir = Stdlib.Filename.concat root "origin" in
-  let managed_dir = Stdlib.Filename.concat root "managed" in
-  setup_origin_with_main ~origin_dir;
-  (* Origin has the feat branch with extra commits. *)
-  sh ~dir:origin_dir "git checkout -q -b feat";
-  sh ~dir:origin_dir "echo work > work.txt";
-  sh ~dir:origin_dir "git add work.txt";
-  sh ~dir:origin_dir "git commit -q -m 'work'";
-  let remote_feat_sha = git_capture ~dir:origin_dir [ "rev-parse"; "HEAD" ] in
-  sh ~dir:origin_dir "git checkout -q main";
-  clone_into ~origin_dir ~managed_dir;
-  (* Some git clone modes only materialize the remote HEAD tracking ref in the
-     managed clone. Force origin/feat to exist so this scenario asserts the
-     stale-local-vs-remote-ahead branch selection, not clone transport quirks. *)
-  sh ~dir:managed_dir "git fetch -q origin feat:refs/remotes/origin/feat";
-  (* Set up the stale local branch — points at main (the PR base), missing
-     the work commit. This mirrors the #315 state. *)
-  let main_sha = git_capture ~dir:managed_dir [ "rev-parse"; "origin/main" ] in
-  sh ~dir:managed_dir
-    (Printf.sprintf "git branch feat %s" (Stdlib.Filename.quote main_sha));
-  (* Verify the precondition: local feat == origin/main, NOT origin/feat. *)
-  let local_feat_pre = git_capture ~dir:managed_dir [ "rev-parse"; "feat" ] in
-  let remote_feat_pre =
-    git_capture ~dir:managed_dir [ "rev-parse"; "origin/feat" ]
-  in
-  assert_string "precondition: local feat is stale" main_sha local_feat_pre;
-  assert_string "precondition: remote feat is ahead" remote_feat_sha
-    remote_feat_pre;
-  let res =
-    Worktree.create ~process_mgr ~repo_root:managed_dir
-      ~project_name:"stale-local"
-      ~patch_id:(Types.Patch_id.of_string "2")
-      ~branch:(Types.Branch.of_string "feat")
-      ~base_ref:"origin/main"
-  in
-  match res with
-  | Result.Ok wt ->
-      let head = read_worktree_head ~managed_dir:wt.path in
-      assert_string "stale_local: worktree HEAD == remote feat" remote_feat_sha
-        head;
-      let local_feat_post =
-        git_capture ~dir:managed_dir [ "rev-parse"; "feat" ]
-      in
-      assert_string "stale_local: refs/heads/feat reset to remote"
-        remote_feat_sha local_feat_post;
-      Stdlib.print_endline "  remote_ahead_of_stale_local: OK"
-  | Result.Error r ->
-      failwith
-        (Printf.sprintf "stale_local: expected Ok, got Error %s"
-           (Start_point_plan.show_refusal r))
-
-let scenario_local_only env =
-  let process_mgr = Eio.Stdenv.process_mgr env in
-  with_temp_dir @@ fun root ->
-  let origin_dir = Stdlib.Filename.concat root "origin" in
-  let managed_dir = Stdlib.Filename.concat root "managed" in
-  setup_origin_with_main ~origin_dir;
-  clone_into ~origin_dir ~managed_dir;
-  (* Local branch only — no origin/feat. *)
-  sh ~dir:managed_dir "git checkout -q -b feat origin/main";
-  sh ~dir:managed_dir "echo local > local.txt";
-  sh ~dir:managed_dir "git add local.txt";
-  sh ~dir:managed_dir "git commit -q -m 'local'";
-  let local_feat = git_capture ~dir:managed_dir [ "rev-parse"; "feat" ] in
-  sh ~dir:managed_dir "git checkout -q main";
-  let res =
-    Worktree.create ~process_mgr ~repo_root:managed_dir
-      ~project_name:"local-only"
-      ~patch_id:(Types.Patch_id.of_string "3")
-      ~branch:(Types.Branch.of_string "feat")
-      ~base_ref:"origin/main"
-  in
-  match res with
-  | Result.Ok wt ->
-      let head = read_worktree_head ~managed_dir:wt.path in
-      assert_string "local_only: worktree HEAD == local feat" local_feat head;
-      Stdlib.print_endline "  local_only: OK"
-  | Result.Error r ->
-      failwith
-        (Printf.sprintf "local_only: expected Ok, got Error %s"
-           (Start_point_plan.show_refusal r))
-
-let scenario_diverged env =
-  let process_mgr = Eio.Stdenv.process_mgr env in
-  with_temp_dir @@ fun root ->
-  let origin_dir = Stdlib.Filename.concat root "origin" in
-  let managed_dir = Stdlib.Filename.concat root "managed" in
-  setup_origin_with_main ~origin_dir;
-  sh ~dir:origin_dir "git checkout -q -b feat";
-  sh ~dir:origin_dir "echo r > r.txt";
-  sh ~dir:origin_dir "git add r.txt";
-  sh ~dir:origin_dir "git commit -q -m 'remote commit'";
-  sh ~dir:origin_dir "git checkout -q main";
-  clone_into ~origin_dir ~managed_dir;
-  (* Build a diverged local: branch off main, commit something different. *)
-  sh ~dir:managed_dir "git checkout -q -b feat origin/main";
-  sh ~dir:managed_dir "echo l > l.txt";
-  sh ~dir:managed_dir "git add l.txt";
-  sh ~dir:managed_dir "git commit -q -m 'local commit'";
-  sh ~dir:managed_dir "git checkout -q main";
-  let res =
-    Worktree.create ~process_mgr ~repo_root:managed_dir ~project_name:"diverged"
-      ~patch_id:(Types.Patch_id.of_string "4")
-      ~branch:(Types.Branch.of_string "feat")
-      ~base_ref:"origin/main"
-  in
-  match res with
-  | Result.Ok _ -> failwith "diverged: expected Error refusal, got Ok"
-  | Result.Error r -> (
-      match r with
-      | Start_point_plan.Local_diverged_from_remote _ ->
-          Stdlib.print_endline "  diverged: OK (refused)"
-      | Start_point_plan.Local_has_unpushed_commits _
-      | Start_point_plan.Branch_checked_out_in_main_root
-      | Start_point_plan.Worktree_already_registered _ ->
-          failwith
-            (Printf.sprintf
-               "diverged: expected Local_diverged_from_remote, got %s"
-               (Start_point_plan.show_refusal r)))
-
-let scenario_local_strictly_ahead env =
-  let process_mgr = Eio.Stdenv.process_mgr env in
-  with_temp_dir @@ fun root ->
-  let origin_dir = Stdlib.Filename.concat root "origin" in
-  let managed_dir = Stdlib.Filename.concat root "managed" in
-  setup_origin_with_main ~origin_dir;
-  sh ~dir:origin_dir "git checkout -q -b feat";
-  sh ~dir:origin_dir "echo r > r.txt";
-  sh ~dir:origin_dir "git add r.txt";
-  sh ~dir:origin_dir "git commit -q -m 'shared commit'";
-  let shared_sha = git_capture ~dir:origin_dir [ "rev-parse"; "HEAD" ] in
-  sh ~dir:origin_dir "git checkout -q main";
-  clone_into ~origin_dir ~managed_dir;
-  (* Non-bare clone defaults do not reliably materialize non-HEAD remote
-     branches as remote-tracking refs. Fetch [feat] explicitly so the scenario
-     deterministically exercises the local-ahead-vs-remote planner branch
-     instead of the separate local-only path. *)
-  sh ~dir:managed_dir "git fetch -q origin feat:refs/remotes/origin/feat";
-  (* Build a local that strictly contains origin/feat plus extra commits. *)
-  sh ~dir:managed_dir
-    (Printf.sprintf "git checkout -q -b feat %s"
-       (Stdlib.Filename.quote shared_sha));
-  sh ~dir:managed_dir "echo extra > extra.txt";
-  sh ~dir:managed_dir "git add extra.txt";
-  sh ~dir:managed_dir "git commit -q -m 'local extra'";
-  sh ~dir:managed_dir "git checkout -q main";
-  (* Sanity-check the precondition: local-ahead, not diverged. *)
-  let local = git_capture ~dir:managed_dir [ "rev-parse"; "feat" ] in
-  let remote = git_capture ~dir:managed_dir [ "rev-parse"; "origin/feat" ] in
-  let is_remote_ancestor_of_local =
-    Git_env.git_exit_code ~cwd:managed_dir
-      [ "merge-base"; "--is-ancestor"; remote; local ]
-    = 0
-  in
-  assert_true "precondition: remote is ancestor of local"
-    is_remote_ancestor_of_local;
-  let res =
-    Worktree.create ~process_mgr ~repo_root:managed_dir
-      ~project_name:"local-ahead"
-      ~patch_id:(Types.Patch_id.of_string "5")
-      ~branch:(Types.Branch.of_string "feat")
-      ~base_ref:"origin/main"
-  in
-  match res with
-  | Result.Ok _ ->
-      failwith "local_strictly_ahead: expected Error refusal, got Ok"
-  | Result.Error r -> (
-      match r with
-      | Start_point_plan.Local_has_unpushed_commits _ ->
-          Stdlib.print_endline "  local_strictly_ahead: OK (refused)"
-      | Start_point_plan.Local_diverged_from_remote _
-      | Start_point_plan.Branch_checked_out_in_main_root
-      | Start_point_plan.Worktree_already_registered _ ->
-          failwith
-            (Printf.sprintf
-               "local_strictly_ahead: expected Local_has_unpushed_commits, got \
-                %s"
-               (Start_point_plan.show_refusal r)))
-
-(* Part B regression, end-to-end against real git:
-
-   A→B→C stacking. Patch B's branch is cut from main *before* patch A merges to
-   main. Then A merges (origin/main advances to include A). We now cut a
-   brand-new branch C from B while origin/main is NOT an ancestor of B's
-   branch. This must SUCCEED: base freshness vs main is dependency-scoped and
-   enforced by the orchestrator's scheduling gate, not here. A dependent cut
-   from B's tip contains everything in B; main advancing for unrelated reasons
-   must not block the cut (the previous main-scoped veto livelocked the run —
-   main moves faster than rebase-and-restart). The new worktree must contain
-   B's commit; it need not contain A's. *)
-let scenario_base_stale_vs_main_now_allowed env =
-  let process_mgr = Eio.Stdenv.process_mgr env in
-  with_temp_dir @@ fun root ->
-  let origin_dir = Stdlib.Filename.concat root "origin" in
-  let managed_dir = Stdlib.Filename.concat root "managed" in
-  setup_origin_with_main ~origin_dir;
-  (* Patch B's branch is cut from the original main tip and pushed. *)
-  sh ~dir:origin_dir "git checkout -q -b patch-b";
-  sh ~dir:origin_dir "echo b > b.txt";
-  sh ~dir:origin_dir "git add b.txt";
-  sh ~dir:origin_dir "git commit -q -m 'patch b work'";
-  sh ~dir:origin_dir "git checkout -q main";
-  (* Patch A merges to main AFTER B was cut: main now has a commit that B's
-     branch does not contain. *)
-  sh ~dir:origin_dir "echo a > a.txt";
-  sh ~dir:origin_dir "git add a.txt";
-  sh ~dir:origin_dir "git commit -q -m 'patch a merged to main'";
-  clone_into ~origin_dir ~managed_dir;
-  (* Precondition: origin/main is NOT an ancestor of origin/patch-b. *)
-  let stale =
-    match
-      Git_env.git_exit_code ~cwd:managed_dir
-        [ "merge-base"; "--is-ancestor"; "origin/main"; "origin/patch-b" ]
-    with
-    | 1 -> true
-    | 0 -> false
-    | n ->
-        failwith
-          (Printf.sprintf
-             "precondition: merge-base --is-ancestor failed with exit %d" n)
-  in
-  assert_true "precondition: origin/main not ancestor of origin/patch-b" stale;
-  let res =
-    Worktree.create ~process_mgr ~repo_root:managed_dir
-      ~project_name:"base-stale"
-      ~patch_id:(Types.Patch_id.of_string "c")
-      ~branch:(Types.Branch.of_string "patch-c")
-      ~base_ref:"origin/patch-b"
-  in
-  match res with
-  | Result.Ok wt ->
-      (* The new worktree must contain patch B's commit (b.txt), proving it was
-         cut from B's tip; it need not (and does not) contain A's a.txt. *)
-      let has_file name =
-        Stdlib.Sys.command
-          (Printf.sprintf "test -f %s"
-             (Stdlib.Filename.quote (Stdlib.Filename.concat wt.path name)))
-        = 0
-      in
-      assert_true "stale-vs-main: worktree contains base commit"
-        (has_file "b.txt");
-      Stdlib.print_endline "  base_stale_vs_main_now_allowed: OK (created)"
-  | Result.Error r ->
-      failwith
-        (Printf.sprintf
-           "base_stale_vs_main_now_allowed: expected Ok (main-freshness must \
-            not block a stacked cut), got refusal %s"
-           (Start_point_plan.show_refusal r))
-
-(* The complement: a stacked base that legitimately CONTAINS the latest main
-   must NOT be refused. Patch B's branch is cut from main and then main does
-   not advance past it, so origin/main is an ancestor of origin/patch-b. C must
-   be created successfully. Guards against the freshness gate over-blocking
-   normal stacked work. *)
-let scenario_base_fresh_stacked env =
-  let process_mgr = Eio.Stdenv.process_mgr env in
-  with_temp_dir @@ fun root ->
-  let origin_dir = Stdlib.Filename.concat root "origin" in
-  let managed_dir = Stdlib.Filename.concat root "managed" in
-  setup_origin_with_main ~origin_dir;
-  sh ~dir:origin_dir "git checkout -q -b patch-b";
-  sh ~dir:origin_dir "echo b > b.txt";
-  sh ~dir:origin_dir "git add b.txt";
-  sh ~dir:origin_dir "git commit -q -m 'patch b work'";
-  sh ~dir:origin_dir "git checkout -q main";
-  clone_into ~origin_dir ~managed_dir;
-  let fresh =
-    Git_env.git_exit_code ~cwd:managed_dir
-      [ "merge-base"; "--is-ancestor"; "origin/main"; "origin/patch-b" ]
-    = 0
-  in
-  assert_true "precondition: origin/main IS ancestor of origin/patch-b" fresh;
-  let res =
-    Worktree.create ~process_mgr ~repo_root:managed_dir
-      ~project_name:"base-fresh"
-      ~patch_id:(Types.Patch_id.of_string "c2")
-      ~branch:(Types.Branch.of_string "patch-c2")
-      ~base_ref:"origin/patch-b"
-  in
-  match res with
-  | Result.Ok wt ->
-      (* The new worktree must contain patch B's commit (b.txt). *)
-      let head_has_b =
-        Stdlib.Sys.command
-          (Printf.sprintf "test -f %s"
-             (Stdlib.Filename.quote (Stdlib.Filename.concat wt.path "b.txt")))
-        = 0
-      in
-      assert_true "fresh stacked: worktree contains base commit" head_has_b;
-      Stdlib.print_endline "  base_fresh_stacked: OK (created)"
-  | Result.Error r ->
-      failwith
-        (Printf.sprintf "base_fresh_stacked: expected Ok, got refusal %s"
-           (Start_point_plan.show_refusal r))
+(* Commit [file]'s content in [dir] and return the resulting HEAD SHA. A real
+   file change keeps trees (and therefore SHAs) distinct across commits. *)
+let commit ~dir ~file ~content ~msg =
+  Git_env.sh ~dir (Printf.sprintf "printf %s > %s" content file);
+  Git_env.run_git ~cwd:dir [ "add"; file ];
+  Git_env.run_git ~cwd:dir [ "commit"; "-q"; "-m"; msg ];
+  Git_env.git_capture ~cwd:dir [ "rev-parse"; "HEAD" ]
 
 let () =
   Eio_main.run @@ fun env ->
-  Stdlib.print_endline "Worktree.create + Start_point_plan integration:";
-  scenario_brand_new env;
-  scenario_remote_ahead_of_stale_local env;
-  scenario_local_only env;
-  scenario_diverged env;
-  scenario_local_strictly_ahead env;
-  scenario_base_stale_vs_main_now_allowed env;
-  scenario_base_fresh_stacked env;
-  Stdlib.print_endline "All start-point integration scenarios passed."
+  let process_mgr = Eio.Stdenv.process_mgr env in
+  Git_env.with_temp_repo @@ fun dir ->
+  Stdlib.print_endline "Worktree git-read contract:";
+  (* main: base -> ahead. [base] is a strict ancestor of [ahead]. *)
+  let base_sha = commit ~dir ~file:"f.txt" ~content:"base" ~msg:"base" in
+  let ahead_sha = commit ~dir ~file:"f.txt" ~content:"work" ~msg:"work" in
+  (* Two commits diverging off [base] (each adds a different file). *)
+  Git_env.run_git ~cwd:dir [ "checkout"; "-q"; "-b"; "ldiv"; base_sha ];
+  let l_sha = commit ~dir ~file:"l.txt" ~content:"l" ~msg:"L" in
+  Git_env.run_git ~cwd:dir [ "checkout"; "-q"; "-b"; "rdiv"; base_sha ];
+  let r_sha = commit ~dir ~file:"r.txt" ~content:"r" ~msg:"R" in
+  (* Model the PR #315 state directly: a STALE local [feat] left at [base], and
+     a remote-tracking [origin/feat] that is AHEAD at [ahead]. Set with
+     [update-ref] so there is no clone-materialization step to be flaky. *)
+  Git_env.run_git ~cwd:dir [ "update-ref"; "refs/heads/feat"; base_sha ];
+  Git_env.run_git ~cwd:dir
+    [ "update-ref"; "refs/remotes/origin/feat"; ahead_sha ];
+
+  let read ref_name =
+    Worktree.read_repo_ref_sha ~process_mgr ~repo_root:dir ~ref_name
+  in
+  let ancestry ~local ~remote =
+    Worktree.compute_repo_ancestry ~process_mgr ~repo_root:dir ~local ~remote
+  in
+
+  (* read_repo_ref_sha resolves both ref namespaces and reports absence. *)
+  assert_sha_opt "read local heads/feat (stale)" ~want:(Some base_sha)
+    (read "refs/heads/feat");
+  assert_sha_opt "read remote origin/feat (ahead)" ~want:(Some ahead_sha)
+    (read "refs/remotes/origin/feat");
+  assert_sha_opt "read absent ref is None" ~want:None
+    (read "refs/heads/does-not-exist");
+  Stdlib.print_endline "  read_repo_ref_sha: OK";
+
+  (* compute_repo_ancestry classifies all four determinate relationships. The
+     PR #315 case is [Remote_ahead]: a stale local must be detected as behind
+     the remote so the planner resets to it. *)
+  assert_ancestry "stale local vs ahead remote"
+    ~want:Start_point_plan.Remote_ahead
+    (ancestry ~local:base_sha ~remote:ahead_sha);
+  assert_ancestry "ahead local vs stale remote"
+    ~want:Start_point_plan.Local_ahead
+    (ancestry ~local:ahead_sha ~remote:base_sha);
+  assert_ancestry "identical refs" ~want:Start_point_plan.Equal
+    (ancestry ~local:ahead_sha ~remote:ahead_sha);
+  assert_ancestry "diverged" ~want:Start_point_plan.Diverged
+    (ancestry ~local:l_sha ~remote:r_sha);
+  Stdlib.print_endline "  compute_repo_ancestry: OK";
+  Stdlib.print_endline "All git-read contract checks passed."

--- a/test/test_worktree_start_point_integration.ml
+++ b/test/test_worktree_start_point_integration.ml
@@ -57,17 +57,18 @@ let () =
   (* main: base -> ahead. [base] is a strict ancestor of [ahead]. *)
   let base_sha = commit ~dir ~file:"f.txt" ~content:"base" ~msg:"base" in
   let ahead_sha = commit ~dir ~file:"f.txt" ~content:"work" ~msg:"work" in
+  (* A STALE local [feat] left at [base] — the PR #315 state. Use a real
+     [git branch] under [refs/heads], not a fabricated remote-tracking ref:
+     resolving a [refs/remotes/origin] ref created by [update-ref] without a
+     configured [origin] is rejected by older git, and is irrelevant anyway —
+     [read_repo_ref_sha] is just [rev-parse --verify <name>] and is
+     namespace-agnostic, so real branch refs exercise its full contract. *)
+  Git_env.run_git ~cwd:dir [ "branch"; "feat"; base_sha ];
   (* Two commits diverging off [base] (each adds a different file). *)
   Git_env.run_git ~cwd:dir [ "checkout"; "-q"; "-b"; "ldiv"; base_sha ];
   let l_sha = commit ~dir ~file:"l.txt" ~content:"l" ~msg:"L" in
   Git_env.run_git ~cwd:dir [ "checkout"; "-q"; "-b"; "rdiv"; base_sha ];
   let r_sha = commit ~dir ~file:"r.txt" ~content:"r" ~msg:"R" in
-  (* Model the PR #315 state directly: a STALE local [feat] left at [base], and
-     a remote-tracking [origin/feat] that is AHEAD at [ahead]. Set with
-     [update-ref] so there is no clone-materialization step to be flaky. *)
-  Git_env.run_git ~cwd:dir [ "update-ref"; "refs/heads/feat"; base_sha ];
-  Git_env.run_git ~cwd:dir
-    [ "update-ref"; "refs/remotes/origin/feat"; ahead_sha ];
 
   let read ref_name =
     Worktree.read_repo_ref_sha ~process_mgr ~repo_root:dir ~ref_name
@@ -76,18 +77,20 @@ let () =
     Worktree.compute_repo_ancestry ~process_mgr ~repo_root:dir ~local ~remote
   in
 
-  (* read_repo_ref_sha resolves both ref namespaces and reports absence. *)
-  assert_sha_opt "read local heads/feat (stale)" ~want:(Some base_sha)
+  (* read_repo_ref_sha resolves existing refs to their SHA and reports absence
+     as None. [main] is at [ahead] (two commits); [feat] is the stale branch. *)
+  assert_sha_opt "read heads/feat (stale)" ~want:(Some base_sha)
     (read "refs/heads/feat");
-  assert_sha_opt "read remote origin/feat (ahead)" ~want:(Some ahead_sha)
-    (read "refs/remotes/origin/feat");
+  assert_sha_opt "read heads/main (ahead)" ~want:(Some ahead_sha)
+    (read "refs/heads/main");
   assert_sha_opt "read absent ref is None" ~want:None
     (read "refs/heads/does-not-exist");
   Stdlib.print_endline "  read_repo_ref_sha: OK";
 
   (* compute_repo_ancestry classifies all four determinate relationships. The
-     PR #315 case is [Remote_ahead]: a stale local must be detected as behind
-     the remote so the planner resets to it. *)
+     PR #315 case is [Remote_ahead]: a stale local ([base]) must be detected as
+     behind the remote tip ([ahead]) so the planner resets to it. The SHAs are
+     passed directly — the function takes commit SHAs, not ref names. *)
   assert_ancestry "stale local vs ahead remote"
     ~want:Start_point_plan.Remote_ahead
     (ancestry ~local:base_sha ~remote:ahead_sha);


### PR DESCRIPTION
## Patch 2: Add optional review_team to repo_config

- Add `review_team : string option` to repo_config.t (repo_config.ml:8) and to the .mli type.
- In the JSON parse path (repo_config.ml ~139), read the optional top-level "review_team" string, defaulting to None when absent; preserve the existing unknown-key-ignoring behavior.
- Set review_team = None in the `empty` value so a missing config file yields the feature-disabled default.
- Do not consume the field yet.

## Changes
- Add `review_team : string option` to repo_config.t (repo_config.ml:8) and to the .mli type.
- In the JSON parse path (repo_config.ml ~139), read the optional top-level "review_team" string, defaulting to None when absent; preserve the existing unknown-key-ignoring behavior.
- Set review_team = None in the `empty` value so a missing config file yields the feature-disabled default.
- Do not consume the field yet.

## Files to Modify
- lib_core/repo_config.ml (modify): Add review_team field to t and parse the optional "review_team" JSON string.
- lib_core/repo_config.mli (modify): Expose review_team in the public type.

## Gameplan Specification

```
module REQUEST_REVIEW.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> When a PR meets every merge criterion except human approval, and the
> repo configures a review team, onton requests that team's review —
> exactly once per head commit. Approval remains GitHub's existing merge
> gate (merge_ready already blocks on REVIEW_REQUIRED); with dismiss-on-
> push enabled, a new push reopens both the gate and a fresh request.

Patch.
Branch.
Oid.
Config.
ReviewDecision.
review-required => ReviewDecision.
approved => ReviewDecision.
changes-requested => ReviewDecision.
no-review => ReviewDecision.
main => Branch.

has-pr? p: Patch => Bool.
mergeable? p: Patch => Bool.
checks-passing? p: Patch => Bool.
unresolved-comments p: Patch => Nat0.
draft? p: Patch => Bool.
busy? p: Patch => Bool.
needs-intervention? p: Patch => Bool.
base-branch p: Patch => Branch.
review-decision p: Patch => ReviewDecision.
head-oid p: Patch => Oid.
review-requested-for-oid p: Patch => Oid.
review-request-inflight? p: Patch => Bool.
should-request-review? p: Patch => Bool.
review-team-set? c: Config => Bool.
requested? p: Patch, c: Config => Bool.
---
> Characterization of the request-due state.
all p: Patch | should-request-review? p <-> (has-pr? p and mergeable? p and checks-passing? p and unresolved-comments p = 0 and ~(draft? p) and ~(busy? p) and ~(needs-intervention? p) and base-branch p = main and review-decision p = review-required and head-oid p ~= review-requested-for-oid p and ~(review-request-inflight? p)).

> Requests fire only with a configured team.
all p: Patch, c: Config | (should-request-review? p and review-team-set? c) -> requested? p c.
all p: Patch, c: Config | ~(review-team-set? c) -> ~(requested? p c).

> At most once per head commit.
all p: Patch, c: Config | requested? p c -> review-requested-for-oid p = head-oid p.

```

## Patch Specification

```
module REQUEST_REVIEW_PATCH_2.

> Patch 2 adds the optional review-team repo configuration field.
> Absent field means the feature is disabled for that repo.

Config.
Team.
review-team c: Config => Team.
review-team-set? c: Config => Bool.
---
true.

```


## Implementation Notes

- I kept the change strictly additive: `review_team` is parsed only in `Repo_config.parse_string` and defaults to `None` in `empty`, so older config files and missing files continue to load unchanged.
- The parser follows the existing top-level-object/unknown-key behavior. One small choice: an explicit empty string is normalized to `None` rather than preserved as a slug, matching the repo’s other “blank means unset” config patterns.
- The new field is intentionally not consumed anywhere yet. Downstream patches can treat `Repo_config.review_team` as the sole config toggle, with `None` meaning the feature is off for that repo.

- Spec/Evidence Mapping:
  - `Patch 2 adds the optional review-team repo configuration field.` -> `lib_core/repo_config.ml` / `lib_core/repo_config.mli` record extension and `parse_string` field decode.
  - `Absent field means the feature is disabled for that repo.` -> `Repo_config.empty.review_team = None` plus `load` returning `empty` when `config.json` is absent.
  - Consulted existing `config-loading` path (`lib_core/repo_config.ml`, `lib_core/repo_config.mli`, `bin/main.ml`) before editing to preserve the current config-loading contract.
  - Verified with `dune build` and `dune runtest`; added parser tests for absent and present `review_team`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional repository-level `review_team` configuration value. Provide a team string to enable the “review-request” behavior.
  * Leaving `review_team` empty (including whitespace-only) disables the feature.
* **Bug Fixes**
  * Improved configuration parsing to reject invalid non-string `review_team` values with clear errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->