### PR TITLE
Pr_body delivery must not be gated on commit presence

### DIFF
--- a/lib/runner_fiber_impl.ml
+++ b/lib/runner_fiber_impl.ml
@@ -2352,16 +2352,25 @@ struct
                                         | _ -> ());
                                         (* Artifact-driven phase (Pr_body): read
                                    the agent's artifact and PATCH the PR body.
-                                   When the artifact is missing AND we saw a
-                                   Write tool call that did not complete, the
-                                   agent was likely blocked mid-call (e.g. by
-                                   OpenCode's --dir sandbox) — signal retry
-                                   via Respond_pr_body_miss so the reconciler
-                                   re-enqueues Pr_body once before escalating
-                                   to needs_intervention. When the artifact is
-                                   missing but we saw no Write failure, the
-                                   agent legitimately chose not to add notes:
-                                   fall through to Respond_ok as before. *)
+                                   Success for this phase is artifact delivery,
+                                   never commit presence — a healthy Pr_body
+                                   session authors the notes file outside the
+                                   worktree and makes no commits, so it arrives
+                                   here as [`No_commits]. Both [`Ok] and
+                                   [`No_commits] sessions run the apply
+                                   (pr_body_respond_plan), and the classify
+                                   verdict owns the arm's result: [`Ok]
+                                   upgrades a no-commit session so Respond_ok
+                                   flips pr_body_delivered and resets the
+                                   no-commit noop counter that
+                                   apply_session_result bumped;
+                                   [`Pr_body_miss] (blocked Write or failed
+                                   PATCH) lets the reconciler re-enqueue
+                                   Pr_body before escalating to
+                                   needs_intervention. A missing/empty
+                                   artifact with no Write failure is the
+                                   agent's deliberate choice not to add notes
+                                   and classifies [`Ok]. *)
                                         let session_ok =
                                           match result with
                                           | `Ok -> true
@@ -2374,44 +2383,62 @@ struct
                                         in
                                         let result =
                                           match payload with
-                                          | Patch_decision.Pr_body_payload
-                                            when session_ok -> (
+                                          | Patch_decision.Pr_body_payload -> (
                                               match
-                                                ( pr_number,
-                                                  Base.List.find
-                                                    gameplan.Gameplan.patches
-                                                    ~f:(fun (p : Patch.t) ->
-                                                      Patch_id.equal p.Patch.id
-                                                        patch_id) )
+                                                Patch_decision
+                                                .pr_body_respond_plan
+                                                  ~session_ok
+                                                  ~session_no_commits
                                               with
-                                              | Some pr, Some patch -> (
-                                                  let artifact_outcome =
-                                                    apply_pr_body_artifact
-                                                      ~runtime ~project_name
-                                                      ~patch_id ~pr_number:pr
-                                                      ~patch ~gameplan
-                                                  in
-                                                  match
-                                                    Patch_decision
-                                                    .classify_pr_body_respond
-                                                      ~artifact_outcome
-                                                      ~tool_failures
-                                                  with
-                                                  | `Pr_body_miss ->
-                                                      `Pr_body_miss
-                                                  | `Ok -> result)
-                                              | None, _ ->
-                                                  log_event runtime ~patch_id
-                                                    "pr-body: no PR number yet \
-                                                     — skipping artifact apply";
+                                              | Patch_decision
+                                                .Pr_body_pass_through ->
                                                   result
-                                              | _, None ->
-                                                  log_event runtime ~patch_id
-                                                    "pr-body: skipping \
-                                                     artifact apply — patch \
-                                                     has no gameplan entry \
-                                                     (likely ad-hoc)";
-                                                  result)
+                                              | Patch_decision.Pr_body_apply
+                                                -> (
+                                                  match
+                                                    ( pr_number,
+                                                      Base.List.find
+                                                        gameplan
+                                                          .Gameplan.patches
+                                                        ~f:(fun (p : Patch.t) ->
+                                                          Patch_id.equal
+                                                            p.Patch.id patch_id)
+                                                    )
+                                                  with
+                                                  | Some pr, Some patch ->
+                                                      let artifact_outcome =
+                                                        apply_pr_body_artifact
+                                                          ~runtime ~project_name
+                                                          ~patch_id
+                                                          ~pr_number:pr ~patch
+                                                          ~gameplan
+                                                      in
+                                                      (Patch_decision
+                                                       .classify_pr_body_respond
+                                                         ~artifact_outcome
+                                                         ~tool_failures
+                                                        :> [ `Failed
+                                                           | `Ok
+                                                           | `No_commits
+                                                           | `Pr_body_miss
+                                                           | `Retry_push
+                                                           | `Review_unresolved
+                                                           ])
+                                                  | None, _ ->
+                                                      log_event runtime
+                                                        ~patch_id
+                                                        "pr-body: no PR number \
+                                                         yet — skipping \
+                                                         artifact apply";
+                                                      result
+                                                  | _, None ->
+                                                      log_event runtime
+                                                        ~patch_id
+                                                        "pr-body: skipping \
+                                                         artifact apply — \
+                                                         patch has no gameplan \
+                                                         entry (likely ad-hoc)";
+                                                      result))
                                           | Patch_decision.Findings_payload
                                               { findings } ->
                                               if session_ok then (
@@ -2577,7 +2604,6 @@ struct
                                                 else `Retry_push
                                               else result
                                           | Patch_decision.Human_payload _
-                                          | Patch_decision.Pr_body_payload
                                           | Patch_decision
                                             .Merge_conflict_payload ->
                                               result

--- a/lib/session_driver.ml
+++ b/lib/session_driver.ml
@@ -803,7 +803,19 @@ module Make (W : Worktree.S) (Env : ENV) = struct
              requires no code changes. Absence of new commits is therefore
              not a failure — override Session_no_commits to Session_ok so
              the no_commits_push_count counter does not march toward
-             needs_intervention and the operation completes cleanly. *)
+             needs_intervention and the operation completes cleanly.
+
+             Pr_body, Review_comments, and Ci stay false DELIBERATELY even
+             though their sessions can legitimately end without commits
+             (Pr_body always does — it authors an artifact outside the
+             worktree). Their no-commit turns are rescued downstream by
+             each kind's own success verdict — artifact delivery
+             (Patch_decision.pr_body_respond_plan +
+             classify_pr_body_respond), comment convergence, CI rerun —
+             which maps the outcome to Respond_ok and resets the counter.
+             Keeping them out of this override preserves the
+             Session_no_commits telemetry and keeps the noop gate armed
+             for the truly-idle case where the verdict does not rescue. *)
                 let no_commits_is_ok =
                   match kind with
                   | Some Types.Operation_kind.Human -> true

--- a/lib_core/patch_decision.ml
+++ b/lib_core/patch_decision.ml
@@ -256,6 +256,31 @@ let classify_pr_body_respond
   | (`Missing | `Empty), true -> `Pr_body_miss
   | (`Ok | `Missing | `Empty), _ -> `Ok
 
+type pr_body_respond_plan = Pr_body_apply | Pr_body_pass_through
+[@@deriving show, eq, sexp_of, compare]
+
+(** Whether the Pr_body respond arm should run the artifact apply and let
+    [classify_pr_body_respond]'s verdict own the respond result.
+
+    Success for the Pr_body phase is artifact delivery, never commit presence: a
+    healthy Pr_body session authors the notes file outside the worktree and
+    makes no commits, so it arrives at the respond arm as a no-commit session
+    (branch SHA unchanged, push up-to-date). Both healthy arrivals —
+    [session_ok] and [session_no_commits] — must attempt the apply; a delivered
+    artifact then upgrades the arm's result to [`Ok] so [Respond_ok] flips
+    [pr_body_delivered] and resets the no-commit noop counter that
+    [apply_session_result] bumped when it saw [Session_no_commits].
+
+    Regression guard: gating the apply on [session_ok] alone starves
+    [pr_body_delivered] — the reconciler re-enqueues Pr_body, every cycle is
+    another no-commit turn, and [no_commits_push_count >= 2] deterministically
+    escalates every patch to needs_intervention right after its first commit
+    (v0.51.0, introduced by the no-commit-turn detector in 938efeb7). *)
+let pr_body_respond_plan ~(session_ok : bool) ~(session_no_commits : bool) :
+    pr_body_respond_plan =
+  if session_ok || session_no_commits then Pr_body_apply
+  else Pr_body_pass_through
+
 (** {2 Opportunistic pr-body artifact sync from any session} *)
 
 (* Treat empty and whitespace-only contents as "no artifact present" so a

--- a/lib_core/patch_decision.mli
+++ b/lib_core/patch_decision.mli
@@ -136,9 +136,31 @@ val classify_pr_body_respond :
 
     Any other combination returns [`Ok].
 
-    Only invoked after a successful session — session-level failures
-    (stale/failed/retry_push) short-circuit upstream in the handler and never
-    reach this function. *)
+    Invoked after a successful or no-commit session ([pr_body_respond_plan]
+    decides eligibility) — session-level failures (stale/failed/retry_push)
+    short-circuit upstream in the handler and never reach this function. The
+    verdict owns the respond result: [`Ok] maps to [Respond_ok] even when the
+    session made no commits, since a healthy Pr_body session authors the
+    artifact outside the worktree and commits nothing. *)
+
+type pr_body_respond_plan =
+  | Pr_body_apply
+      (** Run [apply_pr_body_artifact] and adopt [classify_pr_body_respond]'s
+          verdict as the respond result. *)
+  | Pr_body_pass_through
+      (** Session-level failure — leave the respond result untouched and skip
+          the artifact apply. *)
+[@@deriving show, eq, sexp_of, compare]
+
+val pr_body_respond_plan :
+  session_ok:bool -> session_no_commits:bool -> pr_body_respond_plan
+(** Pure eligibility rule for the Pr_body respond arm: apply on both healthy
+    arrivals, [session_ok] and [session_no_commits]. A healthy Pr_body session
+    makes no commits by design, so [session_no_commits] is its normal arrival
+    state; a delivered artifact upgrades that session to [Respond_ok], which
+    flips [pr_body_delivered] and resets [no_commits_push_count]. Gating the
+    apply on [session_ok] alone deterministically escalated every patch to
+    needs_intervention after two Pr_body cycles (v0.51.0 regression). *)
 
 (** {2 Opportunistic pr-body artifact sync from any session}
 

--- a/test/test_action_outcome_properties.ml
+++ b/test/test_action_outcome_properties.ml
@@ -616,6 +616,74 @@ let () =
   QCheck2.Test.check_exn prop;
   Stdlib.print_endline "AO-13 passed"
 
+(* ========== AO-14: no-commit Pr_body cycle with delivered artifact never
+   marches toward needs_intervention ========== *)
+
+(* Encodes the runner contract restored after the v0.51.0 regression
+   (938efeb7): a healthy Pr_body session authors the notes artifact outside
+   the worktree and makes NO commits, so the session driver reports
+   Session_no_commits (bumping no_commits_push_count) while the runner's
+   artifact verdict maps the respond outcome to Respond_ok — which must reset
+   the counter, flip pr_body_delivered, and leave the agent idle without
+   intervention. The regression skipped the artifact apply for no-commit
+   sessions, so the counter incremented without the Respond_ok reset and every
+   patch escalated at >= 2 right after its first commit. The miss leg checks
+   the other verdict: Respond_pr_body_miss after a no-commit session leaves
+   both counters at 1 — retry-once territory, no intervention yet. *)
+let () =
+  let prop =
+    QCheck2.Test.make
+      ~name:
+        "AO-14: Session_no_commits + Respond_ok Pr_body cycle resets the noop \
+         counter" (QCheck2.Gen.return ()) (fun () ->
+        try
+          let orch, patches, gameplan, pid = bootstrap_one () in
+          (* Miss leg: no-commit session, artifact NOT delivered. *)
+          let orch =
+            make_busy orch patches gameplan pid Operation_kind.Pr_body
+          in
+          let orch =
+            Orchestrator.apply_session_result orch pid
+              Orchestrator.Session_no_commits
+          in
+          assert (Orchestrator.agent orch pid).Patch_agent.busy;
+          assert (
+            (Orchestrator.agent orch pid).Patch_agent.no_commits_push_count = 1);
+          let orch =
+            Orchestrator.apply_respond_outcome orch pid Operation_kind.Pr_body
+              Orchestrator.Respond_pr_body_miss
+          in
+          let a_miss = Orchestrator.agent orch pid in
+          assert (not a_miss.Patch_agent.busy);
+          assert (a_miss.Patch_agent.no_commits_push_count = 1);
+          assert (a_miss.Patch_agent.pr_body_artifact_miss_count = 1);
+          assert (not (Patch_agent.needs_intervention a_miss));
+          (* Delivery leg: second no-commit session, artifact delivered. The
+             counter reaches 2 transiently between apply_session_result and
+             apply_respond_outcome, but Respond_ok resets it before the agent
+             goes idle — the cycle must end clean. *)
+          let orch =
+            make_busy orch patches gameplan pid Operation_kind.Pr_body
+          in
+          let orch =
+            Orchestrator.apply_session_result orch pid
+              Orchestrator.Session_no_commits
+          in
+          let orch =
+            Orchestrator.apply_respond_outcome orch pid Operation_kind.Pr_body
+              Orchestrator.Respond_ok
+          in
+          let a = Orchestrator.agent orch pid in
+          (not a.Patch_agent.busy)
+          && a.Patch_agent.no_commits_push_count = 0
+          && a.Patch_agent.pr_body_delivered
+          && a.Patch_agent.pr_body_artifact_miss_count = 0
+          && not (Patch_agent.needs_intervention a)
+        with _ -> false)
+  in
+  QCheck2.Test.check_exn prop;
+  Stdlib.print_endline "AO-14 passed"
+
 (* AO-surface: thread a bootstrapped orchestrator through every state
    transition / accessor on the orchestrator decision surface and assert it
    stays queryable. Uses the generated [flag] so this counts as a property over

--- a/test/test_patch_decision.ml
+++ b/test/test_patch_decision.ml
@@ -897,23 +897,20 @@ let () =
        Pr_body forever, and no_commits_push_count >= 2 deterministically
        escalated every patch to needs_intervention after its first commit.
        Exhaustive over the bool² input space. *)
-    List.iter
-      [
-        (true, false, Pr_body_apply);
-        (false, true, Pr_body_apply);
-        (true, true, Pr_body_apply);
-        (false, false, Pr_body_pass_through);
-      ]
-      ~f:(fun (session_ok, session_no_commits, expected) ->
-        let got = pr_body_respond_plan ~session_ok ~session_no_commits in
-        if not (equal_pr_body_respond_plan got expected) then
-          failwith
-            (Printf.sprintf
-               "PB-10: pr_body_respond_plan ~session_ok:%b \
-                ~session_no_commits:%b = %s, expected %s"
-               session_ok session_no_commits
-               (show_pr_body_respond_plan got)
-               (show_pr_body_respond_plan expected)));
+    let prop =
+      QCheck2.Test.make
+        ~name:"PB-10: apply iff session is ok or made no commits"
+        QCheck2.Gen.(pair bool bool)
+        (fun (session_ok, session_no_commits) ->
+          let expected =
+            if session_ok || session_no_commits then Pr_body_apply
+            else Pr_body_pass_through
+          in
+          equal_pr_body_respond_plan
+            (pr_body_respond_plan ~session_ok ~session_no_commits)
+            expected)
+    in
+    QCheck2.Test.check_exn prop;
     Stdlib.print_endline "PB-10 passed"
   in
 

--- a/test/test_patch_decision.ml
+++ b/test/test_patch_decision.ml
@@ -886,7 +886,35 @@ let () =
           with _ -> false)
     in
     QCheck2.Test.check_exn prop;
-    Stdlib.print_endline "PB-9 passed"
+    Stdlib.print_endline "PB-9 passed";
+
+    (* PB-10: pr_body_respond_plan — the artifact apply engages for exactly
+       the healthy session arrivals: session_ok or session_no_commits. A
+       healthy Pr_body session authors the notes artifact outside the
+       worktree and makes NO commits, so no-commits is its normal arrival
+       state. Regression guard for v0.51.0 (938efeb7): gating the apply on
+       session_ok alone starved pr_body_delivered, the reconciler re-enqueued
+       Pr_body forever, and no_commits_push_count >= 2 deterministically
+       escalated every patch to needs_intervention after its first commit.
+       Exhaustive over the bool² input space. *)
+    List.iter
+      [
+        (true, false, Pr_body_apply);
+        (false, true, Pr_body_apply);
+        (true, true, Pr_body_apply);
+        (false, false, Pr_body_pass_through);
+      ]
+      ~f:(fun (session_ok, session_no_commits, expected) ->
+        let got = pr_body_respond_plan ~session_ok ~session_no_commits in
+        if not (equal_pr_body_respond_plan got expected) then
+          failwith
+            (Printf.sprintf
+               "PB-10: pr_body_respond_plan ~session_ok:%b \
+                ~session_no_commits:%b = %s, expected %s"
+               session_ok session_no_commits
+               (show_pr_body_respond_plan got)
+               (show_pr_body_respond_plan expected)));
+    Stdlib.print_endline "PB-10 passed"
   in
 
   (* ========== Opportunistic artifact-sync property tests ==========


### PR DESCRIPTION
## Problem

938efeb7 ("Detect no-commit agent turns", first shipped in v0.51.0) made `Push_up_to_date` with an unchanged branch SHA classify as `Session_no_commits`. A healthy Pr_body session authors the notes artifact **outside the worktree** and makes no commits by design, so every Pr_body session now arrives at the respond arm as `` `No_commits`` — where the `when session_ok` guard skipped the artifact apply entirely:

- `pr_body_delivered` stayed false → the reconciler re-enqueued Pr_body
- each cycle was another no-commit turn → `no_commits_push_count` marched
- at `>= 2`, needs_intervention — deterministically, for **every patch, right after its first commit**

Observed: all three patches of `native-python-reasoning-m2` went needs-help within ~90s of their Start sessions (2026-07-13, onton 0.51.0). Final state: `no_commits_push_count: 2`, `pr_body_delivered: false`, `pr_body_artifact_miss_count: 0` on every agent — the designed artifact-miss retry gate never engaged because classification failed upstream of it.

## Fix

Success for the Pr_body phase is **artifact delivery, never commit presence**.

- New pure decision `Patch_decision.pr_body_respond_plan ~session_ok ~session_no_commits`: the artifact apply engages on both healthy arrivals (`` `Ok`` and `` `No_commits``).
- The runner's Pr_body arm adopts `classify_pr_body_respond`'s verdict directly (variant coercion) as its result — a delivered artifact upgrades a no-commit session to `Respond_ok`, which flips `pr_body_delivered` and resets the noop counter that `apply_session_result` bumped. Misses still route through the retry-once-then-intervene path.
- `Review_comments` and `Ci` already rescued their no-commit turns via their own verdicts (comment convergence, failed-job rerun); Pr_body was the only arm gating its verdict on `session_ok`. A comment in `session_driver.ml` now documents why these kinds deliberately stay out of the `no_commits_is_ok` override.

## Tests

- **PB-10** exhausts the plan function's bool² input space.
- **AO-14** encodes the orchestrator-level cycle contract: a no-commit Pr_body session whose artifact delivers resets the counter, sets `pr_body_delivered`, and never intervenes; a miss leaves both counters at 1 (retry-once territory).

Why the liveness interleaving suites didn't catch this: they inject session/respond outcomes as free generator inputs and axiomatize Pr_body delivery in their happy-path contract, so the outcome-production glue in `runner_fiber_impl` was untested. The plan function moves that decision into pure, property-tested code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/406"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786550734&installation_id=126163856&pr_number=406&repository=flowglad%2Fonton&return_to=https%3A%2F%2Fgithub.com%2Fflowglad%2Fonton%2Fpull%2F406&signature=754eb9104bd714794fe49f1fbbe52765e1098f5d2a17a31e2231dabbdc09aedf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->