### PR TITLE
[codex] Fix conflict rebase classification

### DIFF
--- a/lib/worktree.ml
+++ b/lib/worktree.ml
@@ -678,6 +678,35 @@ let is_ancestor ~process_mgr ~path ~ancestor ~descendant =
   in
   code = 0
 
+let git_dir_opt ~process_mgr ~path =
+  let code, stdout, _ =
+    run_git_exit_code ~process_mgr
+      [ "git"; "-C"; path; "rev-parse"; "--git-dir" ]
+  in
+  if code <> 0 then None
+  else
+    let git_dir = String.strip stdout in
+    let git_dir =
+      if Stdlib.Filename.is_relative git_dir then
+        Stdlib.Filename.concat path git_dir
+      else git_dir
+    in
+    Some git_dir
+
+let rebase_in_progress_raw ~process_mgr ~path =
+  match git_dir_opt ~process_mgr ~path with
+  | None -> false
+  | Some git_dir ->
+      Stdlib.Sys.file_exists (Stdlib.Filename.concat git_dir "rebase-merge")
+      || Stdlib.Sys.file_exists (Stdlib.Filename.concat git_dir "rebase-apply")
+
+let classify_rebase_exit_1 ~process_mgr ~path ~stderr conflict =
+  if rebase_in_progress_raw ~process_mgr ~path then Conflict conflict
+  else
+    Error
+      (Printf.sprintf "rebase exited 1 without leaving a rebase in progress: %s"
+         (String.strip stderr))
+
 let rebase_onto ~upstream ~process_mgr ~path ~target ~project_name ~ancestor_ids
     () =
   let target = Types.Branch.to_string target in
@@ -734,7 +763,7 @@ let rebase_onto ~upstream ~process_mgr ~path ~target ~project_name ~ancestor_ids
              available because [classify_unique_commits] failed; the prompt
              renders a Plain-strategy recovery section recommending plain
              [git rebase <target>] instead of [--onto]. *)
-          Conflict
+          classify_rebase_exit_1 ~process_mgr ~path ~stderr:rebase_stderr
             {
               target;
               old_base = (if String.equal upstream target then "" else upstream);
@@ -756,7 +785,7 @@ let rebase_onto ~upstream ~process_mgr ~path ~target ~project_name ~ancestor_ids
           (* Leave rebase in progress for agent to resolve, with the recovery
              info threaded through so the prompt can render the exact --onto
              command the supervisor used. *)
-          Conflict
+          classify_rebase_exit_1 ~process_mgr ~path ~stderr:rebase_stderr
             { target; old_base; unique_commits; strategy = Onto; orig_head }
 
 type push_result = Worktree_parser.push_result =
@@ -951,20 +980,7 @@ let force_push_with_lease ~process_mgr ~path ~branch ~base =
       classify_push_result ~code ~stdout ~stderr
 
 let rebase_in_progress ~process_mgr ~path =
-  let code, stdout, _ =
-    run_git_exit_code ~process_mgr
-      [ "git"; "-C"; path; "rev-parse"; "--git-dir" ]
-  in
-  if code <> 0 then false
-  else
-    let git_dir = String.strip stdout in
-    let git_dir =
-      if Stdlib.Filename.is_relative git_dir then
-        Stdlib.Filename.concat path git_dir
-      else git_dir
-    in
-    Stdlib.Sys.file_exists (Stdlib.Filename.concat git_dir "rebase-merge")
-    || Stdlib.Sys.file_exists (Stdlib.Filename.concat git_dir "rebase-apply")
+  rebase_in_progress_raw ~process_mgr ~path
 
 let read_file_opt path =
   try

--- a/test/test_rebase_onto.ml
+++ b/test/test_rebase_onto.ml
@@ -917,6 +917,16 @@ let assert_rebase_conflict label = function
   | Worktree.Error msg ->
       failwith (Printf.sprintf "%s: expected Conflict, got Error: %s" label msg)
 
+let assert_rebase_error label = function
+  | Worktree.Error msg when not (String.is_empty msg) -> ()
+  | Worktree.Error _ ->
+      failwith (Printf.sprintf "%s: expected non-empty Error" label)
+  | Worktree.Ok -> failwith (Printf.sprintf "%s: expected Error, got Ok" label)
+  | Worktree.Noop ->
+      failwith (Printf.sprintf "%s: expected Error, got Noop" label)
+  | Worktree.Conflict _ ->
+      failwith (Printf.sprintf "%s: expected Error, got Conflict" label)
+
 (** Simulate squash-merge of [branch] into main: checkout main, create a single
     new commit with the same tree diff, then delete [branch]. *)
 let squash_merge ~process_mgr ~dir ~branch =
@@ -1057,6 +1067,34 @@ let () =
        ~upstream:"main" ~project_name:"" ~ancestor_ids:[] ()
    in
    assert_rebase_noop "test4: already up-to-date" result;
+   Stdlib.Sys.command (Printf.sprintf "rm -rf %s" dir) |> ignore);
+
+  (* ── Test 4b: dirty worktree prevents rebase → Error, not Conflict ─ *)
+  (let dir = init_repo () in
+   commit_file ~process_mgr ~dir ~filename:"a.txt" ~content:"a" ~msg:"A"
+   |> ignore;
+   git ~process_mgr ~dir [ "checkout"; "-b"; "feat" ] |> ignore;
+   commit_file ~process_mgr ~dir ~filename:"f.txt" ~content:"f" ~msg:"F"
+   |> ignore;
+   git ~process_mgr ~dir [ "checkout"; "main" ] |> ignore;
+   commit_file ~process_mgr ~dir ~filename:"m.txt" ~content:"m" ~msg:"M"
+   |> ignore;
+   git ~process_mgr ~dir [ "checkout"; "feat" ] |> ignore;
+   let dirty_path = Stdlib.Filename.concat dir "dirty.txt" in
+   let oc = Stdlib.open_out dirty_path in
+   Stdlib.output_string oc "dirty";
+   Stdlib.close_out oc;
+   git ~process_mgr ~dir [ "add"; "dirty.txt" ] |> ignore;
+   let result =
+     Worktree.rebase_onto ~process_mgr ~path:dir
+       ~target:(Types.Branch.of_string "main")
+       ~upstream:"main" ~project_name:"" ~ancestor_ids:[] ()
+   in
+   assert_rebase_error "test4b: dirty worktree" result;
+   let rebase_merge = Stdlib.Filename.concat dir ".git/rebase-merge" in
+   let rebase_apply = Stdlib.Filename.concat dir ".git/rebase-apply" in
+   if Stdlib.Sys.file_exists rebase_merge || Stdlib.Sys.file_exists rebase_apply
+   then failwith "test4b: rebase should not be in progress";
    Stdlib.Sys.command (Printf.sprintf "rm -rf %s" dir) |> ignore);
 
   (* ── Test 5: conflict during rebase → Conflict, working dir clean ─ *)


### PR DESCRIPTION
## Summary

Fixes a conflict-resolution loop where Onton delivered a merge-conflict prompt even though git had not left an in-progress rebase for the patch agent to resolve.

## Root Cause

`Worktree.rebase_onto` treated every `git rebase` exit code 1 as a true conflict. In the observed patch 5 case, git exited 1 before starting a rebase because the worktree was dirty, leaving no `rebase-merge` or `rebase-apply` state and no unmerged index entries.

## Changes

- Classify rebase exit code 1 as `Conflict` only when git actually leaves a rebase in progress.
- Return a structured `Error` with git stderr for exit code 1 cases that do not leave rebase state.
- Add a regression test covering dirty-worktree rebase failure as `Error`, not `Conflict`.

## Validation

- `dune fmt`
- `dune build`
- `dune exec test/test_rebase_onto.exe`
- `dune runtest`
- pre-commit build/test/format check passed during commit
