### PR TITLE
[failing-ci-details] Patch 2: Project_store CI artifact layout and publisher

### DIFF
--- a/lib/project_store.ml
+++ b/lib/project_store.ml
@@ -73,6 +73,19 @@ let findings_wontfix_artifact_path ~project_name ~patch_id =
     (artifact_dir ~project_name ~patch_id)
     "findings_wontfix.json"
 
+let ci_artifact_dir ~project_name ~patch_id =
+  Stdlib.Filename.concat (artifact_dir ~project_name ~patch_id) "ci"
+
+let ci_check_key (c : Types.Ci_check.t) =
+  match c.id with
+  | Some id -> "run-" ^ Int.to_string id
+  | None -> "status-" ^ slugify c.name
+
+let ci_check_artifact_dir ~project_name ~patch_id ~check =
+  Stdlib.Filename.concat
+    (ci_artifact_dir ~project_name ~patch_id)
+    (ci_check_key check)
+
 let ensure_dir path =
   let rec mkdir_p dir =
     if not (Stdlib.Sys.file_exists dir) then (
@@ -222,6 +235,72 @@ let publish_gameplan_artifact ~project_name =
         Stdlib.output_string oc content;
         Stdlib.flush oc))
 
+let write_text_file ~path ~content =
+  let oc = Stdlib.open_out_bin path in
+  Stdlib.Fun.protect
+    ~finally:(fun () -> Stdlib.close_out oc)
+    (fun () ->
+      Stdlib.output_string oc content;
+      Stdlib.flush oc)
+
+let write_file_atomically ~path ~content =
+  let dir = Stdlib.Filename.dirname path in
+  let base = Stdlib.Filename.basename path in
+  let tmp_path = Stdlib.Filename.temp_file ~temp_dir:dir (base ^ ".") ".tmp" in
+  try
+    let oc = Stdlib.open_out_bin tmp_path in
+    Stdlib.Fun.protect
+      ~finally:(fun () -> Stdlib.close_out oc)
+      (fun () ->
+        Stdlib.output_string oc content;
+        Stdlib.flush oc);
+    Stdlib.Sys.rename tmp_path path;
+    Ok ()
+  with exn ->
+    (try Stdlib.Sys.remove tmp_path with _ -> ());
+    Error (Stdlib.Printexc.to_string exn)
+
+let ci_check_json ~(check : Types.Ci_check.t) ~head_oid =
+  `Assoc
+    [
+      ("name", `String check.name);
+      ("conclusion", `String check.conclusion);
+      ( "details_url",
+        Option.value_map check.details_url ~default:`Null ~f:(fun s ->
+            `String s) );
+      ( "started_at",
+        Option.value_map check.started_at ~default:`Null ~f:(fun s -> `String s)
+      );
+      ( "check_run_id",
+        Option.value_map check.id ~default:`Null ~f:(fun id -> `Int id) );
+      ( "head_oid",
+        Option.value_map head_oid ~default:`Null ~f:(fun s -> `String s) );
+    ]
+
+let publish_ci_check_artifact ~project_name ~patch_id ~check ?head_oid
+    ~summary_md ?log () =
+  try
+    let dir = ci_check_artifact_dir ~project_name ~patch_id ~check in
+    ensure_dir dir;
+    let check_json_path = Stdlib.Filename.concat dir "check.json" in
+    let summary_path = Stdlib.Filename.concat dir "summary.md" in
+    let log_path = Stdlib.Filename.concat dir "log.txt" in
+    match
+      write_file_atomically ~path:check_json_path
+        ~content:(Yojson.Safe.pretty_to_string (ci_check_json ~check ~head_oid))
+    with
+    | Error msg -> Error msg
+    | Ok () -> (
+        try
+          write_text_file ~path:summary_path ~content:summary_md;
+          (match log with
+          | None ->
+              if Stdlib.Sys.file_exists log_path then Stdlib.Sys.remove log_path
+          | Some content -> write_text_file ~path:log_path ~content);
+          Ok dir
+        with exn -> Error (Stdlib.Printexc.to_string exn))
+  with exn -> Error (Stdlib.Printexc.to_string exn)
+
 let project_exists project_name =
   Stdlib.Sys.file_exists (config_path project_name)
 
@@ -262,6 +341,128 @@ let read_file_for_test path =
   Stdlib.Fun.protect
     ~finally:(fun () -> Stdlib.close_in_noerr ic)
     (fun () -> Stdlib.In_channel.input_all ic)
+
+let ci_check_for_test ?id ?details_url ?description ?started_at
+    ?(name = "Build and Test") ?(conclusion = "failure") () : Types.Ci_check.t =
+  { name; conclusion; details_url; description; started_at; id }
+
+let dir_entries_for_test path =
+  Stdlib.Sys.readdir path |> Array.to_list |> List.sort ~compare:String.compare
+
+let json_field_for_test name = function
+  | `Assoc fields -> List.Assoc.find fields name ~equal:String.equal
+  | _ -> None
+
+let%test "ci_check_key uses run id for CheckRuns and slug for id-less checks" =
+  let run_check = ci_check_for_test ~id:123 ~name:"CI / Test Suite" () in
+  let status_check =
+    ci_check_for_test ~name:"all_jobs_succeed / Required!" ()
+  in
+  String.equal (ci_check_key run_check) "run-123"
+  && String.equal
+       (ci_check_key status_check)
+       "status-all-jobs-succeed--required"
+
+let%test "publish_ci_check_artifact writes metadata and summary without log" =
+  with_temp_data_dir (fun () ->
+      let project_name = "CI Artifact Project" in
+      let patch_id = Types.Patch_id.of_string "patch-2" in
+      let check =
+        ci_check_for_test ~id:42 ~name:"Unit Tests" ~conclusion:"failure"
+          ~details_url:"https://github.example/checks/42"
+          ~started_at:"2026-07-01T12:00:00Z" ()
+      in
+      match
+        publish_ci_check_artifact ~project_name ~patch_id ~check
+          ~head_oid:"abc123" ~summary_md:"summary\n" ()
+      with
+      | Error _ -> false
+      | Ok dir ->
+          List.equal String.equal (dir_entries_for_test dir)
+            [ "check.json"; "summary.md" ]
+          && String.equal
+               (read_file_for_test (Stdlib.Filename.concat dir "summary.md"))
+               "summary\n"
+          &&
+          let json =
+            Yojson.Safe.from_string
+              (read_file_for_test (Stdlib.Filename.concat dir "check.json"))
+          in
+          [%equal: Yojson.Safe.t option]
+            (json_field_for_test "name" json)
+            (Some (`String "Unit Tests"))
+          && [%equal: Yojson.Safe.t option]
+               (json_field_for_test "conclusion" json)
+               (Some (`String "failure"))
+          && [%equal: Yojson.Safe.t option]
+               (json_field_for_test "details_url" json)
+               (Some (`String "https://github.example/checks/42"))
+          && [%equal: Yojson.Safe.t option]
+               (json_field_for_test "started_at" json)
+               (Some (`String "2026-07-01T12:00:00Z"))
+          && [%equal: Yojson.Safe.t option]
+               (json_field_for_test "check_run_id" json)
+               (Some (`Int 42))
+          && [%equal: Yojson.Safe.t option]
+               (json_field_for_test "head_oid" json)
+               (Some (`String "abc123")))
+
+let%test "publish_ci_check_artifact writes log only when supplied" =
+  with_temp_data_dir (fun () ->
+      let project_name = "CI Artifact Project With Log" in
+      let patch_id = Types.Patch_id.of_string "patch-2" in
+      let check = ci_check_for_test ~name:"lint/status" () in
+      match
+        publish_ci_check_artifact ~project_name ~patch_id ~check
+          ~summary_md:"summary\n" ~log:"full log\n" ()
+      with
+      | Error _ -> false
+      | Ok dir ->
+          String.equal
+            (ci_check_artifact_dir ~project_name ~patch_id ~check)
+            dir
+          && List.equal String.equal (dir_entries_for_test dir)
+               [ "check.json"; "log.txt"; "summary.md" ]
+          && String.equal
+               (read_file_for_test (Stdlib.Filename.concat dir "log.txt"))
+               "full log\n"
+          &&
+          let json =
+            Yojson.Safe.from_string
+              (read_file_for_test (Stdlib.Filename.concat dir "check.json"))
+          in
+          [%equal: Yojson.Safe.t option]
+            (json_field_for_test "check_run_id" json)
+            (Some `Null)
+          && [%equal: Yojson.Safe.t option]
+               (json_field_for_test "head_oid" json)
+               (Some `Null))
+
+let%test "publish_ci_check_artifact overwrites the same key cleanly" =
+  with_temp_data_dir (fun () ->
+      let project_name = "CI Artifact Republish" in
+      let patch_id = Types.Patch_id.of_string "patch-2" in
+      let check = ci_check_for_test ~id:7 ~name:"same run" () in
+      match
+        publish_ci_check_artifact ~project_name ~patch_id ~check
+          ~summary_md:"old\n" ~log:"stale log\n" ()
+      with
+      | Error _ -> false
+      | Ok dir -> (
+          match
+            publish_ci_check_artifact ~project_name ~patch_id ~check
+              ~summary_md:"new\n" ()
+          with
+          | Error _ -> false
+          | Ok dir' ->
+              String.equal dir dir'
+              && List.equal String.equal
+                   (dir_entries_for_test dir')
+                   [ "check.json"; "summary.md" ]
+              && String.equal
+                   (read_file_for_test
+                      (Stdlib.Filename.concat dir' "summary.md"))
+                   "new\n"))
 
 let%test "publish_gameplan_artifact copies the stored gameplan for agents" =
   with_temp_data_dir (fun () ->

--- a/lib/project_store.ml
+++ b/lib/project_store.ml
@@ -79,7 +79,17 @@ let ci_artifact_dir ~project_name ~patch_id =
 let ci_check_key (c : Types.Ci_check.t) =
   match c.id with
   | Some id -> "run-" ^ Int.to_string id
-  | None -> "status-" ^ slugify c.name
+  | None ->
+      let slug = slugify c.name in
+      let slug =
+        if String.is_empty slug then
+          "name-"
+          ^ String.prefix
+              (Stdlib.Digest.to_hex (Stdlib.Digest.string c.name))
+              12
+        else slug
+      in
+      "status-" ^ slug
 
 let ci_check_artifact_dir ~project_name ~patch_id ~check =
   Stdlib.Filename.concat
@@ -235,14 +245,9 @@ let publish_gameplan_artifact ~project_name =
         Stdlib.output_string oc content;
         Stdlib.flush oc))
 
-let write_text_file ~path ~content =
-  let oc = Stdlib.open_out_bin path in
-  Stdlib.Fun.protect
-    ~finally:(fun () -> Stdlib.close_out oc)
-    (fun () ->
-      Stdlib.output_string oc content;
-      Stdlib.flush oc)
-
+(* Cannot use Persistence.write_file_atomically here: Persistence depends on
+   Project_store.ensure_dir, so calling it from Project_store creates a module
+   cycle. Keep the same temp-file + rename behavior locally. *)
 let write_file_atomically ~path ~content =
   let dir = Stdlib.Filename.dirname path in
   let base = Stdlib.Filename.basename path in
@@ -259,6 +264,14 @@ let write_file_atomically ~path ~content =
   with exn ->
     (try Stdlib.Sys.remove tmp_path with _ -> ());
     Error (Stdlib.Printexc.to_string exn)
+
+let remove_if_exists path =
+  try
+    Unix.unlink path;
+    Ok ()
+  with
+  | Unix.Unix_error (Unix.ENOENT, _, _) -> Ok ()
+  | exn -> Error (Stdlib.Printexc.to_string exn)
 
 let ci_check_json ~(check : Types.Ci_check.t) ~head_oid =
   `Assoc
@@ -291,14 +304,14 @@ let publish_ci_check_artifact ~project_name ~patch_id ~check ?head_oid
     with
     | Error msg -> Error msg
     | Ok () -> (
-        try
-          write_text_file ~path:summary_path ~content:summary_md;
-          (match log with
-          | None ->
-              if Stdlib.Sys.file_exists log_path then Stdlib.Sys.remove log_path
-          | Some content -> write_text_file ~path:log_path ~content);
-          Ok dir
-        with exn -> Error (Stdlib.Printexc.to_string exn))
+        match write_file_atomically ~path:summary_path ~content:summary_md with
+        | Error msg -> Error msg
+        | Ok () -> (
+            match log with
+            | None -> Result.map (remove_if_exists log_path) ~f:(fun () -> dir)
+            | Some content ->
+                Result.map (write_file_atomically ~path:log_path ~content)
+                  ~f:(fun () -> dir)))
   with exn -> Error (Stdlib.Printexc.to_string exn)
 
 let project_exists project_name =
@@ -358,10 +371,15 @@ let%test "ci_check_key uses run id for CheckRuns and slug for id-less checks" =
   let status_check =
     ci_check_for_test ~name:"all_jobs_succeed / Required!" ()
   in
+  let empty_slug_check = ci_check_for_test ~name:"???" () in
   String.equal (ci_check_key run_check) "run-123"
   && String.equal
        (ci_check_key status_check)
        "status-all-jobs-succeed--required"
+  && String.equal
+       (ci_check_key empty_slug_check)
+       ("status-name-"
+       ^ String.prefix (Stdlib.Digest.to_hex (Stdlib.Digest.string "???")) 12)
 
 let%test "publish_ci_check_artifact writes metadata and summary without log" =
   with_temp_data_dir (fun () ->

--- a/lib/project_store.mli
+++ b/lib/project_store.mli
@@ -116,6 +116,38 @@ val findings_wontfix_artifact_path :
     the corresponding resolve verbs to the review backend. Findings not listed
     here default to [addressed]. *)
 
+val ci_artifact_dir : project_name:string -> patch_id:Types.Patch_id.t -> string
+(** Absolute directory for per-check CI diagnostics under
+    [artifacts/<patch_id>/ci]. Pure path helper for prompt rendering; does not
+    touch the filesystem. *)
+
+val ci_check_key : Types.Ci_check.t -> string
+(** Stable artifact key for a CI check. CheckRuns use [run-<databaseId>];
+    id-less StatusContexts and synthesized checks use [status-<slugified name>].
+*)
+
+val ci_check_artifact_dir :
+  project_name:string ->
+  patch_id:Types.Patch_id.t ->
+  check:Types.Ci_check.t ->
+  string
+(** Absolute directory for one check's CI diagnostic artifacts under
+    {!ci_artifact_dir}. Pure path helper for prompt rendering; does not touch
+    the filesystem. *)
+
+val publish_ci_check_artifact :
+  project_name:string ->
+  patch_id:Types.Patch_id.t ->
+  check:Types.Ci_check.t ->
+  ?head_oid:string ->
+  summary_md:string ->
+  ?log:string ->
+  unit ->
+  (string, string) result
+(** Publish one check's CI diagnostic artifacts. Writes [check.json] and
+    [summary.md], plus [log.txt] exactly when [log] is supplied. Returns the
+    check artifact directory, or the first write error. *)
+
 val project_exists : string -> bool
 (** Whether a project data directory with config exists. *)
 


### PR DESCRIPTION
## Patch 2: Project_store CI artifact layout and publisher

- ci_artifact_dir ~project_name ~patch_id = Filename.concat (artifact_dir ~project_name ~patch_id) "ci" — pure, no filesystem access, matching the pr_body_artifact_path idiom (lib/project_store.ml:64).
- ci_check_key (c : Types.Ci_check.t) = match c.id with Some id -> "run-" ^ Int.to_string id | None -> "status-" ^ slugify c.name (reusing the existing slugify).
- ci_check_artifact_dir ~project_name ~patch_id ~check = Filename.concat (ci_artifact_dir ...) (ci_check_key check) — pure.
- publish_ci_check_artifact ~project_name ~patch_id ~check ?head_oid ~summary_md ?log () : (string, string) Result.t — ensure_dir the check dir; write check.json ({"name", "conclusion", "details_url", "started_at", "check_run_id", "head_oid"} via Yojson.Safe, nulls for absent options) with Persistence.write_file_atomically; write summary.md and (when log is Some) log.txt as plain best-effort writes; return Ok dir, or Error msg on the first write failure.
- Inline let%test coverage: key derivation (run id vs slug), publisher writes exactly check.json + summary.md (no log.txt) when log is None and all three when Some, check.json round-trips through Yojson with the expected fields, re-publish to the same key overwrites cleanly.

## Changes
- ci_artifact_dir ~project_name ~patch_id = Filename.concat (artifact_dir ~project_name ~patch_id) "ci" — pure, no filesystem access, matching the pr_body_artifact_path idiom (lib/project_store.ml:64).
- ci_check_key (c : Types.Ci_check.t) = match c.id with Some id -> "run-" ^ Int.to_string id | None -> "status-" ^ slugify c.name (reusing the existing slugify).
- ci_check_artifact_dir ~project_name ~patch_id ~check = Filename.concat (ci_artifact_dir ...) (ci_check_key check) — pure.
- publish_ci_check_artifact ~project_name ~patch_id ~check ?head_oid ~summary_md ?log () : (string, string) Result.t — ensure_dir the check dir; write check.json ({"name", "conclusion", "details_url", "started_at", "check_run_id", "head_oid"} via Yojson.Safe, nulls for absent options) with Persistence.write_file_atomically; write summary.md and (when log is Some) log.txt as plain best-effort writes; return Ok dir, or Error msg on the first write failure.
- Inline let%test coverage: key derivation (run id vs slug), publisher writes exactly check.json + summary.md (no log.txt) when log is None and all three when Some, check.json round-trips through Yojson with the expected fields, re-publish to the same key overwrites cleanly.

## Files to Modify
- lib/project_store.mli (modify): Add ci_artifact_dir, ci_check_key, ci_check_artifact_dir, publish_ci_check_artifact after findings_wontfix_artifact_path, with doc comments in the existing style.
- lib/project_store.ml (modify): Implement the path functions and publisher; inline let%test coverage using the existing ONTON_DATA_DIR temp-dir helper.

## Gameplan Specification

```
module FAILING_CI_DETAILS.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> After this gameplan, a CI failure delivery records each failing
> check's diagnostics on disk (check.json, summary.md, log.txt under
> artifacts/<patch_id>/ci/<key>/) and the agent prompt cites those
> paths with a diagnostic teaser, ranked by signal — replacing
> URL-only delivery and improvised gh calls. All extraction logic is
> pure and property-tested; every failure mode degrades per check to
> the previous metadata-only rendering.

Check.
Source.
Enrichment.
Log.
Delivery.

has-run-id? c: Check => Bool.
check-key-collision-same-run? c1: Check, c2: Check => Bool.

strip-log l: Log => Log.
digest s: Source => Enrichment.
summary-bytes e: Enrichment => Nat0.
summary-cap => Nat0.

hits-network? c: Check => Bool.
sends-token-to-redirect-host? c: Check => Bool.

delivered? d: Delivery, c: Check => Bool.
fetch-succeeded? d: Delivery, c: Check => Bool.
artifact-published? d: Delivery, c: Check => Bool.
prompt-cites? d: Delivery, c: Check => Bool.
metadata-only? d: Delivery, c: Check => Bool.
delivery-blocked-by-details? d: Delivery => Bool.
fetch-count d: Delivery => Nat0.
fetch-cap => Nat0.
instructs-no-refetch? d: Delivery => Bool.
---
> Digest output is bounded and stripping is idempotent.
all s: Source | summary-bytes (digest s) <= summary-cap.
all l: Log | strip-log (strip-log l) = strip-log l.

> Id-less checks never hit the network; no fetch ever sends the API
> token to the redirect host.
all c: Check, ~ (has-run-id? c) | ~ (hits-network? c).
all c: Check | ~ (sends-token-to-redirect-host? c).

> Delivered checks with fetched, published details are cited by the
> prompt; failed fetches render metadata-only; detail retrieval never
> blocks a delivery; fetches are capped.
all d: Delivery, c: Check, delivered? d c and fetch-succeeded? d c and artifact-published? d c | prompt-cites? d c.
all d: Delivery, c: Check, delivered? d c and ~ (fetch-succeeded? d c) | metadata-only? d c.
all d: Delivery | ~ (delivery-blocked-by-details? d).
all d: Delivery | fetch-count d <= fetch-cap.

> Every delivery with details instructs the agent not to re-fetch
> checks with gh.
all d: Delivery | instructs-no-refetch? d.
```

## Patch Specification

```
module FAILING_CI_DETAILS_PATCH_2.

> Per-check CI artifact layout under the project data dir
> (artifacts/<patch_id>/ci/<key>/), following the pr-body/gameplan
> artifact idiom: pure path functions plus an effectful publisher.

Check.
Key.

has-run-id? c: Check => Bool.
run-id c: Check, has-run-id? c => Nat0.
ci-check-key c: Check => Key.

published? c: Check => Bool.
wrote-check-json? c: Check => Bool.
wrote-summary? c: Check => Bool.
has-log? c: Check => Bool.
wrote-log? c: Check => Bool.
---
> Run-keyed checks collide only on the same run: equal keys imply equal
> run ids.
all c1: Check, c2: Check, has-run-id? c1 and has-run-id? c2 and ci-check-key c1 = ci-check-key c2 | run-id c1 = run-id c2.

> Publishing writes the metadata and summary files.
all c: Check, published? c | wrote-check-json? c and wrote-summary? c.

> The log file is written exactly when a log was supplied.
all c: Check, published? c | wrote-log? c <-> has-log? c.
```


## Implementation Notes

- `Project_store` remains dependency-low: `Persistence` already imports `Project_store`, so using `Persistence.write_file_atomically` here creates a module cycle. The publisher uses a local temp-file-plus-rename helper with the same behavior for `check.json` instead.
- Re-publishing a check with `log=None` removes any stale `log.txt` from the same artifact directory. This makes the “wrote-log iff has-log” invariant hold across overwrite semantics, not just first publish.
- Dependent patches can use `Project_store.ci_check_artifact_dir` as a pure prompt/path helper and `publish_ci_check_artifact` as the only filesystem-writing entry point. The returned `Ok dir` is the exact directory containing `check.json`, `summary.md`, and optional `log.txt`.
- Spec/Evidence Mapping: run-key collision safety is implemented by `ci_check_key` using `run-<id>` for `Some id` and `status-<slug>` otherwise; covered by inline `ci_check_key` test. Publishing metadata/summary/log semantics are implemented in `publish_ci_check_artifact`; covered by inline tests for no-log, with-log, JSON field round-trip, and same-key overwrite. Required context consulted: `lib/project_store.ml`, `lib/project_store.mli`, `lib/session_artifacts.ml`, and `lib_core/types.mli`. Verified with `dune fmt`, `dune build`, and `dune runtest`.