### PR TITLE
[request-review-before-merge] Patch 4: Add pending QCheck2 stubs for should_request_review

### DIFF
--- a/test/test_patch_agent.ml
+++ b/test/test_patch_agent.ml
@@ -982,6 +982,158 @@ let () =
             let a = set_is_draft a true in
             not (is_approved a ~main_branch:br0)
           with _ -> false);
+      (* PENDING: Patch 5 - should_request_review properties. These stubs
+         compile against the Patch 3 placeholder but do not assert the final
+         predicate yet. *)
+      Test.make
+        ~name:
+          "should_request_review true when ready except REVIEW_REQUIRED on fresh head"
+        ~count:1
+        Gen.(pure (pid0, br0))
+        (fun (pid, br) ->
+          let a =
+            create ~branch:br pid |> fun a -> start_with_pr a ~base_branch:br
+          in
+          let a = complete a in
+          let a = set_merge_ready a true in
+          let a = set_checks_passing a true in
+          let a = set_head_oid a (Some "deadbeef") in
+          let a = set_review_decision a (Some "REVIEW_REQUIRED") in
+          let a = set_unresolved_comment_count a 0 in
+          let a = set_is_draft a false in
+          let a = set_review_requested_for_oid a None in
+          let a = set_review_request_inflight a false in
+          ignore (should_request_review a ~main_branch:br0);
+          true);
+      Test.make ~name:"should_request_review false when checks not passing"
+        ~count:1
+        Gen.(pure (pid0, br0))
+        (fun (pid, br) ->
+          let a =
+            create ~branch:br pid |> fun a -> start_with_pr a ~base_branch:br
+          in
+          let a = complete a in
+          let a = set_merge_ready a false in
+          let a = set_checks_passing a false in
+          let a = set_head_oid a (Some "deadbeef") in
+          let a = set_review_decision a (Some "REVIEW_REQUIRED") in
+          ignore (should_request_review a ~main_branch:br0);
+          true);
+      Test.make ~name:"should_request_review false with unresolved comments"
+        ~count:1
+        Gen.(pure (pid0, br0))
+        (fun (pid, br) ->
+          let a =
+            create ~branch:br pid |> fun a -> start_with_pr a ~base_branch:br
+          in
+          let a = complete a in
+          let a = set_merge_ready a true in
+          let a = set_checks_passing a true in
+          let a = set_unresolved_comment_count a 1 in
+          let a = set_head_oid a (Some "deadbeef") in
+          let a = set_review_decision a (Some "REVIEW_REQUIRED") in
+          ignore (should_request_review a ~main_branch:br0);
+          true);
+      Test.make
+        ~name:
+          "should_request_review false when review approved or changes requested"
+        ~count:1
+        Gen.(pure (pid0, br0))
+        (fun (pid, br) ->
+          let decisions = [ Some "APPROVED"; Some "CHANGES_REQUESTED" ] in
+          List.for_all decisions ~f:(fun decision ->
+              let a =
+                create ~branch:br pid |> fun a ->
+                start_with_pr a ~base_branch:br
+              in
+              let a = complete a in
+              let a = set_merge_ready a true in
+              let a = set_checks_passing a true in
+              let a = set_unresolved_comment_count a 0 in
+              let a = set_head_oid a (Some "deadbeef") in
+              let a = set_review_decision a decision in
+              ignore (should_request_review a ~main_branch:br0);
+              true));
+      Test.make
+        ~name:
+          "should_request_review false when already requested for current head oid"
+        ~count:1
+        Gen.(pure (pid0, br0))
+        (fun (pid, br) ->
+          let a =
+            create ~branch:br pid |> fun a -> start_with_pr a ~base_branch:br
+          in
+          let a = complete a in
+          let a = set_merge_ready a true in
+          let a = set_checks_passing a true in
+          let a = set_unresolved_comment_count a 0 in
+          let a = set_head_oid a (Some "deadbeef") in
+          let a = set_review_decision a (Some "REVIEW_REQUIRED") in
+          let a = set_review_requested_for_oid a (Some "deadbeef") in
+          ignore (should_request_review a ~main_branch:br0);
+          true);
+      Test.make ~name:"should_request_review false when a request is inflight"
+        ~count:1
+        Gen.(pure (pid0, br0))
+        (fun (pid, br) ->
+          let a =
+            create ~branch:br pid |> fun a -> start_with_pr a ~base_branch:br
+          in
+          let a = complete a in
+          let a = set_merge_ready a true in
+          let a = set_checks_passing a true in
+          let a = set_unresolved_comment_count a 0 in
+          let a = set_head_oid a (Some "deadbeef") in
+          let a = set_review_decision a (Some "REVIEW_REQUIRED") in
+          let a = set_review_request_inflight a true in
+          ignore (should_request_review a ~main_branch:br0);
+          true);
+      Test.make
+        ~name:
+          "should_request_review false when draft, busy, needs_intervention, or base is not main"
+        ~count:1
+        Gen.(pure (pid0, br0))
+        (fun (pid, br) ->
+          let make_ready a =
+            let a = set_merge_ready a true in
+            let a = set_checks_passing a true in
+            let a = set_unresolved_comment_count a 0 in
+            let a = set_head_oid a (Some "deadbeef") in
+            let a = set_review_decision a (Some "REVIEW_REQUIRED") in
+            a
+          in
+          let a =
+            create ~branch:br pid |> fun a -> start_with_pr a ~base_branch:br
+          in
+          let a = complete a in
+          let draft_case = make_ready (set_is_draft a true) in
+          let busy_case =
+            make_ready (create ~branch:br pid |> fun a -> start_with_pr a ~base_branch:br)
+          in
+          let intervention_case =
+            let a =
+              create ~branch:br pid |> fun a -> start_with_pr a ~base_branch:br
+            in
+            let a = complete a in
+            let a = increment_ci_failure_count a in
+            let a = increment_ci_failure_count a in
+            let a = increment_ci_failure_count a in
+            make_ready a
+          in
+          let other_base = Branch.of_string "feature/dep" in
+          let other_base_case =
+            let a =
+              create ~branch:br pid |> fun a ->
+              start_with_pr a ~base_branch:other_base
+            in
+            let a = complete a in
+            make_ready a
+          in
+          ignore (should_request_review draft_case ~main_branch:br0);
+          ignore (should_request_review busy_case ~main_branch:br0);
+          ignore (should_request_review intervention_case ~main_branch:br0);
+          ignore (should_request_review other_base_case ~main_branch:br0);
+          true);
       Test.make ~name:"set_pr_number resets bootstrap lifecycle facts" ~count:1
         Gen.(pure pid0)
         (fun pid ->

--- a/test/test_patch_agent.ml
+++ b/test/test_patch_agent.ml
@@ -987,7 +987,8 @@ let () =
          predicate yet. *)
       Test.make
         ~name:
-          "should_request_review true when ready except REVIEW_REQUIRED on fresh head"
+          "should_request_review true when ready except REVIEW_REQUIRED on \
+           fresh head"
         ~count:1
         Gen.(pure (pid0, br0))
         (fun (pid, br) ->
@@ -1036,7 +1037,8 @@ let () =
           true);
       Test.make
         ~name:
-          "should_request_review false when review approved or changes requested"
+          "should_request_review false when review approved or changes \
+           requested"
         ~count:1
         Gen.(pure (pid0, br0))
         (fun (pid, br) ->
@@ -1056,7 +1058,8 @@ let () =
               true));
       Test.make
         ~name:
-          "should_request_review false when already requested for current head oid"
+          "should_request_review false when already requested for current head \
+           oid"
         ~count:1
         Gen.(pure (pid0, br0))
         (fun (pid, br) ->
@@ -1090,7 +1093,8 @@ let () =
           true);
       Test.make
         ~name:
-          "should_request_review false when draft, busy, needs_intervention, or base is not main"
+          "should_request_review false when draft, busy, needs_intervention, \
+           or base is not main"
         ~count:1
         Gen.(pure (pid0, br0))
         (fun (pid, br) ->
@@ -1108,7 +1112,8 @@ let () =
           let a = complete a in
           let draft_case = make_ready (set_is_draft a true) in
           let busy_case =
-            make_ready (create ~branch:br pid |> fun a -> start_with_pr a ~base_branch:br)
+            make_ready
+              (create ~branch:br pid |> fun a -> start_with_pr a ~base_branch:br)
           in
           let intervention_case =
             let a =

--- a/test/test_patch_agent.ml
+++ b/test/test_patch_agent.ml
@@ -1112,6 +1112,7 @@ let () =
           let a = complete a in
           let draft_case = make_ready (set_is_draft a true) in
           let busy_case =
+            (* no complete - busy = true *)
             make_ready
               (create ~branch:br pid |> fun a -> start_with_pr a ~base_branch:br)
           in


### PR DESCRIPTION
## Patch 4: Add pending QCheck2 stubs for should_request_review

- Add pending property: true when mergeable+passing+no-unresolved+not-draft/busy/intervention+base=main+REVIEW_REQUIRED+fresh-oid+not-inflight.
- Add pending property: false when checks are failing or pending.
- Add pending property: false when unresolved_comment_count > 0.
- Add pending property: false when review_decision is APPROVED or CHANGES_REQUESTED.
- Add pending property: false when head_oid equals review_requested_for_oid (already requested).
- Add pending property: false when review_request_inflight is true.
- Add pending property: false when draft, busy, needs_intervention, or base is not main.
- Mark each pending (e.g. comment-out the body or guard the assertion) noting PENDING: Patch 5; the file must still compile, referencing the placeholder should_request_review symbol from Patch 3.

## Changes
- Add pending property: true when mergeable+passing+no-unresolved+not-draft/busy/intervention+base=main+REVIEW_REQUIRED+fresh-oid+not-inflight.
- Add pending property: false when checks are failing or pending.
- Add pending property: false when unresolved_comment_count > 0.
- Add pending property: false when review_decision is APPROVED or CHANGES_REQUESTED.
- Add pending property: false when head_oid equals review_requested_for_oid (already requested).
- Add pending property: false when review_request_inflight is true.
- Add pending property: false when draft, busy, needs_intervention, or base is not main.
- Mark each pending (e.g. comment-out the body or guard the assertion) noting PENDING: Patch 5; the file must still compile, referencing the placeholder should_request_review symbol from Patch 3.

## Files to Modify
- test/test_patch_agent.ml (modify): Add pending QCheck2 property stubs for should_request_review.

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[library] QCheck2** — https://github.com/c-cube/qcheck — Use QCheck2.Test.make ~name ~count gen prop with Gen combinators to build patch-agent states inline, matching the existing is_approved property tests in test_patch_agent.ml; each spec invariant becomes one universally-quantified property.

## Gameplan Specification

```
module REQUEST_REVIEW.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> When a PR meets every merge criterion except human approval, and the
> repo configures a review team, onton requests that team's review —
> exactly once per head commit. Approval remains GitHub's existing merge
> gate (merge_ready already blocks on REVIEW_REQUIRED); with dismiss-on-
> push enabled, a new push reopens both the gate and a fresh request.

Patch.
Branch.
Oid.
Config.
ReviewDecision.
review-required => ReviewDecision.
approved => ReviewDecision.
changes-requested => ReviewDecision.
no-review => ReviewDecision.
main => Branch.

has-pr? p: Patch => Bool.
mergeable? p: Patch => Bool.
checks-passing? p: Patch => Bool.
unresolved-comments p: Patch => Nat0.
draft? p: Patch => Bool.
busy? p: Patch => Bool.
needs-intervention? p: Patch => Bool.
base-branch p: Patch => Branch.
review-decision p: Patch => ReviewDecision.
head-oid p: Patch => Oid.
review-requested-for-oid p: Patch => Oid.
review-request-inflight? p: Patch => Bool.
should-request-review? p: Patch => Bool.
review-team-set? c: Config => Bool.
requested? p: Patch, c: Config => Bool.
---
> Characterization of the request-due state.
all p: Patch | should-request-review? p <-> (has-pr? p and mergeable? p and checks-passing? p and unresolved-comments p = 0 and ~(draft? p) and ~(busy? p) and ~(needs-intervention? p) and base-branch p = main and review-decision p = review-required and head-oid p ~= review-requested-for-oid p and ~(review-request-inflight? p)).

> Requests fire only with a configured team.
all p: Patch, c: Config | (should-request-review? p and review-team-set? c) -> requested? p c.
all p: Patch, c: Config | ~(review-team-set? c) -> ~(requested? p c).

> At most once per head commit.
all p: Patch, c: Config | requested? p c -> review-requested-for-oid p = head-oid p.

```

## Patch Specification

```
module REQUEST_REVIEW_PATCH_4.

> Patch 4 adds pending QCheck2 property stubs for should-request-review?.
> Redeclares the predicate surface so the module is self-contained;
> no new invariant (stubs are implemented in Patch 5).

Patch.
should-request-review? p: Patch => Bool.
---
true.

```


## Implementation Notes

- The new `should_request_review` tests are intentionally non-asserting stubs: they build the exact Patch 3 state shape and only call the placeholder predicate so Patch 5 can replace the `ignore ...; true` bodies with real boolean checks without changing the generator setup.
- I kept the cases close to the existing `is_approved` idiom in `test/test_patch_agent.ml` rather than introducing helpers or fixtures. That keeps the future diff small and makes the final predicate coverage easy to compare against the approval tests.
- The “base is not main” stub uses a distinct branch value for `main_branch` so the eventual negative case is explicit; the other stubs reuse `main_branch = br0` and vary only the relevant cache field.
- Dependent patches should treat `should_request_review` as a pure cached-state predicate only; these tests deliberately do not exercise any Forge or runner behavior.

- Spec/Evidence Mapping:
  - Patch 4 test-scaffold clause: implemented in `test/test_patch_agent.ml` via seven pending QCheck2 cases that compile against the Patch 3 placeholder.
  - Required context `test-idiom`: mirrored by inline `Gen` construction and `QCheck2.Test.make` usage, matching the surrounding `is_approved` block.
  - Verification: `dune build` and `dune runtest` both passed after the edit.