### PR TITLE
[codex] Fix merge queue automerge restart

### DIFF
--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -236,9 +236,7 @@ let apply_poll_result ?(merge_queue_ejection_confirmed = false) t patch_id
     Orchestrator.set_checks_passing t patch_id poll_result.checks_passing
   in
   let t =
-    if merge_queue_failure then
-      let t = Orchestrator.increment_automerge_failure_count t patch_id in
-      Orchestrator.clear_automerge_deadline t patch_id
+    if merge_queue_failure then Orchestrator.clear_automerge_deadline t patch_id
     else t
   in
   let t =
@@ -941,6 +939,12 @@ let apply_automerge_success t patch_id =
 let apply_merge_queue_entered t patch_id entry =
   Orchestrator.entered_merge_queue t patch_id entry
 
+let apply_merge_queue_dequeued t ~now patch_id =
+  let t = Orchestrator.set_merge_queue_entry t patch_id None in
+  let t = Orchestrator.set_automerge_inflight t patch_id false in
+  let t = Orchestrator.reset_automerge_failure_count t patch_id in
+  Orchestrator.set_automerge_deadline t patch_id (now +. automerge_idle_timeout)
+
 (** Apply the durable state change that follows a failed merge call. Clears the
     inflight flag and increments the failure counter. Pushes the deadline out by
     [automerge_idle_timeout] so the retry is at least one idle window away — the
@@ -1545,7 +1549,7 @@ let%test "apply_poll_result turns merge queue ejection into CI feedback" =
   let agent = Orchestrator.agent t pid in
   List.mem agent.queue Operation_kind.Ci ~equal:Operation_kind.equal
   && (not agent.checks_passing) && (not agent.merge_ready)
-  && agent.automerge_failure_count = 1
+  && agent.automerge_failure_count = 0
   && Option.is_none agent.automerge_deadline
   && List.exists agent.ci_checks ~f:Ci_check.is_merge_queue_failure
   && List.exists logs ~f:(fun { message; _ } ->

--- a/lib/patch_controller.mli
+++ b/lib/patch_controller.mli
@@ -230,6 +230,13 @@ val apply_merge_queue_entered :
     useful transition comes from polling GitHub's queue state, not from another
     automerge fire. *)
 
+val apply_merge_queue_dequeued :
+  Orchestrator.t -> now:float -> Patch_id.t -> Orchestrator.t
+(** Record that an automerge dequeue request succeeded. The PR is no longer
+    known to be in GitHub's merge queue, the successful GitHub call clears the
+    consecutive automerge API-failure counter, and the deadline is restarted so
+    a still-ready PR can be enqueued again after the idle window. *)
+
 val apply_automerge_failure :
   Orchestrator.t -> now:float -> Patch_id.t -> Orchestrator.t
 (** Record a failed merge call: clear the inflight flag and increment the

--- a/lib/runner_fiber_impl.ml
+++ b/lib/runner_fiber_impl.ml
@@ -297,7 +297,10 @@ struct
                 | Patch_controller.Dequeue _ -> (
                     match Forge.dequeue_pr ~pr_number with
                     | Ok () ->
-                        push_deadline_and_clear_inflight ();
+                        inflight_cleared := true;
+                        Runtime.update_orchestrator runtime (fun orch ->
+                            Patch_controller.apply_merge_queue_dequeued orch
+                              ~now:(Unix.gettimeofday ()) patch_id);
                         log_event runtime ~patch_id
                           (Printf.sprintf
                              "Automerge dequeued PR #%d from GitHub merge \

--- a/test/test_action_outcome_properties.ml
+++ b/test/test_action_outcome_properties.ml
@@ -785,12 +785,22 @@ let () =
              Patch_controller.apply_merge_queue_entered orch pid observed_entry
            in
            let after_controller = Orchestrator.agent orch pid in
+           let dequeue_now = 100.0 in
+           let orch =
+             Orchestrator.set_automerge_inflight orch pid true |> fun orch ->
+             Orchestrator.set_automerge_deadline orch pid 40.0 |> fun orch ->
+             Orchestrator.increment_automerge_failure_count orch pid
+           in
+           let orch =
+             Patch_controller.apply_merge_queue_dequeued orch ~now:dequeue_now
+               pid
+           in
+           let after_dequeued = Orchestrator.agent orch pid in
            let stuck_entry =
              merge_queue_entry ~state:Pr_state.Mq_unmergeable "stuck-entry"
            in
            let stuck_agent =
-             Patch_agent.set_merge_queue_entry after_controller
-               (Some stuck_entry)
+             Patch_agent.set_merge_queue_entry after_dequeued (Some stuck_entry)
            in
            Option.equal Pr_state.equal_merge_queue_entry
              after_controller.Patch_agent.merge_queue_entry
@@ -799,6 +809,15 @@ let () =
            && Option.is_none after_controller.Patch_agent.automerge_deadline
            && (not after_controller.Patch_agent.automerge_inflight)
            && after_controller.Patch_agent.automerge_failure_count = 0
+           && Option.is_none after_dequeued.Patch_agent.merge_queue_entry
+           && after_dequeued.Patch_agent.merge_queue_required
+           && (not after_dequeued.Patch_agent.automerge_inflight)
+           && after_dequeued.Patch_agent.automerge_failure_count = 0
+           && (match after_dequeued.Patch_agent.automerge_deadline with
+             | Some deadline ->
+                 Float.( = ) deadline
+                   (dequeue_now +. Patch_controller.automerge_idle_timeout)
+             | None -> false)
            && Patch_controller.should_dequeue_merge_queue stuck_agent
                 ~main_branch:main ~entry_id:stuck_entry.Pr_state.id
            && not

--- a/test/test_patch_controller.ml
+++ b/test/test_patch_controller.ml
@@ -1531,6 +1531,41 @@ let () =
         && agent.automerge_failure_count = 0)
   in
 
+  let pending_patch_4_merge_queue_dequeued_restarts_timer =
+    Test.make
+      ~name:
+        "patch_controller: successful merge queue dequeue resets backoff and \
+         restarts timer" QCheck2.Gen.unit (fun () ->
+        let pid = Patch_id.of_string "mq-dequeue-success" in
+        let branch = Branch.of_string "feat/mq-dequeue-success" in
+        let patch = make_patch pid branch in
+        let entry = merge_queue_entry "MQE_dequeue_success" in
+        let agent =
+          make_agent ~patch_id:pid ~branch
+            ~pr_status:(Patch_pr_status.Present (Pr_number.of_int 410))
+            ~merged:false ~queue:[] ~base_branch:(Some main) ~is_draft:false
+            ~pr_body_delivered:true ~start_attempts_without_pr:0
+            ~merge_ready:true ~checks_passing:true ~merge_queue_required:true
+            ~merge_queue_entry:(Some entry) ~automerge_enabled:true
+            ~automerge_deadline:0.0
+            ~automerge_failure_count:Patch_controller.automerge_max_failures ()
+        in
+        let now = 1000.0 in
+        let orch = make_orch patch agent in
+        let orch = Orchestrator.set_automerge_inflight orch pid true in
+        let orch = Patch_controller.apply_merge_queue_dequeued orch ~now pid in
+        let agent = Orchestrator.agent orch pid in
+        Option.is_none agent.merge_queue_entry
+        && agent.merge_queue_required
+        && (not agent.automerge_inflight)
+        && agent.automerge_failure_count = 0
+        &&
+        match agent.automerge_deadline with
+        | Some deadline ->
+            Float.( = ) deadline (now +. Patch_controller.automerge_idle_timeout)
+        | None -> false)
+  in
+
   let pending_patch_4_unapproved_not_enqueued =
     Test.make
       ~name:
@@ -1934,6 +1969,7 @@ let () =
       pending_patch_4_automerge_enqueue_action;
       pending_patch_4_automerge_enqueued_idle;
       pending_patch_4_merge_queue_entered_clears_timer;
+      pending_patch_4_merge_queue_dequeued_restarts_timer;
       pending_patch_4_unapproved_not_enqueued;
       pending_patch_4_automerge_dequeue_on_lost_approval;
       pending_patch_4_transient_unknown_does_not_dequeue;


### PR DESCRIPTION
## Summary

Fixes a merge-queue automerge liveness bug where a PR could be removed from GitHub's merge queue and remain ready but never restart its automerge timer.

## Root Cause

A poll-observed merge-queue ejection was being counted as an automerge API failure, which could push `automerge_failure_count` past the retry cap. Separately, a successful dequeue request only pushed the deadline and cleared inflight state; it did not clear the stale queue entry or reset the API-failure backoff.

## Changes

- Stop incrementing `automerge_failure_count` for poll-observed merge-queue ejections.
- Add a successful dequeue state transition that clears the queue entry, clears inflight, resets automerge backoff, and restarts the deadline.
- Wire successful dequeue handling through that transition.
- Add regression coverage for capped dequeue backoff restarting correctly after a successful dequeue.

## Validation

- `dune fmt`
- `dune build`
- `dune exec test/test_patch_controller.exe`
- `dune exec test/test_automerge_deadline_properties.exe`
- `dune exec test/test_automerge_state_properties.exe`
- `dune runtest`
- pre-commit hook passed: build, runtest, format check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/402"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786061048&installation_id=126163856&pr_number=402&repository=flowglad%2Fonton&return_to=https%3A%2F%2Fgithub.com%2Fflowglad%2Fonton%2Fpull%2F402&signature=d5bea0a97c4795c4fdec4ccf6060d117e0d76a1e05c269b1b0e223042430c50a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->