### PR TITLE
[codex] make CI failure cap configurable

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -35,6 +35,7 @@ type repo_coords = {
 type run_knobs = {
   poll_interval : float;
   max_concurrency : int;
+  max_ci_failures : int;
   headless : bool;
   patch_agent_provider : string option;
   patch_agent_effort : string option;
@@ -301,6 +302,7 @@ let finalize_run ~project_name ~repo_coords ~run_knobs ~backend_inputs
   let {
     poll_interval;
     max_concurrency;
+    max_ci_failures;
     headless;
     patch_agent_provider;
     patch_agent_effort;
@@ -318,7 +320,7 @@ let finalize_run ~project_name ~repo_coords ~run_knobs ~backend_inputs
   Project_store.save_config ~project_name ~github_owner ~github_repo ~backend
     ~model
     ~main_branch:(Branch.to_string main_branch)
-    ~poll_interval ~repo_root ~max_concurrency
+    ~poll_interval ~repo_root ~max_concurrency ~max_ci_failures
     ~url_scheme:(Option.map Managed_repo.string_of_url_scheme url_scheme)
     ();
   (* Refresh the agent-readable gameplan copy under artifacts/ so patch
@@ -337,6 +339,7 @@ let finalize_run ~project_name ~repo_coords ~run_knobs ~backend_inputs
       poll_interval;
       repo_root;
       max_concurrency;
+      max_ci_failures;
       headless;
       patch_agent_provider;
       patch_agent_effort;
@@ -353,7 +356,7 @@ let finalize_run ~project_name ~repo_coords ~run_knobs ~backend_inputs
       values. *)
 let resolve_config ~project ~gameplan_path ~github_token ~backend ~model
     ~main_branch ~poll_interval ~(repo_root : string option) ~max_concurrency
-    ~headless ~(clone_scheme : string option) =
+    ~(max_ci_failures : int option) ~headless ~(clone_scheme : string option) =
   let clone_scheme_override =
     match clone_scheme with
     | None -> None
@@ -385,6 +388,11 @@ let resolve_config ~project ~gameplan_path ~github_token ~backend ~model
     {
       poll_interval;
       max_concurrency;
+      (* Fresh/gameplan default; the resume path re-resolves against the
+         stored per-project value below. *)
+      max_ci_failures =
+        Option.value max_ci_failures
+          ~default:Patch_agent.default_max_ci_failures;
       headless;
       patch_agent_provider;
       patch_agent_effort;
@@ -649,12 +657,19 @@ let resolve_config ~project ~gameplan_path ~github_token ~backend ~model
                   in
                   (* Resume reuses the stored [poll_interval] and
                      [max_concurrency] rather than today's CLI defaults so a
-                     project's settled values survive without explicit flags. *)
+                     project's settled values survive without explicit flags.
+                     [max_ci_failures] can distinguish "flag passed" from
+                     "flag omitted" (it is optional at the CLI layer), so an
+                     explicit flag overrides the stored value; otherwise the
+                     stored value wins. *)
                   let run_knobs =
                     {
                       run_knobs with
                       poll_interval = stored.Project_store.poll_interval;
                       max_concurrency = stored.Project_store.max_concurrency;
+                      max_ci_failures =
+                        Option.value max_ci_failures
+                          ~default:stored.Project_store.max_ci_failures;
                     }
                   in
                   let backend_inputs =
@@ -709,7 +724,15 @@ type constructed_capabilities = {
 type built_fiber_env = (module FIBER_ENV)
 
 let setup_runtime env ~config ~gameplan ~existing_snapshot ~auto_merge =
-  let { Resolved_config.headless; project_name; main_branch; _ } = config in
+  let {
+    Resolved_config.headless;
+    project_name;
+    main_branch;
+    max_ci_failures;
+    _;
+  } =
+    config
+  in
   if headless then
     Sys.set_signal Sys.sigint
       (Sys.Signal_handle
@@ -721,10 +744,10 @@ let setup_runtime env ~config ~gameplan ~existing_snapshot ~auto_merge =
     match existing_snapshot with
     | Some snap ->
         Printf.eprintf "Resuming project %S from saved state.\n%!" project_name;
-        Runtime.create ~gameplan ~main_branch ~snapshot:snap ()
+        Runtime.create ~gameplan ~main_branch ~max_ci_failures ~snapshot:snap ()
     | None ->
         Printf.eprintf "Starting new project %S.\n%!" project_name;
-        Runtime.create ~gameplan ~main_branch ()
+        Runtime.create ~gameplan ~main_branch ~max_ci_failures ()
   in
   (* [--auto-merge] only seeds the initial state of a fresh project. On resume,
      each patch's persisted [automerge_enabled] wins so per-patch user toggles
@@ -1237,11 +1260,12 @@ let run_with_config ~no_lock ~auto_merge ~pr_ops (config : config) gameplan
 
 let run ~project ~gameplan_path ~github_token ~backend ~model
     ~(main_branch : Branch.t option) ~poll_interval ~(repo_root : string option)
-    ~max_concurrency ~headless ~no_lock ~auto_merge ~clone_scheme ~pr_ops =
+    ~max_concurrency ~max_ci_failures ~headless ~no_lock ~auto_merge
+    ~clone_scheme ~pr_ops =
   match
     resolve_config ~project ~gameplan_path ~github_token ~backend ~model
-      ~main_branch ~poll_interval ~repo_root ~max_concurrency ~headless
-      ~clone_scheme
+      ~main_branch ~poll_interval ~repo_root ~max_concurrency ~max_ci_failures
+      ~headless ~clone_scheme
   with
   | Error errs ->
       Base.List.iter errs ~f:(fun e -> Printf.eprintf "Error: %s\n" e);
@@ -1443,6 +1467,20 @@ let max_concurrency_arg =
         ~doc:"Maximum number of concurrent backend sessions (default: 5)."
         ~env:(Cmd.Env.info "ONTON_MAX_CONCURRENCY"))
 
+let max_ci_failures_arg =
+  let open Cmdliner in
+  Arg.(
+    value
+    & opt (some int) None
+    & info [ "max-ci-failures" ] ~docv:"N"
+        ~doc:
+          "Consecutive CI-failure responses per patch before onton stops \
+           enqueueing CI feedback and flags the patch for intervention \
+           (default: 3). Persisted to the project config on first run; on \
+           resume the stored value applies unless this flag is passed, in \
+           which case the flag wins and is persisted."
+        ~env:(Cmd.Env.info "ONTON_MAX_CI_FAILURES"))
+
 let headless_arg =
   let open Cmdliner in
   Arg.(
@@ -1504,8 +1542,8 @@ let auto_merge_arg =
 let main_cmd ~pr_ops =
   let open Cmdliner in
   let run_cmd project gameplan_path github_token backend model main_branch
-      poll_interval repo_root max_concurrency headless upload_debug no_lock
-      prune no_refresh auto_merge clone_scheme =
+      poll_interval repo_root max_concurrency max_ci_failures headless
+      upload_debug no_lock prune no_refresh auto_merge clone_scheme =
     if prune then
       Stdlib.exit
         ( Eio_main.run @@ fun env ->
@@ -1541,14 +1579,16 @@ let main_cmd ~pr_ops =
       run ~project ~gameplan_path ~github_token
         ~backend:(Base.String.strip backend)
         ~model:(Base.String.strip model) ~main_branch ~poll_interval ~repo_root
-        ~max_concurrency ~headless ~no_lock ~auto_merge ~clone_scheme ~pr_ops)
+        ~max_concurrency ~max_ci_failures ~headless ~no_lock ~auto_merge
+        ~clone_scheme ~pr_ops)
   in
   let term =
     Term.(
       const run_cmd $ project_arg $ gameplan_path_arg $ github_token_arg
       $ backend_arg $ model_arg $ main_branch_arg $ poll_interval_arg $ repo_arg
-      $ max_concurrency_arg $ headless_arg $ upload_debug_arg $ no_lock_arg
-      $ prune_arg $ no_refresh_arg $ auto_merge_arg $ clone_scheme_arg)
+      $ max_concurrency_arg $ max_ci_failures_arg $ headless_arg
+      $ upload_debug_arg $ no_lock_arg $ prune_arg $ no_refresh_arg
+      $ auto_merge_arg $ clone_scheme_arg)
   in
   let info =
     Cmd.info "onton" ~version:Version.s

--- a/lib/activity_log_sink.ml
+++ b/lib/activity_log_sink.ml
@@ -62,6 +62,10 @@ let needs_intervention fields =
       (List.mem queue Operation_kind.Human ~equal:Operation_kind.equal)
     ~ci_failure_count:
       (Option.value (int_member fields "ci_failure_count") ~default:0)
+    ~max_ci_failures:
+      (Option.value
+         (int_member fields "max_ci_failures")
+         ~default:Patch_agent.default_max_ci_failures)
     ~start_attempts_without_pr:
       (Option.value (int_member fields "start_attempts_without_pr") ~default:0)
     ~conflict_noop_count:

--- a/lib/activity_log_sink.ml
+++ b/lib/activity_log_sink.ml
@@ -63,6 +63,10 @@ let needs_intervention fields =
     ~ci_failure_count:
       (Option.value (int_member fields "ci_failure_count") ~default:0)
     ~max_ci_failures:
+      (* Pre-field events default to the built-in cap. On resume,
+         Runtime.create re-stamps live agents from config, but historical log
+         reconstruction here cannot recover the cap that was active when the
+         event was emitted. *)
       (Option.value
          (int_member fields "max_ci_failures")
          ~default:Patch_agent.default_max_ci_failures)

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -36,6 +36,11 @@ type t = {
   agents : Patch_agent.t Map.M(Patch_id).t;
   outbox : patch_agent_message Map.M(Message_id).t;
   main_branch : Branch.t;
+  max_ci_failures : int;
+      (* Per-project CI-failure cap stamped onto every agent (including ones
+         added later via [add_agent]/[add_planned_patch]). Set once at startup
+         through [set_max_ci_failures]; defaults to
+         [Patch_agent.default_max_ci_failures]. *)
 }
 
 let create ~patches ~main_branch =
@@ -54,7 +59,13 @@ let create ~patches ~main_branch =
               (Printf.sprintf "Orchestrator.create: duplicate patch id %s"
                  (Patch_id.to_string p.Patch.id)))
   in
-  { graph; agents; outbox = Map.empty (module Message_id); main_branch }
+  {
+    graph;
+    agents;
+    outbox = Map.empty (module Message_id);
+    main_branch;
+    max_ci_failures = Patch_agent.default_max_ci_failures;
+  }
 
 let agent t patch_id =
   match Map.find t.agents patch_id with
@@ -680,10 +691,34 @@ let graph t = t.graph
 
 let restore ~graph ~agents ~outbox ~main_branch () =
   let outbox = Map.filter outbox ~f:(fun msg -> Map.mem agents msg.patch_id) in
-  { graph; agents; outbox; main_branch }
+  (* The snapshot's per-agent [max_ci_failures] values are trusted here for
+     round-trip identity; [Runtime.create] restamps the whole orchestrator
+     with the resolved config value right after restore, so the running cap
+     always comes from config, not from stale persisted state. *)
+  {
+    graph;
+    agents;
+    outbox;
+    main_branch;
+    max_ci_failures = Patch_agent.default_max_ci_failures;
+  }
 
 let main_branch t = t.main_branch
 let set_main_branch t branch = { t with main_branch = branch }
+
+(* Stamps every agent (not just the [t] field) so the pure per-agent decisions
+   ([Patch_decision.on_ci_failure], [Patch_agent.needs_intervention]) see the
+   configured cap. [Patch_agent.set_max_ci_failures] does not bump
+   [generation], so restamping restored agents leaves in-flight outbox
+   messages valid. *)
+let set_max_ci_failures t ~max_ci_failures =
+  {
+    t with
+    max_ci_failures;
+    agents =
+      Map.map t.agents ~f:(Patch_agent.set_max_ci_failures ~max_ci_failures);
+  }
+
 let agents_map t = t.agents
 
 let add_agent t ~patch_id ~branch ~base_branch ~pr_number =
@@ -702,7 +737,10 @@ let add_agent t ~patch_id ~branch ~base_branch ~pr_number =
     (* Do not seed agent.base_branch: persistence infers branch_rebased_onto
        from base_branch when the former is absent, which would fabricate a
        stale-rebase state on round-trip. The poller populates it next tick. *)
-    let agent = Patch_agent.create_adhoc ~patch_id ~branch ~pr_number in
+    let agent =
+      Patch_agent.create_adhoc ~patch_id ~branch ~pr_number
+        ~max_ci_failures:t.max_ci_failures
+    in
     let graph = Graph.add_patch_with_deps t.graph patch_id ~deps in
     { t with graph; agents = Map.set t.agents ~key:patch_id ~data:agent }
 
@@ -714,7 +752,10 @@ let add_planned_patch t (patch : Patch.t) ~deps =
        promotes it to [Ready_start] once its deps are satisfied. The caller is
        responsible for inserting [patch] into the gameplan in the same snapshot
        update so prompt composition can find it. *)
-    let agent = Patch_agent.create ~branch:patch.Patch.branch patch.Patch.id in
+    let agent =
+      Patch_agent.create ~branch:patch.Patch.branch
+        ~max_ci_failures:t.max_ci_failures patch.Patch.id
+    in
     let graph = Graph.add_patch_with_deps t.graph patch.Patch.id ~deps in
     { t with graph; agents = Map.set t.agents ~key:patch.Patch.id ~data:agent }
 

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -193,6 +193,16 @@ val all_agents : t -> Patch_agent.t list
 val graph : t -> Graph.t
 val main_branch : t -> Branch.t
 val set_main_branch : t -> Branch.t -> t
+
+val set_max_ci_failures : t -> max_ci_failures:int -> t
+(** Stamp the per-project CI-failure cap onto the orchestrator and every current
+    agent, and remember it for agents added later
+    ([add_agent]/[add_planned_patch]). Called once at startup by
+    [Runtime.create] with the resolved config value — both for fresh
+    orchestrators and for snapshot restores, so a changed [--max-ci-failures]
+    takes effect on resume. Does not bump agent [generation]s (config stamp, not
+    a state transition). *)
+
 val agents_map : t -> Patch_agent.t Map.M(Patch_id).t
 
 val add_agent :

--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -187,7 +187,10 @@ let apply_poll_result ?(merge_queue_ejection_confirmed = false) t patch_id
                 log "CI failure already delivered — skipping";
                 acc
             | Patch_decision.Cap_reached ->
-                log "CI failure cap reached (>=3) — skipping CI enqueue";
+                log
+                  (Printf.sprintf
+                     "CI failure cap reached (>=%d) — skipping CI enqueue"
+                     agent_before.Patch_agent.max_ci_failures);
                 acc)
         | Operation_kind.Review_comments | Operation_kind.Findings ->
             if is_new then

--- a/lib/persistence.ml
+++ b/lib/persistence.ml
@@ -188,6 +188,7 @@ let patch_agent_to_yojson (a : Patch_agent.t) =
         | None -> `Null
         | Some b -> Branch.yojson_of_t b );
       ("ci_failure_count", `Int a.ci_failure_count);
+      ("max_ci_failures", `Int a.max_ci_failures);
       ( "session_fallback",
         Patch_agent.yojson_of_session_fallback a.session_fallback );
       ( "human_messages",
@@ -357,6 +358,13 @@ let patch_agent_of_yojson ~gameplan json =
                |> Option.map ~f:Branch.of_string
              else None)
        ~ci_failure_count:(int_member "ci_failure_count" json)
+       ~max_ci_failures:
+         (* Legacy snapshots predate the field; the built-in default matches
+            their behavior. [Runtime.create] restamps from config right after
+            restore either way. *)
+         (Option.value
+            (int_member_opt "max_ci_failures" json)
+            ~default:Patch_agent.default_max_ci_failures)
        ~session_fallback ~human_messages ~inflight_human_messages ~ci_checks
        ~merge_ready:(bool_member "merge_ready" json)
        ~head_oid:(string_member_opt "head_oid" json)

--- a/lib/project_store.ml
+++ b/lib/project_store.ml
@@ -141,6 +141,10 @@ type stored_config = {
   poll_interval : float;
   repo_root : string;
   max_concurrency : int;
+  max_ci_failures : int; [@yojson.default Patch_agent.default_max_ci_failures]
+      (* Per-project CI-failure cap (see [Patch_agent.max_ci_failures]).
+         Defaulted on legacy configs predating the field; persisted so a value
+         set once via --max-ci-failures survives flag-less resumes. *)
   url_scheme : string option; [@yojson.default None]
       (* Persisted transport scheme for the managed clone's [origin]. [None]
          on legacy configs predating P0-D; on the next [ensure_managed_repo]
@@ -150,7 +154,7 @@ type stored_config = {
 [@@deriving yojson]
 
 let save_config ~project_name ~github_owner ~github_repo ~backend ~model
-    ~main_branch ~poll_interval ~repo_root ~max_concurrency
+    ~main_branch ~poll_interval ~repo_root ~max_concurrency ~max_ci_failures
     ?(url_scheme : string option = None) () =
   let dir = project_dir project_name in
   ensure_dir dir;
@@ -165,6 +169,7 @@ let save_config ~project_name ~github_owner ~github_repo ~backend ~model
       poll_interval;
       repo_root;
       max_concurrency;
+      max_ci_failures;
       url_scheme;
     }
   in
@@ -581,7 +586,8 @@ let%test "save_config persists no github_token and round-trips" =
       let project_name = "no-token" in
       save_config ~project_name ~github_owner:"o" ~github_repo:"r"
         ~backend:"claude" ~model:"sonnet" ~main_branch:"main" ~poll_interval:5.0
-        ~repo_root:"/tmp/r" ~max_concurrency:4 ();
+        ~repo_root:"/tmp/r" ~max_concurrency:4
+        ~max_ci_failures:Patch_agent.default_max_ci_failures ();
       let raw = read_file_for_test (config_path project_name) in
       (not (String.is_substring raw ~substring:"github_token"))
       &&
@@ -589,4 +595,5 @@ let%test "save_config persists no github_token and round-trips" =
       | Ok cfg ->
           String.equal cfg.project_name project_name
           && String.equal cfg.github_owner "o"
+          && Int.equal cfg.max_ci_failures Patch_agent.default_max_ci_failures
       | Error _ -> false)

--- a/lib/project_store.mli
+++ b/lib/project_store.mli
@@ -49,6 +49,11 @@ type stored_config = {
   poll_interval : float;
   repo_root : string;
   max_concurrency : int;
+  max_ci_failures : int;
+      (** Per-project cap on consecutive CI-failure responses (see
+          {!Patch_agent.max_ci_failures}). Defaults to
+          [Patch_agent.default_max_ci_failures] on legacy configs predating the
+          field. *)
   url_scheme : string option;
       (** Persisted transport for the managed [origin]. [None] on legacy configs
           predating P0-D; gets auto-resolved on the next
@@ -67,6 +72,7 @@ val save_config :
   poll_interval:float ->
   repo_root:string ->
   max_concurrency:int ->
+  max_ci_failures:int ->
   ?url_scheme:string option ->
   unit ->
   unit

--- a/lib/resolved_config.ml
+++ b/lib/resolved_config.ml
@@ -14,6 +14,7 @@ type config = {
   poll_interval : float;
   repo_root : string;
   max_concurrency : int;
+  max_ci_failures : int;
   headless : bool;
   patch_agent_provider : string option;
   patch_agent_effort : string option;
@@ -32,6 +33,7 @@ type t = {
   poll_interval : float;
   repo_root : string;
   max_concurrency : int;
+  max_ci_failures : int;
   headless : bool;
   patch_agent_provider : string option;
   patch_agent_effort : string option;
@@ -46,7 +48,7 @@ let known_patch_agent_providers = [ "anthropic"; "openai" ]
 let known_patch_agent_efforts = [ "low"; "medium"; "high" ]
 
 let validate_resolved_config ~project_name ~backend ~github_token ~github_owner
-    ~github_repo ~main_branch ~poll_interval ~max_concurrency
+    ~github_repo ~main_branch ~poll_interval ~max_concurrency ~max_ci_failures
     ~patch_agent_provider ~patch_agent_effort =
   let errors =
     Base.List.filter_map
@@ -70,6 +72,9 @@ let validate_resolved_config ~project_name ~backend ~github_token ~github_owner
         ( max_concurrency < 1,
           Printf.sprintf "--max-concurrency must be >= 1 (got %d)"
             max_concurrency );
+        ( max_ci_failures < 1,
+          Printf.sprintf "--max-ci-failures must be >= 1 (got %d)"
+            max_ci_failures );
         ( (match patch_agent_provider with
           | Some provider ->
               not
@@ -101,6 +106,7 @@ let of_config (config : config) =
       ~github_repo:config.github_repo ~main_branch:config.main_branch
       ~poll_interval:config.poll_interval
       ~max_concurrency:config.max_concurrency
+      ~max_ci_failures:config.max_ci_failures
       ~patch_agent_provider:config.patch_agent_provider
       ~patch_agent_effort:config.patch_agent_effort
   with
@@ -118,6 +124,7 @@ let of_config (config : config) =
           poll_interval = config.poll_interval;
           repo_root = config.repo_root;
           max_concurrency = config.max_concurrency;
+          max_ci_failures = config.max_ci_failures;
           headless = config.headless;
           patch_agent_provider = config.patch_agent_provider;
           patch_agent_effort = config.patch_agent_effort;

--- a/lib/resolved_config.mli
+++ b/lib/resolved_config.mli
@@ -14,6 +14,10 @@ type config = {
   poll_interval : float;
   repo_root : string;
   max_concurrency : int;
+  max_ci_failures : int;
+      (** Per-project cap on consecutive CI-failure responses per patch (see
+          {!Onton_core.Patch_agent.max_ci_failures}). Resolved from
+          [--max-ci-failures] / stored project config / built-in default. *)
   headless : bool;
   patch_agent_provider : string option;
   patch_agent_effort : string option;
@@ -36,6 +40,7 @@ type t = {
   poll_interval : float;
   repo_root : string;
   max_concurrency : int;
+  max_ci_failures : int;
   headless : bool;
   patch_agent_provider : string option;
   patch_agent_effort : string option;

--- a/lib/runtime.ml
+++ b/lib/runtime.ml
@@ -12,7 +12,8 @@ type snapshot = {
 
 type t = { mutex : Eio.Mutex.t; mutable snap : snapshot }
 
-let create ~gameplan ~(main_branch : Branch.t) ?snapshot () =
+let create ~gameplan ~(main_branch : Branch.t)
+    ?(max_ci_failures = Patch_agent.default_max_ci_failures) ?snapshot () =
   let snap =
     match snapshot with
     | Some s ->
@@ -30,6 +31,16 @@ let create ~gameplan ~(main_branch : Branch.t) ?snapshot () =
           gameplan;
           transcripts = Base.Hashtbl.create (module Patch_id);
         }
+  in
+  (* Config wins over whatever the snapshot (or the constructor default)
+     carried: the cap is a per-project setting resolved from the CLI flag and
+     stored config, re-applied on every startup. *)
+  let snap =
+    {
+      snap with
+      orchestrator =
+        Orchestrator.set_max_ci_failures snap.orchestrator ~max_ci_failures;
+    }
   in
   { mutex = Eio.Mutex.create (); snap }
 

--- a/lib/runtime.mli
+++ b/lib/runtime.mli
@@ -19,9 +19,16 @@ type snapshot = {
 type t
 
 val create :
-  gameplan:Gameplan.t -> main_branch:Branch.t -> ?snapshot:snapshot -> unit -> t
+  gameplan:Gameplan.t ->
+  main_branch:Branch.t ->
+  ?max_ci_failures:int ->
+  ?snapshot:snapshot ->
+  unit ->
+  t
 (** Build initial runtime state from a gameplan, optionally restoring a previous
-    [snapshot]. *)
+    [snapshot]. [max_ci_failures] is the resolved per-project CI-failure cap; it
+    is stamped onto the orchestrator (and every agent) in both the fresh and the
+    restore path, so config always wins over persisted values. *)
 
 (** {2 Atomic read access} *)
 

--- a/lib/tui.ml
+++ b/lib/tui.ml
@@ -362,9 +362,9 @@ let human_intervention_reason (agent : Patch_agent.t) =
              investigate why it vanished"
         | code when String.is_prefix code ~prefix:"ci_failure_count>=" ->
             Printf.sprintf
-              "CI failed %d times in a row \xe2\x80\x94 fix the failing checks \
-               below"
+              "CI failed %d/%d times in a row - fix the failing checks below"
               agent.Patch_agent.ci_failure_count
+              agent.Patch_agent.max_ci_failures
         | "start_attempts_without_pr>=2" ->
             Printf.sprintf
               "Could not open a PR after %d attempts \xe2\x80\x94 open it \

--- a/lib/tui.ml
+++ b/lib/tui.ml
@@ -306,6 +306,9 @@ type patch_view = {
           to render a "(queued)" suffix on busy statuses so a saturated Claude
           semaphore can be told apart from an actively running session. *)
   ci_failures : int;
+  ci_failure_cap : int;
+      (** The agent's [max_ci_failures] — carried so the render code can style
+          at-cap counts without hardcoding the default. *)
   dep_ids : (Patch_id.t * display_status) list;
   has_pr : bool;
   has_conflict : bool;
@@ -357,7 +360,7 @@ let human_intervention_reason (agent : Patch_agent.t) =
         | "pr_missing" ->
             "PR is missing from the remote \xe2\x80\x94 recreate it or \
              investigate why it vanished"
-        | "ci_failure_count>=3" ->
+        | code when String.is_prefix code ~prefix:"ci_failure_count>=" ->
             Printf.sprintf
               "CI failed %d times in a row \xe2\x80\x94 fix the failing checks \
                below"
@@ -486,6 +489,7 @@ let patch_view_of_agent (agent : Patch_agent.t)
     current_op;
     current_op_state = agent.Patch_agent.current_op_state;
     ci_failures = agent.ci_failure_count;
+    ci_failure_cap = agent.max_ci_failures;
     dep_ids;
     has_pr = Patch_agent.has_pr agent;
     has_conflict = agent.has_conflict;
@@ -649,7 +653,7 @@ let render_patch_row ~width ~selected ~now (pv : patch_view) =
     | None -> "  --  "
   in
   let ci_info =
-    if pv.ci_failures >= 3 then
+    if pv.ci_failures >= pv.ci_failure_cap then
       Term.styled [ Term.Sgr.fg_red ] (Printf.sprintf " CI×%d" pv.ci_failures)
     else if pv.ci_failures > 0 then
       Term.styled [ Term.Sgr.fg_yellow ]
@@ -892,7 +896,7 @@ let detail_info_rows (pv : patch_view) ~width ~now =
         match pv.intervention_reason with
         | Some r -> sanitize_text r
         | None ->
-            if pv.ci_failures >= 3 then
+            if pv.ci_failures >= pv.ci_failure_cap then
               Printf.sprintf "CI failed %d times in a row" pv.ci_failures
             else "Session failed unexpectedly"
       in

--- a/lib/tui.mli
+++ b/lib/tui.mli
@@ -97,6 +97,7 @@ type patch_view = {
   current_op : Operation_kind.t option;
   current_op_state : Patch_agent.op_state;
   ci_failures : int;
+  ci_failure_cap : int;
   dep_ids : (Patch_id.t * display_status) list;
   has_pr : bool;
   has_conflict : bool;

--- a/lib_core/patch_agent.ml
+++ b/lib_core/patch_agent.ml
@@ -25,6 +25,7 @@ type t = {
   base_branch : Branch.t option;
   notified_base_branch : Branch.t option;
   ci_failure_count : int;
+  max_ci_failures : int;
   session_fallback : session_fallback;
   human_messages : string list;
   inflight_human_messages : string list;
@@ -143,6 +144,7 @@ let has_pr t = Patch_pr_status.has_pr t.pr_status
 let is_pr_present t = Patch_pr_status.is_pr_present t.pr_status
 let is_pr_missing t = Patch_pr_status.is_missing t.pr_status
 let pr_number t = Patch_pr_status.pr_number t.pr_status
+let default_max_ci_failures = 3
 
 (* Single source of truth for the needs-intervention reason. Returns the
    first triggering condition's short label, or [None] when the predicate
@@ -152,7 +154,7 @@ let pr_number t = Patch_pr_status.pr_number t.pr_status
    event log so operators can grep for "why is this patch stuck?" by
    reason. *)
 let intervention_reason_of_fields ~merged ~has_pr ~is_pr_missing
-    ~session_given_up ~human_in_queue ~ci_failure_count
+    ~session_given_up ~human_in_queue ~ci_failure_count ~max_ci_failures
     ~start_attempts_without_pr ~conflict_noop_count ~no_commits_push_count
     ~context_exhaustion_count ~push_failure_count ~rebase_failure_count
     ~pr_body_artifact_miss_count ~review_unresolved_cycle_count =
@@ -172,7 +174,8 @@ let intervention_reason_of_fields ~merged ~has_pr ~is_pr_missing
        short-circuit on it to keep the predicate self-consistent even for
        callers that don't pre-filter by [merged]. *)
   else if human_in_queue then None
-  else if ci_failure_count >= 3 then Some "ci_failure_count>=3"
+  else if ci_failure_count >= max_ci_failures then
+    Some (Printf.sprintf "ci_failure_count>=%d" max_ci_failures)
   else if (not has_pr) && start_attempts_without_pr >= 2 then
     Some "start_attempts_without_pr>=2"
   else if conflict_noop_count >= 2 then Some "conflict_noop_count>=2"
@@ -192,7 +195,7 @@ let intervention_reason t =
     ~session_given_up:(equal_session_fallback t.session_fallback Given_up)
     ~human_in_queue:
       (List.mem t.queue Operation_kind.Human ~equal:Operation_kind.equal)
-    ~ci_failure_count:t.ci_failure_count
+    ~ci_failure_count:t.ci_failure_count ~max_ci_failures:t.max_ci_failures
     ~start_attempts_without_pr:t.start_attempts_without_pr
     ~conflict_noop_count:t.conflict_noop_count
     ~no_commits_push_count:t.no_commits_push_count
@@ -205,18 +208,18 @@ let intervention_reason t =
 let needs_intervention t = Option.is_some (intervention_reason t)
 
 let needs_intervention_of_fields ~merged ~has_pr ~is_pr_missing
-    ~session_given_up ~human_in_queue ~ci_failure_count
+    ~session_given_up ~human_in_queue ~ci_failure_count ~max_ci_failures
     ~start_attempts_without_pr ~conflict_noop_count ~no_commits_push_count
     ~context_exhaustion_count ~push_failure_count ~rebase_failure_count
     ~pr_body_artifact_miss_count ~review_unresolved_cycle_count =
   Option.is_some
     (intervention_reason_of_fields ~merged ~has_pr ~is_pr_missing
-       ~session_given_up ~human_in_queue ~ci_failure_count
+       ~session_given_up ~human_in_queue ~ci_failure_count ~max_ci_failures
        ~start_attempts_without_pr ~conflict_noop_count ~no_commits_push_count
        ~context_exhaustion_count ~push_failure_count ~rebase_failure_count
        ~pr_body_artifact_miss_count ~review_unresolved_cycle_count)
 
-let create ~branch patch_id =
+let create ~branch ?(max_ci_failures = default_max_ci_failures) patch_id =
   {
     patch_id;
     branch;
@@ -231,6 +234,7 @@ let create ~branch patch_id =
     base_branch = None;
     notified_base_branch = None;
     ci_failure_count = 0;
+    max_ci_failures;
     session_fallback = Fresh_available;
     human_messages = [];
     inflight_human_messages = [];
@@ -277,7 +281,7 @@ let create ~branch patch_id =
     delivered_ci_run_ids = [];
   }
 
-let create_adhoc ~patch_id ~branch ~pr_number =
+let create_adhoc ~patch_id ~branch ~pr_number ~max_ci_failures =
   {
     patch_id;
     branch;
@@ -292,6 +296,7 @@ let create_adhoc ~patch_id ~branch ~pr_number =
     base_branch = None;
     notified_base_branch = None;
     ci_failure_count = 0;
+    max_ci_failures;
     session_fallback = Fresh_available;
     human_messages = [];
     inflight_human_messages = [];
@@ -511,6 +516,11 @@ let increment_ci_failure_count t =
   { t with ci_failure_count = t.ci_failure_count + 1 }
 
 let reset_ci_failure_count t = { t with ci_failure_count = 0 }
+
+(* Config stamp, not a state transition: deliberately does not bump
+   [generation], so restoring a snapshot under a different --max-ci-failures
+   does not invalidate in-flight outbox messages. *)
+let set_max_ci_failures t ~max_ci_failures = { t with max_ci_failures }
 let set_ci_checks t checks = { t with ci_checks = checks }
 
 let record_delivered_ci_run_ids t ids =
@@ -597,8 +607,9 @@ let reset_busy t = if not t.busy then t else { t with busy = false }
 
 let restore ~patch_id ~branch ~pr_status ~has_session ~busy ~merged ~queue
     ~satisfies ~changed ~has_conflict ~base_branch ~notified_base_branch
-    ~ci_failure_count ~session_fallback ~human_messages ~inflight_human_messages
-    ~ci_checks ~merge_ready ?(head_oid = None) ?(review_decision = None)
+    ~ci_failure_count ?(max_ci_failures = default_max_ci_failures)
+    ~session_fallback ~human_messages ~inflight_human_messages ~ci_checks
+    ~merge_ready ?(head_oid = None) ?(review_decision = None)
     ?(unresolved_comment_count = 0) ~mergeability_unknown ~merge_queue_required
     ~merge_queue_entry ~merge_commit_sha ~base_contains_merged_siblings
     ~is_draft ~pr_body_delivered ~pr_body_artifact_miss_count
@@ -625,6 +636,7 @@ let restore ~patch_id ~branch ~pr_status ~has_session ~busy ~merged ~queue
     base_branch;
     notified_base_branch;
     ci_failure_count;
+    max_ci_failures;
     session_fallback;
     human_messages;
     inflight_human_messages;

--- a/lib_core/patch_agent.mli
+++ b/lib_core/patch_agent.mli
@@ -180,8 +180,10 @@ val create_adhoc :
   pr_number:Types.Pr_number.t ->
   max_ci_failures:int ->
   t
-(** Initial state for an ad-hoc patch: has PR, not busy, empty queue.
-    Corresponds to the spec's Add action:
+(** Initial state for an ad-hoc patch: has PR, not busy, empty queue. Ad-hoc
+    agents are created in a live orchestrator context
+    ({!Orchestrator.add_agent}), where the resolved project cap is already known
+    and must be stamped explicitly. Corresponds to the spec's Add action:
     {v PatchCtx ~> Add | p: Patch. --- has-pr' p. ~busy' p. ~in-gameplan' p. v}
 *)
 

--- a/lib_core/patch_agent.mli
+++ b/lib_core/patch_agent.mli
@@ -32,6 +32,14 @@ type t = private {
   base_branch : Types.Branch.t option;
   notified_base_branch : Types.Branch.t option;
   ci_failure_count : int;
+  max_ci_failures : int;
+      (** Per-project cap on consecutive CI-failure responses: at
+          [ci_failure_count >= max_ci_failures] the agent stops enqueueing [Ci]
+          feedback ({!Patch_decision.Cap_reached}) and contributes to
+          [needs_intervention]. Configuration, not state — stamped at
+          construction (and re-stamped on snapshot restore via
+          {!Orchestrator.set_max_ci_failures}) from the [--max-ci-failures] flag
+          / stored project config; defaults to {!default_max_ci_failures}. *)
   session_fallback : session_fallback;
   human_messages : string list;
   inflight_human_messages : string list;
@@ -156,13 +164,21 @@ type t = private {
 }
 [@@deriving show, eq, sexp_of, compare]
 
-val create : branch:Types.Branch.t -> Types.Patch_id.t -> t
-(** Initial state for a patch: no PR, not busy, empty queue. *)
+val default_max_ci_failures : int
+(** Built-in default for [max_ci_failures] (3). Single source of truth: the CLI
+    default, the stored-config fallback for legacy [config.json] files, and the
+    constructor defaults all reference this constant. *)
+
+val create :
+  branch:Types.Branch.t -> ?max_ci_failures:int -> Types.Patch_id.t -> t
+(** Initial state for a patch: no PR, not busy, empty queue. [max_ci_failures]
+    defaults to {!default_max_ci_failures}. *)
 
 val create_adhoc :
   patch_id:Types.Patch_id.t ->
   branch:Types.Branch.t ->
   pr_number:Types.Pr_number.t ->
+  max_ci_failures:int ->
   t
 (** Initial state for an ad-hoc patch: has PR, not busy, empty queue.
     Corresponds to the spec's Add action:
@@ -192,10 +208,12 @@ val pr_number : t -> Types.Pr_number.t option
 val intervention_reason : t -> string option
 (** [Some reason] when the agent needs intervention; [None] otherwise. Returns
     the first triggering condition's short label, in the same priority order as
-    the predicate. The label strings — ["pr_missing"], ["ci_failure_count>=3"],
+    the predicate. The label strings — ["pr_missing"],
     ["conflict_noop_count>=2"], etc. — are stable and intended to land verbatim
     in the event log so operators can grep "why is this patch stuck?" by reason.
-*)
+    The CI label embeds the configured cap (["ci_failure_count>=3"] under the
+    default) — match it by the ["ci_failure_count>="] prefix, not the full
+    string. *)
 
 val intervention_reason_of_fields :
   merged:bool ->
@@ -204,6 +222,7 @@ val intervention_reason_of_fields :
   session_given_up:bool ->
   human_in_queue:bool ->
   ci_failure_count:int ->
+  max_ci_failures:int ->
   start_attempts_without_pr:int ->
   conflict_noop_count:int ->
   no_commits_push_count:int ->
@@ -224,7 +243,7 @@ val needs_intervention : t -> bool
     - [is_pr_missing t] (PR vanished from the remote — bypasses the Human
       exemption; queued Human entries are deferred until [Missing → Present]
       recovery rather than dispatched while [Missing])
-    - [Human] not in queue AND any of: [ci_failure_count >= 3],
+    - [Human] not in queue AND any of: [ci_failure_count >= max_ci_failures],
       [(not has_pr) && start_attempts_without_pr >= 2],
       [conflict_noop_count >= 2], [no_commits_push_count >= 2],
       [context_exhaustion_count >= 2], [push_failure_count >= 3],
@@ -238,6 +257,7 @@ val needs_intervention_of_fields :
   session_given_up:bool ->
   human_in_queue:bool ->
   ci_failure_count:int ->
+  max_ci_failures:int ->
   start_attempts_without_pr:int ->
   conflict_noop_count:int ->
   no_commits_push_count:int ->
@@ -493,6 +513,11 @@ val reset_ci_failure_count : t -> t
 (** Reset [ci_failure_count] to 0. Called by the poller when CI checks pass
     after failures. [needs_intervention] is re-derived automatically. *)
 
+val set_max_ci_failures : t -> max_ci_failures:int -> t
+(** Stamp the per-project CI-failure cap onto the agent. Config, not a state
+    transition: does {e not} bump [generation], so restamping restored agents at
+    startup does not invalidate in-flight outbox messages. *)
+
 val reset_intervention_state : t -> t
 (** Reset [session_fallback] to [Fresh_available], [ci_failure_count] to 0,
     [start_attempts_without_pr] to 0, [conflict_noop_count] to 0,
@@ -647,6 +672,7 @@ val restore :
   base_branch:Types.Branch.t option ->
   notified_base_branch:Types.Branch.t option ->
   ci_failure_count:int ->
+  ?max_ci_failures:int ->
   session_fallback:session_fallback ->
   human_messages:string list ->
   inflight_human_messages:string list ->

--- a/lib_core/patch_decision.ml
+++ b/lib_core/patch_decision.ml
@@ -45,7 +45,8 @@ type ci_decision =
   | Ci_already_delivered
       (** Every currently failing check with a stable run id was already
           delivered to the agent. *)
-  | Cap_reached  (** CI failure count >= 3 — do not enqueue, flag. *)
+  | Cap_reached
+      (** CI failure count >= [max_ci_failures] — do not enqueue, flag. *)
 [@@deriving show, eq, sexp_of, compare]
 
 type human_decision =
@@ -123,7 +124,7 @@ let filter_undelivered_ci_failures (agent : Patch_agent.t) : Ci_check.t list =
             not (List.mem agent.delivered_ci_run_ids id ~equal:Int.equal))
 
 let on_ci_failure (a : Patch_agent.t) : ci_decision =
-  if a.ci_failure_count >= 3 then Cap_reached
+  if a.ci_failure_count >= a.max_ci_failures then Cap_reached
   else if
     a.busy
     && Option.equal Operation_kind.equal a.current_op (Some Operation_kind.Ci)

--- a/lib_core/patch_decision.mli
+++ b/lib_core/patch_decision.mli
@@ -34,11 +34,14 @@ type ci_decision =
   | Ci_already_delivered
       (** Every currently failing check with a stable run id was already
           delivered to the agent. *)
-  | Cap_reached  (** CI failure count >= 3 — do not enqueue, flag. *)
+  | Cap_reached
+      (** CI failure count >= [max_ci_failures] — do not enqueue, flag. *)
 [@@deriving show, eq, sexp_of, compare]
 
 val on_ci_failure : Patch_agent.t -> ci_decision
-(** Decide whether to enqueue a CI failure response or cap. *)
+(** Decide whether to enqueue a CI failure response or cap. The cap is the
+    agent's [max_ci_failures] field (per-project config, default
+    {!Patch_agent.default_max_ci_failures}). *)
 
 type human_decision =
   | Enqueue_human  (** Queue human feedback for processing. *)

--- a/test/test_action_outcome_properties.ml
+++ b/test/test_action_outcome_properties.ml
@@ -610,6 +610,9 @@ let () =
          let orch, _patches, gameplan, pid = bootstrap_one () in
          let mid = Message_id.of_string "ao-surface-msg" in
          let orch = Orchestrator.set_main_branch orch main in
+         let orch = Orchestrator.set_max_ci_failures orch ~max_ci_failures:5 in
+         if (Orchestrator.agent orch pid).Patch_agent.max_ci_failures <> 5 then
+           QCheck2.Test.fail_reportf "max_ci_failures was not stamped";
          (* Compile-time check of the public [Gameplan.add_patch] contract:
             [Ok] carries an immutable [(Gameplan.t * Patch.t)] tuple. *)
          let gameplan_with_added, added_patch =

--- a/test/test_action_outcome_properties.ml
+++ b/test/test_action_outcome_properties.ml
@@ -52,6 +52,8 @@ let () =
   let patches = mk_patches 1 in
   let orch = Orchestrator.create ~patches ~main_branch:main in
   let pid = pid_of_idx patches 0 in
+  let orch = Orchestrator.set_max_ci_failures orch ~max_ci_failures:5 in
+  assert ((Orchestrator.agent orch pid).Patch_agent.max_ci_failures = 5);
   let orch = Orchestrator.fire orch (Orchestrator.Start (pid, main)) in
   assert (Orchestrator.agent orch pid).Patch_agent.busy;
   let orch =

--- a/test/test_intervention_reason.ml
+++ b/test/test_intervention_reason.ml
@@ -48,6 +48,20 @@ let () =
       (* ...and never the innocuous push event that triggered the bug. *)
       assert (not (contains msg "pushed")));
 
+  (* Non-default CI caps are shown as count/cap so operators can see why the
+     configured threshold triggered intervention. *)
+  let custom_cap_stuck =
+    Patch_agent.create ~branch:(Branch.of_string "b") ~max_ci_failures:5
+      (Patch_id.of_string "patch-custom-cap")
+    |> apply 5 Patch_agent.increment_ci_failure_count
+  in
+  assert (Patch_agent.needs_intervention custom_cap_stuck);
+  (match Tui.human_intervention_reason custom_cap_stuck with
+  | None -> assert false
+  | Some msg ->
+      assert (contains msg "ci");
+      assert (contains msg "5/5"));
+
   (* The human reason is present exactly when intervention is needed: the two
      stay in lockstep with the authoritative predicate, so the banner can't
      show a reason for a healthy patch (or hide one for a stuck patch). *)

--- a/test/test_intervention_reason.ml
+++ b/test/test_intervention_reason.ml
@@ -215,6 +215,17 @@ let () =
     ~context_exhaustion_count:0 ~push_failure_count:0 ~rebase_failure_count:0
     ~pr_body_artifact_miss_count:0 ~review_unresolved_cycle_count:1
     ~expected:None;
+  let reason_with_custom_cap =
+    Patch_agent.intervention_reason_of_fields ~merged:false ~has_pr:true
+      ~is_pr_missing:false ~session_given_up:false ~human_in_queue:false
+      ~ci_failure_count:5 ~max_ci_failures:5 ~start_attempts_without_pr:0
+      ~conflict_noop_count:0 ~no_commits_push_count:0
+      ~context_exhaustion_count:0 ~push_failure_count:0 ~rebase_failure_count:0
+      ~pr_body_artifact_miss_count:0 ~review_unresolved_cycle_count:0
+  in
+  assert (
+    Option.equal String.equal reason_with_custom_cap
+      (Some "ci_failure_count>=5"));
   print_endline "PASS: raw intervention field decisions stay in lockstep"
 
 (* Exercise the whole Patch_agent decision surface. Some transitions have
@@ -263,6 +274,7 @@ let () =
              (fun a -> Patch_agent.reset_rebase_failure_count a);
              (fun a -> Patch_agent.increment_review_unresolved_cycle_count a);
              (fun a -> Patch_agent.reset_review_unresolved_cycle_count a);
+             (fun a -> Patch_agent.set_max_ci_failures a ~max_ci_failures:5);
              (fun a -> Patch_agent.reset_ci_failure_count a);
              (fun a -> Patch_agent.reset_context_exhaustion_count a);
              (fun a -> Patch_agent.reset_pr_body_artifact_miss_count a);

--- a/test/test_intervention_reason.ml
+++ b/test/test_intervention_reason.ml
@@ -165,6 +165,7 @@ let assert_raw_fields ~merged ~has_pr ~is_pr_missing ~session_given_up
   let reason =
     Patch_agent.intervention_reason_of_fields ~merged ~has_pr ~is_pr_missing
       ~session_given_up ~human_in_queue ~ci_failure_count
+      ~max_ci_failures:Patch_agent.default_max_ci_failures
       ~start_attempts_without_pr ~conflict_noop_count ~no_commits_push_count
       ~context_exhaustion_count ~push_failure_count ~rebase_failure_count
       ~pr_body_artifact_miss_count ~review_unresolved_cycle_count
@@ -174,6 +175,7 @@ let assert_raw_fields ~merged ~has_pr ~is_pr_missing ~session_given_up
     Bool.equal
       (Patch_agent.needs_intervention_of_fields ~merged ~has_pr ~is_pr_missing
          ~session_given_up ~human_in_queue ~ci_failure_count
+         ~max_ci_failures:Patch_agent.default_max_ci_failures
          ~start_attempts_without_pr ~conflict_noop_count ~no_commits_push_count
          ~context_exhaustion_count ~push_failure_count ~rebase_failure_count
          ~pr_body_artifact_miss_count ~review_unresolved_cycle_count)
@@ -311,38 +313,42 @@ let () =
          let reason_from_fields =
            Patch_agent.intervention_reason_of_fields ~merged:false ~has_pr:false
              ~is_pr_missing:false ~session_given_up:false ~human_in_queue:flag
-             ~ci_failure_count:3 ~start_attempts_without_pr:0
-             ~conflict_noop_count:0 ~no_commits_push_count:0
-             ~context_exhaustion_count:0 ~push_failure_count:0
-             ~rebase_failure_count:0 ~pr_body_artifact_miss_count:0
-             ~review_unresolved_cycle_count:0
+             ~ci_failure_count:3
+             ~max_ci_failures:Patch_agent.default_max_ci_failures
+             ~start_attempts_without_pr:0 ~conflict_noop_count:0
+             ~no_commits_push_count:0 ~context_exhaustion_count:0
+             ~push_failure_count:0 ~rebase_failure_count:0
+             ~pr_body_artifact_miss_count:0 ~review_unresolved_cycle_count:0
          in
          let needs_from_fields =
            Patch_agent.needs_intervention_of_fields ~merged:false ~has_pr:false
              ~is_pr_missing:false ~session_given_up:false ~human_in_queue:flag
-             ~ci_failure_count:3 ~start_attempts_without_pr:0
-             ~conflict_noop_count:0 ~no_commits_push_count:0
-             ~context_exhaustion_count:0 ~push_failure_count:0
-             ~rebase_failure_count:0 ~pr_body_artifact_miss_count:0
-             ~review_unresolved_cycle_count:0
+             ~ci_failure_count:3
+             ~max_ci_failures:Patch_agent.default_max_ci_failures
+             ~start_attempts_without_pr:0 ~conflict_noop_count:0
+             ~no_commits_push_count:0 ~context_exhaustion_count:0
+             ~push_failure_count:0 ~rebase_failure_count:0
+             ~pr_body_artifact_miss_count:0 ~review_unresolved_cycle_count:0
          in
          let rebase_reason =
            Patch_agent.intervention_reason_of_fields ~merged:false ~has_pr:true
              ~is_pr_missing:false ~session_given_up:false ~human_in_queue:false
-             ~ci_failure_count:0 ~start_attempts_without_pr:0
-             ~conflict_noop_count:0 ~no_commits_push_count:0
-             ~context_exhaustion_count:0 ~push_failure_count:0
-             ~rebase_failure_count:2 ~pr_body_artifact_miss_count:0
-             ~review_unresolved_cycle_count:0
+             ~ci_failure_count:0
+             ~max_ci_failures:Patch_agent.default_max_ci_failures
+             ~start_attempts_without_pr:0 ~conflict_noop_count:0
+             ~no_commits_push_count:0 ~context_exhaustion_count:0
+             ~push_failure_count:0 ~rebase_failure_count:2
+             ~pr_body_artifact_miss_count:0 ~review_unresolved_cycle_count:0
          in
          let rebase_needs_intervention =
            Patch_agent.needs_intervention_of_fields ~merged:false ~has_pr:true
              ~is_pr_missing:false ~session_given_up:false ~human_in_queue:false
-             ~ci_failure_count:0 ~start_attempts_without_pr:0
-             ~conflict_noop_count:0 ~no_commits_push_count:0
-             ~context_exhaustion_count:0 ~push_failure_count:0
-             ~rebase_failure_count:2 ~pr_body_artifact_miss_count:0
-             ~review_unresolved_cycle_count:0
+             ~ci_failure_count:0
+             ~max_ci_failures:Patch_agent.default_max_ci_failures
+             ~start_attempts_without_pr:0 ~conflict_noop_count:0
+             ~no_commits_push_count:0 ~context_exhaustion_count:0
+             ~push_failure_count:0 ~rebase_failure_count:2
+             ~pr_body_artifact_miss_count:0 ~review_unresolved_cycle_count:0
          in
          Bool.equal needs_from_fields (Option.is_some reason_from_fields)
          && Bool.equal rebase_needs_intervention (Option.is_some rebase_reason)));

--- a/test/test_patch_agent.ml
+++ b/test/test_patch_agent.ml
@@ -1317,7 +1317,10 @@ let () =
         Gen.(
           triple gen_pid gen_branch (map Pr_number.of_int (int_range 1 9999)))
         (fun (pid, br, pr) ->
-          let a = create_adhoc ~patch_id:pid ~branch:br ~pr_number:pr in
+          let a =
+            create_adhoc ~patch_id:pid ~branch:br ~pr_number:pr
+              ~max_ci_failures:default_max_ci_failures
+          in
           Branch.equal a.branch br);
       Test.make ~name:"patch agent public surface is linked" Gen.unit (fun () ->
           ignore add_human_messages;

--- a/test/test_patch_decision.ml
+++ b/test/test_patch_decision.ml
@@ -119,6 +119,21 @@ let () =
           let a = with_pr pid br in
           let a = increment_ci_failure_count (increment_ci_failure_count a) in
           equal_ci_decision (on_ci_failure a) Enqueue_ci);
+      Test.make ~name:"on_ci_failure: respects configured cap"
+        Gen.(triple gen_pid gen_branch (int_range 1 10))
+        (fun (pid, br, cap) ->
+          let a =
+            create ~branch:br ~max_ci_failures:cap pid |> fun a ->
+            start a ~base_branch:br |> fun a ->
+            set_pr_number a (Pr_number.of_int 1) |> complete
+          in
+          let rec apply_n n f x =
+            if n <= 0 then x else apply_n (n - 1) f (f x)
+          in
+          let below = apply_n (cap - 1) increment_ci_failure_count a in
+          let at_cap = increment_ci_failure_count below in
+          equal_ci_decision (on_ci_failure below) Enqueue_ci
+          && equal_ci_decision (on_ci_failure at_cap) Cap_reached);
       (* ---- on_ci_failure: Ci already queued -> Already_queued ---- *)
       Test.make ~name:"on_ci_failure: Ci in queue -> Already_queued"
         Gen.(pair gen_pid gen_branch)

--- a/test/test_resolved_config_properties.ml
+++ b/test/test_resolved_config_properties.ml
@@ -6,7 +6,7 @@
 open Onton
 open Onton_core
 
-let valid_config ~max_concurrency : Resolved_config.config =
+let valid_config ~max_concurrency ~max_ci_failures : Resolved_config.config =
   {
     Resolved_config.project = Some "project";
     Resolved_config.backend = "claude";
@@ -18,6 +18,7 @@ let valid_config ~max_concurrency : Resolved_config.config =
     Resolved_config.poll_interval = 1.0;
     Resolved_config.repo_root = ".";
     Resolved_config.max_concurrency;
+    Resolved_config.max_ci_failures;
     Resolved_config.headless = true;
     Resolved_config.patch_agent_provider = None;
     Resolved_config.patch_agent_effort = None;
@@ -30,8 +31,26 @@ let max_concurrency_must_be_positive =
     ~count:200
     QCheck2.Gen.(int_range (-20) 0)
     (fun max_concurrency ->
-      match Resolved_config.of_config (valid_config ~max_concurrency) with
+      match
+        Resolved_config.of_config
+          (valid_config ~max_concurrency
+             ~max_ci_failures:Patch_agent.default_max_ci_failures)
+      with
       | Ok _ -> false
       | Error errors -> List.length errors >= 1)
 
-let () = QCheck2.Test.check_exn max_concurrency_must_be_positive
+let max_ci_failures_must_be_positive =
+  QCheck2.Test.make ~name:"resolved config rejects non-positive CI cap"
+    ~count:200
+    QCheck2.Gen.(int_range (-20) 0)
+    (fun max_ci_failures ->
+      match
+        Resolved_config.of_config
+          (valid_config ~max_concurrency:1 ~max_ci_failures)
+      with
+      | Ok _ -> false
+      | Error errors -> List.length errors >= 1)
+
+let () =
+  QCheck2.Test.check_exn max_concurrency_must_be_positive;
+  QCheck2.Test.check_exn max_ci_failures_must_be_positive

--- a/test/test_tui_render_frame.ml
+++ b/test/test_tui_render_frame.ml
@@ -22,6 +22,7 @@ let make_view ~id ~title =
     current_op = None;
     current_op_state = Onton_core.Patch_agent.Queued;
     ci_failures = 0;
+    ci_failure_cap = Onton_core.Patch_agent.default_max_ci_failures;
     dep_ids = [];
     has_pr = false;
     has_conflict = false;


### PR DESCRIPTION
## Summary

Adds a configurable per-project cap for consecutive CI-failure responses before a patch is flagged for intervention.

## What changed

- Added `--max-ci-failures N` and `ONTON_MAX_CI_FAILURES`.
- Persisted `max_ci_failures` in project config, defaulting legacy configs to `3`.
- Applied the resolved cap to restored, fresh, planned, and ad-hoc patch agents.
- Replaced the hardcoded CI cap in patch decisions, intervention reasons, TUI display, activity reconstruction, persistence, and logs.
- Added focused tests for configurable capping, config validation, and persistence.

## Behavior

For a new project, the flag value becomes the project default. For an existing project, the stored default is used unless `--max-ci-failures` is passed, in which case the flag value wins and is persisted.

## Validation

- `dune build`
- `dune runtest`
- `dune fmt`
- Final `dune build`
- Pre-commit hook reran build, tests, and format check successfully.