### PR TITLE
Update Codex routing for GPT-5.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,7 +500,7 @@ Two flags control which agent runs the patches:
 ```sh
 onton --backend claude --model sonnet-4-6
 onton --backend claude --model opus
-onton --backend codex --model gpt-5-codex
+onton --backend codex --model gpt-5.6-sol
 onton --backend gemini --model gemini-2.5-pro
 onton --backend opencode --model anthropic/claude-sonnet-4-5
 ```
@@ -524,7 +524,7 @@ write a per-repo config at
   },
   "routing": {
     "1": { "backend": "claude", "model": "haiku"   },
-    "3": { "backend": "codex",  "model": "gpt-5.5" }
+    "3": { "backend": "codex",  "model": "gpt-5.6-sol" }
   }
 }
 ```
@@ -544,18 +544,22 @@ optional; pin just `backend`, just `model`, or both. Run
 `onton-check-repo-config <owner> <repo>` to verify how a `config.json`
 parses.
 
+For Codex, the built-in ladder maps complexity 1/2/3 to `gpt-5.6-luna`,
+`gpt-5.6-terra`, and `gpt-5.6-sol`. Missing or out-of-range complexity
+conservatively selects Sol.
+
 ### Supported models
 
 Onton passes `--model` through to the backend CLI verbatim, so any model the
 underlying CLI accepts will work. Use unpinned aliases (e.g. `sonnet`,
 `opus`) when you want "current best in tier"; pin a specific version when you
-need reproducibility. The names below are accurate as of February 2026 —
+need reproducibility. The names below are accurate as of July 2026 —
 **check each provider's docs for the current list**:
 
 | Backend | Common model names | Source of truth |
 |---------|-------------------|-----------------|
 | `claude` | `opus`, `sonnet`, `haiku` (unpinned aliases); `claude-opus-4-7`, `claude-sonnet-4-6`, `claude-haiku-4-5` (pinned) | [Anthropic models](https://docs.anthropic.com/en/docs/about-claude/models) |
-| `codex` | `gpt-5-codex`, `gpt-5`, `gpt-5-mini` | [OpenAI models](https://platform.openai.com/docs/models), [Codex CLI README](https://github.com/openai/codex) |
+| `codex` | `gpt-5.6-luna`, `gpt-5.6-terra`, `gpt-5.6-sol` (`gpt-5.6` aliases Sol) | [OpenAI models](https://developers.openai.com/api/docs/models), [Codex CLI README](https://github.com/openai/codex) |
 | `gemini` | `gemini-2.5-pro`, `gemini-2.5-flash` | [Gemini API models](https://ai.google.dev/gemini-api/docs/models) |
 | `opencode` | Provider-prefixed, e.g. `anthropic/claude-sonnet-4-5`, `openai/gpt-5` | [OpenCode docs](https://opencode.ai/docs) |
 | `pi` | Run `pi --help` for the current list | Pi CLI |

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1409,13 +1409,13 @@ let model_arg =
     & info [ "model" ] ~docv:"MODEL"
         ~doc:
           "Model name to pass to the selected backend (e.g. [sonnet], [opus], \
-           [sonnet-4-6] for claude; [gpt-5.5] for codex). The literal value \
-           [auto] picks a model per patch from the gameplan's [complexity] \
-           field (1/2/3 → cheap/standard/strongest tier of the selected \
-           backend). The per-backend ladder can be overridden by writing \
-           [~/.config/onton/<owner>/<repo>/config.json] with a [routing] map; \
-           the same file's [default.{backend,model}] block sets per-repo \
-           defaults below CLI flags and stored values — see \
+           [sonnet-4-6] for claude; [gpt-5.6-sol] for codex). The literal \
+           value [auto] picks a model per patch from the gameplan's \
+           [complexity] field (1/2/3 → cheap/standard/strongest tier of the \
+           selected backend). The per-backend ladder can be overridden by \
+           writing [~/.config/onton/<owner>/<repo>/config.json] with a \
+           [routing] map; the same file's [default.{backend,model}] block sets \
+           per-repo defaults below CLI flags and stored values — see \
            lib_core/repo_config.mli for the schema. When omitted, onton does \
            not pass --model to the underlying CLI, so the backend's own \
            default applies.")

--- a/lib_core/codex_cost.ml
+++ b/lib_core/codex_cost.ml
@@ -65,6 +65,24 @@ type model_pricing = {
 [@@deriving show, eq, sexp_of, compare]
 
 let model_pricing = function
+  | Some "gpt-5.6-luna" ->
+      Some
+        {
+          input_nano_usd_per_1k = 1_000_000L;
+          output_nano_usd_per_1k = 6_000_000L;
+        }
+  | Some "gpt-5.6-terra" ->
+      Some
+        {
+          input_nano_usd_per_1k = 2_500_000L;
+          output_nano_usd_per_1k = 15_000_000L;
+        }
+  | Some ("gpt-5.6-sol" | "gpt-5.6") ->
+      Some
+        {
+          input_nano_usd_per_1k = 5_000_000L;
+          output_nano_usd_per_1k = 30_000_000L;
+        }
   | Some "gpt-5.4-mini" ->
       Some
         {
@@ -84,6 +102,17 @@ let model_pricing = function
           output_nano_usd_per_1k = 30_000_000L;
         }
   | _ -> None
+
+let%test "GPT-5.6 pricing table covers Luna, Terra, Sol, and the Sol alias" =
+  let expect model input output =
+    Option.equal equal_model_pricing
+      (model_pricing (Some model))
+      (Some { input_nano_usd_per_1k = input; output_nano_usd_per_1k = output })
+  in
+  expect "gpt-5.6-luna" 1_000_000L 6_000_000L
+  && expect "gpt-5.6-terra" 2_500_000L 15_000_000L
+  && expect "gpt-5.6-sol" 5_000_000L 30_000_000L
+  && expect "gpt-5.6" 5_000_000L 30_000_000L
 
 let cost_nano_usd_for_tokens tokens nano_usd_per_1k =
   let tokens = Int.max 0 tokens in

--- a/lib_core/codex_event_parser.ml
+++ b/lib_core/codex_event_parser.ml
@@ -126,10 +126,31 @@ let parse_event (line : string) : Types.Stream_event.t list =
 
 let auto_model ~complexity =
   match complexity with
-  | Some 1 -> Some "gpt-5.4-mini"
-  | Some 2 -> Some "gpt-5.4"
-  | Some 3 -> Some "gpt-5.5"
-  | Some _ | None -> Some "gpt-5.5"
+  | Some 1 -> Some "gpt-5.6-luna"
+  | Some 2 -> Some "gpt-5.6-terra"
+  | Some 3 -> Some "gpt-5.6-sol"
+  | Some _ | None -> Some "gpt-5.6-sol"
+
+let%test "auto_model: complexity 1 -> Luna" =
+  Option.equal String.equal
+    (auto_model ~complexity:(Some 1))
+    (Some "gpt-5.6-luna")
+
+let%test "auto_model: complexity 2 -> Terra" =
+  Option.equal String.equal
+    (auto_model ~complexity:(Some 2))
+    (Some "gpt-5.6-terra")
+
+let%test "auto_model: complexity 3 -> Sol" =
+  Option.equal String.equal
+    (auto_model ~complexity:(Some 3))
+    (Some "gpt-5.6-sol")
+
+let%test "auto_model: missing or invalid complexity -> Sol" =
+  Option.equal String.equal (auto_model ~complexity:None) (Some "gpt-5.6-sol")
+  && Option.equal String.equal
+       (auto_model ~complexity:(Some 4))
+       (Some "gpt-5.6-sol")
 
 let%test "build_args fresh (no resume, no model)" =
   let args =

--- a/lib_core/repo_config.mli
+++ b/lib_core/repo_config.mli
@@ -79,7 +79,7 @@ val load :
         },
         "routing": {
           "1": { "backend": "claude", "model": "haiku" },
-          "2": { "backend": "codex",  "model": "gpt-5.4" },
+          "2": { "backend": "codex",  "model": "gpt-5.6-terra" },
           "3": { "backend": "claude", "model": "opus" }
         }
       }

--- a/test/test_codex_cost_properties.ml
+++ b/test/test_codex_cost_properties.ml
@@ -95,7 +95,16 @@ let gen_pricing =
       }
 
 let gen_model_name =
-  QCheck2.Gen.oneof_list [ Some "gpt-5.4-mini"; Some "gpt-5.4"; Some "gpt-5.5" ]
+  QCheck2.Gen.oneof_list
+    [
+      Some "gpt-5.6-luna";
+      Some "gpt-5.6-terra";
+      Some "gpt-5.6-sol";
+      Some "gpt-5.6";
+      Some "gpt-5.4-mini";
+      Some "gpt-5.4";
+      Some "gpt-5.5";
+    ]
 
 (* Cap is large enough that some interleavings stay under and others cross. *)
 let gen_cap_nano_usd =


### PR DESCRIPTION
## Summary

- route Codex complexity tiers 1/2/3 to GPT-5.6 Luna, Terra, and Sol
- add GPT-5.6 pricing coverage, including the `gpt-5.6` Sol alias, so budget caps keep tracking routed models
- update CLI help, configuration examples, documentation, and property-test generators

## Why

OpenAI released the GPT-5.6 Luna/Terra/Sol generation. Onton's built-in Codex `auto` ladder still selected GPT-5.4 mini, GPT-5.4, and GPT-5.5.

## Impact

Codex patches using `--model auto` now select the current cost-sensitive, balanced, or strongest GPT-5.6 tier based on patch complexity. Explicitly configured model names continue to pass through unchanged, and older pricing entries remain supported.

## Validation

- `dune build`
- `dune runtest`
- `dune fmt`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/405"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786543749&installation_id=126163856&pr_number=405&repository=flowglad%2Fonton&return_to=https%3A%2F%2Fgithub.com%2Fflowglad%2Fonton%2Fpull%2F405&signature=2bdae56c0008621c61bc0f7d5522b40b69efdbe7d57d56a62b9edbca66693c90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->