### PR TITLE
Choose merge method from repo config + 405 status, not error prose

### DIFF
--- a/lib/github.ml
+++ b/lib/github.ml
@@ -1655,6 +1655,12 @@ let is_merge_endpoint_rejection = function
   | Transport_error _ ->
       false
 
+(* A 405 from the merge endpoint specifically indicating that the branch
+   requires GitHub's native merge queue. Unlike [is_merge_endpoint_rejection],
+   this still inspects the body to distinguish the merge-queue case from other
+   405 reasons (method-disabled, base-branch-modified). Converting this to a
+   structural check requires a pr_state re-fetch on 405 and is left for a
+   follow-up. *)
 let is_merge_queue_required_error = function
   | Http_error { status = 405; body; _ } ->
       response_error_message_contains body ~substring:"merge queue"
@@ -1899,15 +1905,20 @@ let make ~net ~clock ~token ~owner ~repo ~main_branch :
        failures and propagate immediately; if every permitted method is refused
        we surface the last 405 so the caller can escalate (e.g. enqueue). *)
     let rec attempt ~refreshed ~tried ~last = function
-      | [] ->
-          if refreshed then Error (Option.value_exn last)
-          else
-            let fresh =
-              List.filter (candidate_methods ~refresh:true ()) ~f:(fun m ->
-                  not (List.mem tried m ~equal:equal_method))
-            in
-            if List.is_empty fresh then Error (Option.value_exn last)
-            else attempt ~refreshed:true ~tried ~last fresh
+      | [] -> (
+          match last with
+          | Some e when refreshed -> Error e
+          | Some e ->
+              let fresh =
+                List.filter (candidate_methods ~refresh:true ()) ~f:(fun m ->
+                    not (List.mem tried m ~equal:equal_method))
+              in
+              if List.is_empty fresh then Error e
+              else attempt ~refreshed:true ~tried ~last fresh
+          | None ->
+              (* [candidate_methods] always returns a non-empty list; reaching
+                 here without having tried any method is a programming error. *)
+              assert false)
       | m :: rest -> (
           match merge_pr ~net ~clock client ~pr_number ~merge_method:m with
           | Ok _ as ok -> ok

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -1602,11 +1602,6 @@ let method_allowed (m : repo_merge_methods) = function
   | `Merge -> m.merge
   | `Rebase -> m.rebase
 
-let disable_method (m : repo_merge_methods) = function
-  | `Squash -> { m with squash = false }
-  | `Merge -> { m with merge = false }
-  | `Rebase -> { m with rebase = false }
-
 (* Preference order, most → least preferred. Squash first preserves onton's
    historical default on repos that allow it; the choice is method-agnostic
    downstream — rebase anchoring keys off the actual [mergeCommit.oid] and the
@@ -1648,12 +1643,14 @@ let get_repo_merge_methods ~net ~clock ?timeout t :
           Error (Json_parse_error "could not parse repo merge-method settings"))
   | Error _ as e -> e
 
-(* A non-2xx response meaning "this merge method is disabled on the repo"
-   (GitHub 405 "… merges are not allowed on this repository"), as distinct from
-   a transient/auth/conflict failure that must not trigger method fallback. *)
-let is_method_not_allowed = function
-  | Http_error { status = 405; body; _ } ->
-      response_error_message_contains body ~substring:"not allowed"
+(* A [405 Method Not Allowed] from the merge endpoint: GitHub refused this
+   particular merge attempt — either the method is disabled for the repo or a
+   branch rule blocked it. Classified purely by HTTP status; the body wording
+   (which GitHub varies, and which is sometimes not even JSON) is never
+   inspected. Distinct from a 409 (conflict), 422 (validation), or transport
+   error, which are genuine failures that must not trigger method fallback. *)
+let is_merge_endpoint_rejection = function
+  | Http_error { status = 405; _ } -> true
   | Http_error _ | Json_parse_error _ | Graphql_error _ | Timeout _
   | Transport_error _ ->
       false
@@ -1770,8 +1767,12 @@ let%test "allowed_methods_in_preference: none allowed -> empty" =
     (allowed_methods_in_preference
        { squash = false; merge = false; rebase = false })
 
-let%test "is_method_not_allowed: 405 'not allowed' -> true" =
-  is_method_not_allowed
+(* Status-based, wording-independent: a 405 is a rejection regardless of body,
+   including a non-JSON body (the failure mode behind the squash-retry-forever
+   incident, where the message text was present but unparseable as JSON so the
+   old substring check missed it). *)
+let%test "is_merge_endpoint_rejection: 405 with standard JSON body -> true" =
+  is_merge_endpoint_rejection
     (Http_error
        {
          meth = "PUT";
@@ -1781,22 +1782,26 @@ let%test "is_method_not_allowed: 405 'not allowed' -> true" =
            {|{"message":"Squash merges are not allowed on this repository"}|};
        })
 
-let%test "is_method_not_allowed: 405 without the phrase -> false" =
-  not
-    (is_method_not_allowed
-       (Http_error
-          {
-            meth = "PUT";
-            path = "/merge";
-            status = 405;
-            body = {|{"message":"Pull Request is not mergeable"}|};
-          }))
+let%test "is_merge_endpoint_rejection: 405 with non-JSON body -> true" =
+  is_merge_endpoint_rejection
+    (Http_error
+       {
+         meth = "PUT";
+         path = "/merge";
+         status = 405;
+         body = "Squash merges are not allowed on this repository.";
+       })
 
-let%test "is_method_not_allowed: 409 conflict -> false" =
+let%test "is_merge_endpoint_rejection: 409 conflict -> false" =
   not
-    (is_method_not_allowed
+    (is_merge_endpoint_rejection
        (Http_error
           { meth = "PUT"; path = "/merge"; status = 409; body = "conflict" }))
+
+let%test "is_merge_endpoint_rejection: transport error -> false" =
+  not
+    (is_merge_endpoint_rejection
+       (Transport_error { meth = "PUT"; path = "/merge"; msg = "reset" }))
 
 let%expect_test "show_error includes endpoint + permission hint on 403" =
   let err =
@@ -1845,49 +1850,73 @@ let%expect_test "show_error transport error includes endpoint" =
 let make ~net ~clock ~token ~owner ~repo ~main_branch :
     (module Forge.S with type error = error) =
   let client = create ~token ~owner ~repo ~main_branch in
-  (* Cache the repo's allowed merge methods across calls; populated lazily on
-     the first merge and narrowed if a 405 later reveals a method is disabled. *)
+  (* The repo's allowed merge methods (allow_squash_merge etc.), cached across
+     calls. This config is authoritative for method choice: we read it and pick
+     the preferred *enabled* method rather than guessing and recovering from a
+     405. Refreshed on a 405 because a repo's allowed set can change while onton
+     is running (the stale-cache trap behind the squash-retry-forever incident:
+     onton cached "squash allowed" at startup and kept issuing squash after the
+     repo disabled it). [None] means the config was unreadable this attempt. *)
   let merge_methods_cache = ref None in
-  let resolve_allowed_methods () =
-    match !merge_methods_cache with
-    | Some m -> Some m
-    | None -> (
-        match get_repo_merge_methods ~net ~clock client with
-        | Ok m ->
-            merge_methods_cache := Some m;
-            Some m
-        | Error _ -> None)
+  let fetch_merge_methods () =
+    match get_repo_merge_methods ~net ~clock client with
+    | Ok m ->
+        merge_methods_cache := Some m;
+        Some m
+    | Error _ -> None
+  in
+  (* Methods to attempt, most-preferred first, derived from the repo config.
+     [refresh] forces a fresh read (used after a 405). When the config is
+     unreadable, or readable but reports nothing enabled, fall back to the full
+     preference order and let the per-method 405 handling sort it out — a config
+     hiccup must never block an otherwise-mergeable PR. *)
+  let candidate_methods ~refresh () =
+    let detected =
+      if refresh then fetch_merge_methods ()
+      else
+        match !merge_methods_cache with
+        | Some _ as cached -> cached
+        | None -> fetch_merge_methods ()
+    in
+    match detected with
+    | Some m -> (
+        match allowed_methods_in_preference m with
+        | [] -> merge_method_preference
+        | enabled -> enabled)
+    | None -> merge_method_preference
   in
   let merge_pr_choosing ~pr_number =
-    (* Candidate methods, preferred first: the detected allowed set when we
-       could read it, otherwise the full preference list (a failed detect must
-       not block merges — the 405 fallback below still protects us). *)
-    let order =
-      match resolve_allowed_methods () with
-      | Some m -> allowed_methods_in_preference m
-      | None -> merge_method_preference
+    let equal_method a b =
+      match (a, b) with
+      | `Squash, `Squash | `Merge, `Merge | `Rebase, `Rebase -> true
+      | (`Squash | `Merge | `Rebase), _ -> false
     in
-    let order =
-      if List.is_empty order then merge_method_preference else order
-    in
-    let rec attempt = function
+    (* Try each permitted method in preference order. A 405 means GitHub refused
+       that method — decided by HTTP status, never by matching words in the body
+       (bodies vary and are sometimes not even JSON). On the first 405 we re-read
+       the repo config once, in case its allowed set changed mid-run, then keep
+       trying any still-permitted, not-yet-tried method. Non-405 errors are real
+       failures and propagate immediately; if every permitted method is refused
+       we surface the last 405 so the caller can escalate (e.g. enqueue). *)
+    let rec attempt ~refreshed ~tried ~last = function
       | [] ->
-          assert false
-          (* unreachable: order is always non-empty per the guard above *)
+          if refreshed then Error (Option.value_exn last)
+          else
+            let fresh =
+              List.filter (candidate_methods ~refresh:true ()) ~f:(fun m ->
+                  not (List.mem tried m ~equal:equal_method))
+            in
+            if List.is_empty fresh then Error (Option.value_exn last)
+            else attempt ~refreshed:true ~tried ~last fresh
       | m :: rest -> (
           match merge_pr ~net ~clock client ~pr_number ~merge_method:m with
-          | Error e when is_method_not_allowed e ->
-              (* Stale allow-set: narrow the cache so future merges skip this
-                 method, then try the next candidate. Disabling happens even
-                 when [m] is the last candidate, so a repeat 405 isn't retried
-                 on the next call. *)
-              merge_methods_cache :=
-                Option.map !merge_methods_cache ~f:(fun mm ->
-                    disable_method mm m);
-              if List.is_empty rest then Error e else attempt rest
-          | (Ok _ | Error _) as other -> other)
+          | Ok _ as ok -> ok
+          | Error e when is_merge_endpoint_rejection e ->
+              attempt ~refreshed ~tried:(m :: tried) ~last:(Some e) rest
+          | Error _ as other -> other)
     in
-    attempt order
+    attempt ~refreshed:false ~tried:[] ~last:None
+      (candidate_methods ~refresh:false ())
   in
   let module M = struct
     type nonrec error = error

--- a/lib/github.mli
+++ b/lib/github.mli
@@ -117,10 +117,6 @@ val parse_actions_jobs_response :
     Job database ids become [Ci_check.id], and [html_url] becomes [details_url].
     Pure helper exposed for regression tests. *)
 
-val is_method_not_allowed : error -> bool
-(** True only for the REST 405 response GitHub returns when a merge method is
-    disabled for the repository. *)
-
 val is_merge_queue_required_error : error -> bool
 (** True only for the REST 405 response GitHub returns when the branch requires
     native merge queue use. *)

--- a/test/test_github_merge_commit_null.ml
+++ b/test/test_github_merge_commit_null.ml
@@ -154,7 +154,6 @@ let pending_patch_3_merge_queue_405_detection () =
       }
   in
   assert (Onton.Github.is_merge_queue_required_error merge_queue_err);
-  assert (not (Onton.Github.is_method_not_allowed merge_queue_err));
   assert (not (Onton.Github.is_merge_queue_required_error base_modified_err))
 
 let () =


### PR DESCRIPTION
## What

onton retried a squash merge forever on a repo that disallowed squash (debug case `b46a-9089-7dcf`, PR #5475), logging `Automerge failed — HTTP 405: Squash merges are not allowed` every ~5 min without ever falling back to a merge commit or enqueuing.

## Root cause

`merge_pr_choosing` classified the 405 by matching `"not allowed"` in the response body via `response_error_messages`, which returns `[]` when the body isn't standard `{"message":…}` JSON. `show_error` still printed the text (it has a raw-body fallback the predicates lack), but `is_method_not_allowed` returned `false` → no method fallback, no enqueue. Compounded by a merge-methods cache built once at startup and never refreshed, so a repo settings flip (squash allowed → disabled) mid-run was never picked up.

GitHub returns three distinct **same-status (405)** merge rejections — method-disabled, merge-queue-required, base-branch-modified — differing only in prose, and the body is sometimes not even JSON. Any English-substring logic is fragile.

## Fix (scoped to `merge_pr_choosing`)

1. **No natural language.** Fallback triggers on HTTP **status 405 only** (`is_merge_endpoint_rejection`). Removed `is_method_not_allowed` and `disable_method` (the prose-matching path) plus their tests and `.mli` export.
2. **Read config, pick the preferred enabled method.** `candidate_methods` derives the attempt order from the repo's `allow_*_merge` flags and tries only enabled methods, preferred first. On the first 405 it force-refreshes that config once (settings can change mid-run), then walks any remaining permitted, not-yet-tried method. Non-405 errors propagate as real failures.

Direct_merge vs Enqueue stays structural via `merge_queue_required` (`automerge_action`) — untouched.

## Config reads

- Lazily on the first merge of the process (cold cache → `GET /repos`), cached thereafter.
- Once more, force-refreshed, on the first 405 within a merge call.

No polling / TTL — a silent settings drift that never causes a 405 won't be noticed. Deliberate tradeoff to avoid per-cycle `GET /repos`.

## Out of scope

`is_merge_queue_required_error` (`runner_fiber_impl.ml:348`) still matches "merge queue" prose — a secondary enqueue safety-net for a Direct_merge/merge-queue race. Converting it to structural needs a `pr_state` re-fetch on 405 and interacts with the transient base-branch-modified 405. Left for a follow-up.

## Test

`dune build && dune runtest` green, including the merge-queue-detection test. Added inline tests covering a 405 with a **non-JSON** body (the exact failure mode) and status discrimination (409 / transport → not a rejection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/388"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785509384&installation_id=126163856&pr_number=388&repository=flowglad%2Fonton&return_to=https%3A%2F%2Fgithub.com%2Fflowglad%2Fonton%2Fpull%2F388&signature=72ec7e373028e9407c8f4250f19908f66146842071e7d0a08a03793e734f6860"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->