### PR TITLE
[codex] Add runtime gameplan patch creation

### DIFF
--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -706,6 +706,18 @@ let add_agent t ~patch_id ~branch ~base_branch ~pr_number =
     let graph = Graph.add_patch_with_deps t.graph patch_id ~deps in
     { t with graph; agents = Map.set t.agents ~key:patch_id ~data:agent }
 
+let add_planned_patch t (patch : Patch.t) ~deps =
+  if Map.mem t.agents patch.Patch.id then t
+  else
+    (* Unlike [add_agent], this births a PR-less planned patch (via
+       [Patch_agent.create], the same constructor startup uses) so the poller
+       promotes it to [Ready_start] once its deps are satisfied. The caller is
+       responsible for inserting [patch] into the gameplan in the same snapshot
+       update so prompt composition can find it. *)
+    let agent = Patch_agent.create ~branch:patch.Patch.branch patch.Patch.id in
+    let graph = Graph.add_patch_with_deps t.graph patch.Patch.id ~deps in
+    { t with graph; agents = Map.set t.agents ~key:patch.Patch.id ~data:agent }
+
 type rebase_effect = Push_branch [@@deriving show, eq, sexp_of]
 
 let apply_rebase_result t patch_id rebase_result new_base =

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -215,6 +215,14 @@ val add_agent :
     field is populated by the poller on the next tick. Corresponds to the spec's
     Add action. *)
 
+val add_planned_patch : t -> Patch.t -> deps:Patch_id.t list -> t
+(** Register a runtime-added gameplan patch. No-op if the patch id already
+    exists. Unlike {!add_agent} this births a PR-less agent (via
+    [Patch_agent.create], the startup constructor), so the poller promotes it to
+    [Ready_start] once [deps] are satisfied and its base is fresh. The caller
+    must insert [patch] into the gameplan in the same snapshot update — a
+    [Start] action requires the patch to be present in [gameplan.patches]. *)
+
 (** {2 Persistence support} *)
 
 (** [detail] carries the same formatted reason that [session_driver] writes to

--- a/lib/runtime.ml
+++ b/lib/runtime.ml
@@ -70,6 +70,25 @@ let update_orchestrator_returning t f =
   | Some v -> v
   | None -> assert false
 
+let add_patch t ~title ~description ~dependencies =
+  (* Mutate gameplan and orchestrator together under one lock so a [Start]
+     action never observes a patch that is in the gameplan but not the agent
+     map (or vice versa). On validation failure the snapshot is left untouched. *)
+  let result = ref (Error "add_patch: callback did not run") in
+  update t (fun s ->
+      match Gameplan.add_patch s.gameplan ~title ~description ~dependencies with
+      | Error _ as e ->
+          result := e;
+          s
+      | Ok (gameplan, patch) ->
+          let orchestrator =
+            Orchestrator.add_planned_patch s.orchestrator patch
+              ~deps:patch.Patch.dependencies
+          in
+          result := Ok patch;
+          { s with gameplan; orchestrator });
+  !result
+
 let update_activity_log t f =
   update t (fun s -> { s with activity_log = f s.activity_log })
 

--- a/lib/runtime.mli
+++ b/lib/runtime.mli
@@ -44,6 +44,19 @@ val update_orchestrator_returning :
     new orchestrator state. Useful when you need an atomic check-and-modify that
     also reports what happened. *)
 
+val add_patch :
+  t ->
+  title:string ->
+  description:string ->
+  dependencies:Patch_id.t list ->
+  (Patch.t, string) result
+(** Atomically add a runtime patch to the gameplan and register its agent.
+    Applies {!Gameplan.add_patch} and, on success,
+    {!Orchestrator.add_planned_patch} within a single lock so the two never
+    diverge. Returns the created patch, or [Error msg] (leaving the snapshot
+    untouched) when a dependency id is unknown. The poller picks the patch up on
+    its next tick. *)
+
 val update_activity_log : t -> (Activity_log.t -> Activity_log.t) -> unit
 (** Convenience: update only the activity log. *)
 

--- a/lib/tui.ml
+++ b/lib/tui.ml
@@ -1210,9 +1210,65 @@ let render_manage_overlay ~width ~height ~automerge_enabled ~needs_intervention
       automerge_item;
     ]
     @ Option.to_list bump_item
+    @ [
+        Term.styled [ Term.Sgr.dim ]
+          "    p   Add patch to gameplan (description + dependencies)";
+      ]
   in
   let content = title :: "" :: items in
   let overlay_h = Int.max 0 (Int.min (List.length content) (height - 1)) in
+  let visible = List.sub content ~pos:0 ~len:overlay_h in
+  let pad_line line = if width <= 0 then "" else Term.fit_width width line in
+  List.map visible ~f:pad_line
+
+(** Multi-select dependency picker for the add-patch flow. Lists every existing
+    patch with a checkbox; [cursor] is the highlighted row and [chosen] the
+    toggled-on ids. Rows are windowed to fit [height] around the cursor so long
+    gameplans stay navigable. *)
+let render_deps_overlay ~width ~height ~(views : patch_view list) ~cursor
+    ~(chosen : Patch_id.t list) =
+  let dismiss =
+    Term.styled [ Term.Sgr.dim ]
+      "(↑/↓ move · space toggle · enter confirm · esc cancel)"
+  in
+  let title =
+    Term.styled
+      [ Term.Sgr.bold; Term.Sgr.fg_yellow ]
+      (Printf.sprintf " Select Dependencies  %s" dismiss)
+  in
+  let is_chosen pid = List.mem chosen pid ~equal:Patch_id.equal in
+  let body =
+    if List.is_empty views then
+      [ Term.styled [ Term.Sgr.dim ] "    (no existing patches to depend on)" ]
+    else
+      (* Window the rows around the cursor. Reserve the title + a blank line. *)
+      let total = List.length views in
+      let visible = Int.max 1 (height - 2) in
+      let cursor = Int.max 0 (Int.min cursor (total - 1)) in
+      let start =
+        if total <= visible then 0
+        else Int.max 0 (Int.min (cursor - (visible / 2)) (total - visible))
+      in
+      let window =
+        List.sub views ~pos:start ~len:(Int.min visible (total - start))
+      in
+      List.mapi window ~f:(fun i pv ->
+          let idx = start + i in
+          let mark = if is_chosen pv.patch_id then "[x]" else "[ ]" in
+          let pointer = if idx = cursor then "▸" else " " in
+          let label =
+            Printf.sprintf "%s %s %s  %s" pointer mark
+              (Patch_id.to_string pv.patch_id)
+              pv.title
+          in
+          let line = if width <= 0 then label else Term.fit_width width label in
+          if idx = cursor then Term.styled [ Term.Sgr.reverse ] line
+          else if is_chosen pv.patch_id then
+            Term.styled [ Term.Sgr.fg_green ] line
+          else line)
+  in
+  let content = title :: "" :: body in
+  let overlay_h = Int.max 0 (Int.min (List.length content) height) in
   let visible = List.sub content ~pos:0 ~len:overlay_h in
   let pad_line line = if width <= 0 then "" else Term.fit_width width line in
   List.map visible ~f:pad_line
@@ -1349,7 +1405,7 @@ let views_of_orchestrator ~(orchestrator : Orchestrator.t)
 let render_frame ~width ~height ~selected ~scroll_offset ~view_mode
     ~(activity : activity_entry list) ~project_name ~backend_name ~version
     ~show_help ~show_checks ~checks_scroll ~show_manage ~now ?(transcript = "")
-    ?status_msg ?prompt_line (views : patch_view list) =
+    ?status_msg ?prompt_line ?dep_select (views : patch_view list) =
   let no_patches =
     {
       lines = [];
@@ -1412,90 +1468,103 @@ let render_frame ~width ~height ~selected ~scroll_offset ~view_mode
     in
     { no_patches with lines = overlay; detail_scroll_offset = scroll_offset }
   else
-    let header = render_header ~project_name ~backend_name ~width in
-    let footer = render_footer ~width ~view_mode ?prompt_line () in
-    let status_line =
-      let rendered = render_status_msg ~width status_msg in
-      if String.is_empty rendered then [] else [ rendered ]
-    in
-    match view_mode with
-    | Detail_view patch_id -> (
-        match
-          List.find views ~f:(fun pv -> Patch_id.equal pv.patch_id patch_id)
-        with
-        | Some pv ->
-            let info_h = detail_info_height pv in
-            (* Chrome: header(2) + blank + info + blank before footer + status +
+    match dep_select with
+    | Some (cursor, chosen) ->
+        let overlay =
+          render_deps_overlay ~width ~height ~views ~cursor ~chosen
+        in
+        {
+          no_patches with
+          lines = overlay;
+          detail_scroll_offset = scroll_offset;
+        }
+    | None -> (
+        let header = render_header ~project_name ~backend_name ~width in
+        let footer = render_footer ~width ~view_mode ?prompt_line () in
+        let status_line =
+          let rendered = render_status_msg ~width status_msg in
+          if String.is_empty rendered then [] else [ rendered ]
+        in
+        match view_mode with
+        | Detail_view patch_id -> (
+            match
+              List.find views ~f:(fun pv -> Patch_id.equal pv.patch_id patch_id)
+            with
+            | Some pv ->
+                let info_h = detail_info_height pv in
+                (* Chrome: header(2) + blank + info + blank before footer + status +
                footer *)
-            let fixed =
-              2 + 1 + info_h + 1 + List.length status_line + List.length footer
-            in
-            let max_section = Int.max 0 (height - fixed) in
-            let scroll =
-              { offset = scroll_offset; total = 0; visible = max_section }
-            in
-            let info, transcript_section, at_bottom, clamped_offset =
-              render_detail pv ~width ~scroll ~now ~transcript ()
-            in
-            let lines =
-              header @ [ "" ] @ info @ transcript_section @ [ "" ] @ status_line
-              @ footer
-            in
-            {
-              no_patches with
-              lines;
-              detail_at_bottom = at_bottom;
-              detail_scroll_offset = clamped_offset;
-            }
-        | None ->
-            let lines =
-              header @ [ "" ] @ [ " (patch not found)" ] @ [ "" ] @ status_line
-              @ footer
-            in
-            { no_patches with lines })
-    | Timeline_view ->
-        (* Budget: header(2) + blank + "Timeline" header(1) + scroll
+                let fixed =
+                  2 + 1 + info_h + 1 + List.length status_line
+                  + List.length footer
+                in
+                let max_section = Int.max 0 (height - fixed) in
+                let scroll =
+                  { offset = scroll_offset; total = 0; visible = max_section }
+                in
+                let info, transcript_section, at_bottom, clamped_offset =
+                  render_detail pv ~width ~scroll ~now ~transcript ()
+                in
+                let lines =
+                  header @ [ "" ] @ info @ transcript_section @ [ "" ]
+                  @ status_line @ footer
+                in
+                {
+                  no_patches with
+                  lines;
+                  detail_at_bottom = at_bottom;
+                  detail_scroll_offset = clamped_offset;
+                }
+            | None ->
+                let lines =
+                  header @ [ "" ] @ [ " (patch not found)" ] @ [ "" ]
+                  @ status_line @ footer
+                in
+                { no_patches with lines })
+        | Timeline_view ->
+            (* Budget: header(2) + blank + "Timeline" header(1) + scroll
            indicators(2) + blank before footer + status + footer *)
-        let reserved =
-          2 + 1 + 1 + 2 + 1 + List.length status_line + List.length footer
-        in
-        let max_rows = Int.max 0 (height - reserved) in
-        let scroll =
-          { offset = scroll_offset; total = 0; visible = max_rows }
-        in
-        let timeline = render_timeline ~width ~scroll activity in
-        let lines =
-          header @ [ "" ] @ timeline @ [ "" ] @ status_line @ footer
-        in
-        { no_patches with lines }
-    | List_view ->
-        (* Patches get priority. Reserve only the non-patch, non-activity
+            let reserved =
+              2 + 1 + 1 + 2 + 1 + List.length status_line + List.length footer
+            in
+            let max_rows = Int.max 0 (height - reserved) in
+            let scroll =
+              { offset = scroll_offset; total = 0; visible = max_rows }
+            in
+            let timeline = render_timeline ~width ~scroll activity in
+            let lines =
+              header @ [ "" ] @ timeline @ [ "" ] @ status_line @ footer
+            in
+            { no_patches with lines }
+        | List_view ->
+            (* Patches get priority. Reserve only the non-patch, non-activity
            chrome: header(2) + blank after header + blank before footer +
            status + footer. Scroll indicators are reserved only when patches
            actually overflow, so the rows they would have taken go to
            activity when the list fits. *)
-        let chrome_reserved =
-          2 + 1 + 1 + List.length status_line + List.length footer
-        in
-        let patches_section_max = Int.max 0 (height - chrome_reserved) in
-        let total_views = List.length views in
-        let max_patch_rows =
-          let without_indicators = Int.max 0 (patches_section_max - 1) in
-          if total_views <= without_indicators then without_indicators
-          else Int.max 0 (patches_section_max - 3)
-        in
-        let patches, patch_header_lines, scroll_off, visible_rows =
-          render_patches ~width ~selected ~max_visible:max_patch_rows ~now views
-        in
-        let patches_start_row = 3 + patch_header_lines + 1 in
-        let lines_before_activity =
-          2 (* header *) + 1 (* blank *) + List.length patches
-        in
-        let lines_after_activity =
-          1 (* blank before footer *) + List.length status_line
-          + List.length footer
-        in
-        (* [activity_budget] is the total space available for the activity
+            let chrome_reserved =
+              2 + 1 + 1 + List.length status_line + List.length footer
+            in
+            let patches_section_max = Int.max 0 (height - chrome_reserved) in
+            let total_views = List.length views in
+            let max_patch_rows =
+              let without_indicators = Int.max 0 (patches_section_max - 1) in
+              if total_views <= without_indicators then without_indicators
+              else Int.max 0 (patches_section_max - 3)
+            in
+            let patches, patch_header_lines, scroll_off, visible_rows =
+              render_patches ~width ~selected ~max_visible:max_patch_rows ~now
+                views
+            in
+            let patches_start_row = 3 + patch_header_lines + 1 in
+            let lines_before_activity =
+              2 (* header *) + 1 (* blank *) + List.length patches
+            in
+            let lines_after_activity =
+              1 (* blank before footer *) + List.length status_line
+              + List.length footer
+            in
+            (* [activity_budget] is the total space available for the activity
            block, which when rendered is: 1 blank separator + render_activity
            output ("Activity" header + one line per entry). Need ≥ 3 to fit
            separator + header + 1 entry. The separator is folded into
@@ -1503,27 +1572,27 @@ let render_frame ~width ~height ~selected ~scroll_offset ~view_mode
            sole invariant is [List.length activity_lines ≤ activity_budget],
            and there is no separate prepend at the concat site that could
            drift from the budget. *)
-        let activity_budget =
-          height - lines_before_activity - lines_after_activity
-        in
-        let activity_lines =
-          if List.is_empty activity || activity_budget < 3 then []
-          else
-            let raw = render_activity activity in
-            let max_raw = activity_budget - 1 in
-            "" :: List.take raw (Int.min (List.length raw) max_raw)
-        in
-        let lines =
-          header @ [ "" ] @ patches @ activity_lines @ [ "" ] @ status_line
-          @ footer
-        in
-        {
-          no_patches with
-          lines;
-          patches_start_row;
-          patches_scroll_offset = scroll_off;
-          patch_count = visible_rows;
-        }
+            let activity_budget =
+              height - lines_before_activity - lines_after_activity
+            in
+            let activity_lines =
+              if List.is_empty activity || activity_budget < 3 then []
+              else
+                let raw = render_activity activity in
+                let max_raw = activity_budget - 1 in
+                "" :: List.take raw (Int.min (List.length raw) max_raw)
+            in
+            let lines =
+              header @ [ "" ] @ patches @ activity_lines @ [ "" ] @ status_line
+              @ footer
+            in
+            {
+              no_patches with
+              lines;
+              patches_start_row;
+              patches_scroll_offset = scroll_off;
+              patch_count = visible_rows;
+            })
 
 let frame_to_string (frame : frame) = String.concat ~sep:"\n" frame.lines ^ "\n"
 let detail_at_bottom frame = frame.detail_at_bottom

--- a/lib/tui.ml
+++ b/lib/tui.ml
@@ -1226,7 +1226,7 @@ let render_manage_overlay ~width ~height ~automerge_enabled ~needs_intervention
     toggled-on ids. Rows are windowed to fit [height] around the cursor so long
     gameplans stay navigable. *)
 let render_deps_overlay ~width ~height ~(views : patch_view list) ~cursor
-    ~(chosen : Patch_id.t list) =
+    ~(chosen : Set.M(Patch_id).t) =
   let dismiss =
     Term.styled [ Term.Sgr.dim ]
       "(↑/↓ move · space toggle · enter confirm · esc cancel)"
@@ -1236,7 +1236,7 @@ let render_deps_overlay ~width ~height ~(views : patch_view list) ~cursor
       [ Term.Sgr.bold; Term.Sgr.fg_yellow ]
       (Printf.sprintf " Select Dependencies  %s" dismiss)
   in
-  let is_chosen pid = List.mem chosen pid ~equal:Patch_id.equal in
+  let is_chosen pid = Set.mem chosen pid in
   let body =
     if List.is_empty views then
       [ Term.styled [ Term.Sgr.dim ] "    (no existing patches to depend on)" ]

--- a/lib/tui.mli
+++ b/lib/tui.mli
@@ -214,7 +214,7 @@ val render_frame :
   ?transcript:string ->
   ?status_msg:status_msg ->
   ?prompt_line:prompt_info ->
-  ?dep_select:int * Patch_id.t list ->
+  ?dep_select:int * Set.M(Patch_id).t ->
   patch_view list ->
   frame
 

--- a/lib/tui.mli
+++ b/lib/tui.mli
@@ -214,6 +214,7 @@ val render_frame :
   ?transcript:string ->
   ?status_msg:status_msg ->
   ?prompt_line:prompt_info ->
+  ?dep_select:int * Patch_id.t list ->
   patch_view list ->
   frame
 

--- a/lib/tui_fiber.ml
+++ b/lib/tui_fiber.ml
@@ -108,6 +108,8 @@ struct
       patches_start_row;
       patches_scroll_offset;
       patches_visible_count;
+      dep_select_cursor;
+      dep_select_chosen;
       _;
     } =
       Env.tui_state
@@ -171,6 +173,12 @@ struct
           ~show_manage:
             (Tui_input.equal_input_mode !input_mode Tui_input.Manage_patch)
           ~now ~transcript ?status_msg:!status_msg ?prompt_line:!prompt_line
+          ?dep_select:
+            (if
+               Tui_input.equal_input_mode !input_mode
+                 Tui_input.Select_patch_deps
+             then Some (!dep_select_cursor, !dep_select_chosen)
+             else None)
           views
       in
       detail_scroll := Tui.detail_scroll_offset frame;
@@ -205,6 +213,8 @@ struct
       patches_start_row;
       patches_scroll_offset;
       patches_visible_count;
+      dep_select_cursor;
+      dep_select_chosen;
     } =
       Env.tui_state
     in
@@ -219,9 +229,12 @@ struct
     in
     let sync_input () =
       match !input_mode with
-      | Tui_input.Normal | Tui_input.Manage_patch -> prompt_line := None
+      | Tui_input.Normal | Tui_input.Manage_patch | Tui_input.Select_patch_deps
+        ->
+          prompt_line := None
       | Tui_input.Prompt_pr | Tui_input.Prompt_worktree
-      | Tui_input.Prompt_message | Tui_input.Prompt_broadcast ->
+      | Tui_input.Prompt_message | Tui_input.Prompt_broadcast
+      | Tui_input.Prompt_patch_desc ->
           let prefix = Tui_input.prompt_prefix !input_mode in
           let contents = Tui_input.Edit_buffer.contents buf in
           let cursor_col =
@@ -236,6 +249,9 @@ struct
     in
     let history = Tui_input.History.create () in
     let saved_draft = ref "" in
+    (* Carries the description typed in [Prompt_patch_desc] into the
+       [Prompt_patch_deps] step of the add-patch flow. *)
+    let pending_patch_desc = ref None in
     let eof_count = ref 0 in
     let last_click_time = ref 0.0 in
     let last_click_row = ref (-1) in
@@ -290,6 +306,12 @@ struct
           then (
             (match key with
             | Term.Key.Escape -> input_mode := Tui_input.Normal
+            | Term.Key.Char 'p' ->
+                (* Add a new gameplan patch. Global action, not tied to the
+                   selected patch: begin the two-step description → deps prompt. *)
+                Tui_input.Edit_buffer.clear buf;
+                pending_patch_desc := None;
+                input_mode := Tui_input.Prompt_patch_desc
             | Term.Key.Char 'm' -> (
                 input_mode := Tui_input.Normal;
                 let target_patch_id =
@@ -386,6 +408,81 @@ struct
             | Term.Key.Ctrl _ | Term.Key.Mouse _ | Term.Key.Unknown _ ->
                 ());
             loop ())
+          else if
+            Tui_input.equal_input_mode !input_mode Tui_input.Select_patch_deps
+          then (
+            (* Add-patch step 2: multi-select dependencies. Candidates are the
+               existing patches in display order (same ordering as [views], so
+               the cursor index lines up with the rendered overlay). *)
+            let candidates = !sorted_patch_ids in
+            let n = List.length candidates in
+            (match key with
+            | Term.Key.Escape ->
+                pending_patch_desc := None;
+                input_mode := Tui_input.Normal
+            | Term.Key.Up | Term.Key.Char 'k' ->
+                if n > 0 then
+                  dep_select_cursor := Int.max 0 (!dep_select_cursor - 1)
+            | Term.Key.Down | Term.Key.Char 'j' ->
+                if n > 0 then
+                  dep_select_cursor := Int.min (n - 1) (!dep_select_cursor + 1)
+            | Term.Key.Char ' ' -> (
+                match List.nth candidates !dep_select_cursor with
+                | None -> ()
+                | Some pid ->
+                    if List.mem !dep_select_chosen pid ~equal:Patch_id.equal
+                    then
+                      dep_select_chosen :=
+                        List.filter !dep_select_chosen ~f:(fun p ->
+                            not (Patch_id.equal p pid))
+                    else dep_select_chosen := pid :: !dep_select_chosen)
+            | Term.Key.Enter -> (
+                let description = !pending_patch_desc in
+                pending_patch_desc := None;
+                input_mode := Tui_input.Normal;
+                match description with
+                | None ->
+                    log_event Env.runtime
+                      "Add patch failed — no pending description"
+                | Some description -> (
+                    (* Present deps in display order, not toggle order. *)
+                    let dependencies =
+                      List.filter candidates ~f:(fun p ->
+                          List.mem !dep_select_chosen p ~equal:Patch_id.equal)
+                    in
+                    let title =
+                      if String.length description <= 72 then description
+                      else String.prefix description 71 ^ "…"
+                    in
+                    dep_select_chosen := [];
+                    dep_select_cursor := 0;
+                    match
+                      Runtime.add_patch Env.runtime ~title ~description
+                        ~dependencies
+                    with
+                    | Error msg ->
+                        log_event Env.runtime
+                          (Printf.sprintf "Cannot add patch — %s" msg)
+                    | Ok patch ->
+                        let deps_str =
+                          match patch.Patch.dependencies with
+                          | [] -> "no dependencies"
+                          | ds ->
+                              "depends on "
+                              ^ (List.map ds ~f:Patch_id.to_string
+                                |> String.concat ~sep:", ")
+                        in
+                        log_event Env.runtime ~patch_id:patch.Patch.id
+                          (Printf.sprintf "Added patch %s (%s) — %s"
+                             (Patch_id.to_string patch.Patch.id)
+                             deps_str title)))
+            | Term.Key.Char _ | Term.Key.Tab | Term.Key.Paste _
+            | Term.Key.Backspace | Term.Key.Left | Term.Key.Right
+            | Term.Key.Home | Term.Key.End | Term.Key.Page_up
+            | Term.Key.Page_down | Term.Key.Delete | Term.Key.F _
+            | Term.Key.Ctrl _ | Term.Key.Mouse _ | Term.Key.Unknown _ ->
+                ());
+            loop ())
           else if not (Tui_input.equal_input_mode !input_mode Tui_input.Normal)
           then
             match key with
@@ -395,6 +492,7 @@ struct
             | Term.Key.Escape ->
                 Tui_input.Edit_buffer.clear buf;
                 saved_draft := "";
+                pending_patch_desc := None;
                 Tui_input.History.reset_browse history;
                 input_mode := Tui_input.Normal;
                 loop ()
@@ -639,7 +737,22 @@ struct
                               log_event Env.runtime ~patch_id
                                 (Printf.sprintf "Failed to add worktree — %s"
                                    msg)))
-                | Tui_input.Normal | Tui_input.Manage_patch -> ());
+                | Tui_input.Prompt_patch_desc ->
+                    (* Step 1: capture the description, then open the
+                       dependency-selection overlay. [input_mode] was forced to
+                       [Normal] above, so override it back here. *)
+                    if String.is_empty line then (
+                      pending_patch_desc := None;
+                      log_event Env.runtime
+                        "Add patch cancelled — empty description")
+                    else (
+                      pending_patch_desc := Some line;
+                      dep_select_cursor := 0;
+                      dep_select_chosen := [];
+                      input_mode := Tui_input.Select_patch_deps)
+                | Tui_input.Normal | Tui_input.Manage_patch
+                | Tui_input.Select_patch_deps ->
+                    ());
                 loop ()
             | Term.Key.Backspace ->
                 Tui_input.Edit_buffer.delete_before buf;

--- a/lib/tui_fiber.ml
+++ b/lib/tui_fiber.ml
@@ -311,6 +311,8 @@ struct
                    selected patch: begin the two-step description → deps prompt. *)
                 Tui_input.Edit_buffer.clear buf;
                 pending_patch_desc := None;
+                dep_select_cursor := 0;
+                dep_select_chosen := Set.empty (module Patch_id);
                 input_mode := Tui_input.Prompt_patch_desc
             | Term.Key.Char 'm' -> (
                 input_mode := Tui_input.Normal;
@@ -419,6 +421,8 @@ struct
             (match key with
             | Term.Key.Escape ->
                 pending_patch_desc := None;
+                dep_select_cursor := 0;
+                dep_select_chosen := Set.empty (module Patch_id);
                 input_mode := Tui_input.Normal
             | Term.Key.Up | Term.Key.Char 'k' ->
                 if n > 0 then
@@ -430,32 +434,27 @@ struct
                 match List.nth candidates !dep_select_cursor with
                 | None -> ()
                 | Some pid ->
-                    if List.mem !dep_select_chosen pid ~equal:Patch_id.equal
-                    then
-                      dep_select_chosen :=
-                        List.filter !dep_select_chosen ~f:(fun p ->
-                            not (Patch_id.equal p pid))
-                    else dep_select_chosen := pid :: !dep_select_chosen)
+                    dep_select_chosen :=
+                      if Set.mem !dep_select_chosen pid then
+                        Set.remove !dep_select_chosen pid
+                      else Set.add !dep_select_chosen pid)
             | Term.Key.Enter -> (
                 let description = !pending_patch_desc in
-                pending_patch_desc := None;
-                input_mode := Tui_input.Normal;
                 match description with
                 | None ->
+                    input_mode := Tui_input.Normal;
                     log_event Env.runtime
                       "Add patch failed — no pending description"
                 | Some description -> (
                     (* Present deps in display order, not toggle order. *)
                     let dependencies =
                       List.filter candidates ~f:(fun p ->
-                          List.mem !dep_select_chosen p ~equal:Patch_id.equal)
+                          Set.mem !dep_select_chosen p)
                     in
                     let title =
                       if String.length description <= 72 then description
                       else String.prefix description 71 ^ "…"
                     in
-                    dep_select_chosen := [];
-                    dep_select_cursor := 0;
                     match
                       Runtime.add_patch Env.runtime ~title ~description
                         ~dependencies
@@ -464,6 +463,10 @@ struct
                         log_event Env.runtime
                           (Printf.sprintf "Cannot add patch — %s" msg)
                     | Ok patch ->
+                        pending_patch_desc := None;
+                        input_mode := Tui_input.Normal;
+                        dep_select_chosen := Set.empty (module Patch_id);
+                        dep_select_cursor := 0;
                         let deps_str =
                           match patch.Patch.dependencies with
                           | [] -> "no dependencies"
@@ -493,6 +496,8 @@ struct
                 Tui_input.Edit_buffer.clear buf;
                 saved_draft := "";
                 pending_patch_desc := None;
+                dep_select_cursor := 0;
+                dep_select_chosen := Set.empty (module Patch_id);
                 Tui_input.History.reset_browse history;
                 input_mode := Tui_input.Normal;
                 loop ()
@@ -503,7 +508,10 @@ struct
                 let mode = !input_mode in
                 Tui_input.Edit_buffer.clear buf;
                 saved_draft := "";
-                input_mode := Tui_input.Normal;
+                if
+                  not
+                    (Tui_input.equal_input_mode mode Tui_input.Prompt_patch_desc)
+                then input_mode := Tui_input.Normal;
                 let line = String.strip line in
                 (match mode with
                 | Tui_input.Prompt_message -> (
@@ -739,16 +747,16 @@ struct
                                    msg)))
                 | Tui_input.Prompt_patch_desc ->
                     (* Step 1: capture the description, then open the
-                       dependency-selection overlay. [input_mode] was forced to
-                       [Normal] above, so override it back here. *)
+                       dependency-selection overlay. *)
                     if String.is_empty line then (
                       pending_patch_desc := None;
+                      input_mode := Tui_input.Normal;
                       log_event Env.runtime
                         "Add patch cancelled — empty description")
                     else (
                       pending_patch_desc := Some line;
                       dep_select_cursor := 0;
-                      dep_select_chosen := [];
+                      dep_select_chosen := Set.empty (module Patch_id);
                       input_mode := Tui_input.Select_patch_deps)
                 | Tui_input.Normal | Tui_input.Manage_patch
                 | Tui_input.Select_patch_deps ->

--- a/lib/tui_state.ml
+++ b/lib/tui_state.ml
@@ -18,6 +18,10 @@ type t = {
   patches_scroll_offset : int ref;
   patches_visible_count : int ref;
   detail_scrolls : (Types.Patch_id.t, int * bool) Stdlib.Hashtbl.t;
+  dep_select_cursor : int ref;
+      (** Highlighted row in the add-patch dependency-selection overlay. *)
+  dep_select_chosen : Types.Patch_id.t list ref;
+      (** Currently toggled-on dependencies in that overlay. *)
 }
 
 let create () =
@@ -38,4 +42,6 @@ let create () =
     patches_scroll_offset = ref 0;
     patches_visible_count = ref 0;
     detail_scrolls = Stdlib.Hashtbl.create 16;
+    dep_select_cursor = ref 0;
+    dep_select_chosen = ref [];
   }

--- a/lib/tui_state.ml
+++ b/lib/tui_state.ml
@@ -1,6 +1,8 @@
 (* @archlint.module state
    @archlint.domain session-meta *)
 
+open Base
+
 type t = {
   list_selected : int ref;
   detail_scroll : int ref;
@@ -20,7 +22,7 @@ type t = {
   detail_scrolls : (Types.Patch_id.t, int * bool) Stdlib.Hashtbl.t;
   dep_select_cursor : int ref;
       (** Highlighted row in the add-patch dependency-selection overlay. *)
-  dep_select_chosen : Types.Patch_id.t list ref;
+  dep_select_chosen : Set.M(Types.Patch_id).t ref;
       (** Currently toggled-on dependencies in that overlay. *)
 }
 
@@ -43,5 +45,5 @@ let create () =
     patches_visible_count = ref 0;
     detail_scrolls = Stdlib.Hashtbl.create 16;
     dep_select_cursor = ref 0;
-    dep_select_chosen = ref [];
+    dep_select_chosen = ref (Set.empty (module Types.Patch_id));
   }

--- a/lib/tui_state.mli
+++ b/lib/tui_state.mli
@@ -1,6 +1,8 @@
 (* @archlint.module interface
    @archlint.domain tui-state *)
 
+open Base
+
 type t = {
   list_selected : int ref;
   detail_scroll : int ref;
@@ -20,7 +22,7 @@ type t = {
   detail_scrolls : (Types.Patch_id.t, int * bool) Stdlib.Hashtbl.t;
   dep_select_cursor : int ref;
       (** Highlighted row in the add-patch dependency-selection overlay. *)
-  dep_select_chosen : Types.Patch_id.t list ref;
+  dep_select_chosen : Set.M(Types.Patch_id).t ref;
       (** Currently toggled-on dependencies in that overlay. *)
 }
 

--- a/lib/tui_state.mli
+++ b/lib/tui_state.mli
@@ -18,6 +18,10 @@ type t = {
   patches_scroll_offset : int ref;
   patches_visible_count : int ref;
   detail_scrolls : (Types.Patch_id.t, int * bool) Stdlib.Hashtbl.t;
+  dep_select_cursor : int ref;
+      (** Highlighted row in the add-patch dependency-selection overlay. *)
+  dep_select_chosen : Types.Patch_id.t list ref;
+      (** Currently toggled-on dependencies in that overlay. *)
 }
 
 val create : unit -> t

--- a/lib_core/gameplan_parser.ml
+++ b/lib_core/gameplan_parser.ml
@@ -8,14 +8,9 @@ type t = {
   dependency_graph : Types.Patch_id.t list Map.M(Types.Patch_id).t;
 }
 
-let slugify name =
-  String.lowercase name
-  |> String.map ~f:(fun c ->
-      if Char.is_alphanum c || Char.equal c '-' || Char.equal c '_' then c
-      else '-')
-  |> String.split ~on:'-'
-  |> List.filter ~f:(fun s -> not (String.is_empty s))
-  |> String.concat ~sep:"-"
+(* Single source of truth lives in [Types.Gameplan] so runtime-added patches
+   derive identical branch names; aliased here for the parser and its tests. *)
+let slugify = Types.Gameplan.slugify
 
 let is_valid_patch_id s =
   (not (String.is_empty s))

--- a/lib_core/tui_input_decision.ml
+++ b/lib_core/tui_input_decision.ml
@@ -32,6 +32,10 @@ type input_mode =
   | Prompt_message
   | Prompt_broadcast
   | Manage_patch
+  | Prompt_patch_desc  (** Step 1 of add-patch: enter the patch description. *)
+  | Select_patch_deps
+      (** Step 2 of add-patch: multi-select dependencies from a patch list
+          overlay (space toggles, enter commits). Not a text prompt. *)
 [@@deriving show, eq]
 
 let prompt_prefix = function
@@ -41,6 +45,8 @@ let prompt_prefix = function
   | Prompt_message -> "> "
   | Prompt_broadcast -> "broadcast> "
   | Manage_patch -> ""
+  | Prompt_patch_desc -> "patch description: "
+  | Select_patch_deps -> ""
 
 let of_key (key : Term_key.t) : command =
   match key with

--- a/lib_core/tui_input_decision.mli
+++ b/lib_core/tui_input_decision.mli
@@ -34,6 +34,10 @@ type input_mode =
   | Prompt_message  (** Buffer holds message text, detail view only *)
   | Prompt_broadcast  (** Buffer holds message to send to all active patches *)
   | Manage_patch  (** Menu of break-glass patch actions, detail view only *)
+  | Prompt_patch_desc  (** Add-patch step 1: buffer holds the description *)
+  | Select_patch_deps
+      (** Add-patch step 2: multi-select dependency overlay (not a text prompt)
+      *)
 [@@deriving show, eq]
 
 val prompt_prefix : input_mode -> string

--- a/lib_core/types.ml
+++ b/lib_core/types.ml
@@ -349,4 +349,89 @@ module Gameplan = struct
     open_questions : string list; [@yojson.default []]
   }
   [@@deriving show, eq, sexp_of, compare, yojson]
+
+  (* Canonical project-name → branch-prefix slug. Shared with
+     [Gameplan_parser] (which aliases this) so the branch a runtime-added patch
+     gets is byte-identical to the ones the parser derives at load time. *)
+  let slugify name =
+    String.lowercase name
+    |> String.map ~f:(fun c ->
+        if Char.is_alphanum c || Char.equal c '-' || Char.equal c '_' then c
+        else '-')
+    |> String.split ~on:'-'
+    |> List.filter ~f:(fun s -> not (String.is_empty s))
+    |> String.concat ~sep:"-"
+
+  (* Branch name for a patch id, matching the parser's
+     [{slug}/patch-{id}] convention (gameplan_parser.ml). *)
+  let branch_of_id (t : t) (id : Patch_id.t) : Branch.t =
+    Branch.of_string (slugify t.project_name ^ "/patch-" ^ Patch_id.to_string id)
+
+  (* Smallest [addN] id (N ≥ 1) not already used by a patch. Alphanumeric so it
+     satisfies the parser's id invariant, and never a bare integer so it cannot
+     collide with an ad-hoc PR id (which is [string_of_int pr_number]). *)
+  let next_user_patch_id (t : t) : Patch_id.t =
+    let used =
+      List.map t.patches ~f:(fun p -> Patch_id.to_string p.Patch.id)
+      |> Set.of_list (module String)
+    in
+    let rec pick n =
+      let candidate = "add" ^ Int.to_string n in
+      if Set.mem used candidate then pick (n + 1)
+      else Patch_id.of_string candidate
+    in
+    pick 1
+
+  (* Add a runtime patch carrying only user-supplied intent (title,
+     description, dependencies). Functional-changes / context / reachability
+     stay empty, so the patch agent is prompted with the gameplan context plus
+     this description and nothing else. Returns the updated gameplan and the
+     created patch, or a descriptive error when a dependency id is unknown.
+
+     New patches can only point at pre-existing patches, so the dependency graph
+     stays acyclic by construction. *)
+  let add_patch (t : t) ~(title : string) ~(description : string)
+      ~(dependencies : Patch_id.t list) : (t * Patch.t, string) Result.t =
+    let existing =
+      List.map t.patches ~f:(fun p -> p.Patch.id)
+      |> Set.of_list (module Patch_id)
+    in
+    let unknown =
+      List.filter dependencies ~f:(fun d -> not (Set.mem existing d))
+    in
+    match unknown with
+    | _ :: _ ->
+        Error
+          (Printf.sprintf "Unknown dependency id(s): %s"
+             (List.map unknown ~f:Patch_id.to_string |> String.concat ~sep:", "))
+    | [] ->
+        (* Dedup while preserving first-seen order. *)
+        let dependencies =
+          List.fold dependencies
+            ~init:([], Set.empty (module Patch_id))
+            ~f:(fun (acc, seen) d ->
+              if Set.mem seen d then (acc, seen) else (d :: acc, Set.add seen d))
+          |> fst |> List.rev
+        in
+        let id = next_user_patch_id t in
+        let patch =
+          {
+            Patch.id;
+            title;
+            description;
+            branch = branch_of_id t id;
+            dependencies;
+            spec = "";
+            acceptance_criteria = [];
+            files = [];
+            classification = "";
+            changes = [];
+            test_stubs_introduced = [];
+            test_stubs_implemented = [];
+            complexity = None;
+            precedents = [];
+            required_context = [];
+          }
+        in
+        Ok ({ t with patches = t.patches @ [ patch ] }, patch)
 end

--- a/lib_core/types.mli
+++ b/lib_core/types.mli
@@ -366,4 +366,26 @@ module Gameplan : sig
     open_questions : string list; [@yojson.default []]
   }
   [@@deriving show, eq, sexp_of, compare, yojson]
+
+  val slugify : string -> string
+  (** Canonical project-name → branch-prefix slug. Shared with [Gameplan_parser]
+      so runtime-added and parsed patches derive identical branch names. *)
+
+  val branch_of_id : t -> Patch_id.t -> Branch.t
+  (** Branch for a patch id, matching the parser's [{slug}/patch-{id}]
+      convention. *)
+
+  val add_patch :
+    t ->
+    title:string ->
+    description:string ->
+    dependencies:Patch_id.t list ->
+    (t * Patch.t, string) Result.t
+  (** Append a runtime patch carrying only user intent (title, description,
+      dependencies). The id is auto-generated in an [addN] namespace that cannot
+      collide with numeric ad-hoc PR ids; the branch follows {!branch_of_id};
+      functional-changes/context/reachability are left empty. Returns the
+      updated gameplan and the created patch, or [Error msg] when a dependency
+      id does not name an existing patch. Dependencies are deduped preserving
+      order. Cannot introduce a cycle (the new patch is a graph sink). *)
 end

--- a/test/dune
+++ b/test/dune
@@ -26,6 +26,13 @@
  (libraries onton_core base yojson ppx_yojson_conv_lib))
 
 (test
+ (name test_gameplan_add_patch_properties)
+ (modules test_gameplan_add_patch_properties)
+ (libraries onton_core onton_test_support qcheck-core qcheck-core.runner base)
+ (ocamlopt_flags (:standard -w -40-42))
+ (ocamlc_flags (:standard -w -40-42)))
+
+(test
  (name test_patch_agent)
  (modules test_patch_agent)
  (libraries onton onton_core qcheck-core))

--- a/test/test_action_outcome_properties.ml
+++ b/test/test_action_outcome_properties.ml
@@ -524,6 +524,8 @@ let () =
          let orch, _patches, gameplan, pid = bootstrap_one () in
          let mid = Message_id.of_string "ao-surface-msg" in
          let orch = Orchestrator.set_main_branch orch main in
+         (* Compile-time check of the public [Gameplan.add_patch] contract:
+            [Ok] carries an immutable [(Gameplan.t * Patch.t)] tuple. *)
          let gameplan_with_added, added_patch =
            match
              Gameplan.add_patch gameplan ~title:"runtime patch"
@@ -538,10 +540,11 @@ let () =
              (List.exists gameplan_with_added.Gameplan.patches ~f:(fun p ->
                   Patch_id.equal p.Patch.id added_patch.Patch.id))
          then QCheck2.Test.fail_reportf "added patch missing from gameplan";
-         (* [add_planned_patch] registers the PR-less agent and graph edges; the
-            patch record itself remains owned by [Gameplan.t]. Keep the
-            generated id/deps as the expected immutable contract and assert the
-            orchestrator graph reflects them exactly. *)
+         (* [Gameplan.t] and [Patch.t] are immutable records. [add_planned_patch]
+            registers the PR-less agent and graph edges; the patch record itself
+            remains owned by [Gameplan.t] and cannot be mutated in place. Keep
+            the generated id/deps as the expected immutable contract and assert
+            the orchestrator graph reflects them exactly. *)
          let added_patch_id = added_patch.Patch.id in
          let expected_deps = added_patch.Patch.dependencies in
          let orch =

--- a/test/test_action_outcome_properties.ml
+++ b/test/test_action_outcome_properties.ml
@@ -521,9 +521,31 @@ let () =
   QCheck2.Test.check_exn
     (QCheck2.Test.make ~name:"orchestrator surface preserves well-formedness"
        ~count:50 QCheck2.Gen.bool (fun flag ->
-         let orch, _patches, _gameplan, pid = bootstrap_one () in
+         let orch, _patches, gameplan, pid = bootstrap_one () in
          let mid = Message_id.of_string "ao-surface-msg" in
          let orch = Orchestrator.set_main_branch orch main in
+         let _gameplan_with_added, added_patch =
+           match
+             Gameplan.add_patch gameplan ~title:"runtime patch"
+               ~description:"created from TUI"
+               ~dependencies:(if flag then [ pid ] else [])
+           with
+           | Ok added -> added
+           | Error msg -> QCheck2.Test.fail_reportf "%s" msg
+         in
+         let orch =
+           Orchestrator.add_planned_patch orch added_patch
+             ~deps:added_patch.Patch.dependencies
+         in
+         let added_agent = Orchestrator.agent orch added_patch.Patch.id in
+         if Patch_agent.has_pr added_agent then
+           QCheck2.Test.fail_reportf "planned patch unexpectedly has a PR";
+         if
+           not
+             (List.equal Patch_id.equal
+                (Graph.deps (Orchestrator.graph orch) added_patch.Patch.id)
+                added_patch.Patch.dependencies)
+         then QCheck2.Test.fail_reportf "planned patch deps were not recorded";
          let orch = Orchestrator.set_automerge_enabled orch pid flag in
          let orch = Orchestrator.set_automerge_inflight orch pid flag in
          let orch = Orchestrator.set_automerge_deadline orch pid 1.0 in

--- a/test/test_action_outcome_properties.ml
+++ b/test/test_action_outcome_properties.ml
@@ -524,27 +524,37 @@ let () =
          let orch, _patches, gameplan, pid = bootstrap_one () in
          let mid = Message_id.of_string "ao-surface-msg" in
          let orch = Orchestrator.set_main_branch orch main in
-         let _gameplan_with_added, added_patch =
+         let gameplan_with_added, added_patch =
            match
              Gameplan.add_patch gameplan ~title:"runtime patch"
                ~description:"created from TUI"
                ~dependencies:(if flag then [ pid ] else [])
            with
-           | Ok added -> added
+           | Ok (added : Gameplan.t * Patch.t) -> added
            | Error msg -> QCheck2.Test.fail_reportf "%s" msg
          in
+         if
+           not
+             (List.exists gameplan_with_added.Gameplan.patches ~f:(fun p ->
+                  Patch_id.equal p.Patch.id added_patch.Patch.id))
+         then QCheck2.Test.fail_reportf "added patch missing from gameplan";
+         (* [add_planned_patch] registers the PR-less agent and graph edges; the
+            patch record itself remains owned by [Gameplan.t]. Keep the
+            generated id/deps as the expected immutable contract and assert the
+            orchestrator graph reflects them exactly. *)
+         let added_patch_id = added_patch.Patch.id in
+         let expected_deps = added_patch.Patch.dependencies in
          let orch =
-           Orchestrator.add_planned_patch orch added_patch
-             ~deps:added_patch.Patch.dependencies
+           Orchestrator.add_planned_patch orch added_patch ~deps:expected_deps
          in
-         let added_agent = Orchestrator.agent orch added_patch.Patch.id in
+         let added_agent = Orchestrator.agent orch added_patch_id in
          if Patch_agent.has_pr added_agent then
            QCheck2.Test.fail_reportf "planned patch unexpectedly has a PR";
          if
            not
              (List.equal Patch_id.equal
-                (Graph.deps (Orchestrator.graph orch) added_patch.Patch.id)
-                added_patch.Patch.dependencies)
+                (Graph.deps (Orchestrator.graph orch) added_patch_id)
+                expected_deps)
          then QCheck2.Test.fail_reportf "planned patch deps were not recorded";
          let orch = Orchestrator.set_automerge_enabled orch pid flag in
          let orch = Orchestrator.set_automerge_inflight orch pid flag in

--- a/test/test_gameplan_add_patch_properties.ml
+++ b/test/test_gameplan_add_patch_properties.ml
@@ -20,6 +20,17 @@ let gen_gameplan_and_valid_deps =
       list_size (int_range 0 (List.length ids)) (oneof_list ids) >>= fun deps ->
       return (g, deps)
 
+let prop_totality =
+  QCheck2.Test.make ~name:"add_patch: never raises" ~count:500
+    QCheck2.Gen.(triple gen_gameplan string string)
+    (fun (g, title, description) ->
+      try
+        ignore
+          (Gameplan.add_patch g ~title ~description ~dependencies:[]
+            : (Gameplan.t * Patch.t, string) Result.t);
+        true
+      with _ -> false)
+
 let prop_valid_deps_appends_one_fresh_patch =
   QCheck2.Test.make ~name:"add_patch: valid deps append exactly one fresh patch"
     ~count:500 gen_gameplan_and_valid_deps (fun (g, deps) ->
@@ -89,6 +100,7 @@ let prop_deps_deduped_preserving_order =
 let () =
   let suite =
     [
+      prop_totality;
       prop_valid_deps_appends_one_fresh_patch;
       prop_unknown_dep_rejected;
       prop_deps_deduped_preserving_order;

--- a/test/test_gameplan_add_patch_properties.ml
+++ b/test/test_gameplan_add_patch_properties.ml
@@ -1,0 +1,98 @@
+(* @archlint.module test
+   @archlint.domain anchor *)
+
+open Base
+open Onton_core.Types
+open Onton_test_support.Test_generators
+
+(* [gen_gameplan] always yields at least one patch (base case [patch-0]). *)
+let existing_ids (g : Gameplan.t) =
+  List.map g.Gameplan.patches ~f:(fun p -> p.Patch.id)
+
+(* Pair a gameplan with a random subset (possibly empty) of its own patch ids
+   to use as valid dependencies. *)
+let gen_gameplan_and_valid_deps =
+  let open QCheck2.Gen in
+  gen_gameplan >>= fun g ->
+  match existing_ids g with
+  | [] -> return (g, [])
+  | ids ->
+      list_size (int_range 0 (List.length ids)) (oneof_list ids) >>= fun deps ->
+      return (g, deps)
+
+let prop_valid_deps_appends_one_fresh_patch =
+  QCheck2.Test.make ~name:"add_patch: valid deps append exactly one fresh patch"
+    ~count:500 gen_gameplan_and_valid_deps (fun (g, deps) ->
+      match
+        Gameplan.add_patch g ~title:"t" ~description:"d" ~dependencies:deps
+      with
+      | Error _ -> false
+      | Ok (g', patch) ->
+          let before = existing_ids g in
+          let grew_by_one =
+            List.length g'.Gameplan.patches = List.length g.Gameplan.patches + 1
+          in
+          let appended_last =
+            match List.last g'.Gameplan.patches with
+            | Some p -> Patch.equal p patch
+            | None -> false
+          in
+          (* Generated id is fresh (not among pre-existing ids). *)
+          let id_fresh =
+            not (List.mem before patch.Patch.id ~equal:Patch_id.equal)
+          in
+          (* Branch follows the shared {slug}/patch-{id} convention. *)
+          let branch_ok =
+            Branch.equal patch.Patch.branch
+              (Gameplan.branch_of_id g patch.Patch.id)
+          in
+          (* Referential integrity: the new patch points only at pre-existing
+             patches. This is exactly what keeps the dependency graph acyclic —
+             a sink pointing backward can never close a cycle. *)
+          let deps_backward =
+            List.for_all patch.Patch.dependencies ~f:(fun d ->
+                List.mem before d ~equal:Patch_id.equal)
+          in
+          grew_by_one && appended_last && id_fresh && branch_ok && deps_backward)
+
+let prop_unknown_dep_rejected =
+  QCheck2.Test.make ~name:"add_patch: unknown dependency id is rejected"
+    ~count:500 gen_gameplan (fun g ->
+      (* An id shaped unlike any generated id (those are "patch-N"/"addN"). *)
+      let bogus = Patch_id.of_string "no-such-patch-zzz" in
+      let deps = bogus :: existing_ids g in
+      match
+        Gameplan.add_patch g ~title:"t" ~description:"d" ~dependencies:deps
+      with
+      | Error _ -> true
+      | Ok _ -> false)
+
+let prop_deps_deduped_preserving_order =
+  QCheck2.Test.make ~name:"add_patch: dependencies are deduped in order"
+    ~count:500 gen_gameplan_and_valid_deps (fun (g, deps) ->
+      (* Duplicate every dep; result must equal the order-preserving dedup. *)
+      let doubled = deps @ deps in
+      let expected =
+        List.fold deps
+          ~init:([], Set.empty (module Patch_id))
+          ~f:(fun (acc, seen) d ->
+            if Set.mem seen d then (acc, seen) else (d :: acc, Set.add seen d))
+        |> fst |> List.rev
+      in
+      match
+        Gameplan.add_patch g ~title:"t" ~description:"d" ~dependencies:doubled
+      with
+      | Error _ -> false
+      | Ok (_, patch) ->
+          List.equal Patch_id.equal patch.Patch.dependencies expected)
+
+let () =
+  let suite =
+    [
+      prop_valid_deps_appends_one_fresh_patch;
+      prop_unknown_dep_rejected;
+      prop_deps_deduped_preserving_order;
+    ]
+  in
+  let errcode = QCheck_base_runner.run_tests ~verbose:true suite in
+  if errcode <> 0 then Stdlib.exit errcode

--- a/test/test_tui_input.ml
+++ b/test/test_tui_input.ml
@@ -83,6 +83,8 @@ let () =
            Tui_input.Prompt_message;
            Tui_input.Prompt_broadcast;
            Tui_input.Manage_patch;
+           Tui_input.Prompt_patch_desc;
+           Tui_input.Select_patch_deps;
          ])
       (fun mode ->
         ignore (Tui_input.prompt_prefix mode : string);


### PR DESCRIPTION
## Summary

Adds a TUI flow for creating new patches in a running gameplan. The flow collects a patch description, then opens a modal dependency picker where existing patches can be multi-selected with space and committed with enter.

## What changed

- Added pure `Gameplan.add_patch` support with generated `addN` ids, dependency validation, branch derivation, and order-preserving dependency deduplication.
- Added runtime/orchestrator plumbing so the new patch is inserted into the snapshot gameplan and registered as a planned PR-less patch atomically.
- Added TUI state, input modes, and overlay rendering for the add-patch flow.
- Added QCheck2 coverage for valid/invalid dependency handling and patch insertion invariants.

## Impact

Runtime-added patches are treated like normal gameplan patches: once dependencies are available, the existing poller can start their worktree and patch agent, and the existing prompt renderer includes the gameplan context plus the user-supplied patch description.

Persistence is snapshot-only by design; the original gameplan JSON is not rewritten.

## Validation

- `dune build`
- `dune runtest`