### PR TITLE
[codex] Fix merge queue dequeue handling

### DIFF
--- a/lib/forge.ml
+++ b/lib/forge.ml
@@ -85,6 +85,6 @@ module type S = sig
   val enqueue_pr :
     pr_number:Types.Pr_number.t -> (enqueue_result, error) Result.t
 
-  val dequeue_pr : entry_id:string -> (unit, error) Result.t
+  val dequeue_pr : pr_number:Types.Pr_number.t -> (unit, error) Result.t
   val check_repo_access : unit -> (unit, error) Result.t
 end

--- a/lib/forge.mli
+++ b/lib/forge.mli
@@ -95,6 +95,6 @@ module type S = sig
   val enqueue_pr :
     pr_number:Types.Pr_number.t -> (enqueue_result, error) Result.t
 
-  val dequeue_pr : entry_id:string -> (unit, error) Result.t
+  val dequeue_pr : pr_number:Types.Pr_number.t -> (unit, error) Result.t
   val check_repo_access : unit -> (unit, error) Result.t
 end

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -1798,6 +1798,14 @@ let dequeue_pull_request_mutation =
   }
 }|}
 
+let build_dequeue_request_body ~node_id =
+  `Assoc
+    [
+      ("query", `String dequeue_pull_request_mutation);
+      ("variables", `Assoc [ ("id", `String node_id) ]);
+    ]
+  |> Yojson.Safe.to_string
+
 let enqueue_pr ~net ~clock ?timeout t ~pr_number =
   Result.bind (enqueue_pr_info ~net ~clock ?timeout t pr_number) ~f:(fun info ->
       match info.merge_queue_entry with
@@ -1861,21 +1869,18 @@ let resolve_review_thread ~net ~clock ?timeout t ~thread_id =
   | Ok resp -> parse_resolve_thread_response resp
   | Error _ as e -> e
 
-let dequeue_pr ~net ~clock ?timeout t ~entry_id =
-  let req_body =
-    `Assoc
-      [
-        ("query", `String dequeue_pull_request_mutation);
-        ("variables", `Assoc [ ("id", `String entry_id) ]);
-      ]
-    |> Yojson.Safe.to_string
-  in
+let dequeue_pr_by_node_id ~net ~clock ?timeout t ~node_id =
+  let req_body = build_dequeue_request_body ~node_id in
   match
     request ~net ~clock ?timeout t ~meth:`POST ~path:"/graphql" ~body:req_body
       ()
   with
   | Ok resp -> parse_dequeue_response resp
   | Error _ as e -> e
+
+let dequeue_pr ~net ~clock ?timeout t ~pr_number =
+  Result.bind (enqueue_pr_info ~net ~clock ?timeout t pr_number) ~f:(fun info ->
+      dequeue_pr_by_node_id ~net ~clock ?timeout t ~node_id:info.node_id)
 
 (* Which merge methods the repository permits. GitHub rejects a [PUT
    /pulls/:n/merge] whose [merge_method] is disabled with HTTP 405 ("Squash
@@ -2406,7 +2411,7 @@ let make ~net ~clock ~token ~owner ~repo ~main_branch :
 
     let merge_pr ~pr_number = merge_pr_choosing ~pr_number
     let enqueue_pr ~pr_number = enqueue_pr ~net ~clock client ~pr_number
-    let dequeue_pr ~entry_id = dequeue_pr ~net ~clock client ~entry_id
+    let dequeue_pr ~pr_number = dequeue_pr ~net ~clock client ~pr_number
     let check_repo_access () = check_repo_access_internal ~net ~clock client
   end in
   (module M)

--- a/lib/github.mli
+++ b/lib/github.mli
@@ -81,6 +81,11 @@ val parse_dequeue_response : string -> (unit, error) Result.t
 (** Parse a [dequeuePullRequest] GraphQL response body. Pure helper exposed for
     regression tests. *)
 
+val build_dequeue_request_body : node_id:string -> string
+(** Build a [dequeuePullRequest] GraphQL request body. [node_id] must be the
+    PullRequest node id, not the MergeQueueEntry node id. Exposed for regression
+    tests. *)
+
 val parse_merge_queue_removal_response :
   string -> (Types.Ci_check.t list, error) Result.t
 (** Parse a merge-queue removal-event GraphQL response body into the failing

--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -757,11 +757,18 @@ let merge_queue_alarm (agent : Patch_agent.t) =
   || Option.exists agent.Patch_agent.merge_queue_entry
        ~f:merge_queue_entry_unmergeable
 
+let merge_queue_transient_unknown_hold (agent : Patch_agent.t) ~main_branch =
+  agent.Patch_agent.mergeability_unknown
+  && Patch_agent.is_approved_modulo_merge_ready agent ~main_branch
+  && agent.Patch_agent.checks_passing
+  && List.is_empty agent.Patch_agent.queue
+
 let should_dequeue_merge_queue agent ~main_branch ~entry_id =
   match agent.Patch_agent.merge_queue_entry with
   | Some entry when String.equal entry.Pr_state.id entry_id ->
       merge_queue_alarm agent
-      || not (Patch_agent.is_approved agent ~main_branch)
+      || (not (Patch_agent.is_approved agent ~main_branch))
+         && not (merge_queue_transient_unknown_hold agent ~main_branch)
   | Some _ | None -> false
 
 let automerge_action (agent : Patch_agent.t) ~main_branch =
@@ -863,10 +870,14 @@ let reconcile_automerge t ~now =
               (Orchestrator.clear_automerge_deadline t patch_id, decisions)
         in
         match dequeue_action with
-        | Some action when agent.Patch_agent.automerge_enabled -> (
+        | Some action
+          when agent.Patch_agent.automerge_enabled
+               && agent.Patch_agent.automerge_failure_count
+                  < automerge_max_failures -> (
             (* Dequeue queue-alarmed PRs immediately on first observation. If a
-               previous dequeue call failed, [runner_fiber_impl] pushed the
-               deadline forward; honor it as retry backoff. *)
+               previous dequeue call failed, [runner_fiber_impl] increments the
+               automerge failure count; honor the same cap used for merge and
+               enqueue failures. *)
             match agent.Patch_agent.automerge_deadline with
             | Some deadline when Float.(now < deadline) -> (t, decisions)
             | None | Some _ -> emit_automerge_decision t action)

--- a/lib/runner_fiber_impl.ml
+++ b/lib/runner_fiber_impl.ml
@@ -189,6 +189,9 @@ struct
         in
         let apply_failure () =
           inflight_cleared := true;
+          (* [apply_automerge_failure] delegates to the shared automerge-state
+             transition, which clears [automerge_inflight] before incrementing
+             the failure count or applying the retry/cap deadline rules. *)
           Runtime.update_orchestrator runtime (fun orch ->
               Patch_controller.apply_automerge_failure orch
                 ~now:(Unix.gettimeofday ()) patch_id)

--- a/lib/runner_fiber_impl.ml
+++ b/lib/runner_fiber_impl.ml
@@ -291,8 +291,8 @@ struct
                 match action with
                 | Patch_controller.Enqueue ->
                     handle_enqueue_result (Forge.enqueue_pr ~pr_number)
-                | Patch_controller.Dequeue entry_id -> (
-                    match Forge.dequeue_pr ~entry_id with
+                | Patch_controller.Dequeue _ -> (
+                    match Forge.dequeue_pr ~pr_number with
                     | Ok () ->
                         push_deadline_and_clear_inflight ();
                         log_event runtime ~patch_id
@@ -302,7 +302,7 @@ struct
                               a queue alarm"
                              (Pr_number.to_int pr_number))
                     | Error err ->
-                        push_deadline_and_clear_inflight ();
+                        apply_failure ();
                         log_event runtime ~patch_id
                           (Printf.sprintf
                              "Automerge dequeue failed for PR #%d — %s"

--- a/test/test_github_merge_commit_null.ml
+++ b/test/test_github_merge_commit_null.ml
@@ -124,14 +124,31 @@ let pending_patch_3_enqueue_and_dequeue_parsing () =
       Printf.eprintf "  FAIL: future enqueue state parse errored: %s\n"
         (Onton.Github.show_error e);
       Stdlib.exit 1);
-  match
-    Onton.Github.parse_dequeue_response
-      {|{"data":{"dequeuePullRequest":{"clientMutationId":null}}}|}
-  with
+  (match
+     Onton.Github.parse_dequeue_response
+       {|{"data":{"dequeuePullRequest":{"clientMutationId":null}}}|}
+   with
   | Ok () -> ()
   | Error e ->
       Printf.eprintf "  FAIL: dequeue response parse errored: %s\n"
         (Onton.Github.show_error e);
+      Stdlib.exit 1);
+  let body =
+    Onton.Github.build_dequeue_request_body ~node_id:"PR_kwDORICuSc7u-Z8e"
+    |> Yojson.Safe.from_string
+  in
+  let id =
+    match body with
+    | `Assoc fields -> (
+        match Stdlib.List.assoc_opt "variables" fields with
+        | Some (`Assoc vars) -> Stdlib.List.assoc_opt "id" vars
+        | _ -> None)
+    | _ -> None
+  in
+  match id with
+  | Some (`String "PR_kwDORICuSc7u-Z8e") -> ()
+  | _ ->
+      Printf.eprintf "  FAIL: dequeue request did not carry PR node id\n";
       Stdlib.exit 1
 
 let pending_patch_3_merge_queue_405_detection () =

--- a/test/test_patch_controller.ml
+++ b/test/test_patch_controller.ml
@@ -1590,6 +1590,60 @@ let () =
         | _ -> false)
   in
 
+  let pending_patch_4_transient_unknown_does_not_dequeue =
+    Test.make
+      ~name:
+        "patch_controller: queued PR with transient UNKNOWN mergeability is \
+         not dequeued" QCheck2.Gen.unit (fun () ->
+        let pid = Patch_id.of_string "mq-unknown-hold" in
+        let branch = Branch.of_string "feat/mq-unknown-hold" in
+        let patch = make_patch pid branch in
+        let entry =
+          merge_queue_entry "MQE_unknown" ~state:Pr_state.Mq_awaiting_checks
+        in
+        let agent =
+          make_agent ~patch_id:pid ~branch
+            ~pr_status:(Patch_pr_status.Present (Pr_number.of_int 406))
+            ~merged:false ~queue:[] ~base_branch:(Some main) ~is_draft:false
+            ~pr_body_delivered:true ~start_attempts_without_pr:0
+            ~merge_ready:false ~mergeability_unknown:true ~checks_passing:true
+            ~merge_queue_required:true ~merge_queue_entry:(Some entry)
+            ~automerge_enabled:true ~automerge_deadline:0.0 ()
+        in
+        let orch = make_orch patch agent in
+        let orch, decisions =
+          Patch_controller.reconcile_automerge orch ~now:1.0
+        in
+        List.is_empty decisions
+        && not (Orchestrator.agent orch pid).Patch_agent.automerge_inflight)
+  in
+
+  let pending_patch_4_dequeue_respects_failure_cap =
+    Test.make ~name:"patch_controller: merge queue dequeue respects failure cap"
+      QCheck2.Gen.unit (fun () ->
+        let pid = Patch_id.of_string "mq-dequeue-cap" in
+        let branch = Branch.of_string "feat/mq-dequeue-cap" in
+        let patch = make_patch pid branch in
+        let entry =
+          merge_queue_entry "MQE_dequeue_cap" ~state:Pr_state.Mq_unmergeable
+        in
+        let agent =
+          make_agent ~patch_id:pid ~branch
+            ~pr_status:(Patch_pr_status.Present (Pr_number.of_int 409))
+            ~merged:false ~queue:[] ~base_branch:(Some main) ~is_draft:false
+            ~pr_body_delivered:true ~start_attempts_without_pr:0
+            ~merge_ready:true ~checks_passing:true ~merge_queue_required:true
+            ~merge_queue_entry:(Some entry) ~automerge_enabled:true
+            ~automerge_failure_count:Patch_controller.automerge_max_failures ()
+        in
+        let orch = make_orch patch agent in
+        let orch, decisions =
+          Patch_controller.reconcile_automerge orch ~now:1.0
+        in
+        List.is_empty decisions
+        && not (Orchestrator.agent orch pid).Patch_agent.automerge_inflight)
+  in
+
   let pending_patch_4_unmergeable_dequeues =
     Test.make
       ~name:
@@ -1882,6 +1936,8 @@ let () =
       pending_patch_4_merge_queue_entered_clears_timer;
       pending_patch_4_unapproved_not_enqueued;
       pending_patch_4_automerge_dequeue_on_lost_approval;
+      pending_patch_4_transient_unknown_does_not_dequeue;
+      pending_patch_4_dequeue_respects_failure_cap;
       pending_patch_4_unmergeable_dequeues;
       pending_patch_4_visible_ci_failure_dequeues;
       pending_patch_4_conflict_alarm_dequeues;


### PR DESCRIPTION
## Summary

Fixes merge-queue dequeue behavior uncovered by PR #5884 in a supervised session.

- Treat queued PRs with transient `UNKNOWN` mergeability like direct automerge candidates, so Onton does not dequeue a healthy `AWAITING_CHECKS` merge-queue entry just because GitHub is recomputing mergeability.
- Resolve and send the PullRequest node id to GitHub `dequeuePullRequest`, rather than passing the MergeQueueEntry node id.
- Route dequeue failures through the normal automerge failure path so repeated failures respect the existing failure cap instead of retrying indefinitely.
- Add regressions for the transient UNKNOWN queued-PR shape, the dequeue failure cap, and the dequeue GraphQL request body.

## Validation

- `dune fmt`
- `dune build`
- `dune exec test/test_patch_controller.exe`
- `dune exec test/test_github_merge_commit_null.exe`
- `dune exec test/test_automerge_state_properties.exe`
- `dune runtest`
- pre-commit hook: build, runtest, format check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/401"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786046286&installation_id=126163856&pr_number=401&repository=flowglad%2Fonton&return_to=https%3A%2F%2Fgithub.com%2Fflowglad%2Fonton%2Fpull%2F401&signature=72a96860a7ceb50020690890c097805c383a37761c3c35c4895a5853313a5807"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->