### PR TITLE
Supervisor-owned review-comment resolution via per-file artifacts

### DIFF
--- a/docs/design/patch-agent-prompting.md
+++ b/docs/design/patch-agent-prompting.md
@@ -185,20 +185,28 @@ Strong points:
 - The `[outdated]`/`[at=…]` SHA-anchoring is the gold-standard pattern
   for resilience against later commits — keeps the worker from
   re-doing fixes that already landed.
-- Per-comment IDs and thread IDs let the worker reply via structured
-  GraphQL, not free-form prose.
-- The reply-and-resolve workflow is mechanically specified.
+- Reply/resolve is supervisor-owned, following the pr-body artifact
+  model: the worker writes one response file per comment
+  (`comment_responses/<comment_id>.md`, response text only) and is
+  never asked to reply or resolve itself (gh stays available for its
+  own investigation). After the post-session push succeeds, the
+  supervisor posts each response as a thread reply and resolves that
+  thread (`Comment_responder.respond_after_session`), so a "fixed in
+  <sha>" reply can never precede the fix reaching the remote, and a
+  worker can no longer resolve a thread without responding.
+- Comments without a response file stay unresolved and re-deliver on
+  the next poll — convergence is gated by the orchestrator, not by
+  trusting the worker to have run CLI commands.
 
 Gaps:
 - The prompt does not constrain the worker against re-implementing
   previously-resolved threads or reverting earlier fixes. A short
   "Do not modify code outside the scope of these comments" line would
   help.
-- No mechanism to surface a comment the worker actively disagrees
-  with. Currently the prompt says "implement OR explain why current
-  approach is correct" — but the explanation goes into the GitHub
-  thread, where the orchestrator can't act on it. Consider also
-  writing a structured disagreement record to an artifact file.
+- Disagreement ("the current approach is correct") lands in the
+  response file and thus on the GitHub thread, but the orchestrator
+  does not act on its content — a structured disagreement field could
+  let it distinguish "fixed" from "wontfix" replies.
 
 ### `render_ci_failure_prompt` and `render_ci_failure_unknown_prompt`
 

--- a/lib/activity_log_sink.ml
+++ b/lib/activity_log_sink.ml
@@ -78,6 +78,10 @@ let needs_intervention fields =
       (Option.value
          (int_member fields "pr_body_artifact_miss_count")
          ~default:0)
+    ~review_unresolved_cycle_count:
+      (Option.value
+         (int_member fields "review_unresolved_cycle_count")
+         ~default:0)
 
 let display_status_of_agent_json ~main_branch json =
   let fields = assoc_fields json in

--- a/lib/comment_responder.ml
+++ b/lib/comment_responder.ml
@@ -96,6 +96,10 @@ let respond_after_session ~reply ~resolve ~log ~viewer_login ~artifact_dir
               (List.map
                  (fun id -> Int.to_string (Types.Comment_id.to_int id))
                  ids))));
+  (* Plain unanswered comments deliberately count as non-converged from the
+     first Review session. A missing response file means the delivered thread
+     remains unresolved and should re-deliver; repeated cycles with any such
+     gaps are capped by the caller's review-unresolved counter. *)
   List.iter
     (fun id ->
       let raw_id = Types.Comment_id.to_int id in

--- a/lib/comment_responder.ml
+++ b/lib/comment_responder.ml
@@ -1,0 +1,180 @@
+(* @archlint.module shell
+   @archlint.domain comment-responses *)
+
+let read_file path =
+  try
+    let ic = Stdlib.In_channel.open_text path in
+    Ok
+      (Fun.protect
+         ~finally:(fun () -> Stdlib.In_channel.close ic)
+         (fun () -> Stdlib.In_channel.input_all ic))
+  with Sys_error msg -> Error msg
+
+(* Sorted for determinism: [Comment_responses.plan] is last-entry-wins when
+   duplicate stems map to one comment id ("12.md" and "12.txt"), so a stable
+   listing order makes the winning file deterministic. *)
+let list_response_files artifact_dir =
+  match Stdlib.Sys.readdir artifact_dir with
+  | exception Sys_error _ -> []
+  | names ->
+      let names = Array.to_list names in
+      List.sort String.compare names
+
+let respond_after_session ~reply ~resolve ~log ~viewer_login ~artifact_dir
+    ~delivered () =
+  (* Count of delivered comments fully handled this cycle: reply posted AND
+     thread resolved. Everything short of that leaves the thread unresolved,
+     so the poller re-delivers it — the caller turns a non-converged cycle
+     into [Orchestrator.Respond_review_unresolved] so the retry loop is
+     bounded. *)
+  let converged = ref 0 in
+  let entries =
+    List.filter_map
+      (fun name ->
+        let path = Stdlib.Filename.concat artifact_dir name in
+        match read_file path with
+        | Error msg ->
+            log
+              (Printf.sprintf
+                 "comment-responses: could not read %s (%s) — skipping" path msg);
+            None
+        | Ok contents -> (
+            match
+              Onton_core.Comment_responses.entry_of_file ~filename:name
+                ~contents
+            with
+            | Some _ as e -> e
+            | None ->
+                log
+                  (Printf.sprintf
+                     "comment-responses: ignoring %s — filename is not a \
+                      comment id or the file is blank"
+                     path);
+                None))
+      (list_response_files artifact_dir)
+  in
+  (match Onton_core.Comment_responses.unmatched_entries ~delivered ~entries with
+  | [] -> ()
+  | stray ->
+      log
+        (Printf.sprintf
+           "comment-responses: response file(s) for unknown comment id(s) %s — \
+            ignoring"
+           (String.concat ", "
+              (List.map
+                 (fun (e : Onton_core.Comment_responses.entry) ->
+                   Int.to_string e.comment_id)
+                 stray))));
+  let outcome = Onton_core.Comment_responses.plan ~delivered ~entries in
+  (* Unanswered comments split by thread state. A resolve-retry thread (its
+     last word is onton's own posted reply — the previous cycle's reply
+     landed but the resolve didn't) needs no fresh response file: retry the
+     resolve directly instead of posting a duplicate reply. Everything else
+     genuinely lacks a response and re-delivers on the next poll. *)
+  let retry_unanswered, plain_unanswered =
+    List.partition
+      (fun id ->
+        match
+          List.find_opt
+            (fun (c : Types.Comment.t) ->
+              Types.Comment_id.equal c.Types.Comment.id id)
+            delivered
+        with
+        | Some c ->
+            Onton_core.Comment_responses.is_resolve_retry ~viewer_login c
+        | None -> false)
+      outcome.Onton_core.Comment_responses.unanswered
+  in
+  (match plain_unanswered with
+  | [] -> ()
+  | ids ->
+      log
+        (Printf.sprintf
+           "comment-responses: no response written for comment(s) %s — leaving \
+            unresolved; they will re-deliver on the next poll"
+           (String.concat ", "
+              (List.map
+                 (fun id -> Int.to_string (Types.Comment_id.to_int id))
+                 ids))));
+  List.iter
+    (fun id ->
+      let raw_id = Types.Comment_id.to_int id in
+      let thread_id =
+        List.find_opt
+          (fun (c : Types.Comment.t) ->
+            Types.Comment_id.equal c.Types.Comment.id id)
+          delivered
+        |> Option.map (fun (c : Types.Comment.t) -> c.Types.Comment.thread_id)
+        |> Option.join
+      in
+      match thread_id with
+      | None ->
+          log
+            (Printf.sprintf
+               "comment-responses: comment %d has a posted reply but carries \
+                no thread id — cannot resolve"
+               raw_id)
+      | Some thread_id -> (
+          match resolve ~thread_id with
+          | Ok () ->
+              incr converged;
+              log
+                (Printf.sprintf
+                   "comment-responses: comment %d already carried onton's \
+                    reply — resolve retried without a duplicate reply"
+                   raw_id)
+          | Error msg ->
+              log
+                (Printf.sprintf
+                   "comment-responses: resolve retry for comment %d (thread \
+                    %s) failed — %s"
+                   raw_id thread_id msg)))
+    retry_unanswered;
+  List.iter
+    (fun (a : Onton_core.Comment_responses.action) ->
+      let raw_id = Types.Comment_id.to_int a.comment_id in
+      (* Synthetic ids (negative, issued when GitHub returned no databaseId)
+         are not forge-addressable — the REST reply endpoint would 404. *)
+      if raw_id <= 0 then
+        log
+          (Printf.sprintf
+             "comment-responses: comment %d has a synthetic id — cannot reply; \
+              leaving unresolved"
+             raw_id)
+      else
+        match reply ~comment_id:a.comment_id ~body:a.response with
+        | Error msg ->
+            log
+              (Printf.sprintf
+                 "comment-responses: reply to comment %d failed — %s; leaving \
+                  thread unresolved"
+                 raw_id msg)
+        | Ok () -> (
+            match a.thread_id with
+            | None ->
+                log
+                  (Printf.sprintf
+                     "comment-responses: replied to comment %d but it carries \
+                      no thread id — cannot resolve"
+                     raw_id)
+            | Some thread_id -> (
+                match resolve ~thread_id with
+                | Ok () ->
+                    incr converged;
+                    log
+                      (Printf.sprintf
+                         "comment-responses: replied to and resolved comment %d"
+                         raw_id)
+                | Error msg ->
+                    log
+                      (Printf.sprintf
+                         "comment-responses: replied to comment %d but \
+                          resolving thread %s failed — %s"
+                         raw_id thread_id msg))))
+    outcome.Onton_core.Comment_responses.actions;
+  let distinct_delivered =
+    List.length outcome.Onton_core.Comment_responses.actions
+    + List.length outcome.Onton_core.Comment_responses.unanswered
+  in
+  let unresolved = distinct_delivered - !converged in
+  if unresolved = 0 then `Converged else `Unresolved unresolved

--- a/lib/comment_responder.mli
+++ b/lib/comment_responder.mli
@@ -28,9 +28,9 @@ val respond_after_session :
 (** Decode every file in [artifact_dir] ([<comment_id>.md], response text only;
     see {!Project_store.comment_responses_dir}), join against [delivered], and
     for each match call [reply] then [resolve] (skipped when the comment has no
-    thread id). Unrecognized filenames, blank files, response files for
-    undelivered ids, synthetic (negative) comment ids, and a missing directory
-    are all logged and skipped.
+    thread id). Unrecognized filenames, synthetic/non-positive ids, blank files,
+    response files for undelivered ids, and a missing directory are all logged
+    and skipped.
 
     A delivered comment whose thread already ends with onton's own reply
     ({!Onton_core.Comment_responses.is_resolve_retry} against [viewer_login])

--- a/lib/comment_responder.mli
+++ b/lib/comment_responder.mli
@@ -1,0 +1,46 @@
+(* @archlint.module interface
+   @archlint.domain comment-responses *)
+
+(** Post-Review-session comment resolution: read the agent's per-comment
+    response files and deterministically reply to and then resolve each
+    delivered comment that has one.
+
+    Runs only after the supervisor's post-session push succeeded — a response
+    claiming "fixed in <sha>" must not land on a thread before the fix is on the
+    remote. Comments without a response file are left unresolved; the poller
+    re-detects them and re-delivers on the next Review_comments session.
+
+    Failures are logged but never raise: a flaky forge call must not block the
+    rest of the session pipeline. A failed reply skips the resolve for that
+    comment (never resolve a thread that got no response); a failed resolve
+    after a successful reply is logged and left for the next cycle, where the
+    agent sees the still-unresolved comment along with its posted reply. *)
+
+val respond_after_session :
+  reply:(comment_id:Types.Comment_id.t -> body:string -> (unit, string) result) ->
+  resolve:(thread_id:string -> (unit, string) result) ->
+  log:(string -> unit) ->
+  viewer_login:string option ->
+  artifact_dir:string ->
+  delivered:Types.Comment.t list ->
+  unit ->
+  [ `Converged | `Unresolved of int ]
+(** Decode every file in [artifact_dir] ([<comment_id>.md], response text only;
+    see {!Project_store.comment_responses_dir}), join against [delivered], and
+    for each match call [reply] then [resolve] (skipped when the comment has no
+    thread id). Unrecognized filenames, blank files, response files for
+    undelivered ids, synthetic (negative) comment ids, and a missing directory
+    are all logged and skipped.
+
+    A delivered comment whose thread already ends with onton's own reply
+    ({!Onton_core.Comment_responses.is_resolve_retry} against [viewer_login])
+    needs no response file: its resolve is retried directly, never posting a
+    duplicate reply. [viewer_login = None] disables that detection — every
+    comment is treated as needing a reply.
+
+    Returns [`Converged] when every distinct delivered comment ended this cycle
+    resolved (reply-then-resolve, or a successful resolve retry), else
+    [`Unresolved n] with the count left unresolved (no response file, failed
+    reply/resolve, unaddressable). The caller maps [`Unresolved] to
+    [Orchestrator.Respond_review_unresolved] so the re-delivery loop is bounded
+    by [review_unresolved_cycle_count]. *)

--- a/lib/findings_resolver.ml
+++ b/lib/findings_resolver.ml
@@ -1,16 +1,14 @@
 (* @archlint.module shell
    @archlint.domain review-service *)
 
-let read_artifact path =
-  if not (Stdlib.Sys.file_exists path) then Ok ""
-  else
-    try
-      let ic = Stdlib.In_channel.open_text path in
-      Ok
-        (Fun.protect
-           ~finally:(fun () -> Stdlib.In_channel.close ic)
-           (fun () -> Stdlib.In_channel.input_all ic))
-    with Sys_error msg -> Error msg
+let read_file path =
+  try
+    let ic = Stdlib.In_channel.open_text path in
+    Ok
+      (Fun.protect
+         ~finally:(fun () -> Stdlib.In_channel.close ic)
+         (fun () -> Stdlib.In_channel.input_all ic))
+  with Sys_error msg -> Error msg
 
 let find_review_client review_clients ~backend_name =
   List.find_opt
@@ -19,99 +17,155 @@ let find_review_client review_clients ~backend_name =
       String.equal R.name backend_name)
     review_clients
 
-let resolve_after_session ~review_clients ~log ~findings_registry ~artifact_path
+(* Per-finding verdict derived from the wontfix directory. [Wontfix] carries
+   the file body; [Untrusted] means a file exists for the finding but its
+   content cannot be trusted (unreadable or blank) — fail closed for that
+   finding rather than guess between addressed and wontfix. *)
+type wontfix_verdict = Wontfix of string | Untrusted of string
+
+let resolve_after_session ~review_clients ~log ~findings_registry ~artifact_dir
     ~delivered ?actor () =
-  (* Parse the wontfix artifact. Missing means "no wontfix entries"; read or
-     parse failures fail closed so we do not accidentally mark findings as
-     addressed when the agent's artifact cannot be trusted. *)
-  let wontfix_index : (string, string) Hashtbl.t = Hashtbl.create 8 in
-  let artifact_ok =
-    match read_artifact artifact_path with
-    | Error msg ->
-        log
-          (Printf.sprintf
-             "wontfix artifact at %s could not be read (%s) — skipping \
-              findings resolution"
-             artifact_path msg);
-        false
-    | Ok body -> (
-        match Onton_core.Review_service.parse_wontfix_artifact body with
-        | Ok entries ->
-            List.iter
-              (fun (e : Onton_core.Review_service.wontfix_entry) ->
-                Hashtbl.replace wontfix_index e.id e.reason)
-              entries;
-            true
-        | Error msg ->
-            log
-              (Printf.sprintf
-                 "wontfix artifact at %s could not be parsed (%s) — skipping \
-                  findings resolution"
-                 artifact_path msg);
-            false)
+  (* Index the wontfix directory by expected filename. A missing directory
+     means "no wontfix entries" (every delivered finding is addressed); a
+     directory that exists but cannot be listed fails closed for the whole
+     batch, mirroring the unreadable-artifact behavior this flow has always
+     had. *)
+  let filenames =
+    if not (Stdlib.Sys.file_exists artifact_dir) then Some []
+    else
+      match Stdlib.Sys.readdir artifact_dir with
+      | exception Sys_error msg ->
+          log
+            (Printf.sprintf
+               "wontfix directory at %s could not be listed (%s) — skipping \
+                findings resolution"
+               artifact_dir msg);
+          None
+      | names -> Some (List.sort String.compare (Array.to_list names))
   in
-  if not artifact_ok then (
-    let ids =
-      List.map (fun (f : Onton_core.Review_service.finding) -> f.id) delivered
-    in
-    (match ids with
-    | [] -> ()
-    | _ ->
-        log
-          (Printf.sprintf
-             "Skipped findings resolution for delivered findings; operator \
-              action required for: %s"
-             (String.concat ", " ids)));
-    List.iter
-      (fun (f : Onton_core.Review_service.finding) ->
-        Findings_registry.forget findings_registry ~key:f.id)
-      delivered)
-  else
-    List.iter
-      (fun (f : Onton_core.Review_service.finding) ->
-        match Findings_registry.find findings_registry ~key:f.id with
-        | None ->
-            log
-              (Printf.sprintf
-                 "Skipping resolve for finding %s — no backend registered (was \
-                  it not seen by the poller this session?)"
-                 f.id)
-        | Some entry -> (
-            let kind, reason =
-              match Hashtbl.find_opt wontfix_index f.id with
-              | Some r -> (Onton_core.Review_service.Resolve_wontfix, Some r)
-              | None -> (Onton_core.Review_service.Resolve_addressed, None)
-            in
-            let backend_name = entry.Findings_registry.backend_name in
-            match find_review_client review_clients ~backend_name with
-            | None ->
-                log
-                  (Printf.sprintf
-                     "Skipping resolve for finding %s — review backend %s is \
-                      no longer configured"
-                     f.id backend_name);
-                Findings_registry.forget findings_registry ~key:f.id
-            | Some
-                (module R : Review_service_client.S
-                  with type error = Review_service_client.error) -> (
-                match
-                  R.mark_resolved ~owner:entry.Findings_registry.owner
-                    ~repo:entry.Findings_registry.repo
-                    ~pr_number:entry.Findings_registry.pr_number
-                    ~finding_id:entry.Findings_registry.finding_id ~kind ?actor
-                    ?reason ()
-                with
-                | Ok response ->
-                    log
-                      (Printf.sprintf "Resolved finding %s as %s (server: %s)"
-                         f.id
-                         (Onton_core.Review_service.resolve_kind_to_string kind)
-                         (Onton_core.Review_service.outcome_kind_to_string
-                            response.Onton_core.Review_service.outcome.kind));
-                    Findings_registry.forget findings_registry ~key:f.id
-                | Error err ->
-                    log
-                      (Printf.sprintf "Failed to resolve finding %s — %s" f.id
-                         (R.show_error err));
-                    Findings_registry.forget findings_registry ~key:f.id)))
-      delivered
+  match filenames with
+  | None ->
+      let ids =
+        List.map (fun (f : Onton_core.Review_service.finding) -> f.id) delivered
+      in
+      (match ids with
+      | [] -> ()
+      | _ ->
+          log
+            (Printf.sprintf
+               "Skipped findings resolution for delivered findings; operator \
+                action required for: %s"
+               (String.concat ", " ids)));
+      List.iter
+        (fun (f : Onton_core.Review_service.finding) ->
+          Findings_registry.forget findings_registry ~key:f.id)
+        delivered
+  | Some filenames ->
+      let expected : (string, string) Hashtbl.t = Hashtbl.create 8 in
+      List.iter
+        (fun (f : Onton_core.Review_service.finding) ->
+          let filename =
+            Onton_core.Review_service.wontfix_filename_of_id f.id
+          in
+          (* Distinct composite ids can in principle slug to the same
+             filename; attribution would be a guess, so drop both from the
+             filename index — they fail closed below only if a file with that
+             name actually exists. *)
+          match Hashtbl.find_opt expected filename with
+          | Some prior when not (String.equal prior f.id) ->
+              log
+                (Printf.sprintf
+                   "wontfix filename collision between findings %s and %s — a \
+                    %s file will not be attributed"
+                   prior f.id filename);
+              Hashtbl.remove expected filename
+          | Some _ | None -> Hashtbl.replace expected filename f.id)
+        delivered;
+      let verdicts : (string, wontfix_verdict) Hashtbl.t = Hashtbl.create 8 in
+      List.iter
+        (fun filename ->
+          let path = Stdlib.Filename.concat artifact_dir filename in
+          match Hashtbl.find_opt expected filename with
+          | None ->
+              log
+                (Printf.sprintf
+                   "wontfix: ignoring %s — no delivered finding uses that \
+                    filename"
+                   path)
+          | Some finding_id -> (
+              match read_file path with
+              | Error msg ->
+                  Hashtbl.replace verdicts finding_id
+                    (Untrusted (Printf.sprintf "unreadable (%s)" msg))
+              | Ok contents ->
+                  let reason = String.trim contents in
+                  if String.length reason = 0 then
+                    Hashtbl.replace verdicts finding_id (Untrusted "blank file")
+                  else Hashtbl.replace verdicts finding_id (Wontfix reason)))
+        filenames;
+      List.iter
+        (fun (f : Onton_core.Review_service.finding) ->
+          match Hashtbl.find_opt verdicts f.id with
+          | Some (Untrusted why) ->
+              (* Neither addressed nor wontfix can be reported truthfully —
+                 skip the resolve, keep the operator informed, and forget the
+                 registry entry like every other terminal path. *)
+              log
+                (Printf.sprintf
+                   "Skipping resolve for finding %s — wontfix file is %s; \
+                    operator action required"
+                   f.id why);
+              Findings_registry.forget findings_registry ~key:f.id
+          | (Some (Wontfix _) | None) as verdict -> (
+              match Findings_registry.find findings_registry ~key:f.id with
+              | None ->
+                  log
+                    (Printf.sprintf
+                       "Skipping resolve for finding %s — no backend \
+                        registered (was it not seen by the poller this \
+                        session?)"
+                       f.id)
+              | Some entry -> (
+                  let kind, reason =
+                    match verdict with
+                    | Some (Wontfix r) ->
+                        (Onton_core.Review_service.Resolve_wontfix, Some r)
+                    | Some (Untrusted _) | None ->
+                        (Onton_core.Review_service.Resolve_addressed, None)
+                  in
+                  let backend_name = entry.Findings_registry.backend_name in
+                  match find_review_client review_clients ~backend_name with
+                  | None ->
+                      log
+                        (Printf.sprintf
+                           "Skipping resolve for finding %s — review backend \
+                            %s is no longer configured"
+                           f.id backend_name);
+                      Findings_registry.forget findings_registry ~key:f.id
+                  | Some
+                      (module R : Review_service_client.S
+                        with type error = Review_service_client.error) -> (
+                      match
+                        R.mark_resolved ~owner:entry.Findings_registry.owner
+                          ~repo:entry.Findings_registry.repo
+                          ~pr_number:entry.Findings_registry.pr_number
+                          ~finding_id:entry.Findings_registry.finding_id ~kind
+                          ?actor ?reason ()
+                      with
+                      | Ok response ->
+                          log
+                            (Printf.sprintf
+                               "Resolved finding %s as %s (server: %s)" f.id
+                               (Onton_core.Review_service.resolve_kind_to_string
+                                  kind)
+                               (Onton_core.Review_service.outcome_kind_to_string
+                                  response.Onton_core.Review_service.outcome
+                                    .kind));
+                          Findings_registry.forget findings_registry ~key:f.id
+                      | Error err ->
+                          log
+                            (Printf.sprintf "Failed to resolve finding %s — %s"
+                               f.id (R.show_error err));
+                          Findings_registry.forget findings_registry ~key:f.id))
+              ))
+        delivered

--- a/lib/findings_resolver.mli
+++ b/lib/findings_resolver.mli
@@ -1,12 +1,15 @@
 (* @archlint.module interface
-   @archlint.domain findings-resolver *)
+   @archlint.domain review-service *)
 
-(** Post-Findings-session resolution: read the agent's wontfix artifact and POST
-    [resolve] verbs back to the originating review backends.
+(** Post-Findings-session resolution: read the agent's per-finding wontfix files
+    and POST [resolve] verbs back to the originating review backends.
 
-    Default verb is [addressed] — every delivered finding that is not in the
-    wontfix artifact is reported as fixed. Findings listed in the artifact are
-    reported as [wontfix] with the supplied reason.
+    Default verb is [addressed] — every delivered finding without a wontfix file
+    is reported as fixed. A finding whose wontfix file exists with a nonblank
+    body is reported as [wontfix] with that body as the reason. A finding whose
+    file exists but is blank or unreadable fails closed: neither verb can be
+    reported truthfully, so its resolve is skipped and logged for operator
+    action.
 
     Failures are logged but never raise: a flaky review service must not block
     the rest of the session pipeline. *)
@@ -15,7 +18,7 @@ val resolve_after_session :
   review_clients:Review_service_client.client list ->
   log:(string -> unit) ->
   findings_registry:Findings_registry.t ->
-  artifact_path:string ->
+  artifact_dir:string ->
   delivered:Onton_core.Review_service.finding list ->
   ?actor:string ->
   unit ->
@@ -25,8 +28,12 @@ val resolve_after_session :
     logged and skipped — that means the poller never recorded them, so we don't
     know which backend to talk to.
 
-    [artifact_path] is the absolute path of [findings_wontfix.json]. If the file
-    does not exist, every delivered finding is treated as [addressed]. If the
-    file exists but cannot be read or parsed, resolution is skipped so findings
+    [artifact_dir] is the absolute [findings_wontfix/] directory
+    ({!Project_store.findings_wontfix_dir}); each file inside is named by
+    [Onton_core.Review_service.wontfix_filename_of_id] over a delivered
+    finding's composite id and holds the wontfix reason. Files matching no
+    delivered finding are logged and ignored. A missing directory means no
+    wontfix entries — every delivered finding is [addressed]. A directory that
+    exists but cannot be listed skips resolution for the whole batch so findings
     are not silently marked with the wrong outcome; delivered finding ids are
     logged for operator action and forgotten from the runtime registry. *)

--- a/lib/forge.ml
+++ b/lib/forge.ml
@@ -44,6 +44,15 @@ module type S = sig
   val update_pr_body :
     pr_number:Types.Pr_number.t -> body:string -> (unit, error) Result.t
 
+  val reply_to_review_comment :
+    pr_number:Types.Pr_number.t ->
+    comment_id:Types.Comment_id.t ->
+    body:string ->
+    (unit, error) Result.t
+
+  val resolve_review_thread : thread_id:string -> (unit, error) Result.t
+  val viewer_login : unit -> string option
+
   val create_pull_request :
     title:string ->
     head:Types.Branch.t ->

--- a/lib/forge.mli
+++ b/lib/forge.mli
@@ -44,6 +44,25 @@ module type S = sig
   val update_pr_body :
     pr_number:Types.Pr_number.t -> body:string -> (unit, error) Result.t
 
+  val reply_to_review_comment :
+    pr_number:Types.Pr_number.t ->
+    comment_id:Types.Comment_id.t ->
+    body:string ->
+    (unit, error) Result.t
+  (** Post [body] as a reply on the review-comment thread opened by
+      [comment_id]. The id must be a real forge-issued id — synthetic ids (see
+      {!Types.Comment_id.next_synthetic}) cannot be replied to. *)
+
+  val resolve_review_thread : thread_id:string -> (unit, error) Result.t
+  (** Mark the review thread [thread_id] resolved. [thread_id] is the forge's
+      thread node id as carried on {!Types.Comment.t}. *)
+
+  val viewer_login : unit -> string option
+  (** Login of the account the forge credentials belong to. Fetched lazily and
+      cached for the process lifetime; [None] when the fetch has failed so far —
+      callers fail open (treat every thread as needing a reply). Used to
+      recognize onton's own posted replies on review threads. *)
+
   val create_pull_request :
     title:string ->
     head:Types.Branch.t ->

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -189,14 +189,20 @@ let graphql_query =
           id
           isResolved
           isOutdated
-          # [comments(first: 1)] only returns the thread opener. If a caller
-          # ever needs per-reply SHAs, raise this limit and add pagination.
-          comments(first: 1) {
+          # The whole thread, oldest-first: the opener carries the comment's
+          # identity (databaseId, path, line, SHAs); later nodes are replies
+          # whose bodies get concatenated into the delivered comment so a
+          # re-delivered thread shows its conversation (reviewer follow-ups,
+          # onton's own earlier reply). Threads longer than 50 lose their
+          # newest replies — pathological, and identity must come from the
+          # opener so [last:] is not an option.
+          comments(first: 50) {
             nodes {
               databaseId
               body
               path
               line
+              author { login }
               commit { oid }
               originalCommit { oid }
             }
@@ -301,11 +307,15 @@ type commit_node = {
 type commits = { nodes : commit_node list [@yojson.default []] }
 [@@deriving of_yojson] [@@yojson.allow_extra_fields]
 
+type comment_author = { login : string option [@yojson.default None] }
+[@@deriving of_yojson] [@@yojson.allow_extra_fields]
+
 type comment_node = {
   database_id : int option; [@key "databaseId"] [@yojson.default None]
   body : string; [@yojson.default ""]
   path : string option; [@yojson.default None]
   line : int option; [@yojson.default None]
+  author : comment_author option; [@yojson.default None]
   commit : oid_obj option; [@yojson.default None]
   original_commit : oid_obj option;
       [@key "originalCommit"] [@yojson.default None]
@@ -562,7 +572,45 @@ let comment_of_node ~thread_id ~outdated (n : comment_node) : Types.Comment.t =
     commit_sha = Option.bind n.commit ~f:(fun o -> o.oid);
     original_commit_sha = Option.bind n.original_commit ~f:(fun o -> o.oid);
     outdated;
+    last_reply_author = None;
   }
+
+(* One [Comment.t] per thread. Identity (databaseId, path, line, SHAs) comes
+   from the opener — the REST reply endpoint requires the top-level comment
+   id, and the anchor fields describe the thread, not any one reply. Reply
+   bodies are concatenated with author attribution so a re-delivered thread
+   shows its conversation: reviewer follow-ups and onton's own earlier reply,
+   which is what tells the agent (and the supervisor's logs) that a previous
+   response already posted. [last_reply_author] carries the final reply's
+   login so the responder can detect resolve-retry threads (last word is the
+   viewer's own posted reply). *)
+let comment_of_thread ~thread_id ~outdated (nodes : comment_node list) :
+    Types.Comment.t option =
+  match nodes with
+  | [] -> None
+  | opener :: replies ->
+      let c = comment_of_node ~thread_id ~outdated opener in
+      let body =
+        match replies with
+        | [] -> c.Types.Comment.body
+        | _ ->
+            let rendered =
+              List.map replies ~f:(fun (r : comment_node) ->
+                  let who =
+                    match Option.bind r.author ~f:(fun a -> a.login) with
+                    | Some login -> "@" ^ login
+                    | None -> "(unknown)"
+                  in
+                  Printf.sprintf "%s replied:\n%s" who r.body)
+              |> String.concat ~sep:"\n\n"
+            in
+            c.Types.Comment.body ^ "\n\n" ^ rendered
+      in
+      let last_reply_author =
+        Option.bind (List.last replies) ~f:(fun (r : comment_node) ->
+            Option.bind r.author ~f:(fun a -> a.login))
+      in
+      Some { c with Types.Comment.body; last_reply_author }
 
 let pr_state_of_pull_request ~owner ~merge_queue_required (pr : pull_request) :
     Pr_state.t =
@@ -610,16 +658,15 @@ let pr_state_of_pull_request ~owner ~merge_queue_required (pr : pull_request) :
       ~github_merge_state_status:pr.merge_state_status
   in
   let comments =
-    List.concat_map pr.review_threads.nodes ~f:(fun thread ->
-        if thread.is_resolved then []
+    List.filter_map pr.review_threads.nodes ~f:(fun thread ->
+        if thread.is_resolved then None
         else
           (* [isOutdated] is the authoritative signal from GitHub: the thread's
              anchored lines were changed by a later commit. Do not infer it from
              [commit] vs [originalCommit] — GitHub advances [commit] to whatever
              commit still contains the line, flagging false positives. *)
-          List.map thread.comments.nodes
-            ~f:
-              (comment_of_node ~thread_id:thread.id ~outdated:thread.is_outdated))
+          comment_of_thread ~thread_id:thread.id ~outdated:thread.is_outdated
+            thread.comments.nodes)
   in
   let unresolved_comment_count =
     List.count pr.review_threads.nodes ~f:(fun thread -> not thread.is_resolved)
@@ -737,6 +784,41 @@ let parse_dequeue_response body =
   match Yojson.Safe.from_string body with
   | exception Yojson.Json_error msg -> Error (Json_parse_error msg)
   | json -> parse_dequeue_response_json json
+
+let parse_resolve_thread_response_json json =
+  match graphql_errors json with
+  | Some msgs -> Error (Graphql_error msgs)
+  | None -> (
+      match
+        Json.field "data" json
+        |> Option.bind ~f:(Json.field "resolveReviewThread")
+      with
+      | Some _ -> Ok ()
+      | None ->
+          Error
+            (Json_parse_error "resolveReviewThread response missing payload"))
+
+let parse_resolve_thread_response body =
+  match Yojson.Safe.from_string body with
+  | exception Yojson.Json_error msg -> Error (Json_parse_error msg)
+  | json -> parse_resolve_thread_response_json json
+
+let parse_viewer_login_response_json json =
+  match graphql_errors json with
+  | Some msgs -> Error (Graphql_error msgs)
+  | None -> (
+      match
+        Json.field "data" json
+        |> Option.bind ~f:(Json.field "viewer")
+        |> Option.bind ~f:(Json.string_field "login")
+      with
+      | Some login -> Ok login
+      | None -> Error (Json_parse_error "viewer response missing login"))
+
+let parse_viewer_login_response body =
+  match Yojson.Safe.from_string body with
+  | exception Yojson.Json_error msg -> Error (Json_parse_error msg)
+  | json -> parse_viewer_login_response_json json
 
 type enqueue_pr_info_pull_request = {
   enqueue_info_id : string option; [@key "id"] [@yojson.default None]
@@ -1359,6 +1441,18 @@ let update_pr_body ~net ~clock ?timeout t ~pr_number ~body =
   | Ok _ -> Ok ()
   | Error _ as e -> e
 
+let reply_to_review_comment ~net ~clock ?timeout t ~pr_number ~comment_id ~body
+    =
+  let path =
+    Printf.sprintf "/repos/%s/%s/pulls/%d/comments/%d/replies" t.owner t.repo
+      (Types.Pr_number.to_int pr_number)
+      (Types.Comment_id.to_int comment_id)
+  in
+  let req_body = `Assoc [ ("body", `String body) ] |> Yojson.Safe.to_string in
+  match request ~net ~clock ?timeout t ~meth:`POST ~path ~body:req_body () with
+  | Ok _ -> Ok ()
+  | Error _ as e -> e
+
 (** Create a draft pull request via REST API. Returns the new PR number. *)
 let create_pull_request ~net ~clock ?timeout t ~title ~head ~base ~body ~draft =
   let path = Printf.sprintf "/repos/%s/%s/pulls" t.owner t.repo in
@@ -1575,6 +1669,42 @@ let enqueue_pr ~net ~clock ?timeout t ~pr_number =
               Result.map (parse_enqueue_response resp) ~f:(fun entry ->
                   Enqueued entry)))
 
+let viewer_login_query = {|query { viewer { login } }|}
+
+let fetch_viewer_login ~net ~clock ?timeout t =
+  let req_body =
+    `Assoc [ ("query", `String viewer_login_query) ] |> Yojson.Safe.to_string
+  in
+  match
+    request ~net ~clock ?timeout t ~meth:`POST ~path:"/graphql" ~body:req_body
+      ()
+  with
+  | Ok resp -> parse_viewer_login_response resp
+  | Error _ as e -> e
+
+let resolve_review_thread_mutation =
+  {|mutation($id: ID!) {
+  resolveReviewThread(input: { threadId: $id }) {
+    thread { isResolved }
+  }
+}|}
+
+let resolve_review_thread ~net ~clock ?timeout t ~thread_id =
+  let req_body =
+    `Assoc
+      [
+        ("query", `String resolve_review_thread_mutation);
+        ("variables", `Assoc [ ("id", `String thread_id) ]);
+      ]
+    |> Yojson.Safe.to_string
+  in
+  match
+    request ~net ~clock ?timeout t ~meth:`POST ~path:"/graphql" ~body:req_body
+      ()
+  with
+  | Ok resp -> parse_resolve_thread_response resp
+  | Error _ as e -> e
+
 let dequeue_pr ~net ~clock ?timeout t ~entry_id =
   let req_body =
     `Assoc
@@ -1670,6 +1800,97 @@ let is_merge_queue_required_error = function
 
 (* ── Inline tests ── *)
 
+let thread_fixture_json comments =
+  Printf.sprintf
+    {|{
+      "data": {
+        "repository": {
+          "pullRequest": {
+            "id": "PR_node_1",
+            "state": "OPEN",
+            "mergeable": "MERGEABLE",
+            "isDraft": false,
+            "mergeStateStatus": "CLEAN",
+            "commits": { "nodes": [] },
+            "reviewThreads": { "nodes": [
+              {
+                "id": "PRRT_t1",
+                "isResolved": false,
+                "isOutdated": false,
+                "comments": { "nodes": %s }
+              }
+            ] },
+            "headRefName": "feature-branch",
+            "headRefOid": "abc123",
+            "mergeQueueEntry": null,
+            "mergeCommit": null,
+            "baseRefName": "main",
+            "headRepositoryOwner": { "login": "octo" }
+          }
+        }
+      }
+    }|}
+    comments
+
+let%test
+    "review thread with replies collapses to one comment, opener identity, \
+     concatenated bodies" =
+  let body =
+    thread_fixture_json
+      {|[
+        {"databaseId": 11, "body": "Please rename this.", "path": "lib/a.ml",
+         "line": 5, "author": {"login": "alice"},
+         "commit": {"oid": "aaa"}, "originalCommit": {"oid": "aaa"}},
+        {"databaseId": 12, "body": "Done in abc123.",
+         "author": {"login": "onton-bot"}},
+        {"databaseId": 13, "body": "Not quite — also fix the docs.",
+         "author": {"login": "alice"}}
+      ]|}
+  in
+  match parse_response_json ~owner:"octo" (Yojson.Safe.from_string body) with
+  | Error _ -> false
+  | Ok pr -> (
+      match pr.Pr_state.comments with
+      | [ c ] ->
+          Types.Comment_id.to_int c.Types.Comment.id = 11
+          && Option.equal String.equal c.Types.Comment.thread_id
+               (Some "PRRT_t1")
+          && Option.equal String.equal c.Types.Comment.path (Some "lib/a.ml")
+          && String.equal c.Types.Comment.body
+               "Please rename this.\n\n\
+                @onton-bot replied:\n\
+                Done in abc123.\n\n\
+                @alice replied:\n\
+                Not quite — also fix the docs."
+          && Option.equal String.equal c.Types.Comment.last_reply_author
+               (Some "alice")
+      | _ -> false)
+
+let%test "review thread with only an opener keeps its body verbatim" =
+  let body =
+    thread_fixture_json
+      {|[{"databaseId": 21, "body": "Single comment.",
+          "author": {"login": "alice"}}]|}
+  in
+  match parse_response_json ~owner:"octo" (Yojson.Safe.from_string body) with
+  | Error _ -> false
+  | Ok pr -> (
+      match pr.Pr_state.comments with
+      | [ c ] ->
+          String.equal c.Types.Comment.body "Single comment."
+          && Option.is_none c.Types.Comment.last_reply_author
+      | _ -> false)
+
+let%test "review thread with no comment nodes yields no comment" =
+  let body = thread_fixture_json "[]" in
+  match parse_response_json ~owner:"octo" (Yojson.Safe.from_string body) with
+  | Error _ -> false
+  | Ok pr ->
+      List.is_empty pr.Pr_state.comments
+      (* The thread still counts as unresolved even without parseable
+         comments — the count comes from the thread node, not the join. *)
+      && pr.Pr_state.unresolved_comment_count = 1
+
 let%test "parse_rest_pr_list open PR" =
   let body =
     {|[{"number":42,"state":"open","merged_at":null,"base":{"ref":"main"},"node_id":"PR_1"}]|}
@@ -1708,6 +1929,38 @@ let%test "parse_rest_pr_list mixed" =
 
 let%test "parse_rest_pr_list invalid json" =
   match parse_rest_pr_list "not json" with Error _ -> true | Ok _ -> false
+
+let%test "parse_resolve_thread_response: ok payload" =
+  match
+    parse_resolve_thread_response
+      {|{"data":{"resolveReviewThread":{"thread":{"isResolved":true}}}}|}
+  with
+  | Ok () -> true
+  | Error _ -> false
+
+let%test "parse_resolve_thread_response: graphql errors -> Error" =
+  match
+    parse_resolve_thread_response
+      {|{"data":null,"errors":[{"message":"Could not resolve to a node"}]}|}
+  with
+  | Error (Graphql_error msgs) ->
+      List.exists msgs ~f:(fun msg ->
+          String.is_substring msg ~substring:"Could not resolve")
+  | Error (Http_error _ | Json_parse_error _ | Timeout _ | Transport_error _)
+  | Ok () ->
+      false
+
+let%test "parse_resolve_thread_response: missing payload -> Error" =
+  match parse_resolve_thread_response {|{"data":{}}|} with
+  | Error (Json_parse_error _) -> true
+  | Error (Http_error _ | Graphql_error _ | Timeout _ | Transport_error _)
+  | Ok () ->
+      false
+
+let%test "parse_resolve_thread_response: invalid json -> Error" =
+  match parse_resolve_thread_response "not json" with
+  | Error _ -> true
+  | Ok _ -> false
 
 let%test "interpret_merge_response merged=true -> Merge_succeeded" =
   match
@@ -1864,6 +2117,20 @@ let make ~net ~clock ~token ~owner ~repo ~main_branch :
      onton cached "squash allowed" at startup and kept issuing squash after the
      repo disabled it). [None] means the config was unreadable this attempt. *)
   let merge_methods_cache = ref None in
+  (* Viewer login (the token's user), fetched lazily and cached forever — a
+     token's identity cannot change mid-run. [None] means every fetch so far
+     failed; callers fail open (treat every thread as needing a reply). *)
+  let viewer_login_cache = ref None in
+  let viewer_login_cached () =
+    match !viewer_login_cache with
+    | Some login -> Some login
+    | None -> (
+        match fetch_viewer_login ~net ~clock client with
+        | Ok login ->
+            viewer_login_cache := Some login;
+            Some login
+        | Error _ -> None)
+  in
   let fetch_merge_methods () =
     match get_repo_merge_methods ~net ~clock client with
     | Ok m ->
@@ -1957,6 +2224,14 @@ let make ~net ~clock ~token ~owner ~repo ~main_branch :
 
     let update_pr_body ~pr_number ~body =
       update_pr_body ~net ~clock client ~pr_number ~body
+
+    let reply_to_review_comment ~pr_number ~comment_id ~body =
+      reply_to_review_comment ~net ~clock client ~pr_number ~comment_id ~body
+
+    let resolve_review_thread ~thread_id =
+      resolve_review_thread ~net ~clock client ~thread_id
+
+    let viewer_login () = viewer_login_cached ()
 
     let create_pull_request ~title ~head ~base ~body ~draft =
       create_pull_request ~net ~clock client ~title ~head ~base ~body ~draft

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -1130,6 +1130,15 @@ type respond_outcome =
             increments [pr_body_artifact_miss_count] and lets the reconciler
             re-enqueue. At cap (>=2) the agent surfaces via
             [needs_intervention]. *)
+  | Respond_review_unresolved
+      (** Review_comments session finished cleanly (push shipped) but the
+          post-push responder could not reply-and-resolve every delivered
+          comment: missing response file, failed reply/resolve forge call, or an
+          unaddressable comment (synthetic id, no thread id). Increments
+          [review_unresolved_cycle_count] and lets the poller re-deliver the
+          still-unresolved threads. At cap (>=2) the agent surfaces via
+          [needs_intervention] — the loop's only terminator now that thread
+          resolution is supervisor-owned. *)
 [@@deriving show, eq, sexp_of]
 
 let apply_respond_outcome t patch_id kind outcome =
@@ -1142,6 +1151,10 @@ let apply_respond_outcome t patch_id kind outcome =
       let t = complete t patch_id in
       update_agent t patch_id
         ~f:Patch_agent.increment_pr_body_artifact_miss_count
+  | Respond_review_unresolved ->
+      let t = complete t patch_id in
+      update_agent t patch_id
+        ~f:Patch_agent.increment_review_unresolved_cycle_count
   | Respond_ok ->
       let t = complete t patch_id in
       (* Only count CI fix attempts that actually delivered a payload with
@@ -1156,6 +1169,12 @@ let apply_respond_outcome t patch_id kind outcome =
         if Operation_kind.equal kind Operation_kind.Merge_conflict then
           let t = clear_has_conflict t patch_id in
           reset_conflict_noop_count t patch_id
+        else t
+      in
+      let t =
+        if Operation_kind.equal kind Operation_kind.Review_comments then
+          update_agent t patch_id
+            ~f:Patch_agent.reset_review_unresolved_cycle_count
         else t
       in
       if Operation_kind.equal kind Operation_kind.Pr_body then

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -310,19 +310,25 @@ type respond_outcome =
   | Respond_stale
   | Respond_skip_empty
   | Respond_pr_body_miss
+  | Respond_review_unresolved
 [@@deriving show, eq, sexp_of]
 
 val apply_respond_outcome :
   t -> Patch_id.t -> Operation_kind.t -> respond_outcome -> t
 (** Apply the outcome of a Respond action fiber. [Respond_ok] -> complete +
     kind-specific transitions (Merge_conflict -> clear_has_conflict +
-    reset_conflict_noop_count; Pr_body -> set_pr_body_delivered +
+    reset_conflict_noop_count; Review_comments ->
+    reset_review_unresolved_cycle_count so the cap counts only consecutive
+    non-converged cycles; Pr_body -> set_pr_body_delivered +
     reset_pr_body_artifact_miss_count so the cap counts only consecutive
     misses). [Respond_failed] -> complete_failed (restores inflight human
     messages). [Respond_skip_empty] -> complete. [Respond_retry_push] ->
     complete. [Respond_stale] -> identity. [Respond_pr_body_miss] -> complete +
     increment_pr_body_artifact_miss_count (does NOT set_pr_body_delivered — the
-    reconciler re-enqueues Pr_body naturally). *)
+    reconciler re-enqueues Pr_body naturally). [Respond_review_unresolved] ->
+    complete + increment_review_unresolved_cycle_count — the still-unresolved
+    threads re-deliver via the next poll until the cap (>=2) surfaces the agent
+    through [needs_intervention]. *)
 
 type force_complete_reason = Cancelled | Unexpected_exception
 [@@deriving show, eq, sexp_of]

--- a/lib/persistence.ml
+++ b/lib/persistence.ml
@@ -206,6 +206,7 @@ let patch_agent_to_yojson (a : Patch_agent.t) =
       ("is_draft", `Bool a.is_draft);
       ("pr_body_delivered", `Bool a.pr_body_delivered);
       ("pr_body_artifact_miss_count", `Int a.pr_body_artifact_miss_count);
+      ("review_unresolved_cycle_count", `Int a.review_unresolved_cycle_count);
       ("start_attempts_without_pr", `Int a.start_attempts_without_pr);
       ("conflict_noop_count", `Int a.conflict_noop_count);
       ("no_commits_push_count", `Int a.no_commits_push_count);
@@ -392,6 +393,10 @@ let patch_agent_of_yojson ~gameplan json =
        ~pr_body_artifact_miss_count:
          (Option.value
             (int_member_opt "pr_body_artifact_miss_count" json)
+            ~default:0)
+       ~review_unresolved_cycle_count:
+         (Option.value
+            (int_member_opt "review_unresolved_cycle_count" json)
             ~default:0)
        ~start_attempts_without_pr:(int_member "start_attempts_without_pr" json)
        ~conflict_noop_count:

--- a/lib/project_store.ml
+++ b/lib/project_store.ml
@@ -64,14 +64,26 @@ let gameplan_artifact_path project_name =
 let pr_body_artifact_path ~project_name ~patch_id =
   Stdlib.Filename.concat (artifact_dir ~project_name ~patch_id) "pr-body.md"
 
-(** Absolute path the agent writes [findings_wontfix.json] to during a Findings
-    session. Lives alongside [pr-body.md] under [artifacts/<patch_id>/]. The
-    supervisor reads it after the session to decide which findings to POST as
-    ["wontfix"]; everything not listed is POSTed as ["addressed"]. *)
-let findings_wontfix_artifact_path ~project_name ~patch_id =
+(** Absolute directory the agent writes per-finding wontfix files to during a
+    Findings session ([<slugged_finding_id>.md], reason text only; see
+    [Review_service.wontfix_filename_of_id]). Lives alongside [pr-body.md] under
+    [artifacts/<patch_id>/]. The supervisor reads it after the session to decide
+    which findings to POST as ["wontfix"]; findings without a file are POSTed as
+    ["addressed"]. *)
+let findings_wontfix_dir ~project_name ~patch_id =
   Stdlib.Filename.concat
     (artifact_dir ~project_name ~patch_id)
-    "findings_wontfix.json"
+    "findings_wontfix"
+
+(** Absolute directory the agent writes per-comment response files to during a
+    Review_comments session ([<comment_id>.md], response text only). Lives
+    alongside [pr-body.md] under [artifacts/<patch_id>/]. After a successful
+    post-session push the supervisor reads the files and, for every delivered
+    comment with a response, replies to the thread and resolves it. *)
+let comment_responses_dir ~project_name ~patch_id =
+  Stdlib.Filename.concat
+    (artifact_dir ~project_name ~patch_id)
+    "comment_responses"
 
 let ensure_dir path =
   let rec mkdir_p dir =
@@ -80,6 +92,15 @@ let ensure_dir path =
       Stdlib.Sys.mkdir dir 0o755)
   in
   mkdir_p path
+
+let reset_artifact_dir path =
+  ensure_dir path;
+  match Stdlib.Sys.readdir path with
+  | exception Sys_error _ -> ()
+  | names ->
+      Array.iter names ~f:(fun name ->
+          try Unix.unlink (Stdlib.Filename.concat path name)
+          with Unix.Unix_error (Unix.ENOENT, _, _) -> ())
 
 type stored_config = {
   project_name : string;

--- a/lib/project_store.ml
+++ b/lib/project_store.ml
@@ -100,13 +100,13 @@ let reset_artifact_dir path =
   | names ->
       Array.iter names ~f:(fun name ->
           let entry_path = Stdlib.Filename.concat path name in
-          try
-            if not (Stdlib.Sys.is_directory entry_path) then
-              Unix.unlink entry_path
-          with
-          | Sys_error _ -> ()
-          | Unix.Unix_error (Unix.ENOENT, _, _) -> ()
-          | Unix.Unix_error (Unix.EISDIR, _, _) -> ())
+          let is_dir =
+            try Stdlib.Sys.is_directory entry_path with Sys_error _ -> true
+          in
+          if not is_dir then
+            try Unix.unlink entry_path with
+            | Unix.Unix_error (Unix.ENOENT, _, _) -> ()
+            | Unix.Unix_error (Unix.EISDIR, _, _) -> ())
 
 type stored_config = {
   project_name : string;

--- a/lib/project_store.ml
+++ b/lib/project_store.ml
@@ -99,8 +99,14 @@ let reset_artifact_dir path =
   | exception Sys_error _ -> ()
   | names ->
       Array.iter names ~f:(fun name ->
-          try Unix.unlink (Stdlib.Filename.concat path name)
-          with Unix.Unix_error (Unix.ENOENT, _, _) -> ())
+          let entry_path = Stdlib.Filename.concat path name in
+          try
+            if not (Stdlib.Sys.is_directory entry_path) then
+              Unix.unlink entry_path
+          with
+          | Sys_error _ -> ()
+          | Unix.Unix_error (Unix.ENOENT, _, _) -> ()
+          | Unix.Unix_error (Unix.EISDIR, _, _) -> ())
 
 type stored_config = {
   project_name : string;

--- a/lib/project_store.mli
+++ b/lib/project_store.mli
@@ -33,6 +33,12 @@ val config_path : string -> string
 val ensure_dir : string -> unit
 (** Create a directory and parents if needed. *)
 
+val reset_artifact_dir : string -> unit
+(** Create the directory if needed and delete every file directly inside it.
+    Used at session setup on per-item artifact directories
+    ({!comment_responses_dir}, {!findings_wontfix_dir}) so stale files from a
+    prior session can never be replayed as fresh agent output. *)
+
 type stored_config = {
   project_name : string;
   github_owner : string;
@@ -108,13 +114,25 @@ val pr_body_artifact_path :
     project's data directory at [artifacts/<patch_id>/pr-body.md] — outside the
     worktree so it can never be accidentally committed. *)
 
-val findings_wontfix_artifact_path :
+val findings_wontfix_dir :
   project_name:string -> patch_id:Types.Patch_id.t -> string
-(** Absolute path of the [findings_wontfix.json] artifact for a Findings
-    session. The agent writes a JSON list of [{id, reason}] for any finding it
-    has decided not to fix; the supervisor consumes it post-session and POSTs
-    the corresponding resolve verbs to the review backend. Findings not listed
-    here default to [addressed]. *)
+(** Absolute path of the [findings_wontfix/] artifact directory for a Findings
+    session. For any finding it has decided not to fix, the agent writes the
+    reason to the per-finding file named on the finding's prompt block
+    ([Onton_core.Review_service.wontfix_filename_of_id]); the supervisor
+    consumes the directory post-session and POSTs the corresponding resolve
+    verbs to the review backend. Findings without a file default to [addressed];
+    a present-but-blank or unreadable file fails closed — that finding's resolve
+    is skipped rather than guessed. *)
+
+val comment_responses_dir :
+  project_name:string -> patch_id:Types.Patch_id.t -> string
+(** Absolute path of the [comment_responses/] artifact directory for a
+    Review_comments session. The agent writes one [<comment_id>.md] file per
+    comment, containing just the response text; after a successful post-session
+    push the supervisor replies to and resolves every delivered comment with a
+    response file. Comments without one stay unresolved and re-deliver on the
+    next poll. *)
 
 val project_exists : string -> bool
 (** Whether a project data directory with config exists. *)

--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -858,7 +858,8 @@ Keep it concise — a few bullet points usually suffices. If you have nothing ma
 let short_sha s = if String.length s <= 7 then s else String.sub s ~pos:0 ~len:7
 
 let render_turn_layer_review ~(project_name : string) ?pr_number
-    ?current_head_sha (comments : Comment.t list) : string =
+    ?current_head_sha ?viewer_login ~(artifact_dir : string)
+    (comments : Comment.t list) : string =
   match comments with
   | [] -> "No review comments to address."
   | _ ->
@@ -902,8 +903,13 @@ let render_turn_layer_review ~(project_name : string) ?pr_number
               | None -> ""
             in
             let outdated = if is_outdated c then " [outdated]" else "" in
-            Printf.sprintf "- **Comment**%s%s%s%s%s: %s" location db_id
-              thread_ref anchor outdated c.Comment.body)
+            let retry =
+              if Comment_responses.is_resolve_retry ~viewer_login c then
+                " [response already posted]"
+              else ""
+            in
+            Printf.sprintf "- **Comment**%s%s%s%s%s%s: %s" location db_id
+              thread_ref anchor outdated retry c.Comment.body)
         |> String.concat ~sep:"\n\n"
       in
       (* Both [pr_ctx] and [sha_anchor] are splatted into the
@@ -944,8 +950,8 @@ let render_turn_layer_review ~(project_name : string) ?pr_number
               "\n\n\
                Review anchored at %s. Current branch HEAD is `%s`.\n\
                If a comment is marked `[outdated]` or refers to code that no \
-               longer exists at HEAD, reply acknowledging it's addressed in a \
-               later commit and skip — do not re-do the change."
+               longer exists at HEAD, write a response acknowledging it's \
+               addressed in a later commit and skip — do not re-do the change."
               anchored (short_sha head)
         | _ -> ""
       in
@@ -968,7 +974,19 @@ let render_turn_layer_review ~(project_name : string) ?pr_number
           ("reviewed_at_sha", reviewed_at_sha_var);
           ("current_head_sha", current_head_sha_var);
           ("sha_anchor", sha_anchor);
+          ("artifact_dir", artifact_dir);
         ]
+      in
+      let retry_note =
+        if
+          List.exists comments ~f:(fun c ->
+              Comment_responses.is_resolve_retry ~viewer_login c)
+        then
+          " Exception: comments marked [response already posted] already carry \
+           your reply as the thread's last message; the supervisor will retry \
+           resolving them — write a response file for one of those only if you \
+           have something new to add."
+        else ""
       in
       render_with_override ~project_name ~name:"turn_review" ~vars
         ~default:(fun () ->
@@ -977,31 +995,31 @@ let render_turn_layer_review ~(project_name : string) ?pr_number
              The following review comments need to be addressed on your PR:\n\n\
              %s\n\n\
              For each comment:\n\
-             1. Implement the requested change, OR explain why the current \
-             approach is correct.\n\
-             2. Reply to the comment thread:\n\
-            \   `gh api \
-             repos/{owner}/{repo}/pulls/%s/comments/{comment_id}/replies -f \
-             body=\"your response\"`\n\
-            \   (`{owner}/{repo}` is resolved automatically by `gh` when run \
-             inside the repo)\n\
-             3. Resolve the thread using the thread_id:\n\
-            \   `gh api graphql -f query='mutation { \
-             resolveReviewThread(input: {threadId: \"{thread_id}\"}) { thread \
-             { isResolved } } }'`\n\n\
+             1. Implement the requested change, OR decide the current approach \
+             is correct.\n\
+             2. Write your response to `%s/<comment_id>.md` (the \
+             [comment_id=...] shown above), containing just the response text.\n\
+            \   Use the Write tool with that absolute path — the directory is \
+             outside the worktree on purpose; do not commit it.\n\n\
+             Write a response file for EVERY comment listed above.%s After \
+             this session the supervisor pushes your commits, then posts each \
+             response as a reply on its comment thread and resolves that \
+             thread. A comment without a response file stays unresolved and \
+             will be re-delivered to you.\n\n\
              After addressing all comments, commit your changes. The \
              supervisor will push them for you — do not run `git push`."
-            pr_ctx sha_anchor formatted pr_num_str)
+            pr_ctx sha_anchor formatted artifact_dir retry_note)
 
 let render_review_prompt ~(project_name : string) ?agents_md ?pr_number
-    ?current_head_sha ?patch ?gameplan ?base_branch (comments : Comment.t list)
-    : string =
+    ?current_head_sha ?viewer_login ?patch ?gameplan ?base_branch
+    ~(artifact_dir : string) (comments : Comment.t list) : string =
   layered_prefix ~project_name ?pr_number ?patch ?gameplan ?base_branch
     ?agents_md ()
-  ^ render_turn_layer_review ~project_name ?pr_number ?current_head_sha comments
+  ^ render_turn_layer_review ~project_name ?pr_number ?current_head_sha
+      ?viewer_login ~artifact_dir comments
 
 let render_turn_layer_findings ~(project_name : string) ?pr_number
-    ?current_head_sha ~artifact_path (findings : Review_service.finding list) :
+    ?current_head_sha ~artifact_dir (findings : Review_service.finding list) :
     string =
   let pr_num_str =
     match pr_number with
@@ -1032,9 +1050,15 @@ let render_turn_layer_findings ~(project_name : string) ?pr_number
               else Printf.sprintf "%s:%d-%d" f.path f.start_line f.end_line
             in
             Printf.sprintf
-              "## [%s] finding %s\nanchor: %s\nposting_sha: %s\n\n%s"
+              "## [%s] finding %s\n\
+               anchor: %s\n\
+               posting_sha: %s\n\
+               wontfix_file: %s\n\n\
+               %s"
               (Review_service.severity_to_string f.severity)
-              f.id lines f.posting_sha f.body)
+              f.id lines f.posting_sha
+              (Review_service.wontfix_filename_of_id f.id)
+              f.body)
         |> String.concat ~sep:"\n\n---\n\n"
   in
   let vars =
@@ -1049,7 +1073,7 @@ let render_turn_layer_findings ~(project_name : string) ?pr_number
       ("pr_ref", pr_num_str);
       ("current_head_sha", Option.value current_head_sha ~default:"");
       ("sha_anchor", sha_anchor);
-      ("artifact_path", artifact_path);
+      ("artifact_dir", artifact_dir);
     ]
   in
   render_with_override ~project_name ~name:"turn_findings" ~vars
@@ -1058,33 +1082,30 @@ let render_turn_layer_findings ~(project_name : string) ?pr_number
         "You are reviewing pull request %s. The findings below come from a \
          review service, not from GitHub review threads — there is no thread \
          to reply to. To resolve a finding, you must EITHER (a) make code \
-         changes that address it, OR (b) explicitly mark it as wontfix in an \
-         artifact file.%s\n\n\
+         changes that address it, OR (b) explicitly mark it as wontfix.%s\n\n\
          %s\n\n\
          ## Resolving findings\n\
          - For each finding you fix in code, do nothing extra: it will be \
          reported back as `addressed` after this session.\n\
          - For each finding you decide NOT to fix (out of scope, false \
-         positive, intentional, etc.), write an entry to the artifact file at \
-         `%s`. The supervisor reads it after this session and reports those \
-         findings as `wontfix`.\n\
-         - Artifact format: a JSON array of objects with required string field \
-         `id` (the composite finding id shown above) and required string field \
-         `reason`.\n\
-         - If you create or update the artifact, use the Write tool with the \
-         absolute path above (it is outside the worktree on purpose — do not \
-         commit it).\n\n\
+         positive, intentional, etc.), write the reason (plain text) to \
+         `%s/<wontfix_file>`, using that finding's `wontfix_file` name shown \
+         above. The supervisor reads the directory after this session and \
+         reports those findings as `wontfix`.\n\
+         - Use the Write tool with the absolute path (the directory is outside \
+         the worktree on purpose — do not commit it). One file per finding, \
+         reason text only.\n\n\
          After addressing the in-scope findings, commit your changes. The \
          supervisor will push them for you — do not run `git push`."
-        pr_num_str sha_anchor formatted artifact_path)
+        pr_num_str sha_anchor formatted artifact_dir)
 
 let render_findings_prompt ~(project_name : string) ?agents_md ?pr_number
-    ?current_head_sha ?patch ?gameplan ?base_branch ~artifact_path
+    ?current_head_sha ?patch ?gameplan ?base_branch ~artifact_dir
     (findings : Review_service.finding list) : string =
   layered_prefix ~project_name ?pr_number ?patch ?gameplan ?base_branch
     ?agents_md ()
   ^ render_turn_layer_findings ~project_name ?pr_number ?current_head_sha
-      ~artifact_path findings
+      ~artifact_dir findings
 
 let render_turn_layer_ci ~(project_name : string) ?pr_number
     (checks : Ci_check.t list) : string =
@@ -1857,6 +1878,7 @@ let%test
   let review_prompt =
     render_review_prompt ~project_name:"onton" ~agents_md ~pr_number
       ~patch:patch_a ~gameplan ~base_branch:"main"
+      ~artifact_dir:"/data/artifacts/patch-a/comment_responses"
       [
         Comment.
           {
@@ -1868,6 +1890,7 @@ let%test
             commit_sha = None;
             original_commit_sha = None;
             outdated = false;
+            last_reply_author = None;
           };
       ]
   in
@@ -2153,6 +2176,7 @@ let%test "review prompt formats comments" =
           commit_sha = None;
           original_commit_sha = None;
           outdated = false;
+          last_reply_author = None;
         };
       Comment.
         {
@@ -2164,18 +2188,28 @@ let%test "review prompt formats comments" =
           commit_sha = None;
           original_commit_sha = None;
           outdated = false;
+          last_reply_author = None;
         };
     ]
   in
-  let result = render_review_prompt ~project_name:"test" comments in
+  let result =
+    render_review_prompt ~project_name:"test"
+      ~artifact_dir:"/data/artifacts/p1/comment_responses" comments
+  in
   String.is_substring result ~substring:"# Review Comments"
   && String.is_substring result ~substring:"on `lib/foo.ml` (line 42)"
   && String.is_substring result ~substring:"[comment_id=1]"
   && String.is_substring result ~substring:"[thread_id=PRRT_thread1]"
   && String.is_substring result ~substring:"Fix this function."
   && String.is_substring result ~substring:"General feedback."
-  && String.is_substring result ~substring:"resolveReviewThread"
-  && String.is_substring result ~substring:"gh api repos/"
+  && String.is_substring result
+       ~substring:"/data/artifacts/p1/comment_responses/<comment_id>.md"
+  (* The response procedure must not point the agent at the forge CLI —
+     reply/resolve is supervisor-owned, keyed off the response files. (The
+     agent remains free to use gh for its own investigation; the prompt just
+     never asks it to reply or resolve.) *)
+  && (not (String.is_substring result ~substring:"resolveReviewThread"))
+  && (not (String.is_substring result ~substring:"gh api"))
   (* Back-compat: no SHAs → no preamble, no [at=…], no [outdated]. *)
   && (not (String.is_substring result ~substring:"Review anchored at"))
   && (not (String.is_substring result ~substring:"[at="))
@@ -2198,12 +2232,14 @@ let%expect_test "review prompt includes SHA preamble and per-bullet anchor" =
           commit_sha = Some "47525fdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
           original_commit_sha = Some "47525fdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
           outdated = false;
+          last_reply_author = None;
         };
     ]
   in
   let result =
     render_review_prompt ~project_name:"test"
-      ~current_head_sha:"da442c5bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" comments
+      ~current_head_sha:"da442c5bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      ~artifact_dir:"/data/artifacts/p1/comment_responses" comments
   in
   Stdlib.print_endline result;
   [%expect
@@ -2211,19 +2247,18 @@ let%expect_test "review prompt includes SHA preamble and per-bullet anchor" =
     # Review Comments
 
     Review anchored at commit `47525fd`. Current branch HEAD is `da442c5`.
-    If a comment is marked `[outdated]` or refers to code that no longer exists at HEAD, reply acknowledging it's addressed in a later commit and skip — do not re-do the change.
+    If a comment is marked `[outdated]` or refers to code that no longer exists at HEAD, write a response acknowledging it's addressed in a later commit and skip — do not re-do the change.
 
     The following review comments need to be addressed on your PR:
 
     - **Comment** on `lib/foo.ml` (line 10) [comment_id=1] [thread_id=PRRT_thread1] [at=47525fd]: Still relevant.
 
     For each comment:
-    1. Implement the requested change, OR explain why the current approach is correct.
-    2. Reply to the comment thread:
-       `gh api repos/{owner}/{repo}/pulls/{pr_number}/comments/{comment_id}/replies -f body="your response"`
-       (`{owner}/{repo}` is resolved automatically by `gh` when run inside the repo)
-    3. Resolve the thread using the thread_id:
-       `gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "{thread_id}"}) { thread { isResolved } } }'`
+    1. Implement the requested change, OR decide the current approach is correct.
+    2. Write your response to `/data/artifacts/p1/comment_responses/<comment_id>.md` (the [comment_id=...] shown above), containing just the response text.
+       Use the Write tool with that absolute path — the directory is outside the worktree on purpose; do not commit it.
+
+    Write a response file for EVERY comment listed above. After this session the supervisor pushes your commits, then posts each response as a reply on its comment thread and resolves that thread. A comment without a response file stays unresolved and will be re-delivered to you.
 
     After addressing all comments, commit your changes. The supervisor will push them for you — do not run `git push`.
     |}]
@@ -2244,12 +2279,14 @@ let%expect_test "review prompt marks outdated comments" =
           commit_sha = Some "da442c5bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
           original_commit_sha = Some "47525fdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
           outdated = true;
+          last_reply_author = None;
         };
     ]
   in
   let result =
     render_review_prompt ~project_name:"test"
-      ~current_head_sha:"da442c5bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" comments
+      ~current_head_sha:"da442c5bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      ~artifact_dir:"/data/artifacts/p1/comment_responses" comments
   in
   Stdlib.print_endline result;
   [%expect
@@ -2257,19 +2294,18 @@ let%expect_test "review prompt marks outdated comments" =
     # Review Comments
 
     Review anchored at commit `47525fd`. Current branch HEAD is `da442c5`.
-    If a comment is marked `[outdated]` or refers to code that no longer exists at HEAD, reply acknowledging it's addressed in a later commit and skip — do not re-do the change.
+    If a comment is marked `[outdated]` or refers to code that no longer exists at HEAD, write a response acknowledging it's addressed in a later commit and skip — do not re-do the change.
 
     The following review comments need to be addressed on your PR:
 
     - **Comment** on `lib/foo.ml` [comment_id=1] [thread_id=PRRT_outdated] [at=47525fd] [outdated]: This line moved.
 
     For each comment:
-    1. Implement the requested change, OR explain why the current approach is correct.
-    2. Reply to the comment thread:
-       `gh api repos/{owner}/{repo}/pulls/{pr_number}/comments/{comment_id}/replies -f body="your response"`
-       (`{owner}/{repo}` is resolved automatically by `gh` when run inside the repo)
-    3. Resolve the thread using the thread_id:
-       `gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "{thread_id}"}) { thread { isResolved } } }'`
+    1. Implement the requested change, OR decide the current approach is correct.
+    2. Write your response to `/data/artifacts/p1/comment_responses/<comment_id>.md` (the [comment_id=...] shown above), containing just the response text.
+       Use the Write tool with that absolute path — the directory is outside the worktree on purpose; do not commit it.
+
+    Write a response file for EVERY comment listed above. After this session the supervisor pushes your commits, then posts each response as a reply on its comment thread and resolves that thread. A comment without a response file stays unresolved and will be re-delivered to you.
 
     After addressing all comments, commit your changes. The supervisor will push them for you — do not run `git push`.
     |}]
@@ -2289,12 +2325,14 @@ let%expect_test
           commit_sha = Some "47525fdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
           original_commit_sha = Some "47525fdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
           outdated = false;
+          last_reply_author = None;
         };
     ]
   in
   let result =
     render_review_prompt ~project_name:"test" ~pr_number:(Pr_number.of_int 42)
-      ~current_head_sha:"da442c5bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" comments
+      ~current_head_sha:"da442c5bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      ~artifact_dir:"/data/artifacts/p1/comment_responses" comments
   in
   Stdlib.print_endline result;
   (* Exactly one blank line between "# Review Comments" / "PR: #42" /
@@ -2306,22 +2344,68 @@ let%expect_test
     PR: #42
 
     Review anchored at commit `47525fd`. Current branch HEAD is `da442c5`.
-    If a comment is marked `[outdated]` or refers to code that no longer exists at HEAD, reply acknowledging it's addressed in a later commit and skip — do not re-do the change.
+    If a comment is marked `[outdated]` or refers to code that no longer exists at HEAD, write a response acknowledging it's addressed in a later commit and skip — do not re-do the change.
 
     The following review comments need to be addressed on your PR:
 
     - **Comment** on `lib/foo.ml` (line 10) [comment_id=1] [thread_id=PRRT_thread1] [at=47525fd]: Still relevant.
 
     For each comment:
-    1. Implement the requested change, OR explain why the current approach is correct.
-    2. Reply to the comment thread:
-       `gh api repos/{owner}/{repo}/pulls/42/comments/{comment_id}/replies -f body="your response"`
-       (`{owner}/{repo}` is resolved automatically by `gh` when run inside the repo)
-    3. Resolve the thread using the thread_id:
-       `gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "{thread_id}"}) { thread { isResolved } } }'`
+    1. Implement the requested change, OR decide the current approach is correct.
+    2. Write your response to `/data/artifacts/p1/comment_responses/<comment_id>.md` (the [comment_id=...] shown above), containing just the response text.
+       Use the Write tool with that absolute path — the directory is outside the worktree on purpose; do not commit it.
+
+    Write a response file for EVERY comment listed above. After this session the supervisor pushes your commits, then posts each response as a reply on its comment thread and resolves that thread. A comment without a response file stays unresolved and will be re-delivered to you.
 
     After addressing all comments, commit your changes. The supervisor will push them for you — do not run `git push`.
     |}]
+
+let%test "review prompt marks resolve-retry comments only with viewer known" =
+  let make_comment ~id ~last_reply_author : Comment.t =
+    Comment.
+      {
+        id = Comment_id.of_int id;
+        thread_id = Some (Printf.sprintf "PRRT_%d" id);
+        body = "Body.";
+        path = None;
+        line = None;
+        commit_sha = None;
+        original_commit_sha = None;
+        outdated = false;
+        last_reply_author;
+      }
+  in
+  let comments =
+    [
+      make_comment ~id:1 ~last_reply_author:(Some "onton-bot");
+      make_comment ~id:2 ~last_reply_author:(Some "alice");
+      make_comment ~id:3 ~last_reply_author:None;
+    ]
+  in
+  let with_viewer =
+    render_review_prompt ~project_name:"test" ~viewer_login:"onton-bot"
+      ~artifact_dir:"/data/artifacts/p1/comment_responses" comments
+  in
+  let without_viewer =
+    render_review_prompt ~project_name:"test"
+      ~artifact_dir:"/data/artifacts/p1/comment_responses" comments
+  in
+  let tagged_line prompt id =
+    match
+      List.find (String.split_lines prompt) ~f:(fun l ->
+          String.is_substring l ~substring:(Printf.sprintf "[comment_id=%d]" id))
+    with
+    | Some line ->
+        String.is_substring line ~substring:"[response already posted]"
+    | None -> false
+  in
+  tagged_line with_viewer 1
+  && (not (tagged_line with_viewer 2))
+  && (not (tagged_line with_viewer 3))
+  && String.is_substring with_viewer
+       ~substring:"Exception: comments marked [response already posted]"
+  (* Unknown viewer fails open: no tags, no exception sentence. *)
+  && not (String.is_substring without_viewer ~substring:"already posted")
 
 let%test "review prompt does not mark file-level comments as outdated" =
   let comments : Comment.t list =
@@ -2338,12 +2422,14 @@ let%test "review prompt does not mark file-level comments as outdated" =
           commit_sha = Some "47525fdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
           original_commit_sha = Some "47525fdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
           outdated = false;
+          last_reply_author = None;
         };
     ]
   in
   let result =
     render_review_prompt ~project_name:"test"
-      ~current_head_sha:"47525fdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" comments
+      ~current_head_sha:"47525fdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      ~artifact_dir:"/data/artifacts/p1/comment_responses" comments
   in
   (* The preamble references "[outdated]" literally, so we can't just grep the
      whole result. Assert directly on the bullet line that contains the comment

--- a/lib/prompt.mli
+++ b/lib/prompt.mli
@@ -76,8 +76,19 @@ val render_turn_layer_review :
   project_name:string ->
   ?pr_number:Pr_number.t ->
   ?current_head_sha:string ->
+  ?viewer_login:string ->
+  artifact_dir:string ->
   Comment.t list ->
   string
+(** [artifact_dir] is the absolute [comment_responses/] directory the agent is
+    told to write per-comment response files to
+    ({!Project_store.comment_responses_dir}, one [<comment_id>.md] per comment).
+    The agent is not asked to reply or resolve itself; the supervisor replies to
+    and resolves every comment with a written response after it pushes the
+    session's commits. [viewer_login] (the forge token's account) marks comments
+    whose thread already ends with onton's own reply as
+    [response already posted] — those need no fresh response file, only a
+    resolve retry. *)
 
 val render_turn_layer_ci :
   project_name:string -> ?pr_number:Pr_number.t -> Ci_check.t list -> string
@@ -143,9 +154,11 @@ val render_review_prompt :
   ?agents_md:string ->
   ?pr_number:Pr_number.t ->
   ?current_head_sha:string ->
+  ?viewer_login:string ->
   ?patch:Patch.t ->
   ?gameplan:Gameplan.t ->
   ?base_branch:string ->
+  artifact_dir:string ->
   Comment.t list ->
   string
 
@@ -157,15 +170,16 @@ val render_findings_prompt :
   ?patch:Patch.t ->
   ?gameplan:Gameplan.t ->
   ?base_branch:string ->
-  artifact_path:string ->
+  artifact_dir:string ->
   Review_service.finding list ->
   string
 (** Findings session prompt. Renders each finding with its severity, anchor
-    (path:start_line-end_line), posting SHA, and body. Instructs the agent to
+    (path:start_line-end_line), posting SHA, per-finding [wontfix_file] name
+    ({!Review_service.wontfix_filename_of_id}), and body. Instructs the agent to
     address findings via code edits and, for any finding it cannot or should not
-    fix, write a JSON list of [{id, reason}] objects to [artifact_path]
-    ([findings_wontfix.json]). Findings not listed in the artifact are POSTed as
-    [addressed] to the originating review backend after the session. *)
+    fix, write the reason to [artifact_dir/<wontfix_file>]
+    ({!Project_store.findings_wontfix_dir}). Findings without a file are POSTed
+    as [addressed] to the originating review backend after the session. *)
 
 val render_ci_failure_prompt :
   project_name:string ->

--- a/lib/runner_fiber_impl.ml
+++ b/lib/runner_fiber_impl.ml
@@ -1613,6 +1613,7 @@ struct
                                              | `Ok
                                              | `Pr_body_miss
                                              | `Retry_push
+                                             | `Review_unresolved
                                              | `Skip_empty
                                              | `Stale ])
                                       in
@@ -1984,12 +1985,29 @@ struct
                                                   ~f:(fun ps ->
                                                     ps.Pr_state.head_oid)
                                               in
+                                              let artifact_dir =
+                                                Project_store
+                                                .comment_responses_dir
+                                                  ~project_name ~patch_id
+                                              in
+                                              (* Clear stale response files
+                                             from a prior Review session. The
+                                             directory is stable per-patch;
+                                             without this, a leftover file
+                                             whose reply already posted (but
+                                             whose resolve failed) would be
+                                             replayed as a duplicate reply. *)
+                                              Project_store.reset_artifact_dir
+                                                artifact_dir;
                                               Prompt.render_review_prompt
                                                 ~project_name ?agents_md
                                                 ?pr_number ?current_head_sha
+                                                ?viewer_login:
+                                                  (Forge.viewer_login ())
                                                 ?patch:patch_for_layer ~gameplan
                                                 ~base_branch:
-                                                  base_branch_for_layer comments
+                                                  base_branch_for_layer
+                                                ~artifact_dir comments
                                           | Patch_decision.Findings_payload
                                               { findings } ->
                                               let current_head_sha =
@@ -1997,27 +2015,20 @@ struct
                                                   ~f:(fun ps ->
                                                     ps.Pr_state.head_oid)
                                               in
-                                              let artifact_path =
+                                              let artifact_dir =
                                                 Project_store
-                                                .findings_wontfix_artifact_path
+                                                .findings_wontfix_dir
                                                   ~project_name ~patch_id
                                               in
-                                              Project_store.ensure_dir
-                                                (Stdlib.Filename.dirname
-                                                   artifact_path);
-                                              (try Unix.unlink artifact_path
-                                               with
-                                               | Unix.Unix_error
-                                                   (Unix.ENOENT, _, _)
-                                               ->
-                                                 ());
+                                              Project_store.reset_artifact_dir
+                                                artifact_dir;
                                               Prompt.render_findings_prompt
                                                 ~project_name ?agents_md
                                                 ?pr_number ?current_head_sha
                                                 ?patch:patch_for_layer ~gameplan
                                                 ~base_branch:
                                                   base_branch_for_layer
-                                                ~artifact_path findings
+                                                ~artifact_dir findings
                                           | Patch_decision.Human_payload
                                               { messages } ->
                                               Prompt.render_human_message_prompt
@@ -2163,7 +2174,8 @@ struct
                                             :> [ `Failed
                                                | `Ok
                                                | `Pr_body_miss
-                                               | `Retry_push ])
+                                               | `Retry_push
+                                               | `Review_unresolved ])
                                         in
                                         (match result with
                                         | `Ok
@@ -2236,9 +2248,9 @@ struct
                                           | Patch_decision.Findings_payload
                                               { findings } ->
                                               if session_ok then (
-                                                let artifact_path =
+                                                let artifact_dir =
                                                   Project_store
-                                                  .findings_wontfix_artifact_path
+                                                  .findings_wontfix_dir
                                                     ~project_name ~patch_id
                                                 in
                                                 Findings_resolver
@@ -2248,7 +2260,7 @@ struct
                                                     log_event runtime ~patch_id
                                                       msg)
                                                   ~findings_registry
-                                                  ~artifact_path
+                                                  ~artifact_dir
                                                   ~delivered:findings
                                                   ~actor:
                                                     (Printf.sprintf "onton:%s"
@@ -2281,9 +2293,72 @@ struct
                                                       findings_registry
                                                       ~key:f.Review_service.id);
                                                 result
+                                          | Patch_decision.Review_payload
+                                              { comments } ->
+                                              (* Supervisor-owned comment
+                                             response/resolution. [`Ok] from
+                                             the session driver implies the
+                                             post-session push shipped (push
+                                             failure surfaces as
+                                             [`Retry_push]), so replies
+                                             claiming a fix never precede the
+                                             fix reaching the remote. On a
+                                             failed session the response
+                                             files are left in place but not
+                                             posted — the poller re-detects
+                                             the unresolved threads and the
+                                             next Review session re-delivers
+                                             (its setup clears the stale
+                                             files). *)
+                                              if session_ok then
+                                                match
+                                                  Comment_responder
+                                                  .respond_after_session
+                                                    ~reply:(fun
+                                                        ~comment_id ~body ->
+                                                      match pr_number with
+                                                      | None ->
+                                                          Error
+                                                            "no PR number \
+                                                             recorded for this \
+                                                             patch"
+                                                      | Some pr ->
+                                                          Base.Result.map_error
+                                                            (Forge
+                                                             .reply_to_review_comment
+                                                               ~pr_number:pr
+                                                               ~comment_id ~body)
+                                                            ~f:Forge.show_error)
+                                                    ~resolve:(fun ~thread_id ->
+                                                      Base.Result.map_error
+                                                        (Forge
+                                                         .resolve_review_thread
+                                                           ~thread_id)
+                                                        ~f:Forge.show_error)
+                                                    ~log:(fun msg ->
+                                                      log_event runtime
+                                                        ~patch_id msg)
+                                                    ~viewer_login:
+                                                      (Forge.viewer_login ())
+                                                    ~artifact_dir:
+                                                      (Project_store
+                                                       .comment_responses_dir
+                                                         ~project_name ~patch_id)
+                                                    ~delivered:comments ()
+                                                with
+                                                | `Converged -> result
+                                                | `Unresolved _ ->
+                                                    `Review_unresolved
+                                              else (
+                                                log_event runtime ~patch_id
+                                                  "comment-responses: session \
+                                                   did not complete cleanly — \
+                                                   skipping reply/resolve; \
+                                                   unresolved comments will \
+                                                   re-deliver";
+                                                result)
                                           | Patch_decision.Human_payload _
                                           | Patch_decision.Ci_payload _
-                                          | Patch_decision.Review_payload _
                                           | Patch_decision.Pr_body_payload
                                           | Patch_decision
                                             .Merge_conflict_payload ->
@@ -2395,6 +2470,7 @@ struct
                                           :> [ `Failed
                                              | `Ok
                                              | `Pr_body_miss
+                                             | `Review_unresolved
                                              | `Retry_push
                                              | `Skip_empty
                                              | `Stale ])
@@ -2407,6 +2483,8 @@ struct
                           | `Failed -> Orchestrator.Respond_failed
                           | `Retry_push -> Orchestrator.Respond_retry_push
                           | `Pr_body_miss -> Orchestrator.Respond_pr_body_miss
+                          | `Review_unresolved ->
+                              Orchestrator.Respond_review_unresolved
                           | `Ok -> Orchestrator.Respond_ok
                         in
                         Runtime.update_orchestrator runtime (fun orch ->
@@ -2455,6 +2533,32 @@ struct
                                   (Printf.sprintf
                                      "Patch %s: pr-body artifact repeatedly \
                                       missing — human review needed"
+                                     (Patch_id.to_string patch_id))
+                                ()
+                        | Orchestrator.Respond_review_unresolved ->
+                            (* Per-comment causes are already logged by
+                             Comment_responder; this line records the counter
+                             march so an operator can see how close the loop
+                             is to the cap. *)
+                            let agent =
+                              Runtime.read runtime (fun snap ->
+                                  Orchestrator.agent snap.Runtime.orchestrator
+                                    patch_id)
+                            in
+                            log_event runtime ~patch_id
+                              (Printf.sprintf
+                                 "comment-responses: non-converged review \
+                                  cycle recorded (cycle count: %d)%s"
+                                 agent.Patch_agent.review_unresolved_cycle_count
+                                 (if Patch_agent.needs_intervention agent then
+                                    "; escalating to human review"
+                                  else "; unresolved comments will re-deliver"));
+                            if Patch_agent.needs_intervention agent then
+                              set_status ~level:Tui.Error
+                                ~text:
+                                  (Printf.sprintf
+                                     "Patch %s: review comments repeatedly \
+                                      left unresolved — human review needed"
                                      (Patch_id.to_string patch_id))
                                 ()
                         | Orchestrator.Respond_ok ->

--- a/lib/runner_fiber_impl.ml
+++ b/lib/runner_fiber_impl.ml
@@ -1923,6 +1923,21 @@ struct
                                           (Stdlib.Filename.concat wt_path
                                              "AGENTS.md")
                                       in
+                                      let review_artifact_dir =
+                                        match payload with
+                                        | Patch_decision.Review_payload _ ->
+                                            Some
+                                              (Project_store
+                                               .comment_responses_dir
+                                                 ~project_name ~patch_id)
+                                        | Patch_decision.Ci_payload _
+                                        | Patch_decision.Findings_payload _
+                                        | Patch_decision.Human_payload _
+                                        | Patch_decision.Pr_body_payload
+                                        | Patch_decision.Merge_conflict_payload
+                                          ->
+                                            None
+                                      in
                                       log_event runtime ~patch_id
                                         (match payload with
                                         | Patch_decision.Review_payload
@@ -1986,9 +2001,10 @@ struct
                                                     ps.Pr_state.head_oid)
                                               in
                                               let artifact_dir =
-                                                Project_store
-                                                .comment_responses_dir
-                                                  ~project_name ~patch_id
+                                                match review_artifact_dir with
+                                                | Some artifact_dir ->
+                                                    artifact_dir
+                                                | None -> assert false
                                               in
                                               (* Clear stale response files
                                              from a prior Review session. The
@@ -2341,9 +2357,12 @@ struct
                                                     ~viewer_login:
                                                       (Forge.viewer_login ())
                                                     ~artifact_dir:
-                                                      (Project_store
-                                                       .comment_responses_dir
-                                                         ~project_name ~patch_id)
+                                                      (match
+                                                         review_artifact_dir
+                                                       with
+                                                      | Some artifact_dir ->
+                                                          artifact_dir
+                                                      | None -> assert false)
                                                     ~delivered:comments ()
                                                 with
                                                 | `Converged -> result

--- a/lib_core/comment_responses.ml
+++ b/lib_core/comment_responses.ml
@@ -1,0 +1,232 @@
+(* @archlint.module core
+   @archlint.domain comment-responses *)
+
+open Base
+open Types
+
+type entry = { comment_id : int; response : string }
+[@@deriving show, eq, sexp_of, compare]
+
+type action = {
+  comment_id : Comment_id.t;
+  thread_id : string option;
+  response : string;
+}
+[@@deriving show, eq, sexp_of, compare]
+
+type outcome = { actions : action list; unanswered : Comment_id.t list }
+[@@deriving show, eq, sexp_of, compare]
+
+(* The filename stem is the comment id: "12345.md" -> 12345. A single
+   extension is stripped; "12345" bare works too. Anything whose stem is not
+   all digits (with optional leading '-') is rejected — the caller logs those
+   filenames as unrecognized. *)
+let comment_id_of_filename filename =
+  let base = Stdlib.Filename.basename filename in
+  let stem = Stdlib.Filename.remove_extension base in
+  let is_digits s =
+    (not (String.is_empty s)) && String.for_all s ~f:Char.is_digit
+  in
+  let unsigned =
+    match String.chop_prefix stem ~prefix:"-" with Some s -> s | None -> stem
+  in
+  if is_digits unsigned then Stdlib.int_of_string_opt stem else None
+
+let entry_of_file ~filename ~contents : entry option =
+  match comment_id_of_filename filename with
+  | None -> None
+  | Some comment_id ->
+      let response = String.strip contents in
+      if String.is_empty response then None else Some { comment_id; response }
+
+(* True when the thread's last word is onton's own posted reply, so a
+   re-delivery only needs its resolve retried — replying again would be a
+   duplicate. Purely positional: only a viewer-authored *reply* counts.
+   Openers are always reviewer feedback, even when authored by the viewer's
+   login (a human co-reviewing from the token's account) — co-reviewers open
+   threads, they never correspond mid-thread, so position disambiguates
+   authorship where login cannot. An unknown viewer fails open to false: a
+   possible duplicate reply beats silently never replying. *)
+let is_resolve_retry ~(viewer_login : string option) (c : Comment.t) : bool =
+  match viewer_login with
+  | None -> false
+  | Some viewer ->
+      Option.equal String.equal c.Comment.last_reply_author (Some viewer)
+
+let plan ~(delivered : Comment.t list) ~(entries : entry list) : outcome =
+  (* Last entry per comment_id wins. Duplicate stems for one id (e.g. "12.md"
+     and "12.txt") are pathological; feeding entries in sorted-filename order
+     makes the pick deterministic. *)
+  let index =
+    List.fold entries
+      ~init:(Map.empty (module Int))
+      ~f:(fun acc e -> Map.set acc ~key:e.comment_id ~data:e)
+  in
+  (* One action per distinct delivered comment id, in delivered order. GitHub
+     comment ids are unique, but a duplicate in [delivered] must not produce a
+     duplicate reply. *)
+  let _, rev_actions, rev_unanswered =
+    List.fold delivered
+      ~init:(Set.empty (module Int), [], [])
+      ~f:(fun (seen, actions, unanswered) (c : Comment.t) ->
+        let raw_id = Comment_id.to_int c.Comment.id in
+        if Set.mem seen raw_id then (seen, actions, unanswered)
+        else
+          let seen = Set.add seen raw_id in
+          match Map.find index raw_id with
+          | Some e ->
+              let action =
+                {
+                  comment_id = c.Comment.id;
+                  thread_id = c.Comment.thread_id;
+                  response = e.response;
+                }
+              in
+              (seen, action :: actions, unanswered)
+          | None -> (seen, actions, c.Comment.id :: unanswered))
+  in
+  { actions = List.rev rev_actions; unanswered = List.rev rev_unanswered }
+
+let unmatched_entries ~(delivered : Comment.t list) ~(entries : entry list) :
+    entry list =
+  let delivered_ids =
+    Set.of_list
+      (module Int)
+      (List.map delivered ~f:(fun c -> Comment_id.to_int c.Comment.id))
+  in
+  List.filter entries ~f:(fun e -> not (Set.mem delivered_ids e.comment_id))
+
+(* {2 Inline tests} *)
+
+let comment ?(thread_id = None) ?(last_reply_author = None) id : Comment.t =
+  {
+    Comment.id = Comment_id.of_int id;
+    thread_id;
+    body = "body";
+    path = None;
+    line = None;
+    commit_sha = None;
+    original_commit_sha = None;
+    outdated = false;
+    last_reply_author;
+  }
+
+let%test "is_resolve_retry: viewer-authored last reply" =
+  is_resolve_retry ~viewer_login:(Some "onton-bot")
+    (comment ~last_reply_author:(Some "onton-bot") 1)
+
+let%test "is_resolve_retry: someone else's last reply is not a retry" =
+  not
+    (is_resolve_retry ~viewer_login:(Some "onton-bot")
+       (comment ~last_reply_author:(Some "alice") 1))
+
+let%test "is_resolve_retry: opener-only thread is never a retry" =
+  (* Even a viewer-authored opener is reviewer feedback (a human co-reviewing
+     from the token's account) — only a *reply* position marks onton's own
+     response. *)
+  not (is_resolve_retry ~viewer_login:(Some "onton-bot") (comment 1))
+
+let%test "is_resolve_retry: unknown viewer fails open to false" =
+  not
+    (is_resolve_retry ~viewer_login:None
+       (comment ~last_reply_author:(Some "onton-bot") 1))
+
+let%test "entry_of_file: id.md with content" =
+  match entry_of_file ~filename:"12345.md" ~contents:"fixed in abc123\n" with
+  | Some { comment_id = 12345; response = "fixed in abc123" } -> true
+  | _ -> false
+
+let%test "entry_of_file: bare id, no extension" =
+  match entry_of_file ~filename:"7.txt" ~contents:"r" with
+  | Some { comment_id = 7; _ } -> (
+      match entry_of_file ~filename:"7" ~contents:"r" with
+      | Some { comment_id = 7; _ } -> true
+      | _ -> false)
+  | _ -> false
+
+let%test "entry_of_file: absolute path uses basename" =
+  match
+    entry_of_file ~filename:"/data/artifacts/p1/comment_responses/42.md"
+      ~contents:"done"
+  with
+  | Some { comment_id = 42; response = "done" } -> true
+  | _ -> false
+
+let%test "entry_of_file: negative (synthetic) ids parse" =
+  match entry_of_file ~filename:"-3.md" ~contents:"r" with
+  | Some { comment_id = -3; _ } -> true
+  | _ -> false
+
+let%test "entry_of_file: non-numeric stem rejected" =
+  Option.is_none (entry_of_file ~filename:"notes.md" ~contents:"r")
+  && Option.is_none (entry_of_file ~filename:"comment-12.md" ~contents:"r")
+  && Option.is_none (entry_of_file ~filename:".md" ~contents:"r")
+  && Option.is_none (entry_of_file ~filename:"" ~contents:"r")
+
+let%test "entry_of_file: blank content rejected" =
+  Option.is_none (entry_of_file ~filename:"12.md" ~contents:"  \n\t ")
+  && Option.is_none (entry_of_file ~filename:"12.md" ~contents:"")
+
+let%test "plan: joins entries to delivered comments in delivered order" =
+  let delivered =
+    [ comment ~thread_id:(Some "T1") 1; comment ~thread_id:(Some "T2") 2 ]
+  in
+  let entries =
+    [
+      { comment_id = 2; response = "second" };
+      { comment_id = 1; response = "first" };
+    ]
+  in
+  let o = plan ~delivered ~entries in
+  equal_outcome o
+    {
+      actions =
+        [
+          {
+            comment_id = Comment_id.of_int 1;
+            thread_id = Some "T1";
+            response = "first";
+          };
+          {
+            comment_id = Comment_id.of_int 2;
+            thread_id = Some "T2";
+            response = "second";
+          };
+        ];
+      unanswered = [];
+    }
+
+let%test "plan: last entry wins for a duplicated comment_id" =
+  let delivered = [ comment 1 ] in
+  let entries =
+    [
+      { comment_id = 1; response = "draft" };
+      { comment_id = 1; response = "final" };
+    ]
+  in
+  let o = plan ~delivered ~entries in
+  match o.actions with [ { response = "final"; _ } ] -> true | _ -> false
+
+let%test "plan: reports unanswered comments; unmatched_entries reports strays" =
+  let delivered = [ comment 1; comment 2 ] in
+  let entries =
+    [ { comment_id = 2; response = "r" }; { comment_id = 99; response = "s" } ]
+  in
+  let o = plan ~delivered ~entries in
+  equal_outcome o
+    {
+      actions =
+        [
+          { comment_id = Comment_id.of_int 2; thread_id = None; response = "r" };
+        ];
+      unanswered = [ Comment_id.of_int 1 ];
+    }
+  && equal_entry
+       (List.hd_exn (unmatched_entries ~delivered ~entries))
+       { comment_id = 99; response = "s" }
+
+let%test "plan: duplicate delivered ids produce a single action" =
+  let delivered = [ comment 1; comment 1 ] in
+  let entries = [ { comment_id = 1; response = "once" } ] in
+  let o = plan ~delivered ~entries in
+  List.length o.actions = 1

--- a/lib_core/comment_responses.ml
+++ b/lib_core/comment_responses.ml
@@ -17,20 +17,19 @@ type action = {
 type outcome = { actions : action list; unanswered : Comment_id.t list }
 [@@deriving show, eq, sexp_of, compare]
 
-(* The filename stem is the comment id: "12345.md" -> 12345. A single
-   extension is stripped; "12345" bare works too. Anything whose stem is not
-   all digits (with optional leading '-') is rejected — the caller logs those
-   filenames as unrecognized. *)
+(* The filename stem is the forge-addressable comment id: "12345.md" ->
+   12345. A single extension is stripped; "12345" bare works too. Anything
+   non-positive or whose stem is not all digits is rejected — the caller logs
+   those filenames as unrecognized. *)
 let comment_id_of_filename filename =
   let base = Stdlib.Filename.basename filename in
   let stem = Stdlib.Filename.remove_extension base in
   let is_digits s =
     (not (String.is_empty s)) && String.for_all s ~f:Char.is_digit
   in
-  let unsigned =
-    match String.chop_prefix stem ~prefix:"-" with Some s -> s | None -> stem
-  in
-  if is_digits unsigned then Stdlib.int_of_string_opt stem else None
+  match Stdlib.int_of_string_opt stem with
+  | Some comment_id when comment_id > 0 && is_digits stem -> Some comment_id
+  | _ -> None
 
 let entry_of_file ~filename ~contents : entry option =
   match comment_id_of_filename filename with
@@ -152,10 +151,9 @@ let%test "entry_of_file: absolute path uses basename" =
   | Some { comment_id = 42; response = "done" } -> true
   | _ -> false
 
-let%test "entry_of_file: negative (synthetic) ids parse" =
-  match entry_of_file ~filename:"-3.md" ~contents:"r" with
-  | Some { comment_id = -3; _ } -> true
-  | _ -> false
+let%test "entry_of_file: synthetic/non-positive ids rejected" =
+  Option.is_none (entry_of_file ~filename:"-3.md" ~contents:"r")
+  && Option.is_none (entry_of_file ~filename:"0.md" ~contents:"r")
 
 let%test "entry_of_file: non-numeric stem rejected" =
   Option.is_none (entry_of_file ~filename:"notes.md" ~contents:"r")

--- a/lib_core/comment_responses.mli
+++ b/lib_core/comment_responses.mli
@@ -46,10 +46,10 @@ val is_resolve_retry : viewer_login:string option -> Types.Comment.t -> bool
     reply rather than closed to silence. *)
 
 val entry_of_file : filename:string -> contents:string -> entry option
-(** Decode one response file. The basename's stem (extension stripped) must be
-    an integer — that is the comment id; [contents] is stripped and must be
-    nonblank. Returns [None] for unrecognized filenames or blank files. Never
-    raises. *)
+(** Decode one response file. The basename's stem (extension stripped) must be a
+    positive, forge-addressable integer — that is the comment id; [contents] is
+    stripped and must be nonblank. Returns [None] for unrecognized filenames,
+    synthetic/non-positive ids, or blank files. Never raises. *)
 
 val plan : delivered:Types.Comment.t list -> entries:entry list -> outcome
 (** Join decoded entries against the comments delivered to the session. When

--- a/lib_core/comment_responses.mli
+++ b/lib_core/comment_responses.mli
@@ -1,0 +1,63 @@
+(* @archlint.module interface
+   @archlint.domain comment-responses *)
+
+(** Pure decision logic for the review-comment response artifacts.
+
+    During a Review_comments session the agent is not asked to reply to or
+    resolve review threads itself. It writes one response file per comment under
+    the [comment_responses/] artifact directory (see
+    {!Project_store.comment_responses_dir} in the effectful layer): the file is
+    named [<comment_id>.md] — the id shown as [comment_id=…] in the review
+    prompt — and contains just the response text. After the supervisor pushes
+    the session's commits, it joins the response files against the comments that
+    were delivered to the session and, for each match, replies to the comment
+    thread and then resolves it.
+
+    This module owns the total filename/content decoding and the join; the
+    directory listing and forge side effects live in [lib/comment_responder.ml].
+*)
+
+type entry = { comment_id : int; response : string }
+[@@deriving show, eq, sexp_of, compare]
+
+type action = {
+  comment_id : Types.Comment_id.t;
+  thread_id : string option;
+  response : string;
+}
+[@@deriving show, eq, sexp_of, compare]
+
+type outcome = {
+  actions : action list;
+      (** One per delivered comment with a response, in delivered order. *)
+  unanswered : Types.Comment_id.t list;
+      (** Delivered comments the agent wrote no response for; they stay
+          unresolved and re-deliver on the next poll. *)
+}
+[@@deriving show, eq, sexp_of, compare]
+
+val is_resolve_retry : viewer_login:string option -> Types.Comment.t -> bool
+(** True when the thread's last word is a reply authored by [viewer_login] —
+    onton's own posted response (position disambiguates authorship even when a
+    human co-reviews from the token's account: co-reviewers open threads, they
+    never correspond mid-thread). Such a comment needs its resolve retried, not
+    another reply, and needs no fresh response file. [viewer_login = None]
+    (viewer fetch failed) is always [false] — fail open to a possible duplicate
+    reply rather than closed to silence. *)
+
+val entry_of_file : filename:string -> contents:string -> entry option
+(** Decode one response file. The basename's stem (extension stripped) must be
+    an integer — that is the comment id; [contents] is stripped and must be
+    nonblank. Returns [None] for unrecognized filenames or blank files. Never
+    raises. *)
+
+val plan : delivered:Types.Comment.t list -> entries:entry list -> outcome
+(** Join decoded entries against the comments delivered to the session. When
+    several entries share a [comment_id], the last one wins — pass entries in
+    sorted-filename order to make that pick deterministic. Duplicate delivered
+    ids yield a single action (first occurrence's thread_id). *)
+
+val unmatched_entries :
+  delivered:Types.Comment.t list -> entries:entry list -> entry list
+(** Entries whose [comment_id] matches no delivered comment — stale files from
+    an interrupted cleanup or agent typos; the caller logs them. *)

--- a/lib_core/patch_agent.ml
+++ b/lib_core/patch_agent.ml
@@ -63,6 +63,15 @@ type t = {
           blocked mid-write (see [Orchestrator.Respond_pr_body_miss]). At >=2
           contributes to [needs_intervention]. Reset by
           [reset_intervention_state]. *)
+  review_unresolved_cycle_count : int;
+      (** Consecutive Review_comments sessions that completed cleanly but did
+          not reply-and-resolve every delivered comment (missing response file,
+          failed reply/resolve call, or an unaddressable comment — see
+          [Orchestrator.Respond_review_unresolved]). Without this cap the loop
+          has no terminator: the agent cannot resolve threads itself, so a
+          comment it never responds to re-enqueues a session every poll,
+          forever. At [>= 2] contributes to [needs_intervention]. Reset by a
+          fully-converged review cycle and by [reset_intervention_state]. *)
   start_attempts_without_pr : int;
   conflict_noop_count : int;
   no_commits_push_count : int;
@@ -146,7 +155,7 @@ let intervention_reason_of_fields ~merged ~has_pr ~is_pr_missing
     ~session_given_up ~human_in_queue ~ci_failure_count
     ~start_attempts_without_pr ~conflict_noop_count ~no_commits_push_count
     ~context_exhaustion_count ~push_failure_count ~rebase_failure_count
-    ~pr_body_artifact_miss_count =
+    ~pr_body_artifact_miss_count ~review_unresolved_cycle_count =
   if merged then None
   else if session_given_up then Some "session_fallback=given_up"
   else if is_pr_missing then Some "pr_missing"
@@ -173,6 +182,8 @@ let intervention_reason_of_fields ~merged ~has_pr ~is_pr_missing
   else if rebase_failure_count >= 2 then Some "rebase_failure_count>=2"
   else if pr_body_artifact_miss_count >= 2 then
     Some "pr_body_artifact_miss_count>=2"
+  else if review_unresolved_cycle_count >= 2 then
+    Some "review_unresolved_cycle_count>=2"
   else None
 
 let intervention_reason t =
@@ -189,6 +200,7 @@ let intervention_reason t =
     ~push_failure_count:t.push_failure_count
     ~rebase_failure_count:t.rebase_failure_count
     ~pr_body_artifact_miss_count:t.pr_body_artifact_miss_count
+    ~review_unresolved_cycle_count:t.review_unresolved_cycle_count
 
 let needs_intervention t = Option.is_some (intervention_reason t)
 
@@ -196,13 +208,13 @@ let needs_intervention_of_fields ~merged ~has_pr ~is_pr_missing
     ~session_given_up ~human_in_queue ~ci_failure_count
     ~start_attempts_without_pr ~conflict_noop_count ~no_commits_push_count
     ~context_exhaustion_count ~push_failure_count ~rebase_failure_count
-    ~pr_body_artifact_miss_count =
+    ~pr_body_artifact_miss_count ~review_unresolved_cycle_count =
   Option.is_some
     (intervention_reason_of_fields ~merged ~has_pr ~is_pr_missing
        ~session_given_up ~human_in_queue ~ci_failure_count
        ~start_attempts_without_pr ~conflict_noop_count ~no_commits_push_count
        ~context_exhaustion_count ~push_failure_count ~rebase_failure_count
-       ~pr_body_artifact_miss_count)
+       ~pr_body_artifact_miss_count ~review_unresolved_cycle_count)
 
 let create ~branch patch_id =
   {
@@ -238,6 +250,7 @@ let create ~branch patch_id =
     is_draft = false;
     pr_body_delivered = false;
     pr_body_artifact_miss_count = 0;
+    review_unresolved_cycle_count = 0;
     start_attempts_without_pr = 0;
     conflict_noop_count = 0;
     no_commits_push_count = 0;
@@ -298,6 +311,7 @@ let create_adhoc ~patch_id ~branch ~pr_number =
     is_draft = false;
     pr_body_delivered = true;
     pr_body_artifact_miss_count = 0;
+    review_unresolved_cycle_count = 0;
     start_attempts_without_pr = 0;
     conflict_noop_count = 0;
     no_commits_push_count = 0;
@@ -405,6 +419,12 @@ let increment_pr_body_artifact_miss_count t =
 
 let reset_pr_body_artifact_miss_count t =
   { t with pr_body_artifact_miss_count = 0 }
+
+let increment_review_unresolved_cycle_count t =
+  { t with review_unresolved_cycle_count = t.review_unresolved_cycle_count + 1 }
+
+let reset_review_unresolved_cycle_count t =
+  { t with review_unresolved_cycle_count = 0 }
 
 let set_base_branch t branch =
   let notified =
@@ -570,6 +590,7 @@ let reset_intervention_state t =
     push_failure_count = 0;
     rebase_failure_count = 0;
     pr_body_artifact_miss_count = 0;
+    review_unresolved_cycle_count = 0;
   }
 
 let reset_busy t = if not t.busy then t else { t with busy = false }
@@ -581,14 +602,15 @@ let restore ~patch_id ~branch ~pr_status ~has_session ~busy ~merged ~queue
     ?(unresolved_comment_count = 0) ~mergeability_unknown ~merge_queue_required
     ~merge_queue_entry ~merge_commit_sha ~base_contains_merged_siblings
     ~is_draft ~pr_body_delivered ~pr_body_artifact_miss_count
-    ~start_attempts_without_pr ~conflict_noop_count ~no_commits_push_count
-    ~context_exhaustion_count ~push_failure_count ~rebase_failure_count
-    ~branch_rebased_onto ~branch_rebased_onto_sha ~anchor_history
-    ~checks_passing ~current_op ~current_op_state ~current_message_id
-    ~generation ~worktree_path ~branch_blocked ~llm_session_id
-    ~automerge_enabled ~automerge_deadline ~automerge_inflight
-    ?(review_requested_for_oid = None) ?(review_request_inflight = false)
-    ~automerge_failure_count ~delivered_ci_run_ids () =
+    ?(review_unresolved_cycle_count = 0) ~start_attempts_without_pr
+    ~conflict_noop_count ~no_commits_push_count ~context_exhaustion_count
+    ~push_failure_count ~rebase_failure_count ~branch_rebased_onto
+    ~branch_rebased_onto_sha ~anchor_history ~checks_passing ~current_op
+    ~current_op_state ~current_message_id ~generation ~worktree_path
+    ~branch_blocked ~llm_session_id ~automerge_enabled ~automerge_deadline
+    ~automerge_inflight ?(review_requested_for_oid = None)
+    ?(review_request_inflight = false) ~automerge_failure_count
+    ~delivered_ci_run_ids () =
   {
     patch_id;
     branch;
@@ -619,6 +641,7 @@ let restore ~patch_id ~branch ~pr_status ~has_session ~busy ~merged ~queue
     is_draft;
     pr_body_delivered;
     pr_body_artifact_miss_count;
+    review_unresolved_cycle_count;
     start_attempts_without_pr;
     conflict_noop_count;
     no_commits_push_count;

--- a/lib_core/patch_agent.mli
+++ b/lib_core/patch_agent.mli
@@ -72,6 +72,17 @@ type t = private {
           [needs_intervention] at [>= 2]. Zero in fresh snapshots and older
           snapshots that didn't persist the field. Reset by
           [reset_intervention_state] and by [Respond_ok] for [Pr_body]. *)
+  review_unresolved_cycle_count : int;
+      (** Consecutive Review_comments sessions that completed cleanly
+          ([Respond_ok]-shaped) but did not reply-and-resolve every delivered
+          comment: missing response file, failed reply/resolve forge call, or an
+          unaddressable comment (synthetic id, no thread id). The loop's only
+          terminator — the agent cannot resolve threads itself, so a comment it
+          never responds to would otherwise re-enqueue a session every poll
+          forever. Contributes to [needs_intervention] at [>= 2]. Zero in fresh
+          and older snapshots. Reset by a fully-converged review cycle
+          ([Respond_ok] for [Review_comments]) and by
+          [reset_intervention_state]. *)
   start_attempts_without_pr : int;
   conflict_noop_count : int;
   no_commits_push_count : int;
@@ -200,6 +211,7 @@ val intervention_reason_of_fields :
   push_failure_count:int ->
   rebase_failure_count:int ->
   pr_body_artifact_miss_count:int ->
+  review_unresolved_cycle_count:int ->
   string option
 (** Raw-field form of {!intervention_reason}. This is the canonical pure
     decision for callers that reconstruct agent status from persisted telemetry
@@ -216,7 +228,8 @@ val needs_intervention : t -> bool
       [(not has_pr) && start_attempts_without_pr >= 2],
       [conflict_noop_count >= 2], [no_commits_push_count >= 2],
       [context_exhaustion_count >= 2], [push_failure_count >= 3],
-      [rebase_failure_count >= 2], [pr_body_artifact_miss_count >= 2]. *)
+      [rebase_failure_count >= 2], [pr_body_artifact_miss_count >= 2],
+      [review_unresolved_cycle_count >= 2]. *)
 
 val needs_intervention_of_fields :
   merged:bool ->
@@ -232,6 +245,7 @@ val needs_intervention_of_fields :
   push_failure_count:int ->
   rebase_failure_count:int ->
   pr_body_artifact_miss_count:int ->
+  review_unresolved_cycle_count:int ->
   bool
 (** [Option.is_some (intervention_reason_of_fields ...)]. *)
 
@@ -436,6 +450,16 @@ val increment_pr_body_artifact_miss_count : t -> t
 val reset_pr_body_artifact_miss_count : t -> t
 (** Reset [pr_body_artifact_miss_count] to 0. *)
 
+val increment_review_unresolved_cycle_count : t -> t
+(** Record a Review_comments session that completed cleanly but left at least
+    one delivered comment without a posted reply-and-resolve. Called from
+    [Orchestrator.apply_respond_outcome] on [Respond_review_unresolved]. After 2
+    such consecutive cycles, [needs_intervention] triggers — the retry-once-
+    then-intervene contract shared with [pr_body_artifact_miss_count]. *)
+
+val reset_review_unresolved_cycle_count : t -> t
+(** Reset [review_unresolved_cycle_count] to 0. *)
+
 val set_checks_passing : t -> bool -> t
 (** Set the checks_passing flag from GitHub CI status. *)
 
@@ -639,6 +663,7 @@ val restore :
   is_draft:bool ->
   pr_body_delivered:bool ->
   pr_body_artifact_miss_count:int ->
+  ?review_unresolved_cycle_count:int ->
   start_attempts_without_pr:int ->
   conflict_noop_count:int ->
   no_commits_push_count:int ->

--- a/lib_core/review_service.ml
+++ b/lib_core/review_service.ml
@@ -268,40 +268,18 @@ let parse_error_message body =
       | _ -> None)
   | _ -> None
 
-type wontfix_entry = { id : string; reason : string }
-[@@deriving show, eq, sexp_of, compare]
-
-let parse_wontfix_artifact body : (wontfix_entry list, string) Result.t =
-  let nonblank_string_opt = function
-    | `String s ->
-        let s = String.strip s in
-        if String.is_empty s then None else Some s
-    | `Null -> None
-    | _ -> None
+(* Composite finding ids ([Findings_registry.make_key]) contain '/' and '#'
+   and so cannot name a file verbatim. The supervisor slugs the id into a
+   filesystem-safe filename, prints it on the finding's prompt block, and
+   inverts the same mapping over the delivered findings post-session — the
+   agent copies a filename, it never encodes anything itself. *)
+let wontfix_filename_of_id id =
+  let slug =
+    String.map id ~f:(fun c ->
+        if Char.is_alphanum c || Char.equal c '.' || Char.equal c '-' then c
+        else '_')
   in
-  let trimmed = String.strip body in
-  if String.is_empty trimmed then Ok []
-  else
-    match Yojson.Safe.from_string trimmed with
-    | exception Yojson.Json_error msg ->
-        Error (Printf.sprintf "wontfix artifact: %s" msg)
-    | `List entries ->
-        let field_nonblank field entry =
-          match Json.field field entry with
-          | Some v -> nonblank_string_opt v
-          | None -> None
-        in
-        let parsed =
-          List.filter_map entries ~f:(fun entry ->
-              match entry with
-              | `Assoc _ ->
-                  let id = field_nonblank "id" entry in
-                  let reason = field_nonblank "reason" entry in
-                  Option.map2 id reason ~f:(fun id reason -> { id; reason })
-              | _ -> None)
-        in
-        Ok parsed
-    | _ -> Error "wontfix artifact must be a JSON array"
+  slug ^ ".md"
 
 (* {2 Inline tests} *)
 
@@ -457,50 +435,15 @@ let%test "parse_outcome: partial lastReply -> None (skipped)" =
   | Ok o -> Option.is_none o.last_reply
   | Error _ -> false
 
-let%test "parse_wontfix_artifact: empty string -> Ok []" =
-  match parse_wontfix_artifact "" with
-  | Ok [] -> true
-  | Ok _ -> false
-  | Error _ -> false
+let%test "wontfix_filename_of_id: composite key slugs to safe filename" =
+  String.equal
+    (wontfix_filename_of_id "coderabbit/acme/widgets#42/f-12")
+    "coderabbit_acme_widgets_42_f-12.md"
 
-let%test "parse_wontfix_artifact: whitespace-only -> Ok []" =
-  match parse_wontfix_artifact "   \n\t  " with
-  | Ok [] -> true
-  | Ok _ -> false
-  | Error _ -> false
+let%test "wontfix_filename_of_id: dots and dashes preserved" =
+  String.equal (wontfix_filename_of_id "svc/a.b#1/x-1.v2") "svc_a.b_1_x-1.v2.md"
 
-let%test "parse_wontfix_artifact: empty array -> Ok []" =
-  match parse_wontfix_artifact "[]" with
-  | Ok [] -> true
-  | Ok _ -> false
-  | Error _ -> false
-
-let%test "parse_wontfix_artifact: well-formed entries" =
-  let raw =
-    {|[{"id":" a ","reason":" out of scope "},{"id":"b","reason":"false positive"}]|}
-  in
-  match parse_wontfix_artifact raw with
-  | Ok [ a; b ] ->
-      String.equal a.id "a"
-      && String.equal a.reason "out of scope"
-      && String.equal b.id "b"
-      && String.equal b.reason "false positive"
-  | Ok _ -> false
-  | Error _ -> false
-
-let%test "parse_wontfix_artifact: malformed entries skipped, valid ones kept" =
-  let raw =
-    {|[{"id":"a","reason":"r"},{"id":"only-id"},{"reason":"only-r"},{"id":"  ","reason":"r"},{"id":"b","reason":"  "}]|}
-  in
-  match parse_wontfix_artifact raw with
-  | Ok [ e ] -> String.equal e.id "a" && String.equal e.reason "r"
-  | Ok _ -> false
-  | Error _ -> false
-
-let%test "parse_wontfix_artifact: invalid JSON -> Error" =
-  match parse_wontfix_artifact "not json" with Error _ -> true | Ok _ -> false
-
-let%test "parse_wontfix_artifact: object instead of array -> Error" =
-  match parse_wontfix_artifact {|{"id":"a","reason":"r"}|} with
-  | Error _ -> true
-  | Ok _ -> false
+let%test "wontfix_filename_of_id: never contains a path separator" =
+  List.for_all [ "a/b/c"; "/"; ""; "a b\tc"; "..//.."; "\\evil" ] ~f:(fun id ->
+      (not (String.contains (wontfix_filename_of_id id) '/'))
+      && String.is_suffix (wontfix_filename_of_id id) ~suffix:".md")

--- a/lib_core/review_service.mli
+++ b/lib_core/review_service.mli
@@ -147,16 +147,11 @@ val parse_error_message : string -> string option
 
 (** {2 Wontfix artifact} *)
 
-type wontfix_entry = { id : string; reason : string }
-[@@deriving show, eq, sexp_of, compare]
-
-val parse_wontfix_artifact :
-  string -> (wontfix_entry list, string) Stdlib.Result.t
-(** Decode the agent-authored [findings_wontfix.json] artifact: a JSON array of
-    [{id, reason}] objects. Returns [Ok []] on the empty string, an empty array,
-    or a missing file — callers normalize those cases the same way: no findings
-    declared wontfix.
-
-    Total over arbitrary input — invalid JSON or schema returns [Error _] rather
-    than raising. Entries with missing/empty [id] or [reason] are skipped (not
-    an error) so a single malformed row doesn't poison the whole list. *)
+val wontfix_filename_of_id : string -> string
+(** Filesystem-safe filename for a finding's wontfix file: the composite finding
+    id with every character outside [[A-Za-z0-9.-]] replaced by ['_'], plus a
+    [".md"] suffix. Composite ids ({!Findings_registry.make_key}) contain ['/']
+    and ['#'], so they cannot name a file verbatim; the supervisor prints this
+    filename on the finding's prompt block and inverts the same mapping over the
+    delivered findings post-session — the agent only ever copies a filename.
+    Total; never raises. *)

--- a/lib_core/types.ml
+++ b/lib_core/types.ml
@@ -124,6 +124,12 @@ module Comment = struct
       commit_sha : string option; [@yojson.default None]
       original_commit_sha : string option; [@yojson.default None]
       outdated : bool; [@yojson.default false]
+      last_reply_author : string option; [@yojson.default None]
+          (** Login of the last reply's author; [None] for opener-only threads.
+              When it equals the viewer login, the thread's last word is onton's
+              own posted reply (co-reviewers open threads, they don't correspond
+              mid-thread), so a re-delivery only needs the resolve retried — not
+              a duplicate reply. *)
     }
     [@@deriving show, eq, sexp_of, compare, yojson]
   end

--- a/lib_core/types.mli
+++ b/lib_core/types.mli
@@ -98,6 +98,13 @@ module Comment : sig
     commit_sha : string option; [@yojson.default None]
     original_commit_sha : string option; [@yojson.default None]
     outdated : bool; [@yojson.default false]
+    last_reply_author : string option; [@yojson.default None]
+        (** Login of the last reply's author; [None] for opener-only threads.
+            When it equals the viewer login, the thread's last word is onton's
+            own posted reply — position disambiguates authorship even when a
+            human co-reviews from the same account, because co-reviewers open
+            threads and never correspond mid-thread. A re-delivered thread in
+            that state only needs its resolve retried, not a duplicate reply. *)
   }
   [@@deriving show, eq, sexp_of, compare, yojson]
 

--- a/lib_test/test_generators.ml
+++ b/lib_test/test_generators.ml
@@ -69,6 +69,7 @@ let gen_comment =
           commit_sha = None;
           original_commit_sha = None;
           outdated;
+          last_reply_author = None;
         })
 
 let gen_patch =

--- a/test/dune
+++ b/test/dune
@@ -11,6 +11,13 @@
  (ocamlc_flags (:standard -w -40-42)))
 
 (test
+ (name test_comment_responses_properties)
+ (modules test_comment_responses_properties)
+ (libraries onton_core qcheck-core qcheck-core.runner base)
+ (ocamlopt_flags (:standard -w -40-42))
+ (ocamlc_flags (:standard -w -40-42)))
+
+(test
  (name test_github_merge_commit_null)
  (modules test_github_merge_commit_null)
  (libraries onton onton_core yojson))

--- a/test/dune
+++ b/test/dune
@@ -4,6 +4,11 @@
  (libraries onton onton_core))
 
 (test
+ (name test_project_store)
+ (modules test_project_store)
+ (libraries onton unix))
+
+(test
  (name test_automerge_deadline_properties)
  (modules test_automerge_deadline_properties)
  (libraries onton onton_core onton_test_support qcheck-core qcheck-core.runner)

--- a/test/test_action_outcome_properties.ml
+++ b/test/test_action_outcome_properties.ml
@@ -87,6 +87,7 @@ let () =
       Orchestrator.Respond_retry_push;
       Orchestrator.Respond_skip_empty;
       Orchestrator.Respond_pr_body_miss;
+      Orchestrator.Respond_review_unresolved;
     ]
   in
   let respond_kinds =
@@ -423,6 +424,7 @@ let () =
       Orchestrator.Respond_retry_push;
       Orchestrator.Respond_stale;
       Orchestrator.Respond_pr_body_miss;
+      Orchestrator.Respond_review_unresolved;
     ]
   in
   let prop =
@@ -512,6 +514,88 @@ let () =
   in
   QCheck2.Test.check_exn prop;
   Stdlib.print_endline "AO-11 passed"
+
+(* ========== AO-12: Respond_review_unresolved retry semantics ========== *)
+
+(* Respond_review_unresolved must: (a) clear busy so the next poll's
+   Review_comments re-enqueue can deliver, (b) increment
+   review_unresolved_cycle_count by exactly 1 each call. Encodes the same
+   retry-once-then-intervene contract as AO-10 for the review loop — the
+   loop's only terminator, since the agent cannot resolve threads itself. *)
+let () =
+  let prop =
+    QCheck2.Test.make ~name:"AO-12: Respond_review_unresolved retry semantics"
+      (QCheck2.Gen.return ()) (fun () ->
+        try
+          let orch, patches, gameplan, pid = bootstrap_one () in
+          let orch =
+            make_busy orch patches gameplan pid Operation_kind.Review_comments
+          in
+          let before =
+            (Orchestrator.agent orch pid)
+              .Patch_agent.review_unresolved_cycle_count
+          in
+          let orch =
+            Orchestrator.apply_respond_outcome orch pid
+              Operation_kind.Review_comments
+              Orchestrator.Respond_review_unresolved
+          in
+          let a = Orchestrator.agent orch pid in
+          (not a.Patch_agent.busy)
+          && a.Patch_agent.review_unresolved_cycle_count = before + 1
+        with _ -> false)
+  in
+  QCheck2.Test.check_exn prop;
+  Stdlib.print_endline "AO-12 passed"
+
+(* ========== AO-13: Respond_ok + Review_comments resets the cycle count
+   ========== *)
+
+(* The cap [review_unresolved_cycle_count >= 2] must count consecutive
+   non-converged cycles, not lifetime ones. A converged cycle (every delivered
+   comment replied to and resolved) resets the counter, so an old
+   non-convergence cannot combine with a later single one to trigger
+   intervention. Respond_ok for other kinds must NOT reset it. *)
+let () =
+  let prop =
+    QCheck2.Test.make
+      ~name:"AO-13: Respond_ok + Review_comments resets cycle count"
+      (QCheck2.Gen.return ()) (fun () ->
+        try
+          let orch, patches, gameplan, pid = bootstrap_one () in
+          let orch =
+            make_busy orch patches gameplan pid Operation_kind.Review_comments
+          in
+          let orch =
+            Orchestrator.apply_respond_outcome orch pid
+              Operation_kind.Review_comments
+              Orchestrator.Respond_review_unresolved
+          in
+          assert (
+            (Orchestrator.agent orch pid)
+              .Patch_agent.review_unresolved_cycle_count = 1);
+          (* Respond_ok on an unrelated kind leaves the counter alone. *)
+          let orch = make_busy orch patches gameplan pid Operation_kind.Human in
+          let orch =
+            Orchestrator.apply_respond_outcome orch pid Operation_kind.Human
+              Orchestrator.Respond_ok
+          in
+          assert (
+            (Orchestrator.agent orch pid)
+              .Patch_agent.review_unresolved_cycle_count = 1);
+          let orch =
+            make_busy orch patches gameplan pid Operation_kind.Review_comments
+          in
+          let orch =
+            Orchestrator.apply_respond_outcome orch pid
+              Operation_kind.Review_comments Orchestrator.Respond_ok
+          in
+          (Orchestrator.agent orch pid)
+            .Patch_agent.review_unresolved_cycle_count = 0
+        with _ -> false)
+  in
+  QCheck2.Test.check_exn prop;
+  Stdlib.print_endline "AO-13 passed"
 
 (* AO-surface: thread a bootstrapped orchestrator through every state
    transition / accessor on the orchestrator decision surface and assert it

--- a/test/test_comment_responses_properties.ml
+++ b/test/test_comment_responses_properties.ml
@@ -31,6 +31,9 @@ let gen_comment =
   let* id = gen_comment_id in
   let* thread_id = option (map (fun n -> Printf.sprintf "T%d" n) nat_small) in
   let* outdated = bool in
+  let* last_reply_author =
+    option (oneof_list [ "onton-bot"; "alice"; "reviewer"; "" ])
+  in
   return
     Types.Comment.
       {
@@ -42,7 +45,7 @@ let gen_comment =
         commit_sha = None;
         original_commit_sha = None;
         outdated;
-        last_reply_author = None;
+        last_reply_author;
       }
 
 let gen_entry =
@@ -56,6 +59,22 @@ let gen_delivered =
   QCheck2.Gen.list_size (QCheck2.Gen.int_range 0 20) gen_comment
 
 let gen_entries = QCheck2.Gen.list_size (QCheck2.Gen.int_range 0 20) gen_entry
+
+(* CR-RETRY-1: resolve-retry classification is a total equality check against
+   the authenticated viewer, and unknown viewers fail open to false. *)
+let prop_is_resolve_retry =
+  QCheck2.Test.make ~count:500
+    ~name:"CR-RETRY-1: is_resolve_retry matches viewer-authored last reply"
+    QCheck2.Gen.(
+      pair (option (oneof_list [ "onton-bot"; "alice"; "" ])) gen_comment)
+    (fun (viewer_login, comment) ->
+      try
+        Bool.equal
+          (Comment_responses.is_resolve_retry ~viewer_login comment)
+          (Option.equal String.equal comment.Types.Comment.last_reply_author
+             viewer_login
+          && Option.is_some viewer_login)
+      with _ -> false)
 
 (* CR-TOT-1: entry_of_file is total over arbitrary filename/content pairs. *)
 let prop_entry_of_file_total =
@@ -235,6 +254,7 @@ let () =
     [
       prop_entry_of_file_total;
       prop_entry_of_file_sound;
+      prop_is_resolve_retry;
       prop_plan_total;
       prop_plan_partitions_delivered;
       prop_plan_actions_iff_entry;

--- a/test/test_comment_responses_properties.ml
+++ b/test/test_comment_responses_properties.ml
@@ -1,0 +1,248 @@
+(* @archlint.module test
+   @archlint.domain comment-responses *)
+
+open Base
+open Onton_core
+
+(* Filenames: mix of valid ("<int>.md", "<int>", "<int>.txt") and junk. *)
+let gen_filename =
+  let open QCheck2.Gen in
+  oneof_weighted
+    [
+      ( 3,
+        let* id = int_range (-100) 100_000 in
+        let* ext = oneof_list [ ".md"; ".txt"; "" ] in
+        return (Int.to_string id ^ ext) );
+      (1, oneof_list [ "notes.md"; "comment-12.md"; ".md"; ""; "12a.md"; "a12" ]);
+    ]
+
+let gen_contents =
+  let open QCheck2.Gen in
+  oneof_weighted
+    [
+      (3, string_size ~gen:printable (int_range 1 200));
+      (1, oneof_list [ ""; "   "; " \n\t "; "\n\n" ]);
+    ]
+
+let gen_comment_id = QCheck2.Gen.int_range (-5) 40
+
+let gen_comment =
+  let open QCheck2.Gen in
+  let* id = gen_comment_id in
+  let* thread_id = option (map (fun n -> Printf.sprintf "T%d" n) nat_small) in
+  let* outdated = bool in
+  return
+    Types.Comment.
+      {
+        id = Types.Comment_id.of_int id;
+        thread_id;
+        body = "body";
+        path = None;
+        line = None;
+        commit_sha = None;
+        original_commit_sha = None;
+        outdated;
+        last_reply_author = None;
+      }
+
+let gen_entry =
+  let open QCheck2.Gen in
+  let* comment_id = gen_comment_id in
+  let* response = string_size ~gen:printable (int_range 1 50) in
+  let response = "r" ^ response in
+  return Comment_responses.{ comment_id; response }
+
+let gen_delivered =
+  QCheck2.Gen.list_size (QCheck2.Gen.int_range 0 20) gen_comment
+
+let gen_entries = QCheck2.Gen.list_size (QCheck2.Gen.int_range 0 20) gen_entry
+
+(* CR-TOT-1: entry_of_file is total over arbitrary filename/content pairs. *)
+let prop_entry_of_file_total =
+  QCheck2.Test.make ~count:500 ~name:"CR-TOT-1: entry_of_file never raises"
+    QCheck2.Gen.(pair gen_filename gen_contents)
+    (fun (filename, contents) ->
+      try
+        ignore
+          (Comment_responses.entry_of_file ~filename ~contents
+            : Comment_responses.entry option);
+        true
+      with _ -> false)
+
+(* CR-DEC-1: a decoded entry's id round-trips the filename stem and its
+   response is the stripped contents (nonblank). *)
+let prop_entry_of_file_sound =
+  QCheck2.Test.make ~count:500
+    ~name:"CR-DEC-1: decoded entry matches stem and stripped contents"
+    QCheck2.Gen.(pair gen_filename gen_contents)
+    (fun (filename, contents) ->
+      match Comment_responses.entry_of_file ~filename ~contents with
+      | None -> true
+      | Some { comment_id; response } ->
+          let stem =
+            Stdlib.Filename.remove_extension (Stdlib.Filename.basename filename)
+          in
+          String.equal (Int.to_string comment_id) stem
+          && String.equal response (String.strip contents)
+          && not (String.is_empty response))
+
+(* CR-TOT-2: plan is total. *)
+let prop_plan_total =
+  QCheck2.Test.make ~count:500 ~name:"CR-TOT-2: plan never raises"
+    QCheck2.Gen.(pair gen_delivered gen_entries)
+    (fun (delivered, entries) ->
+      try
+        ignore
+          (Comment_responses.plan ~delivered ~entries
+            : Comment_responses.outcome);
+        true
+      with _ -> false)
+
+(* CR-PLAN-1: partition — every distinct delivered id is either actioned or
+   unanswered, never both; nothing else appears. *)
+let prop_plan_partitions_delivered =
+  QCheck2.Test.make ~count:500
+    ~name:"CR-PLAN-1: actions + unanswered partition distinct delivered ids"
+    QCheck2.Gen.(pair gen_delivered gen_entries)
+    (fun (delivered, entries) ->
+      let o = Comment_responses.plan ~delivered ~entries in
+      let action_ids =
+        List.map o.Comment_responses.actions ~f:(fun a ->
+            Types.Comment_id.to_int a.Comment_responses.comment_id)
+      in
+      let unanswered_ids =
+        List.map o.Comment_responses.unanswered ~f:Types.Comment_id.to_int
+      in
+      let combined = action_ids @ unanswered_ids in
+      let distinct_delivered =
+        List.map delivered ~f:(fun c ->
+            Types.Comment_id.to_int c.Types.Comment.id)
+        |> List.dedup_and_sort ~compare:Int.compare
+      in
+      List.equal Int.equal
+        (List.sort combined ~compare:Int.compare)
+        distinct_delivered
+      && not
+           (List.exists action_ids ~f:(fun id ->
+                List.mem unanswered_ids id ~equal:Int.equal)))
+
+(* CR-PLAN-2: an id is actioned iff some entry carries it. *)
+let prop_plan_actions_iff_entry =
+  QCheck2.Test.make ~count:500
+    ~name:"CR-PLAN-2: delivered id actioned iff an entry exists for it"
+    QCheck2.Gen.(pair gen_delivered gen_entries)
+    (fun (delivered, entries) ->
+      let o = Comment_responses.plan ~delivered ~entries in
+      let entry_ids =
+        List.map entries ~f:(fun e -> e.Comment_responses.comment_id)
+      in
+      List.for_all delivered ~f:(fun c ->
+          let id = Types.Comment_id.to_int c.Types.Comment.id in
+          let actioned =
+            List.exists o.Comment_responses.actions ~f:(fun a ->
+                Types.Comment_id.to_int a.Comment_responses.comment_id = id)
+          in
+          Bool.equal actioned (List.mem entry_ids id ~equal:Int.equal)))
+
+(* CR-PLAN-3: last entry wins — each action's response equals the response of
+   the last entry with that comment_id. *)
+let prop_plan_last_entry_wins =
+  QCheck2.Test.make ~count:500 ~name:"CR-PLAN-3: last entry wins"
+    QCheck2.Gen.(pair gen_delivered gen_entries)
+    (fun (delivered, entries) ->
+      let o = Comment_responses.plan ~delivered ~entries in
+      List.for_all o.Comment_responses.actions ~f:(fun a ->
+          let id = Types.Comment_id.to_int a.Comment_responses.comment_id in
+          match
+            List.filter entries ~f:(fun e ->
+                e.Comment_responses.comment_id = id)
+          with
+          | [] -> false
+          | matching ->
+              String.equal a.Comment_responses.response
+                (List.last_exn matching).Comment_responses.response))
+
+(* CR-PLAN-4: actions preserve first-occurrence delivered order and carry the
+   first occurrence's thread_id. *)
+let prop_plan_order_and_thread =
+  QCheck2.Test.make ~count:500
+    ~name:
+      "CR-PLAN-4: delivered order preserved; thread_id from first occurrence"
+    QCheck2.Gen.(pair gen_delivered gen_entries)
+    (fun (delivered, entries) ->
+      let o = Comment_responses.plan ~delivered ~entries in
+      let first_occurrence_order =
+        List.fold delivered ~init:[] ~f:(fun acc c ->
+            let id = Types.Comment_id.to_int c.Types.Comment.id in
+            if List.mem acc id ~equal:Int.equal then acc else acc @ [ id ])
+      in
+      let action_ids =
+        List.map o.Comment_responses.actions ~f:(fun a ->
+            Types.Comment_id.to_int a.Comment_responses.comment_id)
+      in
+      let expected_order =
+        List.filter first_occurrence_order ~f:(fun id ->
+            List.mem action_ids id ~equal:Int.equal)
+      in
+      List.equal Int.equal action_ids expected_order
+      && List.for_all o.Comment_responses.actions ~f:(fun a ->
+          let id = Types.Comment_id.to_int a.Comment_responses.comment_id in
+          match
+            List.find delivered ~f:(fun c ->
+                Types.Comment_id.to_int c.Types.Comment.id = id)
+          with
+          | None -> false
+          | Some c ->
+              Option.equal String.equal a.Comment_responses.thread_id
+                c.Types.Comment.thread_id))
+
+(* CR-PLAN-5: unmatched_entries are exactly the entries whose id is not
+   delivered, and they never intersect the actioned ids. *)
+let prop_unmatched_entries =
+  QCheck2.Test.make ~count:500
+    ~name:"CR-PLAN-5: unmatched_entries = entries with undelivered ids"
+    QCheck2.Gen.(pair gen_delivered gen_entries)
+    (fun (delivered, entries) ->
+      let unmatched = Comment_responses.unmatched_entries ~delivered ~entries in
+      let delivered_ids =
+        List.map delivered ~f:(fun c ->
+            Types.Comment_id.to_int c.Types.Comment.id)
+      in
+      List.for_all entries ~f:(fun e ->
+          let is_unmatched =
+            List.mem unmatched e ~equal:Comment_responses.equal_entry
+          in
+          Bool.equal is_unmatched
+            (not
+               (List.mem delivered_ids e.Comment_responses.comment_id
+                  ~equal:Int.equal))))
+
+(* CR-PLAN-6: no entries -> no actions, everything unanswered (boundary). *)
+let prop_no_entries_all_unanswered =
+  QCheck2.Test.make ~count:200
+    ~name:"CR-PLAN-6: empty entries -> all distinct delivered unanswered"
+    gen_delivered (fun delivered ->
+      let o = Comment_responses.plan ~delivered ~entries:[] in
+      List.is_empty o.Comment_responses.actions
+      && List.length o.Comment_responses.unanswered
+         = List.length
+             (List.dedup_and_sort ~compare:Int.compare
+                (List.map delivered ~f:(fun c ->
+                     Types.Comment_id.to_int c.Types.Comment.id))))
+
+let () =
+  let suite =
+    [
+      prop_entry_of_file_total;
+      prop_entry_of_file_sound;
+      prop_plan_total;
+      prop_plan_partitions_delivered;
+      prop_plan_actions_iff_entry;
+      prop_plan_last_entry_wins;
+      prop_plan_order_and_thread;
+      prop_unmatched_entries;
+      prop_no_entries_all_unanswered;
+    ]
+  in
+  let exit_code = QCheck_base_runner.run_tests ~verbose:true suite in
+  if exit_code <> 0 then Stdlib.exit exit_code

--- a/test/test_intervention_reason.ml
+++ b/test/test_intervention_reason.ml
@@ -161,13 +161,13 @@ let assert_raw_fields ~merged ~has_pr ~is_pr_missing ~session_given_up
     ~human_in_queue ~ci_failure_count ~start_attempts_without_pr
     ~conflict_noop_count ~no_commits_push_count ~context_exhaustion_count
     ~push_failure_count ~rebase_failure_count ~pr_body_artifact_miss_count
-    ~expected =
+    ~review_unresolved_cycle_count ~expected =
   let reason =
     Patch_agent.intervention_reason_of_fields ~merged ~has_pr ~is_pr_missing
       ~session_given_up ~human_in_queue ~ci_failure_count
       ~start_attempts_without_pr ~conflict_noop_count ~no_commits_push_count
       ~context_exhaustion_count ~push_failure_count ~rebase_failure_count
-      ~pr_body_artifact_miss_count
+      ~pr_body_artifact_miss_count ~review_unresolved_cycle_count
   in
   assert (Option.equal String.equal reason expected);
   assert (
@@ -176,7 +176,7 @@ let assert_raw_fields ~merged ~has_pr ~is_pr_missing ~session_given_up
          ~session_given_up ~human_in_queue ~ci_failure_count
          ~start_attempts_without_pr ~conflict_noop_count ~no_commits_push_count
          ~context_exhaustion_count ~push_failure_count ~rebase_failure_count
-         ~pr_body_artifact_miss_count)
+         ~pr_body_artifact_miss_count ~review_unresolved_cycle_count)
       (Option.is_some expected))
 
 let () =
@@ -184,12 +184,35 @@ let () =
     ~session_given_up:false ~human_in_queue:false ~ci_failure_count:0
     ~start_attempts_without_pr:0 ~conflict_noop_count:0 ~no_commits_push_count:0
     ~context_exhaustion_count:0 ~push_failure_count:0 ~rebase_failure_count:2
-    ~pr_body_artifact_miss_count:0 ~expected:(Some "rebase_failure_count>=2");
+    ~pr_body_artifact_miss_count:0 ~review_unresolved_cycle_count:0
+    ~expected:(Some "rebase_failure_count>=2");
   assert_raw_fields ~merged:false ~has_pr:true ~is_pr_missing:false
     ~session_given_up:false ~human_in_queue:true ~ci_failure_count:3
     ~start_attempts_without_pr:0 ~conflict_noop_count:0 ~no_commits_push_count:0
     ~context_exhaustion_count:0 ~push_failure_count:0 ~rebase_failure_count:0
-    ~pr_body_artifact_miss_count:0 ~expected:None;
+    ~pr_body_artifact_miss_count:0 ~review_unresolved_cycle_count:0
+    ~expected:None;
+  (* The review-loop cap fires like every other counter... *)
+  assert_raw_fields ~merged:false ~has_pr:true ~is_pr_missing:false
+    ~session_given_up:false ~human_in_queue:false ~ci_failure_count:0
+    ~start_attempts_without_pr:0 ~conflict_noop_count:0 ~no_commits_push_count:0
+    ~context_exhaustion_count:0 ~push_failure_count:0 ~rebase_failure_count:0
+    ~pr_body_artifact_miss_count:0 ~review_unresolved_cycle_count:2
+    ~expected:(Some "review_unresolved_cycle_count>=2");
+  (* ...respects the Human exemption... *)
+  assert_raw_fields ~merged:false ~has_pr:true ~is_pr_missing:false
+    ~session_given_up:false ~human_in_queue:true ~ci_failure_count:0
+    ~start_attempts_without_pr:0 ~conflict_noop_count:0 ~no_commits_push_count:0
+    ~context_exhaustion_count:0 ~push_failure_count:0 ~rebase_failure_count:0
+    ~pr_body_artifact_miss_count:0 ~review_unresolved_cycle_count:2
+    ~expected:None;
+  (* ...and stays quiet one increment below the cap. *)
+  assert_raw_fields ~merged:false ~has_pr:true ~is_pr_missing:false
+    ~session_given_up:false ~human_in_queue:false ~ci_failure_count:0
+    ~start_attempts_without_pr:0 ~conflict_noop_count:0 ~no_commits_push_count:0
+    ~context_exhaustion_count:0 ~push_failure_count:0 ~rebase_failure_count:0
+    ~pr_body_artifact_miss_count:0 ~review_unresolved_cycle_count:1
+    ~expected:None;
   print_endline "PASS: raw intervention field decisions stay in lockstep"
 
 (* Exercise the whole Patch_agent decision surface. Some transitions have
@@ -290,6 +313,7 @@ let () =
              ~conflict_noop_count:0 ~no_commits_push_count:0
              ~context_exhaustion_count:0 ~push_failure_count:0
              ~rebase_failure_count:0 ~pr_body_artifact_miss_count:0
+             ~review_unresolved_cycle_count:0
          in
          let needs_from_fields =
            Patch_agent.needs_intervention_of_fields ~merged:false ~has_pr:false
@@ -298,6 +322,7 @@ let () =
              ~conflict_noop_count:0 ~no_commits_push_count:0
              ~context_exhaustion_count:0 ~push_failure_count:0
              ~rebase_failure_count:0 ~pr_body_artifact_miss_count:0
+             ~review_unresolved_cycle_count:0
          in
          let rebase_reason =
            Patch_agent.intervention_reason_of_fields ~merged:false ~has_pr:true
@@ -306,6 +331,7 @@ let () =
              ~conflict_noop_count:0 ~no_commits_push_count:0
              ~context_exhaustion_count:0 ~push_failure_count:0
              ~rebase_failure_count:2 ~pr_body_artifact_miss_count:0
+             ~review_unresolved_cycle_count:0
          in
          let rebase_needs_intervention =
            Patch_agent.needs_intervention_of_fields ~merged:false ~has_pr:true
@@ -314,6 +340,7 @@ let () =
              ~conflict_noop_count:0 ~no_commits_push_count:0
              ~context_exhaustion_count:0 ~push_failure_count:0
              ~rebase_failure_count:2 ~pr_body_artifact_miss_count:0
+             ~review_unresolved_cycle_count:0
          in
          Bool.equal needs_from_fields (Option.is_some reason_from_fields)
          && Bool.equal rebase_needs_intervention (Option.is_some rebase_reason)));

--- a/test/test_intervention_reason.ml
+++ b/test/test_intervention_reason.ml
@@ -259,6 +259,8 @@ let () =
              (fun a -> Patch_agent.reset_push_failure_count a);
              (fun a -> Patch_agent.increment_rebase_failure_count a);
              (fun a -> Patch_agent.reset_rebase_failure_count a);
+             (fun a -> Patch_agent.increment_review_unresolved_cycle_count a);
+             (fun a -> Patch_agent.reset_review_unresolved_cycle_count a);
              (fun a -> Patch_agent.reset_ci_failure_count a);
              (fun a -> Patch_agent.reset_context_exhaustion_count a);
              (fun a -> Patch_agent.reset_pr_body_artifact_miss_count a);

--- a/test/test_project_store.ml
+++ b/test/test_project_store.ml
@@ -1,0 +1,24 @@
+open Onton
+
+let write_file path contents =
+  let oc = Stdlib.Out_channel.open_text path in
+  Fun.protect
+    ~finally:(fun () -> Stdlib.Out_channel.close oc)
+    (fun () -> Stdlib.Out_channel.output_string oc contents)
+
+let () =
+  let root =
+    Stdlib.Filename.concat
+      (Stdlib.Filename.get_temp_dir_name ())
+      (Printf.sprintf "onton-project-store-%d" (Unix.getpid ()))
+  in
+  let file_path = Stdlib.Filename.concat root "stale.md" in
+  let subdir = Stdlib.Filename.concat root "nested" in
+  Project_store.ensure_dir subdir;
+  write_file file_path "stale";
+  Project_store.reset_artifact_dir root;
+  assert (not (Stdlib.Sys.file_exists file_path));
+  assert (Stdlib.Sys.is_directory subdir);
+  Unix.rmdir subdir;
+  Unix.rmdir root;
+  print_endline "test_project_store: OK"

--- a/test/test_project_store.ml
+++ b/test/test_project_store.ml
@@ -1,3 +1,6 @@
+(* @archlint.module test
+   @archlint.domain project-store *)
+
 open Onton
 
 let write_file path contents =

--- a/test/test_review_service_properties.ml
+++ b/test/test_review_service_properties.ml
@@ -8,9 +8,9 @@ open Onton_core
 
     AGENTS.md mandates that pure modules be total — every parser must return a
     [Result] over arbitrary input rather than raising. The properties below fuzz
-    the four wire-shaped entry points ([parse_findings_response_string],
-    [parse_resolve_response_string], [parse_error_message],
-    [parse_wontfix_artifact]) plus the small enum coders. *)
+    the wire-shaped entry points ([parse_findings_response_string],
+    [parse_resolve_response_string], [parse_error_message]) plus
+    [wontfix_filename_of_id] and the small enum coders. *)
 
 (* ─────────────────────────────────────────────────────────────────────────
    Generators
@@ -152,9 +152,27 @@ let prop_error_total =
   totality ~name:"parse_error_message total" (fun s ->
       Review_service.parse_error_message s)
 
-let prop_wontfix_total =
-  totality ~name:"parse_wontfix_artifact total" (fun s ->
-      Review_service.parse_wontfix_artifact s)
+let prop_wontfix_filename_total_and_safe =
+  QCheck2.Test.make
+    ~name:"wontfix_filename_of_id total, path-safe, .md-suffixed" ~count:500
+    QCheck2.Gen.string (fun id ->
+      let filename = Review_service.wontfix_filename_of_id id in
+      (not (String.contains filename '/'))
+      && (not (String.contains filename '\\'))
+      && String.is_suffix filename ~suffix:".md"
+      && String.for_all filename ~f:(fun c ->
+          Char.is_alphanum c || Char.equal c '.' || Char.equal c '-'
+          || Char.equal c '_'))
+
+(* Injective up to the slug: ids that differ only in slugged-away characters
+   may collide (handled by the resolver), but the mapping must be a pure
+   function — equal ids always produce equal filenames. *)
+let prop_wontfix_filename_deterministic =
+  QCheck2.Test.make ~name:"wontfix_filename_of_id deterministic" ~count:200
+    QCheck2.Gen.string (fun id ->
+      String.equal
+        (Review_service.wontfix_filename_of_id id)
+        (Review_service.wontfix_filename_of_id id))
 
 (* All findings the parser keeps must round-trip the severity/outcome enums. *)
 let prop_findings_kept_have_known_enums =
@@ -357,22 +375,16 @@ let prop_parse_resolve_response_string_inline =
       let _ = Review_service.parse_resolve_response_string s in
       true)
 
-let prop_parse_wontfix_artifact_inline =
-  QCheck2.Test.make ~name:"parse_wontfix_artifact inline totality" ~count:200
-    QCheck2.Gen.string (fun s ->
-      let _ = Review_service.parse_wontfix_artifact s in
-      true)
-
 let () =
   let suite =
     [
       prop_findings_total;
       prop_resolve_total;
       prop_error_total;
-      prop_wontfix_total;
+      prop_wontfix_filename_total_and_safe;
+      prop_wontfix_filename_deterministic;
       prop_parse_error_message_inline;
       prop_parse_resolve_response_string_inline;
-      prop_parse_wontfix_artifact_inline;
       prop_findings_kept_have_known_enums;
       prop_severity_round_trip;
       prop_outcome_kind_round_trip;

--- a/test/test_state_properties.ml
+++ b/test/test_state_properties.ml
@@ -34,6 +34,7 @@ let update_comments_round_trips_pending =
           commit_sha = None;
           original_commit_sha = None;
           outdated = false;
+          last_reply_author = None;
         }
       in
       let state =


### PR DESCRIPTION
## What

Restructures how review-comment response/resolution works, following the pr-body artifact model, plus the structural fixes that fall out of it.

### Comment responses: agent writes files, supervisor replies & resolves
- Review agents no longer run `gh api .../replies` / `resolveReviewThread`. The prompt points each comment at `artifacts/<patch_id>/comment_responses/<comment_id>.md` (response text only, one file per comment); `gh` stays available for investigation but the response procedure never touches the forge.
- After the post-session push succeeds (`` `Ok`` from the session driver implies the push shipped), `Comment_responder` joins response files against the delivered comments and **replies then resolves** each match via new `Forge.S` operations (`reply_to_review_comment` REST, `resolve_review_thread` GraphQL). A "fixed in `<sha>`" reply can never precede the fix reaching the remote.
- Comments without a response file stay unresolved and re-deliver on the next poll — convergence is orchestrator-gated, not prompt-trusted.

### Loop termination cap
`review_unresolved_cycle_count` counts consecutive clean-but-non-converged review cycles (missing response file, failed reply/resolve, unaddressable comment). At `>= 2`, `needs_intervention` fires via the new `Respond_review_unresolved` outcome — the loop's only terminator now that the agent can't resolve threads itself. Converged cycles reset it. Persisted, default 0 for older snapshots.

### Full-thread delivery
The PR-state fetch now takes `comments(first: 50)` with author logins. Each unresolved thread still collapses to one `Comment.t` (identity from the opener — the REST reply endpoint requires the top-level id), but the body concatenates replies with attribution, so re-delivered threads show reviewer follow-ups and onton's own earlier reply.

### Reply dedup (co-reviewer aware)
`Comment.t` carries `last_reply_author`; when the thread's last word is a reply authored by the forge viewer (`Forge.viewer_login`, fetched lazily, cached), the responder retries the **resolve only** — no duplicate reply, no fresh response file required, and the prompt tags the comment `[response already posted]`. Purely positional: openers are always reviewer feedback even when a human co-reviews from the token's account (co-reviewers open threads, never correspond mid-thread). Unknown viewer fails open to a normal reply.

### Findings wontfix migrated to the same per-file pattern
`artifacts/<patch_id>/findings_wontfix/<slugged_id>.md` — composite finding ids contain `/`, so the supervisor slugs the filename and prints it on each finding's prompt block. Absence still means `addressed`; a present-but-blank/unreadable file now **fails closed** for that finding instead of silently flipping a deliberate wontfix to `addressed`. Shared `Project_store.reset_artifact_dir` clears both artifact directories at session setup so stale files never replay.

## Tests
- New pure module `Comment_responses` (decode, join, resolve-retry decision) with a 9-property QCheck2 suite (`test_comment_responses_properties.ml`)
- AO-12/AO-13 respond-outcome properties for the cycle counter; new variant added to AO-2/AO-9 pools
- Intervention-reason cases (fires at 2, quiet at 1, Human exemption)
- GraphQL parse tests: resolveReviewThread response, thread collapse/attribution/`last_reply_author`, wontfix filename safety properties
- Prompt tests rewritten for the artifact instructions, resolve-retry tagging, and absence of any forge-CLI instruction

`dune build`, `dune runtest`, `dune fmt`, and `check-no-raw-yojson` all clean.

## Known gaps (deliberate, not in scope)
- No reconciliation sweep for the crash window between push and respond — files are cleared and regenerated next cycle (convergent, wastes one agent pass).
- Threads >50 comments compute `last_reply_author` from a truncated window (logged in the query; pagination deferred until it ever occurs).
- No structured wontfix/disagreement channel on comments yet — a response file always resolves as "handled".

🤖 Generated with [Claude Code](https://claude.com/claude-code)