### PR TITLE
Handle merge queue push locks

### DIFF
--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -195,6 +195,7 @@ let mark_merged t patch_id =
               if
                 dep_agent.Patch_agent.merged
                 || (not (Patch_agent.has_pr dep_agent))
+                || Patch_agent.in_merge_queue dep_agent
                 || List.mem dep_agent.Patch_agent.queue Operation_kind.Rebase
                      ~equal:Operation_kind.equal
               then t
@@ -241,6 +242,7 @@ let enqueue_rebase_for_stranded_dependents t patch_id =
               if
                 d.Patch_agent.merged
                 || (not (Patch_agent.has_pr d))
+                || Patch_agent.in_merge_queue d
                 || List.mem d.Patch_agent.queue Operation_kind.Rebase
                      ~equal:Operation_kind.equal
                 || not
@@ -825,6 +827,7 @@ let apply_rebase_with_anchor t patch_id rebase_result new_base anchor_events =
 type rebase_push_resolution =
   | Rebase_push_ok
   | Rebase_push_failed
+  | Rebase_push_queue_locked
   | Rebase_push_error
 [@@deriving show, eq, sexp_of]
 
@@ -833,7 +836,24 @@ let apply_rebase_push_result t patch_id
   match push_outcome with
   | None -> (t, Rebase_push_ok) (* no push effect emitted; already handled *)
   | Some Worktree.Push_ok | Some Worktree.Push_up_to_date -> (t, Rebase_push_ok)
-  | Some (Worktree.Push_rejected _) ->
+  | Some (Worktree.Push_rejected Push_reject_classify.Merge_queue_locked) ->
+      (* GitHub locked the head branch because the PR is queued in a merge
+         queue — there is no conflict and nothing to retry. Drop the push: the
+         local rebase already succeeded, so [branch_rebased_onto] is current;
+         if the PR merges from the queue nothing re-fires, and if it is
+         ejected as Conflicting the poll path enqueues [Merge_conflict], whose
+         local no-op + now-unlocked push syncs the remote. Reading this as a
+         conflict is exactly the conflict_noop_count>=2 spiral this arm
+         prevents. *)
+      (t, Rebase_push_queue_locked)
+  | Some
+      (Worktree.Push_rejected
+         ( Push_reject_classify.Workflow_scope_missing
+         | Push_reject_classify.Branch_protection
+         | Push_reject_classify.Push_pattern_block
+         | Push_reject_classify.Lease_violation
+         | Push_reject_classify.Hook_failure _ | Push_reject_classify.Unknown _
+         | Push_reject_classify.Local_state_unsafe _ )) ->
       let t = set_has_conflict t patch_id in
       let t = enqueue t patch_id Operation_kind.Merge_conflict in
       (t, Rebase_push_failed)
@@ -930,10 +950,28 @@ let apply_conflict_push_result t patch_id decision
   | Conflict_resolved, Some Worktree.Push_ok -> (t, Conflict_done)
   | Conflict_resolved, Some Worktree.Push_up_to_date -> (t, Conflict_done)
   | ( Conflict_resolved,
+      Some (Worktree.Push_rejected Push_reject_classify.Merge_queue_locked) ) ->
+      (* The PR is queued in a merge queue, so there is no conflict to keep
+         chasing — treat the resolution as done rather than re-enqueueing.
+         Also undo the noop-counter increment from the [Noop] rebase arm: the
+         noop was evidence of a queued clean PR, not of a stuck conflict, and
+         with [has_conflict] already cleared no poll-path reset would undo the
+         stray increment. *)
+      let t = reset_conflict_noop_count t patch_id in
+      (t, Conflict_done)
+  | ( Conflict_resolved,
       ( None
       | Some
-          ( Worktree.Push_rejected _ | Worktree.Push_no_commits
-          | Worktree.Push_error _ | Worktree.Push_worktree_missing ) ) ) ->
+          ( Worktree.Push_rejected
+              ( Push_reject_classify.Workflow_scope_missing
+              | Push_reject_classify.Branch_protection
+              | Push_reject_classify.Push_pattern_block
+              | Push_reject_classify.Lease_violation
+              | Push_reject_classify.Hook_failure _
+              | Push_reject_classify.Unknown _
+              | Push_reject_classify.Local_state_unsafe _ )
+          | Worktree.Push_no_commits | Worktree.Push_error _
+          | Worktree.Push_worktree_missing ) ) ) ->
       let t = set_has_conflict t patch_id in
       let t = enqueue t patch_id Operation_kind.Merge_conflict in
       (t, Conflict_retry_push)

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -409,6 +409,7 @@ val apply_rebase_with_anchor :
 type rebase_push_resolution =
   | Rebase_push_ok
   | Rebase_push_failed
+  | Rebase_push_queue_locked
   | Rebase_push_error
 [@@deriving show, eq, sexp_of]
 
@@ -421,6 +422,12 @@ val apply_rebase_push_result :
     - [Rebase_push_ok]: push succeeded or was up-to-date; no further action.
     - [Rebase_push_failed]: push was rejected (lease failure); resets conflict
       state and enqueues [Merge_conflict] so the next poll cycle retries.
+    - [Rebase_push_queue_locked]: push was rejected because the PR is queued in
+      a merge queue ([Push_reject_classify.Merge_queue_locked]). Inert: no
+      conflict state, no enqueue. The local rebase already landed so
+      [branch_rebased_onto] is current; a merge from the queue needs nothing
+      further, and an ejection-as-Conflicting surfaces through the poll path,
+      whose conflict-resolution no-op + now-unlocked push syncs the remote.
     - [Rebase_push_error]: infrastructure error; enqueues [Rebase] to retry
       without entering the conflict path. *)
 

--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -751,15 +751,31 @@ type review_request_decision = {
 let merge_queue_entry_unmergeable (entry : Pr_state.merge_queue_entry) =
   Pr_state.equal_merge_queue_entry_state entry.state Pr_state.Mq_unmergeable
 
+let merge_queue_alarm (agent : Patch_agent.t) =
+  agent.Patch_agent.has_conflict
+  || List.exists agent.Patch_agent.ci_checks ~f:Ci_check.is_failure
+  || Option.exists agent.Patch_agent.merge_queue_entry
+       ~f:merge_queue_entry_unmergeable
+
+let should_dequeue_merge_queue agent ~main_branch ~entry_id =
+  match agent.Patch_agent.merge_queue_entry with
+  | Some entry when String.equal entry.Pr_state.id entry_id ->
+      merge_queue_alarm agent
+      || not (Patch_agent.is_approved agent ~main_branch)
+  | Some _ | None -> false
+
 let automerge_action (agent : Patch_agent.t) ~main_branch =
   let approved = Patch_agent.is_approved agent ~main_branch in
   match (agent.Patch_agent.merge_queue_required, agent.merge_queue_entry) with
-  | true, Some entry when merge_queue_entry_unmergeable entry -> None
-  | true, Some entry when not approved -> Some (Dequeue entry.id)
+  | true, Some entry
+    when should_dequeue_merge_queue agent ~main_branch ~entry_id:entry.id ->
+      Some (Dequeue entry.id)
   | true, Some _ -> None
   | true, None when approved -> Some Enqueue
   | true, None -> None
-  | false, Some entry when not approved -> Some (Dequeue entry.id)
+  | false, Some entry
+    when should_dequeue_merge_queue agent ~main_branch ~entry_id:entry.id ->
+      Some (Dequeue entry.id)
   | false, Some _ -> None
   | false, None -> Some Direct_merge
 
@@ -821,68 +837,69 @@ let reconcile_automerge t ~now =
            so both guards must stay in sync. *)
         (t, decisions)
       else
-        let unmergeable_entry =
-          Option.exists agent.Patch_agent.merge_queue_entry
-            ~f:merge_queue_entry_unmergeable
+        let dequeue_action =
+          Option.bind agent.Patch_agent.merge_queue_entry ~f:(fun entry ->
+              if
+                should_dequeue_merge_queue agent ~main_branch
+                  ~entry_id:entry.Pr_state.id
+              then Some (Dequeue entry.id)
+              else None)
         in
-        let approved = Patch_agent.is_approved agent ~main_branch in
-        let cleanup_candidate =
-          Option.is_some agent.Patch_agent.merge_queue_entry && not approved
+        let emit_automerge_decision t action =
+          match Patch_agent.pr_number agent with
+          | Some pr_number when Patch_agent.is_pr_present agent ->
+              let t = Orchestrator.set_automerge_inflight t patch_id true in
+              ( t,
+                {
+                  merge_patch_id = patch_id;
+                  merge_pr_number = pr_number;
+                  action;
+                }
+                :: decisions )
+          | Some _ | None ->
+              (* Defensive clear so a future predicate change can't leave a
+                 patch with a permanently-elapsed deadline that fires every
+                 tick. *)
+              (Orchestrator.clear_automerge_deadline t patch_id, decisions)
         in
-        let candidate =
-          if unmergeable_entry then false
-          else if cleanup_candidate then
-            agent.Patch_agent.automerge_enabled
-            && agent.Patch_agent.automerge_failure_count
-               < automerge_max_failures
-          else is_automerge_candidate agent ~main_branch
-        in
-        match (candidate, agent.Patch_agent.automerge_deadline) with
-        | false, Some _ when automerge_transient_hold agent ~main_branch ->
-            (* merge_ready dropped only because GitHub is recomputing
+        match dequeue_action with
+        | Some action when agent.Patch_agent.automerge_enabled -> (
+            (* Dequeue queue-alarmed PRs immediately on first observation. If a
+               previous dequeue call failed, [runner_fiber_impl] pushed the
+               deadline forward; honor it as retry backoff. *)
+            match agent.Patch_agent.automerge_deadline with
+            | Some deadline when Float.(now < deadline) -> (t, decisions)
+            | None | Some _ -> emit_automerge_decision t action)
+        | Some _ | None -> (
+            let candidate = is_automerge_candidate agent ~main_branch in
+            match (candidate, agent.Patch_agent.automerge_deadline) with
+            | false, Some _ when automerge_transient_hold agent ~main_branch ->
+                (* merge_ready dropped only because GitHub is recomputing
                mergeability (mergeStateStatus = UNKNOWN) after the base
                advanced — typically a sibling patch merging. Hold the existing
                deadline so the idle window keeps counting real elapsed time
                instead of restarting on every sibling merge. We do not fire
                here (firing requires merge_ready / CLEAN); the next CLEAN poll
                re-qualifies the candidate and the preserved deadline elapses. *)
-            (t, decisions)
-        | false, Some _ ->
-            (* Feedback arrived, lost approval, CI flipped, or failure cap
+                (t, decisions)
+            | false, Some _ ->
+                (* Feedback arrived, lost approval, CI flipped, or failure cap
                hit: drop the deadline so the next reconcile re-arms a fresh
                idle window once the patch becomes a candidate again. *)
-            (Orchestrator.clear_automerge_deadline t patch_id, decisions)
-        | false, None -> (t, decisions)
-        | true, None ->
-            let deadline = now +. automerge_idle_timeout in
-            (Orchestrator.set_automerge_deadline t patch_id deadline, decisions)
-        | true, Some deadline ->
-            if Float.( >= ) now deadline then
-              match Patch_agent.pr_number agent with
-              | Some pr_number when Patch_agent.is_pr_present agent -> (
+                (Orchestrator.clear_automerge_deadline t patch_id, decisions)
+            | false, None -> (t, decisions)
+            | true, None ->
+                let deadline = now +. automerge_idle_timeout in
+                ( Orchestrator.set_automerge_deadline t patch_id deadline,
+                  decisions )
+            | true, Some deadline ->
+                if Float.( >= ) now deadline then
                   match automerge_action agent ~main_branch with
                   | None ->
                       ( Orchestrator.clear_automerge_deadline t patch_id,
                         decisions )
-                  | Some action ->
-                      let t =
-                        Orchestrator.set_automerge_inflight t patch_id true
-                      in
-                      ( t,
-                        {
-                          merge_patch_id = patch_id;
-                          merge_pr_number = pr_number;
-                          action;
-                        }
-                        :: decisions ))
-              | Some _ | None ->
-                  (* Unreachable today because [is_automerge_candidate]
-                     requires [is_approved] which requires [has_pr]. Defensive
-                     clear so a future predicate change can't leave a patch
-                     with a permanently-elapsed deadline that fires every
-                     tick. *)
-                  (Orchestrator.clear_automerge_deadline t patch_id, decisions)
-            else (t, decisions))
+                  | Some action -> emit_automerge_decision t action
+                else (t, decisions)))
   |> fun (t, decisions) -> (t, List.rev decisions)
 
 let reconcile_review_requests t =

--- a/lib/patch_controller.mli
+++ b/lib/patch_controller.mli
@@ -180,6 +180,13 @@ val automerge_transient_hold : Patch_agent.t -> main_branch:Branch.t -> bool
     checks, queued feedback, or a hit failure cap all fall through to the normal
     clear. *)
 
+val should_dequeue_merge_queue :
+  Patch_agent.t -> main_branch:Branch.t -> entry_id:string -> bool
+(** [true] when an already-enqueued PR should be removed from GitHub's merge
+    queue. This includes explicit queue alarms ([UNMERGEABLE] entries, conflict
+    state, or visible failing checks) and lost approval. The runner uses the
+    same predicate as [reconcile_automerge] for its pre-flight recheck. *)
+
 val reconcile_automerge :
   Orchestrator.t -> now:float -> Orchestrator.t * automerge_decision list
 (** Reconcile the automerge deadline for every agent and return decisions to

--- a/lib/poller_fiber.ml
+++ b/lib/poller_fiber.ml
@@ -627,6 +627,7 @@ struct
                       busy = a.Patch_agent.busy;
                       needs_intervention = Patch_agent.needs_intervention a;
                       branch_blocked = a.Patch_agent.branch_blocked;
+                      in_merge_queue = Patch_agent.in_merge_queue a;
                       queue = a.Patch_agent.queue;
                       base_branch =
                         Option.value a.Patch_agent.base_branch ~default:main;

--- a/lib/runner_fiber_impl.ml
+++ b/lib/runner_fiber_impl.ml
@@ -1256,6 +1256,10 @@ struct
                             log_event runtime ~patch_id
                               "Enqueued merge-conflict after rebase push \
                                rejection"
+                        | Orchestrator.Rebase_push_queue_locked ->
+                            log_event runtime ~patch_id
+                              "Rebase push rejected: PR is queued in the merge \
+                               queue; dropping (queue will merge or eject)"
                         | Orchestrator.Rebase_push_error ->
                             log_event runtime ~patch_id
                               "Enqueued rebase retry after push error");

--- a/lib/runner_fiber_impl.ml
+++ b/lib/runner_fiber_impl.ml
@@ -270,13 +270,9 @@ struct
                           && List.is_empty agent.Patch_agent.queue
                           && agent.Patch_agent.automerge_failure_count
                              < Patch_controller.automerge_max_failures
-                      | Patch_controller.Dequeue entry_id -> (
-                          (not (Patch_agent.is_approved agent ~main_branch))
-                          &&
-                          match agent.Patch_agent.merge_queue_entry with
-                          | Some entry ->
-                              String.equal entry.Pr_state.id entry_id
-                          | None -> false)))
+                      | Patch_controller.Dequeue entry_id ->
+                          Patch_controller.should_dequeue_merge_queue agent
+                            ~main_branch ~entry_id))
             in
             if not still_candidate then (
               log_event runtime ~patch_id
@@ -302,7 +298,8 @@ struct
                         log_event runtime ~patch_id
                           (Printf.sprintf
                              "Automerge dequeued PR #%d from GitHub merge \
-                              queue after approval was lost"
+                              queue after approval was lost or GitHub reported \
+                              a queue alarm"
                              (Pr_number.to_int pr_number))
                     | Error err ->
                         push_deadline_and_clear_inflight ();

--- a/lib_core/patch_agent.ml
+++ b/lib_core/patch_agent.ml
@@ -457,6 +457,7 @@ let set_unresolved_comment_count t unresolved_comment_count =
 let set_mergeability_unknown t v = { t with mergeability_unknown = v }
 let set_merge_queue_required t v = { t with merge_queue_required = v }
 let set_merge_queue_entry t merge_queue_entry = { t with merge_queue_entry }
+let in_merge_queue t = Option.is_some t.merge_queue_entry
 let set_merge_commit_sha t sha = { t with merge_commit_sha = sha }
 
 let set_base_contains_merged_siblings t v =

--- a/lib_core/patch_agent.mli
+++ b/lib_core/patch_agent.mli
@@ -397,6 +397,16 @@ val set_merge_queue_required : t -> bool -> t
 val set_merge_queue_entry : t -> Pr_state.merge_queue_entry option -> t
 (** Set the current merge-queue entry, if any. *)
 
+val in_merge_queue : t -> bool
+(** [true] when the PR currently sits in a merge queue
+    ([merge_queue_entry <> None], refreshed every poll via
+    [Automerge_state.observe_merge_queue]). While true, the head branch is
+    push-locked by GitHub ([Push_reject_classify.Merge_queue_locked]) and the
+    queue itself validates against the latest base — so rebase/conflict demand
+    for the patch is redundant and its pushes are guaranteed to be rejected.
+    Enqueue-side gates ([Reconciler] detectors, [Orchestrator.mark_merged] and
+    the stranded-dependent cascade) consult this predicate. *)
+
 val set_merge_commit_sha : t -> string option -> t
 (** Record the squash/merge commit SHA (GitHub [mergeCommit.oid]) when the PR is
     observed merged. *)

--- a/lib_core/poller.ml
+++ b/lib_core/poller.ml
@@ -50,9 +50,16 @@ let poll ~was_merged (pr : Pr_state.t) =
     (* world-has-finding f p -> queue' p findings.
        Mirror of the comment rule, but for review-service backends. *)
     let acc = if has_findings then Operation_kind.Findings :: acc else acc in
-    (* world-has-conflict p -> queue' p merge-conflict *)
+    (* world-has-conflict p and ~enqueued p -> queue' p merge-conflict.
+       While the PR sits in a merge queue its head branch is push-locked
+       (GH006), so a Merge_conflict op could only no-op locally and bounce off
+       the lock — walking conflict_noop_count toward spurious intervention. A
+       Conflicting report while queued is transient: a genuine conflict makes
+       GitHub eject the PR, the entry clears, and the next poll enqueues
+       normally (the gate self-opens). *)
     let acc =
-      if Pr_state.has_conflict pr then Operation_kind.Merge_conflict :: acc
+      if Pr_state.has_conflict pr && not (Pr_state.enqueued pr) then
+        Operation_kind.Merge_conflict :: acc
       else acc
     in
     (* world-ci-failed p -> queue' p ci *)

--- a/lib_core/poller.mli
+++ b/lib_core/poller.mli
@@ -12,14 +12,23 @@ open Types
     ---
     all c: Comment, p: Patch |
         world-has-comment c p and ~resolved c -> queue' p review-comments.
-    all p: Patch | world-has-conflict p -> queue' p merge-conflict.
+    all p: Patch |
+        world-has-conflict p and ~world-enqueued p -> queue' p merge-conflict.
     all p: Patch | world-has-conflict p -> has-conflict' p.
     all p: Patch | world-ci-failed p -> queue' p ci.
     all p: Patch | world-merged p -> merged' p.
     all p: Patch | merged p -> merged' p.
     all p: Patch | mergeable' p = world-mergeable p.
     all p: Patch | checks-passing' p = world-checks-passing p.
-    v} *)
+    v}
+
+    The [~world-enqueued] conjunct on the merge-conflict rule is the merge-queue
+    gate: while a PR sits in a merge queue its head branch is push-locked (GH006
+    [Merge_queue_locked]), so a [Merge_conflict] op could only no-op locally and
+    bounce off the lock, walking [conflict_noop_count] toward spurious
+    intervention. The [has-conflict'] {e flag} rule stays ungated — it purely
+    mirrors GitHub state, and a genuine conflict makes GitHub eject the PR from
+    the queue, after which the next poll enqueues the op normally. *)
 
 type t = {
   queue : Operation_kind.t list;  (** Operations to enqueue for this patch. *)

--- a/lib_core/push_reject_classify.ml
+++ b/lib_core/push_reject_classify.ml
@@ -8,6 +8,7 @@ type rejection =
   | Branch_protection
   | Push_pattern_block
   | Lease_violation
+  | Merge_queue_locked
   | Hook_failure of string
   | Unknown of string
   | Local_state_unsafe of { reason : string }
@@ -72,6 +73,13 @@ let classify ~stderr ~stdout:_ =
     || contains_ci stderr "without `workflow` scope"
   then Workflow_scope_missing
   else if
+    (* Must precede [Branch_protection]: the merge-queue lock message carries
+       both of that recognizer's fingerprints (GH006 + the hook-declined
+       trailer) alongside its own queue-specific lines. *)
+    contains_ci stderr "has been added to a merge queue"
+    || contains_ci stderr "queued for merging cannot be updated"
+  then Merge_queue_locked
+  else if
     contains_ci stderr "GH006: Protected branch update failed"
     || contains_ci stderr "protected branch hook declined"
     || contains_ci stderr "Cannot force-push to a protected branch"
@@ -100,13 +108,14 @@ let short_label = function
   | Branch_protection -> "branch_protection"
   | Push_pattern_block -> "push_pattern_block"
   | Lease_violation -> "lease_violation"
+  | Merge_queue_locked -> "merge_queue_locked"
   | Hook_failure _ -> "hook_failure"
   | Unknown _ -> "unknown_rejection"
   | Local_state_unsafe _ -> "local_state_unsafe"
 
 let detail_excerpt = function
   | Workflow_scope_missing | Branch_protection | Push_pattern_block
-  | Lease_violation ->
+  | Lease_violation | Merge_queue_locked ->
       None
   | Hook_failure s | Unknown s ->
       if String.is_empty (String.strip s) then None else Some s
@@ -118,4 +127,4 @@ let is_permanent = function
   | Workflow_scope_missing | Branch_protection | Push_pattern_block
   | Hook_failure _ | Local_state_unsafe _ ->
       true
-  | Lease_violation | Unknown _ -> false
+  | Lease_violation | Merge_queue_locked | Unknown _ -> false

--- a/lib_core/push_reject_classify.mli
+++ b/lib_core/push_reject_classify.mli
@@ -14,6 +14,9 @@
       [needs_intervention] instead of looping. See [is_permanent].
     - [Lease_violation] is a real race (the remote ref advanced between fetch
       and push). Retrying after a re-fetch is the correct response.
+    - [Merge_queue_locked] is {e transient} by construction: GitHub locks the
+      head branch of a PR that is queued in a merge queue, and the lock clears
+      by itself when the PR merges or is dequeued/ejected.
     - [Unknown] is anything we don't recognize; treated conservatively as
       transient so we don't accidentally trip intervention on novel server
       messages. *)
@@ -33,6 +36,27 @@ type rejection =
   | Lease_violation
       (** [stale info] / [fetch first] — the remote ref moved between the lease
           read and the push; a re-fetch will resolve it. *)
+  | Merge_queue_locked
+      (** GitHub's head-branch lock for a PR that is queued in a merge queue.
+          The full rejection reads (verbatim, wrapped by the server):
+
+          {v
+remote: error: GH006: Protected branch update failed for refs/heads/<branch>.
+remote: error: A pull request for this branch has been added to a merge queue. Branches that
+remote: are queued for merging cannot be updated. To modify this branch, dequeue the
+remote: associated pull request.
+! [remote rejected]  <sha> -> <branch> (protected branch hook declined)
+          v}
+
+          Fingerprints: [has been added to a merge queue] /
+          [queued for merging cannot be updated] — each sits on a single
+          [remote:] line, so substring matching survives the server's
+          line-wrapping. The blob {e also} contains both [Branch_protection]
+          fingerprints ([GH006: Protected branch update failed],
+          [protected branch hook declined]), so this recognizer must run before
+          that one. Transient: the lock clears by itself when the PR merges or
+          is dequeued/ejected — never escalate it to intervention, and never
+          read it as a merge conflict. *)
   | Hook_failure of string
       (** Any other [remote: …] message preceding [! [remote rejected]]; the
           excerpt is preserved verbatim for the activity log. *)
@@ -61,14 +85,15 @@ val short_label : rejection -> string
 
 val detail_excerpt : rejection -> string option
 (** The server-supplied detail line, if any (truncated to 200 chars). [None] for
-    variants that carry no payload ([Lease_violation], the named variants). Used
-    by callers that want to emit a follow-up activity-log line with the raw
-    server message. *)
+    variants that carry no payload ([Lease_violation], [Merge_queue_locked], the
+    named variants). Used by callers that want to emit a follow-up activity-log
+    line with the raw server message. *)
 
 val is_permanent : rejection -> bool
 (** [true] for rejections that will not resolve on retry under the current
     credentials and branch state ([Workflow_scope_missing], [Branch_protection],
     [Push_pattern_block], [Hook_failure]); [false] for [Lease_violation]
-    (genuine race) and [Unknown] (conservative — we don't escalate on something
+    (genuine race), [Merge_queue_locked] (self-clears when the queued PR merges
+    or is dequeued) and [Unknown] (conservative — we don't escalate on something
     we don't understand). The orchestrator uses this to short-circuit the
     push-failure counter and flip directly to intervention. *)

--- a/lib_core/reconciler.ml
+++ b/lib_core/reconciler.ml
@@ -11,6 +11,7 @@ type patch_view = {
   busy : bool;
   needs_intervention : bool;
   branch_blocked : bool;
+  in_merge_queue : bool;
   queue : Operation_kind.t list;
   base_branch : Branch.t;
   branch_rebased_onto : Branch.t option;
@@ -78,7 +79,7 @@ let detect_rebases graph views ~newly_merged =
       match Map.find view_by_id dep_id with
       | Some v
         when (not (Set.mem newly_merged_set dep_id))
-             && v.has_pr && (not v.merged)
+             && v.has_pr && (not v.merged) && (not v.in_merge_queue)
              && not
                   (List.mem v.queue Operation_kind.Rebase
                      ~equal:Operation_kind.equal) ->
@@ -101,7 +102,7 @@ let detect_rebases graph views ~newly_merged =
 let detect_notified_base_drift views =
   List.filter_map views ~f:(fun v ->
       if
-        v.has_pr && (not v.merged)
+        v.has_pr && (not v.merged) && (not v.in_merge_queue)
         && not
              (List.mem v.queue Operation_kind.Rebase ~equal:Operation_kind.equal)
       then
@@ -118,7 +119,7 @@ let detect_notified_base_drift views =
 let detect_stale_bases graph views ~has_merged ~branch_of ~main =
   List.filter_map views ~f:(fun v ->
       if
-        v.has_pr && (not v.merged)
+        v.has_pr && (not v.merged) && (not v.in_merge_queue)
         && (not
               (List.mem v.queue Operation_kind.Rebase
                  ~equal:Operation_kind.equal))
@@ -197,7 +198,7 @@ let detect_sibling_stale_bases graph views ~has_merged =
   let base_rebasable b =
     match Map.find view_by_id b with
     | Some bv ->
-        bv.has_pr
+        bv.has_pr && (not bv.in_merge_queue)
         && not
              (List.mem bv.queue Operation_kind.Rebase
                 ~equal:Operation_kind.equal)

--- a/lib_core/reconciler.mli
+++ b/lib_core/reconciler.mli
@@ -19,6 +19,12 @@ type patch_view = {
   busy : bool;
   needs_intervention : bool;
   branch_blocked : bool;
+  in_merge_queue : bool;
+      (** Whether the PR currently has a merge-queue entry. While true, GitHub
+          push-locks the head branch and the queue validates freshness against
+          the latest base, so rebase demand for this patch is suppressed at
+          enqueue time. The detectors are level-triggered, so demand
+          re-materializes on the first reconcile tick after ejection/dequeue. *)
   queue : Types.Operation_kind.t list;
   base_branch : Types.Branch.t;
   branch_rebased_onto : Types.Branch.t option;
@@ -84,7 +90,9 @@ val detect_rebases :
   action list
 (** [detect_rebases graph views ~newly_merged] returns [Enqueue_rebase] for
     dependents of [newly_merged] patches that have a PR, are not merged, and do
-    not already have a rebase queued. *)
+    not already have a rebase queued. Suppresses targets that are in the merge
+    queue: they are already being validated by GitHub and their head branch is
+    push-locked until merge or ejection. *)
 
 val detect_notified_base_drift : patch_view list -> action list
 (** [detect_notified_base_drift views] returns [Enqueue_rebase] for agents whose
@@ -97,7 +105,21 @@ val detect_notified_base_drift : patch_view list -> action list
     passes.
 
     Same precondition guards as other rebase detectors: has_pr, !merged,
-    !Rebase-in-queue. *)
+    !in_merge_queue, !Rebase-in-queue. *)
+
+val detect_stale_bases :
+  Graph.t ->
+  patch_view list ->
+  has_merged:(Types.Patch_id.t -> bool) ->
+  branch_of:(Types.Patch_id.t -> Types.Branch.t) ->
+  main:Types.Branch.t ->
+  action list
+(** [detect_stale_bases graph views ~has_merged ~branch_of ~main] returns
+    [Enqueue_rebase] for PR-backed, unmerged, non-queued patches whose current
+    [base_branch] differs from the structural base computed by
+    [Graph.initial_base]. Same rebase-demand gate as the other detectors:
+    suppresses patches in the merge queue because GitHub already validates them
+    against current base and their heads are push-locked. *)
 
 val detect_sibling_stale_bases :
   Graph.t ->
@@ -115,10 +137,11 @@ val detect_sibling_stale_bases :
     [Start (P, base = B)] ([Base_missing_merged_sibling]) relies on exactly this
     demand to ever become runnable. The target is enqueued (not [P]); [P]'s own
     start/rebase is gated separately by [Start_eligibility]. Skips when the
-    target has no PR yet or already has a [Rebase] queued, so queued/unstarted
-    dependencies are never rebase-enqueued by this detector. This is the demand
-    that the other three detectors miss, because the chain layers are *siblings*
-    of [P]'s merged deps, not dependents of them. *)
+    target has no PR yet, is in the merge queue, or already has a [Rebase]
+    queued, so queued/unstarted dependencies are never rebase-enqueued by this
+    detector. This is the demand that the other three detectors miss, because
+    the chain layers are *siblings* of [P]'s merged deps, not dependents of
+    them. *)
 
 val plan_operations :
   patch_view list ->

--- a/lib_test/test_generators.ml
+++ b/lib_test/test_generators.ml
@@ -494,6 +494,7 @@ let gen_patch_view =
             busy;
             needs_intervention;
             branch_blocked;
+            in_merge_queue = false;
             queue;
             base_branch;
             (* Conservative default for existing randomized tests: no drift
@@ -780,6 +781,7 @@ let apply_reconcile_actions orch ~main ~branch_of =
             busy = a.Onton_core.Patch_agent.busy;
             needs_intervention = Onton_core.Patch_agent.needs_intervention a;
             branch_blocked = a.Onton_core.Patch_agent.branch_blocked;
+            in_merge_queue = Onton_core.Patch_agent.in_merge_queue a;
             queue = a.Onton_core.Patch_agent.queue;
             base_branch =
               Option.value a.Onton_core.Patch_agent.base_branch ~default:main;

--- a/test/test_action_outcome_properties.ml
+++ b/test/test_action_outcome_properties.ml
@@ -26,6 +26,9 @@ let gen_merge_queue_entry =
     (string_size ~gen:(char_range 'a' 'z') (int_range 1 16))
     (oneof_list states) (int_range 0 99)
 
+let merge_queue_entry ?(state = Pr_state.Mq_queued) id =
+  Pr_state.{ id; state; position = 0 }
+
 (** Bootstrap a single-patch orchestrator with an idle agent that has a PR. *)
 let bootstrap_one () =
   let patches = mk_patches 1 in
@@ -782,6 +785,13 @@ let () =
              Patch_controller.apply_merge_queue_entered orch pid observed_entry
            in
            let after_controller = Orchestrator.agent orch pid in
+           let stuck_entry =
+             merge_queue_entry ~state:Pr_state.Mq_unmergeable "stuck-entry"
+           in
+           let stuck_agent =
+             Patch_agent.set_merge_queue_entry after_controller
+               (Some stuck_entry)
+           in
            Option.equal Pr_state.equal_merge_queue_entry
              after_controller.Patch_agent.merge_queue_entry
              (Some observed_entry)
@@ -789,6 +799,11 @@ let () =
            && Option.is_none after_controller.Patch_agent.automerge_deadline
            && (not after_controller.Patch_agent.automerge_inflight)
            && after_controller.Patch_agent.automerge_failure_count = 0
+           && Patch_controller.should_dequeue_merge_queue stuck_agent
+                ~main_branch:main ~entry_id:stuck_entry.Pr_state.id
+           && not
+                (Patch_controller.should_dequeue_merge_queue stuck_agent
+                   ~main_branch:main ~entry_id:"different-entry")
          with
          | QCheck2.Test.Test_fail _ as exn -> raise exn
          | _ -> false));

--- a/test/test_fanin_liveness_interleavings.ml
+++ b/test/test_fanin_liveness_interleavings.ml
@@ -357,6 +357,7 @@ let view_of_agent ~sibling_rebase_target (a : Patch_agent.t) :
     busy = a.Patch_agent.busy;
     needs_intervention = Patch_agent.needs_intervention a;
     branch_blocked = a.Patch_agent.branch_blocked;
+    in_merge_queue = Patch_agent.in_merge_queue a;
     queue = a.Patch_agent.queue;
     base_branch = Option.value a.Patch_agent.base_branch ~default:main;
     branch_rebased_onto = a.Patch_agent.branch_rebased_onto;

--- a/test/test_interleaving_properties.ml
+++ b/test/test_interleaving_properties.ml
@@ -2184,6 +2184,7 @@ let () =
                   busy = ag.Patch_agent.busy;
                   needs_intervention = Patch_agent.needs_intervention ag;
                   branch_blocked = ag.Patch_agent.branch_blocked;
+                  in_merge_queue = Patch_agent.in_merge_queue ag;
                   queue = ag.Patch_agent.queue;
                   base_branch =
                     Option.value ag.Patch_agent.base_branch ~default:main;
@@ -2833,6 +2834,7 @@ let reconcile_views_of orch =
           busy = ag.Patch_agent.busy;
           needs_intervention = Patch_agent.needs_intervention ag;
           branch_blocked = ag.Patch_agent.branch_blocked;
+          in_merge_queue = Patch_agent.in_merge_queue ag;
           queue = ag.Patch_agent.queue;
           base_branch = Option.value ag.Patch_agent.base_branch ~default:main;
           branch_rebased_onto = ag.Patch_agent.branch_rebased_onto;

--- a/test/test_intervention_reason.ml
+++ b/test/test_intervention_reason.ml
@@ -20,6 +20,7 @@ let agent () =
   Patch_agent.create ~branch:(Branch.of_string "b")
     (Patch_id.of_string "patch-1")
 
+let merge_queue_entry id = Pr_state.{ id; state = Mq_queued; position = 0 }
 let rec apply n f x = if n <= 0 then x else apply (n - 1) f (f x)
 
 let contains s sub =
@@ -34,7 +35,12 @@ let () =
   (* A healthy agent needs no intervention and has no banner reason. *)
   let a = agent () in
   assert (not (Patch_agent.needs_intervention a));
+  assert (not (Patch_agent.in_merge_queue a));
   assert (Option.is_none (Tui.human_intervention_reason a));
+  let queued =
+    Patch_agent.set_merge_queue_entry a (Some (merge_queue_entry "mq-1"))
+  in
+  assert (Patch_agent.in_merge_queue queued);
 
   (* Three CI failures is the documented threshold for intervention. *)
   let stuck = apply 3 Patch_agent.increment_ci_failure_count a in
@@ -328,6 +334,7 @@ let () =
              (agent ()) transitions
          in
          let _history = Patch_agent.anchor_history a in
+         let _in_merge_queue = Patch_agent.in_merge_queue a in
          let _priority = Patch_agent.highest_priority a in
          let _approved =
            Patch_agent.is_approved_modulo_merge_ready a ~main_branch:main

--- a/test/test_orchestrator_properties.ml
+++ b/test/test_orchestrator_properties.ml
@@ -13,6 +13,28 @@ open Onton_core.Types
     arbitrary command sequences. *)
 
 let main = Branch.of_string "main"
+let merge_queue_entry = Pr_state.{ id = "mq"; state = Mq_queued; position = 1 }
+
+let patch ?(dependencies = []) id =
+  let id = Patch_id.of_string id in
+  Patch.
+    {
+      id;
+      title = Patch_id.to_string id;
+      description = "";
+      branch = Branch.of_string (Patch_id.to_string id);
+      dependencies;
+      spec = "";
+      acceptance_criteria = [];
+      files = [];
+      classification = "";
+      changes = [];
+      test_stubs_introduced = [];
+      test_stubs_implemented = [];
+      complexity = None;
+      precedents = [];
+      required_context = [];
+    }
 
 (* Stub conflict_info: the orchestrator's Conflict arm doesn't inspect the
    payload, so a Plain-strategy zero-info value is a sound stand-in. *)
@@ -717,6 +739,71 @@ let () =
         with _ -> false)
   in
 
+  let prop_mark_merged_skips_merge_queue_dependents =
+    Test.make
+      ~name:
+        "MQ-CASCADE-1: mark_merged does not enqueue Rebase for dependent in \
+         merge queue"
+      Gen.(return ())
+      (fun () ->
+        try
+          let parent = patch "parent" in
+          let child = patch "child" ~dependencies:[ parent.Patch.id ] in
+          let patches = [ parent; child ] in
+          let orch = Orchestrator.create ~patches ~main_branch:main in
+          let orch =
+            Orchestrator.set_pr_number orch child.Patch.id (Pr_number.of_int 2)
+          in
+          let orch =
+            Orchestrator.set_merge_queue_entry orch child.Patch.id
+              (Some merge_queue_entry)
+          in
+          let orch = Orchestrator.mark_merged orch parent.Patch.id in
+          let child_agent = Orchestrator.agent orch child.Patch.id in
+          not
+            (List.mem child_agent.Patch_agent.queue Operation_kind.Rebase
+               ~equal:Operation_kind.equal)
+        with _ -> false)
+  in
+
+  let prop_rebase_cascade_skips_merge_queue_dependents =
+    Test.make
+      ~name:
+        "MQ-CASCADE-2: completed rebase does not strand-enqueue queued \
+         dependent"
+      Gen.(return ())
+      (fun () ->
+        try
+          let parent = patch "parent" in
+          let child = patch "child" ~dependencies:[ parent.Patch.id ] in
+          let patches = [ parent; child ] in
+          let orch = Orchestrator.create ~patches ~main_branch:main in
+          let orch =
+            Orchestrator.set_pr_number orch parent.Patch.id (Pr_number.of_int 1)
+          in
+          let orch =
+            Orchestrator.fire orch
+              (Orchestrator.Start (child.Patch.id, parent.Patch.branch))
+          in
+          let orch =
+            Orchestrator.set_pr_number orch child.Patch.id (Pr_number.of_int 2)
+          in
+          let orch = Orchestrator.complete orch child.Patch.id in
+          let orch =
+            Orchestrator.set_merge_queue_entry orch child.Patch.id
+              (Some merge_queue_entry)
+          in
+          let orch, _effects =
+            Orchestrator.apply_rebase_result orch parent.Patch.id Worktree.Ok
+              main
+          in
+          let child_agent = Orchestrator.agent orch child.Patch.id in
+          not
+            (List.mem child_agent.Patch_agent.queue Operation_kind.Rebase
+               ~equal:Operation_kind.equal)
+        with _ -> false)
+  in
+
   (* ========== apply_rebase_push_result properties ========== *)
 
   (* Push_ok -> Rebase_push_ok, no conflict *)
@@ -798,6 +885,45 @@ let () =
               && a.Patch_agent.has_conflict
               && List.mem a.Patch_agent.queue Operation_kind.Merge_conflict
                    ~equal:Operation_kind.equal
+        with _ -> false)
+  in
+
+  (* ARP-QL-1: a merge-queue-locked rejection is inert — the PR is queued, so
+     there is no conflict and nothing to retry. Guards the incident spiral
+     where the queue lock was read as a conflict. *)
+  let prop_rebase_push_queue_locked =
+    Test.make
+      ~name:
+        "ARP-QL-1: apply_rebase_push_result: Push_rejected Merge_queue_locked \
+         -> Rebase_push_queue_locked, no conflict, nothing enqueued"
+      (Gen.pair gen_patch_list_unique gen_branch) (fun (patches, new_base) ->
+        try
+          match patches with
+          | [] -> true
+          | first :: _ ->
+              let pid = first.Patch.id in
+              let orch = Orchestrator.create ~patches ~main_branch:main in
+              let orch, _effects, _actions = tick orch ~patches in
+              let orch, _effects =
+                Orchestrator.apply_rebase_result orch pid Worktree.Ok new_base
+              in
+              let orch, resolution =
+                Orchestrator.apply_rebase_push_result orch pid
+                  (Some
+                     (Worktree.Push_rejected
+                        Push_reject_classify.Merge_queue_locked))
+              in
+              let a = Orchestrator.agent orch pid in
+              Orchestrator.equal_rebase_push_resolution resolution
+                Orchestrator.Rebase_push_queue_locked
+              && (not a.Patch_agent.has_conflict)
+              && (not
+                    (List.mem a.Patch_agent.queue Operation_kind.Merge_conflict
+                       ~equal:Operation_kind.equal))
+              && (not
+                    (List.mem a.Patch_agent.queue Operation_kind.Rebase
+                       ~equal:Operation_kind.equal))
+              && not (Patch_agent.needs_intervention a)
         with _ -> false)
   in
 
@@ -1098,6 +1224,48 @@ let () =
               && a.Patch_agent.has_conflict
               && List.mem a.Patch_agent.queue Operation_kind.Merge_conflict
                    ~equal:Operation_kind.equal
+        with _ -> false)
+  in
+
+  (* ACP-QL-1: a Noop conflict-resolution whose push hits the merge-queue lock
+     is done, not stuck: the noop was evidence of a queued clean PR. The stray
+     noop-counter increment from the Noop arm must be undone, or repeated
+     queue-locked pushes walk conflict_noop_count to the >=2 intervention
+     threshold (the incident's exact spiral). *)
+  let prop_conflict_push_queue_locked =
+    Test.make
+      ~name:
+        "ACP-QL-1: apply_conflict_push_result: Resolved(Noop) + Push_rejected \
+         Merge_queue_locked -> Conflict_done, noop counter reset"
+      (Gen.pair gen_patch_list_unique gen_branch) (fun (patches, new_base) ->
+        try
+          match patches with
+          | [] -> true
+          | first :: _ ->
+              let pid = first.Patch.id in
+              let orch = Orchestrator.create ~patches ~main_branch:main in
+              let orch, _effects, _actions = tick orch ~patches in
+              let orch, decision, _effects =
+                Orchestrator.apply_conflict_rebase_result orch pid Worktree.Noop
+                  new_base
+              in
+              (Orchestrator.agent orch pid).Patch_agent.conflict_noop_count = 1
+              &&
+              let orch, resolution =
+                Orchestrator.apply_conflict_push_result orch pid decision
+                  (Some
+                     (Worktree.Push_rejected
+                        Push_reject_classify.Merge_queue_locked))
+              in
+              let a = Orchestrator.agent orch pid in
+              Orchestrator.equal_conflict_resolution resolution
+                Orchestrator.Conflict_done
+              && a.Patch_agent.conflict_noop_count = 0
+              && (not a.Patch_agent.has_conflict)
+              && (not
+                    (List.mem a.Patch_agent.queue Operation_kind.Merge_conflict
+                       ~equal:Operation_kind.equal))
+              && not (Patch_agent.needs_intervention a)
         with _ -> false)
   in
 
@@ -1687,9 +1855,12 @@ let () =
       prop_rebase_success_resets_rebase_failure_budget;
       prop_rebase_success_preserves_session_fallback;
       prop_rebase_conflict_resets_rebase_failure_budget;
+      prop_mark_merged_skips_merge_queue_dependents;
+      prop_rebase_cascade_skips_merge_queue_dependents;
       prop_rebase_push_ok;
       prop_rebase_push_up_to_date;
       prop_rebase_push_rejected;
+      prop_rebase_push_queue_locked;
       prop_rebase_push_error;
       prop_rebase_push_none;
       prop_conflict_rebase_ok;
@@ -1701,6 +1872,7 @@ let () =
       prop_conflict_rebase_sets_base;
       prop_conflict_push_resolved_ok;
       prop_conflict_push_resolved_rejected;
+      prop_conflict_push_queue_locked;
       prop_conflict_push_deliver_ok;
       prop_conflict_push_deliver_up_to_date;
       prop_conflict_push_deliver_no_push;

--- a/test/test_patch_controller.ml
+++ b/test/test_patch_controller.ml
@@ -56,18 +56,18 @@ let make_orch patch agent =
 
 let make_agent ?(merge_ready = false) ?(mergeability_unknown = false)
     ?(merge_queue_required = false) ?(merge_queue_entry = None)
-    ?(checks_passing = false) ?(head_oid = None) ?(review_decision = None)
-    ?(unresolved_comment_count = 0) ?(review_requested_for_oid = None)
-    ?(review_request_inflight = false) ?(automerge_enabled = false)
-    ?automerge_deadline ?(automerge_failure_count = 0) ~patch_id ~branch
-    ~pr_status ~merged ~queue ~base_branch ~is_draft ~pr_body_delivered
-    ~start_attempts_without_pr () =
+    ?(checks_passing = false) ?(ci_checks = []) ?(has_conflict = false)
+    ?(head_oid = None) ?(review_decision = None) ?(unresolved_comment_count = 0)
+    ?(review_requested_for_oid = None) ?(review_request_inflight = false)
+    ?(automerge_enabled = false) ?automerge_deadline
+    ?(automerge_failure_count = 0) ~patch_id ~branch ~pr_status ~merged ~queue
+    ~base_branch ~is_draft ~pr_body_delivered ~start_attempts_without_pr () =
   Patch_agent.restore ~patch_id ~branch ~pr_status ~has_session:false
-    ~busy:false ~merged ~queue ~satisfies:false ~changed:false
-    ~has_conflict:false ~base_branch ~notified_base_branch:base_branch
-    ~ci_failure_count:0 ~session_fallback:Patch_agent.Fresh_available
-    ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[] ~merge_ready
-    ~head_oid ~review_decision ~unresolved_comment_count ~mergeability_unknown
+    ~busy:false ~merged ~queue ~satisfies:false ~changed:false ~has_conflict
+    ~base_branch ~notified_base_branch:base_branch ~ci_failure_count:0
+    ~session_fallback:Patch_agent.Fresh_available ~human_messages:[]
+    ~inflight_human_messages:[] ~ci_checks ~merge_ready ~head_oid
+    ~review_decision ~unresolved_comment_count ~mergeability_unknown
     ~merge_queue_required ~merge_queue_entry ~is_draft ~pr_body_delivered
     ~pr_body_artifact_miss_count:0 ~start_attempts_without_pr
     ~conflict_noop_count:0 ~no_commits_push_count:0 ~context_exhaustion_count:0
@@ -1590,35 +1590,117 @@ let () =
         | _ -> false)
   in
 
-  let pending_patch_4_unmergeable_clears_automerge_deadline =
+  let pending_patch_4_unmergeable_dequeues =
     Test.make
       ~name:
-        "patch_controller: Patch 4 UNMERGEABLE entry clears automerge deadline"
+        "patch_controller: Patch 4 UNMERGEABLE entry dequeues from merge queue"
       QCheck2.Gen.unit (fun () ->
         let pid = Patch_id.of_string "mq-unmergeable" in
         let branch = Branch.of_string "feat/mq-unmergeable" in
         let patch = make_patch pid branch in
+        let pr_number = Pr_number.of_int 404 in
+        let entry =
+          merge_queue_entry "MQE_unmergeable" ~state:Pr_state.Mq_unmergeable
+        in
         let agent =
           make_agent ~patch_id:pid ~branch
-            ~pr_status:(Patch_pr_status.Present (Pr_number.of_int 404))
-            ~merged:false ~queue:[] ~base_branch:(Some main) ~is_draft:false
+            ~pr_status:(Patch_pr_status.Present pr_number) ~merged:false
+            ~queue:[] ~base_branch:(Some main) ~is_draft:false
             ~pr_body_delivered:true ~start_attempts_without_pr:0
             ~merge_ready:true ~checks_passing:true ~merge_queue_required:true
-            ~merge_queue_entry:
-              (Some
-                 (merge_queue_entry "MQE_unmergeable"
-                    ~state:Pr_state.Mq_unmergeable))
-            ~automerge_enabled:true ~automerge_deadline:0.0 ()
+            ~merge_queue_entry:(Some entry) ~automerge_enabled:true
+            ~automerge_deadline:0.0 ()
         in
         let orch = make_orch patch agent in
         let orch, decisions =
           Patch_controller.reconcile_automerge orch ~now:1.0
         in
-        let agent = Orchestrator.agent orch pid in
-        List.is_empty decisions
-        && agent.Patch_agent.automerge_failure_count = 0
-        && (not agent.Patch_agent.automerge_inflight)
-        && Option.is_none agent.Patch_agent.automerge_deadline)
+        match decisions with
+        | [ { Patch_controller.merge_patch_id; merge_pr_number; action } ] ->
+            Patch_id.equal merge_patch_id pid
+            && Pr_number.equal merge_pr_number pr_number
+            && Patch_controller.equal_merge_action action
+                 (Patch_controller.Dequeue entry.Pr_state.id)
+            && (Orchestrator.agent orch pid).Patch_agent.automerge_inflight
+        | _ -> false)
+  in
+
+  let pending_patch_4_visible_ci_failure_dequeues =
+    Test.make
+      ~name:
+        "patch_controller: queued PR with visible failing check dequeues from \
+         merge queue" QCheck2.Gen.unit (fun () ->
+        let pid = Patch_id.of_string "mq-ci-failure" in
+        let branch = Branch.of_string "feat/mq-ci-failure" in
+        let patch = make_patch pid branch in
+        let pr_number = Pr_number.of_int 407 in
+        let entry = merge_queue_entry "MQE_ci_failure" in
+        let failing_check =
+          Ci_check.
+            {
+              name = "ci";
+              conclusion = "failure";
+              details_url = None;
+              description = None;
+              started_at = None;
+              id = Some 407;
+            }
+        in
+        let agent =
+          make_agent ~patch_id:pid ~branch
+            ~pr_status:(Patch_pr_status.Present pr_number) ~merged:false
+            ~queue:[] ~base_branch:(Some main) ~is_draft:false
+            ~pr_body_delivered:true ~start_attempts_without_pr:0
+            ~merge_ready:false ~checks_passing:false
+            ~ci_checks:[ failing_check ] ~merge_queue_required:true
+            ~merge_queue_entry:(Some entry) ~automerge_enabled:true ()
+        in
+        let orch = make_orch patch agent in
+        let orch, decisions =
+          Patch_controller.reconcile_automerge orch ~now:1.0
+        in
+        match decisions with
+        | [ { Patch_controller.merge_patch_id; merge_pr_number; action } ] ->
+            Patch_id.equal merge_patch_id pid
+            && Pr_number.equal merge_pr_number pr_number
+            && Patch_controller.equal_merge_action action
+                 (Patch_controller.Dequeue entry.Pr_state.id)
+            && (Orchestrator.agent orch pid).Patch_agent.automerge_inflight
+        | _ -> false)
+  in
+
+  let pending_patch_4_conflict_alarm_dequeues =
+    Test.make
+      ~name:
+        "patch_controller: queued PR with conflict alarm dequeues from merge \
+         queue"
+      QCheck2.Gen.unit (fun () ->
+        let pid = Patch_id.of_string "mq-conflict" in
+        let branch = Branch.of_string "feat/mq-conflict" in
+        let patch = make_patch pid branch in
+        let pr_number = Pr_number.of_int 408 in
+        let entry = merge_queue_entry "MQE_conflict" in
+        let agent =
+          make_agent ~patch_id:pid ~branch
+            ~pr_status:(Patch_pr_status.Present pr_number) ~merged:false
+            ~queue:[] ~base_branch:(Some main) ~is_draft:false
+            ~pr_body_delivered:true ~start_attempts_without_pr:0
+            ~merge_ready:true ~checks_passing:true ~has_conflict:true
+            ~merge_queue_required:true ~merge_queue_entry:(Some entry)
+            ~automerge_enabled:true ()
+        in
+        let orch = make_orch patch agent in
+        let orch, decisions =
+          Patch_controller.reconcile_automerge orch ~now:1.0
+        in
+        match decisions with
+        | [ { Patch_controller.merge_patch_id; merge_pr_number; action } ] ->
+            Patch_id.equal merge_patch_id pid
+            && Pr_number.equal merge_pr_number pr_number
+            && Patch_controller.equal_merge_action action
+                 (Patch_controller.Dequeue entry.Pr_state.id)
+            && (Orchestrator.agent orch pid).Patch_agent.automerge_inflight
+        | _ -> false)
   in
 
   (* A direct-merge patch that is approval-ready in every respect but reads
@@ -1800,7 +1882,9 @@ let () =
       pending_patch_4_merge_queue_entered_clears_timer;
       pending_patch_4_unapproved_not_enqueued;
       pending_patch_4_automerge_dequeue_on_lost_approval;
-      pending_patch_4_unmergeable_clears_automerge_deadline;
+      pending_patch_4_unmergeable_dequeues;
+      pending_patch_4_visible_ci_failure_dequeues;
+      pending_patch_4_conflict_alarm_dequeues;
       prop_missing_adhoc_does_not_crash_reconcile;
       prop_apply_poll_lifts_missing_to_present;
       prop_child_of_missing_parent_not_startable;

--- a/test/test_poller_properties.ml
+++ b/test/test_poller_properties.ml
@@ -4,6 +4,9 @@
 open Base
 open Onton_core.Types
 
+let merge_queue_entry =
+  Onton_core.Pr_state.{ id = "mq"; state = Mq_queued; position = 1 }
+
 let () =
   let open QCheck2 in
   let open Onton_test_support.Test_generators in
@@ -36,6 +39,47 @@ let () =
             (Onton_core.Pr_state.equal_merge_state
                result.Onton_core.Poller.merge_state
                Onton_core.Pr_state.Conflicting));
+      Test.make
+        ~name:
+          "POLL-MQ-1: Conflicting enqueues Merge_conflict iff not in merge \
+           queue"
+        ~count:500 gen_pr_state (fun pr ->
+          let conflicting =
+            {
+              pr with
+              Onton_core.Pr_state.status = Onton_core.Pr_state.Open;
+              merge_state = Onton_core.Pr_state.Conflicting;
+              merge_queue_entry = None;
+            }
+          in
+          let queued =
+            {
+              conflicting with
+              Onton_core.Pr_state.merge_queue_entry = Some merge_queue_entry;
+            }
+          in
+          let unqueued_result =
+            Onton_core.Poller.poll ~was_merged:false conflicting
+          in
+          let queued_result = Onton_core.Poller.poll ~was_merged:false queued in
+          List.mem unqueued_result.Onton_core.Poller.queue
+            Operation_kind.Merge_conflict ~equal:Operation_kind.equal
+          && not
+               (List.mem queued_result.Onton_core.Poller.queue
+                  Operation_kind.Merge_conflict ~equal:Operation_kind.equal));
+      Test.make
+        ~name:"POLL-MQ-2: Conflicting still mirrors has_conflict while queued"
+        ~count:500 gen_pr_state (fun pr ->
+          let queued =
+            {
+              pr with
+              Onton_core.Pr_state.status = Onton_core.Pr_state.Open;
+              merge_state = Onton_core.Pr_state.Conflicting;
+              Onton_core.Pr_state.merge_queue_entry = Some merge_queue_entry;
+            }
+          in
+          let result = Onton_core.Poller.poll ~was_merged:false queued in
+          Onton_core.Poller.has_conflict result);
       Test.make ~name:"Poller.mergeability_unknown iff merge_state = Unknown"
         ~count:500 gen_pr_state (fun pr ->
           let result = Onton_core.Poller.poll ~was_merged:false pr in

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -438,8 +438,8 @@ let () =
   let main = Types.Branch.of_string "main" in
   let mk_view ?(has_pr = true) ?(merged = false) ?(busy = false)
       ?(needs_intervention = false) ?(branch_blocked = false) ?(queue = [])
-      ?(base_contains_merged_siblings = true) ?(sibling_rebase_target = None) id
-      =
+      ?(in_merge_queue = false) ?(base_contains_merged_siblings = true)
+      ?(sibling_rebase_target = None) id =
     Reconciler.
       {
         id;
@@ -448,6 +448,7 @@ let () =
         busy;
         needs_intervention;
         branch_blocked;
+        in_merge_queue;
         queue;
         base_branch = main;
         branch_rebased_onto = Some main;
@@ -1131,12 +1132,13 @@ let () =
   let prop_psf8_transient_reason_does_not_escalate =
     Test.make
       ~name:
-        "PSF-8: Session_push_failed with Lease_violation / None / Unknown does \
-         NOT immediately escalate to Given_up"
+        "PSF-8: Session_push_failed with Lease_violation / Merge_queue_locked \
+         / None / Unknown does NOT immediately escalate to Given_up"
       (Gen.oneof
          [
            Gen.return None;
            Gen.return (Some Push_reject_classify.Lease_violation);
+           Gen.return (Some Push_reject_classify.Merge_queue_locked);
            Gen.return (Some (Push_reject_classify.Unknown ""));
          ])
       (fun reason ->

--- a/test/test_push_plan_integration.ml
+++ b/test/test_push_plan_integration.ml
@@ -96,6 +96,7 @@ let scenario_branch_switched env =
       | Push_reject_classify.Branch_protection
       | Push_reject_classify.Push_pattern_block
       | Push_reject_classify.Lease_violation
+      | Push_reject_classify.Merge_queue_locked
       | Push_reject_classify.Hook_failure _ | Push_reject_classify.Unknown _ )
   | Worktree.Push_ok | Worktree.Push_up_to_date | Worktree.Push_no_commits
   | Worktree.Push_worktree_missing | Worktree.Push_error _ ->
@@ -202,6 +203,7 @@ let scenario_local_missing_remote env =
       | Push_reject_classify.Branch_protection
       | Push_reject_classify.Push_pattern_block
       | Push_reject_classify.Lease_violation
+      | Push_reject_classify.Merge_queue_locked
       | Push_reject_classify.Hook_failure _ | Push_reject_classify.Unknown _ )
   | Worktree.Push_ok | Worktree.Push_up_to_date | Worktree.Push_no_commits
   | Worktree.Push_worktree_missing | Worktree.Push_error _ ->
@@ -262,6 +264,7 @@ let scenario_happy_path env =
       | Push_reject_classify.Branch_protection
       | Push_reject_classify.Push_pattern_block
       | Push_reject_classify.Lease_violation
+      | Push_reject_classify.Merge_queue_locked
       | Push_reject_classify.Hook_failure _ | Push_reject_classify.Unknown _
       | Push_reject_classify.Local_state_unsafe _ )
   | Worktree.Push_worktree_missing | Worktree.Push_error _ ->
@@ -332,6 +335,7 @@ let to_rejection_partition =
           | Push_reject_classify.Branch_protection
           | Push_reject_classify.Push_pattern_block
           | Push_reject_classify.Lease_violation
+          | Push_reject_classify.Merge_queue_locked
           | Push_reject_classify.Hook_failure _ | Push_reject_classify.Unknown _
             ) ->
           false)

--- a/test/test_push_reject_classify_properties.ml
+++ b/test/test_push_reject_classify_properties.ml
@@ -70,6 +70,20 @@ let generic_hook_stderr =
    To https://github.com/o/r.git\n\
    ! [remote rejected]   foo -> foo (pre-receive hook declined)"
 
+(* The merge-queue head-branch lock. Deliberately contains BOTH
+   [Branch_protection] fingerprints (the GH006 header and the hook-declined
+   trailer) around the queue-specific lines, exactly as GitHub emits it — the
+   recognizer-order property PRC-17 depends on that. *)
+let merge_queue_locked_stderr =
+  "remote: error: GH006: Protected branch update failed for refs/heads/foo.\n\
+   remote: error: A pull request for this branch has been added to a merge \
+   queue. Branches that\n\
+   remote: are queued for merging cannot be updated. To modify this branch, \
+   dequeue the\n\
+   remote: associated pull request.\n\
+   To https://github.com/o/r.git\n\
+   ! [remote rejected]   foo -> foo (protected branch hook declined)"
+
 (* ---------- Properties ---------- *)
 
 let prop_totality =
@@ -121,7 +135,8 @@ let prop_generic_hook =
       | Push_reject_classify.Workflow_scope_missing
       | Push_reject_classify.Branch_protection
       | Push_reject_classify.Push_pattern_block
-      | Push_reject_classify.Lease_violation | Push_reject_classify.Unknown _
+      | Push_reject_classify.Lease_violation
+      | Push_reject_classify.Merge_queue_locked | Push_reject_classify.Unknown _
       | Push_reject_classify.Local_state_unsafe _ ->
           false)
 
@@ -134,6 +149,7 @@ let prop_empty_stderr =
       | Push_reject_classify.Branch_protection
       | Push_reject_classify.Push_pattern_block
       | Push_reject_classify.Lease_violation
+      | Push_reject_classify.Merge_queue_locked
       | Push_reject_classify.Hook_failure _
       | Push_reject_classify.Local_state_unsafe _ ->
           false)
@@ -167,7 +183,10 @@ let prop_detail_excerpt_none_for_named =
               Push_reject_classify.Push_pattern_block)
       && Option.is_none
            (Push_reject_classify.detail_excerpt
-              Push_reject_classify.Lease_violation))
+              Push_reject_classify.Lease_violation)
+      && Option.is_none
+           (Push_reject_classify.detail_excerpt
+              Push_reject_classify.Merge_queue_locked))
 
 let prop_permanence_matches_variant =
   Test.make ~count:300
@@ -182,8 +201,9 @@ let prop_permanence_matches_variant =
         | Push_reject_classify.Hook_failure _
         | Push_reject_classify.Local_state_unsafe _ ->
             true
-        | Push_reject_classify.Lease_violation | Push_reject_classify.Unknown _
-          ->
+        | Push_reject_classify.Lease_violation
+        | Push_reject_classify.Merge_queue_locked
+        | Push_reject_classify.Unknown _ ->
             false
       in
       Bool.equal (Push_reject_classify.is_permanent r) expected)
@@ -239,11 +259,35 @@ let prop_unknown_truncation =
       | Push_reject_classify.Branch_protection
       | Push_reject_classify.Push_pattern_block
       | Push_reject_classify.Lease_violation
+      | Push_reject_classify.Merge_queue_locked
       | Push_reject_classify.Local_state_unsafe _ ->
           (* sanitization stripped all letters, so the named-fingerprint arms
              and the planner-only Local_state_unsafe arm are unreachable here
              — but the type system can't know that. *)
           true)
+
+let prop_merge_queue_locked =
+  Test.make ~name:"PRC-16: merge-queue lock fingerprint -> Merge_queue_locked"
+    (Gen.return ()) (fun () ->
+      Push_reject_classify.equal_rejection
+        (Push_reject_classify.classify ~stderr:merge_queue_locked_stderr
+           ~stdout:"")
+        Push_reject_classify.Merge_queue_locked)
+
+let prop_merge_queue_beats_branch_protection =
+  Test.make
+    ~name:
+      "PRC-17: merge-queue lock beats Branch_protection despite carrying both \
+       GH006 fingerprints, and the plain GH006 blob still classifies \
+       Branch_protection" (Gen.return ()) (fun () ->
+      Push_reject_classify.equal_rejection
+        (Push_reject_classify.classify ~stderr:merge_queue_locked_stderr
+           ~stdout:"")
+        Push_reject_classify.Merge_queue_locked
+      && Push_reject_classify.equal_rejection
+           (Push_reject_classify.classify ~stderr:branch_protection_stderr
+              ~stdout:"")
+           Push_reject_classify.Branch_protection)
 
 let () =
   List.iter
@@ -264,5 +308,7 @@ let () =
       prop_recognizer_priority;
       prop_local_state_unsafe;
       prop_unknown_truncation;
+      prop_merge_queue_locked;
+      prop_merge_queue_beats_branch_protection;
     ];
   Stdlib.print_endline "Push_reject_classify: all properties passed"

--- a/test/test_reconciler_properties.ml
+++ b/test/test_reconciler_properties.ml
@@ -93,6 +93,7 @@ let gen_rebase_scenario =
                   busy = false;
                   needs_intervention = false;
                   branch_blocked = false;
+                  in_merge_queue = false;
                   queue = [];
                   base_branch = main;
                   branch_rebased_onto = Some main;
@@ -157,6 +158,7 @@ let prop_detect_rebases_skips_already_queued =
                 busy = false;
                 needs_intervention = false;
                 branch_blocked = false;
+                in_merge_queue = false;
                 queue = [ Types.Operation_kind.Rebase ];
                 base_branch = main;
                 branch_rebased_onto = Some main;
@@ -170,6 +172,59 @@ let prop_detect_rebases_skips_already_queued =
         let actions = Reconciler.detect_rebases graph views ~newly_merged in
         List.is_empty actions
       with _ -> false)
+
+let prop_detect_rebases_skips_merge_queue_target =
+  QCheck2.Test.make
+    ~name:"REC-MQ-1a: detect_rebases skips dependents in merge queue" ~count:1
+    QCheck2.Gen.(return ())
+    (fun () ->
+      let p1 = Types.Patch_id.of_string "p1" in
+      let p2 = Types.Patch_id.of_string "p2" in
+      let main = Types.Branch.of_string "main" in
+      let patch id dependencies : Types.Patch.t =
+        {
+          id;
+          title = Types.Patch_id.to_string id;
+          description = "";
+          branch = Types.Branch.of_string (Types.Patch_id.to_string id);
+          dependencies;
+          spec = "";
+          acceptance_criteria = [];
+          files = [];
+          classification = "";
+          changes = [];
+          test_stubs_introduced = [];
+          test_stubs_implemented = [];
+          complexity = None;
+          precedents = [];
+          required_context = [];
+        }
+      in
+      let graph = Graph.of_patches [ patch p1 []; patch p2 [ p1 ] ] in
+      let views =
+        let view id ~merged ~in_merge_queue =
+          Reconciler.
+            {
+              id;
+              has_pr = true;
+              merged;
+              busy = false;
+              needs_intervention = false;
+              branch_blocked = false;
+              in_merge_queue;
+              queue = [];
+              base_branch = main;
+              branch_rebased_onto = Some main;
+              base_contains_merged_siblings = true;
+              sibling_rebase_target = None;
+            }
+        in
+        [
+          view p1 ~merged:true ~in_merge_queue:false;
+          view p2 ~merged:false ~in_merge_queue:true;
+        ]
+      in
+      List.is_empty (Reconciler.detect_rebases graph views ~newly_merged:[ p1 ]))
 
 (* ========== plan_operations properties ========== *)
 
@@ -196,6 +251,7 @@ let gen_plan_scenario =
                   busy;
                   needs_intervention = intervention;
                   branch_blocked = false;
+                  in_merge_queue = false;
                   queue;
                   base_branch = main;
                   branch_rebased_onto = Some main;
@@ -365,6 +421,7 @@ let gen_reconcile_scenario =
                   busy = false;
                   needs_intervention = false;
                   branch_blocked = false;
+                  in_merge_queue = false;
                   queue = [];
                   base_branch = main;
                   branch_rebased_onto = Some main;
@@ -430,7 +487,8 @@ let other_br = Types.Branch.of_string "other"
 
 let mk_view ~id ?(has_pr = true) ?(merged = false) ?(queue = [])
     ?(base_branch = main_br) ?(branch_rebased_onto = Some main_br)
-    ?(base_contains_merged_siblings = true) ?(sibling_rebase_target = None) () =
+    ?(in_merge_queue = false) ?(base_contains_merged_siblings = true)
+    ?(sibling_rebase_target = None) () =
   Reconciler.
     {
       id;
@@ -439,6 +497,7 @@ let mk_view ~id ?(has_pr = true) ?(merged = false) ?(queue = [])
       busy = false;
       needs_intervention = false;
       branch_blocked = false;
+      in_merge_queue;
       queue;
       base_branch;
       branch_rebased_onto;
@@ -517,6 +576,17 @@ let prop_drift_silent_when_rebase_queued =
       in
       List.is_empty (Reconciler.detect_notified_base_drift [ v ]))
 
+let prop_drift_silent_when_in_merge_queue =
+  QCheck2.Test.make
+    ~name:"REC-MQ-1b: drift detector skips patches in merge queue" ~count:1
+    QCheck2.Gen.(return ())
+    (fun () ->
+      let v =
+        mk_view ~id:(pid "p1") ~in_merge_queue:true ~base_branch:main_br
+          ~branch_rebased_onto:(Some dep_br) ()
+      in
+      List.is_empty (Reconciler.detect_notified_base_drift [ v ]))
+
 let prop_drift_always_produces_enqueue_rebase =
   QCheck2.Test.make ~name:"drift: every emitted action is Enqueue_rebase"
     ~count:200
@@ -536,6 +606,56 @@ let prop_drift_always_produces_enqueue_rebase =
       |> List.for_all ~f:(function
         | Reconciler.Enqueue_rebase _ -> true
         | Reconciler.Mark_merged _ | Reconciler.Start_operation _ -> false))
+
+let prop_stale_base_suppressed_while_in_merge_queue =
+  QCheck2.Test.make
+    ~name:"REC-MQ-1d: stale-base detector skips patches in merge queue" ~count:1
+    QCheck2.Gen.(return ())
+    (fun () ->
+      let p = pid "p1" in
+      let patch : Types.Patch.t =
+        {
+          id = p;
+          title = "t";
+          description = "";
+          branch = Types.Branch.of_string "p1";
+          dependencies = [];
+          spec = "";
+          acceptance_criteria = [];
+          files = [];
+          classification = "";
+          changes = [];
+          test_stubs_introduced = [];
+          test_stubs_implemented = [];
+          complexity = None;
+          precedents = [];
+          required_context = [];
+        }
+      in
+      let graph = Graph.of_patches [ patch ] in
+      let has_merged _ = false in
+      let branch_of _ = main_br in
+      let view ~in_merge_queue =
+        mk_view ~id:p ~in_merge_queue ~base_branch:dep_br
+          ~branch_rebased_onto:(Some dep_br) ()
+      in
+      let unqueued =
+        Reconciler.detect_stale_bases graph
+          [ view ~in_merge_queue:false ]
+          ~has_merged ~branch_of ~main:main_br
+      in
+      let queued =
+        Reconciler.detect_stale_bases graph
+          [ view ~in_merge_queue:true ]
+          ~has_merged ~branch_of ~main:main_br
+      in
+      (match unqueued with
+        | [ Reconciler.Enqueue_rebase pid ] -> Types.Patch_id.equal pid p
+        | [] | _ :: _ :: _
+        | [ Reconciler.Mark_merged _ ]
+        | [ Reconciler.Start_operation _ ] ->
+            false)
+      && List.is_empty queued)
 
 (* End-to-end: reconcile emits Enqueue_rebase on a drifted view when no
    other detector would have caught it (base_branch already matches
@@ -802,6 +922,28 @@ let prop_fanin_silent_when_base_has_no_pr =
         (Reconciler.detect_sibling_stale_bases graph views
            ~has_merged:(merged_in merged)))
 
+let prop_fanin_silent_when_base_in_merge_queue =
+  QCheck2.Test.make
+    ~name:"REC-MQ-1c: sibling detector skips target in merge queue" ~count:1
+    QCheck2.Gen.(return ())
+    (fun () ->
+      let graph = fanin_graph () in
+      let merged = [ pid "d1"; pid "d3" ] in
+      let views =
+        [
+          mk_view ~id:(pid "p")
+            ~base_branch:(branch_of (pid "d2"))
+            ~branch_rebased_onto:(Some (branch_of (pid "d2")))
+            ~base_contains_merged_siblings:false
+            ~sibling_rebase_target:(Some (pid "d2"))
+            ();
+          mk_view ~id:(pid "d2") ~in_merge_queue:true ();
+        ]
+      in
+      List.is_empty
+        (Reconciler.detect_sibling_stale_bases graph views
+           ~has_merged:(merged_in merged)))
+
 (* The fan-in patch P most in need of this detector is an *unstarted* one: its
    pending Start(P, base=B) is deferred by Start_eligibility
    ([Base_missing_merged_sibling]) until B absorbs the merged sibling, and an
@@ -950,6 +1092,7 @@ let () =
       prop_detect_rebases_never_targets_merged;
       prop_detect_rebases_targets_are_dependents;
       prop_detect_rebases_skips_already_queued;
+      prop_detect_rebases_skips_merge_queue_target;
       prop_plan_skips_busy;
       prop_plan_skips_intervention;
       prop_plan_skips_no_pr;
@@ -967,7 +1110,9 @@ let () =
       prop_drift_silent_on_merged;
       prop_drift_silent_on_no_pr;
       prop_drift_silent_when_rebase_queued;
+      prop_drift_silent_when_in_merge_queue;
       prop_drift_always_produces_enqueue_rebase;
+      prop_stale_base_suppressed_while_in_merge_queue;
       prop_reconcile_e2e_catches_drift;
       prop_reconcile_dedup_rebase;
       prop_fanin_perm_open_d2;
@@ -977,6 +1122,7 @@ let () =
       prop_fanin_no_rebase_when_contained;
       prop_fanin_idempotent_when_queued;
       prop_fanin_silent_when_base_has_no_pr;
+      prop_fanin_silent_when_base_in_merge_queue;
       prop_fanin_unstarted_p_enqueues_base_rebase;
       prop_fanin_only_enqueue_rebase;
       prop_fanin_silent_off_edge;

--- a/test/test_reconciler_properties.ml
+++ b/test/test_reconciler_properties.ml
@@ -657,6 +657,58 @@ let prop_stale_base_suppressed_while_in_merge_queue =
             false)
       && List.is_empty queued)
 
+let prop_detect_stale_bases_enqueues_wrong_base =
+  QCheck2.Test.make
+    ~name:"detect_stale_bases: enqueues rebase when recorded base is stale"
+    ~count:1
+    QCheck2.Gen.(return ())
+    (fun () ->
+      let p1 = pid "p1" in
+      let p2 = pid "p2" in
+      let dep_branch = Types.Branch.of_string "dep" in
+      let patch id branch dependencies : Types.Patch.t =
+        {
+          id;
+          title = Types.Patch_id.to_string id;
+          description = "";
+          branch;
+          dependencies;
+          spec = "";
+          acceptance_criteria = [];
+          files = [];
+          classification = "";
+          changes = [];
+          test_stubs_introduced = [];
+          test_stubs_implemented = [];
+          complexity = None;
+          precedents = [];
+          required_context = [];
+        }
+      in
+      let graph =
+        Graph.of_patches
+          [
+            patch p1 dep_branch [];
+            patch p2 (Types.Branch.of_string "feature") [ p1 ];
+          ]
+      in
+      let view =
+        mk_view ~id:p2 ~base_branch:dep_branch
+          ~branch_rebased_onto:(Some dep_branch) ()
+      in
+      let actions =
+        Reconciler.detect_stale_bases graph [ view ]
+          ~has_merged:(fun p -> Types.Patch_id.equal p p1)
+          ~branch_of:(fun _ -> dep_branch)
+          ~main:main_br
+      in
+      match actions with
+      | [ Reconciler.Enqueue_rebase p ] -> Types.Patch_id.equal p p2
+      | [] | _ :: _ :: _
+      | [ Reconciler.Mark_merged _ ]
+      | [ Reconciler.Start_operation _ ] ->
+          false)
+
 (* End-to-end: reconcile emits Enqueue_rebase on a drifted view when no
    other detector would have caught it (base_branch already matches
    initial_base, merged list is empty, no newly_merged). This is the exact
@@ -1113,6 +1165,7 @@ let () =
       prop_drift_silent_when_in_merge_queue;
       prop_drift_always_produces_enqueue_rebase;
       prop_stale_base_suppressed_while_in_merge_queue;
+      prop_detect_stale_bases_enqueues_wrong_base;
       prop_reconcile_e2e_catches_drift;
       prop_reconcile_dedup_rebase;
       prop_fanin_perm_open_d2;

--- a/test/test_reconciler_properties.ml
+++ b/test/test_reconciler_properties.ml
@@ -660,12 +660,12 @@ let prop_stale_base_suppressed_while_in_merge_queue =
 let prop_detect_stale_bases_enqueues_wrong_base =
   QCheck2.Test.make
     ~name:"detect_stale_bases: enqueues rebase when recorded base is stale"
-    ~count:1
-    QCheck2.Gen.(return ())
-    (fun () ->
+    ~count:1 QCheck2.Gen.bool (fun use_alt_dep_branch ->
       let p1 = pid "p1" in
       let p2 = pid "p2" in
-      let dep_branch = Types.Branch.of_string "dep" in
+      let dep_branch =
+        Types.Branch.of_string (if use_alt_dep_branch then "dep-alt" else "dep")
+      in
       let patch id branch dependencies : Types.Patch.t =
         {
           id;


### PR DESCRIPTION
## Summary

- classify GitHub merge-queue head-branch push locks as `Merge_queue_locked` instead of branch protection
- treat queue-locked rebase/conflict pushes as inert so they do not create fake conflicts or trip noop intervention
- suppress rebase and merge-conflict demand while a PR is currently in the merge queue

## Root Cause

GitHub rejects force-pushes to a PR head branch while that PR is in the merge queue using a GH006 protected-branch-looking message. Onton classified that as branch protection and the rebase push path converted the rejection into conflict state, causing repeated no-op conflict attempts and spurious `needs-help`.

## Validation

- `dune exec test/test_push_reject_classify_properties.exe`
- `dune exec test/test_poller_properties.exe`
- `dune exec test/test_reconciler_properties.exe`
- `dune exec test/test_orchestrator_properties.exe`
- `dune build`
- `dune runtest`
- `dune fmt`
- final `dune build`
- pre-commit hook: build, runtest, format check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/400"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786039686&installation_id=126163856&pr_number=400&repository=flowglad%2Fonton&return_to=https%3A%2F%2Fgithub.com%2Fflowglad%2Fonton%2Fpull%2F400&signature=5e6e20328f1a16c724fb6f95b61a1b8f5cb905cd854fd5443789f699d0f79b82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->