### PR TITLE
[failing-ci-details] Patch 5: Wire detail fetch + artifact publish into the Ci delivery path

### DIFF
--- a/lib/runner_fiber_impl.ml
+++ b/lib/runner_fiber_impl.ml
@@ -1365,7 +1365,6 @@ struct
                               Some "no current failures")
                       else None
                     in
-                    let ci_merge_queue_removal_checks = ref [] in
                     With_busy_guard.run ~patch_id (fun () ->
                         let result =
                           match ci_skip_reason with
@@ -1379,6 +1378,7 @@ struct
                               `Skip_empty
                           | None ->
                               with_session_slot (fun () ->
+                                  let ci_merge_queue_removal_checks = ref [] in
                                   Runtime.update_orchestrator runtime
                                     (fun orch ->
                                       Orchestrator.mark_running orch patch_id);

--- a/lib/runner_fiber_impl.ml
+++ b/lib/runner_fiber_impl.ml
@@ -2092,17 +2092,23 @@ struct
                                                                    .Ci_check
                                                                     .name msg);
                                                             None)
-                                                  with exn ->
-                                                    log_event runtime ~patch_id
-                                                      (Printf.sprintf
-                                                         "CI detail processing \
-                                                          failed for %s (%s) — \
-                                                          delivering metadata \
-                                                          only"
-                                                         check.Ci_check.name
-                                                         (Stdlib.Printexc
-                                                          .to_string exn));
-                                                    None
+                                                  with
+                                                  | Eio.Cancel.Cancelled _ as
+                                                    exn ->
+                                                      raise exn
+                                                  | exn ->
+                                                      log_event runtime
+                                                        ~patch_id
+                                                        (Printf.sprintf
+                                                           "CI detail \
+                                                            processing failed \
+                                                            for %s (%s) — \
+                                                            delivering \
+                                                            metadata only"
+                                                           check.Ci_check.name
+                                                           (Stdlib.Printexc
+                                                            .to_string exn));
+                                                      None
                                                 in
                                                 let detailed_checks =
                                                   Base.List.map checks_to_fetch

--- a/lib/runner_fiber_impl.ml
+++ b/lib/runner_fiber_impl.ml
@@ -1365,6 +1365,7 @@ struct
                               Some "no current failures")
                       else None
                     in
+                    let ci_merge_queue_removal_checks = ref [] in
                     With_busy_guard.run ~patch_id (fun () ->
                         let result =
                           match ci_skip_reason with
@@ -1416,6 +1417,8 @@ struct
                                                   ~pr_number:pr_num
                                               with
                                               | Ok (_ :: _ as real) ->
+                                                  ci_merge_queue_removal_checks :=
+                                                    real;
                                                   log_event runtime ~patch_id
                                                     (Printf.sprintf
                                                        "Fetched %d failing \
@@ -1985,14 +1988,141 @@ struct
                                                   ~base_branch:
                                                     base_branch_for_layer ()
                                               else
-                                                Prompt.render_ci_failure_prompt
+                                                let fetch_cap = 10 in
+                                                let checks_to_fetch, extra =
+                                                  Base.List.split_n
+                                                    failed_checks fetch_cap
+                                                in
+                                                if
+                                                  not (Base.List.is_empty extra)
+                                                then
+                                                  log_event runtime ~patch_id
+                                                    (Printf.sprintf
+                                                       "Skipping CI detail \
+                                                        fetch for %d check(s) \
+                                                        over cap — delivering \
+                                                        metadata only"
+                                                       (Base.List.length extra));
+                                                let current_head_oid =
+                                                  Base.Option.bind
+                                                    fresh_pr_state ~f:(fun ps ->
+                                                      ps.Pr_state.head_oid)
+                                                in
+                                                let is_merge_queue_removal_check
+                                                    check =
+                                                  Base.List.mem
+                                                    !ci_merge_queue_removal_checks
+                                                    check ~equal:Ci_check.equal
+                                                in
+                                                let head_oid_for_check check =
+                                                  match check.Ci_check.id with
+                                                  | Some _
+                                                    when not
+                                                           (is_merge_queue_removal_check
+                                                              check) ->
+                                                      current_head_oid
+                                                  | Some _ | None -> None
+                                                in
+                                                let detail_for_check check =
+                                                  try
+                                                    match
+                                                      Forge
+                                                      .check_failure_details
+                                                        ~check
+                                                    with
+                                                    | Error e ->
+                                                        log_event runtime
+                                                          ~patch_id
+                                                          (Printf.sprintf
+                                                             "CI detail fetch \
+                                                              failed for %s \
+                                                              (%s) — \
+                                                              delivering \
+                                                              metadata only"
+                                                             check.Ci_check.name
+                                                             (Forge.show_error e));
+                                                        None
+                                                    | Ok source -> (
+                                                        let enrichment =
+                                                          Ci_log_digest.digest
+                                                            source
+                                                        in
+                                                        let log =
+                                                          Base.Option.map
+                                                            source
+                                                              .Ci_log_digest.log
+                                                            ~f:
+                                                              Ci_log_digest
+                                                              .strip_log
+                                                        in
+                                                        match
+                                                          Project_store
+                                                          .publish_ci_check_artifact
+                                                            ~project_name
+                                                            ~patch_id ~check
+                                                            ?head_oid:
+                                                              (head_oid_for_check
+                                                                 check)
+                                                            ~summary_md:
+                                                              enrichment
+                                                                .Ci_log_digest
+                                                                 .summary_md
+                                                            ?log ()
+                                                        with
+                                                        | Ok artifact_dir ->
+                                                            Some
+                                                              Prompt.
+                                                                {
+                                                                  artifact_dir;
+                                                                  enrichment;
+                                                                }
+                                                        | Error msg ->
+                                                            log_event runtime
+                                                              ~patch_id
+                                                              (Printf.sprintf
+                                                                 "CI detail \
+                                                                  artifact \
+                                                                  publish \
+                                                                  failed for \
+                                                                  %s (%s) — \
+                                                                  delivering \
+                                                                  metadata \
+                                                                  only"
+                                                                 check
+                                                                   .Ci_check
+                                                                    .name msg);
+                                                            None)
+                                                  with exn ->
+                                                    log_event runtime ~patch_id
+                                                      (Printf.sprintf
+                                                         "CI detail processing \
+                                                          failed for %s (%s) — \
+                                                          delivering metadata \
+                                                          only"
+                                                         check.Ci_check.name
+                                                         (Stdlib.Printexc
+                                                          .to_string exn));
+                                                    None
+                                                in
+                                                let detailed_checks =
+                                                  Base.List.map checks_to_fetch
+                                                    ~f:(fun check ->
+                                                      ( check,
+                                                        detail_for_check check
+                                                      ))
+                                                  @ Base.List.map extra
+                                                      ~f:(fun check ->
+                                                        (check, None))
+                                                in
+                                                Prompt
+                                                .render_ci_failure_prompt_detailed
                                                   ~project_name ?agents_md
                                                   ?pr_number
                                                   ?patch:patch_for_layer
                                                   ~gameplan
                                                   ~base_branch:
                                                     base_branch_for_layer
-                                                  failed_checks
+                                                  detailed_checks
                                           | Patch_decision.Review_payload
                                               { comments } ->
                                               let current_head_sha =


### PR DESCRIPTION
## Patch 5: Wire detail fetch + artifact publish into the Ci delivery path

- In the Patch_decision.Ci_payload { failed_checks } prompt branch (lib/runner_fiber_impl.ml:1958-1979), replace the Prompt.render_ci_failure_prompt call: map failed_checks (first 10; if more, log_event the dropped count) to (check, detail option) pairs.
- Per check: Forge.check_failure_details ~check → on Error e: log_event (Printf.sprintf "CI detail fetch failed for %s (%s) — delivering metadata only" name (Forge.show_error e)); detail = None. On Ok source: let enrichment = Ci_log_digest.digest source; let log = Option.map source.log ~f:Ci_log_digest.strip_log; match Project_store.publish_ci_check_artifact ~project_name ~patch_id ~check ?head_oid ~summary_md:enrichment.summary_md ?log () with Ok dir -> Some { Prompt.artifact_dir = dir; enrichment } | Error msg -> log_event ...; None.
- head_oid comes from fresh_pr_state (Option.bind fresh_pr_state ~f:(fun ps -> ps.Pr_state.head_oid)), matching the Review/Findings branches' current_head_sha pattern (lib/runner_fiber_impl.ml:1982-1998); pass it only for checks whose id is present AND that are not merge-queue removal checks — checks appended by the merge_queue_removal_checks fetch ran on a different commit, so detect them by membership in that fetched list and omit head_oid for them.
- Render via Prompt.render_ci_failure_prompt_detailed with the same layer args as the existing call (project_name/agents_md/pr_number/patch_for_layer/gameplan/base_branch_for_layer).
- Leave untouched: the empty-failed_checks render_ci_failure_unknown_prompt branch, the freshness gate, Patch_decision, and the delivered_ci_run_ids recording at lib/runner_fiber_impl.ml:2104-2117 (it reads the payload, not the rendered prompt).

## Changes
- In the Patch_decision.Ci_payload { failed_checks } prompt branch (lib/runner_fiber_impl.ml:1958-1979), replace the Prompt.render_ci_failure_prompt call: map failed_checks (first 10; if more, log_event the dropped count) to (check, detail option) pairs.
- Per check: Forge.check_failure_details ~check → on Error e: log_event (Printf.sprintf "CI detail fetch failed for %s (%s) — delivering metadata only" name (Forge.show_error e)); detail = None. On Ok source: let enrichment = Ci_log_digest.digest source; let log = Option.map source.log ~f:Ci_log_digest.strip_log; match Project_store.publish_ci_check_artifact ~project_name ~patch_id ~check ?head_oid ~summary_md:enrichment.summary_md ?log () with Ok dir -> Some { Prompt.artifact_dir = dir; enrichment } | Error msg -> log_event ...; None.
- head_oid comes from fresh_pr_state (Option.bind fresh_pr_state ~f:(fun ps -> ps.Pr_state.head_oid)), matching the Review/Findings branches' current_head_sha pattern (lib/runner_fiber_impl.ml:1982-1998); pass it only for checks whose id is present AND that are not merge-queue removal checks — checks appended by the merge_queue_removal_checks fetch ran on a different commit, so detect them by membership in that fetched list and omit head_oid for them.
- Render via Prompt.render_ci_failure_prompt_detailed with the same layer args as the existing call (project_name/agents_md/pr_number/patch_for_layer/gameplan/base_branch_for_layer).
- Leave untouched: the empty-failed_checks render_ci_failure_unknown_prompt branch, the freshness gate, Patch_decision, and the delivered_ci_run_ids recording at lib/runner_fiber_impl.ml:2104-2117 (it reads the payload, not the rendered prompt).

## Reachability

- **Per-check artifact directories are written during a CI failure delivery**
  - `lib/runner_fiber_impl.ml` `Ci_payload prompt branch (line ~1958)` → `lib/github.ml` `check_failure_details` → `lib_core/ci_log_digest.ml` `digest` *(created by this gameplan)* → `lib/project_store.ml` `publish_ci_check_artifact`
- **The CI prompt cites artifact paths, teasers, and the do-not-refetch instruction**
  - `lib/runner_fiber_impl.ml` `Ci_payload prompt branch (line ~1958)` → `lib/prompt.ml` `render_ci_failure_prompt_detailed` → `lib/prompt.ml` `render_turn_layer_ci_detailed`
- **Checks are ranked by signal with low-signal aggregators collapsed**
  - `lib/runner_fiber_impl.ml` `Ci_payload prompt branch (line ~1958)` → `lib/prompt.ml` `render_turn_layer_ci_detailed`
- **Detail-fetch failures degrade a check to metadata-only rendering without blocking delivery**
  - `lib/runner_fiber_impl.ml` `Ci_payload prompt branch (line ~1958)` → `lib/github.ml` `check_failure_details` → `lib/prompt.ml` `render_turn_layer_ci_detailed`

## Files to Modify
- lib/runner_fiber_impl.ml (modify): In the Ci_payload prompt branch (~line 1958): fetch details per delivered check (cap 10), digest, publish artifacts, and render via render_ci_failure_prompt_detailed. Empty-failed_checks branch unchanged.

## Gameplan Specification

```
module FAILING_CI_DETAILS.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> After this gameplan, a CI failure delivery records each failing
> check's diagnostics on disk (check.json, summary.md, log.txt under
> artifacts/<patch_id>/ci/<key>/) and the agent prompt cites those
> paths with a diagnostic teaser, ranked by signal — replacing
> URL-only delivery and improvised gh calls. All extraction logic is
> pure and property-tested; every failure mode degrades per check to
> the previous metadata-only rendering.

Check.
Source.
Enrichment.
Log.
Delivery.

has-run-id? c: Check => Bool.
check-key-collision-same-run? c1: Check, c2: Check => Bool.

strip-log l: Log => Log.
digest s: Source => Enrichment.
summary-bytes e: Enrichment => Nat0.
summary-cap => Nat0.

hits-network? c: Check => Bool.
sends-token-to-redirect-host? c: Check => Bool.

delivered? d: Delivery, c: Check => Bool.
fetch-succeeded? d: Delivery, c: Check => Bool.
artifact-published? d: Delivery, c: Check => Bool.
prompt-cites? d: Delivery, c: Check => Bool.
metadata-only? d: Delivery, c: Check => Bool.
delivery-blocked-by-details? d: Delivery => Bool.
fetch-count d: Delivery => Nat0.
fetch-cap => Nat0.
instructs-no-refetch? d: Delivery => Bool.
---
> Digest output is bounded and stripping is idempotent.
all s: Source | summary-bytes (digest s) <= summary-cap.
all l: Log | strip-log (strip-log l) = strip-log l.

> Id-less checks never hit the network; no fetch ever sends the API
> token to the redirect host.
all c: Check, ~ (has-run-id? c) | ~ (hits-network? c).
all c: Check | ~ (sends-token-to-redirect-host? c).

> Delivered checks with fetched, published details are cited by the
> prompt; failed fetches render metadata-only; detail retrieval never
> blocks a delivery; fetches are capped.
all d: Delivery, c: Check, delivered? d c and fetch-succeeded? d c and artifact-published? d c | prompt-cites? d c.
all d: Delivery, c: Check, delivered? d c and ~ (fetch-succeeded? d c) | metadata-only? d c.
all d: Delivery | ~ (delivery-blocked-by-details? d).
all d: Delivery | fetch-count d <= fetch-cap.

> Every delivery with details instructs the agent not to re-fetch
> checks with gh.
all d: Delivery | instructs-no-refetch? d.
```

## Patch Specification

```
module FAILING_CI_DETAILS_PATCH_5.

> Delivery wiring: the Ci_payload branch fetches details for delivered
> checks, publishes per-check artifacts, and renders the detailed
> prompt. Detail failures degrade per check and never block delivery.

Check.
Delivery.

delivered? d: Delivery, c: Check => Bool.
fetch-succeeded? d: Delivery, c: Check => Bool.
artifact-published? d: Delivery, c: Check => Bool.
prompt-cites? d: Delivery, c: Check => Bool.
metadata-only? d: Delivery, c: Check => Bool.
delivery-blocked-by-details? d: Delivery => Bool.
fetch-count d: Delivery => Nat0.
fetch-cap => Nat0.
---
> Every delivered check whose details were fetched and published is
> cited by the prompt.
all d: Delivery, c: Check, delivered? d c and fetch-succeeded? d c and artifact-published? d c | prompt-cites? d c.

> A delivered check whose detail fetch or publish failed renders
> metadata-only (today's behavior).
all d: Delivery, c: Check, delivered? d c and ~ (fetch-succeeded? d c) | metadata-only? d c.

> Detail retrieval never blocks or errors a delivery.
all d: Delivery | ~ (delivery-blocked-by-details? d).

> Per-delivery detail fetches are capped.
all d: Delivery | fetch-count d <= fetch-cap.
```


## Implementation Notes

- Detail fetches are capped at 10 checks, but only the fetch/publish work is capped: checks beyond the cap are still passed to the detailed renderer as `(check, None)` so the prompt preserves metadata-only visibility for every delivered failure. The log message says those over-cap checks are delivered metadata-only.
- The runner records the concrete checks returned by `Forge.merge_queue_removal_checks` in the respond path and uses membership in that list to suppress `head_oid` when publishing artifacts. The synthetic merge-queue placeholder remains id-less and also gets no `head_oid`.
- The per-check enrichment path is wrapped in a local `try ... with` in addition to handling `Forge.Error` and publisher `Error`; any unexpected digest/publish exception degrades only that check to metadata-only and keeps the CI delivery moving.
- No public APIs changed. This patch only wires existing Patch 1-4 surfaces from `runner_fiber_impl.ml`: `Forge.check_failure_details`, `Ci_log_digest.digest`/`strip_log`, `Project_store.publish_ci_check_artifact`, and `Prompt.render_ci_failure_prompt_detailed`.

Spec/Evidence Mapping:
- Fetched and published details are cited by the prompt: `lib/runner_fiber_impl.ml` builds `(Ci_check.t * Prompt.ci_check_detail option)` pairs and calls `Prompt.render_ci_failure_prompt_detailed`; `dune build` and `dune runtest` passed.
- Failed fetch/publish/detail processing renders metadata-only: every failure branch returns `None` for that check and logs the degradation; `dune build` and `dune runtest` passed.
- Detail retrieval does not block delivery: the CI prompt is still rendered with metadata-only entries when details fail or are over cap; unexpected exceptions inside one check are caught locally; `dune build` and `dune runtest` passed.
- Fetch count is capped: only `Base.List.split_n failed_checks 10`'s first segment calls `Forge.check_failure_details`; remaining checks are appended as metadata-only; `dune build` and `dune runtest` passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI failure handling so more check details are shown when available, while gracefully falling back to metadata-only information when details can’t be fetched.
  * Kept failure prompts accurate by preserving the merge-queue failure marker and showing richer per-check results.
  * Reduced unnecessary detail fetching for lower-priority checks, helping avoid incomplete or noisy CI failure output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->