### PR TITLE
[failing-ci-details] Patch 4: Detailed CI prompt renderers (rank, collapse, artifact citations)

### DIFF
--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -1187,7 +1187,7 @@ let render_ci_detail_lines (detail : ci_check_detail) =
             detail.artifact_dir;
         ]
   in
-  "\n" ^ String.concat lines ~sep:"\n"
+  String.concat lines ~sep:"\n"
 
 let order_ci_detail_items items =
   let indexed = List.mapi items ~f:(fun index item -> (index, item)) in
@@ -1239,7 +1239,7 @@ let render_turn_layer_ci_detailed ~(project_name : string) ?pr_number
               render_ci_check_line check
               ^
               match detail with
-              | Some detail -> render_ci_detail_lines detail
+              | Some detail -> "\n" ^ render_ci_detail_lines detail
               | None -> "")
         in
         let collapsed_line =
@@ -1252,8 +1252,7 @@ let render_turn_layer_ci_detailed ~(project_name : string) ?pr_number
               in
               [
                 Printf.sprintf
-                  "\n\
-                   Also failing (low diagnostic signal): %s — details recorded \
+                  "Also failing (low diagnostic signal): %s — details recorded \
                    under their artifact directories."
                   names;
               ]
@@ -1275,7 +1274,10 @@ let render_turn_layer_ci_detailed ~(project_name : string) ?pr_number
         items
         |> List.count ~f:(fun (_, detail) -> Option.is_some detail)
         |> Int.to_string );
-      ("collapsed_count", collapsed |> List.length |> Int.to_string);
+      ( "collapsed_count",
+        collapsed
+        |> List.count ~f:(fun (_, detail) -> Option.is_some detail)
+        |> Int.to_string );
       ( "pr_number",
         match pr_number with
         | Some n -> Int.to_string (Pr_number.to_int n)
@@ -2334,7 +2336,10 @@ let%test
          "Also failing (low diagnostic signal): all-jobs-succeed — details \
           recorded under their artifact directories."
   && String.is_substring with_high
-       ~substring:"check.json)\n\nAlso failing (low diagnostic signal)"
+       ~substring:"check.json)\nAlso failing (low diagnostic signal)"
+  && (not
+        (String.is_substring with_high
+           ~substring:"check.json)\n\nAlso failing (low diagnostic signal)"))
   && not
        (String.is_substring with_high
           ~substring:"artifacts/4/ci/run-low/summary.md")

--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -1233,7 +1233,7 @@ let render_turn_layer_ci_detailed ~(project_name : string) ?pr_number
   let formatted_checks =
     match visible with
     | [] -> "No CI failures."
-    | _ ->
+    | _ -> (
         let rendered =
           List.map visible ~f:(fun (check, detail) ->
               render_ci_check_line check
@@ -1257,7 +1257,11 @@ let render_turn_layer_ci_detailed ~(project_name : string) ?pr_number
                   names;
               ]
         in
-        String.concat (rendered @ collapsed_line) ~sep:"\n"
+        String.concat rendered ~sep:"\n"
+        ^
+        match collapsed_line with
+        | [] -> ""
+        | _ -> "\n\n" ^ String.concat collapsed_line ~sep:"\n")
   in
   let pr_ctx =
     match pr_number with
@@ -2333,10 +2337,7 @@ let%test
          "Also failing (low diagnostic signal): all-jobs-succeed — details \
           recorded under their artifact directories."
   && String.is_substring with_high
-       ~substring:"check.json)\nAlso failing (low diagnostic signal)"
-  && (not
-        (String.is_substring with_high
-           ~substring:"check.json)\n\nAlso failing (low diagnostic signal)"))
+       ~substring:"check.json)\n\nAlso failing (low diagnostic signal)"
   && not
        (String.is_substring with_high
           ~substring:"artifacts/4/ci/run-low/summary.md")

--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -1107,31 +1107,37 @@ let render_findings_prompt ~(project_name : string) ?agents_md ?pr_number
   ^ render_turn_layer_findings ~project_name ?pr_number ?current_head_sha
       ~artifact_dir findings
 
+type ci_check_detail = {
+  artifact_dir : string;
+  enrichment : Ci_log_digest.enrichment;
+}
+
+let render_ci_check_line (c : Ci_check.t) =
+  let id =
+    match c.Ci_check.id with
+    | Some id -> Printf.sprintf " [check_id=%d]" id
+    | None -> ""
+  in
+  let url =
+    match c.Ci_check.details_url with
+    | Some u -> Printf.sprintf " (%s)" u
+    | None -> ""
+  in
+  let desc =
+    match c.Ci_check.description with
+    | Some d -> Printf.sprintf "\n  %s" d
+    | None -> ""
+  in
+  Printf.sprintf "- **%s**: %s%s%s%s" c.Ci_check.name c.Ci_check.conclusion id
+    url desc
+
 let render_turn_layer_ci ~(project_name : string) ?pr_number
     (checks : Ci_check.t list) : string =
   match checks with
   | [] -> "No CI failures."
   | _ ->
       let formatted =
-        List.map checks ~f:(fun (c : Ci_check.t) ->
-            let id =
-              match c.Ci_check.id with
-              | Some id -> Printf.sprintf " [check_id=%d]" id
-              | None -> ""
-            in
-            let url =
-              match c.Ci_check.details_url with
-              | Some u -> Printf.sprintf " (%s)" u
-              | None -> ""
-            in
-            let desc =
-              match c.Ci_check.description with
-              | Some d -> Printf.sprintf "\n  %s" d
-              | None -> ""
-            in
-            Printf.sprintf "- **%s**: %s%s%s%s" c.Ci_check.name
-              c.Ci_check.conclusion id url desc)
-        |> String.concat ~sep:"\n"
+        List.map checks ~f:render_ci_check_line |> String.concat ~sep:"\n"
       in
       let pr_ctx =
         match pr_number with
@@ -1159,11 +1165,139 @@ let render_turn_layer_ci ~(project_name : string) ?pr_number
              them for you — do not run `git push`."
             pr_ctx formatted)
 
+let ci_detailed_footer =
+  "Diagnostics for each check are recorded at the paths above — read \
+   summary.md first, grep log.txt for more. Do NOT re-fetch check results or \
+   logs with gh."
+
+let render_ci_detail_lines (detail : ci_check_detail) =
+  let teaser =
+    match detail.enrichment.Ci_log_digest.teaser with
+    | Some teaser when not (String.is_empty (String.strip teaser)) ->
+        Printf.sprintf "\n  error: %s" teaser
+    | Some _ | None -> ""
+  in
+  Printf.sprintf
+    "%s\n  details: %s/summary.md (full log: log.txt, metadata: check.json)"
+    teaser detail.artifact_dir
+
+let order_ci_detail_items items =
+  let indexed = List.mapi items ~f:(fun index item -> (index, item)) in
+  let with_details, without_details =
+    List.partition_map indexed ~f:(fun (index, ((_, detail) as item)) ->
+        match detail with
+        | Some detail -> First (index, item, detail)
+        | None -> Second (index, item))
+  in
+  let sorted_with_details =
+    List.sort with_details
+      ~compare:(fun (idx_a, _, detail_a) (idx_b, _, detail_b) ->
+        match
+          Int.descending detail_a.enrichment.Ci_log_digest.signal
+            detail_b.enrichment.Ci_log_digest.signal
+        with
+        | 0 -> Int.compare idx_a idx_b
+        | cmp -> cmp)
+  in
+  List.map sorted_with_details ~f:(fun (_, item, _) -> item)
+  @ List.map without_details ~f:(fun (_, item) -> item)
+
+let render_turn_layer_ci_detailed ~(project_name : string) ?pr_number
+    (items : (Ci_check.t * ci_check_detail option) list) : string =
+  let has_above_threshold =
+    List.exists items ~f:(function
+      | _, Some detail ->
+          detail.enrichment.Ci_log_digest.signal
+          >= Ci_log_digest.collapse_signal_threshold
+      | _, None -> false)
+  in
+  let should_collapse = function
+    | _, Some detail ->
+        has_above_threshold
+        && detail.enrichment.Ci_log_digest.signal
+           < Ci_log_digest.collapse_signal_threshold
+    | _, None -> false
+  in
+  let ordered = order_ci_detail_items items in
+  let visible, collapsed =
+    List.partition_tf ordered ~f:(Fn.non should_collapse)
+  in
+  let formatted_checks =
+    match visible with
+    | [] -> "No CI failures."
+    | _ ->
+        let rendered =
+          List.map visible ~f:(fun (check, detail) ->
+              render_ci_check_line check
+              ^
+              match detail with
+              | Some detail -> render_ci_detail_lines detail
+              | None -> "")
+        in
+        let collapsed_line =
+          match collapsed with
+          | [] -> []
+          | _ ->
+              let names =
+                List.map collapsed ~f:(fun (check, _) -> check.Ci_check.name)
+                |> String.concat ~sep:", "
+              in
+              [
+                Printf.sprintf
+                  "Also failing (low diagnostic signal): %s — details recorded \
+                   under their artifact directories."
+                  names;
+              ]
+        in
+        String.concat (rendered @ collapsed_line) ~sep:"\n"
+  in
+  let pr_ctx =
+    match pr_number with
+    | Some n -> Printf.sprintf "\n\nPR: #%d\n" (Pr_number.to_int n)
+    | None -> ""
+  in
+  let vars =
+    [
+      ("project_name", project_name);
+      ("checks", formatted_checks);
+      ("footer", ci_detailed_footer);
+      ("count", Int.to_string (List.length items));
+      ( "detail_count",
+        items
+        |> List.count ~f:(fun (_, detail) -> Option.is_some detail)
+        |> Int.to_string );
+      ( "collapsed_count",
+        collapsed
+        |> List.count ~f:(fun (_, detail) -> Option.is_some detail)
+        |> Int.to_string );
+      ( "pr_number",
+        match pr_number with
+        | Some n -> Int.to_string (Pr_number.to_int n)
+        | None -> "" );
+    ]
+  in
+  render_with_override ~project_name ~name:"turn_ci" ~vars ~default:(fun () ->
+      Printf.sprintf
+        "# CI Failures%s\n\n\
+         The following CI checks failed:\n\n\
+         %s\n\n\
+         %s\n\n\
+         After making your changes, commit them. The supervisor will push them \
+         for you — do not run `git push`."
+        pr_ctx formatted_checks ci_detailed_footer)
+
 let render_ci_failure_prompt ~(project_name : string) ?agents_md ?pr_number
     ?patch ?gameplan ?base_branch (checks : Ci_check.t list) : string =
   layered_prefix ~project_name ?pr_number ?patch ?gameplan ?base_branch
     ?agents_md ()
   ^ render_turn_layer_ci ~project_name ?pr_number checks
+
+let render_ci_failure_prompt_detailed ~(project_name : string) ?agents_md
+    ?pr_number ?patch ?gameplan ?base_branch
+    (items : (Ci_check.t * ci_check_detail option) list) : string =
+  layered_prefix ~project_name ?pr_number ?patch ?gameplan ?base_branch
+    ?agents_md ()
+  ^ render_turn_layer_ci_detailed ~project_name ?pr_number items
 
 let render_turn_layer_ci_unknown ~(project_name : string) ?pr_number () =
   let pr_ctx =
@@ -2117,6 +2251,106 @@ let%test "ci failure prompt renders check ids when present" =
   in
   String.is_substring ci_prompt ~substring:"[check_id=12345]"
   && String.is_substring ci_prompt ~substring:"https://example.test/check"
+
+let test_ci_check ?id ?details_url ?description name conclusion =
+  Ci_check.{ name; conclusion; details_url; description; started_at = None; id }
+
+let test_ci_detail ?teaser ~artifact_dir ~signal () =
+  {
+    artifact_dir;
+    enrichment = Ci_log_digest.{ summary_md = ""; teaser; signal };
+  }
+
+let prompt_index prompt needle = String.substr_index prompt ~pattern:needle
+
+let%test
+    "render_turn_layer_ci_detailed cites artifact dirs and teasers, orders by \
+     signal, and instructs no gh re-fetch" =
+  let high = test_ci_check "typecheck" "FAILURE" in
+  let low = test_ci_check "lint" "FAILURE" in
+  let prompt =
+    render_turn_layer_ci_detailed ~project_name:"onton"
+      [
+        ( low,
+          Some
+            (test_ci_detail ~artifact_dir:"artifacts/4/ci/run-10" ~signal:300
+               ~teaser:"lint failed" ()) );
+        ( high,
+          Some
+            (test_ci_detail ~artifact_dir:"artifacts/4/ci/run-11" ~signal:500
+               ~teaser:"type error" ()) );
+      ]
+  in
+  let high_pos = prompt_index prompt "- **typecheck**" in
+  let low_pos = prompt_index prompt "- **lint**" in
+  Option.value_map high_pos ~default:false ~f:(fun high_i ->
+      Option.value_map low_pos ~default:false ~f:(fun low_i -> high_i < low_i))
+  && String.is_substring prompt ~substring:"error: type error"
+  && String.is_substring prompt
+       ~substring:
+         "artifacts/4/ci/run-11/summary.md (full log: log.txt, metadata: \
+          check.json)"
+  && String.is_substring prompt
+       ~substring:"Do NOT re-fetch check results or logs with gh."
+
+let%test
+    "render_turn_layer_ci_detailed collapses low-signal checks only when a \
+     high-signal check exists" =
+  let high = test_ci_check "unit" "FAILURE" in
+  let low = test_ci_check "all-jobs-succeed" "FAILURE" in
+  let without_high =
+    render_turn_layer_ci_detailed ~project_name:"onton"
+      [
+        ( low,
+          Some
+            (test_ci_detail ~artifact_dir:"artifacts/4/ci/run-low" ~signal:1 ())
+        );
+      ]
+  in
+  let with_high =
+    render_turn_layer_ci_detailed ~project_name:"onton"
+      [
+        ( low,
+          Some
+            (test_ci_detail ~artifact_dir:"artifacts/4/ci/run-low" ~signal:1 ())
+        );
+        ( high,
+          Some
+            (test_ci_detail ~artifact_dir:"artifacts/4/ci/run-high"
+               ~signal:Ci_log_digest.collapse_signal_threshold ()) );
+      ]
+  in
+  String.is_substring without_high ~substring:"- **all-jobs-succeed**"
+  && String.is_substring without_high
+       ~substring:"artifacts/4/ci/run-low/summary.md"
+  && String.is_substring with_high
+       ~substring:
+         "Also failing (low diagnostic signal): all-jobs-succeed — details \
+          recorded under their artifact directories."
+  && not
+       (String.is_substring with_high
+          ~substring:"artifacts/4/ci/run-low/summary.md")
+
+let ci_check_lines rendered =
+  rendered |> String.split_lines
+  |> List.filter ~f:(String.is_prefix ~prefix:"- **")
+
+let%test
+    "render_turn_layer_ci_detailed with all-None details preserves the \
+     metadata-only line format" =
+  let checks =
+    [
+      test_ci_check ~id:123 ~details_url:"https://example.test/check"
+        ~description:"compiler failed" "build" "FAILURE";
+      test_ci_check "lint" "FAILURE";
+    ]
+  in
+  let legacy = render_turn_layer_ci ~project_name:"onton" checks in
+  let detailed =
+    render_turn_layer_ci_detailed ~project_name:"onton"
+      (List.map checks ~f:(fun check -> (check, None)))
+  in
+  List.equal String.equal (ci_check_lines legacy) (ci_check_lines detailed)
 
 let%test "human and pr_body prompts do not include the gameplan layer" =
   let human_prompt =

--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -1274,10 +1274,7 @@ let render_turn_layer_ci_detailed ~(project_name : string) ?pr_number
         items
         |> List.count ~f:(fun (_, detail) -> Option.is_some detail)
         |> Int.to_string );
-      ( "collapsed_count",
-        collapsed
-        |> List.count ~f:(fun (_, detail) -> Option.is_some detail)
-        |> Int.to_string );
+      ("collapsed_count", collapsed |> List.length |> Int.to_string);
       ( "pr_number",
         match pr_number with
         | Some n -> Int.to_string (Pr_number.to_int n)

--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -1171,15 +1171,23 @@ let ci_detailed_footer =
    logs with gh."
 
 let render_ci_detail_lines (detail : ci_check_detail) =
-  let teaser =
+  let lines =
     match detail.enrichment.Ci_log_digest.teaser with
     | Some teaser when not (String.is_empty (String.strip teaser)) ->
-        Printf.sprintf "\n  error: %s" teaser
-    | Some _ | None -> ""
+        [
+          Printf.sprintf "  error: %s" teaser;
+          Printf.sprintf
+            "  details: %s/summary.md (full log: log.txt, metadata: check.json)"
+            detail.artifact_dir;
+        ]
+    | Some _ | None ->
+        [
+          Printf.sprintf
+            "  details: %s/summary.md (full log: log.txt, metadata: check.json)"
+            detail.artifact_dir;
+        ]
   in
-  Printf.sprintf
-    "%s\n  details: %s/summary.md (full log: log.txt, metadata: check.json)"
-    teaser detail.artifact_dir
+  "\n" ^ String.concat lines ~sep:"\n"
 
 let order_ci_detail_items items =
   let indexed = List.mapi items ~f:(fun index item -> (index, item)) in
@@ -1244,7 +1252,8 @@ let render_turn_layer_ci_detailed ~(project_name : string) ?pr_number
               in
               [
                 Printf.sprintf
-                  "Also failing (low diagnostic signal): %s — details recorded \
+                  "\n\
+                   Also failing (low diagnostic signal): %s — details recorded \
                    under their artifact directories."
                   names;
               ]
@@ -1266,10 +1275,7 @@ let render_turn_layer_ci_detailed ~(project_name : string) ?pr_number
         items
         |> List.count ~f:(fun (_, detail) -> Option.is_some detail)
         |> Int.to_string );
-      ( "collapsed_count",
-        collapsed
-        |> List.count ~f:(fun (_, detail) -> Option.is_some detail)
-        |> Int.to_string );
+      ("collapsed_count", collapsed |> List.length |> Int.to_string);
       ( "pr_number",
         match pr_number with
         | Some n -> Int.to_string (Pr_number.to_int n)
@@ -2327,6 +2333,8 @@ let%test
        ~substring:
          "Also failing (low diagnostic signal): all-jobs-succeed — details \
           recorded under their artifact directories."
+  && String.is_substring with_high
+       ~substring:"check.json)\n\nAlso failing (low diagnostic signal)"
   && not
        (String.is_substring with_high
           ~substring:"artifacts/4/ci/run-low/summary.md")

--- a/lib/prompt.mli
+++ b/lib/prompt.mli
@@ -93,6 +93,17 @@ val render_turn_layer_review :
 val render_turn_layer_ci :
   project_name:string -> ?pr_number:Pr_number.t -> Ci_check.t list -> string
 
+type ci_check_detail = {
+  artifact_dir : string;
+  enrichment : Ci_log_digest.enrichment;
+}
+
+val render_turn_layer_ci_detailed :
+  project_name:string ->
+  ?pr_number:Pr_number.t ->
+  (Ci_check.t * ci_check_detail option) list ->
+  string
+
 val render_turn_layer_ci_unknown :
   project_name:string -> ?pr_number:Pr_number.t -> unit -> string
 
@@ -189,6 +200,16 @@ val render_ci_failure_prompt :
   ?gameplan:Gameplan.t ->
   ?base_branch:string ->
   Ci_check.t list ->
+  string
+
+val render_ci_failure_prompt_detailed :
+  project_name:string ->
+  ?agents_md:string ->
+  ?pr_number:Pr_number.t ->
+  ?patch:Patch.t ->
+  ?gameplan:Gameplan.t ->
+  ?base_branch:string ->
+  (Ci_check.t * ci_check_detail option) list ->
   string
 
 val render_ci_failure_unknown_prompt :


### PR DESCRIPTION
## Patch 4: Detailed CI prompt renderers (rank, collapse, artifact citations)

- Define type ci_check_detail = { artifact_dir : string; enrichment : Ci_log_digest.enrichment } in prompt.mli.
- render_turn_layer_ci_detailed ~project_name ?pr_number (items : (Ci_check.t * ci_check_detail option) list) : string — per-check block reusing render_turn_layer_ci's existing name/conclusion/[check_id=..]/URL line format (lib/prompt.ml:1094-1112), extended with, when detail is Some: a teaser line ('  error: <teaser>') and an artifact citation ('  details: <artifact_dir>/summary.md (full log: log.txt, metadata: check.json)').
- Ordering: items with details sort by descending enrichment.signal (stable within ties, preserving input order); detail-less items follow in input order.
- Collapse: when at least one item has enrichment.signal >= Ci_log_digest.collapse_signal_threshold, items with details and signal < threshold collapse to a single trailing line 'Also failing (low diagnostic signal): <name>, <name> — details recorded under their artifact directories.' When no item reaches the threshold, nothing collapses.
- Footer (always, in the detailed layer): 'Diagnostics for each check are recorded at the paths above — read summary.md first, grep log.txt for more. Do NOT re-fetch check results or logs with gh.' Compose through render_with_override with the existing "turn_ci" template name, passing the enriched checks block through the existing {{checks}} var (so user template overrides keep working) plus new vars.
- render_ci_failure_prompt_detailed mirrors render_ci_failure_prompt's signature (project_name/agents_md/pr_number/patch/gameplan/base_branch — see lib/prompt.ml:1141) over the item list, composing layered_prefix ^ render_turn_layer_ci_detailed.
- Inline let%test coverage: artifact path + teaser presence; signal-descending order; collapse fires only when a super-threshold item exists; all-None items render byte-identical check lines to render_turn_layer_ci (same formatting helper); footer instruction present.

## Changes
- Define type ci_check_detail = { artifact_dir : string; enrichment : Ci_log_digest.enrichment } in prompt.mli.
- render_turn_layer_ci_detailed ~project_name ?pr_number (items : (Ci_check.t * ci_check_detail option) list) : string — per-check block reusing render_turn_layer_ci's existing name/conclusion/[check_id=..]/URL line format (lib/prompt.ml:1094-1112), extended with, when detail is Some: a teaser line ('  error: <teaser>') and an artifact citation ('  details: <artifact_dir>/summary.md (full log: log.txt, metadata: check.json)').
- Ordering: items with details sort by descending enrichment.signal (stable within ties, preserving input order); detail-less items follow in input order.
- Collapse: when at least one item has enrichment.signal >= Ci_log_digest.collapse_signal_threshold, items with details and signal < threshold collapse to a single trailing line 'Also failing (low diagnostic signal): <name>, <name> — details recorded under their artifact directories.' When no item reaches the threshold, nothing collapses.
- Footer (always, in the detailed layer): 'Diagnostics for each check are recorded at the paths above — read summary.md first, grep log.txt for more. Do NOT re-fetch check results or logs with gh.' Compose through render_with_override with the existing "turn_ci" template name, passing the enriched checks block through the existing {{checks}} var (so user template overrides keep working) plus new vars.
- render_ci_failure_prompt_detailed mirrors render_ci_failure_prompt's signature (project_name/agents_md/pr_number/patch/gameplan/base_branch — see lib/prompt.ml:1141) over the item list, composing layered_prefix ^ render_turn_layer_ci_detailed.
- Inline let%test coverage: artifact path + teaser presence; signal-descending order; collapse fires only when a super-threshold item exists; all-None items render byte-identical check lines to render_turn_layer_ci (same formatting helper); footer instruction present.

## Files to Modify
- lib/prompt.mli (modify): Add ci_check_detail type and render_turn_layer_ci_detailed / render_ci_failure_prompt_detailed next to the existing CI renderers (existing signatures unchanged).
- lib/prompt.ml (modify): Implement the detailed turn layer + prompt composer; inline let%test coverage next to the existing prompt tests.

## Gameplan Specification

```
module FAILING_CI_DETAILS.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> After this gameplan, a CI failure delivery records each failing
> check's diagnostics on disk (check.json, summary.md, log.txt under
> artifacts/<patch_id>/ci/<key>/) and the agent prompt cites those
> paths with a diagnostic teaser, ranked by signal — replacing
> URL-only delivery and improvised gh calls. All extraction logic is
> pure and property-tested; every failure mode degrades per check to
> the previous metadata-only rendering.

Check.
Source.
Enrichment.
Log.
Delivery.

has-run-id? c: Check => Bool.
check-key-collision-same-run? c1: Check, c2: Check => Bool.

strip-log l: Log => Log.
digest s: Source => Enrichment.
summary-bytes e: Enrichment => Nat0.
summary-cap => Nat0.

hits-network? c: Check => Bool.
sends-token-to-redirect-host? c: Check => Bool.

delivered? d: Delivery, c: Check => Bool.
fetch-succeeded? d: Delivery, c: Check => Bool.
artifact-published? d: Delivery, c: Check => Bool.
prompt-cites? d: Delivery, c: Check => Bool.
metadata-only? d: Delivery, c: Check => Bool.
delivery-blocked-by-details? d: Delivery => Bool.
fetch-count d: Delivery => Nat0.
fetch-cap => Nat0.
instructs-no-refetch? d: Delivery => Bool.
---
> Digest output is bounded and stripping is idempotent.
all s: Source | summary-bytes (digest s) <= summary-cap.
all l: Log | strip-log (strip-log l) = strip-log l.

> Id-less checks never hit the network; no fetch ever sends the API
> token to the redirect host.
all c: Check, ~ (has-run-id? c) | ~ (hits-network? c).
all c: Check | ~ (sends-token-to-redirect-host? c).

> Delivered checks with fetched, published details are cited by the
> prompt; failed fetches render metadata-only; detail retrieval never
> blocks a delivery; fetches are capped.
all d: Delivery, c: Check, delivered? d c and fetch-succeeded? d c and artifact-published? d c | prompt-cites? d c.
all d: Delivery, c: Check, delivered? d c and ~ (fetch-succeeded? d c) | metadata-only? d c.
all d: Delivery | ~ (delivery-blocked-by-details? d).
all d: Delivery | fetch-count d <= fetch-cap.

> Every delivery with details instructs the agent not to re-fetch
> checks with gh.
all d: Delivery | instructs-no-refetch? d.
```

## Patch Specification

```
module FAILING_CI_DETAILS_PATCH_4.

> Detailed CI prompt rendering: per-check artifact citations, signal
> ranking, low-signal collapse, and the do-not-refetch instruction.

Item.
Rendering.

has-detail? i: Item => Bool.
signal-of i: Item => Nat0.
collapse-threshold => Nat0.

position r: Rendering, i: Item => Nat0.
collapsed? r: Rendering, i: Item => Bool.
cites-artifact-dir? r: Rendering, i: Item => Bool.
some-above-threshold? r: Rendering => Bool.
instructs-no-refetch? r: Rendering => Bool.
---
> Enriched items are ordered by descending signal.
all r: Rendering, i1: Item, i2: Item, has-detail? i1 and has-detail? i2 and signal-of i1 > signal-of i2 | position r i1 <= position r i2.

> An item is collapsed only when it is below the threshold and some
> item in the same rendering reaches it.
all r: Rendering, i: Item, collapsed? r i | signal-of i < collapse-threshold and some-above-threshold? r.

> Every non-collapsed enriched item cites its artifact directory.
all r: Rendering, i: Item, has-detail? i and ~ (collapsed? r i) | cites-artifact-dir? r i.

> Every detailed rendering instructs the agent not to re-fetch checks.
all r: Rendering | instructs-no-refetch? r.
```


## Implementation Notes

- Added one shared `render_ci_check_line` helper in `lib/prompt.ml` and routed both legacy and detailed CI renderers through it. This keeps metadata-only check rows byte-identical for downstream degradation paths while avoiding duplicate formatting logic.
- Detailed rendering still uses the existing `turn_ci` override name and passes the enriched block through `{{checks}}`; the new supplemental override vars are `footer`, `detail_count`, and `collapsed_count`. A custom `prompts/turn_ci.md` override must include `{{footer}}` itself if it wants the built-in no-refetch text to appear under an override.
- Sorting is implemented by tagging each input with its original index, sorting only `Some detail` items by descending `enrichment.signal` with index tie-breaks, then appending `None` items in original order. Low-signal detailed items are collapsed only after that ordering pass, so collapsed names follow the same deterministic order.
- Teaser rendering is intentionally omitted when `enrichment.teaser` is `None` or whitespace-only; artifact citation is still emitted for every non-collapsed detailed item.
- Spec/Evidence Mapping: descending enriched ordering, low-signal collapse guard, artifact citation, and no-refetch instruction are implemented in `render_turn_layer_ci_detailed` in `lib/prompt.ml`; required context was `lib/prompt.ml`/`lib/prompt.mli`; evidence is inline `let%test` coverage plus passing `dune fmt`, `dune build`, and `dune runtest`.