### PR TITLE
Don't treat merge-queue conflicts as CI failures

### DIFF
--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -89,7 +89,7 @@ let enqueue_pr_body_if_needed t patch_id (agent : Patch_agent.t) =
     if already_queued then t
     else Orchestrator.enqueue t patch_id Operation_kind.Pr_body
 
-let apply_poll_result t patch_id
+let apply_poll_result ?(merge_queue_ejection_confirmed = false) t patch_id
     ({ poll_result; base_branch; branch_in_root; worktree_path } :
       poll_observation) =
   let logs = ref [] in
@@ -98,14 +98,11 @@ let apply_poll_result t patch_id
     let agent = Orchestrator.agent t patch_id in
     let application =
       Merge_queue_decision.apply ~previous_entry:agent.merge_queue_entry
-        poll_result
+        ~ejection_confirmed:merge_queue_ejection_confirmed poll_result
     in
     if application.merge_queue_ejected then
       log "Merge queue removed PR after checks failed — treating as CI failure";
-    if application.merge_queue_unmergeable then
-      log "Merge queue marked PR unmergeable — treating as CI failure";
-    ( application.poll_result,
-      application.merge_queue_ejected || application.merge_queue_unmergeable )
+    (application.poll_result, application.merge_queue_ejected)
   in
   (* If the agent was [Missing] and we have a successful poll observation,
      lift it back to [Present] before applying any world-state updates. The
@@ -1506,7 +1503,7 @@ let%test "apply_poll_result turns merge queue ejection into CI feedback" =
       }
   in
   let t, logs, _ =
-    apply_poll_result t pid
+    apply_poll_result ~merge_queue_ejection_confirmed:true t pid
       {
         poll_result;
         base_branch = Some main;
@@ -1523,11 +1520,13 @@ let%test "apply_poll_result turns merge queue ejection into CI feedback" =
   && List.exists logs ~f:(fun { message; _ } ->
       String.is_substring message ~substring:"Merge queue removed PR")
 
-let%test
-    "apply_poll_result turns unmergeable merge queue entry into CI feedback" =
+(* An [Mq_unmergeable] entry that is still in the queue is, in a stacked merge
+   queue, almost always a conflict with the sibling ahead of it — not a check
+   failure. It must not synthesize a CI failure; the PR stays untouched and the
+   conflict surfaces later through [merge_state = Conflicting]. *)
+let%test "apply_poll_result leaves an unmergeable in-queue entry untouched" =
   let _patch, t = make_orchestrator ~patch_id:pid ~main_branch:main in
   let t = make_approved_agent t in
-  let t = Orchestrator.set_automerge_deadline t pid 1.0 in
   let poll_result =
     Poller.
       {
@@ -1548,8 +1547,10 @@ let%test
         merge_commit_sha = None;
       }
   in
-  let t, logs, _ =
-    apply_poll_result t pid
+  (* Irrelevant verdict on purpose: an in-queue entry is not an ejection, so
+     even a [true] confirmation must not produce synthesis. *)
+  let t, _, _ =
+    apply_poll_result ~merge_queue_ejection_confirmed:true t pid
       {
         poll_result;
         base_branch = Some main;
@@ -1558,15 +1559,56 @@ let%test
       }
   in
   let agent = Orchestrator.agent t pid in
-  List.mem agent.queue Operation_kind.Ci ~equal:Operation_kind.equal
-  && (not agent.checks_passing) && (not agent.merge_ready)
-  && Option.exists agent.merge_queue_entry ~f:(fun entry ->
-      Pr_state.equal_merge_queue_entry_state entry.state Pr_state.Mq_unmergeable)
-  && agent.automerge_failure_count = 1
-  && Option.is_none agent.automerge_deadline
-  && List.exists agent.ci_checks ~f:Ci_check.is_merge_queue_failure
-  && List.exists logs ~f:(fun { message; _ } ->
-      String.is_substring message ~substring:"marked PR unmergeable")
+  (not (List.mem agent.queue Operation_kind.Ci ~equal:Operation_kind.equal))
+  && agent.checks_passing && agent.merge_ready
+  && agent.automerge_failure_count = 0
+  && not (List.exists agent.ci_checks ~f:Ci_check.is_merge_queue_failure)
+
+(* The user-facing regression: a PR ejected from the queue while still green and
+   mergeable, but ejected because of a conflict with the sibling ahead of it.
+   The poller's removal-event fetch found no failing merge-group checks, so
+   [merge_queue_ejection_confirmed = false]. We must NOT report a CI failure. *)
+let%test "apply_poll_result leaves an unconfirmed (conflict) ejection alone" =
+  let _patch, t = make_orchestrator ~patch_id:pid ~main_branch:main in
+  let t = make_approved_agent t in
+  let t = Orchestrator.set_merge_queue_required t pid true in
+  let t =
+    Orchestrator.set_merge_queue_entry t pid
+      (Some Pr_state.{ id = "MQE_1"; state = Mq_awaiting_checks; position = 1 })
+  in
+  let poll_result =
+    Poller.
+      {
+        queue = [];
+        merged = false;
+        closed = false;
+        is_draft = false;
+        merge_state = Pr_state.Mergeable;
+        merge_ready = true;
+        head_oid = None;
+        review_decision = Some "APPROVED";
+        unresolved_comment_count = 0;
+        merge_queue_required = true;
+        merge_queue_entry = None;
+        checks_passing = true;
+        ci_checks = [];
+        merge_commit_sha = None;
+      }
+  in
+  let t, _, _ =
+    apply_poll_result ~merge_queue_ejection_confirmed:false t pid
+      {
+        poll_result;
+        base_branch = Some main;
+        branch_in_root = false;
+        worktree_path = None;
+      }
+  in
+  let agent = Orchestrator.agent t pid in
+  (not (List.mem agent.queue Operation_kind.Ci ~equal:Operation_kind.equal))
+  && agent.checks_passing && agent.merge_ready
+  && agent.automerge_failure_count = 0
+  && not (List.exists agent.ci_checks ~f:Ci_check.is_merge_queue_failure)
 
 let%test "reconcile_automerge clears deadline on merged agent" =
   let _patch, t = make_orchestrator ~patch_id:pid ~main_branch:main in

--- a/lib/patch_controller.mli
+++ b/lib/patch_controller.mli
@@ -41,6 +41,7 @@ val reconcile_patch :
     effects. The same snapshot always produces the same result. *)
 
 val apply_poll_result :
+  ?merge_queue_ejection_confirmed:bool ->
   Orchestrator.t ->
   Patch_id.t ->
   poll_observation ->
@@ -48,7 +49,13 @@ val apply_poll_result :
 (** Apply a GitHub poll observation to durable state. Returns the updated
     orchestrator, log entries, and whether the patch became newly branch-
     blocked in this step. This is the controller-owned pure poll ingestion step.
-*)
+
+    [merge_queue_ejection_confirmed] is the poller's verdict on a merge-queue
+    ejection (default [false]): [true] when the removal event confirmed a real
+    merge-group check failure — or the confirming fetch errored, erring toward
+    surfacing it — and [false] for a conflict-driven ejection, which is left to
+    surface through normal [Merge_conflict] handling. Consulted only when the PR
+    actually left the queue while green and mergeable; ignored otherwise. *)
 
 val apply_replacement_pr :
   Orchestrator.t ->

--- a/lib/poller_fiber.ml
+++ b/lib/poller_fiber.ml
@@ -444,6 +444,53 @@ struct
                         if not (String.equal path default) then Some path
                         else None
                 in
+                (* Merge-queue ejection disambiguation. When a PR leaves the
+                   queue while still green and mergeable, that is either a
+                   hidden merge-group check failure (real, must surface) or a
+                   conflict with the sibling ahead of it (must NOT surface as a
+                   CI failure — it resolves through normal [Merge_conflict]
+                   handling once [merge_state] flips). Poll signals alone can't
+                   tell them apart; the removal event's [beforeCommit] can. We
+                   fetch it only on the rare ejection transition, and fail open
+                   (treat a fetch error as a real failure) so a transient error
+                   never silently drops a genuine merge-group failure — the
+                   runner re-fetches the real check names at delivery. *)
+                let merge_queue_ejection_confirmed =
+                  let previous_entry =
+                    Runtime.read runtime (fun snap ->
+                        match
+                          Orchestrator.find_agent snap.Runtime.orchestrator
+                            patch_id
+                        with
+                        | Some a -> a.Patch_agent.merge_queue_entry
+                        | None -> None)
+                  in
+                  let is_ejection =
+                    Merge_queue_decision.should_treat_ejection_as_ci_failure
+                      ~previous_entry poll_result
+                  in
+                  if is_ejection then (
+                    match Forge.merge_queue_removal_checks ~pr_number with
+                    | Ok (_ :: _) ->
+                        Runtime_logging.log_event runtime ~patch_id
+                          "Merge queue ejection: removal event shows failing \
+                           merge-group checks — treating as CI failure";
+                        true
+                    | Ok [] ->
+                        Runtime_logging.log_event runtime ~patch_id
+                          "Merge queue ejection with no failing merge-group \
+                           checks — treating as a conflict, not CI; awaiting \
+                           conflict signal";
+                        false
+                    | Error e ->
+                        Runtime_logging.log_event runtime ~patch_id
+                          (Printf.sprintf
+                             "Merge queue ejection: failed to fetch removal \
+                              checks (%s) — treating as CI failure to be safe"
+                             (Forge.show_error e));
+                        true)
+                  else false
+                in
                 let observation =
                   Patch_controller.
                     {
@@ -453,7 +500,12 @@ struct
                       worktree_path = worktree_candidate;
                     }
                 in
-                Some (patch_id, observation, failed_ci, ci_checks_truncated))
+                Some
+                  ( patch_id,
+                    observation,
+                    merge_queue_ejection_confirmed,
+                    failed_ci,
+                    ci_checks_truncated ))
       in
       (* Phase 2: Single atomic update — apply all poll results + reconcile.
        This prevents the runner from seeing an intermediate state where
@@ -465,13 +517,18 @@ struct
               List.fold observations ~init:(orch, [], [])
                 ~f:(fun
                     (orch, poll_events, sides)
-                    (patch_id, obs, failed_ci, ci_truncated)
+                    ( patch_id,
+                      obs,
+                      merge_queue_ejection_confirmed,
+                      failed_ci,
+                      ci_truncated )
                   ->
                   match Orchestrator.find_agent orch patch_id with
                   | None -> (orch, poll_events, sides)
                   | Some agent_before ->
                       let orch, log_entries, newly_blocked =
-                        Patch_controller.apply_poll_result orch patch_id obs
+                        Patch_controller.apply_poll_result
+                          ~merge_queue_ejection_confirmed orch patch_id obs
                       in
                       let agent_after = Orchestrator.agent orch patch_id in
                       let log_messages =

--- a/lib_core/merge_queue_decision.ml
+++ b/lib_core/merge_queue_decision.ml
@@ -4,16 +4,26 @@
 open Base
 open Types
 
-type application = {
-  poll_result : Poller.t;
-  merge_queue_ejected : bool;
-  merge_queue_unmergeable : bool;
-}
+type application = { poll_result : Poller.t; merge_queue_ejected : bool }
 [@@deriving show, eq]
 
 let has_current_failure (poll_result : Poller.t) =
   List.exists poll_result.ci_checks ~f:Ci_check.is_failure
 
+(* A PR that was in the merge queue last poll and is now gone, while its own
+   head checks are still green and it still looks mergeable. GitHub runs
+   merge-queue CI on the ephemeral merge-group commit (not the PR head), so a
+   PR ejected because a {e required check} failed there shows all-green
+   PR-head signals — this predicate is how we notice that hidden failure.
+
+   It is NOT, on its own, proof of a check failure: a PR ejected because its
+   speculative merge {e conflicts} with a sibling ahead of it in the queue
+   looks identical at the poll level (still clean against [main], head checks
+   green). The two are only distinguishable by the removal event's
+   [beforeCommit]: a check-failure ejection carries a failing merge-group
+   rollup, a conflict ejection carries none. The effectful poller fetches that
+   and passes the verdict in via [~ejection_confirmed]; this predicate just
+   gates {e whether} the fetch is worth doing. *)
 let should_treat_ejection_as_ci_failure ~previous_entry (poll_result : Poller.t)
     =
   let had_merge_queue_entry = Option.is_some previous_entry in
@@ -21,17 +31,6 @@ let should_treat_ejection_as_ci_failure ~previous_entry (poll_result : Poller.t)
   && Option.is_none poll_result.merge_queue_entry
   && (not poll_result.merged) && (not poll_result.closed)
   && poll_result.merge_ready && poll_result.checks_passing
-  && not (has_current_failure poll_result)
-
-let should_treat_unmergeable_as_ci_failure (poll_result : Poller.t) =
-  let merge_queue_unmergeable =
-    Option.exists poll_result.merge_queue_entry ~f:(fun entry ->
-        Pr_state.equal_merge_queue_entry_state entry.state
-          Pr_state.Mq_unmergeable)
-  in
-  poll_result.merge_queue_required && merge_queue_unmergeable
-  && (not poll_result.merged) && (not poll_result.closed)
-  && poll_result.checks_passing
   && not (has_current_failure poll_result)
 
 let apply_failure (poll_result : Poller.t) =
@@ -43,22 +42,18 @@ let apply_failure (poll_result : Poller.t) =
     ci_checks = Ci_check.merge_queue_failure () :: poll_result.ci_checks;
   }
 
-let apply ~previous_entry poll_result =
-  if should_treat_ejection_as_ci_failure ~previous_entry poll_result then
-    {
-      poll_result = apply_failure poll_result;
-      merge_queue_ejected = true;
-      merge_queue_unmergeable = false;
-    }
-  else if should_treat_unmergeable_as_ci_failure poll_result then
-    {
-      poll_result = apply_failure poll_result;
-      merge_queue_ejected = false;
-      merge_queue_unmergeable = true;
-    }
-  else
-    {
-      poll_result;
-      merge_queue_ejected = false;
-      merge_queue_unmergeable = false;
-    }
+(* Synthesize a CI failure for a merge-queue ejection only when the caller has
+   [~ejection_confirmed] it was a real check failure (the removal event's
+   merge-group commit carried failing checks, or the confirming fetch errored
+   and we err on the side of surfacing it). When the ejection was a conflict
+   with a sibling — [ejection_confirmed = false] — we do nothing: the patch
+   agent must not be told to "look for failing checks" that do not exist. The
+   conflict surfaces on its own once the sibling merges and the PR's
+   [merge_state] flips to [Conflicting], which enqueues [Merge_conflict]
+   through the normal path. *)
+let apply ~previous_entry ~ejection_confirmed poll_result =
+  if
+    ejection_confirmed
+    && should_treat_ejection_as_ci_failure ~previous_entry poll_result
+  then { poll_result = apply_failure poll_result; merge_queue_ejected = true }
+  else { poll_result; merge_queue_ejected = false }

--- a/lib_core/merge_queue_decision.mli
+++ b/lib_core/merge_queue_decision.mli
@@ -1,17 +1,28 @@
 (* @archlint.module interface
    @archlint.domain merge-queue-decision *)
 
-type application = {
-  poll_result : Poller.t;
-  merge_queue_ejected : bool;
-  merge_queue_unmergeable : bool;
-}
+type application = { poll_result : Poller.t; merge_queue_ejected : bool }
 [@@deriving show, eq]
 
 val should_treat_ejection_as_ci_failure :
   previous_entry:Pr_state.merge_queue_entry option -> Poller.t -> bool
-
-val should_treat_unmergeable_as_ci_failure : Poller.t -> bool
+(** True when a PR left the merge queue since the previous poll while its own
+    head checks are still green and it still looks mergeable. This is the
+    {e candidate} condition for a hidden merge-group check failure; it is also
+    satisfied by a conflict-driven ejection, so it only gates whether the
+    confirming removal-event fetch is worth doing — it does not, by itself,
+    decide that a CI failure occurred. *)
 
 val apply :
-  previous_entry:Pr_state.merge_queue_entry option -> Poller.t -> application
+  previous_entry:Pr_state.merge_queue_entry option ->
+  ejection_confirmed:bool ->
+  Poller.t ->
+  application
+(** Rewrite [poll_result] into a synthetic CI failure (enqueue [Ci], mark not
+    merge-ready, append the merge-queue placeholder check) only when
+    [should_treat_ejection_as_ci_failure] holds {e and} [~ejection_confirmed] is
+    true. [ejection_confirmed] is supplied by the effectful poller from the
+    removal event's merge-group rollup: [true] for a real check failure (or an
+    errored fetch, erring toward surfacing it), [false] for a conflict-driven
+    ejection. When not confirmed, [poll_result] is returned unchanged and the
+    conflict is left to surface through normal [Merge_conflict] handling. *)

--- a/test/test_merge_queue_decision_properties.ml
+++ b/test/test_merge_queue_decision_properties.ml
@@ -119,23 +119,15 @@ let expected_ejection ~previous_entry (poll : Poller.t) =
   && poll.checks_passing
   && not (visible_failure poll)
 
-let expected_unmergeable (poll : Poller.t) =
-  let has_unmergeable_entry =
-    Option.exists poll.merge_queue_entry ~f:(fun entry ->
-        Pr_state.equal_merge_queue_entry_state entry.state
-          Pr_state.Mq_unmergeable)
-  in
-  poll.merge_queue_required && has_unmergeable_entry && (not poll.merged)
-  && (not poll.closed) && poll.checks_passing
-  && not (visible_failure poll)
-
 let prop_totality =
   QCheck2.Test.make ~name:"MQD total over arbitrary prior entry + poll"
     ~count:2000
-    QCheck2.Gen.(pair gen_previous_entry gen_poll_result)
-    (fun (previous_entry, poll) ->
+    QCheck2.Gen.(triple gen_previous_entry gen_poll_result bool)
+    (fun (previous_entry, poll, ejection_confirmed) ->
       try
-        let _ = Merge_queue_decision.apply ~previous_entry poll in
+        let _ =
+          Merge_queue_decision.apply ~previous_entry ~ejection_confirmed poll
+        in
         true
       with _ -> false)
 
@@ -148,13 +140,6 @@ let prop_exact_predicate =
         (Merge_queue_decision.should_treat_ejection_as_ci_failure
            ~previous_entry poll)
         (expected_ejection ~previous_entry poll))
-
-let prop_exact_unmergeable_predicate =
-  QCheck2.Test.make ~name:"MQD unmergeable iff every predicate term holds"
-    ~count:2000 gen_poll_result (fun poll ->
-      Bool.equal
-        (Merge_queue_decision.should_treat_unmergeable_as_ci_failure poll)
-        (expected_unmergeable poll))
 
 let boundary_cases =
   [
@@ -190,29 +175,6 @@ let boundary_cases =
     ("ejected", Some previous_entry, base_ejection_poll, true);
   ]
 
-let unmergeable_poll =
-  {
-    base_ejection_poll with
-    Poller.merge_queue_entry =
-      Some Pr_state.{ id = "MQE_2"; state = Mq_unmergeable; position = 4 };
-  }
-
-let unmergeable_boundary_cases =
-  [
-    ( "queue not required",
-      { unmergeable_poll with merge_queue_required = false },
-      false );
-    ("merged", { unmergeable_poll with merged = true }, false);
-    ("closed", { unmergeable_poll with closed = true }, false);
-    ( "checks not passing",
-      { unmergeable_poll with checks_passing = false },
-      false );
-    ( "current failure already visible",
-      { unmergeable_poll with ci_checks = [ failing_check ] },
-      false );
-    ("unmergeable", unmergeable_poll, true);
-  ]
-
 let prop_boundary_cases =
   QCheck2.Test.make ~name:"MQD boundary guard matrix" ~count:1 QCheck2.Gen.unit
     (fun () ->
@@ -223,46 +185,40 @@ let prop_boundary_cases =
                ~previous_entry poll)
             expected))
 
-let prop_unmergeable_boundary_cases =
-  QCheck2.Test.make ~name:"MQD unmergeable boundary guard matrix" ~count:1
-    QCheck2.Gen.unit (fun () ->
-      List.for_all unmergeable_boundary_cases ~f:(fun (_name, poll, expected) ->
-          Bool.equal
-            (Merge_queue_decision.should_treat_unmergeable_as_ci_failure poll)
-            expected))
-
+(* Synthesis fires iff the ejection predicate holds AND the caller confirmed it
+   (the removal event carried a real merge-group failure). An unconfirmed
+   ejection — a conflict — must leave the poll result untouched. *)
 let prop_apply_shape =
-  QCheck2.Test.make ~name:"MQD apply rewrites only merge-queue failure cases"
+  QCheck2.Test.make ~name:"MQD apply rewrites only confirmed ejections"
     ~count:2000
-    QCheck2.Gen.(pair gen_previous_entry gen_poll_result)
-    (fun (previous_entry, poll) ->
-      let result = Merge_queue_decision.apply ~previous_entry poll in
-      if expected_ejection ~previous_entry poll || expected_unmergeable poll
-      then
-        Bool.equal result.merge_queue_ejected
-          (expected_ejection ~previous_entry poll)
-        && Bool.equal result.merge_queue_unmergeable (expected_unmergeable poll)
+    QCheck2.Gen.(triple gen_previous_entry gen_poll_result bool)
+    (fun (previous_entry, poll, ejection_confirmed) ->
+      let result =
+        Merge_queue_decision.apply ~previous_entry ~ejection_confirmed poll
+      in
+      if ejection_confirmed && expected_ejection ~previous_entry poll then
+        result.merge_queue_ejected
         && List.exists result.poll_result.queue ~f:(Operation_kind.equal Ci)
         && (not result.poll_result.merge_ready)
         && (not result.poll_result.checks_passing)
         && List.exists result.poll_result.ci_checks
              ~f:Ci_check.is_merge_queue_failure
       else
-        (not result.merge_queue_ejected)
-        && (not result.merge_queue_unmergeable)
-        && Poller.equal result.poll_result poll)
+        (not result.merge_queue_ejected) && Poller.equal result.poll_result poll)
 
 let prop_idempotent =
   QCheck2.Test.make ~name:"MQD apply is idempotent for a fixed prior entry"
     ~count:1000
-    QCheck2.Gen.(pair gen_previous_entry gen_poll_result)
-    (fun (previous_entry, poll) ->
-      let first = Merge_queue_decision.apply ~previous_entry poll in
+    QCheck2.Gen.(triple gen_previous_entry gen_poll_result bool)
+    (fun (previous_entry, poll, ejection_confirmed) ->
+      let first =
+        Merge_queue_decision.apply ~previous_entry ~ejection_confirmed poll
+      in
       let second =
-        Merge_queue_decision.apply ~previous_entry first.poll_result
+        Merge_queue_decision.apply ~previous_entry ~ejection_confirmed
+          first.poll_result
       in
       (not second.merge_queue_ejected)
-      && (not second.merge_queue_unmergeable)
       && Poller.equal second.poll_result first.poll_result)
 
 let prop_interleaving_threaded_prior_state =
@@ -272,27 +228,27 @@ let prop_interleaving_threaded_prior_state =
        ejection decisions"
     ~count:1000
     QCheck2.Gen.(
-      pair gen_previous_entry (list_size (int_range 0 20) gen_poll_result))
+      pair gen_previous_entry
+        (list_size (int_range 0 20) (pair gen_poll_result bool)))
     (fun (initial_previous_entry, polls) ->
       let _last_previous, ok =
         List.fold polls ~init:(initial_previous_entry, true)
-          ~f:(fun (previous_entry, ok) poll ->
-            let result = Merge_queue_decision.apply ~previous_entry poll in
+          ~f:(fun (previous_entry, ok) (poll, ejection_confirmed) ->
+            let result =
+              Merge_queue_decision.apply ~previous_entry ~ejection_confirmed
+                poll
+            in
             let expected =
-              expected_ejection ~previous_entry poll
-              || expected_unmergeable poll
+              ejection_confirmed && expected_ejection ~previous_entry poll
             in
             let local_ok =
               let synthetic_failure =
                 List.exists result.poll_result.ci_checks
                   ~f:Ci_check.is_merge_queue_failure
               in
-              Bool.equal
-                (result.merge_queue_ejected || result.merge_queue_unmergeable)
-                expected
+              Bool.equal result.merge_queue_ejected expected
               &&
-              if result.merge_queue_ejected || result.merge_queue_unmergeable
-              then
+              if result.merge_queue_ejected then
                 synthetic_failure
                 && (not result.poll_result.checks_passing)
                 && List.exists result.poll_result.queue
@@ -308,9 +264,7 @@ let () =
     [
       prop_totality;
       prop_exact_predicate;
-      prop_exact_unmergeable_predicate;
       prop_boundary_cases;
-      prop_unmergeable_boundary_cases;
       prop_apply_shape;
       prop_idempotent;
       prop_interleaving_threaded_prior_state;


### PR DESCRIPTION
## Problem

A PR ejected from the GitHub merge queue — or marked `Mq_unmergeable` while still queued — was synthesized into a fake `"GitHub merge queue"` CI-failure check, which woke the patch agent to **"look for failing checks."**

In a stacked merge queue, the dominant cause of those states is a **conflict with the patch ahead**, not a failed check. The PR's own head checks are green and it still looks mergeable against `main`, so the agent finds nothing to fix and spins. This is exactly what happened to Patch 4 (PR #5462): it entered the queue, was immediately marked `Mq_unmergeable` (speculative-merge conflict with the patch ahead), and onton reported a CI failure and prompted the agent to chase non-existent checks — while `checks_passing` was `true` the whole time. The real conflict only surfaced ~6 min later when `merge_state` flipped to `Conflicting`.

## Why it's hard

Poll-level signals are **identical** for a conflict ejection and a real merge-group check failure (both: ejected/unmergeable, `merge_ready=true`, `checks_passing=true`). The only thing that distinguishes them is the removal event's `beforeCommit` — the ephemeral merge-group commit GitHub actually ran checks on: a check-failure ejection carries a failing rollup, a conflict ejection carries none.

## Fix

- **Drop the `Mq_unmergeable → CI-failure` path entirely.** An in-queue unmergeable entry is now left untouched; the conflict surfaces on its own when `merge_state` flips to `Conflicting` and the normal `Merge_conflict` path runs.
- **Gate ejection synthesis on the removal-event fetch.** On the (rare) ejection transition the poller calls `merge_queue_removal_checks`:
  - `Ok (_ :: _)` → real merge-group failures → synthesize a CI failure.
  - `Ok []` → conflict → do nothing.
  - `Error` → **fail open** (synthesize anyway) so a transient fetch error never silently drops a genuine failure; the runner re-fetches the real check names at delivery.

`Merge_queue_decision.apply` now takes `~ejection_confirmed`; the poller computes it and threads it through `apply_poll_result` (as an optional arg, default `false`).

The synthetic placeholder + runner deferred fetch are intentionally retained — the placeholder is the durable signal the runner uses to deliver real check names despite a green PR head, and gating synthesis at the poll path already eliminates the spurious-CI-on-conflict path at the source.

## Tests

- Property tests updated for the new `~ejection_confirmed` gate.
- New inline tests: an in-queue `Mq_unmergeable` entry is left untouched; an unconfirmed (conflict) ejection produces no CI failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)