### PR TITLE
[failing-ci-details] Patch 1: Pure CI log digest module (lib_core/ci_log_digest)

### DIFF
--- a/lib_core/ci_log_digest.ml
+++ b/lib_core/ci_log_digest.ml
@@ -1,0 +1,218 @@
+open Base
+
+type annotation = {
+  path : string option;
+  line : int option;
+  level : string;
+  message : string;
+}
+
+type source = { annotations : annotation list; log : string option }
+type enrichment = { summary_md : string; teaser : string option; signal : int }
+
+let summary_total_cap_bytes = 49_152
+let marker_context_lines = 30
+let error_window_lines = 100
+let collapse_signal_threshold = 200
+let is_digit = function '0' .. '9' -> true | _ -> false
+
+let is_timestamp_prefix s =
+  let len = String.length s in
+  if len < 22 then false
+  else
+    let char_at i = String.get s i in
+    is_digit (char_at 0)
+    && is_digit (char_at 1)
+    && is_digit (char_at 2)
+    && is_digit (char_at 3)
+    && Char.equal (char_at 4) '-'
+    && is_digit (char_at 5)
+    && is_digit (char_at 6)
+    && Char.equal (char_at 7) '-'
+    && is_digit (char_at 8)
+    && is_digit (char_at 9)
+    && Char.equal (char_at 10) 'T'
+    && is_digit (char_at 11)
+    && is_digit (char_at 12)
+    && Char.equal (char_at 13) ':'
+    && is_digit (char_at 14)
+    && is_digit (char_at 15)
+    && Char.equal (char_at 16) ':'
+    && is_digit (char_at 17)
+    && is_digit (char_at 18)
+
+let drop_timestamp_prefix line =
+  if not (is_timestamp_prefix line) then line
+  else
+    match String.lfindi line ~f:(fun _ c -> Char.equal c 'Z') with
+    | Some z
+      when z + 1 < String.length line
+           && Char.equal (String.get line (z + 1)) ' ' ->
+        String.drop_prefix line (z + 2)
+    | _ -> line
+
+let is_ansi_final c =
+  let code = Char.to_int c in
+  code >= 0x40 && code <= 0x7e
+
+let strip_ansi line =
+  let len = String.length line in
+  let buf = Buffer.create len in
+  let rec loop i =
+    if i >= len then Buffer.contents buf
+    else
+      let c = String.get line i in
+      if
+        Char.equal c '\027'
+        && i + 1 < len
+        && Char.equal (String.get line (i + 1)) '['
+      then (
+        let rec skip j =
+          if j >= len then None
+          else if is_ansi_final (String.get line j) then Some (j + 1)
+          else skip (j + 1)
+        in
+        match skip (i + 2) with
+        | Some next -> loop next
+        | None ->
+            Buffer.add_char buf c;
+            loop (i + 1))
+      else (
+        Buffer.add_char buf c;
+        loop (i + 1))
+  in
+  loop 0
+
+let strip_log log =
+  String.split_lines log
+  |> List.map ~f:(fun line ->
+      line |> strip_ansi |> drop_timestamp_prefix |> strip_ansi)
+  |> String.concat ~sep:"\n"
+
+let contains s needle = String.is_substring s ~substring:needle
+
+let is_failure_marker line =
+  contains line "(fail)" || contains line "=== FAIL" || contains line "✕"
+  || contains line "❌"
+
+let is_error_line line = contains (String.strip line) "::error"
+let is_hash_error_line line = contains line "##[error]"
+
+let annotation_line (a : annotation) =
+  let path = Option.value a.path ~default:"<unknown>" in
+  let line = match a.line with Some n -> Int.to_string n | None -> "?" in
+  "- " ^ path ^ ":" ^ line ^ ": " ^ a.message
+
+let failure_annotations annotations =
+  annotations
+  |> List.filter ~f:(fun (a : annotation) ->
+      String.Caseless.equal (String.strip a.level) "failure")
+  |> List.map ~f:annotation_line
+
+let range_indices ~line_count ~before idx =
+  let first = Int.max 0 (idx - before) in
+  List.range first (Int.min line_count (idx + 1))
+
+let unique_indices indices = indices |> List.dedup_and_sort ~compare:Int.compare
+
+let lines_at lines indices =
+  List.filter_map indices ~f:(fun i -> List.nth lines i)
+
+let first_matching_line lines ~f = List.find lines ~f
+
+let error_message_part line =
+  match String.substr_index line ~pattern:"::error" with
+  | None -> String.strip line
+  | Some idx ->
+      let rest = String.drop_prefix line (idx + String.length "::error") in
+      let rest =
+        match String.substr_index rest ~pattern:"::" with
+        | Some msg_idx -> String.drop_prefix rest (msg_idx + 2)
+        | None -> rest
+      in
+      let stripped = String.strip rest in
+      if String.is_empty stripped then String.strip line else stripped
+
+let diagnostic_bytes lines = lines |> String.concat ~sep:"\n" |> String.length
+
+let non_boilerplate_section4_lines lines =
+  List.filter lines ~f:(fun line ->
+      let stripped = String.strip line in
+      (not (String.is_empty stripped))
+      && not (contains stripped "Process completed with exit code"))
+
+let section title lines =
+  if List.is_empty lines then None
+  else Some ("## " ^ title ^ "\n\n" ^ String.concat lines ~sep:"\n" ^ "\n")
+
+let append_capped pieces =
+  let truncation_note = "\n\n[diagnostic summary truncated]\n" in
+  let note_len = String.length truncation_note in
+  let rec loop acc used = function
+    | [] -> String.concat (List.rev acc) ~sep:""
+    | piece :: rest ->
+        let len = String.length piece in
+        if used + len <= summary_total_cap_bytes then
+          loop (piece :: acc) (used + len) rest
+        else
+          let remaining = summary_total_cap_bytes - used in
+          if remaining <= 0 then String.concat (List.rev acc) ~sep:""
+          else if remaining <= note_len then
+            let clipped = String.prefix truncation_note remaining in
+            String.concat (List.rev (clipped :: acc)) ~sep:""
+          else
+            let prefix_len = remaining - note_len in
+            let clipped = String.prefix piece prefix_len ^ truncation_note in
+            ignore rest;
+            String.concat (List.rev (clipped :: acc)) ~sep:""
+  in
+  loop [] 0 pieces
+
+let digest (source : source) =
+  let stripped_log = source.log |> Option.value ~default:"" |> strip_log in
+  let lines = String.split_lines stripped_log in
+  let line_count = List.length lines in
+  let annotation_lines = failure_annotations source.annotations in
+  let error_lines = List.filter lines ~f:is_error_line in
+  let marker_indices =
+    List.filter_mapi lines ~f:(fun i line ->
+        if is_failure_marker line then Some i else None)
+  in
+  let hash_error_indices =
+    List.filter_mapi lines ~f:(fun i line ->
+        if is_hash_error_line line then Some i else None)
+  in
+  let marker_context =
+    marker_indices
+    |> List.concat_map
+         ~f:(range_indices ~line_count ~before:marker_context_lines)
+    |> unique_indices |> lines_at lines
+  in
+  let hash_error_window =
+    hash_error_indices
+    |> List.concat_map ~f:(range_indices ~line_count ~before:error_window_lines)
+    |> unique_indices |> lines_at lines
+  in
+  let teaser =
+    match first_matching_line lines ~f:is_error_line with
+    | Some line -> Some (error_message_part line)
+    | None ->
+        first_matching_line lines ~f:is_failure_marker
+        |> Option.map ~f:(fun line -> String.strip line)
+  in
+  let signal =
+    diagnostic_bytes annotation_lines
+    + diagnostic_bytes error_lines
+    + diagnostic_bytes marker_context
+    + diagnostic_bytes (non_boilerplate_section4_lines hash_error_window)
+  in
+  let pieces =
+    [
+      section "Failure annotations" annotation_lines;
+      section "Literal ::error lines" error_lines;
+      section "Failure marker context" marker_context;
+      section "Pre-##[error] window" hash_error_window;
+    ]
+    |> List.filter_opt
+  in
+  { summary_md = append_capped pieces; teaser; signal }

--- a/lib_core/ci_log_digest.ml
+++ b/lib_core/ci_log_digest.ml
@@ -86,8 +86,26 @@ let strip_ansi line =
   in
   loop 0
 
+let normalize_newlines s =
+  let len = String.length s in
+  let buf = Buffer.create len in
+  let rec loop i =
+    if i >= len then Buffer.contents buf
+    else
+      match String.get s i with
+      | '\r' ->
+          Buffer.add_char buf '\n';
+          if i + 1 < len && Char.equal (String.get s (i + 1)) '\n' then
+            loop (i + 2)
+          else loop (i + 1)
+      | c ->
+          Buffer.add_char buf c;
+          loop (i + 1)
+  in
+  loop 0
+
 let strip_log log =
-  String.split log ~on:'\n'
+  normalize_newlines log |> String.split_lines
   |> List.map ~f:(fun line ->
       line |> strip_ansi |> drop_timestamp_prefix |> strip_ansi)
   |> String.concat ~sep:"\n"
@@ -151,23 +169,31 @@ let section title lines =
 let append_capped pieces =
   let truncation_note = "\n\n[diagnostic summary truncated]\n" in
   let note_len = String.length truncation_note in
+  let concat_rev acc = String.concat (List.rev acc) ~sep:"" in
+  let with_truncation_note output =
+    let len = String.length output in
+    if len + note_len <= summary_total_cap_bytes then output ^ truncation_note
+    else if summary_total_cap_bytes <= note_len then
+      String.prefix truncation_note summary_total_cap_bytes
+    else
+      String.prefix output (summary_total_cap_bytes - note_len)
+      ^ truncation_note
+  in
   let rec loop acc used = function
-    | [] -> String.concat (List.rev acc) ~sep:""
+    | [] -> concat_rev acc
     | piece :: rest ->
         let len = String.length piece in
-        if used + len <= summary_total_cap_bytes then
+        if used + len < summary_total_cap_bytes then
           loop (piece :: acc) (used + len) rest
+        else if used + len = summary_total_cap_bytes then
+          let output = concat_rev (piece :: acc) in
+          if List.is_empty rest then output else with_truncation_note output
         else
           let remaining = summary_total_cap_bytes - used in
-          if remaining <= 0 then String.concat (List.rev acc) ~sep:""
-          else if remaining <= note_len then
-            let clipped = String.prefix truncation_note remaining in
-            String.concat (List.rev (clipped :: acc)) ~sep:""
+          if remaining <= 0 then with_truncation_note (concat_rev acc)
           else
-            let prefix_len = remaining - note_len in
-            let clipped = String.prefix piece prefix_len ^ truncation_note in
-            ignore rest;
-            String.concat (List.rev (clipped :: acc)) ~sep:""
+            let partial = String.prefix piece remaining in
+            with_truncation_note (concat_rev (partial :: acc))
   in
   loop [] 0 pieces
 

--- a/lib_core/ci_log_digest.ml
+++ b/lib_core/ci_log_digest.ml
@@ -1,3 +1,6 @@
+(* @archlint.module core
+   @archlint.domain ci-log-digest *)
+
 open Base
 
 type annotation = {

--- a/lib_core/ci_log_digest.ml
+++ b/lib_core/ci_log_digest.ml
@@ -84,7 +84,7 @@ let strip_ansi line =
   loop 0
 
 let strip_log log =
-  String.split_lines log
+  String.split log ~on:'\n'
   |> List.map ~f:(fun line ->
       line |> strip_ansi |> drop_timestamp_prefix |> strip_ansi)
   |> String.concat ~sep:"\n"

--- a/lib_core/ci_log_digest.ml
+++ b/lib_core/ci_log_digest.ml
@@ -21,28 +21,44 @@ let is_digit = function '0' .. '9' -> true | _ -> false
 
 let is_timestamp_prefix s =
   let len = String.length s in
-  if len < 22 then false
+  if len < 20 then false
   else
     let char_at i = String.get s i in
-    is_digit (char_at 0)
-    && is_digit (char_at 1)
-    && is_digit (char_at 2)
-    && is_digit (char_at 3)
-    && Char.equal (char_at 4) '-'
-    && is_digit (char_at 5)
-    && is_digit (char_at 6)
-    && Char.equal (char_at 7) '-'
-    && is_digit (char_at 8)
-    && is_digit (char_at 9)
-    && Char.equal (char_at 10) 'T'
-    && is_digit (char_at 11)
-    && is_digit (char_at 12)
-    && Char.equal (char_at 13) ':'
-    && is_digit (char_at 14)
-    && is_digit (char_at 15)
-    && Char.equal (char_at 16) ':'
-    && is_digit (char_at 17)
-    && is_digit (char_at 18)
+    let rec fraction i seen_digit =
+      if i >= len then false
+      else
+        let c = char_at i in
+        if Char.equal c 'Z' then seen_digit
+        else if is_digit c then fraction (i + 1) true
+        else false
+    in
+    let date_time_prefix =
+      is_digit (char_at 0)
+      && is_digit (char_at 1)
+      && is_digit (char_at 2)
+      && is_digit (char_at 3)
+      && Char.equal (char_at 4) '-'
+      && is_digit (char_at 5)
+      && is_digit (char_at 6)
+      && Char.equal (char_at 7) '-'
+      && is_digit (char_at 8)
+      && is_digit (char_at 9)
+      && Char.equal (char_at 10) 'T'
+      && is_digit (char_at 11)
+      && is_digit (char_at 12)
+      && Char.equal (char_at 13) ':'
+      && is_digit (char_at 14)
+      && is_digit (char_at 15)
+      && Char.equal (char_at 16) ':'
+      && is_digit (char_at 17)
+      && is_digit (char_at 18)
+    in
+    date_time_prefix
+    &&
+    match char_at 19 with
+    | 'Z' -> true
+    | '.' -> fraction 20 false
+    | _ -> false
 
 let drop_timestamp_prefix line =
   if not (is_timestamp_prefix line) then line

--- a/lib_core/ci_log_digest.ml
+++ b/lib_core/ci_log_digest.ml
@@ -105,7 +105,7 @@ let normalize_newlines s =
   loop 0
 
 let strip_log log =
-  normalize_newlines log |> String.split_lines
+  normalize_newlines log |> String.split ~on:'\n'
   |> List.map ~f:(fun line ->
       line |> strip_ansi |> drop_timestamp_prefix |> strip_ansi)
   |> String.concat ~sep:"\n"
@@ -170,14 +170,10 @@ let append_capped pieces =
   let truncation_note = "\n\n[diagnostic summary truncated]\n" in
   let note_len = String.length truncation_note in
   let concat_rev acc = String.concat (List.rev acc) ~sep:"" in
-  let with_truncation_note output =
-    let len = String.length output in
-    if len + note_len <= summary_total_cap_bytes then output ^ truncation_note
-    else if summary_total_cap_bytes <= note_len then
-      String.prefix truncation_note summary_total_cap_bytes
-    else
-      String.prefix output (summary_total_cap_bytes - note_len)
-      ^ truncation_note
+  let append_note_if_room output =
+    let remaining = summary_total_cap_bytes - String.length output in
+    if remaining <= 0 then output
+    else output ^ String.prefix truncation_note (Int.min note_len remaining)
   in
   let rec loop acc used = function
     | [] -> concat_rev acc
@@ -187,13 +183,15 @@ let append_capped pieces =
           loop (piece :: acc) (used + len) rest
         else if used + len = summary_total_cap_bytes then
           let output = concat_rev (piece :: acc) in
-          if List.is_empty rest then output else with_truncation_note output
+          if List.is_empty rest then output else append_note_if_room output
         else
           let remaining = summary_total_cap_bytes - used in
-          if remaining <= 0 then with_truncation_note (concat_rev acc)
+          if remaining <= 0 then concat_rev acc
+          else if remaining <= note_len then
+            concat_rev acc ^ String.prefix truncation_note remaining
           else
-            let partial = String.prefix piece remaining in
-            with_truncation_note (concat_rev (partial :: acc))
+            let partial = String.prefix piece (remaining - note_len) in
+            concat_rev (partial :: acc) ^ truncation_note
   in
   loop [] 0 pieces
 

--- a/lib_core/ci_log_digest.mli
+++ b/lib_core/ci_log_digest.mli
@@ -1,3 +1,6 @@
+(* @archlint.module interface
+   @archlint.domain ci-log-digest *)
+
 type annotation = {
   path : string option;
   line : int option;

--- a/lib_core/ci_log_digest.mli
+++ b/lib_core/ci_log_digest.mli
@@ -1,0 +1,16 @@
+type annotation = {
+  path : string option;
+  line : int option;
+  level : string;
+  message : string;
+}
+
+type source = { annotations : annotation list; log : string option }
+type enrichment = { summary_md : string; teaser : string option; signal : int }
+
+val summary_total_cap_bytes : int
+val marker_context_lines : int
+val error_window_lines : int
+val collapse_signal_threshold : int
+val strip_log : string -> string
+val digest : source -> enrichment

--- a/test/dune
+++ b/test/dune
@@ -98,6 +98,15 @@
  (ocamlc_flags (:standard -w -40-42)))
 
 (test
+ (name test_ci_log_digest_properties)
+ (modules test_ci_log_digest_properties)
+ (libraries onton_core qcheck-core qcheck-core.runner base)
+ (deps
+  (glob_files fixtures/ci_logs/*.log))
+ (ocamlopt_flags (:standard -w -40-42))
+ (ocamlc_flags (:standard -w -40-42)))
+
+(test
  (name test_merge_queue_decision_properties)
  (modules test_merge_queue_decision_properties)
  (libraries onton_core qcheck-core qcheck-core.runner)

--- a/test/fixtures/ci_logs/bun_test_fail.log
+++ b/test/fixtures/ci_logs/bun_test_fail.log
@@ -1,0 +1,81 @@
+@pkg test:unit: src/routes.test.ts:
+@pkg test:unit: 16 | const user = await createUser()
+@pkg test:unit: 17 | expect(user.email).toBe("a@example.com")
+@pkg test:unit: 18 | expect(user.id).toBeString()
+@pkg test:unit:                  ^
+@pkg test:unit: TypeError: expected user.id to be a string
+@pkg test:unit: ::error file=packages/api/src/routes.test.ts,line=18,col=7,title=TypeError::expected user.id to be a string
+@pkg test:unit: (fail) routes > creates user
+@pkg test:unit: 1 pass
+@pkg test:unit: 1 fail
+passing output after failure 01
+passing output after failure 02
+passing output after failure 03
+passing output after failure 04
+passing output after failure 05
+passing output after failure 06
+passing output after failure 07
+passing output after failure 08
+passing output after failure 09
+passing output after failure 10
+passing output after failure 11
+passing output after failure 12
+passing output after failure 13
+passing output after failure 14
+passing output after failure 15
+passing output after failure 16
+passing output after failure 17
+passing output after failure 18
+passing output after failure 19
+passing output after failure 20
+passing output after failure 21
+passing output after failure 22
+passing output after failure 23
+passing output after failure 24
+passing output after failure 25
+passing output after failure 26
+passing output after failure 27
+passing output after failure 28
+passing output after failure 29
+passing output after failure 30
+passing output after failure 31
+passing output after failure 32
+passing output after failure 33
+passing output after failure 34
+passing output after failure 35
+passing output after failure 36
+passing output after failure 37
+passing output after failure 38
+passing output after failure 39
+passing output after failure 40
+passing output after failure 41
+passing output after failure 42
+passing output after failure 43
+passing output after failure 44
+passing output after failure 45
+passing output after failure 46
+passing output after failure 47
+passing output after failure 48
+passing output after failure 49
+passing output after failure 50
+passing output after failure 51
+passing output after failure 52
+passing output after failure 53
+passing output after failure 54
+passing output after failure 55
+passing output after failure 56
+passing output after failure 57
+passing output after failure 58
+passing output after failure 59
+passing output after failure 60
+passing output after failure 61
+passing output after failure 62
+passing output after failure 63
+passing output after failure 64
+passing output after failure 65
+passing output after failure 66
+passing output after failure 67
+passing output after failure 68
+passing output after failure 69
+passing output after failure 70
+##[error]Process completed with exit code 1.

--- a/test/fixtures/ci_logs/lowerability_fail.log
+++ b/test/fixtures/ci_logs/lowerability_fail.log
@@ -1,0 +1,9 @@
+2026-07-01T19:33:20.1348805Z ##[group]Run pnpm ts-lowerability
+2026-07-01T19:33:21.1348805Z Checking packages/api
+2026-07-01T19:33:22.1348805Z lowerability: validating exported types
+2026-07-01T19:33:23.1348805Z src/lowerability.ts:42:13 - error TS2322: Type 'number' is not assignable to type 'string'.
+2026-07-01T19:33:24.1348805Z   const lowerable: string = computedCount
+2026-07-01T19:33:25.1348805Z             \027[31m~~~~~~~~~\027[0m
+2026-07-01T19:33:26.1348805Z === FAIL src/lowerability.ts:42:13 type lowerability
+2026-07-01T19:33:27.1348805Z ##[endgroup]
+2026-07-01T19:33:28.1348805Z ##[error]Process completed with exit code 1.

--- a/test/fixtures/ci_logs/mid_job_fail.log
+++ b/test/fixtures/ci_logs/mid_job_fail.log
@@ -1,0 +1,17 @@
+Run biome check
+lint/src/server.ts:9:3 lint/suspicious/noExplicitAny
+  Unexpected any. Specify a different type.
+  7 | export function handler(req: Request) {
+  8 |   const payload = req.json()
+> 9 |   return payload as any
+    |                  ^^^
+Checked 84 files in 80ms. No fixes applied.
+Found 1 error.
+##[error]Process completed with exit code 1.
+Run upload coverage
+coverage uploaded successfully
+Run cleanup
+cache saved
+POST_FAILURE_PASSING_STEP_SENTINEL
+Run notify
+notification sent

--- a/test/fixtures/ci_logs/no_marker_fail.log
+++ b/test/fixtures/ci_logs/no_marker_fail.log
@@ -1,0 +1,7 @@
+Preparing deploy
+Uploading bundle
+Waiting for health check
+Deploy failed while waiting for health check
+Service returned status 503 from /ready
+Last response body: warming up
+##[error]Process completed with exit code 1.

--- a/test/test_ci_log_digest_properties.ml
+++ b/test/test_ci_log_digest_properties.ml
@@ -115,6 +115,12 @@ let test_strip_log_removes_timestamps_and_ansi () =
   assert (String.equal stripped "red\nplain");
   assert (String.equal (Ci_log_digest.strip_log stripped) stripped)
 
+let test_strip_log_removes_bare_second_timestamps () =
+  let input = "2026-07-01T19:33:24Z bare\n2026-07-01T19:33:25.1Z fractional" in
+  let stripped = Ci_log_digest.strip_log input in
+  assert (String.equal stripped "bare\nfractional");
+  assert (String.equal (Ci_log_digest.strip_log stripped) stripped)
+
 let test_strip_log_normalizes_crlf () =
   let input =
     "2026-07-01T19:33:24.1348805Z first\r\nsecond\rthird\r\r\nfourth"
@@ -195,6 +201,7 @@ let test_exact_cap_preserves_content () =
 
 let () =
   test_strip_log_removes_timestamps_and_ansi ();
+  test_strip_log_removes_bare_second_timestamps ();
   test_strip_log_normalizes_crlf ();
   test_lowerability_fixture ();
   test_bun_fixture ();

--- a/test/test_ci_log_digest_properties.ml
+++ b/test/test_ci_log_digest_properties.ml
@@ -1,0 +1,149 @@
+(* @archlint.module test
+   @archlint.domain ci-log-digest *)
+
+open Base
+open Onton_core
+
+let read_fixture name =
+  let path = "fixtures/ci_logs/" ^ name in
+  let ic = Stdlib.open_in_bin path in
+  Exn.protect
+    ~finally:(fun () -> Stdlib.close_in_noerr ic)
+    ~f:(fun () ->
+      let len = Stdlib.in_channel_length ic in
+      Stdlib.really_input_string ic len)
+
+let contains haystack needle = String.is_substring haystack ~substring:needle
+
+let gen_arbitrary_bytes =
+  QCheck2.Gen.(
+    string_size
+      ~gen:(char_range (Char.of_int_exn 0) (Char.of_int_exn 255))
+      (int_range 0 20_000))
+
+let gen_plain_line =
+  let open QCheck2.Gen in
+  let safe_char =
+    oneof_list
+      [ 'a'; 'b'; 'c'; 'x'; 'y'; 'z'; '0'; '1'; ' '; '-'; '_'; '/'; ':' ]
+  in
+  string_size ~gen:safe_char (int_range 0 80)
+
+let gen_marker_free_log =
+  QCheck2.Gen.(
+    list_size (int_range 0 80) gen_plain_line >|= fun lines ->
+    String.concat lines ~sep:"\n")
+
+let gen_error_lines_log =
+  let open QCheck2.Gen in
+  let* prefix = list_size (int_range 0 12) gen_plain_line in
+  let* suffix = list_size (int_range 0 12) gen_plain_line in
+  let* error_count = int_range 1 8 in
+  let* errors =
+    list_size (return error_count)
+      (map
+         (fun msg ->
+           "@pkg test:unit: ::error \
+            file=src/example.ts,line=4,col=2,title=fail::" ^ msg)
+         gen_plain_line)
+  in
+  return (String.concat (prefix @ errors @ suffix) ~sep:"\n", errors)
+
+let prop_digest_total_and_capped =
+  QCheck2.Test.make ~count:500
+    ~name:"digest is total and summary_md stays within the byte cap"
+    gen_arbitrary_bytes (fun log ->
+      try
+        let e = Ci_log_digest.digest { annotations = []; log = Some log } in
+        String.length e.summary_md <= Ci_log_digest.summary_total_cap_bytes
+      with _ -> false)
+
+let prop_literal_error_lines_preserved =
+  QCheck2.Test.make
+    ~name:"literal ::error lines are preserved in the summary when under cap"
+    gen_error_lines_log (fun (log, errors) ->
+      let e = Ci_log_digest.digest { annotations = []; log = Some log } in
+      e.signal > 0
+      && List.for_all errors ~f:(fun line -> contains e.summary_md line)
+      &&
+      match e.teaser with
+      | Some teaser -> contains teaser "::error" || not (String.is_empty teaser)
+      | None -> false)
+
+let prop_marker_free_has_no_signal_or_teaser =
+  QCheck2.Test.make ~name:"marker-free logs produce zero signal and no teaser"
+    gen_marker_free_log (fun log ->
+      let e = Ci_log_digest.digest { annotations = []; log = Some log } in
+      Int.equal e.signal 0 && Option.is_none e.teaser)
+
+let prop_strip_log_idempotent =
+  QCheck2.Test.make ~count:500 ~name:"strip_log is idempotent"
+    gen_arbitrary_bytes (fun log ->
+      let stripped = Ci_log_digest.strip_log log in
+      String.equal (Ci_log_digest.strip_log stripped) stripped)
+
+let assert_contains label haystack needle =
+  if not (contains haystack needle) then
+    failwith (Printf.sprintf "%s: expected substring %S" label needle)
+
+let assert_not_contains label haystack needle =
+  if contains haystack needle then
+    failwith (Printf.sprintf "%s: unexpected substring %S" label needle)
+
+let test_strip_log_removes_timestamps_and_ansi () =
+  let input = "2026-07-01T19:33:24.1348805Z \027[31mred\027[0m\nplain" in
+  let stripped = Ci_log_digest.strip_log input in
+  assert (String.equal stripped "red\nplain");
+  assert (String.equal (Ci_log_digest.strip_log stripped) stripped)
+
+let test_lowerability_fixture () =
+  let log = read_fixture "lowerability_fail.log" in
+  let e = Ci_log_digest.digest { annotations = []; log = Some log } in
+  assert_contains "lowerability summary" e.summary_md
+    "src/lowerability.ts:42:13";
+  match e.teaser with
+  | Some teaser ->
+      assert_contains "lowerability teaser" teaser "src/lowerability.ts:42:13"
+  | None -> failwith "lowerability teaser: expected Some _"
+
+let test_bun_fixture () =
+  let log = read_fixture "bun_test_fail.log" in
+  let e = Ci_log_digest.digest { annotations = []; log = Some log } in
+  assert_contains "bun summary" e.summary_md
+    "::error file=packages/api/src/routes.test.ts,line=18,col=7,title=TypeError";
+  assert_contains "bun summary" e.summary_md
+    "TypeError: expected user.id to be a string";
+  assert_contains "bun summary" e.summary_md "18 | expect(user.id).toBeString()"
+
+let test_mid_job_fixture () =
+  let log = read_fixture "mid_job_fail.log" in
+  let e = Ci_log_digest.digest { annotations = []; log = Some log } in
+  assert_contains "mid-job summary" e.summary_md
+    "lint/src/server.ts:9:3 lint/suspicious/noExplicitAny";
+  assert_contains "mid-job summary" e.summary_md
+    "Unexpected any. Specify a different type.";
+  assert_not_contains "mid-job summary" e.summary_md
+    "POST_FAILURE_PASSING_STEP_SENTINEL"
+
+let test_no_marker_fixture () =
+  let log = read_fixture "no_marker_fail.log" in
+  let e = Ci_log_digest.digest { annotations = []; log = Some log } in
+  assert (not (String.is_empty e.summary_md));
+  assert_contains "no-marker summary" e.summary_md
+    "Deploy failed while waiting for health check"
+
+let () =
+  test_strip_log_removes_timestamps_and_ansi ();
+  test_lowerability_fixture ();
+  test_bun_fixture ();
+  test_mid_job_fixture ();
+  test_no_marker_fixture ();
+  let tests =
+    [
+      prop_digest_total_and_capped;
+      prop_literal_error_lines_preserved;
+      prop_marker_free_has_no_signal_or_teaser;
+      prop_strip_log_idempotent;
+    ]
+  in
+  Stdlib.exit (QCheck_base_runner.run_tests ~verbose:false tests)

--- a/test/test_ci_log_digest_properties.ml
+++ b/test/test_ci_log_digest_properties.ml
@@ -76,19 +76,24 @@ let prop_literal_error_lines_preserved =
   QCheck2.Test.make
     ~name:"literal ::error lines are preserved in the summary when under cap"
     gen_error_lines_log (fun (log, errors) ->
-      let e = Ci_log_digest.digest { annotations = []; log = Some log } in
-      e.signal > 0
-      && List.for_all errors ~f:(fun line -> contains e.summary_md line)
-      &&
-      match e.teaser with
-      | Some teaser -> contains teaser "::error" || not (String.is_empty teaser)
-      | None -> false)
+      try
+        let e = Ci_log_digest.digest { annotations = []; log = Some log } in
+        e.signal > 0
+        && List.for_all errors ~f:(fun line -> contains e.summary_md line)
+        &&
+        match e.teaser with
+        | Some teaser ->
+            contains teaser "::error" || not (String.is_empty teaser)
+        | None -> false
+      with _ -> false)
 
 let prop_marker_free_has_no_signal_or_teaser =
   QCheck2.Test.make ~name:"marker-free logs produce zero signal and no teaser"
     gen_marker_free_log (fun log ->
-      let e = Ci_log_digest.digest { annotations = []; log = Some log } in
-      Int.equal e.signal 0 && Option.is_none e.teaser)
+      try
+        let e = Ci_log_digest.digest { annotations = []; log = Some log } in
+        Int.equal e.signal 0 && Option.is_none e.teaser
+      with _ -> false)
 
 let prop_strip_log_idempotent =
   QCheck2.Test.make ~count:500 ~name:"strip_log is idempotent"
@@ -108,6 +113,14 @@ let test_strip_log_removes_timestamps_and_ansi () =
   let input = "2026-07-01T19:33:24.1348805Z \027[31mred\027[0m\nplain" in
   let stripped = Ci_log_digest.strip_log input in
   assert (String.equal stripped "red\nplain");
+  assert (String.equal (Ci_log_digest.strip_log stripped) stripped)
+
+let test_strip_log_normalizes_crlf () =
+  let input =
+    "2026-07-01T19:33:24.1348805Z first\r\nsecond\rthird\r\r\nfourth"
+  in
+  let stripped = Ci_log_digest.strip_log input in
+  assert (String.equal stripped "first\nsecond\nthird\n\nfourth");
   assert (String.equal (Ci_log_digest.strip_log stripped) stripped)
 
 let test_lowerability_fixture () =
@@ -146,12 +159,28 @@ let test_no_marker_fixture () =
   assert_contains "no-marker summary" e.summary_md
     "Deploy failed while waiting for health check"
 
+let test_truncation_is_noted () =
+  let message = String.make (Ci_log_digest.summary_total_cap_bytes * 2) 'a' in
+  let annotation =
+    Ci_log_digest.
+      { path = Some "src/large.ts"; line = Some 1; level = "failure"; message }
+  in
+  let e =
+    Ci_log_digest.digest
+      { annotations = [ annotation ]; log = Some "::error ::later section" }
+  in
+  assert (String.length e.summary_md <= Ci_log_digest.summary_total_cap_bytes);
+  assert_contains "truncation summary" e.summary_md
+    "diagnostic summary truncated"
+
 let () =
   test_strip_log_removes_timestamps_and_ansi ();
+  test_strip_log_normalizes_crlf ();
   test_lowerability_fixture ();
   test_bun_fixture ();
   test_mid_job_fixture ();
   test_no_marker_fixture ();
+  test_truncation_is_noted ();
   let tests =
     [
       prop_digest_total_and_capped;

--- a/test/test_ci_log_digest_properties.ml
+++ b/test/test_ci_log_digest_properties.ml
@@ -15,6 +15,20 @@ let read_fixture name =
 
 let contains haystack needle = String.is_substring haystack ~substring:needle
 
+let printable_counterexample s =
+  let render chars =
+    chars
+    |> List.map ~f:(fun c ->
+        let code = Char.to_int c in
+        if code >= 32 && code <= 126 then String.of_char c
+        else Printf.sprintf "\\x%02x" code)
+    |> String.concat ~sep:""
+  in
+  let chars = String.to_list s in
+  Printf.sprintf "len=%d head=%S tail=%S" (String.length s)
+    (chars |> Fn.flip List.take 160 |> render)
+    (chars |> List.rev |> Fn.flip List.take 160 |> List.rev |> render)
+
 let gen_arbitrary_bytes =
   QCheck2.Gen.(
     string_size
@@ -78,7 +92,7 @@ let prop_marker_free_has_no_signal_or_teaser =
 
 let prop_strip_log_idempotent =
   QCheck2.Test.make ~count:500 ~name:"strip_log is idempotent"
-    gen_arbitrary_bytes (fun log ->
+    ~print:printable_counterexample gen_arbitrary_bytes (fun log ->
       let stripped = Ci_log_digest.strip_log log in
       String.equal (Ci_log_digest.strip_log stripped) stripped)
 

--- a/test/test_ci_log_digest_properties.ml
+++ b/test/test_ci_log_digest_properties.ml
@@ -173,6 +173,26 @@ let test_truncation_is_noted () =
   assert_contains "truncation summary" e.summary_md
     "diagnostic summary truncated"
 
+let test_exact_cap_preserves_content () =
+  let prefix = "## Failure annotations\n\n- p:1: " in
+  let suffix = "\n" in
+  let message_len =
+    Ci_log_digest.summary_total_cap_bytes - String.length prefix
+    - String.length suffix
+  in
+  let message = String.make message_len 'z' in
+  let annotation =
+    Ci_log_digest.{ path = Some "p"; line = Some 1; level = "failure"; message }
+  in
+  let e =
+    Ci_log_digest.digest
+      { annotations = [ annotation ]; log = Some "::error ::later section" }
+  in
+  assert (String.length e.summary_md <= Ci_log_digest.summary_total_cap_bytes);
+  assert_not_contains "exact-cap summary" e.summary_md
+    "diagnostic summary truncated";
+  assert (String.is_suffix e.summary_md ~suffix:(String.make 32 'z' ^ "\n"))
+
 let () =
   test_strip_log_removes_timestamps_and_ansi ();
   test_strip_log_normalizes_crlf ();
@@ -181,6 +201,7 @@ let () =
   test_mid_job_fixture ();
   test_no_marker_fixture ();
   test_truncation_is_noted ();
+  test_exact_cap_preserves_content ();
   let tests =
     [
       prop_digest_total_and_capped;


### PR DESCRIPTION
## Patch 1: Pure CI log digest module (lib_core/ci_log_digest)

- Create lib_core/ci_log_digest.mli with types annotation ({path : string option; line : int option; level : string; message : string}), source ({annotations : annotation list; log : string option}), enrichment ({summary_md : string; teaser : string option; signal : int}); values strip_log : string -> string, digest : source -> enrichment; and int constants summary_total_cap_bytes = 49152, marker_context_lines = 30, error_window_lines = 100, collapse_signal_threshold = 200.
- strip_log: split on newlines; drop a leading timestamp prefix per line when the line starts with an ISO-8601 timestamp followed by a space (the GitHub job-log format, e.g. '2026-07-01T19:33:24.1348805Z '); strip ANSI escape sequences (ESC '[' ... final byte in @-~). Total: malformed lines pass through unchanged; idempotent on its own output.
- digest (operates on strip_log-normalized text): section 1 — failure-level annotations only (level = "failure"), formatted as '- <path>:<line>: <message>'; section 2 — every line whose trimmed content (after any job prefix like '@pkg script: ') contains the literal '::error' marker, verbatim; section 3 — for each failure-marker line matching any of '(fail)', '=== FAIL', '✕', '❌', the preceding marker_context_lines lines; section 4 — for each '##[error]' line, the preceding error_window_lines lines. Deduplicate overlapping ranges; apply per-section and 48KB total caps, dropping later sections first and noting truncation in the summary.
- signal = byte length of extracted diagnostic content (sections 1-3 plus non-boilerplate section-4 content); teaser = first literal ::error line (message part), else first failure-marker line, else None.
- Write QCheck2 properties in test/test_ci_log_digest_properties.ml: (a) digest never raises and summary_md length <= summary_total_cap_bytes for arbitrary byte strings; (b) every literal ::error line in a generated log appears in summary_md when under caps; (c) logs generated with no markers/::error/##[error] produce signal = 0 and teaser = None; (d) strip_log (strip_log s) = strip_log s; properties derived from the shapes documented in the fixture descriptions, not from the implementation.
- Add fixture regression tests: lowerability_fail.log → teaser contains the path:line:col diagnostic; bun_test_fail.log → summary contains the ::error file=... line and the TypeError code-frame context; mid_job_fail.log → summary contains the failing step's diagnostics and NONE of the post-##[error] passing-step content; no_marker_fail.log → non-empty summary from the ##[error] window alone.
- Add the test/dune stanza following the test_github_target_properties pattern, with (deps (glob_files fixtures/ci_logs/*.log)) so fixtures are available at runtime.

## Changes
- Create lib_core/ci_log_digest.mli with types annotation ({path : string option; line : int option; level : string; message : string}), source ({annotations : annotation list; log : string option}), enrichment ({summary_md : string; teaser : string option; signal : int}); values strip_log : string -> string, digest : source -> enrichment; and int constants summary_total_cap_bytes = 49152, marker_context_lines = 30, error_window_lines = 100, collapse_signal_threshold = 200.
- strip_log: split on newlines; drop a leading timestamp prefix per line when the line starts with an ISO-8601 timestamp followed by a space (the GitHub job-log format, e.g. '2026-07-01T19:33:24.1348805Z '); strip ANSI escape sequences (ESC '[' ... final byte in @-~). Total: malformed lines pass through unchanged; idempotent on its own output.
- digest (operates on strip_log-normalized text): section 1 — failure-level annotations only (level = "failure"), formatted as '- <path>:<line>: <message>'; section 2 — every line whose trimmed content (after any job prefix like '@pkg script: ') contains the literal '::error' marker, verbatim; section 3 — for each failure-marker line matching any of '(fail)', '=== FAIL', '✕', '❌', the preceding marker_context_lines lines; section 4 — for each '##[error]' line, the preceding error_window_lines lines. Deduplicate overlapping ranges; apply per-section and 48KB total caps, dropping later sections first and noting truncation in the summary.
- signal = byte length of extracted diagnostic content (sections 1-3 plus non-boilerplate section-4 content); teaser = first literal ::error line (message part), else first failure-marker line, else None.
- Write QCheck2 properties in test/test_ci_log_digest_properties.ml: (a) digest never raises and summary_md length <= summary_total_cap_bytes for arbitrary byte strings; (b) every literal ::error line in a generated log appears in summary_md when under caps; (c) logs generated with no markers/::error/##[error] produce signal = 0 and teaser = None; (d) strip_log (strip_log s) = strip_log s; properties derived from the shapes documented in the fixture descriptions, not from the implementation.
- Add fixture regression tests: lowerability_fail.log → teaser contains the path:line:col diagnostic; bun_test_fail.log → summary contains the ::error file=... line and the TypeError code-frame context; mid_job_fail.log → summary contains the failing step's diagnostics and NONE of the post-##[error] passing-step content; no_marker_fail.log → non-empty summary from the ##[error] window alone.
- Add the test/dune stanza following the test_github_target_properties pattern, with (deps (glob_files fixtures/ci_logs/*.log)) so fixtures are available at runtime.

## Files to Modify
- lib_core/ci_log_digest.mli (create): Interface: annotation/source/enrichment types, strip_log, digest, exposed constants (summary_total_cap_bytes=49152, marker_context_lines=30, error_window_lines=100, collapse_signal_threshold=200).
- lib_core/ci_log_digest.ml (create): Implementation of strip_log and the extraction ladder; pure, Base-only (re available if regex is preferred over manual scanning).
- test/test_ci_log_digest_properties.ml (create): QCheck2 properties (totality, cap, ::error preservation, marker-free ⇒ zero signal, strip_log idempotence) plus fixture-file regression tests.
- test/fixtures/ci_logs/lowerability_fail.log (create): Fixture mirroring the ts-lowerability shape: 29-char ISO-timestamp prefix on every line, ANSI color codes, ##[group]/##[endgroup] step markers, a '=== FAIL <path>' marker with a path:line:col diagnostic ~3 lines before a single trailing '##[error]Process completed with exit code 1.'
- test/fixtures/ci_logs/bun_test_fail.log (create): Fixture mirroring the bun-test shape: '@pkg test:unit: ' turbo prefixes, a code frame + TypeError + literal '::error file=...,line=...,col=...,title=...' line followed by a '(fail) suite > test name' marker mid-log, a pass/fail summary block, and the ##[error] marker ~70 lines later with passing output in between.
- test/fixtures/ci_logs/mid_job_fail.log (create): Fixture mirroring the Biome/lint shape: the failing step's diagnostics and ##[error] marker mid-file, followed by several hundred lines of passing if:always() steps and teardown — regression-pins that extraction anchors on ##[error], never tail-of-file.
- test/fixtures/ci_logs/no_marker_fail.log (create): Fixture mirroring the deploy/Momentic shape: no ::error lines and no (fail)/FAIL markers; only the ##[error] window fires.
- test/dune (modify): Add the test_ci_log_digest_properties stanza (libraries onton_core qcheck-core qcheck-core.runner base, -w -40-42 flags) with fixture deps.

## Gameplan Specification

```
module FAILING_CI_DETAILS.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> After this gameplan, a CI failure delivery records each failing
> check's diagnostics on disk (check.json, summary.md, log.txt under
> artifacts/<patch_id>/ci/<key>/) and the agent prompt cites those
> paths with a diagnostic teaser, ranked by signal — replacing
> URL-only delivery and improvised gh calls. All extraction logic is
> pure and property-tested; every failure mode degrades per check to
> the previous metadata-only rendering.

Check.
Source.
Enrichment.
Log.
Delivery.

has-run-id? c: Check => Bool.
check-key-collision-same-run? c1: Check, c2: Check => Bool.

strip-log l: Log => Log.
digest s: Source => Enrichment.
summary-bytes e: Enrichment => Nat0.
summary-cap => Nat0.

hits-network? c: Check => Bool.
sends-token-to-redirect-host? c: Check => Bool.

delivered? d: Delivery, c: Check => Bool.
fetch-succeeded? d: Delivery, c: Check => Bool.
artifact-published? d: Delivery, c: Check => Bool.
prompt-cites? d: Delivery, c: Check => Bool.
metadata-only? d: Delivery, c: Check => Bool.
delivery-blocked-by-details? d: Delivery => Bool.
fetch-count d: Delivery => Nat0.
fetch-cap => Nat0.
instructs-no-refetch? d: Delivery => Bool.
---
> Digest output is bounded and stripping is idempotent.
all s: Source | summary-bytes (digest s) <= summary-cap.
all l: Log | strip-log (strip-log l) = strip-log l.

> Id-less checks never hit the network; no fetch ever sends the API
> token to the redirect host.
all c: Check, ~ (has-run-id? c) | ~ (hits-network? c).
all c: Check | ~ (sends-token-to-redirect-host? c).

> Delivered checks with fetched, published details are cited by the
> prompt; failed fetches render metadata-only; detail retrieval never
> blocks a delivery; fetches are capped.
all d: Delivery, c: Check, delivered? d c and fetch-succeeded? d c and artifact-published? d c | prompt-cites? d c.
all d: Delivery, c: Check, delivered? d c and ~ (fetch-succeeded? d c) | metadata-only? d c.
all d: Delivery | ~ (delivery-blocked-by-details? d).
all d: Delivery | fetch-count d <= fetch-cap.

> Every delivery with details instructs the agent not to re-fetch
> checks with gh.
all d: Delivery | instructs-no-refetch? d.
```

## Patch Specification

```
module FAILING_CI_DETAILS_PATCH_1.

> Pure CI log digest (lib_core/ci_log_digest): extraction ladder over
> raw GitHub Actions job logs. Total over arbitrary strings; output
> bounded. Constants grounded in the provisioning-agent failed-job
> corpus (2026-07-01).

Log.
Source.
Enrichment.

strip-log l: Log => Log.
digest s: Source => Enrichment.

summary-bytes e: Enrichment => Nat0.
signal e: Enrichment => Nat0.
has-teaser? e: Enrichment => Bool.
summary-cap => Nat0.

log-of s: Source => Log.
error-line-count l: Log => Nat0.
marker-count l: Log => Nat0.
failure-annotation-count s: Source => Nat0.
---
> The digest is bounded: no summary exceeds the cap.
all s: Source | summary-bytes (digest s) <= summary-cap.

> Stripping is idempotent.
all l: Log | strip-log (strip-log l) = strip-log l.

> A source with no failure annotations, no literal ::error lines and no
> failure markers digests to zero signal and no teaser.
all s: Source, failure-annotation-count s = 0 and error-line-count (log-of s) = 0 and marker-count (log-of s) = 0 | signal (digest s) = 0 and ~ (has-teaser? (digest s)).

> Any literal ::error line yields positive signal.
all s: Source, error-line-count (log-of s) > 0 | signal (digest s) > 0.
```


## Implementation Notes

- `Ci_log_digest.strip_log` normalizes each line to a fixed point in one pass: ANSI removal, timestamp-prefix removal, then ANSI removal again. This handles logs where color codes precede the GitHub timestamp while preserving malformed/unterminated CSI sequences unchanged.
- The summary builder is intentionally conservative: sections are emitted in priority order and clipped at the global 48 KB byte cap with a truncation note. There is no separate smaller per-section byte constant; later sections are the ones that fall off when the cap is reached.
- Section 3 and 4 range extraction deduplicates overlapping line windows within each section. A line can still appear in multiple sections when it is independently useful, for example a literal `::error` line that is also in marker context.
- Teaser extraction falls back to the full `::error` line when the marker has no message body after `::`; otherwise it uses the message body. For non-`::error` failures it uses the first failure-marker line, so dependent prompt code can treat `teaser = Some _` as display-ready but should not assume it is path-only or message-only.
- Annotation formatting uses `<unknown>` and `?` for missing path/line values. Downstream artifact JSON can pass GitHub annotations through without inventing fake locations.
- Spec/Evidence Mapping: bounded digest and strip idempotence are implemented in `Ci_log_digest.append_capped` / `strip_log` and covered by `test_ci_log_digest_properties` QCheck properties; zero-signal marker-free behavior and positive `::error` signal are covered by generated properties; corpus-shape expectations are pinned by the four `test/fixtures/ci_logs/*.log` regression tests. Required context consulted: `test/dune` and `test/test_github_target_properties.ml` for the QCheck test stanza/style.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new CI log digest summary that condenses build failures into a short markdown report, including a teaser and signal score.
  * Improved log cleanup so summaries are easier to read, with handling for timestamps, color codes, and line-ending differences.

* **Tests**
  * Added property-based and fixture-based coverage to validate digest length limits, failure detection, truncation behavior, and stable output for common CI log patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->