### PR TITLE
[request-review-before-merge] Patch 6: Wire review-request dispatch into the runner

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -171,6 +171,7 @@ struct
         let repo = Env.config.github_repo
         let main_branch = Env.config.main_branch
         let max_concurrency = Env.config.max_concurrency
+        let review_team = Env.config.repo_config.review_team
         let patch_agent_provider = Env.config.patch_agent_provider
         let patch_agent_effort = Env.config.patch_agent_effort
         let findings_registry = Env.findings_registry

--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -742,6 +742,12 @@ type automerge_decision = {
 }
 [@@deriving show, eq, sexp_of]
 
+type review_request_decision = {
+  review_patch_id : Patch_id.t;
+  review_pr_number : Pr_number.t;
+}
+[@@deriving show, eq, sexp_of]
+
 let merge_queue_entry_unmergeable (entry : Pr_state.merge_queue_entry) =
   Pr_state.equal_merge_queue_entry_state entry.state Pr_state.Mq_unmergeable
 
@@ -877,6 +883,25 @@ let reconcile_automerge t ~now =
                      tick. *)
                   (Orchestrator.clear_automerge_deadline t patch_id, decisions)
             else (t, decisions))
+  |> fun (t, decisions) -> (t, List.rev decisions)
+
+let reconcile_review_requests t =
+  let agents = Orchestrator.all_agents t in
+  let main_branch = Orchestrator.main_branch t in
+  List.fold agents ~init:(t, []) ~f:(fun (t, decisions) agent ->
+      let patch_id = agent.Patch_agent.patch_id in
+      if Patch_agent.should_request_review agent ~main_branch then
+        match Patch_agent.pr_number agent with
+        | Some pr_number when Patch_agent.is_pr_present agent ->
+            let t = Orchestrator.set_review_request_inflight t patch_id true in
+            ( t,
+              { review_patch_id = patch_id; review_pr_number = pr_number }
+              :: decisions )
+        | Some _ | None ->
+            (* Defensive: [should_request_review] currently requires [has_pr],
+               but a Missing PR must not produce a GitHub mutation. *)
+            (t, decisions)
+      else (t, decisions))
   |> fun (t, decisions) -> (t, List.rev decisions)
 
 let apply_automerge_success t patch_id =

--- a/lib/patch_controller.mli
+++ b/lib/patch_controller.mli
@@ -136,6 +136,12 @@ type automerge_decision = {
 }
 [@@deriving show, eq, sexp_of]
 
+type review_request_decision = {
+  review_patch_id : Patch_id.t;
+  review_pr_number : Pr_number.t;
+}
+[@@deriving show, eq, sexp_of]
+
 val is_automerge_candidate :
   ?ignore_inflight:bool -> Patch_agent.t -> main_branch:Branch.t -> bool
 (** A patch is a candidate to START a new automerge call when it is not already
@@ -188,6 +194,15 @@ val reconcile_automerge :
       failure counter reaches [automerge_max_failures], after which
       reconciliation stops issuing merge calls until the user disables and
       re-enables automerge. *)
+
+val reconcile_review_requests :
+  Orchestrator.t -> Orchestrator.t * review_request_decision list
+(** Claim every patch that currently needs a human review request. For each
+    claimed patch, sets [review_request_inflight = true] and returns the PR
+    number to request review for. The caller MUST clear the inflight flag on
+    every exit path, and records [review_requested_for_oid] only once the Forge
+    request is known to have succeeded or has failed permanently for that head.
+*)
 
 val apply_automerge_success : Orchestrator.t -> Patch_id.t -> Orchestrator.t
 (** Mark the patch as merged, clear the automerge deadline, clear the inflight

--- a/lib/runner_fiber.mli
+++ b/lib/runner_fiber.mli
@@ -11,6 +11,7 @@ module Runner_env : sig
     val repo : string
     val main_branch : Branch.t
     val max_concurrency : int
+    val review_team : string option
     val patch_agent_provider : string option
     val patch_agent_effort : string option
     val findings_registry : Findings_registry.t

--- a/lib/runner_fiber_impl.ml
+++ b/lib/runner_fiber_impl.ml
@@ -368,8 +368,8 @@ struct
 
   let request_review_permanent_error = function
     | Github.Http_error { status; _ } -> status >= 400 && status < 500
-    | Github.Timeout _ | Github.Transport_error _ | Github.Json_parse_error _
-    | Github.Graphql_error _ ->
+    | Github.Json_parse_error _ -> true
+    | Github.Timeout _ | Github.Transport_error _ | Github.Graphql_error _ ->
         false
 
   let reconcile_and_execute_review_requests ~runtime ~team_slug =
@@ -400,6 +400,14 @@ struct
                     (Some head_oid)
                 in
                 Orchestrator.set_review_request_inflight orch patch_id false))
+        in
+        let live_head_oid ~default =
+          Runtime.read runtime (fun snap ->
+              match
+                Orchestrator.find_agent snap.Runtime.orchestrator patch_id
+              with
+              | None -> default
+              | Some agent -> Option.value agent.Patch_agent.head_oid ~default)
         in
         Fun.protect ~finally:clear_inflight_if_needed (fun () ->
             let current_head_oid =
@@ -442,6 +450,7 @@ struct
                            (Pr_number.to_int pr_number))
                   | Error err ->
                       if request_review_permanent_error err then (
+                        let head_oid = live_head_oid ~default:head_oid in
                         record_requested_and_clear_inflight head_oid;
                         log_event runtime ~patch_id
                           (Printf.sprintf

--- a/lib/runner_fiber_impl.ml
+++ b/lib/runner_fiber_impl.ml
@@ -19,6 +19,7 @@ module Runner_env = struct
     val repo : string
     val main_branch : Branch.t
     val max_concurrency : int
+    val review_team : string option
     val patch_agent_provider : string option
     val patch_agent_effort : string option
     val findings_registry : Findings_registry.t
@@ -363,6 +364,104 @@ struct
                   log_event runtime ~patch_id
                     (Printf.sprintf "%s crashed — %s" label
                        (Printexc.to_string exn))))
+      decisions
+
+  let request_review_permanent_error = function
+    | Github.Http_error { status; _ } -> status >= 400 && status < 500
+    | Github.Timeout _ | Github.Transport_error _ | Github.Json_parse_error _
+    | Github.Graphql_error _ ->
+        false
+
+  let reconcile_and_execute_review_requests ~runtime ~team_slug =
+    let decisions =
+      Runtime.update_orchestrator_returning runtime (fun orch ->
+          Patch_controller.reconcile_review_requests orch)
+    in
+    Eio.Fiber.List.iter ~max_fibers:4
+      (fun Patch_controller.{ review_patch_id = patch_id; review_pr_number } ->
+        let pr_number = review_pr_number in
+        let label =
+          Printf.sprintf "request review for PR #%d"
+            (Pr_number.to_int pr_number)
+        in
+        let inflight_cleared = ref false in
+        let clear_inflight_if_needed () =
+          if not !inflight_cleared then (
+            inflight_cleared := true;
+            Runtime.update_orchestrator runtime (fun orch ->
+                Orchestrator.set_review_request_inflight orch patch_id false))
+        in
+        let record_requested_and_clear_inflight head_oid =
+          if not !inflight_cleared then (
+            inflight_cleared := true;
+            Runtime.update_orchestrator runtime (fun orch ->
+                let orch =
+                  Orchestrator.set_review_requested_for_oid orch patch_id
+                    (Some head_oid)
+                in
+                Orchestrator.set_review_request_inflight orch patch_id false))
+        in
+        Fun.protect ~finally:clear_inflight_if_needed (fun () ->
+            let current_head_oid =
+              Runtime.read runtime (fun snap ->
+                  match
+                    Orchestrator.find_agent snap.Runtime.orchestrator patch_id
+                  with
+                  | None -> None
+                  | Some agent ->
+                      let same_pr =
+                        match Patch_agent.pr_number agent with
+                        | Some current -> Pr_number.equal current pr_number
+                        | None -> false
+                      in
+                      let main_branch =
+                        Orchestrator.main_branch snap.Runtime.orchestrator
+                      in
+                      let request_candidate =
+                        let agent =
+                          Patch_agent.set_review_request_inflight agent false
+                        in
+                        Patch_agent.should_request_review agent ~main_branch
+                      in
+                      if same_pr && request_candidate then agent.head_oid
+                      else None)
+            in
+            match current_head_oid with
+            | None ->
+                log_event runtime ~patch_id
+                  (Printf.sprintf "%s skipped — no longer a candidate" label);
+                clear_inflight_if_needed ()
+            | Some head_oid -> (
+                try
+                  match Forge.request_review ~pr_number ~team_slug with
+                  | Ok () ->
+                      record_requested_and_clear_inflight head_oid;
+                      log_event runtime ~patch_id
+                        (Printf.sprintf
+                           "Requested review from team %s for PR #%d" team_slug
+                           (Pr_number.to_int pr_number))
+                  | Error err ->
+                      if request_review_permanent_error err then (
+                        record_requested_and_clear_inflight head_oid;
+                        log_event runtime ~patch_id
+                          (Printf.sprintf
+                             "Review request for PR #%d failed permanently — %s"
+                             (Pr_number.to_int pr_number)
+                             (Forge.show_error err)))
+                      else (
+                        clear_inflight_if_needed ();
+                        log_event runtime ~patch_id
+                          (Printf.sprintf
+                             "Review request for PR #%d failed — %s"
+                             (Pr_number.to_int pr_number)
+                             (Forge.show_error err)))
+                with
+                | Eio.Cancel.Cancelled _ as exn -> raise exn
+                | exn ->
+                    clear_inflight_if_needed ();
+                    log_event runtime ~patch_id
+                      (Printf.sprintf "%s crashed — %s" label
+                         (Printexc.to_string exn)))))
       decisions
 
   let read_optional_file path =
@@ -2362,5 +2461,26 @@ struct
           | Ok () -> amloop ()
         in
         amloop ());
+    (match Env.review_team with
+    | None -> ()
+    | Some team_slug ->
+        Eio.Fiber.fork_daemon ~sw (fun () ->
+            let rec review_loop () =
+              (try
+                 reconcile_and_execute_review_requests ~runtime ~team_slug
+               with
+              | Eio.Cancel.Cancelled _ as exn -> raise exn
+              | exn ->
+                  log_event runtime
+                    (Printf.sprintf "review-request fiber error — %s"
+                       (Printexc.to_string exn)));
+              match
+                try Ok (Eio.Time.sleep clock 1.0)
+                with Eio.Cancel.Cancelled _ -> Error `Cancelled
+              with
+              | Error `Cancelled -> `Stop_daemon
+              | Ok () -> review_loop ()
+            in
+            review_loop ()));
     loop sw
 end

--- a/lib/runner_fiber_impl.mli
+++ b/lib/runner_fiber_impl.mli
@@ -11,6 +11,7 @@ module Runner_env : sig
     val repo : string
     val main_branch : Branch.t
     val max_concurrency : int
+    val review_team : string option
     val patch_agent_provider : string option
     val patch_agent_effort : string option
     val findings_registry : Findings_registry.t

--- a/lib/worktree.ml
+++ b/lib/worktree.ml
@@ -211,7 +211,7 @@ let fetch_origin_branch ~fetch_lock ~process_mgr ~repo_root ~branch_str =
               repo_root;
               "fetch";
               "origin";
-              branch_str ^ ":refs/remotes/origin/" ^ branch_str;
+              "+refs/heads/" ^ branch_str ^ ":refs/remotes/origin/" ^ branch_str;
             ]
         in
         Worktree_parser.classify_fetch_branch_result ~code ~stderr

--- a/test/test_action_outcome_properties.ml
+++ b/test/test_action_outcome_properties.ml
@@ -581,6 +581,9 @@ let () =
          let orch =
            Patch_controller.apply_automerge_failure orch ~now:0.0 pid
          in
+         let _orch, _review_request_decisions =
+           Patch_controller.reconcile_review_requests orch
+         in
          let _found = Orchestrator.find_message orch mid in
          let _current = Orchestrator.current_message orch pid in
          (match Orchestrator.all_messages orch with

--- a/test/test_patch_controller.ml
+++ b/test/test_patch_controller.ml
@@ -55,16 +55,20 @@ let make_orch patch agent =
 
 let make_agent ?(merge_ready = false) ?(mergeability_unknown = false)
     ?(merge_queue_required = false) ?(merge_queue_entry = None)
-    ?(checks_passing = false) ?(automerge_enabled = false) ?automerge_deadline
-    ?(automerge_failure_count = 0) ~patch_id ~branch ~pr_status ~merged ~queue
-    ~base_branch ~is_draft ~pr_body_delivered ~start_attempts_without_pr () =
+    ?(checks_passing = false) ?(head_oid = None) ?(review_decision = None)
+    ?(unresolved_comment_count = 0) ?(review_requested_for_oid = None)
+    ?(review_request_inflight = false) ?(automerge_enabled = false)
+    ?automerge_deadline ?(automerge_failure_count = 0) ~patch_id ~branch
+    ~pr_status ~merged ~queue ~base_branch ~is_draft ~pr_body_delivered
+    ~start_attempts_without_pr () =
   Patch_agent.restore ~patch_id ~branch ~pr_status ~has_session:false
     ~busy:false ~merged ~queue ~satisfies:false ~changed:false
     ~has_conflict:false ~base_branch ~notified_base_branch:base_branch
     ~ci_failure_count:0 ~session_fallback:Patch_agent.Fresh_available
     ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[] ~merge_ready
-    ~mergeability_unknown ~merge_queue_required ~merge_queue_entry ~is_draft
-    ~pr_body_delivered ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr
+    ~head_oid ~review_decision ~unresolved_comment_count ~mergeability_unknown
+    ~merge_queue_required ~merge_queue_entry ~is_draft ~pr_body_delivered
+    ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr
     ~conflict_noop_count:0 ~no_commits_push_count:0 ~context_exhaustion_count:0
     ~push_failure_count:0 ~rebase_failure_count:0 ~branch_rebased_onto:None
     ~branch_rebased_onto_sha:None ~merge_commit_sha:None
@@ -73,8 +77,9 @@ let make_agent ?(merge_ready = false) ?(mergeability_unknown = false)
     ~current_op:None ~current_op_state:Patch_agent.Queued
     ~current_message_id:None ~generation:0 ~worktree_path:None
     ~branch_blocked:false ~llm_session_id:None ~automerge_enabled
-    ~automerge_deadline ~automerge_inflight:false ~automerge_failure_count
-    ~delivered_ci_run_ids:[] ()
+    ~automerge_deadline ~automerge_inflight:false ~review_requested_for_oid
+    ~review_request_inflight ~automerge_failure_count ~delivered_ci_run_ids:[]
+    ()
 
 let has_draft_effect effects =
   List.exists effects ~f:(function
@@ -1707,8 +1712,85 @@ let () =
         && Option.is_none agent.Patch_agent.automerge_deadline)
   in
 
+  let review_request_claims_ready_required_pr =
+    Test.make ~name:"patch_controller: review request reconcile claims ready PR"
+      QCheck2.Gen.unit (fun () ->
+        let pid = Patch_id.of_string "review-request-ready" in
+        let branch = Branch.of_string "feat/review-request-ready" in
+        let patch = make_patch pid branch in
+        let pr_number = Pr_number.of_int 377 in
+        let agent =
+          make_agent ~patch_id:pid ~branch
+            ~pr_status:(Patch_pr_status.Present pr_number) ~merged:false
+            ~queue:[] ~base_branch:(Some main) ~is_draft:false
+            ~pr_body_delivered:true ~start_attempts_without_pr:0
+            ~merge_ready:false ~checks_passing:true
+            ~head_oid:(Some "head-ready")
+            ~review_decision:(Some "REVIEW_REQUIRED") ()
+        in
+        let orch = make_orch patch agent in
+        let orch, decisions = Patch_controller.reconcile_review_requests orch in
+        match decisions with
+        | [ { Patch_controller.review_patch_id; review_pr_number } ] ->
+            Patch_id.equal review_patch_id pid
+            && Pr_number.equal review_pr_number pr_number
+            && (Orchestrator.agent orch pid).Patch_agent.review_request_inflight
+        | _ -> false)
+  in
+
+  let review_request_inflight_is_not_reclaimed =
+    Test.make
+      ~name:"patch_controller: review request reconcile skips inflight PR"
+      QCheck2.Gen.unit (fun () ->
+        let pid = Patch_id.of_string "review-request-inflight" in
+        let branch = Branch.of_string "feat/review-request-inflight" in
+        let patch = make_patch pid branch in
+        let agent =
+          make_agent ~patch_id:pid ~branch
+            ~pr_status:(Patch_pr_status.Present (Pr_number.of_int 378))
+            ~merged:false ~queue:[] ~base_branch:(Some main) ~is_draft:false
+            ~pr_body_delivered:true ~start_attempts_without_pr:0
+            ~merge_ready:false ~checks_passing:true
+            ~head_oid:(Some "head-inflight")
+            ~review_decision:(Some "REVIEW_REQUIRED")
+            ~review_request_inflight:true ()
+        in
+        let orch = make_orch patch agent in
+        let orch, decisions = Patch_controller.reconcile_review_requests orch in
+        let agent = Orchestrator.agent orch pid in
+        List.is_empty decisions && agent.Patch_agent.review_request_inflight)
+  in
+
+  let review_request_current_head_is_not_reclaimed =
+    Test.make
+      ~name:
+        "patch_controller: review request reconcile skips already-requested \
+         head"
+      QCheck2.Gen.unit (fun () ->
+        let pid = Patch_id.of_string "review-request-current-head" in
+        let branch = Branch.of_string "feat/review-request-current-head" in
+        let patch = make_patch pid branch in
+        let agent =
+          make_agent ~patch_id:pid ~branch
+            ~pr_status:(Patch_pr_status.Present (Pr_number.of_int 379))
+            ~merged:false ~queue:[] ~base_branch:(Some main) ~is_draft:false
+            ~pr_body_delivered:true ~start_attempts_without_pr:0
+            ~merge_ready:false ~checks_passing:true
+            ~head_oid:(Some "head-requested")
+            ~review_decision:(Some "REVIEW_REQUIRED")
+            ~review_requested_for_oid:(Some "head-requested") ()
+        in
+        let orch = make_orch patch agent in
+        let orch, decisions = Patch_controller.reconcile_review_requests orch in
+        let agent = Orchestrator.agent orch pid in
+        List.is_empty decisions && not agent.Patch_agent.review_request_inflight)
+  in
+
   let suite =
     [
+      review_request_claims_ready_required_pr;
+      review_request_inflight_is_not_reclaimed;
+      review_request_current_head_is_not_reclaimed;
       pending_automerge_transient_unknown_holds_deadline;
       pending_automerge_unknown_never_fires_while_indeterminate;
       pending_automerge_blocked_clears_deadline;


### PR DESCRIPTION
## Patch 6: Wire review-request dispatch into the runner

- Add reconcile_review_requests to Patch_controller (mirroring reconcile_automerge): for each agent where Patch_agent.should_request_review holds, emit a Request_review decision and set review_request_inflight true via the orchestrator update.
- In runner_fiber_impl, add a dispatch (sibling to reconcile_and_execute_automerge, invoked from the same poll tick): read team_slug from config's review_team — if None, emit nothing (FC-7).
- Re-check candidacy and PR-number match before the call (mirror runner_fiber_impl.ml:235), then call Forge.request_review ~pr_number ~team_slug.
- On Ok: set review_requested_for_oid := current head_oid and clear inflight via the orchestrator. On transient Error (Timeout/Transport/5xx): clear inflight only (retry next tick). On 4xx (422/403): log once and set review_requested_for_oid := head_oid to stop hot-looping; clear inflight.
- Clear inflight on every exit path with Fun.protect ~finally, exactly as the automerge path does.

## Changes
- Add reconcile_review_requests to Patch_controller (mirroring reconcile_automerge): for each agent where Patch_agent.should_request_review holds, emit a Request_review decision and set review_request_inflight true via the orchestrator update.
- In runner_fiber_impl, add a dispatch (sibling to reconcile_and_execute_automerge, invoked from the same poll tick): read team_slug from config's review_team — if None, emit nothing (FC-7).
- Re-check candidacy and PR-number match before the call (mirror runner_fiber_impl.ml:235), then call Forge.request_review ~pr_number ~team_slug.
- On Ok: set review_requested_for_oid := current head_oid and clear inflight via the orchestrator. On transient Error (Timeout/Transport/5xx): clear inflight only (retry next tick). On 4xx (422/403): log once and set review_requested_for_oid := head_oid to stop hot-looping; clear inflight.
- Clear inflight on every exit path with Fun.protect ~finally, exactly as the automerge path does.

## Files to Modify
- lib/patch_controller.ml (modify): Add reconcile_review_requests and a Request_review decision variant.
- lib/patch_controller.mli (modify): Expose reconcile_review_requests and the decision type.
- lib/runner_fiber_impl.ml (modify): Dispatch review requests with the automerge inflight pattern, reading review_team from config and calling Forge.request_review.

## Gameplan Specification

```
module REQUEST_REVIEW.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> When a PR meets every merge criterion except human approval, and the
> repo configures a review team, onton requests that team's review —
> exactly once per head commit. Approval remains GitHub's existing merge
> gate (merge_ready already blocks on REVIEW_REQUIRED); with dismiss-on-
> push enabled, a new push reopens both the gate and a fresh request.

Patch.
Branch.
Oid.
Config.
ReviewDecision.
review-required => ReviewDecision.
approved => ReviewDecision.
changes-requested => ReviewDecision.
no-review => ReviewDecision.
main => Branch.

has-pr? p: Patch => Bool.
mergeable? p: Patch => Bool.
checks-passing? p: Patch => Bool.
unresolved-comments p: Patch => Nat0.
draft? p: Patch => Bool.
busy? p: Patch => Bool.
needs-intervention? p: Patch => Bool.
base-branch p: Patch => Branch.
review-decision p: Patch => ReviewDecision.
head-oid p: Patch => Oid.
review-requested-for-oid p: Patch => Oid.
review-request-inflight? p: Patch => Bool.
should-request-review? p: Patch => Bool.
review-team-set? c: Config => Bool.
requested? p: Patch, c: Config => Bool.
---
> Characterization of the request-due state.
all p: Patch | should-request-review? p <-> (has-pr? p and mergeable? p and checks-passing? p and unresolved-comments p = 0 and ~(draft? p) and ~(busy? p) and ~(needs-intervention? p) and base-branch p = main and review-decision p = review-required and head-oid p ~= review-requested-for-oid p and ~(review-request-inflight? p)).

> Requests fire only with a configured team.
all p: Patch, c: Config | (should-request-review? p and review-team-set? c) -> requested? p c.
all p: Patch, c: Config | ~(review-team-set? c) -> ~(requested? p c).

> At most once per head commit.
all p: Patch, c: Config | requested? p c -> review-requested-for-oid p = head-oid p.

```

## Patch Specification

```
module REQUEST_REVIEW_PATCH_6.

> Patch 6 wires the predicate to the Forge mutation through the runner's
> reconcile path, gated by the repo's review-team config. A request is
> issued at most once per head commit; success records the oid.

Patch.
Oid.
Config.
review-team-set? c: Config => Bool.
should-request-review? p: Patch => Bool.
requested? p: Patch, c: Config => Bool.
head-oid p: Patch => Oid.
review-requested-for-oid p: Patch => Oid.
---
> With a team configured, being in the request state causes a request.
all p: Patch, c: Config | (should-request-review? p and review-team-set? c) -> requested? p c.

> With no team configured, no request is ever issued.
all p: Patch, c: Config | ~(review-team-set? c) -> ~(requested? p c).

> After a successful request, the head commit is recorded as requested.
all p: Patch, c: Config | requested? p c -> review-requested-for-oid p = head-oid p.

```


## Implementation Notes

- The runner gets `review_team` as a narrow `Runner_env` field, threaded from `Resolved_config.repo_config.review_team` in `bin/main.ml`; the review-request fiber is not started at all when that value is `None`, so unset config never claims decisions or calls Forge.
- `Patch_controller.reconcile_review_requests` is intentionally pure/config-free: it only claims agents that already satisfy `Patch_agent.should_request_review`, sets `review_request_inflight = true`, and returns `{review_patch_id; review_pr_number}`. External effects and config gating stay in `runner_fiber_impl`.
- The runner re-checks the claimed PR number and request candidacy immediately before `Forge.request_review`. Because the claim itself sets `review_request_inflight = true`, the re-check evaluates `Patch_agent.should_request_review` on a copy with only that inflight flag cleared, mirroring automerge's "ignore our own claim" pattern without changing the pure predicate API.
- Permanent request failures are classified as any GitHub HTTP 4xx, not only 403/422. They record the current head oid and clear inflight to avoid hot-looping on non-retryable request problems such as permissions, validation, or stale resource errors. Timeouts, transport errors, 5xx, JSON parse errors, and GraphQL errors clear inflight only and retry on a later tick.
- Spec/Evidence Mapping: configured-team request dispatch is `Runner_fiber_impl.reconcile_and_execute_review_requests` plus the `Env.review_team` fiber gate; no-team no-op is the `None -> ()` branch before spawning the fiber; at-most-once per head is `record_requested_and_clear_inflight` setting `review_requested_for_oid = Some head_oid` after `Ok` or permanent 4xx. Verified with `dune fmt`, `dune build`, and `dune runtest`.