### PR TITLE
Paginate statusCheckRollup.contexts to fix >100-checks merge deadlock

### DIFF
--- a/lib/github.ml
+++ b/lib/github.ml
@@ -1009,11 +1009,10 @@ let fetch_all_contexts ~net ~clock ?timeout t ~oid :
     (Types.Ci_check.t list, error) Result.t =
   let rec loop ~after ~page acc =
     if page >= max_context_pages then (
-      Stdlib.prerr_endline
-        (Printf.sprintf
-           "onton: statusCheckRollup contexts exceeded %d pages for commit %s \
-            — using partial list"
-           max_context_pages oid);
+      Eio.traceln
+        "onton: statusCheckRollup contexts exceeded %d pages for commit %s — \
+         using partial list"
+        max_context_pages oid;
       Ok (List.concat (List.rev acc)))
     else
       let body = build_contexts_request_body t ~oid ~after in

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -267,30 +267,34 @@ type context_node = {
 
 type page_info = {
   has_next_page : bool; [@key "hasNextPage"] [@yojson.default false]
+  end_cursor : string option; [@key "endCursor"] [@yojson.default None]
 }
 [@@deriving of_yojson] [@@yojson.allow_extra_fields]
 
 type contexts = {
   page_info : page_info;
-      [@key "pageInfo"] [@yojson.default { has_next_page = false }]
+      [@key "pageInfo"]
+      [@yojson.default { has_next_page = false; end_cursor = None }]
   nodes : context_node list; [@yojson.default []]
 }
 [@@deriving of_yojson] [@@yojson.allow_extra_fields]
 
 type status_check_rollup = {
   contexts : contexts;
-      [@yojson.default { page_info = { has_next_page = false }; nodes = [] }]
+      [@yojson.default
+        { page_info = { has_next_page = false; end_cursor = None }; nodes = [] }]
 }
 [@@deriving of_yojson] [@@yojson.allow_extra_fields]
 
 type commit = {
+  oid : string option; [@yojson.default None]
   status_check_rollup : status_check_rollup option;
       [@key "statusCheckRollup"] [@yojson.default None]
 }
 [@@deriving of_yojson] [@@yojson.allow_extra_fields]
 
 type commit_node = {
-  commit : commit; [@yojson.default { status_check_rollup = None }]
+  commit : commit; [@yojson.default { oid = None; status_check_rollup = None }]
 }
 [@@deriving of_yojson] [@@yojson.allow_extra_fields]
 
@@ -420,6 +424,128 @@ let ci_check_of_context (n : context_node) : Types.Ci_check.t option =
             id = None;
           })
   | Some _ | None -> None
+
+let graphql_errors json =
+  match Json.field "errors" json with
+  | None -> None
+  | Some errors_json -> (
+      match Json.list errors_json with
+      | Some [] -> None
+      | Some errors ->
+          Some (List.filter_map errors ~f:(Json.string_field "message"))
+      | None -> Some [])
+
+(* Paginated fetch of a commit's [statusCheckRollup.contexts], keyed by commit
+   OID via [repository.object]. The main poll query and the merge-queue-removal
+   query both cap contexts at [first: 100] and so go stale on PRs with >100
+   checks; this query (looped over [after:]) recovers the complete list. Keyed by
+   OID rather than re-traversing [commits(last:1)] / [timelineItems] so the same
+   loop serves both the PR-head commit and the ephemeral merge-group
+   [beforeCommit]. The node selection mirrors [graphql_query] verbatim. *)
+let contexts_by_oid_query =
+  {|query($owner: String!, $repo: String!, $oid: GitObjectID!, $after: String) {
+  repository(owner: $owner, name: $repo) {
+    object(oid: $oid) {
+      ... on Commit {
+        statusCheckRollup {
+          contexts(first: 100, after: $after) {
+            pageInfo { hasNextPage endCursor }
+            nodes {
+              ... on CheckRun {
+                __typename
+                databaseId
+                name
+                conclusion
+                detailsUrl
+                text
+                startedAt
+              }
+              ... on StatusContext {
+                __typename
+                context
+                state
+                targetUrl
+                description
+                createdAt
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}|}
+
+let build_contexts_request_body t ~oid ~after =
+  let variables =
+    `Assoc
+      [
+        ("owner", `String t.owner);
+        ("repo", `String t.repo);
+        ("oid", `String oid);
+        ("after", match after with Some c -> `String c | None -> `Null);
+      ]
+  in
+  `Assoc [ ("query", `String contexts_by_oid_query); ("variables", variables) ]
+  |> Yojson.Safe.to_string
+
+type contexts_commit = {
+  status_check_rollup : status_check_rollup option;
+      [@key "statusCheckRollup"] [@yojson.default None]
+}
+[@@deriving of_yojson] [@@yojson.allow_extra_fields]
+
+type contexts_repository = {
+  obj : contexts_commit option; [@key "object"] [@yojson.default None]
+}
+[@@deriving of_yojson] [@@yojson.allow_extra_fields]
+
+type contexts_data = {
+  repository : contexts_repository option; [@yojson.default None]
+}
+[@@deriving of_yojson] [@@yojson.allow_extra_fields]
+
+type contexts_response = { data : contexts_data option [@yojson.default None] }
+[@@deriving of_yojson] [@@yojson.allow_extra_fields]
+
+(* Parse one page of the [contexts_by_oid_query] response into its mapped checks
+   plus the [(has_next_page, end_cursor)] needed to drive pagination. A missing
+   object/rollup is a non-error empty page (the commit may be gc'd or carry no
+   rollup) — the loop simply stops. Pure; total on malformed input. *)
+let parse_contexts_page_json json :
+    (Types.Ci_check.t list * bool * string option, error) Result.t =
+  match graphql_errors json with
+  | Some msgs -> Error (Graphql_error msgs)
+  | None -> (
+      match Json.try_of_yojson contexts_response_of_yojson json with
+      | Error msg -> Error (Json_parse_error msg)
+      | Ok r ->
+          let contexts =
+            r.data
+            |> Option.bind ~f:(fun (d : contexts_data) -> d.repository)
+            |> Option.bind ~f:(fun (repo : contexts_repository) -> repo.obj)
+            |> Option.bind ~f:(fun (c : contexts_commit) ->
+                c.status_check_rollup)
+            |> Option.map ~f:(fun (rollup : status_check_rollup) ->
+                rollup.contexts)
+          in
+          let checks =
+            match contexts with
+            | None -> []
+            | Some ctx -> List.filter_map ctx.nodes ~f:ci_check_of_context
+          in
+          let has_next_page, end_cursor =
+            match contexts with
+            | None -> (false, None)
+            | Some ctx -> (ctx.page_info.has_next_page, ctx.page_info.end_cursor)
+          in
+          Ok (checks, has_next_page, end_cursor))
+
+let parse_contexts_page body :
+    (Types.Ci_check.t list * bool * string option, error) Result.t =
+  match Yojson.Safe.from_string body with
+  | exception Yojson.Json_error msg -> Error (Json_parse_error msg)
+  | json -> parse_contexts_page_json json
 
 let comment_of_node ~thread_id ~outdated (n : comment_node) : Types.Comment.t =
   let id =
@@ -565,16 +691,6 @@ let parse_response ~owner body =
   try parse_response_json ~owner (Yojson.Safe.from_string body)
   with Yojson.Json_error msg -> Error (Json_parse_error msg)
 
-let graphql_errors json =
-  match Json.field "errors" json with
-  | None -> None
-  | Some errors_json -> (
-      match Json.list errors_json with
-      | Some [] -> None
-      | Some errors ->
-          Some (List.filter_map errors ~f:(Json.string_field "message"))
-      | None -> Some [])
-
 let merge_queue_entry_field ~context json =
   match json with
   | None -> Error (Json_parse_error (context ^ " missing mergeQueueEntry"))
@@ -679,8 +795,9 @@ let parse_enqueue_pr_info_response body =
    merge-group commit, not the PR head, so [pr_state]'s PR-head rollup never
    sees those failures. The [RemovedFromMergeQueueEvent.beforeCommit] is that
    merge-group commit; its [statusCheckRollup] is the run shown in the PR's
-   "N of M checks passed" removal panel. We reuse [commit] (its [oid] is
-   ignored via allow-extra-fields) and [ci_check_of_context] verbatim. *)
+   "N of M checks passed" removal panel. We reuse [commit] (capturing its [oid]
+   so a truncated rollup can be re-fetched by OID) and [ci_check_of_context]
+   verbatim. *)
 type removal_event_node = {
   before_commit : commit option; [@key "beforeCommit"] [@yojson.default None]
 }
@@ -733,6 +850,46 @@ let parse_merge_queue_removal_response body =
                           ~f:checks_of_commit)
                   in
                   Ok (List.filter checks ~f:Types.Ci_check.is_failure))))
+
+(* Detect a {e truncated} merge-group rollup and surface the [beforeCommit] OID
+   so the I/O layer can paginate it (mirrors the [pr_state] truncation handling).
+   [parse_merge_queue_removal_response] returns [Ok []] on truncation — correct
+   for a pure parser that only sees page 1 — and this companion tells the wrapper
+   when that empty result is hiding more pages. [Some oid] only when the latest
+   removal event's rollup reports [hasNextPage] and carries an OID; [None]
+   otherwise (no event, complete rollup, missing OID, or malformed body). Pure;
+   total on malformed input. *)
+let parse_merge_queue_removal_pagination body : string option =
+  match Yojson.Safe.from_string body with
+  | exception Yojson.Json_error _ -> None
+  | json -> (
+      match graphql_errors json with
+      | Some _ -> None
+      | None -> (
+          let pr_json =
+            Json.field "data" json
+            |> Option.bind ~f:(Json.field "repository")
+            |> Option.bind ~f:(Json.field "pullRequest")
+          in
+          match pr_json with
+          | None -> None
+          | Some pr_json -> (
+              match
+                Json.try_of_yojson merge_queue_removal_pull_request_of_yojson
+                  pr_json
+              with
+              | Error _ -> None
+              | Ok pr ->
+                  List.find_map pr.timeline_items.nodes ~f:(fun n ->
+                      match n.before_commit with
+                      | None -> None
+                      | Some c ->
+                          let truncated =
+                            Option.value_map c.status_check_rollup
+                              ~default:false ~f:(fun rollup ->
+                                rollup.contexts.page_info.has_next_page)
+                          in
+                          if truncated then c.oid else None))))
 
 let https_config () =
   match Ca_certs.authenticator () with
@@ -837,13 +994,73 @@ let check_repo_access_internal ~net ~clock ?timeout t =
   | Ok _ -> Ok ()
   | Error _ as e -> e
 
+(* Runaway guard: at 100 contexts/page this caps a single rollup at 2500 checks,
+   far above any real PR while bounding the request count if GitHub ever returns
+   a non-terminating cursor. *)
+let max_context_pages = 25
+
+(* Fetch every page of a commit's [statusCheckRollup.contexts], following the
+   [endCursor] until exhausted, and return the complete mapped check list. Only
+   invoked on the rare truncated rollup (>100 contexts); the first page is
+   re-fetched here too, trading one extra request for not threading the first
+   query's cursor through [Pr_state.t]. Any request/parse error aborts and is
+   propagated so callers can fall back to their conservative behavior. *)
+let fetch_all_contexts ~net ~clock ?timeout t ~oid :
+    (Types.Ci_check.t list, error) Result.t =
+  let rec loop ~after ~page acc =
+    if page >= max_context_pages then (
+      Stdlib.prerr_endline
+        (Printf.sprintf
+           "onton: statusCheckRollup contexts exceeded %d pages for commit %s \
+            — using partial list"
+           max_context_pages oid);
+      Ok (List.concat (List.rev acc)))
+    else
+      let body = build_contexts_request_body t ~oid ~after in
+      match
+        request ~net ~clock ?timeout t ~meth:`POST ~path:"/graphql" ~body ()
+      with
+      | Error _ as e -> e
+      | Ok resp_str -> (
+          match parse_contexts_page resp_str with
+          | Error _ as e -> e
+          | Ok (checks, has_next_page, end_cursor) -> (
+              let acc = checks :: acc in
+              match (has_next_page, end_cursor) with
+              | true, (Some _ as cursor) ->
+                  loop ~after:cursor ~page:(page + 1) acc
+              (* hasNextPage with no cursor would loop forever — stop with what we
+                 have rather than spin. *)
+              | true, None | false, _ -> Ok (List.concat (List.rev acc))))
+  in
+  loop ~after:None ~page:0 []
+
 let pr_state ~net ~clock ?timeout t pr =
   let body = build_request_body t pr in
   match
     request ~net ~clock ?timeout t ~meth:`POST ~path:"/graphql" ~body ()
   with
-  | Ok resp_str -> parse_response ~owner:t.owner resp_str
   | Error _ as e -> e
+  | Ok resp_str -> (
+      match parse_response ~owner:t.owner resp_str with
+      | Error _ as e -> e
+      | Ok state -> (
+          if
+            (* The first-page rollup was complete: trust it as-is. *)
+            not state.Pr_state.ci_checks_truncated
+          then Ok state
+          else
+            (* >100 contexts: the parser conservatively downgraded a passing
+               rollup to Pending. Paginate the full set and re-derive. On a
+               missing head OID or any pagination failure, keep the conservative
+               state — identical to pre-pagination behavior, never worse. *)
+            match state.Pr_state.head_oid with
+            | None -> Ok state
+            | Some oid -> (
+                match fetch_all_contexts ~net ~clock ?timeout t ~oid with
+                | Error _ -> Ok state
+                | Ok all_checks ->
+                    Ok (Pr_state.with_resolved_checks state ~all_checks))))
 
 let enqueue_info_query =
   {|query($owner: String!, $repo: String!, $number: Int!) {
@@ -877,9 +1094,11 @@ let enqueue_pr_info ~net ~clock ?timeout t pr =
   | Error _ as e -> e
 
 (* [last: 1] yields the most recent removal — the failure that ejected the PR.
-   [contexts(first: 100)] is unpaginated, matching [graphql_query]'s documented
-   cap. A truncated rollup is treated as unknown so callers keep their synthetic
-   merge-queue placeholder instead of replacing it with a partial failure list. *)
+   [contexts(first: 100)] fetches the first page; on a truncated rollup (>100
+   contexts) [merge_queue_removal_checks] re-fetches the complete list by
+   [beforeCommit] OID via [fetch_all_contexts], so a merge-group with many checks
+   still surfaces its real failures instead of falling back to the synthetic
+   placeholder. *)
 let merge_queue_removal_query =
   {|query($owner: String!, $repo: String!, $number: Int!) {
   repository(owner: $owner, name: $repo) {
@@ -942,8 +1161,20 @@ let merge_queue_removal_checks ~net ~clock ?timeout t pr =
   match
     request ~net ~clock ?timeout t ~meth:`POST ~path:"/graphql" ~body ()
   with
-  | Ok resp_str -> parse_merge_queue_removal_response resp_str
   | Error _ as e -> e
+  | Ok resp_str -> (
+      match parse_merge_queue_removal_pagination resp_str with
+      (* Complete first page (or no event): the pure parser already has the full
+         failure list. *)
+      | None -> parse_merge_queue_removal_response resp_str
+      (* >100 contexts on the merge-group commit: paginate by OID and filter to
+         failures over the complete set. On any pagination failure, fall back to
+         the pure parser (which returns [Ok []] for the truncated case), keeping
+         the synthetic placeholder rather than a partial list. *)
+      | Some oid -> (
+          match fetch_all_contexts ~net ~clock ?timeout t ~oid with
+          | Ok all -> Ok (List.filter all ~f:Types.Ci_check.is_failure)
+          | Error _ -> parse_merge_queue_removal_response resp_str))
 
 (** Parse the REST response from [GET /repos/:owner/:repo/pulls]. Returns a list
     of [(pr_number, base_branch, merged)] for non-CLOSED PRs, newest first. Pure

--- a/lib/github.mli
+++ b/lib/github.mli
@@ -88,6 +88,20 @@ val parse_merge_queue_removal_response :
     [Ok []] when there is no removal event / no failing checks. Pure helper
     exposed for regression tests. *)
 
+val parse_contexts_page :
+  string -> (Types.Ci_check.t list * bool * string option, error) Result.t
+(** Parse one page of the OID-keyed [statusCheckRollup.contexts] pagination
+    query into [(checks, has_next_page, end_cursor)]. A missing object/rollup
+    yields an empty page with [has_next_page = false]. Pure helper exposed for
+    regression tests. *)
+
+val parse_merge_queue_removal_pagination : string -> string option
+(** [Some oid] when the latest merge-queue removal event's [beforeCommit] rollup
+    is truncated ([hasNextPage]) and carries an OID — the signal that
+    [parse_merge_queue_removal_response]'s [Ok []] is hiding further pages that
+    the caller should paginate by OID. [None] otherwise. Pure helper exposed for
+    regression tests. *)
+
 val is_method_not_allowed : error -> bool
 (** True only for the REST 405 response GitHub returns when a merge method is
     disabled for the repository. *)

--- a/lib_core/pr_state.ml
+++ b/lib_core/pr_state.ml
@@ -167,6 +167,33 @@ let derive_check_status (checks : Types.Ci_check.t list) : check_status =
   then Passing
   else Pending
 
+(** Recompute the rollup-derived fields after the {e complete} (paginated) check
+    list is known. The poll query fetches only the first page of
+    [statusCheckRollup.contexts]; when that page is truncated the parser
+    conservatively downgrades a derived [Passing] to [Pending] (it cannot prove
+    page 2+ also passes). Once the effectful layer has fetched every page it
+    calls this with the full list to replace that conservative verdict with the
+    real one — [check_status] re-derived over [all_checks], [merge_ready]
+    re-derived from it, and [ci_checks_truncated] cleared.
+
+    [merge_ready_divergence] is intentionally left untouched: it is
+    diagnostics-only (logged once, never a decision input, never persisted) and
+    recomputing it would require the raw [mergeStateStatus], which is not
+    carried on [t]. *)
+let with_resolved_checks (st : t) ~(all_checks : Types.Ci_check.t list) : t =
+  let check_status = derive_check_status all_checks in
+  let merge_ready =
+    merge_ready_of ~merge_state:st.merge_state ~check_status
+      ~review_decision:st.review_decision
+  in
+  {
+    st with
+    ci_checks = all_checks;
+    ci_checks_truncated = false;
+    check_status;
+    merge_ready;
+  }
+
 (* -- review_blocking -- *)
 
 let%test "review_blocking: REVIEW_REQUIRED blocks" =
@@ -331,3 +358,93 @@ let%test "divergence: exhaustive spec agreement" =
                     String.equal d.github_merge_state_status status
                     && Bool.equal d.derived_merge_ready merge_ready
                 | None -> false)))
+
+(* -- with_resolved_checks -- *)
+
+let check ~conclusion : Types.Ci_check.t =
+  {
+    Types.Ci_check.name = "c";
+    conclusion;
+    details_url = None;
+    description = None;
+    started_at = None;
+    id = None;
+  }
+
+(* A truncated, conservatively-Pending state: the first page was all-passing but
+   [ci_checks_truncated] forced [check_status = Pending] and [merge_ready =
+   false] upstream. This is the wedged shape [with_resolved_checks] must undo. *)
+let truncated_pending_state : t =
+  {
+    status = Open;
+    is_draft = false;
+    merge_state = Mergeable;
+    merge_ready = false;
+    merge_ready_divergence = None;
+    review_decision = None;
+    check_status = Pending;
+    ci_checks = [ check ~conclusion:"success" ];
+    ci_checks_truncated = true;
+    comments = [];
+    unresolved_comment_count = 0;
+    findings = [];
+    node_id = None;
+    merge_queue_required = false;
+    merge_queue_entry = None;
+    head_branch = None;
+    head_oid = Some "deadbeef";
+    merge_commit_sha = None;
+    base_branch = None;
+    is_fork = false;
+  }
+
+let%test "with_resolved_checks: all-passing full set recovers Passing + ready" =
+  let all = List.init 102 ~f:(fun _ -> check ~conclusion:"success") in
+  let st = with_resolved_checks truncated_pending_state ~all_checks:all in
+  equal_check_status st.check_status Passing
+  && st.merge_ready
+  && (not st.ci_checks_truncated)
+  && List.length st.ci_checks = 102
+
+let%test "with_resolved_checks: neutral/skipped count as passing" =
+  let all =
+    [
+      check ~conclusion:"success";
+      check ~conclusion:"skipped";
+      check ~conclusion:"neutral";
+    ]
+  in
+  let st = with_resolved_checks truncated_pending_state ~all_checks:all in
+  equal_check_status st.check_status Passing && st.merge_ready
+
+let%test
+    "with_resolved_checks: a failure on a later page stays Failing + not ready"
+    =
+  let all =
+    check ~conclusion:"failure"
+    :: List.init 50 ~f:(fun _ -> check ~conclusion:"success")
+  in
+  let st = with_resolved_checks truncated_pending_state ~all_checks:all in
+  equal_check_status st.check_status Failing && not st.merge_ready
+
+let%test "with_resolved_checks: a still-running check keeps Pending + not ready"
+    =
+  let all =
+    check ~conclusion:"pending"
+    :: List.init 50 ~f:(fun _ -> check ~conclusion:"success")
+  in
+  let st = with_resolved_checks truncated_pending_state ~all_checks:all in
+  equal_check_status st.check_status Pending && not st.merge_ready
+
+let%test "with_resolved_checks: a blocking review still gates readiness" =
+  let all = [ check ~conclusion:"success" ] in
+  let st =
+    with_resolved_checks
+      { truncated_pending_state with review_decision = Some "REVIEW_REQUIRED" }
+      ~all_checks:all
+  in
+  equal_check_status st.check_status Passing && not st.merge_ready
+
+let%test "with_resolved_checks: always clears the truncated flag" =
+  let st = with_resolved_checks truncated_pending_state ~all_checks:[] in
+  not st.ci_checks_truncated

--- a/lib_core/pr_state.mli
+++ b/lib_core/pr_state.mli
@@ -101,6 +101,14 @@ val derive_check_status : Ci_check.t list -> check_status
     independent of GitHub's [statusCheckRollup.state] (which treats cancelled
     runs as FAILURE). See implementation for exact semantics. *)
 
+val with_resolved_checks : t -> all_checks:Ci_check.t list -> t
+(** Recompute the rollup-derived fields ([check_status], [merge_ready],
+    [ci_checks], [ci_checks_truncated]) from the {e complete} paginated check
+    list. The effectful layer calls this after fetching every page of
+    [statusCheckRollup.contexts] to replace the conservative
+    truncated-page-downgrade ([Passing] forced to [Pending]) with the real
+    verdict. [merge_ready_divergence] is left untouched (diagnostics-only). *)
+
 val review_blocking : string option -> bool
 (** [true] when a GitHub [reviewDecision] blocks merging
     ([REVIEW_REQUIRED]/[CHANGES_REQUESTED]). [APPROVED] and [None] (no review

--- a/test/test_github_merge_queue_removal.ml
+++ b/test/test_github_merge_queue_removal.ml
@@ -167,6 +167,93 @@ let test_graphql_errors_propagate () =
       Stdlib.Printf.eprintf "  FAIL: graphql errors did not propagate\n";
       Stdlib.exit 1
 
+(* -- parse_merge_queue_removal_pagination -- *)
+
+let paginate = Onton.Github.parse_merge_queue_removal_pagination
+
+(* A truncated merge-group rollup must surface its beforeCommit OID so the I/O
+   layer knows the [Ok []] from [parse] is hiding more pages. *)
+let test_pagination_detects_truncated_oid () =
+  match paginate (removal_body ~nodes:truncated_event) with
+  | Some "mergegroupsha123" ->
+      Stdlib.print_endline "  truncated rollup → Some oid: OK"
+  | _ ->
+      Stdlib.Printf.eprintf "  FAIL: truncated rollup did not surface oid\n";
+      Stdlib.exit 1
+
+(* A complete rollup (hasNextPage:false) needs no pagination → None. *)
+let test_pagination_none_when_complete () =
+  match paginate (removal_body ~nodes:mixed_event) with
+  | None -> Stdlib.print_endline "  complete rollup → None: OK"
+  | Some _ ->
+      Stdlib.Printf.eprintf "  FAIL: complete rollup asked for pagination\n";
+      Stdlib.exit 1
+
+let test_pagination_none_when_empty () =
+  match paginate (removal_body ~nodes:"[]") with
+  | None -> Stdlib.print_endline "  empty timeline → None: OK"
+  | Some _ ->
+      Stdlib.Printf.eprintf "  FAIL: empty timeline asked for pagination\n";
+      Stdlib.exit 1
+
+(* -- parse_contexts_page -- *)
+
+let parse_page = Onton.Github.parse_contexts_page
+
+let contexts_page_body ~has_next ~cursor ~nodes =
+  Printf.sprintf
+    {|{ "data": { "repository": { "object": {
+      "statusCheckRollup": { "contexts": {
+        "pageInfo": { "hasNextPage": %b, "endCursor": %s },
+        "nodes": %s
+      } } } } } }|}
+    has_next cursor nodes
+
+let test_contexts_page_parses_checks_and_cursor () =
+  let nodes =
+    {|[
+      { "__typename": "CheckRun", "databaseId": 1, "name": "build",
+        "conclusion": "SUCCESS", "detailsUrl": null, "text": null,
+        "startedAt": null },
+      { "__typename": "StatusContext", "context": "legacy",
+        "state": "FAILURE", "targetUrl": null, "description": null,
+        "createdAt": null }
+    ]|}
+  in
+  match
+    parse_page (contexts_page_body ~has_next:true ~cursor:{|"CURSOR2"|} ~nodes)
+  with
+  | Ok (checks, true, Some "CURSOR2") when List.length checks = 2 ->
+      Stdlib.print_endline "  contexts page → checks + next cursor: OK"
+  | Ok _ ->
+      Stdlib.Printf.eprintf "  FAIL: contexts page parsed wrong shape\n";
+      Stdlib.exit 1
+  | Error e ->
+      Stdlib.Printf.eprintf "  FAIL: contexts page errored: %s\n"
+        (Onton.Github.show_error e);
+      Stdlib.exit 1
+
+(* A missing object (gc'd commit / no rollup) is a non-error terminal page. *)
+let test_contexts_page_missing_object_is_terminal () =
+  match parse_page {|{ "data": { "repository": { "object": null } } }|} with
+  | Ok ([], false, None) ->
+      Stdlib.print_endline "  missing object → empty terminal page: OK"
+  | Ok _ ->
+      Stdlib.Printf.eprintf
+        "  FAIL: missing object returned non-terminal page\n";
+      Stdlib.exit 1
+  | Error e ->
+      Stdlib.Printf.eprintf "  FAIL: missing object errored: %s\n"
+        (Onton.Github.show_error e);
+      Stdlib.exit 1
+
+let test_contexts_page_graphql_errors_propagate () =
+  match parse_page {|{ "errors": [ { "message": "boom" } ] }|} with
+  | Error _ -> Stdlib.print_endline "  contexts page graphql errors → Error: OK"
+  | Ok _ ->
+      Stdlib.Printf.eprintf "  FAIL: contexts page swallowed graphql errors\n";
+      Stdlib.exit 1
+
 let () =
   test_mixed_returns_only_failures ();
   test_truncated_rollup_is_ok_empty ();
@@ -174,4 +261,10 @@ let () =
   test_null_before_commit_is_ok_empty ();
   test_missing_pull_request_is_ok_empty ();
   test_graphql_errors_propagate ();
+  test_pagination_detects_truncated_oid ();
+  test_pagination_none_when_complete ();
+  test_pagination_none_when_empty ();
+  test_contexts_page_parses_checks_and_cursor ();
+  test_contexts_page_missing_object_is_terminal ();
+  test_contexts_page_graphql_errors_propagate ();
   Stdlib.print_endline "test_github_merge_queue_removal: OK"

--- a/test/test_pr_state_properties.ml
+++ b/test/test_pr_state_properties.ml
@@ -168,6 +168,56 @@ let prop_derive_check_status =
       if has_failure then Pr_state.equal_check_status result Pr_state.Failing
       else Pr_state.equal_check_status result Pr_state.Passing)
 
+let prop_with_resolved_checks =
+  QCheck2.Test.make
+    ~name:"with_resolved_checks replaces checks and recomputes derived fields"
+    ~count:300
+    QCheck2.Gen.(
+      triple gen_merge_state gen_check_status
+        (list_size (int_range 0 6)
+           (oneof_list
+              [
+                "success";
+                "skipped";
+                "neutral";
+                "failure";
+                "error";
+                "cancelled";
+                "in_progress";
+              ])))
+    (fun (merge_state, initial_check_status, conclusions) ->
+      let all_checks = List.map (fun c -> gen_ci_check c) conclusions in
+      let divergence =
+        Some
+          {
+            Pr_state.github_merge_state_status = "BLOCKED";
+            derived_merge_ready = true;
+          }
+      in
+      let st =
+        {
+          base with
+          Pr_state.merge_state;
+          review_decision = Some "APPROVED";
+          check_status = initial_check_status;
+          ci_checks = [ gen_ci_check "cancelled" ];
+          ci_checks_truncated = true;
+          merge_ready = false;
+          merge_ready_divergence = divergence;
+        }
+      in
+      let result = Pr_state.with_resolved_checks st ~all_checks in
+      let expected_check_status = Pr_state.derive_check_status all_checks in
+      result.Pr_state.ci_checks = all_checks
+      && (not result.Pr_state.ci_checks_truncated)
+      && Pr_state.equal_check_status result.Pr_state.check_status
+           expected_check_status
+      && Bool.equal result.Pr_state.merge_ready
+           (Pr_state.merge_ready_of ~merge_state
+              ~check_status:expected_check_status
+              ~review_decision:st.Pr_state.review_decision)
+      && result.Pr_state.merge_ready_divergence = divergence)
+
 (* merge_ready_divergence_of: Some iff a status was reported and the verdicts
    disagree (github_ready = status="CLEAN"). *)
 let prop_merge_ready_divergence =
@@ -201,4 +251,5 @@ let () =
   QCheck2.Test.check_exn prop_no_unresolved_comments;
   QCheck2.Test.check_exn prop_merge_queue_predicates;
   QCheck2.Test.check_exn prop_derive_check_status;
+  QCheck2.Test.check_exn prop_with_resolved_checks;
   QCheck2.Test.check_exn prop_merge_ready_divergence

--- a/test/test_worktree_setup_base_fetch_integration.ml
+++ b/test/test_worktree_setup_base_fetch_integration.ml
@@ -85,6 +85,31 @@ let assert_string label want got =
   if not (String.equal want got) then
     failwith (Printf.sprintf "%s: expected %S got %S" label want got)
 
+let remote_head_sha ~dir ~ref_name =
+  match
+    git_capture ~dir [ "ls-remote"; "origin"; "refs/heads/" ^ ref_name ]
+    |> String.lsplit2 ~on:'\t'
+  with
+  | Some (sha, _) when not (String.is_empty sha) -> Some sha
+  | _ -> None
+
+let wait_for_remote_head ~dir ~ref_name ~sha =
+  let rec loop attempts_left =
+    match remote_head_sha ~dir ~ref_name with
+    | Some visible when String.equal visible sha -> visible
+    | _ when attempts_left > 0 ->
+        Unix.sleepf 0.05;
+        loop (attempts_left - 1)
+    | Some visible ->
+        failwith
+          (Printf.sprintf
+             "remote %s did not advertise pushed tip: expected %S got %S"
+             ref_name sha visible)
+    | None ->
+        failwith (Printf.sprintf "remote %s did not advertise any tip" ref_name)
+  in
+  loop 40
+
 let mk_patch ~pid ~branch =
   Types.Patch.
     {
@@ -173,7 +198,10 @@ let scenario_stale_local_main env =
   sh ~dir:writer_dir "git add dep.txt";
   sh ~dir:writer_dir "git commit -q -m 'dep squash'";
   sh ~dir:writer_dir "git push -q origin main";
-  let origin_tip = git_capture ~dir:writer_dir [ "rev-parse"; "main" ] in
+  let pushed_tip = git_capture ~dir:writer_dir [ "rev-parse"; "main" ] in
+  let origin_tip =
+    wait_for_remote_head ~dir:managed_dir ~ref_name:"main" ~sha:pushed_tip
+  in
   assert_string "precondition: local main is stale" clone_time_main
     (git_capture ~dir:managed_dir [ "rev-parse"; "main" ]);
   let wt =


### PR DESCRIPTION
## Problem

A PR with **more than 100 CI check contexts** wedges forever in `awaiting feedback` even when it is genuinely mergeable, all checks pass, and no review is outstanding.

Root cause: the poll query fetches only `statusCheckRollup { contexts(first: 100) }` (`lib/github.ml`) and never paginates. In `pr_state_of_pull_request`, when the connection reports `hasNextPage` (`truncated`), a derived `Passing` is downgraded to `Pending` ("never approve a merge that might fail on page 2+"). Since nothing ever fetches page 2+, any PR with >100 contexts is permanently `Pending` → persisted `checks_passing = false` / `merge_ready = false` → `is_automerge_candidate` is never satisfied → `display_status.derive` returns `Awaiting_feedback` indefinitely.

Observed live on a real PR with 102 contexts (`mergeable: MERGEABLE`, `reviewDecision: null`, rollup `state: SUCCESS`).

The same unpaginated `contexts(first: 100)` cap also exists on the merge-queue-removal path (`checks_of_commit` returned `[]` on truncation) — identical bug class, fixed here too.

## Fix

Paginate the rollup contexts **by commit OID** via `repository.object(oid:)`, following `endCursor` to completion, then re-derive the aggregate status over the complete list. Keying by OID lets a single helper serve both the PR-head rollup and the merge-group `beforeCommit` rollup.

- **`lib_core/pr_state.ml`** — pure `with_resolved_checks` recomputes `check_status` / `merge_ready` / `ci_checks` and clears `ci_checks_truncated` from the full paginated list. `merge_ready_divergence` left untouched (diagnostics-only).
- **`lib/github.ml`** — `page_info.end_cursor` + `commit.oid`; `contexts_by_oid_query` + `fetch_all_contexts` (page-capped loop); `pr_state` paginates when truncated, with a conservative fallback (unchanged behavior) on missing OID / pagination error; merge-queue-removal path paginates via new `parse_merge_queue_removal_pagination`.
- Regression tests for `parse_contexts_page` and the removal pagination helper; inline tests for `with_resolved_checks`.

The truncation downgrade remains as the safety fallback for the OID-missing / pagination-error paths, so behavior is never worse than today.

## Effect on the stuck case

After this ships and the orchestrator restarts, the next poll fetches all contexts, derives the real `Passing`, flips `checks_passing`/`merge_ready` true, and the PR leaves `awaiting feedback` and proceeds to automerge. The persisted snapshot is corrected by that poll (not hand-edited).

## Testing

`dune build`, `dune runtest`, `dune fmt` all clean. Pre-commit hook (build + test + format) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/380"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785009948&installation_id=126163856&pr_number=380&repository=flowglad%2Fonton&return_to=https%3A%2F%2Fgithub.com%2Fflowglad%2Fonton%2Fpull%2F380&signature=4a0c5a413d022673af7aedf0fc5f0e3cc26065019e768e118527bb2c5aff2049"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->