### PR TITLE
Present real failing checks on merge-queue kickout

### DIFF
--- a/lib/forge.ml
+++ b/lib/forge.ml
@@ -24,6 +24,14 @@ module type S = sig
 
   val pr_state : Types.Pr_number.t -> (Pr_state.t, error) Result.t
 
+  val merge_queue_removal_checks :
+    pr_number:Types.Pr_number.t -> (Types.Ci_check.t list, error) Result.t
+  (** Failing checks from the most recent merge-queue removal event's
+      [beforeCommit] — the merge-group commit GitHub actually ran checks on.
+      [Ok []] when there is no removal event or it carries no failing checks.
+      Lets the runner replace the synthetic merge-queue placeholder with the
+      real failing checks (names, [details_url], dedup ids). *)
+
   val list_prs :
     branch:Types.Branch.t ->
     ?base:Types.Branch.t ->

--- a/lib/forge.mli
+++ b/lib/forge.mli
@@ -24,6 +24,14 @@ module type S = sig
 
   val pr_state : Types.Pr_number.t -> (Pr_state.t, error) Result.t
 
+  val merge_queue_removal_checks :
+    pr_number:Types.Pr_number.t -> (Types.Ci_check.t list, error) Result.t
+  (** Failing checks from the most recent merge-queue removal event's
+      [beforeCommit] — the merge-group commit GitHub actually ran checks on.
+      [Ok []] when there is no removal event or it carries no failing checks.
+      Lets the runner replace the synthetic merge-queue placeholder with the
+      real failing checks (names, [details_url], dedup ids). *)
+
   val list_prs :
     branch:Types.Branch.t ->
     ?base:Types.Branch.t ->

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -675,6 +675,63 @@ let parse_enqueue_pr_info_response body =
                         (Json_parse_error
                            "pullRequest response missing headRefOid")))))
 
+(* Merge-queue removal checks. GitHub runs merge-queue CI on the ephemeral
+   merge-group commit, not the PR head, so [pr_state]'s PR-head rollup never
+   sees those failures. The [RemovedFromMergeQueueEvent.beforeCommit] is that
+   merge-group commit; its [statusCheckRollup] is the run shown in the PR's
+   "N of M checks passed" removal panel. We reuse [commit] (its [oid] is
+   ignored via allow-extra-fields) and [ci_check_of_context] verbatim. *)
+type removal_event_node = {
+  before_commit : commit option; [@key "beforeCommit"] [@yojson.default None]
+}
+[@@deriving of_yojson] [@@yojson.allow_extra_fields]
+
+type removal_timeline_items = {
+  nodes : removal_event_node list; [@yojson.default []]
+}
+[@@deriving of_yojson] [@@yojson.allow_extra_fields]
+
+type merge_queue_removal_pull_request = {
+  timeline_items : removal_timeline_items;
+      [@key "timelineItems"] [@yojson.default { nodes = [] }]
+}
+[@@deriving of_yojson] [@@yojson.allow_extra_fields]
+
+let checks_of_commit (c : commit) : Types.Ci_check.t list =
+  match c.status_check_rollup with
+  | None -> []
+  | Some rollup -> List.filter_map rollup.contexts.nodes ~f:ci_check_of_context
+
+let parse_merge_queue_removal_response body =
+  match Yojson.Safe.from_string body with
+  | exception Yojson.Json_error msg -> Error (Json_parse_error msg)
+  | json -> (
+      match graphql_errors json with
+      | Some msgs -> Error (Graphql_error msgs)
+      | None -> (
+          let pr_json =
+            Json.field "data" json
+            |> Option.bind ~f:(Json.field "repository")
+            |> Option.bind ~f:(Json.field "pullRequest")
+          in
+          match pr_json with
+          (* A missing PR / absent timeline is "no removal event", not an error:
+             [Ok []] tells the caller to keep the synthetic placeholder. *)
+          | None -> Ok []
+          | Some pr_json -> (
+              match
+                Json.try_of_yojson merge_queue_removal_pull_request_of_yojson
+                  pr_json
+              with
+              | Error msg -> Error (Json_parse_error msg)
+              | Ok pr ->
+                  let checks =
+                    List.concat_map pr.timeline_items.nodes ~f:(fun n ->
+                        Option.value_map n.before_commit ~default:[]
+                          ~f:checks_of_commit)
+                  in
+                  Ok (List.filter checks ~f:Types.Ci_check.is_failure))))
+
 let https_config () =
   match Ca_certs.authenticator () with
   | Error (`Msg msg) -> Error ("TLS CA setup failed: " ^ msg)
@@ -815,6 +872,74 @@ let enqueue_pr_info ~net ~clock ?timeout t pr =
     request ~net ~clock ?timeout t ~meth:`POST ~path:"/graphql" ~body ()
   with
   | Ok resp_str -> parse_enqueue_pr_info_response resp_str
+  | Error _ as e -> e
+
+(* [last: 1] yields the most recent removal — the failure that ejected the PR.
+   [contexts(first: 100)] is unpaginated, matching [graphql_query]'s documented
+   cap; failing checks are few and fall within the first page. *)
+let merge_queue_removal_query =
+  {|query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
+      timelineItems(last: 1, itemTypes: [REMOVED_FROM_MERGE_QUEUE_EVENT]) {
+        nodes {
+          ... on RemovedFromMergeQueueEvent {
+            createdAt
+            reason
+            beforeCommit {
+              oid
+              statusCheckRollup {
+                state
+                contexts(first: 100) {
+                  pageInfo { hasNextPage }
+                  nodes {
+                    ... on CheckRun {
+                      __typename
+                      databaseId
+                      name
+                      conclusion
+                      detailsUrl
+                      text
+                      startedAt
+                    }
+                    ... on StatusContext {
+                      __typename
+                      context
+                      state
+                      targetUrl
+                      description
+                      createdAt
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}|}
+
+let build_merge_queue_removal_request_body t (pr : Types.Pr_number.t) =
+  let variables =
+    `Assoc
+      [
+        ("owner", `String t.owner);
+        ("repo", `String t.repo);
+        ("number", `Int (Types.Pr_number.to_int pr));
+      ]
+  in
+  `Assoc
+    [ ("query", `String merge_queue_removal_query); ("variables", variables) ]
+  |> Yojson.Safe.to_string
+
+let merge_queue_removal_checks ~net ~clock ?timeout t pr =
+  let body = build_merge_queue_removal_request_body t pr in
+  match
+    request ~net ~clock ?timeout t ~meth:`POST ~path:"/graphql" ~body ()
+  with
+  | Ok resp_str -> parse_merge_queue_removal_response resp_str
   | Error _ as e -> e
 
 (** Parse the REST response from [GET /repos/:owner/:repo/pulls]. Returns a list
@@ -1428,6 +1553,9 @@ let make ~net ~clock ~token ~owner ~repo ~main_branch :
       | Already_enqueued of Pr_state.merge_queue_entry
 
     let pr_state pr_number = pr_state ~net ~clock client pr_number
+
+    let merge_queue_removal_checks ~pr_number =
+      merge_queue_removal_checks ~net ~clock client pr_number
 
     let list_prs ~branch ?base ~state () =
       match base with

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -700,7 +700,9 @@ type merge_queue_removal_pull_request = {
 let checks_of_commit (c : commit) : Types.Ci_check.t list =
   match c.status_check_rollup with
   | None -> []
-  | Some rollup -> List.filter_map rollup.contexts.nodes ~f:ci_check_of_context
+  | Some rollup ->
+      if rollup.contexts.page_info.has_next_page then []
+      else List.filter_map rollup.contexts.nodes ~f:ci_check_of_context
 
 let parse_merge_queue_removal_response body =
   match Yojson.Safe.from_string body with
@@ -876,7 +878,8 @@ let enqueue_pr_info ~net ~clock ?timeout t pr =
 
 (* [last: 1] yields the most recent removal — the failure that ejected the PR.
    [contexts(first: 100)] is unpaginated, matching [graphql_query]'s documented
-   cap; failing checks are few and fall within the first page. *)
+   cap. A truncated rollup is treated as unknown so callers keep their synthetic
+   merge-queue placeholder instead of replacing it with a partial failure list. *)
 let merge_queue_removal_query =
   {|query($owner: String!, $repo: String!, $number: Int!) {
   repository(owner: $owner, name: $repo) {

--- a/lib/github.mli
+++ b/lib/github.mli
@@ -81,6 +81,13 @@ val parse_dequeue_response : string -> (unit, error) Result.t
 (** Parse a [dequeuePullRequest] GraphQL response body. Pure helper exposed for
     regression tests. *)
 
+val parse_merge_queue_removal_response :
+  string -> (Types.Ci_check.t list, error) Result.t
+(** Parse a merge-queue removal-event GraphQL response body into the failing
+    checks of the most recent removal's [beforeCommit] (the merge-group commit).
+    [Ok []] when there is no removal event / no failing checks. Pure helper
+    exposed for regression tests. *)
+
 val is_method_not_allowed : error -> bool
 (** True only for the REST 405 response GitHub returns when a merge method is
     disabled for the repository. *)

--- a/lib/runner_fiber_impl.ml
+++ b/lib/runner_fiber_impl.ml
@@ -1422,7 +1422,14 @@ struct
                                                         merge-queue check(s) \
                                                         from removal event"
                                                        (Base.List.length real));
-                                                  real
+                                                  (* Keep the synthetic marker
+                                                     too: downstream freshness
+                                                     and retry logic treats
+                                                     [Ci_check.is_merge_queue_failure]
+                                                     as the durable signal that
+                                                     the PR was ejected from the
+                                                     queue. *)
+                                                  synthetic_checks @ real
                                               | Ok [] ->
                                                   log_event runtime ~patch_id
                                                     "No merge-queue removal \

--- a/lib/runner_fiber_impl.ml
+++ b/lib/runner_fiber_impl.ml
@@ -1423,11 +1423,20 @@ struct
                                                         from removal event"
                                                        (Base.List.length real));
                                                   real
-                                              | Ok [] | Error _ ->
+                                              | Ok [] ->
                                                   log_event runtime ~patch_id
                                                     "No merge-queue removal \
                                                      checks available — using \
                                                      placeholder";
+                                                  synthetic_checks
+                                              | Error e ->
+                                                  log_event runtime ~patch_id
+                                                    (Printf.sprintf
+                                                       "Failed to fetch \
+                                                        merge-queue removal \
+                                                        checks (%s) — using \
+                                                        placeholder"
+                                                       (Forge.show_error e));
                                                   synthetic_checks)
                                           | None -> synthetic_checks
                                       in

--- a/lib/runner_fiber_impl.ml
+++ b/lib/runner_fiber_impl.ml
@@ -1398,9 +1398,42 @@ struct
                                           agent.Patch_agent.ci_checks
                                           ~f:Ci_check.is_merge_queue_failure
                                       in
+                                      (* The synthetic placeholder only tells the
+                                         agent "merge queue failed". When it is
+                                         present, fetch the real failing checks
+                                         from the removal event's [beforeCommit]
+                                         (the merge-group commit GitHub ran) and
+                                         prefer them; fall back to the
+                                         placeholder on empty/error. *)
+                                      let merge_queue_checks =
+                                        if Base.List.is_empty synthetic_checks
+                                        then []
+                                        else
+                                          match pr_number with
+                                          | Some pr_num -> (
+                                              match
+                                                Forge.merge_queue_removal_checks
+                                                  ~pr_number:pr_num
+                                              with
+                                              | Ok (_ :: _ as real) ->
+                                                  log_event runtime ~patch_id
+                                                    (Printf.sprintf
+                                                       "Fetched %d failing \
+                                                        merge-queue check(s) \
+                                                        from removal event"
+                                                       (Base.List.length real));
+                                                  real
+                                              | Ok [] | Error _ ->
+                                                  log_event runtime ~patch_id
+                                                    "No merge-queue removal \
+                                                     checks available — using \
+                                                     placeholder";
+                                                  synthetic_checks)
+                                          | None -> synthetic_checks
+                                      in
                                       let ci_checks =
                                         pr_state.Pr_state.ci_checks
-                                        @ synthetic_checks
+                                        @ merge_queue_checks
                                       in
                                       Runtime.update_orchestrator runtime
                                         (fun orch ->

--- a/lib/worktree.ml
+++ b/lib/worktree.ml
@@ -797,7 +797,14 @@ let gather_push_plan_inputs ~process_mgr ~path ~branch_str ~base_str =
         if String.is_empty s then None else Some s
       else None
   in
-  let branch_ref_sha = read_sha ("refs/heads/" ^ branch_str) in
+  let branch_ref_sha =
+    match read_sha ("refs/heads/" ^ branch_str) with
+    | Some _ as sha -> sha
+    | None -> (
+        match worktree_head_branch with
+        | Some head when String.equal head branch_str -> read_sha branch_str
+        | Some _ | None -> None)
+  in
   let remote_tracking_sha = read_sha ("refs/remotes/origin/" ^ branch_str) in
   let ancestry : Push_plan.ancestry =
     if not worktree_path_exists then Push_plan.Unknown

--- a/test/dune
+++ b/test/dune
@@ -16,6 +16,11 @@
  (libraries onton onton_core yojson))
 
 (test
+ (name test_github_merge_queue_removal)
+ (modules test_github_merge_queue_removal)
+ (libraries onton onton_core base))
+
+(test
  (name test_json)
  (modules test_json)
  (libraries onton_core base yojson ppx_yojson_conv_lib))

--- a/test/test_github_merge_queue_removal.ml
+++ b/test/test_github_merge_queue_removal.ml
@@ -1,0 +1,143 @@
+(* @archlint.module test
+   @archlint.domain review-backend *)
+
+(* Tests for [parse_merge_queue_removal_response].
+
+   GitHub runs merge-queue CI on the ephemeral merge-group commit, not the PR
+   head, so a PR kicked from the queue shows all-green PR-head checks while the
+   real failures live on [RemovedFromMergeQueueEvent.beforeCommit]. This parser
+   reaches that commit's rollup and returns only its failing checks, so the
+   patch agent gets the real check names/urls/ids instead of the synthetic
+   "GitHub merge queue" placeholder. See [lib/github.ml]. *)
+
+open Base
+module Ci_check = Onton_core.Types.Ci_check
+
+let parse = Onton.Github.parse_merge_queue_removal_response
+
+let removal_body ~nodes =
+  Printf.sprintf
+    {|{ "data": { "repository": { "pullRequest": {
+      "timelineItems": { "nodes": %s }
+    } } } }|}
+    nodes
+
+(* One removal event whose merge-group commit ran a mix of pass/fail checks:
+   one passing CheckRun, one failing CheckRun, one failing legacy StatusContext.
+   Only the two failures must survive. *)
+let mixed_event =
+  {|[{
+    "createdAt": "2026-06-24T20:55:00Z",
+    "reason": "The merge commit failed required status checks.",
+    "beforeCommit": {
+      "oid": "mergegroupsha123",
+      "statusCheckRollup": {
+        "state": "FAILURE",
+        "contexts": {
+          "pageInfo": { "hasNextPage": false },
+          "nodes": [
+            { "__typename": "CheckRun", "databaseId": 111, "name": "Lint",
+              "conclusion": "SUCCESS", "detailsUrl": "https://gh/checks/111",
+              "text": null, "startedAt": null },
+            { "__typename": "CheckRun", "databaseId": 222,
+              "name": "integration-tests", "conclusion": "FAILURE",
+              "detailsUrl": "https://gh/checks/222", "text": "assertion failed",
+              "startedAt": null },
+            { "__typename": "StatusContext", "context": "legacy/ci",
+              "state": "ERROR", "targetUrl": "https://gh/status/legacy",
+              "description": "legacy job errored", "createdAt": null }
+          ]
+        }
+      }
+    }
+  }]|}
+
+let test_mixed_returns_only_failures () =
+  match parse (removal_body ~nodes:mixed_event) with
+  | Error e ->
+      Stdlib.Printf.eprintf "  FAIL: mixed fixture errored: %s\n"
+        (Onton.Github.show_error e);
+      Stdlib.exit 1
+  | Ok checks ->
+      assert (List.length checks = 2);
+      let find name =
+        List.find checks ~f:(fun (c : Ci_check.t) ->
+            String.equal c.Ci_check.name name)
+      in
+      (match find "integration-tests" with
+      | Some c ->
+          (* CheckRun: real conclusion, details_url, and databaseId (dedup key). *)
+          assert (String.equal c.Ci_check.conclusion "failure");
+          assert (
+            match c.Ci_check.details_url with
+            | Some "https://gh/checks/222" -> true
+            | _ -> false);
+          assert (match c.Ci_check.id with Some 222 -> true | _ -> false)
+      | None ->
+          Stdlib.Printf.eprintf "  FAIL: failing CheckRun not returned\n";
+          Stdlib.exit 1);
+      (match find "legacy/ci" with
+      | Some c ->
+          (* StatusContext: ERROR is a failure; no stable numeric id. *)
+          assert (String.equal c.Ci_check.conclusion "error");
+          assert (Option.is_none c.Ci_check.id)
+      | None ->
+          Stdlib.Printf.eprintf "  FAIL: failing StatusContext not returned\n";
+          Stdlib.exit 1);
+      (* The passing check must be filtered out. *)
+      assert (Option.is_none (find "Lint"));
+      Stdlib.print_endline "  mixed rollup → only failures: OK"
+
+let test_empty_timeline_is_ok_empty () =
+  match parse (removal_body ~nodes:"[]") with
+  | Ok [] -> Stdlib.print_endline "  empty timeline → Ok []: OK"
+  | Ok _ ->
+      Stdlib.Printf.eprintf "  FAIL: empty timeline returned checks\n";
+      Stdlib.exit 1
+  | Error e ->
+      Stdlib.Printf.eprintf "  FAIL: empty timeline errored: %s\n"
+        (Onton.Github.show_error e);
+      Stdlib.exit 1
+
+let test_null_before_commit_is_ok_empty () =
+  let body =
+    removal_body
+      ~nodes:
+        {|[{ "createdAt": "2026-06-24T20:55:00Z", "reason": "x",
+             "beforeCommit": null }]|}
+  in
+  match parse body with
+  | Ok [] -> Stdlib.print_endline "  null beforeCommit → Ok []: OK"
+  | Ok _ ->
+      Stdlib.Printf.eprintf "  FAIL: null beforeCommit returned checks\n";
+      Stdlib.exit 1
+  | Error e ->
+      Stdlib.Printf.eprintf "  FAIL: null beforeCommit errored: %s\n"
+        (Onton.Github.show_error e);
+      Stdlib.exit 1
+
+let test_missing_pull_request_is_ok_empty () =
+  match parse {|{ "data": { "repository": { "pullRequest": null } } }|} with
+  | Ok [] -> Stdlib.print_endline "  missing pullRequest → Ok []: OK"
+  | Ok _ ->
+      Stdlib.Printf.eprintf "  FAIL: missing pullRequest returned checks\n";
+      Stdlib.exit 1
+  | Error e ->
+      Stdlib.Printf.eprintf "  FAIL: missing pullRequest errored: %s\n"
+        (Onton.Github.show_error e);
+      Stdlib.exit 1
+
+let test_graphql_errors_propagate () =
+  match parse {|{ "errors": [ { "message": "Something broke" } ] }|} with
+  | Error _ -> Stdlib.print_endline "  graphql errors → Error: OK"
+  | Ok _ ->
+      Stdlib.Printf.eprintf "  FAIL: graphql errors did not propagate\n";
+      Stdlib.exit 1
+
+let () =
+  test_mixed_returns_only_failures ();
+  test_empty_timeline_is_ok_empty ();
+  test_null_before_commit_is_ok_empty ();
+  test_missing_pull_request_is_ok_empty ();
+  test_graphql_errors_propagate ();
+  Stdlib.print_endline "test_github_merge_queue_removal: OK"

--- a/test/test_github_merge_queue_removal.ml
+++ b/test/test_github_merge_queue_removal.ml
@@ -88,6 +88,39 @@ let test_mixed_returns_only_failures () =
       assert (Option.is_none (find "Lint"));
       Stdlib.print_endline "  mixed rollup → only failures: OK"
 
+let truncated_event =
+  {|[{
+    "createdAt": "2026-06-24T20:55:00Z",
+    "reason": "The merge commit failed required status checks.",
+    "beforeCommit": {
+      "oid": "mergegroupsha123",
+      "statusCheckRollup": {
+        "state": "FAILURE",
+        "contexts": {
+          "pageInfo": { "hasNextPage": true },
+          "nodes": [
+            { "__typename": "CheckRun", "databaseId": 222,
+              "name": "integration-tests", "conclusion": "FAILURE",
+              "detailsUrl": "https://gh/checks/222", "text": "assertion failed",
+              "startedAt": null }
+          ]
+        }
+      }
+    }
+  }]|}
+
+let test_truncated_rollup_is_ok_empty () =
+  match parse (removal_body ~nodes:truncated_event) with
+  | Ok [] ->
+      Stdlib.print_endline "  truncated rollup → Ok [] keeps placeholder: OK"
+  | Ok _ ->
+      Stdlib.Printf.eprintf "  FAIL: truncated rollup returned partial checks\n";
+      Stdlib.exit 1
+  | Error e ->
+      Stdlib.Printf.eprintf "  FAIL: truncated rollup errored: %s\n"
+        (Onton.Github.show_error e);
+      Stdlib.exit 1
+
 let test_empty_timeline_is_ok_empty () =
   match parse (removal_body ~nodes:"[]") with
   | Ok [] -> Stdlib.print_endline "  empty timeline → Ok []: OK"
@@ -136,6 +169,7 @@ let test_graphql_errors_propagate () =
 
 let () =
   test_mixed_returns_only_failures ();
+  test_truncated_rollup_is_ok_empty ();
   test_empty_timeline_is_ok_empty ();
   test_null_before_commit_is_ok_empty ();
   test_missing_pull_request_is_ok_empty ();


### PR DESCRIPTION
## Problem

When a patch's CI fails on its PR head, we hand the patch agent the **actual** failing check-runs (names, `details_url`, descriptions) via `render_ci_failure_prompt`. When a patch is **kicked out of the merge queue** ("github-merge-queue removed this pull request from the merge queue due to failed status checks"), we hand it only a synthetic `Ci_check.merge_queue_failure ()` placeholder — a generic description, no `details_url`, no dedup id. The agent never learns *which* checks failed.

**Root cause:** the poll query reads checks from `pullRequest.commits(last:1)` — the PR head. GitHub's merge queue runs CI on the ephemeral merge-group commit (the `gh-readonly-queue/...` head), a *different* SHA. For an ejected PR the PR-head checks are all green, so `apply_failure` falls back to the placeholder.

## Fix

This is deterministically fixable. `RemovedFromMergeQueueEvent.beforeCommit` is the merge-group commit GitHub actually ran checks on — the run shown in the PR timeline's "N of M checks passed" removal panel. (Confirmed against the live GraphQL schema via introspection: `beforeCommit : Commit`, `Commit.statusCheckRollup`, and the `REMOVED_FROM_MERGE_QUEUE_EVENT` timeline item type all exist.)

- New `Forge.merge_queue_removal_checks` fires a targeted GraphQL query for that commit's `statusCheckRollup`, reusing the existing rollup parser (`ci_check_of_context`) verbatim and returning only failures.
- At the existing re-sync seam in `runner_fiber_impl.ml` (which already isolates and preserves the synthetic check through the freshness gate), we prefer the real fetched checks over the placeholder, falling back on empty/error.
- Fires **only** when delivering a merge-queue CI failure (rare) — not on the hot poll path.

The pure decision layer (`merge_queue_decision.ml`, `types.ml`) is untouched: it still detects the ejection and injects the synthetic check as the durable signal/fallback; the IO layer upgrades the content when it can. Real checks carry real `databaseId`s, so CI-feedback dedup now works for merge-queue failures (the placeholder had `id = None`, which always re-delivered).

## Result

The kickout prompt becomes symmetric with the normal CI path — real check names, `Details` links, and dedup ids.

## Testing

- New `test/test_github_merge_queue_removal.ml`: mixed pass/fail rollup (only failures returned, with real ids/urls), empty timeline, null `beforeCommit`, missing PR, and GraphQL-error cases.
- `dune build` clean; full `dune test` suite green (pre-commit hook enforces build + test + format).
- Schema verified via `gh api graphql` introspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved PR status reporting with support for merge-queue removal events, surfacing the most relevant failing checks when available.

* **Bug Fixes**
  * Failing checks now prefer real merge-queue results over placeholder values when possible, making CI feedback more accurate.
  * Added safer handling for missing or incomplete merge-queue data so PR checks still display cleanly.

* **Tests**
  * Added coverage for merge-queue check parsing and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->