### PR TITLE
Make "in merge queue" a standalone display status

### DIFF
--- a/lib/tui.ml
+++ b/lib/tui.ml
@@ -13,6 +13,7 @@ open Types
 type display_status = Display_status.t =
   | Merged
   | Needs_help
+  | In_merge_queue
   | Approved_idle
   | Approved_running
   | Fixing_ci
@@ -38,6 +39,7 @@ type status_display = { label : string; color : string }
 let label = function
   | Merged -> "merged"
   | Needs_help -> "needs-help"
+  | In_merge_queue -> "in-merge-queue"
   | Approved_idle -> "approved"
   | Approved_running -> "approved-running"
   | Fixing_ci -> "fixing-ci"
@@ -59,6 +61,7 @@ let label = function
 let color = function
   | Merged -> Term.Sgr.fg_green
   | Needs_help -> Term.Sgr.fg_red
+  | In_merge_queue -> Term.Sgr.fg_cyan
   | Approved_idle -> Term.Sgr.fg_green
   | Approved_running -> Term.Sgr.fg_cyan
   | Fixing_ci -> Term.Sgr.fg_yellow
@@ -153,6 +156,7 @@ let%test "scroll_indicators no scroll needed" =
 let status_style = function
   | Merged -> [ Term.Sgr.fg_green; Term.Sgr.bold ]
   | Needs_help -> [ Term.Sgr.fg_red; Term.Sgr.bold ]
+  | In_merge_queue -> [ Term.Sgr.fg_cyan; Term.Sgr.bold ]
   | Approved_idle -> [ Term.Sgr.fg_green ]
   | Approved_running -> [ Term.Sgr.fg_green; Term.Sgr.bold ]
   | Fixing_ci | Addressing_review | Addressing_findings | Resolving_conflict
@@ -168,6 +172,7 @@ let status_style = function
 let status_indicator = function
   | Merged -> "✓"
   | Needs_help -> "!"
+  | In_merge_queue -> "⇥"
   | Approved_idle -> "✓"
   | Approved_running -> "▶"
   | Fixing_ci | Addressing_review | Addressing_findings | Resolving_conflict
@@ -417,6 +422,8 @@ let patch_view_of_agent (agent : Patch_agent.t)
     |> State.Patch_ctx.set_has_pr ~patch_id ~value:(Patch_agent.has_pr agent)
     |> State.Patch_ctx.set_approved ~patch_id
          ~value:(Patch_agent.is_approved agent ~main_branch)
+    |> State.Patch_ctx.set_enqueued ~patch_id
+         ~value:(Option.is_some agent.merge_queue_entry)
     |> State.Patch_ctx.set_ci_failure_count ~patch_id
          ~count:agent.ci_failure_count
     |> fun ctx ->
@@ -449,6 +456,8 @@ let patch_view_of_agent (agent : Patch_agent.t)
                      ~value:(Patch_agent.has_pr dep_agent)
                 |> State.Patch_ctx.set_approved ~patch_id:dep_id
                      ~value:(Patch_agent.is_approved dep_agent ~main_branch)
+                |> State.Patch_ctx.set_enqueued ~patch_id:dep_id
+                     ~value:(Option.is_some dep_agent.merge_queue_entry)
                 |> State.Patch_ctx.set_ci_failure_count ~patch_id:dep_id
                      ~count:dep_agent.ci_failure_count
                 |> fun ctx ->
@@ -510,28 +519,35 @@ let render_status_badge ?(queued = false) status =
   render_badge ~style:(status_style status) ~indicator:(status_indicator status)
     ~label:lbl
 
-let merge_queue_badge_state = function
-  | Pr_state.Mq_queued -> (Awaiting_feedback, "mq-queued")
-  | Pr_state.Mq_awaiting_checks -> (Awaiting_feedback, "mq-awaiting-checks")
-  | Pr_state.Mq_mergeable -> (Approved_idle, "mq-mergeable")
-  | Pr_state.Mq_unmergeable -> (Needs_help, "mq-unmergeable")
-  | Pr_state.Mq_locked -> (Ci_queued, "mq-locked")
+(* The primary status column owns "in merge queue" ([In_merge_queue]); the badge
+   only conveys the GitHub sub-state + queue position as detail, rendered in the
+   In_merge_queue style. It no longer borrows other statuses' colors. *)
+let merge_queue_badge_label = function
+  | Pr_state.Mq_queued -> "mq-queued"
+  | Pr_state.Mq_awaiting_checks -> "mq-awaiting-checks"
+  | Pr_state.Mq_mergeable -> "mq-mergeable"
+  | Pr_state.Mq_unmergeable -> "mq-unmergeable"
+  | Pr_state.Mq_locked -> "mq-locked"
 
 let render_merge_queue_badge = function
   | None -> ""
   | Some (entry : Pr_state.merge_queue_entry) ->
-      let status, state_label = merge_queue_badge_state entry.state in
-      render_badge ~style:(status_style status)
-        ~indicator:(status_indicator status)
-        ~label:(Printf.sprintf "%s #%d" state_label entry.position)
+      render_badge
+        ~style:(status_style In_merge_queue)
+        ~indicator:(status_indicator In_merge_queue)
+        ~label:
+          (Printf.sprintf "%s #%d"
+             (merge_queue_badge_label entry.state)
+             entry.position)
 
 let is_running_status = function
   | Fixing_ci | Addressing_review | Addressing_findings | Resolving_conflict
   | Responding_to_human | Writing_pr_body | Rebasing | Starting | Updating
   | Approved_running ->
       true
-  | Merged | Needs_help | Approved_idle | Ci_queued | Review_queued
-  | Findings_queued | Awaiting_feedback | Blocked_by_dep | Pending ->
+  | Merged | Needs_help | In_merge_queue | Approved_idle | Ci_queued
+  | Review_queued | Findings_queued | Awaiting_feedback | Blocked_by_dep
+  | Pending ->
       false
 
 (** {1 Frame rendering} *)

--- a/lib/tui.mli
+++ b/lib/tui.mli
@@ -12,6 +12,7 @@ open Types
 type display_status = Display_status.t =
   | Merged
   | Needs_help
+  | In_merge_queue
   | Approved_idle
   | Approved_running
   | Fixing_ci

--- a/lib_core/display_status.ml
+++ b/lib_core/display_status.ml
@@ -15,6 +15,7 @@ open Types
 type t =
   | Merged
   | Needs_help
+  | In_merge_queue
   | Approved_idle
   | Approved_running
   | Fixing_ci
@@ -62,6 +63,7 @@ let derive (ctx : State.Patch_ctx.t) ~patch_id
     ~(current_op : Operation_kind.t option) ~(main_branch : Branch.t) =
   if State.Patch_ctx.is_merged ctx ~patch_id then Merged
   else if State.Patch_ctx.needs_intervention ctx ~patch_id then Needs_help
+  else if State.Patch_ctx.is_enqueued ctx ~patch_id then In_merge_queue
   else if State.Patch_ctx.is_approved ctx ~patch_id then
     if State.Patch_ctx.is_busy ctx ~patch_id then Approved_running
     else Approved_idle
@@ -106,6 +108,41 @@ let%test "needs_help over approved" =
          ~value:true
   in
   equal Needs_help
+    (derive ctx ~patch_id:(Patch_id.of_string "1") ~current_op:None
+       ~main_branch:(Branch.of_string "main"))
+
+let%test "in_merge_queue over approved" =
+  let ctx =
+    State.Patch_ctx.empty
+    |> State.Patch_ctx.set_approved ~patch_id:(Patch_id.of_string "1")
+         ~value:true
+    |> State.Patch_ctx.set_enqueued ~patch_id:(Patch_id.of_string "1")
+         ~value:true
+  in
+  equal In_merge_queue
+    (derive ctx ~patch_id:(Patch_id.of_string "1") ~current_op:None
+       ~main_branch:(Branch.of_string "main"))
+
+let%test "needs_help over in_merge_queue" =
+  let ctx =
+    State.Patch_ctx.empty
+    |> State.Patch_ctx.set_needs_intervention ~patch_id:(Patch_id.of_string "1")
+         ~value:true
+    |> State.Patch_ctx.set_enqueued ~patch_id:(Patch_id.of_string "1")
+         ~value:true
+  in
+  equal Needs_help
+    (derive ctx ~patch_id:(Patch_id.of_string "1") ~current_op:None
+       ~main_branch:(Branch.of_string "main"))
+
+let%test "merged over in_merge_queue" =
+  let ctx =
+    State.Patch_ctx.empty
+    |> State.Patch_ctx.set_merged ~patch_id:(Patch_id.of_string "1") ~value:true
+    |> State.Patch_ctx.set_enqueued ~patch_id:(Patch_id.of_string "1")
+         ~value:true
+  in
+  equal Merged
     (derive ctx ~patch_id:(Patch_id.of_string "1") ~current_op:None
        ~main_branch:(Branch.of_string "main"))
 
@@ -277,5 +314,7 @@ let%test "legacy Awaiting_review decodes to Awaiting_feedback" =
   && equal Awaiting_feedback (t_of_yojson (`String "Awaiting_review"))
 
 let%test "current statuses round-trip through yojson" =
-  List.for_all [ Awaiting_feedback; Ci_queued; Merged; Pending; Needs_help ]
-    ~f:(fun s -> equal s (t_of_yojson (yojson_of_t s)))
+  List.for_all
+    [
+      Awaiting_feedback; Ci_queued; Merged; Pending; Needs_help; In_merge_queue;
+    ] ~f:(fun s -> equal s (t_of_yojson (yojson_of_t s)))

--- a/lib_core/state.ml
+++ b/lib_core/state.ml
@@ -31,6 +31,7 @@ module Patch_ctx = struct
     needs_intervention : bool Map.M(Patch_id).t;
     merged : bool Map.M(Patch_id).t;
     approved : bool Map.M(Patch_id).t;
+    enqueued : bool Map.M(Patch_id).t;
     ci_failure_count : int Map.M(Patch_id).t;
     base_branch : Branch.t Map.M(Patch_id).t;
   }
@@ -45,6 +46,7 @@ module Patch_ctx = struct
       needs_intervention = Map.empty (module Patch_id);
       merged = Map.empty (module Patch_id);
       approved = Map.empty (module Patch_id);
+      enqueued = Map.empty (module Patch_id);
       ci_failure_count = Map.empty (module Patch_id);
       base_branch = Map.empty (module Patch_id);
     }
@@ -95,6 +97,12 @@ module Patch_ctx = struct
   let set_approved t ~patch_id ~value =
     { t with approved = Map.set t.approved ~key:patch_id ~data:value }
 
+  let is_enqueued t ~patch_id =
+    Map.find t.enqueued patch_id |> Option.value ~default:false
+
+  let set_enqueued t ~patch_id ~value =
+    { t with enqueued = Map.set t.enqueued ~key:patch_id ~data:value }
+
   let ci_failure_count t ~patch_id =
     Map.find t.ci_failure_count patch_id |> Option.value ~default:0
 
@@ -122,6 +130,7 @@ module Patch_ctx = struct
         Map.keys t.needs_intervention;
         Map.keys t.merged;
         Map.keys t.approved;
+        Map.keys t.enqueued;
         Map.keys t.ci_failure_count;
         Map.keys t.base_branch;
       ]

--- a/lib_core/state.mli
+++ b/lib_core/state.mli
@@ -39,6 +39,8 @@ module Patch_ctx : sig
   val set_merged : t -> patch_id:Patch_id.t -> value:bool -> t
   val is_approved : t -> patch_id:Patch_id.t -> bool
   val set_approved : t -> patch_id:Patch_id.t -> value:bool -> t
+  val is_enqueued : t -> patch_id:Patch_id.t -> bool
+  val set_enqueued : t -> patch_id:Patch_id.t -> value:bool -> t
   val ci_failure_count : t -> patch_id:Patch_id.t -> int
   val set_ci_failure_count : t -> patch_id:Patch_id.t -> count:int -> t
   val increment_ci_failure_count : t -> patch_id:Patch_id.t -> t

--- a/lib_test/test_generators.ml
+++ b/lib_test/test_generators.ml
@@ -561,6 +561,7 @@ let all_display_statuses : Onton.Tui.display_status list =
   let id = function
     | Merged -> Merged
     | Needs_help -> Needs_help
+    | In_merge_queue -> In_merge_queue
     | Approved_idle -> Approved_idle
     | Approved_running -> Approved_running
     | Fixing_ci -> Fixing_ci
@@ -583,6 +584,7 @@ let all_display_statuses : Onton.Tui.display_status list =
     [
       Merged;
       Needs_help;
+      In_merge_queue;
       Approved_idle;
       Approved_running;
       Fixing_ci;

--- a/test/test_display_status_properties.ml
+++ b/test/test_display_status_properties.ml
@@ -42,6 +42,7 @@ type flag =
   | Set_merged of bool
   | Set_needs_intervention of bool
   | Set_approved of bool
+  | Set_enqueued of bool
   | Set_busy of bool
   | Set_has_pr of bool
   | Set_queued_ci of bool
@@ -56,6 +57,7 @@ let gen_flag =
       map (fun b -> Set_merged b) gen_bool;
       map (fun b -> Set_needs_intervention b) gen_bool;
       map (fun b -> Set_approved b) gen_bool;
+      map (fun b -> Set_enqueued b) gen_bool;
       map (fun b -> Set_busy b) gen_bool;
       map (fun b -> Set_has_pr b) gen_bool;
       map (fun b -> Set_queued_ci b) gen_bool;
@@ -69,6 +71,7 @@ let apply_flag ctx = function
   | Set_needs_intervention value ->
       State.Patch_ctx.set_needs_intervention ctx ~patch_id ~value
   | Set_approved value -> State.Patch_ctx.set_approved ctx ~patch_id ~value
+  | Set_enqueued value -> State.Patch_ctx.set_enqueued ctx ~patch_id ~value
   | Set_busy value -> State.Patch_ctx.set_busy ctx ~patch_id ~value
   | Set_has_pr value -> State.Patch_ctx.set_has_pr ctx ~patch_id ~value
   | Set_queued_ci value ->
@@ -123,6 +126,24 @@ let prop_needs_help_beats_approved =
         State.Patch_ctx.set_needs_intervention ctx ~patch_id ~value:true
       in
       Display_status.equal Needs_help
+        (Display_status.derive ctx ~patch_id ~current_op ~main_branch))
+
+let prop_enqueued_beats_approved =
+  QCheck2.Test.make
+    ~name:
+      "enqueued + not merged + not needs_intervention ⇒ In_merge_queue even \
+       when approved + busy + ..."
+    ~count:500
+    QCheck2.Gen.(pair gen_ctx gen_op)
+    (fun (ctx, current_op) ->
+      (* In_merge_queue sits below merged/needs_intervention and above
+         approved/busy/queued — pin the two that dominate it to false. *)
+      let ctx = State.Patch_ctx.set_merged ctx ~patch_id ~value:false in
+      let ctx =
+        State.Patch_ctx.set_needs_intervention ctx ~patch_id ~value:false
+      in
+      let ctx = State.Patch_ctx.set_enqueued ctx ~patch_id ~value:true in
+      Display_status.equal In_merge_queue
         (Display_status.derive ctx ~patch_id ~current_op ~main_branch))
 
 let prop_approved_busy_is_running =
@@ -182,6 +203,7 @@ let gen_status : Display_status.t QCheck2.Gen.t =
       [
         Merged;
         Needs_help;
+        In_merge_queue;
         Approved_idle;
         Approved_running;
         Fixing_ci;
@@ -221,6 +243,7 @@ let () =
       prop_total;
       prop_merged_dominates;
       prop_needs_help_beats_approved;
+      prop_enqueued_beats_approved;
       prop_approved_busy_is_running;
       prop_pending_when_no_pr;
       prop_blocked_by_dep_requires_off_main;

--- a/test/test_display_status_properties.ml
+++ b/test/test_display_status_properties.ml
@@ -151,10 +151,11 @@ let prop_approved_busy_is_running =
     ~name:"approved + busy ⇒ Approved_running regardless of current_op"
     ~count:500 gen_op (fun current_op ->
       let ctx =
-        ( ( ( State.Patch_ctx.empty |> fun c ->
-              State.Patch_ctx.set_merged c ~patch_id ~value:false )
-          |> fun c ->
-            State.Patch_ctx.set_needs_intervention c ~patch_id ~value:false )
+        ( ( ( ( State.Patch_ctx.empty |> fun c ->
+                State.Patch_ctx.set_merged c ~patch_id ~value:false )
+            |> fun c ->
+              State.Patch_ctx.set_needs_intervention c ~patch_id ~value:false )
+          |> fun c -> State.Patch_ctx.set_enqueued c ~patch_id ~value:false )
         |> fun c -> State.Patch_ctx.set_approved c ~patch_id ~value:true )
         |> fun c -> State.Patch_ctx.set_busy c ~patch_id ~value:true
       in

--- a/test/test_display_status_properties.ml
+++ b/test/test_display_status_properties.ml
@@ -122,6 +122,7 @@ let prop_needs_help_beats_approved =
     (fun (ctx, current_op) ->
       (* needs_intervention beats every flag except merged. *)
       let ctx = State.Patch_ctx.set_merged ctx ~patch_id ~value:false in
+      let ctx = State.Patch_ctx.set_enqueued ctx ~patch_id ~value:false in
       let ctx =
         State.Patch_ctx.set_needs_intervention ctx ~patch_id ~value:true
       in


### PR DESCRIPTION
## What

A PR in GitHub's merge queue previously rendered as `Approved_idle` with borrowed-color mq-check badges layered on (`Mq_mergeable` → green, `Mq_unmergeable` → red, etc.), split across two derivation paths: `Display_status.derive` (which couldn't see the queue at all) and a parallel badge mapping in `tui.ml`. Being in the merge queue is now its own standalone display status.

## Changes

**Pure (`lib_core`):**
- `state.ml`/`.mli` — `Patch_ctx` gains an `enqueued` flag (`is_enqueued`/`set_enqueued`), mirroring `approved`.
- `display_status.ml` — new `In_merge_queue` variant; `derive` returns it from `is_enqueued`, ranked **above** `is_approved` and **below** `Merged`/`Needs_help`.

**Effectful (`lib`):**
- `tui.ml` — both `Patch_ctx` projections set `enqueued` from `merge_queue_entry`; the variant is handled in `label`/`color`/`status_style`/`status_indicator`/`is_running_status`. Dropped `merge_queue_badge_state`'s color-borrowing — the badge now only conveys sub-state + queue position in the `In_merge_queue` style.

## The one thing left untouched, on purpose

The `is_approved` **predicate** still flips true while a PR is enqueued, and it must. `patch_controller.ml` `automerge_action` dequeues any queued-but-not-approved PR — conflating display state with approval would yank every PR back out of the queue. This is a display-taxonomy change only. `Mq_unmergeable` still escalates via the existing CI-failure path to `Needs_help`, which outranks `In_merge_queue`.

## Tests

`test_display_status_properties.ml`: `enqueued` added to the totality + round-trip generators, plus a new dominance property — `enqueued ∧ ¬merged ∧ ¬needs_intervention ⇒ In_merge_queue` across the full cross-product of other flags + ops. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/386"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785337796&installation_id=126163856&pr_number=386&repository=flowglad%2Fonton&return_to=https%3A%2F%2Fgithub.com%2Fflowglad%2Fonton%2Fpull%2F386&signature=a6f8dd31fa9a3b1f9e93dd06023f95a247e2a3dec96effbc7448630f838007e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “in merge queue” status for patches, shown with its own label, color, and icon.
  * Patches now reflect queue state more clearly in the interface, including related dependency patches.

* **Bug Fixes**
  * Improved status handling so queued patches are displayed consistently and no longer appear as running.
  * Updated status logic so queue state is correctly prioritized alongside other patch states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->