### PR TITLE
Surface merge queue Actions check ids

### DIFF
--- a/lib/forge.ml
+++ b/lib/forge.ml
@@ -28,9 +28,11 @@ module type S = sig
     pr_number:Types.Pr_number.t -> (Types.Ci_check.t list, error) Result.t
   (** Failing checks from the most recent merge-queue removal event's
       [beforeCommit] — the merge-group commit GitHub actually ran checks on.
-      [Ok []] when there is no removal event or it carries no failing checks.
-      Lets the runner replace the synthetic merge-queue placeholder with the
-      real failing checks (names, [details_url], dedup ids). *)
+      Implementations may fall back to the matching [merge_group] Actions run
+      when the removal event omits the failing rollup. [Ok []] when no source
+      carries failing checks. Lets the runner replace the synthetic merge-queue
+      placeholder with the real failing checks (names, [details_url], dedup
+      ids). *)
 
   val list_prs :
     branch:Types.Branch.t ->

--- a/lib/forge.mli
+++ b/lib/forge.mli
@@ -28,9 +28,11 @@ module type S = sig
     pr_number:Types.Pr_number.t -> (Types.Ci_check.t list, error) Result.t
   (** Failing checks from the most recent merge-queue removal event's
       [beforeCommit] — the merge-group commit GitHub actually ran checks on.
-      [Ok []] when there is no removal event or it carries no failing checks.
-      Lets the runner replace the synthetic merge-queue placeholder with the
-      real failing checks (names, [details_url], dedup ids). *)
+      Implementations may fall back to the matching [merge_group] Actions run
+      when the removal event omits the failing rollup. [Ok []] when no source
+      carries failing checks. Lets the runner replace the synthetic merge-queue
+      placeholder with the real failing checks (names, [details_url], dedup
+      ids). *)
 
   val list_prs :
     branch:Types.Branch.t ->

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -891,6 +891,85 @@ let parse_merge_queue_removal_pagination body : string option =
                           in
                           if truncated then c.oid else None))))
 
+type actions_workflow_run = {
+  database_id : int option; [@key "id"] [@yojson.default None]
+  event : string option; [@yojson.default None]
+  head_branch : string option; [@key "head_branch"] [@yojson.default None]
+  status : string option; [@yojson.default None]
+  conclusion : string option; [@yojson.default None]
+}
+[@@deriving of_yojson] [@@yojson.allow_extra_fields]
+
+type actions_runs_response = {
+  workflow_runs : actions_workflow_run list;
+      [@key "workflow_runs"] [@yojson.default []]
+}
+[@@deriving of_yojson] [@@yojson.allow_extra_fields]
+
+let merge_group_branch_prefix ~main_branch ~pr_number =
+  Printf.sprintf "gh-readonly-queue/%s/pr-%d-"
+    (Types.Branch.to_string main_branch)
+    (Types.Pr_number.to_int pr_number)
+
+let parse_merge_group_run_id ~main_branch ~pr_number body =
+  match Yojson.Safe.from_string body with
+  | exception Yojson.Json_error msg -> Error (Json_parse_error msg)
+  | json -> (
+      match Json.try_of_yojson actions_runs_response_of_yojson json with
+      | Error msg -> Error (Json_parse_error msg)
+      | Ok resp ->
+          let branch_prefix =
+            merge_group_branch_prefix ~main_branch ~pr_number
+          in
+          Ok
+            (List.find_map resp.workflow_runs ~f:(fun run ->
+                 let matches =
+                   Option.equal String.equal run.event (Some "merge_group")
+                   && Option.equal String.equal run.status (Some "completed")
+                   && Option.equal String.equal run.conclusion (Some "failure")
+                   && Option.exists run.head_branch ~f:(fun branch ->
+                       String.is_prefix branch ~prefix:branch_prefix)
+                 in
+                 if matches then run.database_id else None)))
+
+type actions_job = {
+  database_id : int option; [@key "id"] [@yojson.default None]
+  name : string option; [@yojson.default None]
+  conclusion : string option; [@yojson.default None]
+  html_url : string option; [@key "html_url"] [@yojson.default None]
+  started_at : string option; [@key "started_at"] [@yojson.default None]
+}
+[@@deriving of_yojson] [@@yojson.allow_extra_fields]
+
+type actions_jobs_response = { jobs : actions_job list [@yojson.default []] }
+[@@deriving of_yojson] [@@yojson.allow_extra_fields]
+
+let ci_check_of_actions_job (job : actions_job) =
+  Option.map job.name ~f:(fun name ->
+      let conclusion =
+        Option.value_map job.conclusion ~default:"pending" ~f:String.lowercase
+      in
+      {
+        Types.Ci_check.name;
+        conclusion;
+        details_url = job.html_url;
+        description = None;
+        started_at = job.started_at;
+        id = job.database_id;
+      })
+
+let parse_actions_jobs_response body =
+  match Yojson.Safe.from_string body with
+  | exception Yojson.Json_error msg -> Error (Json_parse_error msg)
+  | json -> (
+      match Json.try_of_yojson actions_jobs_response_of_yojson json with
+      | Error msg -> Error (Json_parse_error msg)
+      | Ok resp ->
+          resp.jobs
+          |> List.filter_map ~f:ci_check_of_actions_job
+          |> List.filter ~f:Types.Ci_check.is_failure
+          |> Result.return)
+
 let https_config () =
   match Ca_certs.authenticator () with
   | Error (`Msg msg) -> Error ("TLS CA setup failed: " ^ msg)
@@ -1155,6 +1234,39 @@ let build_merge_queue_removal_request_body t (pr : Types.Pr_number.t) =
     [ ("query", `String merge_queue_removal_query); ("variables", variables) ]
   |> Yojson.Safe.to_string
 
+let merge_group_actions_checks ~net ~clock ?timeout t pr =
+  let runs_path = Printf.sprintf "/repos/%s/%s/actions/runs" t.owner t.repo in
+  let runs_query = [ ("event", [ "merge_group" ]); ("per_page", [ "20" ]) ] in
+  match
+    request ~net ~clock ?timeout t ~meth:`GET ~path:runs_path ~query:runs_query
+      ()
+  with
+  | Error _ as e -> e
+  | Ok runs_body -> (
+      match
+        parse_merge_group_run_id ~main_branch:t.main_branch ~pr_number:pr
+          runs_body
+      with
+      | Error _ as e -> e
+      | Ok None -> Ok []
+      | Ok (Some run_id) -> (
+          let jobs_path =
+            Printf.sprintf "/repos/%s/%s/actions/runs/%d/jobs" t.owner t.repo
+              run_id
+          in
+          let jobs_query = [ ("per_page", [ "100" ]) ] in
+          match
+            request ~net ~clock ?timeout t ~meth:`GET ~path:jobs_path
+              ~query:jobs_query ()
+          with
+          | Error _ as e -> e
+          | Ok jobs_body -> parse_actions_jobs_response jobs_body))
+
+let merge_group_actions_fallback_if_empty ~net ~clock ?timeout t pr result =
+  match Result.ok result with
+  | Some [] -> merge_group_actions_checks ~net ~clock ?timeout t pr
+  | _ -> result
+
 let merge_queue_removal_checks ~net ~clock ?timeout t pr =
   let body = build_merge_queue_removal_request_body t pr in
   match
@@ -1165,15 +1277,22 @@ let merge_queue_removal_checks ~net ~clock ?timeout t pr =
       match parse_merge_queue_removal_pagination resp_str with
       (* Complete first page (or no event): the pure parser already has the full
          failure list. *)
-      | None -> parse_merge_queue_removal_response resp_str
+      | None ->
+          parse_merge_queue_removal_response resp_str
+          |> merge_group_actions_fallback_if_empty ~net ~clock ?timeout t pr
       (* >100 contexts on the merge-group commit: paginate by OID and filter to
          failures over the complete set. On any pagination failure, fall back to
          the pure parser (which returns [Ok []] for the truncated case), keeping
          the synthetic placeholder rather than a partial list. *)
       | Some oid -> (
           match fetch_all_contexts ~net ~clock ?timeout t ~oid with
-          | Ok all -> Ok (List.filter all ~f:Types.Ci_check.is_failure)
-          | Error _ -> parse_merge_queue_removal_response resp_str))
+          | Ok all ->
+              Ok (List.filter all ~f:Types.Ci_check.is_failure)
+              |> merge_group_actions_fallback_if_empty ~net ~clock ?timeout t pr
+          | Error _ ->
+              parse_merge_queue_removal_response resp_str
+              |> merge_group_actions_fallback_if_empty ~net ~clock ?timeout t pr
+          ))
 
 (** Parse the REST response from [GET /repos/:owner/:repo/pulls]. Returns a list
     of [(pr_number, base_branch, merged)] for non-CLOSED PRs, newest first. Pure

--- a/lib/github.mli
+++ b/lib/github.mli
@@ -102,6 +102,21 @@ val parse_merge_queue_removal_pagination : string -> string option
     the caller should paginate by OID. [None] otherwise. Pure helper exposed for
     regression tests. *)
 
+val parse_merge_group_run_id :
+  main_branch:Types.Branch.t ->
+  pr_number:Types.Pr_number.t ->
+  string ->
+  (int option, error) Result.t
+(** Parse a REST [GET /actions/runs] response and return the newest failed
+    [merge_group] workflow run id for this PR's merge-queue branch, when one is
+    present. Pure helper exposed for regression tests. *)
+
+val parse_actions_jobs_response :
+  string -> (Types.Ci_check.t list, error) Result.t
+(** Parse a REST [GET /actions/runs/:id/jobs] response into failing job checks.
+    Job database ids become [Ci_check.id], and [html_url] becomes [details_url].
+    Pure helper exposed for regression tests. *)
+
 val is_method_not_allowed : error -> bool
 (** True only for the REST 405 response GitHub returns when a merge method is
     disabled for the repository. *)

--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -1093,6 +1093,11 @@ let render_turn_layer_ci ~(project_name : string) ?pr_number
   | _ ->
       let formatted =
         List.map checks ~f:(fun (c : Ci_check.t) ->
+            let id =
+              match c.Ci_check.id with
+              | Some id -> Printf.sprintf " [check_id=%d]" id
+              | None -> ""
+            in
             let url =
               match c.Ci_check.details_url with
               | Some u -> Printf.sprintf " (%s)" u
@@ -1103,8 +1108,8 @@ let render_turn_layer_ci ~(project_name : string) ?pr_number
               | Some d -> Printf.sprintf "\n  %s" d
               | None -> ""
             in
-            Printf.sprintf "- **%s**: %s%s%s" c.Ci_check.name
-              c.Ci_check.conclusion url desc)
+            Printf.sprintf "- **%s**: %s%s%s%s" c.Ci_check.name
+              c.Ci_check.conclusion id url desc)
         |> String.concat ~sep:"\n"
       in
       let pr_ctx =
@@ -2071,6 +2076,24 @@ let%test "follow-up prompts without patch+gameplan emit only the turn layer" =
   in
   (* No layered prefix: the prompt does not start with the project heading. *)
   not (String.is_prefix ci_prompt ~prefix:"# [onton]")
+
+let%test "ci failure prompt renders check ids when present" =
+  let ci_prompt =
+    render_ci_failure_prompt ~project_name:"onton"
+      [
+        Ci_check.
+          {
+            name = "build";
+            conclusion = "FAILURE";
+            details_url = Some "https://example.test/check";
+            description = None;
+            started_at = None;
+            id = Some 12345;
+          };
+      ]
+  in
+  String.is_substring ci_prompt ~substring:"[check_id=12345]"
+  && String.is_substring ci_prompt ~substring:"https://example.test/check"
 
 let%test "human and pr_body prompts do not include the gameplan layer" =
   let human_prompt =

--- a/lib/worktree.ml
+++ b/lib/worktree.ml
@@ -141,18 +141,28 @@ let run_git ~process_mgr args =
    [compute_ancestry], so the worktree-creation planner inputs can be gathered
    before the type re-exports and the heavier rebase/push functions below. *)
 let run_git_exit_code ~process_mgr args =
-  Eio.Switch.run @@ fun sw ->
-  let stdout_buf = Buffer.create 0 in
+  let stdout_buf = Buffer.create 256 in
   let stderr_buf = Buffer.create 64 in
   let env = Stdlib.Lazy.force clean_git_env in
-  let child =
-    retry_transient_spawn (fun () ->
-        Eio.Process.spawn ~sw process_mgr ~env
-          ~stdout:(Eio.Flow.buffer_sink stdout_buf)
-          ~stderr:(Eio.Flow.buffer_sink stderr_buf)
-          args)
-  in
+  (* [Eio.Process.await] reports the exit status but does NOT wait for the
+     internal fibers that copy the child's stdout/stderr pipes into these
+     buffers (only [Eio.Process.run] documents that it does). Reading
+     [Buffer.contents] inside the switch — right after [await] — therefore
+     races the copy fibers: under scheduling load the buffer can still be empty
+     or partial when read. That manifested as a flaky [rev-parse --abbrev-ref
+     HEAD] returning "" → [worktree_head_branch = None] → a spurious
+     branch-switched push refusal. The switch only releases (and so joins the
+     copy fibers) when its body returns, so read the buffers *after*
+     [Eio.Switch.run] completes. *)
   let code =
+    Eio.Switch.run @@ fun sw ->
+    let child =
+      retry_transient_spawn (fun () ->
+          Eio.Process.spawn ~sw process_mgr ~env
+            ~stdout:(Eio.Flow.buffer_sink stdout_buf)
+            ~stderr:(Eio.Flow.buffer_sink stderr_buf)
+            args)
+    in
     match Eio.Process.await child with `Exited c -> c | `Signaled s -> 128 + s
   in
   (code, Buffer.contents stdout_buf, Buffer.contents stderr_buf)

--- a/lib/worktree.ml
+++ b/lib/worktree.ml
@@ -165,7 +165,12 @@ let run_git_exit_code ~process_mgr args =
     in
     match Eio.Process.await child with `Exited c -> c | `Signaled s -> 128 + s
   in
-  (code, Buffer.contents stdout_buf, Buffer.contents stderr_buf)
+  (* Read the buffers only here, after [Eio.Switch.run] has returned: that join
+     point is what guarantees the copy fibers have finished. Bind them outside
+     the switch body explicitly so this stays obvious. *)
+  let stdout = Buffer.contents stdout_buf in
+  let stderr = Buffer.contents stderr_buf in
+  (code, stdout, stderr)
 
 (* Read a ref's SHA from the main repo (NOT a worktree). Returns [None] if the
    ref does not exist or git fails. Used by [Worktree.create] to feed inputs to

--- a/test/test_github_merge_queue_removal.ml
+++ b/test/test_github_merge_queue_removal.ml
@@ -254,6 +254,102 @@ let test_contexts_page_graphql_errors_propagate () =
       Stdlib.Printf.eprintf "  FAIL: contexts page swallowed graphql errors\n";
       Stdlib.exit 1
 
+(* -- merge_group Actions fallback parsers -- *)
+
+let test_merge_group_run_id_finds_failed_queue_run () =
+  let body =
+    {|{
+      "workflow_runs": [
+        {
+          "id": 28256333724,
+          "event": "merge_group",
+          "head_branch": "gh-readonly-queue/main/pr-5275-aaaaaaaa",
+          "status": "completed",
+          "conclusion": "failure"
+        },
+        {
+          "id": 28256333725,
+          "event": "merge_group",
+          "head_branch": "gh-readonly-queue/main/pr-5276-64c999dbf3c6f6a0c1dd005410489e9b6292e01c",
+          "status": "completed",
+          "conclusion": "failure"
+        },
+        {
+          "id": 28256333726,
+          "event": "pull_request",
+          "head_branch": "gh-readonly-queue/main/pr-5276-bbbbbbbb",
+          "status": "completed",
+          "conclusion": "failure"
+        }
+      ]
+    }|}
+  in
+  match
+    Onton.Github.parse_merge_group_run_id
+      ~main_branch:(Onton_core.Types.Branch.of_string "main")
+      ~pr_number:(Onton_core.Types.Pr_number.of_int 5276)
+      body
+  with
+  | Ok (Some 28256333725) ->
+      Stdlib.print_endline "  merge_group runs → matching failed run id: OK"
+  | Ok _ ->
+      Stdlib.Printf.eprintf "  FAIL: merge_group run id did not match\n";
+      Stdlib.exit 1
+  | Error e ->
+      Stdlib.Printf.eprintf "  FAIL: merge_group runs errored: %s\n"
+        (Onton.Github.show_error e);
+      Stdlib.exit 1
+
+let test_actions_jobs_response_returns_failing_jobs_with_ids () =
+  let body =
+    {|{
+      "jobs": [
+        {
+          "id": 83720238027,
+          "name": "Lint",
+          "conclusion": "success",
+          "html_url": "https://github.com/flowglad/provisioning-agent/actions/runs/28256333725/job/83720238027",
+          "started_at": "2026-06-26T01:00:00Z"
+        },
+        {
+          "id": 83720238028,
+          "name": "Test Migrations (dev)",
+          "conclusion": "failure",
+          "html_url": "https://github.com/flowglad/provisioning-agent/actions/runs/28256333725/job/83720238028",
+          "started_at": "2026-06-26T01:01:00Z"
+        },
+        {
+          "id": 83720238029,
+          "name": "Deploy preview",
+          "conclusion": "cancelled",
+          "html_url": "https://github.com/flowglad/provisioning-agent/actions/runs/28256333725/job/83720238029",
+          "started_at": "2026-06-26T01:02:00Z"
+        }
+      ]
+    }|}
+  in
+  match Onton.Github.parse_actions_jobs_response body with
+  | Ok [ check ] ->
+      assert (String.equal check.Ci_check.name "Test Migrations (dev)");
+      assert (String.equal check.Ci_check.conclusion "failure");
+      assert (
+        match check.Ci_check.id with Some 83720238028 -> true | _ -> false);
+      assert (
+        match check.Ci_check.details_url with
+        | Some
+            "https://github.com/flowglad/provisioning-agent/actions/runs/28256333725/job/83720238028"
+          ->
+            true
+        | _ -> false);
+      Stdlib.print_endline "  Actions jobs → failing job id/url: OK"
+  | Ok _ ->
+      Stdlib.Printf.eprintf "  FAIL: Actions jobs returned wrong checks\n";
+      Stdlib.exit 1
+  | Error e ->
+      Stdlib.Printf.eprintf "  FAIL: Actions jobs errored: %s\n"
+        (Onton.Github.show_error e);
+      Stdlib.exit 1
+
 let () =
   test_mixed_returns_only_failures ();
   test_truncated_rollup_is_ok_empty ();
@@ -267,4 +363,6 @@ let () =
   test_contexts_page_parses_checks_and_cursor ();
   test_contexts_page_missing_object_is_terminal ();
   test_contexts_page_graphql_errors_propagate ();
+  test_merge_group_run_id_finds_failed_queue_run ();
+  test_actions_jobs_response_returns_failing_jobs_with_ids ();
   Stdlib.print_endline "test_github_merge_queue_removal: OK"

--- a/test/test_push_plan_integration.ml
+++ b/test/test_push_plan_integration.ml
@@ -156,10 +156,24 @@ let scenario_local_missing_remote env =
     failwith
       (Printf.sprintf "precondition: origin/feat=%s expected remote feat %s"
          tracked_feat remote_feat_sha);
-  (* Reassert [feat] as the checked-out branch. The local branch remains at
-     [shared_feat_sha], a strict ancestor of [origin/feat] while still ahead of
-     base, so the ancestry refusal is not pre-empted by No_commits_ahead_of_base. *)
-  sh ~dir:managed_dir "git checkout -q -B feat";
+  (* Pin HEAD to [feat] deterministically. We never left [feat] in this
+     scenario, so the working tree and index already match it; the only thing
+     that must be true for the planner is that HEAD is a symbolic ref to
+     [refs/heads/feat]. Earlier revisions used [git checkout -q -B feat] here,
+     but a full checkout touches the index/worktree and is sensitive to ambient
+     config — on CI it intermittently left the planner observing the
+     branch-switched guard instead of the intended stale-local refusal. Writing
+     the symref directly avoids the checkout heuristics entirely. *)
+  sh ~dir:managed_dir "git symbolic-ref HEAD refs/heads/feat";
+  (* Verify the exact value the planner reads ([rev-parse --abbrev-ref HEAD]):
+     if HEAD is not on [feat] the planner would (correctly) refuse with
+     branch-switched, so surface that as a clear precondition rather than a
+     misleading stale-local assertion failure. *)
+  let head_branch =
+    git_capture ~dir:managed_dir [ "rev-parse"; "--abbrev-ref"; "HEAD" ]
+  in
+  if not (String.equal head_branch "feat") then
+    failwith (Printf.sprintf "precondition: HEAD=%s expected feat" head_branch);
   (* Sanity: local feat != remote feat. *)
   let local_feat = git_capture ~dir:managed_dir [ "rev-parse"; "feat" ] in
   if not (String.equal local_feat shared_feat_sha) then


### PR DESCRIPTION
## Summary
- render CI check IDs in patch-agent prompts when a check carries a numeric ID
- when merge-queue removal rollups are empty, fall back to the matching failed `merge_group` Actions run and fetch failed jobs
- add regression coverage for the observed merge-group run `28256333725` / job `83720238028`

## Tests
- `dune build`
- `dune exec test/test_github_merge_queue_removal.exe`
- `dune exec test/test_merge_queue_decision_properties.exe`
- `dune runtest`
- `dune fmt`
- commit hook: build + tests + format check