### PR TITLE
Fix CI dedupe liveness

### DIFF
--- a/lib/forge.ml
+++ b/lib/forge.ml
@@ -41,6 +41,9 @@ module type S = sig
       to an empty source for checks without a stable run id, and return [Error]
       only when every attempted details endpoint failed hard. *)
 
+  val rerun_failed_jobs_for_check :
+    check:Types.Ci_check.t -> (unit, error) Result.t
+
   val list_prs :
     branch:Types.Branch.t ->
     ?base:Types.Branch.t ->

--- a/lib/forge.mli
+++ b/lib/forge.mli
@@ -41,6 +41,12 @@ module type S = sig
       to an empty source for checks without a stable run id, and return [Error]
       only when every attempted details endpoint failed hard. *)
 
+  val rerun_failed_jobs_for_check :
+    check:Types.Ci_check.t -> (unit, error) Result.t
+  (** Re-run only the failed jobs for the workflow run that produced [check].
+      Implementations should reject checks that do not carry a workflow-run
+      identity rather than falling back to a full workflow rerun. *)
+
   val list_prs :
     branch:Types.Branch.t ->
     ?base:Types.Branch.t ->

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -1061,6 +1061,21 @@ let parse_actions_jobs_response body =
           |> List.filter ~f:Types.Ci_check.is_failure
           |> Result.return)
 
+let parse_actions_run_id_from_url url =
+  let marker = "/actions/runs/" in
+  match String.substr_index url ~pattern:marker with
+  | None -> None
+  | Some pos ->
+      let start = pos + String.length marker in
+      let rest = String.drop_prefix url start in
+      let len =
+        match String.findi rest ~f:(fun _ ch -> not (Char.is_digit ch)) with
+        | None -> String.length rest
+        | Some (idx, _) -> idx
+      in
+      let id = String.prefix rest len in
+      if String.is_empty id then None else Int.of_string_opt id
+
 let digest_annotation_of_check_annotation (a : check_annotation) :
     Ci_log_digest.annotation =
   {
@@ -1304,6 +1319,24 @@ let check_failure_details ~net ~clock t ~(check : Types.Ci_check.t) =
       | Ok annotations, Error _ -> Ok { Ci_log_digest.annotations; log = None }
       | Error _, Ok log -> Ok { Ci_log_digest.annotations = []; log }
       | Error _, Error log_error -> Error log_error)
+
+let rerun_failed_jobs_for_check ~net ~clock ?timeout t
+    ~(check : Types.Ci_check.t) =
+  match Option.bind check.details_url ~f:parse_actions_run_id_from_url with
+  | None ->
+      Error
+        (Json_parse_error
+           (Printf.sprintf
+              "check %S has no GitHub Actions workflow run URL; refusing full \
+               rerun"
+              check.name))
+  | Some run_id ->
+      let path =
+        Printf.sprintf "/repos/%s/%s/actions/runs/%d/rerun-failed-jobs" t.owner
+          t.repo run_id
+      in
+      Result.map (request ~net ~clock ?timeout t ~meth:`POST ~path ())
+        ~f:(fun _ -> ())
 
 let check_repo_access_internal ~net ~clock ?timeout t =
   let path = Printf.sprintf "/repos/%s/%s" t.owner t.repo in
@@ -2379,6 +2412,9 @@ let make ~net ~clock ~token ~owner ~repo ~main_branch :
 
     let check_failure_details ~check =
       check_failure_details ~net ~clock client ~check
+
+    let rerun_failed_jobs_for_check ~check =
+      rerun_failed_jobs_for_check ~net ~clock client ~check
 
     let list_prs ~branch ?base ~state () =
       match base with

--- a/lib/github.mli
+++ b/lib/github.mli
@@ -122,6 +122,11 @@ val parse_actions_jobs_response :
     Job database ids become [Ci_check.id], and [html_url] becomes [details_url].
     Pure helper exposed for regression tests. *)
 
+val parse_actions_run_id_from_url : string -> int option
+(** Parse the workflow run id from a GitHub Actions URL containing
+    [/actions/runs/<id>]. Returns [None] for non-Actions URLs or malformed ids.
+    Pure helper exposed for regression tests. *)
+
 val parse_check_annotations_response :
   string -> (Ci_log_digest.annotation list, error) Result.t
 (** Parse a REST [GET /check-runs/:id/annotations] response into digest

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -1196,6 +1196,7 @@ type respond_outcome =
   | Respond_ok
   | Respond_failed
   | Respond_retry_push
+  | Respond_no_commits
   | Respond_stale
   | Respond_skip_empty
   | Respond_pr_body_miss
@@ -1226,6 +1227,7 @@ let apply_respond_outcome t patch_id kind outcome =
   | Respond_stale -> t
   | Respond_failed -> complete_failed t patch_id
   | Respond_retry_push -> complete t patch_id
+  | Respond_no_commits -> complete t patch_id
   | Respond_skip_empty -> complete t patch_id
   | Respond_pr_body_miss ->
       let t = complete t patch_id in

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -1246,6 +1246,9 @@ let apply_respond_outcome t patch_id kind outcome =
         else t
       in
       let t =
+        update_agent t patch_id ~f:Patch_agent.reset_no_commits_push_count
+      in
+      let t =
         if Operation_kind.equal kind Operation_kind.Merge_conflict then
           let t = clear_has_conflict t patch_id in
           reset_conflict_noop_count t patch_id

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -1152,7 +1152,7 @@ let apply_session_result t patch_id result =
       let t = update_agent t patch_id ~f:Patch_agent.on_context_exhausted in
       complete_failed t patch_id
 
-let combine_session_and_push ~(session : session_result)
+let combine_session_and_push ~branch_changed ~(session : session_result)
     ~(push : Worktree.push_result) : session_result =
   (* Push_worktree_missing dominates every prior session outcome: even if the
      LLM session reported [Session_ok], the worktree (and thus the local
@@ -1167,7 +1167,8 @@ let combine_session_and_push ~(session : session_result)
       match session with
       | Session_ok -> (
           match push with
-          | Worktree.Push_ok | Worktree.Push_up_to_date -> Session_ok
+          | Worktree.Push_ok | Worktree.Push_up_to_date ->
+              if branch_changed then Session_ok else Session_no_commits
           | Worktree.Push_no_commits -> Session_no_commits
           | Worktree.Push_rejected reason -> Session_push_failed (Some reason)
           | Worktree.Push_error _ -> Session_push_failed None

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -274,6 +274,7 @@ val apply_session_result : t -> Patch_id.t -> session_result -> t
     [Session_push_failed]). [busy] remains [true]. The caller MUST follow up in
     the same atomic snapshot write with either
     [apply_start_outcome _ Start_failed] (Start path) or
+    [apply_respond_outcome _ _ Respond_no_commits] /
     [apply_respond_outcome _ _ Respond_retry_push] (Respond path) to clear
     [busy]. This two-phase design is deliberate: the LLM session itself
     succeeded (messages were delivered; commits were made locally), so any
@@ -323,6 +324,7 @@ type respond_outcome =
   | Respond_ok
   | Respond_failed
   | Respond_retry_push
+  | Respond_no_commits
   | Respond_stale
   | Respond_skip_empty
   | Respond_pr_body_miss
@@ -338,13 +340,14 @@ val apply_respond_outcome :
     non-converged cycles; Pr_body -> set_pr_body_delivered +
     reset_pr_body_artifact_miss_count so the cap counts only consecutive
     misses). [Respond_failed] -> complete_failed (restores inflight human
-    messages). [Respond_skip_empty] -> complete. [Respond_retry_push] ->
-    complete. [Respond_stale] -> identity. [Respond_pr_body_miss] -> complete +
-    increment_pr_body_artifact_miss_count (does NOT set_pr_body_delivered — the
-    reconciler re-enqueues Pr_body naturally). [Respond_review_unresolved] ->
-    complete + increment_review_unresolved_cycle_count — the still-unresolved
-    threads re-deliver via the next poll until the cap (>=2) surfaces the agent
-    through [needs_intervention]. *)
+    messages). [Respond_skip_empty], [Respond_retry_push], and
+    [Respond_no_commits] -> complete. [Respond_stale] -> identity.
+    [Respond_pr_body_miss] -> complete + increment_pr_body_artifact_miss_count
+    (does NOT set_pr_body_delivered — the reconciler re-enqueues Pr_body
+    naturally). [Respond_review_unresolved] -> complete +
+    increment_review_unresolved_cycle_count — the still-unresolved threads
+    re-deliver via the next poll until the cap (>=2) surfaces the agent through
+    [needs_intervention]. *)
 
 type force_complete_reason = Cancelled | Unexpected_exception
 [@@deriving show, eq, sexp_of]

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -332,8 +332,8 @@ type respond_outcome =
 val apply_respond_outcome :
   t -> Patch_id.t -> Operation_kind.t -> respond_outcome -> t
 (** Apply the outcome of a Respond action fiber. [Respond_ok] -> complete +
-    kind-specific transitions (Merge_conflict -> clear_has_conflict +
-    reset_conflict_noop_count; Review_comments ->
+    reset_no_commits_push_count + kind-specific transitions (Merge_conflict ->
+    clear_has_conflict + reset_conflict_noop_count; Review_comments ->
     reset_review_unresolved_cycle_count so the cap counts only consecutive
     non-converged cycles; Pr_body -> set_pr_body_delivered +
     reset_pr_body_artifact_miss_count so the cap counts only consecutive

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -286,14 +286,20 @@ val apply_session_result : t -> Patch_id.t -> session_result -> t
     [push_failure_count >= 3] or [Given_up]. *)
 
 val combine_session_and_push :
-  session:session_result -> push:Worktree.push_result -> session_result
+  branch_changed:bool ->
+  session:session_result ->
+  push:Worktree.push_result ->
+  session_result
 (** Pure: fold the LLM session outcome and the supervisor's post-session push
     outcome into a single [session_result] for [apply_session_result].
     - A pre-existing LLM failure ([Session_process_error], [Session_failed],
       [Session_no_resume], [Session_give_up], [Session_worktree_missing],
       [Session_push_failed _]) is preserved unchanged — the push outcome doesn't
       change anything.
-    - [Session_ok] with [Push_ok] or [Push_up_to_date] stays [Session_ok].
+    - [Session_ok] with [Push_ok] or [Push_up_to_date] stays [Session_ok] when
+      [branch_changed] is true. When [branch_changed] is false, it becomes
+      [Session_no_commits]: the agent turn finished but did not create a new
+      commit, even if the branch already had older commits ahead of base.
     - [Session_ok] with [Push_rejected reason] becomes
       [Session_push_failed (Some reason)] — the LLM ran fine but the remote
       refused commits; the classified reason rides along so the orchestrator can
@@ -301,9 +307,9 @@ val combine_session_and_push :
       branch-protection, push-pattern, hook).
     - [Session_ok] with [Push_error _] becomes [Session_push_failed None] — a
       transport/local git error, always treated as transient.
-    - [Session_ok] with [Push_no_commits] becomes [Session_no_commits] — the LLM
-      ran cleanly but left no commits on the branch, so the push was skipped (a
-      base-equal branch can't become a PR). *)
+    - [Session_ok] with [Push_no_commits] becomes [Session_no_commits] — the
+      branch has no commits ahead of base, so the push was skipped (a base-equal
+      branch can't become a PR). *)
 
 type start_outcome = Start_ok | Start_failed | Start_stale
 [@@deriving show, eq, sexp_of]

--- a/lib/runner_fiber_impl.ml
+++ b/lib/runner_fiber_impl.ml
@@ -2700,7 +2700,7 @@ struct
                           | `Stale -> Orchestrator.Respond_stale
                           | `Skip_empty -> Orchestrator.Respond_skip_empty
                           | `Failed -> Orchestrator.Respond_failed
-                          | `No_commits -> Orchestrator.Respond_retry_push
+                          | `No_commits -> Orchestrator.Respond_no_commits
                           | `Retry_push -> Orchestrator.Respond_retry_push
                           | `Pr_body_miss -> Orchestrator.Respond_pr_body_miss
                           | `Review_unresolved ->
@@ -2794,6 +2794,7 @@ struct
                                 ~expires_at:(Unix.gettimeofday () +. 10.0)
                                 ()
                         | Orchestrator.Respond_stale
+                        | Orchestrator.Respond_no_commits
                         | Orchestrator.Respond_retry_push
                         | Orchestrator.Respond_skip_empty ->
                             ())))

--- a/lib/runner_fiber_impl.ml
+++ b/lib/runner_fiber_impl.ml
@@ -945,13 +945,14 @@ struct
                                         (r
                                           :> [ `Failed
                                              | `Ok
+                                             | `No_commits
                                              | `Retry_push
                                              | `Stale ])))
                             in
                             let start_outcome =
                               match result with
                               | `Stale -> Orchestrator.Start_stale
-                              | `Failed | `Retry_push ->
+                              | `Failed | `Retry_push | `No_commits ->
                                   Orchestrator.Start_failed
                               | `Ok -> Orchestrator.Start_ok
                             in
@@ -1621,6 +1622,7 @@ struct
                                         (result
                                           :> [ `Failed
                                              | `Ok
+                                             | `No_commits
                                              | `Pr_body_miss
                                              | `Retry_push
                                              | `Review_unresolved
@@ -2332,6 +2334,7 @@ struct
                                           (result
                                             :> [ `Failed
                                                | `Ok
+                                               | `No_commits
                                                | `Pr_body_miss
                                                | `Retry_push
                                                | `Review_unresolved ])
@@ -2362,6 +2365,11 @@ struct
                                         let session_ok =
                                           match result with
                                           | `Ok -> true
+                                          | _ -> false
+                                        in
+                                        let session_no_commits =
+                                          match result with
+                                          | `No_commits -> true
                                           | _ -> false
                                         in
                                         let result =
@@ -2459,17 +2467,19 @@ struct
                                              the session driver implies the
                                              post-session push shipped (push
                                              failure surfaces as
-                                             [`Retry_push]), so replies
-                                             claiming a fix never precede the
-                                             fix reaching the remote. On a
-                                             failed session the response
-                                             files are left in place but not
-                                             posted — the poller re-detects
-                                             the unresolved threads and the
-                                             next Review session re-delivers
-                                             (its setup clears the stale
-                                             files). *)
-                                              if session_ok then
+                                             [`Retry_push]). [`No_commits] is
+                                             also eligible because a
+                                             comment-only answer has no code
+                                             fix to push. On a failed session
+                                             the response files are left in
+                                             place but not posted — the poller
+                                             re-detects the unresolved threads
+                                             and the next Review session
+                                             re-delivers (its setup clears the
+                                             stale files). *)
+                                              if
+                                                session_ok || session_no_commits
+                                              then
                                                 match
                                                   Comment_responder
                                                   .respond_after_session
@@ -2508,7 +2518,10 @@ struct
                                                       | None -> assert false)
                                                     ~delivered:comments ()
                                                 with
-                                                | `Converged -> result
+                                                | `Converged ->
+                                                    if session_no_commits then
+                                                      `Ok
+                                                    else result
                                                 | `Unresolved _ ->
                                                     `Review_unresolved
                                               else (
@@ -2519,8 +2532,51 @@ struct
                                                    unresolved comments will \
                                                    re-deliver";
                                                 result)
+                                          | Patch_decision.Ci_payload
+                                              { failed_checks } ->
+                                              if session_no_commits then
+                                                let rerun_results =
+                                                  Base.List.map failed_checks
+                                                    ~f:(fun check ->
+                                                      match
+                                                        Forge
+                                                        .rerun_failed_jobs_for_check
+                                                          ~check
+                                                      with
+                                                      | Ok () ->
+                                                          log_event runtime
+                                                            ~patch_id
+                                                            (Printf.sprintf
+                                                               "ci-rerun: \
+                                                                requested \
+                                                                failed-job \
+                                                                rerun for %s"
+                                                               check
+                                                                 .Ci_check.name);
+                                                          true
+                                                      | Error err ->
+                                                          log_event runtime
+                                                            ~patch_id
+                                                            (Printf.sprintf
+                                                               "ci-rerun: \
+                                                                failed to \
+                                                                request \
+                                                                failed-job \
+                                                                rerun for %s — \
+                                                                %s"
+                                                               check
+                                                                 .Ci_check.name
+                                                               (Forge.show_error
+                                                                  err));
+                                                          false)
+                                                in
+                                                if
+                                                  Base.List.exists rerun_results
+                                                    ~f:(fun x -> x)
+                                                then `Ok
+                                                else `Retry_push
+                                              else result
                                           | Patch_decision.Human_payload _
-                                          | Patch_decision.Ci_payload _
                                           | Patch_decision.Pr_body_payload
                                           | Patch_decision
                                             .Merge_conflict_payload ->
@@ -2631,6 +2687,7 @@ struct
                                         (result
                                           :> [ `Failed
                                              | `Ok
+                                             | `No_commits
                                              | `Pr_body_miss
                                              | `Review_unresolved
                                              | `Retry_push
@@ -2643,6 +2700,7 @@ struct
                           | `Stale -> Orchestrator.Respond_stale
                           | `Skip_empty -> Orchestrator.Respond_skip_empty
                           | `Failed -> Orchestrator.Respond_failed
+                          | `No_commits -> Orchestrator.Respond_retry_push
                           | `Retry_push -> Orchestrator.Respond_retry_push
                           | `Pr_body_miss -> Orchestrator.Respond_pr_body_miss
                           | `Review_unresolved ->

--- a/lib/session_driver.ml
+++ b/lib/session_driver.ml
@@ -836,15 +836,13 @@ module Make (W : Worktree.S) (Env : ENV) = struct
                 let final_user_result =
                   match final_session_result with
                   | Orchestrator.Session_ok -> user_result
-                  | Orchestrator.Session_push_failed _
-                  | Orchestrator.Session_no_commits ->
-                      (* LLM session ran fine but commits didn't ship (push failed
-                   or the agent made no commits) — signal retry so the
-                   Respond path uses Respond_retry_push (clean complete) and
-                   the reconciler re-enqueues the operation naturally. After
-                   2 consecutive no-commit sessions, needs_intervention fires
-                   and the scheduler stops re-enqueueing. *)
+                  | Orchestrator.Session_push_failed _ ->
+                      (* LLM session ran fine but commits didn't ship because
+                         push failed — signal retry so the Respond path uses
+                         Respond_retry_push (clean complete) and the reconciler
+                         re-enqueues the operation naturally. *)
                       `Retry_push
+                  | Orchestrator.Session_no_commits -> `No_commits
                   | Orchestrator.Session_process_error _
                   | Orchestrator.Session_no_resume
                   | Orchestrator.Session_failed _ | Orchestrator.Session_give_up

--- a/lib/session_driver.ml
+++ b/lib/session_driver.ml
@@ -179,6 +179,13 @@ module Make (W : Worktree.S) (Env : ENV) = struct
         | Worktree_setup.Refused -> (`Failed, [])
         | Worktree_setup.Path worktree_path ->
             let cwd = Eio.Path.(fs / worktree_path) in
+            let pre_session_branch_sha =
+              let branch_str =
+                Types.Branch.to_string agent.Patch_agent.branch
+              in
+              W.read_branch_sha ~path:worktree_path
+                ~ref_name:("refs/heads/" ^ branch_str)
+            in
             (* Read once at session start so the per-event callback below can
              persist the session id to the crash-recovery sidecar without
              repeated env lookups.  When unset, the sidecar write is a no-op:
@@ -744,6 +751,11 @@ module Make (W : Worktree.S) (Env : ENV) = struct
                 let push_outcome =
                   W.force_push_with_lease ~path:worktree_path ~branch ~base
                 in
+                let branch_changed =
+                  not
+                    (Option.equal String.equal pre_session_branch_sha
+                       push_local_sha)
+                in
                 (match push_outcome with
                 | Worktree.Push_ok ->
                     log_event runtime ~patch_id "runner: pushed after session"
@@ -773,6 +785,13 @@ module Make (W : Worktree.S) (Env : ENV) = struct
                 | Worktree.Push_error msg ->
                     log_event runtime ~patch_id
                       (Printf.sprintf "runner: push error after session: %s" msg));
+                if
+                  (not branch_changed)
+                  && Orchestrator.equal_session_result session_result
+                       Orchestrator.Session_ok
+                then
+                  log_event runtime ~patch_id
+                    "runner: session made no new commit";
                 (* Combine LLM session outcome with push outcome into a single
              session_result via the pure decision in
              [Orchestrator.combine_session_and_push]. user_result mirrors:
@@ -799,7 +818,7 @@ module Make (W : Worktree.S) (Env : ENV) = struct
                 in
                 let final_session_result =
                   let combined =
-                    Orchestrator.combine_session_and_push
+                    Orchestrator.combine_session_and_push ~branch_changed
                       ~session:session_result ~push:push_outcome
                   in
                   match combined with

--- a/lib/session_driver.ml
+++ b/lib/session_driver.ml
@@ -752,9 +752,9 @@ module Make (W : Worktree.S) (Env : ENV) = struct
                   W.force_push_with_lease ~path:worktree_path ~branch ~base
                 in
                 let branch_changed =
-                  not
-                    (Option.equal String.equal pre_session_branch_sha
-                       push_local_sha)
+                  match (pre_session_branch_sha, push_local_sha) with
+                  | Some before, Some after -> not (String.equal before after)
+                  | None, _ | _, None -> true
                 in
                 (match push_outcome with
                 | Worktree.Push_ok ->

--- a/lib/session_driver.mli
+++ b/lib/session_driver.mli
@@ -33,7 +33,7 @@ module Make (_ : Worktree.S) (_ : ENV) : sig
     on_pr_detected:(Types.Pr_number.t -> unit) ->
     backend:Llm_backend.t ->
     complexity:int option ->
-    [ `Ok | `Failed | `Retry_push ] * (string * string) list
+    [ `Ok | `Failed | `Retry_push | `No_commits ] * (string * string) list
   (** Returns the supervisor disposition and the list of [(tool_name, status)]
       pairs for any tool calls that did not reach a [completed] state (used by
       the Pr_body classifier to disambiguate "agent chose not to write" from
@@ -69,7 +69,7 @@ module Make (_ : Worktree.S) (_ : ENV) : sig
     on_pr_detected:(Types.Pr_number.t -> unit) ->
     session:long_lived_session ->
     complexity:int option ->
-    [ `Ok | `Failed | `Retry_push ] * (string * string) list
+    [ `Ok | `Failed | `Retry_push | `No_commits ] * (string * string) list
   (** Long-lived backend counterpart to {!run}. It shares the same supervisor
       bookkeeping and delivers the rendered turn over [backend.prompt] instead
       of spawning a fresh backend process. *)

--- a/lib_core/patch_decision.ml
+++ b/lib_core/patch_decision.ml
@@ -138,7 +138,9 @@ let on_ci_failure (a : Patch_agent.t) : ci_decision =
     in
     match (has_known_failure, has_undelivered_failure) with
     | true, false ->
-        if a.ci_failure_count > 0 then Enqueue_ci else Ci_already_delivered
+        if a.ci_failure_count > 0 && a.ci_failure_count < a.max_ci_failures then
+          Enqueue_ci
+        else Ci_already_delivered
     | false, _ ->
         (* The poll queue can report a CI failure before GitHub has returned
            the failed check rows. With no stable run id available to dedup

--- a/lib_core/patch_decision.ml
+++ b/lib_core/patch_decision.ml
@@ -137,7 +137,8 @@ let on_ci_failure (a : Patch_agent.t) : ci_decision =
       not (List.is_empty (filter_undelivered_ci_failures a))
     in
     match (has_known_failure, has_undelivered_failure) with
-    | true, false -> Ci_already_delivered
+    | true, false ->
+        if a.ci_failure_count > 0 then Enqueue_ci else Ci_already_delivered
     | false, _ ->
         (* The poll queue can report a CI failure before GitHub has returned
            the failed check rows. With no stable run id available to dedup

--- a/test/test_action_outcome_properties.ml
+++ b/test/test_action_outcome_properties.ml
@@ -90,6 +90,7 @@ let () =
       Orchestrator.Respond_ok;
       Orchestrator.Respond_failed;
       Orchestrator.Respond_retry_push;
+      Orchestrator.Respond_no_commits;
       Orchestrator.Respond_skip_empty;
       Orchestrator.Respond_pr_body_miss;
       Orchestrator.Respond_review_unresolved;
@@ -335,7 +336,7 @@ let () =
 (* ========== AO-7: Ci respond counter is bumped only on Respond_ok ========== *)
 
 (* Respond_ok bumps ci_failure_count; Skip_empty / Failed / Retry_push /
-   Stale do NOT. This locks in the invariant that a CI fix attempt only
+   No_commits / Stale do NOT. This locks in the invariant that a CI fix attempt only
    counts against the cap when a real payload was delivered. Regression for
    the production incident where cancelled-only rollups drove the cap to 3
    and forced needs_intervention without any actionable failures. *)
@@ -380,6 +381,13 @@ let () =
   let orch =
     Orchestrator.apply_respond_outcome orch pid Operation_kind.Ci
       Orchestrator.Respond_retry_push
+  in
+  assert (ci_count orch pid = before);
+  (* Respond_no_commits does NOT bump *)
+  let orch, pid, before = with_ci_busy () in
+  let orch =
+    Orchestrator.apply_respond_outcome orch pid Operation_kind.Ci
+      Orchestrator.Respond_no_commits
   in
   assert (ci_count orch pid = before);
   (* Respond_stale does NOT bump *)
@@ -432,6 +440,7 @@ let () =
       Orchestrator.Respond_failed;
       Orchestrator.Respond_skip_empty;
       Orchestrator.Respond_retry_push;
+      Orchestrator.Respond_no_commits;
       Orchestrator.Respond_stale;
       Orchestrator.Respond_pr_body_miss;
       Orchestrator.Respond_review_unresolved;

--- a/test/test_action_outcome_properties.ml
+++ b/test/test_action_outcome_properties.ml
@@ -352,10 +352,15 @@ let () =
   (* Respond_ok bumps *)
   let orch, pid, before = with_ci_busy () in
   let orch =
+    Orchestrator.apply_session_result orch pid Orchestrator.Session_no_commits
+  in
+  assert ((Orchestrator.agent orch pid).Patch_agent.no_commits_push_count = 1);
+  let orch =
     Orchestrator.apply_respond_outcome orch pid Operation_kind.Ci
       Orchestrator.Respond_ok
   in
   assert (ci_count orch pid = before + 1);
+  assert ((Orchestrator.agent orch pid).Patch_agent.no_commits_push_count = 0);
   (* Respond_skip_empty does NOT bump *)
   let orch, pid, before = with_ci_busy () in
   let orch =

--- a/test/test_dependency_injection_functors.ml
+++ b/test/test_dependency_injection_functors.ml
@@ -138,7 +138,7 @@ let _check_narrowed_run :
     on_pr_detected:(Pr_number.t -> unit) ->
     backend:Llm_backend.t ->
     complexity:int option ->
-    [ `Ok | `Failed | `Retry_push ] * (string * string) list =
+    [ `Ok | `Failed | `Retry_push | `No_commits ] * (string * string) list =
   SD.run
 
 (* Compile-time assertion: run_long_lived accepts only per-session inputs. *)
@@ -151,7 +151,7 @@ let _check_narrowed_run_long_lived :
     on_pr_detected:(Pr_number.t -> unit) ->
     session:SD.long_lived_session ->
     complexity:int option ->
-    [ `Ok | `Failed | `Retry_push ] * (string * string) list =
+    [ `Ok | `Failed | `Retry_push | `No_commits ] * (string * string) list =
   SD.run_long_lived
 
 let () =
@@ -236,7 +236,7 @@ let () =
       on_pr_detected:(Pr_number.t -> unit) ->
       backend:Llm_backend.t ->
       complexity:int option ->
-      [ `Ok | `Failed | `Retry_push ] * (string * string) list =
+      [ `Ok | `Failed | `Retry_push | `No_commits ] * (string * string) list =
     SD.run
   in
   ignore check_narrowed_run;

--- a/test/test_github_merge_queue_removal.ml
+++ b/test/test_github_merge_queue_removal.ml
@@ -350,6 +350,23 @@ let test_actions_jobs_response_returns_failing_jobs_with_ids () =
         (Onton.Github.show_error e);
       Stdlib.exit 1
 
+let test_actions_run_id_from_url () =
+  let cases =
+    [
+      ( "https://github.com/o/r/actions/runs/28256333725/job/83720238028",
+        Some 28256333725 );
+      ("https://github.com/o/r/actions/runs/123456789", Some 123456789);
+      ("https://github.com/o/r/runs/123456789", None);
+      ("https://example.com/actions/runs/not-a-number/job/1", None);
+    ]
+  in
+  List.iter cases ~f:(fun (url, expected) ->
+      let actual = Onton.Github.parse_actions_run_id_from_url url in
+      if not (Option.equal Int.equal actual expected) then (
+        Stdlib.Printf.eprintf "  FAIL: run id parse for %s\n" url;
+        Stdlib.exit 1));
+  Stdlib.print_endline "  Actions URL → workflow run id: OK"
+
 let () =
   test_mixed_returns_only_failures ();
   test_truncated_rollup_is_ok_empty ();
@@ -365,4 +382,5 @@ let () =
   test_contexts_page_graphql_errors_propagate ();
   test_merge_group_run_id_finds_failed_queue_run ();
   test_actions_jobs_response_returns_failing_jobs_with_ids ();
+  test_actions_run_id_from_url ();
   Stdlib.print_endline "test_github_merge_queue_removal: OK"

--- a/test/test_interleaving_properties.ml
+++ b/test/test_interleaving_properties.ml
@@ -2462,8 +2462,8 @@ let converged orch pid =
 let respond_outcome_of session_result =
   match session_result with
   | Orchestrator.Session_ok -> Orchestrator.Respond_ok
-  | Orchestrator.Session_push_failed _ | Orchestrator.Session_no_commits ->
-      Orchestrator.Respond_retry_push
+  | Orchestrator.Session_push_failed _ -> Orchestrator.Respond_retry_push
+  | Orchestrator.Session_no_commits -> Orchestrator.Respond_no_commits
   | Orchestrator.Session_process_error _ | Orchestrator.Session_no_resume
   | Orchestrator.Session_failed _ | Orchestrator.Session_give_up
   | Orchestrator.Session_worktree_missing

--- a/test/test_interleaving_properties.ml
+++ b/test/test_interleaving_properties.ml
@@ -1732,6 +1732,85 @@ let () =
   QCheck2.Test.check_exn prop_pi9b;
   Stdlib.print_endline "PI-9b passed"
 
+(** PI-9c: A completed CI attempt does not permanently suppress the same still
+    failing stable CheckRun.
+
+    Regression for rls-principal-parameterization patch 1: the first CI response
+    delivered the failing CheckRun ids and completed, bumping
+    [ci_failure_count]. The next polls still saw the same failing ids, but dedup
+    treated them as "already delivered" forever, leaving the agent idle with
+    [queue=[]] and failing checks. Once a CI attempt has completed, the same
+    failing run is actionable again until the configured failure cap is reached.
+*)
+let () =
+  let prop_pi9c =
+    QCheck2.Test.make
+      ~name:"PI-9c: same failed CI run after completed attempt is re-enqueued"
+      ~count:200
+      QCheck2.Gen.(int_range 1 1_000_000)
+      (fun run_id ->
+        let patches = mk_patches 1 in
+        match patches with
+        | [] -> true
+        | first :: _ ->
+            let pid = first.Patch.id in
+            let orch = bootstrap patches in
+            let orch =
+              Orchestrator.record_delivered_ci_run_ids orch pid [ run_id ]
+            in
+            let orch = Orchestrator.increment_ci_failure_count orch pid in
+            let before = Orchestrator.agent orch pid in
+            let check =
+              Ci_check.
+                {
+                  name = "App Unit Tests";
+                  conclusion = "failure";
+                  details_url = None;
+                  description = None;
+                  started_at = None;
+                  id = Some run_id;
+                }
+            in
+            let poll_result =
+              {
+                Poller.queue = [ Operation_kind.Ci ];
+                merged = false;
+                closed = false;
+                is_draft = false;
+                merge_state = Pr_state.Mergeable;
+                merge_ready = false;
+                head_oid = None;
+                review_decision = None;
+                unresolved_comment_count = 0;
+                merge_queue_required = false;
+                merge_queue_entry = None;
+                checks_passing = false;
+                ci_checks = [ check ];
+                merge_commit_sha = None;
+              }
+            in
+            let orch, _logs, _blocked =
+              Patch_controller.apply_poll_result orch pid
+                Patch_controller.
+                  {
+                    poll_result;
+                    base_branch = None;
+                    branch_in_root = false;
+                    worktree_path = None;
+                  }
+            in
+            let agent = Orchestrator.agent orch pid in
+            (not before.Patch_agent.busy)
+            && List.is_empty before.Patch_agent.queue
+            && Int.(before.Patch_agent.ci_failure_count > 0)
+            && List.mem before.Patch_agent.delivered_ci_run_ids run_id
+                 ~equal:Int.equal
+            && List.mem agent.Patch_agent.queue Operation_kind.Ci
+                 ~equal:Operation_kind.equal)
+  in
+  QCheck2.Test.check_exn prop_pi9c;
+  Stdlib.print_endline "PI-9c passed"
+
 (** PI-10: Random interleavings with ad-hoc patches preserve invariants.
     Exercises Add_adhoc/Remove_adhoc commands alongside the standard vocabulary,
     including the case where ad-hoc patches are removed while busy. *)

--- a/test/test_patch_controller.ml
+++ b/test/test_patch_controller.ml
@@ -730,11 +730,85 @@ let () =
           ~equal:Operation_kind.equal)
   in
 
-  let prop_delivered_ci_run_does_not_reenqueue =
+  let prop_delivered_ci_run_does_not_reenqueue_before_attempt =
     Test.make
       ~name:
-        "patch_controller: delivered failing CI run is not re-enqueued from \
-         poll"
+        "patch_controller: delivered failing CI run is not re-enqueued before \
+         an attempt"
+      ~count:200
+      Gen.(triple gen_patch_id gen_branch (int_range 1 1_000_000))
+      (fun (pid, branch, run_id) ->
+        let patch = make_patch pid branch in
+        let check =
+          Ci_check.
+            {
+              name = "ts2pant";
+              conclusion = "failure";
+              details_url = None;
+              description = None;
+              started_at = None;
+              id = Some run_id;
+            }
+        in
+        let agent =
+          Patch_agent.restore ~patch_id:pid ~branch
+            ~pr_status:(Patch_pr_status.Present (Pr_number.of_int 42))
+            ~has_session:true ~busy:false ~merged:false ~queue:[]
+            ~satisfies:false ~changed:true ~has_conflict:false
+            ~base_branch:(Some main) ~notified_base_branch:(Some main)
+            ~ci_failure_count:0 ~session_fallback:Patch_agent.Fresh_available
+            ~human_messages:[] ~inflight_human_messages:[] ~ci_checks:[]
+            ~merge_ready:false ~mergeability_unknown:false
+            ~merge_queue_required:false ~merge_queue_entry:None ~is_draft:false
+            ~pr_body_delivered:true ~pr_body_artifact_miss_count:0
+            ~start_attempts_without_pr:0 ~conflict_noop_count:0
+            ~no_commits_push_count:0 ~context_exhaustion_count:0
+            ~push_failure_count:0 ~rebase_failure_count:0
+            ~branch_rebased_onto:None ~branch_rebased_onto_sha:None
+            ~merge_commit_sha:None ~base_contains_merged_siblings:true
+            ~anchor_history:Onton_core.Anchor_history.empty
+            ~checks_passing:false ~current_op:None
+            ~current_op_state:Patch_agent.Queued ~current_message_id:None
+            ~generation:0 ~worktree_path:None ~branch_blocked:false
+            ~llm_session_id:None ~automerge_enabled:false
+            ~automerge_deadline:None ~automerge_inflight:false
+            ~automerge_failure_count:0 ~delivered_ci_run_ids:[ run_id ] ()
+        in
+        let orch = make_orch patch agent in
+        let poll =
+          Poller.
+            {
+              queue = [ Operation_kind.Ci ];
+              merged = false;
+              closed = false;
+              is_draft = false;
+              merge_state = Pr_state.Mergeable;
+              merge_ready = false;
+              head_oid = None;
+              review_decision = None;
+              unresolved_comment_count = 0;
+              merge_queue_required = false;
+              merge_queue_entry = None;
+              checks_passing = false;
+              ci_checks = [ check ];
+              merge_commit_sha = None;
+            }
+        in
+        let orch, _logs, _newly_blocked =
+          Patch_controller.apply_poll_result orch pid
+            (make_poll_observation poll)
+        in
+        let agent = Orchestrator.agent orch pid in
+        not
+          (List.mem agent.Patch_agent.queue Operation_kind.Ci
+             ~equal:Operation_kind.equal))
+  in
+
+  let prop_delivered_ci_run_reenqueues_after_attempt =
+    Test.make
+      ~name:
+        "patch_controller: completed attempt with same failing CI run \
+         re-enqueues"
       ~count:200
       Gen.(triple gen_patch_id gen_branch (int_range 1 1_000_000))
       (fun (pid, branch, run_id) ->
@@ -799,9 +873,8 @@ let () =
             (make_poll_observation poll)
         in
         let agent = Orchestrator.agent orch pid in
-        not
-          (List.mem agent.Patch_agent.queue Operation_kind.Ci
-             ~equal:Operation_kind.equal))
+        List.mem agent.Patch_agent.queue Operation_kind.Ci
+          ~equal:Operation_kind.equal)
   in
 
   let prop_new_ci_run_after_skip_empty_is_delivered =
@@ -1994,7 +2067,8 @@ let () =
       prop_poll_to_controller_promotes_ready_after_pr_body;
       prop_poll_ci_failure_never_erases_pr_body_followup;
       prop_idle_ci_failure_count_allows_reenqueue;
-      prop_delivered_ci_run_does_not_reenqueue;
+      prop_delivered_ci_run_does_not_reenqueue_before_attempt;
+      prop_delivered_ci_run_reenqueues_after_attempt;
       prop_new_ci_run_after_skip_empty_is_delivered;
       prop_poll_result_persists_world_flags;
       prop_poll_observation_updates_branch_metadata;

--- a/test/test_patch_decision.ml
+++ b/test/test_patch_decision.ml
@@ -161,8 +161,8 @@ let () =
           equal_ci_decision (on_ci_failure a) Enqueue_ci);
       Test.make
         ~name:
-          "on_ci_failure: all known failing run ids delivered -> already \
-           delivered"
+          "on_ci_failure: all known failing run ids delivered before attempt \
+           -> already delivered"
         Gen.(triple gen_pid gen_branch (int_range 1 1_000_000))
         (fun (pid, br, run_id) ->
           let check =
@@ -182,6 +182,29 @@ let () =
             record_delivered_ci_run_ids a [ run_id ]
           in
           equal_ci_decision (on_ci_failure a) Ci_already_delivered);
+      Test.make
+        ~name:
+          "on_ci_failure: completed attempt with same failing run id retries"
+        Gen.(triple gen_pid gen_branch (int_range 1 1_000_000))
+        (fun (pid, br, run_id) ->
+          let check =
+            Ci_check.
+              {
+                name = "test";
+                conclusion = "failure";
+                details_url = None;
+                description = None;
+                started_at = None;
+                id = Some run_id;
+              }
+          in
+          let a =
+            with_pr pid br |> fun a ->
+            set_ci_checks a [ check ] |> fun a ->
+            record_delivered_ci_run_ids a [ run_id ] |> fun a ->
+            increment_ci_failure_count a
+          in
+          equal_ci_decision (on_ci_failure a) Enqueue_ci);
       Test.make
         ~name:
           "on_ci_failure: id-less failing check remains deliverable after \

--- a/test/test_patch_decision.ml
+++ b/test/test_patch_decision.ml
@@ -207,6 +207,32 @@ let () =
           equal_ci_decision (on_ci_failure a) Enqueue_ci);
       Test.make
         ~name:
+          "on_ci_failure: completed attempt with same failing run id respects \
+           cap"
+        Gen.(triple gen_pid gen_branch (int_range 1 1_000_000))
+        (fun (pid, br, run_id) ->
+          let check =
+            Ci_check.
+              {
+                name = "test";
+                conclusion = "failure";
+                details_url = None;
+                description = None;
+                started_at = None;
+                id = Some run_id;
+              }
+          in
+          let a =
+            with_pr pid br |> fun a ->
+            set_ci_checks a [ check ] |> fun a ->
+            record_delivered_ci_run_ids a [ run_id ] |> fun a ->
+            increment_ci_failure_count a |> fun a ->
+            increment_ci_failure_count a |> fun a ->
+            increment_ci_failure_count a
+          in
+          equal_ci_decision (on_ci_failure a) Cap_reached);
+      Test.make
+        ~name:
           "on_ci_failure: id-less failing check remains deliverable after \
            delivered ids"
         Gen.(pair gen_pid gen_branch)

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -1156,17 +1156,37 @@ let () =
     Test.make ~name:"CP-1: Session_ok + Push_ok = Session_ok" (Gen.return ())
       (fun () ->
         Orchestrator.equal_session_result
-          (Orchestrator.combine_session_and_push ~session:Session_ok
-             ~push:Worktree.Push_ok)
+          (Orchestrator.combine_session_and_push ~branch_changed:true
+             ~session:Session_ok ~push:Worktree.Push_ok)
           Session_ok)
   in
   let prop_cp2_ok_uptodate =
     Test.make ~name:"CP-2: Session_ok + Push_up_to_date = Session_ok"
       (Gen.return ()) (fun () ->
         Orchestrator.equal_session_result
-          (Orchestrator.combine_session_and_push ~session:Session_ok
-             ~push:Worktree.Push_up_to_date)
+          (Orchestrator.combine_session_and_push ~branch_changed:true
+             ~session:Session_ok ~push:Worktree.Push_up_to_date)
           Session_ok)
+  in
+  let prop_cp2b_ok_uptodate_unchanged_branch =
+    Test.make
+      ~name:
+        "CP-2b: Session_ok + Push_up_to_date + unchanged branch = \
+         Session_no_commits" (Gen.return ()) (fun () ->
+        Orchestrator.equal_session_result
+          (Orchestrator.combine_session_and_push ~branch_changed:false
+             ~session:Session_ok ~push:Worktree.Push_up_to_date)
+          Session_no_commits)
+  in
+  let prop_cp2c_ok_pushok_unchanged_branch =
+    Test.make
+      ~name:
+        "CP-2c: Session_ok + Push_ok + unchanged branch = Session_no_commits"
+      (Gen.return ()) (fun () ->
+        Orchestrator.equal_session_result
+          (Orchestrator.combine_session_and_push ~branch_changed:false
+             ~session:Session_ok ~push:Worktree.Push_ok)
+          Session_no_commits)
   in
   let prop_cp3_ok_rejected =
     Test.make
@@ -1174,7 +1194,8 @@ let () =
         "CP-3: Session_ok + Push_rejected = Session_push_failed (Some reason)"
       (Gen.return ()) (fun () ->
         Orchestrator.equal_session_result
-          (Orchestrator.combine_session_and_push ~session:Session_ok
+          (Orchestrator.combine_session_and_push ~branch_changed:true
+             ~session:Session_ok
              ~push:(Worktree.Push_rejected Push_reject_classify.Lease_violation))
           (Session_push_failed (Some Push_reject_classify.Lease_violation)))
   in
@@ -1182,8 +1203,8 @@ let () =
     Test.make ~name:"CP-4: Session_ok + Push_error = Session_push_failed None"
       Gen.string_small (fun msg ->
         Orchestrator.equal_session_result
-          (Orchestrator.combine_session_and_push ~session:Session_ok
-             ~push:(Worktree.Push_error msg))
+          (Orchestrator.combine_session_and_push ~branch_changed:true
+             ~session:Session_ok ~push:(Worktree.Push_error msg))
           (Session_push_failed None))
   in
   let gen_non_ok_session : Orchestrator.session_result Gen.t =
@@ -1223,15 +1244,16 @@ let () =
          (Push_worktree_missing excluded — handled by CP-7)" ~count:300
       (Gen.pair gen_non_ok_session gen_push) (fun (session, push) ->
         Orchestrator.equal_session_result
-          (Orchestrator.combine_session_and_push ~session ~push)
+          (Orchestrator.combine_session_and_push ~branch_changed:false ~session
+             ~push)
           session)
   in
   let prop_cp6_ok_no_commits =
     Test.make ~name:"CP-6: Session_ok + Push_no_commits = Session_no_commits"
       (Gen.return ()) (fun () ->
         Orchestrator.equal_session_result
-          (Orchestrator.combine_session_and_push ~session:Session_ok
-             ~push:Worktree.Push_no_commits)
+          (Orchestrator.combine_session_and_push ~branch_changed:true
+             ~session:Session_ok ~push:Worktree.Push_no_commits)
           Session_no_commits)
   in
   (* Push_worktree_missing means the worktree directory was deleted between
@@ -1247,7 +1269,7 @@ let () =
         "CP-7: any session + Push_worktree_missing = Session_worktree_missing"
       gen_any_session (fun session ->
         Orchestrator.equal_session_result
-          (Orchestrator.combine_session_and_push ~session
+          (Orchestrator.combine_session_and_push ~branch_changed:false ~session
              ~push:Worktree.Push_worktree_missing)
           Session_worktree_missing)
   in
@@ -1582,6 +1604,8 @@ let () =
       prop_psf8_transient_reason_does_not_escalate;
       prop_cp1_ok_pushok;
       prop_cp2_ok_uptodate;
+      prop_cp2b_ok_uptodate_unchanged_branch;
+      prop_cp2c_ok_pushok_unchanged_branch;
       prop_cp3_ok_rejected;
       prop_cp4_ok_error;
       prop_cp5_failure_dominates;

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -1367,7 +1367,7 @@ let () =
         in
         let a = Orchestrator.agent orch pid in
         (* Session_no_commits defers completion to apply_respond_outcome
-           via Respond_retry_push, so agent stays busy after
+           via Respond_no_commits, so agent stays busy after
            apply_session_result alone. *)
         a.Patch_agent.busy)
   in

--- a/test/test_worktree_missing_recovery.ml
+++ b/test/test_worktree_missing_recovery.ml
@@ -61,8 +61,8 @@ let () =
      gone with the directory, so the combined outcome must route through
      the pre-session-failure path. *)
   let combined =
-    Orchestrator.combine_session_and_push ~session:Orchestrator.Session_ok
-      ~push:Worktree.Push_worktree_missing
+    Orchestrator.combine_session_and_push ~branch_changed:true
+      ~session:Orchestrator.Session_ok ~push:Worktree.Push_worktree_missing
   in
   if
     not


### PR DESCRIPTION
## Summary

Fixes a CI feedback liveness bug where an idle patch could stay stuck with failing checks after the same stable CheckRun IDs had already been delivered once.

## Root Cause

`Patch_decision.on_ci_failure` treated every currently failing check whose stable run id was already present in `delivered_ci_run_ids` as permanently delivered. After a completed CI attempt incremented `ci_failure_count`, later polls for the same still-failing run returned `Ci_already_delivered`, leaving the agent idle with `queue=[]` and no path to retry or reach the CI failure cap.

The production transcript also showed a second masking problem: the CI agent turn completed successfully, made no new commit, and the post-session push reported `Push_up_to_date` because older branch commits were already on the remote. That was folded into `Session_ok` instead of the first-class `Session_no_commits` path.

## Changes

- Re-enqueue CI for already-delivered failing run IDs once at least one CI attempt has completed, until the configured cap is reached.
- Preserve first-delivery dedupe before any completed CI attempt.
- Detect successful agent turns that leave the branch SHA unchanged and fold successful/up-to-date pushes into `Session_no_commits`.
- Split no-commit session results from push retry results so feedback deliveries can handle them explicitly.
- For no-commit review turns, post and resolve written review responses; if no response file exists, keep the unresolved/redelivery path.
- For no-commit CI turns, request GitHub Actions `rerun-failed-jobs` for the workflow run behind each failed check, without falling back to a full rerun.
- Keep Human and Findings no-commit turns allowed.
- Add pure decision, controller, interleaving, session/push-combine, action-outcome, and GitHub Actions URL parser regression coverage for the observed stuck states.

## Validation

- `dune fmt`
- `dune build`
- `dune exec test/test_patch_decision.exe`
- `dune exec test/test_patch_controller.exe`
- `dune exec test/test_interleaving_properties.exe`
- `dune exec test/test_properties.exe`
- `dune exec test/test_worktree_missing_recovery.exe`
- `dune exec test/test_github_merge_queue_removal.exe`
- `dune exec test/test_action_outcome_properties.exe`
- `dune exec test/test_dependency_injection_functors.exe`
- `dune runtest`
- pre-commit hook passed during all commits: build, runtest, format check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for rerunning failed CI jobs from a check, and improved handling for sessions that complete without creating new commits.
* **Bug Fixes**
  * Refined how successful sessions are classified when no branch changes occurred.
  * Improved CI failure handling so previously delivered failures can be reprocessed appropriately.
  * Updated response handling so “no commits” outcomes complete cleanly instead of being treated as retry-only cases.
* **Tests**
  * Added and expanded coverage for CI reruns, no-commit outcomes, and branch-change behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->