### PR TITLE
[request-review-before-merge] Patch 5: Implement should_request_review and enable tests

### DIFF
--- a/lib_core/patch_agent.ml
+++ b/lib_core/patch_agent.ml
@@ -471,7 +471,23 @@ let is_approved_modulo_merge_ready t ~main_branch =
 let is_approved t ~main_branch =
   t.merge_ready && is_approved_modulo_merge_ready t ~main_branch
 
-let should_request_review _t ~main_branch:_ = false
+let should_request_review t ~main_branch =
+  has_pr t
+  && (not t.has_conflict)
+  && (not t.mergeability_unknown)
+  && t.checks_passing
+  && t.unresolved_comment_count = 0
+  && (not t.is_draft)
+  && (not t.busy)
+  && (not (needs_intervention t))
+  && Option.equal Branch.equal t.base_branch (Some main_branch)
+  && Option.equal String.equal t.review_decision (Some "REVIEW_REQUIRED")
+  &&
+  match t.head_oid with
+  | None -> false
+  | Some head_oid ->
+      not (Option.equal String.equal (Some head_oid) t.review_requested_for_oid)
+  && not t.review_request_inflight
 
 let increment_ci_failure_count t =
   { t with ci_failure_count = t.ci_failure_count + 1 }

--- a/lib_core/patch_agent.ml
+++ b/lib_core/patch_agent.ml
@@ -472,21 +472,19 @@ let is_approved t ~main_branch =
   t.merge_ready && is_approved_modulo_merge_ready t ~main_branch
 
 let should_request_review t ~main_branch =
-  has_pr t
-  && (not t.has_conflict)
+  has_pr t && (not t.has_conflict)
   && (not t.mergeability_unknown)
   && t.checks_passing
   && t.unresolved_comment_count = 0
-  && (not t.is_draft)
-  && (not t.busy)
+  && (not t.is_draft) && (not t.busy)
   && (not (needs_intervention t))
   && Option.equal Branch.equal t.base_branch (Some main_branch)
   && Option.equal String.equal t.review_decision (Some "REVIEW_REQUIRED")
-  &&
-  (match t.head_oid with
-  | None -> false
-  | Some head_oid ->
-      not (Option.equal String.equal (Some head_oid) t.review_requested_for_oid))
+  && (match t.head_oid with
+    | None -> false
+    | Some head_oid ->
+        not
+          (Option.equal String.equal (Some head_oid) t.review_requested_for_oid))
   && not t.review_request_inflight
 
 let increment_ci_failure_count t =

--- a/lib_core/patch_agent.ml
+++ b/lib_core/patch_agent.ml
@@ -483,10 +483,10 @@ let should_request_review t ~main_branch =
   && Option.equal Branch.equal t.base_branch (Some main_branch)
   && Option.equal String.equal t.review_decision (Some "REVIEW_REQUIRED")
   &&
-  match t.head_oid with
+  (match t.head_oid with
   | None -> false
   | Some head_oid ->
-      not (Option.equal String.equal (Some head_oid) t.review_requested_for_oid)
+      not (Option.equal String.equal (Some head_oid) t.review_requested_for_oid))
   && not t.review_request_inflight
 
 let increment_ci_failure_count t =

--- a/test/test_patch_agent.ml
+++ b/test/test_patch_agent.ml
@@ -1129,9 +1129,9 @@ let () =
             let a = complete a in
             make_ready a
           in
-          not (should_request_review draft_case ~main_branch:br0)
-          && not (should_request_review busy_case ~main_branch:br0)
-          && not (should_request_review intervention_case ~main_branch:br0)
+          (not (should_request_review draft_case ~main_branch:br0))
+          && (not (should_request_review busy_case ~main_branch:br0))
+          && (not (should_request_review intervention_case ~main_branch:br0))
           && not (should_request_review other_base_case ~main_branch:br0));
       Test.make ~name:"set_pr_number resets bootstrap lifecycle facts" ~count:1
         Gen.(pure pid0)

--- a/test/test_patch_agent.ml
+++ b/test/test_patch_agent.ml
@@ -1004,8 +1004,7 @@ let () =
           let a = set_is_draft a false in
           let a = set_review_requested_for_oid a None in
           let a = set_review_request_inflight a false in
-          ignore (should_request_review a ~main_branch:br0);
-          true);
+          should_request_review a ~main_branch:br0);
       Test.make ~name:"should_request_review false when checks not passing"
         ~count:1
         Gen.(pure (pid0, br0))
@@ -1018,8 +1017,7 @@ let () =
           let a = set_checks_passing a false in
           let a = set_head_oid a (Some "deadbeef") in
           let a = set_review_decision a (Some "REVIEW_REQUIRED") in
-          ignore (should_request_review a ~main_branch:br0);
-          true);
+          not (should_request_review a ~main_branch:br0));
       Test.make ~name:"should_request_review false with unresolved comments"
         ~count:1
         Gen.(pure (pid0, br0))
@@ -1033,8 +1031,7 @@ let () =
           let a = set_unresolved_comment_count a 1 in
           let a = set_head_oid a (Some "deadbeef") in
           let a = set_review_decision a (Some "REVIEW_REQUIRED") in
-          ignore (should_request_review a ~main_branch:br0);
-          true);
+          not (should_request_review a ~main_branch:br0));
       Test.make
         ~name:
           "should_request_review false when review approved or changes \
@@ -1054,8 +1051,7 @@ let () =
               let a = set_unresolved_comment_count a 0 in
               let a = set_head_oid a (Some "deadbeef") in
               let a = set_review_decision a decision in
-              ignore (should_request_review a ~main_branch:br0);
-              true));
+              not (should_request_review a ~main_branch:br0)));
       Test.make
         ~name:
           "should_request_review false when already requested for current head \
@@ -1073,8 +1069,7 @@ let () =
           let a = set_head_oid a (Some "deadbeef") in
           let a = set_review_decision a (Some "REVIEW_REQUIRED") in
           let a = set_review_requested_for_oid a (Some "deadbeef") in
-          ignore (should_request_review a ~main_branch:br0);
-          true);
+          not (should_request_review a ~main_branch:br0));
       Test.make ~name:"should_request_review false when a request is inflight"
         ~count:1
         Gen.(pure (pid0, br0))
@@ -1089,8 +1084,7 @@ let () =
           let a = set_head_oid a (Some "deadbeef") in
           let a = set_review_decision a (Some "REVIEW_REQUIRED") in
           let a = set_review_request_inflight a true in
-          ignore (should_request_review a ~main_branch:br0);
-          true);
+          not (should_request_review a ~main_branch:br0));
       Test.make
         ~name:
           "should_request_review false when draft, busy, needs_intervention, \
@@ -1135,11 +1129,10 @@ let () =
             let a = complete a in
             make_ready a
           in
-          ignore (should_request_review draft_case ~main_branch:br0);
-          ignore (should_request_review busy_case ~main_branch:br0);
-          ignore (should_request_review intervention_case ~main_branch:br0);
-          ignore (should_request_review other_base_case ~main_branch:br0);
-          true);
+          not (should_request_review draft_case ~main_branch:br0)
+          && not (should_request_review busy_case ~main_branch:br0)
+          && not (should_request_review intervention_case ~main_branch:br0)
+          && not (should_request_review other_base_case ~main_branch:br0));
       Test.make ~name:"set_pr_number resets bootstrap lifecycle facts" ~count:1
         Gen.(pure pid0)
         (fun pid ->


### PR DESCRIPTION
## Patch 5: Implement should_request_review and enable tests

- Implement should_request_review t ~main_branch as the conjunction: has_pr t AND mergeable (merge_state = Mergeable / not has_conflict) AND checks_passing t AND unresolved_comment_count t = 0 AND not is_draft AND not busy AND not (needs_intervention t) AND base_branch = main_branch AND review_decision = Some "REVIEW_REQUIRED" AND (head_oid is Some AND head_oid <> review_requested_for_oid) AND not review_request_inflight.
- Reuse existing accessors/helpers where they exist (mirror is_approved's structure); do not duplicate merge_ready logic — this predicate deliberately wants REVIEW_REQUIRED true, the inverse of merge_ready's review block.
- Enable and implement all QCheck2 properties from Patch 4.

## Changes
- Implement should_request_review t ~main_branch as the conjunction: has_pr t AND mergeable (merge_state = Mergeable / not has_conflict) AND checks_passing t AND unresolved_comment_count t = 0 AND not is_draft AND not busy AND not (needs_intervention t) AND base_branch = main_branch AND review_decision = Some "REVIEW_REQUIRED" AND (head_oid is Some AND head_oid <> review_requested_for_oid) AND not review_request_inflight.
- Reuse existing accessors/helpers where they exist (mirror is_approved's structure); do not duplicate merge_ready logic — this predicate deliberately wants REVIEW_REQUIRED true, the inverse of merge_ready's review block.
- Enable and implement all QCheck2 properties from Patch 4.

## Files to Modify
- lib_core/patch_agent.ml (modify): Replace the should_request_review placeholder with the real predicate.
- test/test_patch_agent.ml (modify): Remove pending markers and implement the property bodies.

## Gameplan Specification

```
module REQUEST_REVIEW.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> When a PR meets every merge criterion except human approval, and the
> repo configures a review team, onton requests that team's review —
> exactly once per head commit. Approval remains GitHub's existing merge
> gate (merge_ready already blocks on REVIEW_REQUIRED); with dismiss-on-
> push enabled, a new push reopens both the gate and a fresh request.

Patch.
Branch.
Oid.
Config.
ReviewDecision.
review-required => ReviewDecision.
approved => ReviewDecision.
changes-requested => ReviewDecision.
no-review => ReviewDecision.
main => Branch.

has-pr? p: Patch => Bool.
mergeable? p: Patch => Bool.
checks-passing? p: Patch => Bool.
unresolved-comments p: Patch => Nat0.
draft? p: Patch => Bool.
busy? p: Patch => Bool.
needs-intervention? p: Patch => Bool.
base-branch p: Patch => Branch.
review-decision p: Patch => ReviewDecision.
head-oid p: Patch => Oid.
review-requested-for-oid p: Patch => Oid.
review-request-inflight? p: Patch => Bool.
should-request-review? p: Patch => Bool.
review-team-set? c: Config => Bool.
requested? p: Patch, c: Config => Bool.
---
> Characterization of the request-due state.
all p: Patch | should-request-review? p <-> (has-pr? p and mergeable? p and checks-passing? p and unresolved-comments p = 0 and ~(draft? p) and ~(busy? p) and ~(needs-intervention? p) and base-branch p = main and review-decision p = review-required and head-oid p ~= review-requested-for-oid p and ~(review-request-inflight? p)).

> Requests fire only with a configured team.
all p: Patch, c: Config | (should-request-review? p and review-team-set? c) -> requested? p c.
all p: Patch, c: Config | ~(review-team-set? c) -> ~(requested? p c).

> At most once per head commit.
all p: Patch, c: Config | requested? p c -> review-requested-for-oid p = head-oid p.

```

## Patch Specification

```
module REQUEST_REVIEW_PATCH_5.

> Patch 5 implements should-request-review? and enables the property
> tests. The predicate is true exactly when the PR meets every merge
> criterion except human approval, on a head commit not already
> requested, with no request in flight.

Patch.
Branch.
Oid.
ReviewDecision.
review-required => ReviewDecision.
approved => ReviewDecision.
changes-requested => ReviewDecision.
no-review => ReviewDecision.
main => Branch.

has-pr? p: Patch => Bool.
mergeable? p: Patch => Bool.
checks-passing? p: Patch => Bool.
unresolved-comments p: Patch => Nat0.
draft? p: Patch => Bool.
busy? p: Patch => Bool.
needs-intervention? p: Patch => Bool.
base-branch p: Patch => Branch.
review-decision p: Patch => ReviewDecision.
head-oid p: Patch => Oid.
review-requested-for-oid p: Patch => Oid.
review-request-inflight? p: Patch => Bool.
should-request-review? p: Patch => Bool.
---
> The full characterization of when a review request is due.
all p: Patch | should-request-review? p <-> (has-pr? p and mergeable? p and checks-passing? p and unresolved-comments p = 0 and ~(draft? p) and ~(busy? p) and ~(needs-intervention? p) and base-branch p = main and review-decision p = review-required and head-oid p ~= review-requested-for-oid p and ~(review-request-inflight? p)).

> Approval already granted, or changes requested, never triggers a request.
all p: Patch, review-decision p ~= review-required | ~(should-request-review? p).

> A commit already requested is never re-requested.
all p: Patch, head-oid p = review-requested-for-oid p | ~(should-request-review? p).

```


## Implementation Notes

- `should_request_review` uses the agent's cached mergeability signals as `not has_conflict && not mergeability_unknown`, not `merge_ready`. That is the key inversion versus approval: `merge_ready` is expected to be false when `review_decision = REVIEW_REQUIRED`, so reusing it here would make the predicate unsatisfiable.
- I kept the implementation as a pure cached-state predicate in `Patch_agent` with no new helpers or API surface. The only logic added is the `head_oid` gate: `None` fails closed, and `Some head_oid` only passes when it differs from `review_requested_for_oid`.
- No plan deviation in behavior, but there is a practical modeling detail for dependent patches: `Patch_agent` still does not store `Pr_state.merge_state` directly. If later code needs "mergeable except approval" at runner/reconciler time, it should continue to read this predicate or the existing cached booleans, not expect a new enum field to exist.
- The Patch 4 stubs were converted into real assertions without changing their setup shape, so later patches can compare review-request eligibility tests directly against the nearby `is_approved` cases in `test/test_patch_agent.ml`.

- Spec/Evidence Mapping:
  - Patch-spec biconditional for `should-request-review?`: implemented in `lib_core/patch_agent.ml` via the new conjunction over cached fields; exercised by the positive case plus each blocking-condition property in `test/test_patch_agent.ml`.
  - `review-decision ~= review-required -> not should-request-review?`: covered explicitly by the `"review approved or changes requested"` property test.
  - `head-oid = review-requested-for-oid -> not should-request-review?`: covered explicitly by the `"already requested for current head oid"` property test.
  - Required context consulted: `lib_core/pr_state.ml`, `lib_core/patch_agent.{ml,mli}`, and `test/test_patch_agent.ml` to mirror the existing approval predicate structure without reintroducing `merge_ready`.
  - Verification: `dune build` and `dune runtest` passed on the committed patch.