### PR TITLE
[failing-ci-details] Patch 3: Forge capability: check_failure_details (annotations + job log)

### DIFF
--- a/lib/forge.ml
+++ b/lib/forge.ml
@@ -34,6 +34,13 @@ module type S = sig
       placeholder with the real failing checks (names, [details_url], dedup
       ids). *)
 
+  val check_failure_details :
+    check:Types.Ci_check.t -> (Ci_log_digest.source, error) Result.t
+  (** Best-effort diagnostics for a failing CI check. Implementations should
+      return [Ok] with any partial annotation/log data they can fetch, degrade
+      to an empty source for checks without a stable run id, and return [Error]
+      only when every attempted details endpoint failed hard. *)
+
   val list_prs :
     branch:Types.Branch.t ->
     ?base:Types.Branch.t ->

--- a/lib/forge.mli
+++ b/lib/forge.mli
@@ -34,6 +34,13 @@ module type S = sig
       placeholder with the real failing checks (names, [details_url], dedup
       ids). *)
 
+  val check_failure_details :
+    check:Types.Ci_check.t -> (Ci_log_digest.source, error) Result.t
+  (** Best-effort diagnostics for a failing CI check. Implementations should
+      return [Ok] with any partial annotation/log data they can fetch, degrade
+      to an empty source for checks without a stable run id, and return [Error]
+      only when every attempted details endpoint failed hard. *)
+
   val list_prs :
     branch:Types.Branch.t ->
     ?base:Types.Branch.t ->

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -1119,6 +1119,18 @@ let fetch_signed_job_log ~client ~sw ~url =
   | Eio.Cancel.Cancelled _ as exn -> raise exn
   | _ -> Ok None
 
+let drain_response_body flow =
+  let buf = Bytes.create 4096 in
+  let rec loop () =
+    ignore (Eio.Flow.single_read flow (Cstruct.of_bytes buf));
+    loop ()
+  in
+  try loop () with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | End_of_file -> ()
+  | Eio.Exn.Io _ | Invalid_argument _ -> ()
+  | _ -> ()
+
 let fetch_job_log ~net ~clock t ~id =
   let path =
     Printf.sprintf "/repos/%s/%s/actions/jobs/%d/logs" t.owner t.repo id
@@ -1148,6 +1160,7 @@ let fetch_job_log ~net ~clock t ~id =
           let status = Http.Response.status resp |> Http.Status.to_int in
           match status with
           | 302 -> (
+              drain_response_body resp_body;
               match Http.Header.get (Http.Response.headers resp) "location" with
               | None ->
                   Error

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -944,6 +944,15 @@ type actions_job = {
 type actions_jobs_response = { jobs : actions_job list [@yojson.default []] }
 [@@deriving of_yojson] [@@yojson.allow_extra_fields]
 
+type check_annotation = {
+  path : string option; [@yojson.default None]
+  start_line : int option; [@key "start_line"] [@yojson.default None]
+  annotation_level : string option;
+      [@key "annotation_level"] [@yojson.default None]
+  message : string option; [@yojson.default None]
+}
+[@@deriving of_yojson] [@@yojson.allow_extra_fields]
+
 let ci_check_of_actions_job (job : actions_job) =
   Option.map job.name ~f:(fun name ->
       let conclusion =
@@ -970,6 +979,26 @@ let parse_actions_jobs_response body =
           |> List.filter ~f:Types.Ci_check.is_failure
           |> Result.return)
 
+let digest_annotation_of_check_annotation (a : check_annotation) :
+    Ci_log_digest.annotation =
+  {
+    path = a.path;
+    line = a.start_line;
+    level = Option.value a.annotation_level ~default:"";
+    message = Option.value a.message ~default:"";
+  }
+
+let parse_check_annotations_response body =
+  match Yojson.Safe.from_string body with
+  | exception Yojson.Json_error msg -> Error (Json_parse_error msg)
+  | json -> (
+      match
+        Json.try_of_yojson (list_of_yojson check_annotation_of_yojson) json
+      with
+      | Error msg -> Error (Json_parse_error msg)
+      | Ok annotations ->
+          Ok (List.map annotations ~f:digest_annotation_of_check_annotation))
+
 let https_config () =
   match Ca_certs.authenticator () with
   | Error (`Msg msg) -> Error ("TLS CA setup failed: " ^ msg)
@@ -986,6 +1015,8 @@ let https_fun tls_config uri flow =
   (Tls_eio.client_of_flow tls_config ?host flow :> _ Eio.Flow.two_way)
 
 let max_response_size = 1_000_000
+let max_job_log_response_size = 10_000_000
+let job_log_timeout = 60.0
 
 (** Default per-request timeout, in seconds. Matches review_service_client.
     Without a timeout, a TCP connect stuck in SYN_SENT can block the calling
@@ -1050,7 +1081,7 @@ let request ~net ~clock ?(timeout = default_timeout) t ~meth ~path ?(query = [])
           let status = Http.Response.status resp |> Http.Status.to_int in
           let resp_str =
             Eio.Buf_read.(
-              of_flow ~max_size:max_response_size resp_body |> take_all)
+              of_flow ~max_size:max_job_log_response_size resp_body |> take_all)
           in
           if status >= 200 && status < 300 then Ok resp_str
           else
@@ -1066,6 +1097,128 @@ let request ~net ~clock ?(timeout = default_timeout) t ~meth ~path ?(query = [])
   match Eio.Time.with_timeout clock timeout (fun () -> Ok (do_request ())) with
   | Ok inner -> inner
   | Error `Timeout -> Error (Timeout { meth = meth_s; path; seconds = timeout })
+
+let fetch_signed_job_log ~net ~clock ~url =
+  let path = url in
+  let do_request () : (string option, error) Result.t =
+    try
+      Mirage_crypto_rng_unix.use_default ();
+      Result.bind
+        (Result.map_error (https_config ()) ~f:(fun msg ->
+             Transport_error { meth = "GET"; path; msg }))
+        ~f:(fun tls_config ->
+          let client =
+            Cohttp_eio.Client.make ~https:(Some (https_fun tls_config)) net
+          in
+          let uri = Uri.of_string url in
+          let headers =
+            Http.Header.of_list
+              [
+                ("Accept", "text/plain, application/octet-stream, */*");
+                ("User-Agent", "onton/0.1.0");
+              ]
+          in
+          Eio.Switch.run @@ fun sw ->
+          let resp, resp_body = Cohttp_eio.Client.get client ~sw ~headers uri in
+          let status = Http.Response.status resp |> Http.Status.to_int in
+          let resp_str =
+            Eio.Buf_read.(
+              of_flow ~max_size:max_job_log_response_size resp_body |> take_all)
+          in
+          if status >= 200 && status < 300 then Ok (Some resp_str) else Ok None)
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | _ -> Ok None
+  in
+  match
+    Eio.Time.with_timeout clock job_log_timeout (fun () -> Ok (do_request ()))
+  with
+  | Ok inner -> inner
+  | Error `Timeout -> Ok None
+
+let fetch_job_log ~net ~clock t ~id =
+  let path =
+    Printf.sprintf "/repos/%s/%s/actions/jobs/%d/logs" t.owner t.repo id
+  in
+  let do_request () : (string option, error) Result.t =
+    try
+      Mirage_crypto_rng_unix.use_default ();
+      Result.bind
+        (Result.map_error (https_config ()) ~f:(fun msg ->
+             Transport_error { meth = "GET"; path; msg }))
+        ~f:(fun tls_config ->
+          let client =
+            Cohttp_eio.Client.make ~https:(Some (https_fun tls_config)) net
+          in
+          let uri = Uri.of_string ("https://api.github.com" ^ path) in
+          let headers =
+            Http.Header.of_list
+              [
+                ("Authorization", "Bearer " ^ t.token);
+                ("Accept", "application/vnd.github+json");
+                ("User-Agent", "onton/0.1.0");
+                ("X-GitHub-Api-Version", "2022-11-28");
+              ]
+          in
+          Eio.Switch.run @@ fun sw ->
+          let resp, resp_body = Cohttp_eio.Client.get client ~sw ~headers uri in
+          let status = Http.Response.status resp |> Http.Status.to_int in
+          let resp_str =
+            Eio.Buf_read.(
+              of_flow ~max_size:max_response_size resp_body |> take_all)
+          in
+          match status with
+          | 302 -> (
+              match Http.Header.get (Http.Response.headers resp) "location" with
+              | None ->
+                  Error
+                    (Transport_error
+                       {
+                         meth = "GET";
+                         path;
+                         msg = "log redirect missing Location";
+                       })
+              | Some url -> fetch_signed_job_log ~net ~clock ~url)
+          | 404 -> Ok None
+          | status when status >= 200 && status < 300 -> Ok (Some resp_str)
+          | status ->
+              Error (Http_error { meth = "GET"; path; status; body = resp_str }))
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn ->
+        Error (Transport_error { meth = "GET"; path; msg = Exn.to_string exn })
+  in
+  match
+    Eio.Time.with_timeout clock job_log_timeout (fun () -> Ok (do_request ()))
+  with
+  | Ok inner -> inner
+  | Error `Timeout ->
+      Error (Timeout { meth = "GET"; path; seconds = job_log_timeout })
+
+let fetch_check_annotations ~net ~clock t ~id =
+  let path =
+    Printf.sprintf "/repos/%s/%s/check-runs/%d/annotations" t.owner t.repo id
+  in
+  let query = [ ("per_page", [ "100" ]) ] in
+  match request ~net ~clock t ~meth:`GET ~path ~query () with
+  | Ok body -> parse_check_annotations_response body
+  | Error (Http_error { status = 404; _ }) -> Ok []
+  | Error
+      (( Http_error _ | Json_parse_error _ | Graphql_error _ | Timeout _
+       | Transport_error _ ) as err) ->
+      Error err
+
+let check_failure_details ~net ~clock t ~(check : Types.Ci_check.t) =
+  match check.id with
+  | None -> Ok { Ci_log_digest.annotations = []; log = None }
+  | Some id -> (
+      let annotations_result = fetch_check_annotations ~net ~clock t ~id in
+      let log_result = fetch_job_log ~net ~clock t ~id in
+      match (annotations_result, log_result) with
+      | Ok annotations, Ok log -> Ok { Ci_log_digest.annotations; log }
+      | Ok annotations, Error _ -> Ok { Ci_log_digest.annotations; log = None }
+      | Error _, Ok log -> Ok { Ci_log_digest.annotations = []; log }
+      | Error _, Error log_error -> Error log_error)
 
 let check_repo_access_internal ~net ~clock ?timeout t =
   let path = Printf.sprintf "/repos/%s/%s" t.owner t.repo in
@@ -1948,6 +2101,9 @@ let make ~net ~clock ~token ~owner ~repo ~main_branch :
 
     let merge_queue_removal_checks ~pr_number =
       merge_queue_removal_checks ~net ~clock client pr_number
+
+    let check_failure_details ~check =
+      check_failure_details ~net ~clock client ~check
 
     let list_prs ~branch ?base ~state () =
       match base with

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -1081,7 +1081,7 @@ let request ~net ~clock ?(timeout = default_timeout) t ~meth ~path ?(query = [])
           let status = Http.Response.status resp |> Http.Status.to_int in
           let resp_str =
             Eio.Buf_read.(
-              of_flow ~max_size:max_job_log_response_size resp_body |> take_all)
+              of_flow ~max_size:max_response_size resp_body |> take_all)
           in
           if status >= 200 && status < 300 then Ok resp_str
           else
@@ -1098,43 +1098,26 @@ let request ~net ~clock ?(timeout = default_timeout) t ~meth ~path ?(query = [])
   | Ok inner -> inner
   | Error `Timeout -> Error (Timeout { meth = meth_s; path; seconds = timeout })
 
-let fetch_signed_job_log ~net ~clock ~url =
-  let path = url in
-  let do_request () : (string option, error) Result.t =
-    try
-      Mirage_crypto_rng_unix.use_default ();
-      Result.bind
-        (Result.map_error (https_config ()) ~f:(fun msg ->
-             Transport_error { meth = "GET"; path; msg }))
-        ~f:(fun tls_config ->
-          let client =
-            Cohttp_eio.Client.make ~https:(Some (https_fun tls_config)) net
-          in
-          let uri = Uri.of_string url in
-          let headers =
-            Http.Header.of_list
-              [
-                ("Accept", "text/plain, application/octet-stream, */*");
-                ("User-Agent", "onton/0.1.0");
-              ]
-          in
-          Eio.Switch.run @@ fun sw ->
-          let resp, resp_body = Cohttp_eio.Client.get client ~sw ~headers uri in
-          let status = Http.Response.status resp |> Http.Status.to_int in
-          let resp_str =
-            Eio.Buf_read.(
-              of_flow ~max_size:max_job_log_response_size resp_body |> take_all)
-          in
-          if status >= 200 && status < 300 then Ok (Some resp_str) else Ok None)
-    with
-    | Eio.Cancel.Cancelled _ as exn -> raise exn
-    | _ -> Ok None
-  in
-  match
-    Eio.Time.with_timeout clock job_log_timeout (fun () -> Ok (do_request ()))
+let fetch_signed_job_log ~client ~sw ~url =
+  try
+    let uri = Uri.of_string url in
+    let headers =
+      Http.Header.of_list
+        [
+          ("Accept", "text/plain, application/octet-stream, */*");
+          ("User-Agent", "onton/0.1.0");
+        ]
+    in
+    let resp, resp_body = Cohttp_eio.Client.get client ~sw ~headers uri in
+    let status = Http.Response.status resp |> Http.Status.to_int in
+    let resp_str =
+      Eio.Buf_read.(
+        of_flow ~max_size:max_job_log_response_size resp_body |> take_all)
+    in
+    if status >= 200 && status < 300 then Ok (Some resp_str) else Ok None
   with
-  | Ok inner -> inner
-  | Error `Timeout -> Ok None
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | _ -> Ok None
 
 let fetch_job_log ~net ~clock t ~id =
   let path =
@@ -1163,10 +1146,6 @@ let fetch_job_log ~net ~clock t ~id =
           Eio.Switch.run @@ fun sw ->
           let resp, resp_body = Cohttp_eio.Client.get client ~sw ~headers uri in
           let status = Http.Response.status resp |> Http.Status.to_int in
-          let resp_str =
-            Eio.Buf_read.(
-              of_flow ~max_size:max_response_size resp_body |> take_all)
-          in
           match status with
           | 302 -> (
               match Http.Header.get (Http.Response.headers resp) "location" with
@@ -1178,10 +1157,20 @@ let fetch_job_log ~net ~clock t ~id =
                          path;
                          msg = "log redirect missing Location";
                        })
-              | Some url -> fetch_signed_job_log ~net ~clock ~url)
+              | Some url -> fetch_signed_job_log ~client ~sw ~url)
           | 404 -> Ok None
-          | status when status >= 200 && status < 300 -> Ok (Some resp_str)
+          | status when status >= 200 && status < 300 ->
+              let resp_str =
+                Eio.Buf_read.(
+                  of_flow ~max_size:max_job_log_response_size resp_body
+                  |> take_all)
+              in
+              Ok (Some resp_str)
           | status ->
+              let resp_str =
+                Eio.Buf_read.(
+                  of_flow ~max_size:max_response_size resp_body |> take_all)
+              in
               Error (Http_error { meth = "GET"; path; status; body = resp_str }))
     with
     | Eio.Cancel.Cancelled _ as exn -> raise exn
@@ -1203,9 +1192,10 @@ let fetch_check_annotations ~net ~clock t ~id =
   match request ~net ~clock t ~meth:`GET ~path ~query () with
   | Ok body -> parse_check_annotations_response body
   | Error (Http_error { status = 404; _ }) -> Ok []
+  | Error (Transport_error _) -> Ok []
   | Error
-      (( Http_error _ | Json_parse_error _ | Graphql_error _ | Timeout _
-       | Transport_error _ ) as err) ->
+      ((Http_error _ | Json_parse_error _ | Graphql_error _ | Timeout _) as err)
+    ->
       Error err
 
 let check_failure_details ~net ~clock t ~(check : Types.Ci_check.t) =

--- a/lib/github.mli
+++ b/lib/github.mli
@@ -117,6 +117,12 @@ val parse_actions_jobs_response :
     Job database ids become [Ci_check.id], and [html_url] becomes [details_url].
     Pure helper exposed for regression tests. *)
 
+val parse_check_annotations_response :
+  string -> (Ci_log_digest.annotation list, error) Result.t
+(** Parse a REST [GET /check-runs/:id/annotations] response into digest
+    annotations. Extra fields and explicit [null] path/line values are
+    tolerated. Pure helper exposed for regression tests. *)
+
 val is_merge_queue_required_error : error -> bool
 (** True only for the REST 405 response GitHub returns when the branch requires
     native merge queue use. *)

--- a/test/dune
+++ b/test/dune
@@ -21,6 +21,11 @@
  (libraries onton onton_core base))
 
 (test
+ (name test_github_check_details)
+ (modules test_github_check_details)
+ (libraries onton onton_core base yojson))
+
+(test
  (name test_json)
  (modules test_json)
  (libraries onton_core base yojson ppx_yojson_conv_lib))

--- a/test/test_github_check_details.ml
+++ b/test/test_github_check_details.ml
@@ -1,3 +1,6 @@
+(* @archlint.module test
+   @archlint.domain github *)
+
 open Base
 open Onton_core
 

--- a/test/test_github_check_details.ml
+++ b/test/test_github_check_details.ml
@@ -1,0 +1,72 @@
+open Base
+open Onton_core
+
+let assert_ok_annotations body ~f =
+  match Onton.Github.parse_check_annotations_response body with
+  | Ok annotations -> f annotations
+  | Error err ->
+      failwith
+        (Printf.sprintf "unexpected parse error: %s"
+           (Onton.Github.show_error err))
+
+let test_field_mapping_and_nulls () =
+  let body =
+    {|
+[
+  {
+    "path": "lib/foo.ml",
+    "start_line": 42,
+    "annotation_level": "failure",
+    "message": "expected int",
+    "end_line": 42,
+    "raw_details": "extra detail"
+  },
+  {
+    "path": null,
+    "start_line": null,
+    "annotation_level": "warning",
+    "message": "ignored shape is still mapped",
+    "unexpected": {"nested": true}
+  }
+]
+|}
+  in
+  assert_ok_annotations body ~f:(function
+    | [ first; second ] ->
+        assert (
+          Option.equal String.equal first.Ci_log_digest.path (Some "lib/foo.ml"));
+        assert (Option.equal Int.equal first.Ci_log_digest.line (Some 42));
+        assert (String.equal first.Ci_log_digest.level "failure");
+        assert (String.equal first.Ci_log_digest.message "expected int");
+        assert (Option.is_none second.Ci_log_digest.path);
+        assert (Option.is_none second.Ci_log_digest.line);
+        assert (String.equal second.Ci_log_digest.level "warning");
+        assert (
+          String.equal second.Ci_log_digest.message
+            "ignored shape is still mapped")
+    | annotations ->
+        failwith
+          (Printf.sprintf "unexpected annotation count: %d"
+             (List.length annotations)))
+
+let test_empty_array () =
+  assert_ok_annotations "[]" ~f:(function
+    | [] -> ()
+    | _ -> failwith "expected empty annotation list")
+
+let test_malformed_json () =
+  match Onton.Github.parse_check_annotations_response "{not json" with
+  | Error (Onton.Github.Json_parse_error _) -> ()
+  | Ok _ -> failwith "expected Json_parse_error"
+  | Error
+      (( Onton.Github.Http_error _ | Onton.Github.Graphql_error _
+       | Onton.Github.Timeout _ | Onton.Github.Transport_error _ ) as err) ->
+      failwith
+        (Printf.sprintf "expected Json_parse_error, got %s"
+           (Onton.Github.show_error err))
+
+let () =
+  test_field_mapping_and_nulls ();
+  test_empty_array ();
+  test_malformed_json ();
+  Stdlib.print_endline "test_github_check_details: OK"


### PR DESCRIPTION
## Patch 3: Forge capability: check_failure_details (annotations + job log)

- Add to module type S in BOTH lib/forge.mli and lib/forge.ml (the sig is duplicated verbatim): val check_failure_details : check:Types.Ci_check.t -> (Ci_log_digest.source, error) Result.t, documented as best-effort — Ok with partial data on any single-endpoint failure; Error only when every attempted endpoint failed hard.
- parse_check_annotations_response : string -> (Ci_log_digest.annotation list, error) Result.t — pure ppx_yojson_conv parser mapping REST fields {path, start_line, annotation_level, message} to Ci_log_digest.annotation {path; line; level; message}, tolerating extra fields ([@yojson.allow_extra_fields]) and null path/line; expose in github.mli mirroring parse_actions_jobs_response (lib/github.mli:114).
- Annotations fetch: request ~meth:`GET ~path:(sprintf "/repos/%s/%s/check-runs/%d/annotations" owner repo id) ~query:[("per_page", ["100"])] — one page only (>100 annotations adds nothing given digest caps); Http_error {status=404} → Ok [].
- Log fetch: GET (sprintf "/repos/%s/%s/actions/jobs/%d/logs" owner repo id) via a new internal helper that does NOT treat 302 as failure: read the Location header from the redirect response, then issue a plain GET to that URL WITHOUT the Authorization header (the signed blob URL must not receive the PAT), with max response size 10_000_000 bytes and a 60.0s timeout (the shared request helper's 1MB max_response_size and 30s default are insufficient — see CR-github-rest). 404 (non-Actions check run, expired log), oversize, or redirect-target failure → Ok None for the log.
- check_failure_details ~check: when check.Types.Ci_check.id = None, return Ok { annotations = []; log = None } without any network call. Otherwise fetch annotations then log; assemble Ci_log_digest.source; return Error only when both fetches failed with non-404 errors (propagate the log fetch's error).
- Wire the new function into the module returned by make (lib/github.ml:1856), closing over ~net ~clock and the client record like the existing operations.
- Tests in test/test_github_check_details.ml: annotation field mapping including null path/line, extra-field tolerance, malformed JSON → Json_parse_error, empty array → Ok [].

## Changes
- Add to module type S in BOTH lib/forge.mli and lib/forge.ml (the sig is duplicated verbatim): val check_failure_details : check:Types.Ci_check.t -> (Ci_log_digest.source, error) Result.t, documented as best-effort — Ok with partial data on any single-endpoint failure; Error only when every attempted endpoint failed hard.
- parse_check_annotations_response : string -> (Ci_log_digest.annotation list, error) Result.t — pure ppx_yojson_conv parser mapping REST fields {path, start_line, annotation_level, message} to Ci_log_digest.annotation {path; line; level; message}, tolerating extra fields ([@yojson.allow_extra_fields]) and null path/line; expose in github.mli mirroring parse_actions_jobs_response (lib/github.mli:114).
- Annotations fetch: request ~meth:`GET ~path:(sprintf "/repos/%s/%s/check-runs/%d/annotations" owner repo id) ~query:[("per_page", ["100"])] — one page only (>100 annotations adds nothing given digest caps); Http_error {status=404} → Ok [].
- Log fetch: GET (sprintf "/repos/%s/%s/actions/jobs/%d/logs" owner repo id) via a new internal helper that does NOT treat 302 as failure: read the Location header from the redirect response, then issue a plain GET to that URL WITHOUT the Authorization header (the signed blob URL must not receive the PAT), with max response size 10_000_000 bytes and a 60.0s timeout (the shared request helper's 1MB max_response_size and 30s default are insufficient — see CR-github-rest). 404 (non-Actions check run, expired log), oversize, or redirect-target failure → Ok None for the log.
- check_failure_details ~check: when check.Types.Ci_check.id = None, return Ok { annotations = []; log = None } without any network call. Otherwise fetch annotations then log; assemble Ci_log_digest.source; return Error only when both fetches failed with non-404 errors (propagate the log fetch's error).
- Wire the new function into the module returned by make (lib/github.ml:1856), closing over ~net ~clock and the client record like the existing operations.
- Tests in test/test_github_check_details.ml: annotation field mapping including null path/line, extra-field tolerance, malformed JSON → Json_parse_error, empty array → Ok [].

## Files to Modify
- lib/forge.mli (modify): Add check_failure_details to module type S with a doc comment in the merge_queue_removal_checks style.
- lib/forge.ml (modify): Mirror the identical val in the duplicated module type S.
- lib/github.ml (modify): Implement parse_check_annotations_response (pure), a redirect-following log fetch, check_failure_details, and wire it into the module returned by make.
- lib/github.mli (modify): Expose parse_check_annotations_response for regression tests, alongside parse_actions_jobs_response.
- test/test_github_check_details.ml (create): Regression tests for the pure annotations parser (field mapping, level filtering, malformed input).
- test/dune (modify): Add the test_github_check_details stanza (libraries onton onton_core base yojson).

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[documentation] GitHub REST: List check run annotations** — https://docs.github.com/en/rest/checks/runs#list-check-run-annotations — Defines the annotation object shape (path, start_line, annotation_level, message) that parse_check_annotations_response maps to Ci_log_digest.annotation, and the per_page pagination this patch deliberately limits to one page.
- **[documentation] GitHub REST: Download job logs for a workflow run** — https://docs.github.com/en/rest/actions/workflow-jobs#download-job-logs-for-a-workflow-run — Documents the 302-redirect contract (Location header carries a short-lived signed URL) the new redirect-following helper implements, and that the endpoint is keyed by job id — which equals the check-run databaseId for Actions-backed check runs.

## Gameplan Specification

```
module FAILING_CI_DETAILS.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> After this gameplan, a CI failure delivery records each failing
> check's diagnostics on disk (check.json, summary.md, log.txt under
> artifacts/<patch_id>/ci/<key>/) and the agent prompt cites those
> paths with a diagnostic teaser, ranked by signal — replacing
> URL-only delivery and improvised gh calls. All extraction logic is
> pure and property-tested; every failure mode degrades per check to
> the previous metadata-only rendering.

Check.
Source.
Enrichment.
Log.
Delivery.

has-run-id? c: Check => Bool.
check-key-collision-same-run? c1: Check, c2: Check => Bool.

strip-log l: Log => Log.
digest s: Source => Enrichment.
summary-bytes e: Enrichment => Nat0.
summary-cap => Nat0.

hits-network? c: Check => Bool.
sends-token-to-redirect-host? c: Check => Bool.

delivered? d: Delivery, c: Check => Bool.
fetch-succeeded? d: Delivery, c: Check => Bool.
artifact-published? d: Delivery, c: Check => Bool.
prompt-cites? d: Delivery, c: Check => Bool.
metadata-only? d: Delivery, c: Check => Bool.
delivery-blocked-by-details? d: Delivery => Bool.
fetch-count d: Delivery => Nat0.
fetch-cap => Nat0.
instructs-no-refetch? d: Delivery => Bool.
---
> Digest output is bounded and stripping is idempotent.
all s: Source | summary-bytes (digest s) <= summary-cap.
all l: Log | strip-log (strip-log l) = strip-log l.

> Id-less checks never hit the network; no fetch ever sends the API
> token to the redirect host.
all c: Check, ~ (has-run-id? c) | ~ (hits-network? c).
all c: Check | ~ (sends-token-to-redirect-host? c).

> Delivered checks with fetched, published details are cited by the
> prompt; failed fetches render metadata-only; detail retrieval never
> blocks a delivery; fetches are capped.
all d: Delivery, c: Check, delivered? d c and fetch-succeeded? d c and artifact-published? d c | prompt-cites? d c.
all d: Delivery, c: Check, delivered? d c and ~ (fetch-succeeded? d c) | metadata-only? d c.
all d: Delivery | ~ (delivery-blocked-by-details? d).
all d: Delivery | fetch-count d <= fetch-cap.

> Every delivery with details instructs the agent not to re-fetch
> checks with gh.
all d: Delivery | instructs-no-refetch? d.
```

## Patch Specification

```
module FAILING_CI_DETAILS_PATCH_3.

> Forge capability: best-effort retrieval of failing-check details
> (annotations + job log) from GitHub, with credential hygiene on the
> signed log-download redirect.

Check.
Fetch.

has-run-id? c: Check => Bool.
fetch-of c: Check => Fetch.

hits-network? c: Check => Bool.
yields-empty-source? c: Check => Bool.
returns-error? c: Check => Bool.
annotations-failed-hard? f: Fetch => Bool.
log-failed-hard? f: Fetch => Bool.
sends-token-to-redirect-host? f: Fetch => Bool.
---
> Checks without a stable run id (StatusContext, synthetic merge-queue
> markers) never hit the network and yield the empty source.
all c: Check, ~ (has-run-id? c) | ~ (hits-network? c) and yields-empty-source? c and ~ (returns-error? c).

> An error is returned only when both endpoint fetches failed hard
> (404s and oversize responses are degradation, not failure).
all c: Check, returns-error? c | annotations-failed-hard? (fetch-of c) and log-failed-hard? (fetch-of c).

> The signed log-download redirect is never sent the API token.
all f: Fetch | ~ (sends-token-to-redirect-host? f).
```


## Implementation Notes

- `check_failure_details` treats annotation parse failures as hard annotation failures, but softens annotation transport/buffer failures to `Ok []` so an oversized annotation payload degrades instead of blocking details delivery. The only propagated error is still the log-side error when both annotation and log attempts failed hard.
- The signed log redirect helper intentionally uses an unauthenticated `GET` path instead of the shared GitHub `request` helper. It reuses the parent log-fetch client/switch, sends only `Accept` and `User-Agent`, applies the 10 MB cap, and degrades any redirect-target failure to `Ok None`; the parent log fetch supplies the 60s timeout for the full redirect flow.
- The initial `/actions/jobs/:id/logs` response now checks the status before reading a body. For the expected 302 path it drains the redirect body, reads `Location`, then follows the signed URL; direct 2xx log bodies use the 10 MB cap, while non-2xx error bodies use the normal 1 MB API cap.
- `parse_check_annotations_response` maps missing `annotation_level`/`message` to empty strings rather than rejecting the annotation. This keeps the parser tolerant like the surrounding REST decoders; the digest layer can still decide which levels are meaningful.
- No network tests were added. Coverage for this patch is focused on the pure parser, while credential hygiene is enforced structurally by the separate unauthenticated redirect helper.

Spec/Evidence Mapping:
- Id-less checks never hit the network: `Github.check_failure_details` returns `Ok { annotations = []; log = None }` before any fetch when `Ci_check.id = None`; verified by `dune build`.
- Error only when both endpoints fail hard: `check_failure_details` combines annotation/log results so any single success or degradation returns `Ok`; annotation 404 and transport/buffer failures are soft degradations; verified by `dune build`.
- No token on redirect host: `fetch_signed_job_log` does not include an `Authorization` header and is only called after reading the API response `Location`; verified by code inspection plus `dune build`.
- Annotation parser behavior: `test/test_github_check_details.ml` covers field mapping, null path/line, extra-field tolerance, malformed JSON, and empty arrays; verified with `dune exec test/test_github_check_details.exe` and `dune runtest`.