### PR TITLE
Bound supervisor-owned Git pushes

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -789,7 +789,7 @@ let construct_capabilities ~net (setup : runtime_setup) =
   in
   let module Forge = (val forge) in
   let worktree_client =
-    Worktree.make ~process_mgr:setup.process_mgr ~repo_root
+    Worktree.make ~clock:setup.clock ~process_mgr:setup.process_mgr ~repo_root
   in
   let module WorktreeClient = (val worktree_client) in
   (match Forge.check_repo_access () with

--- a/lib/worktree.ml
+++ b/lib/worktree.ml
@@ -913,7 +913,7 @@ let gather_push_plan_inputs ~process_mgr ~path ~branch_str ~base_str =
     ancestry,
     commits_ahead_of_base )
 
-let force_push_with_lease ~process_mgr ~path ~branch ~base =
+let force_push_with_lease_unbounded ~process_mgr ~path ~branch ~base =
   let branch_str = Types.Branch.to_string branch in
   let base_str = Types.Branch.to_string base in
   let ( worktree_path_exists,
@@ -978,6 +978,19 @@ let force_push_with_lease ~process_mgr ~path ~branch ~base =
       in
       let code, stdout, stderr = run_git_exit_code ~process_mgr args in
       classify_push_result ~code ~stdout ~stderr
+
+let default_push_timeout_seconds = 120.0
+
+let force_push_with_lease ?(timeout_seconds = default_push_timeout_seconds)
+    ~clock ~process_mgr ~path ~branch ~base () =
+  match
+    Eio.Time.with_timeout clock timeout_seconds (fun () ->
+        Ok (force_push_with_lease_unbounded ~process_mgr ~path ~branch ~base))
+  with
+  | Ok result -> result
+  | Error `Timeout ->
+      Push_error
+        (Printf.sprintf "git push timed out after %.0fs" timeout_seconds)
 
 let rebase_in_progress ~process_mgr ~path =
   rebase_in_progress_raw ~process_mgr ~path
@@ -1162,7 +1175,7 @@ end
 
 type client = (module S)
 
-let make ~process_mgr ~repo_root =
+let make ~clock ~process_mgr ~repo_root =
   (module struct
     let resolve_main_root () = resolve_main_root ~process_mgr ~repo_root
 
@@ -1209,7 +1222,7 @@ let make ~process_mgr ~repo_root =
         ~ancestor_ids
 
     let force_push_with_lease ~path ~branch ~base =
-      force_push_with_lease ~process_mgr ~path ~branch ~base
+      force_push_with_lease ~clock ~process_mgr ~path ~branch ~base ()
 
     let rebase_in_progress ~path = rebase_in_progress ~process_mgr ~path
   end : S)

--- a/lib/worktree.mli
+++ b/lib/worktree.mli
@@ -401,12 +401,18 @@ val classify_push_result :
     the branch has no commits ahead of base). *)
 
 val force_push_with_lease :
+  ?timeout_seconds:float ->
+  clock:float Eio.Time.clock_ty Eio.Time.clock ->
   process_mgr:_ Eio.Process.mgr ->
   path:string ->
   branch:Types.Branch.t ->
   base:Types.Branch.t ->
+  unit ->
   push_result
-(** Force-push with lease the given branch from the worktree at [path]. Thin
+(** Force-push with lease the given branch from the worktree at [path], bounded
+    by [timeout_seconds] (120 seconds by default). A deadline expiry cancels the
+    git process and returns [Push_error], allowing the runner to complete the
+    current operation and retry instead of remaining busy indefinitely. Thin
     effectful orchestrator: runs [git rev-list --count base..HEAD], applies
     [push_gate_from_count] to decide whether to push, and classifies the push
     output via [classify_push_result]. See [push_gate_from_count] and
@@ -489,7 +495,11 @@ end
 
 type client = (module S)
 
-val make : process_mgr:_ Eio.Process.mgr -> repo_root:string -> client
+val make :
+  clock:float Eio.Time.clock_ty Eio.Time.clock ->
+  process_mgr:_ Eio.Process.mgr ->
+  repo_root:string ->
+  client
 
 val find_for_branch :
   process_mgr:_ Eio.Process.mgr ->

--- a/test/test_interleaving_properties.ml
+++ b/test/test_interleaving_properties.ml
@@ -1972,6 +1972,78 @@ let () =
   QCheck2.Test.check_exn prop_pi13;
   Stdlib.print_endline "PI-13 passed"
 
+(** PI-13b: a post-session push deadline is a liveness boundary for an active
+    Review_comments operation. Polls may freely interleave while the push is
+    pending and repeatedly observe the same unresolved threads. Once the
+    deadline is represented as [Push_error], the exact production transition
+    (combine session+push → apply_session_result → apply_respond_outcome) must
+    release [busy] in that same step. Repeating the failure reaches the visible
+    intervention terminal state within the push-failure cap; it cannot remain in
+    Addressing_review forever.
+
+    This is the state-machine regression for PR 6374, where Codex exited but an
+    unbounded supervisor-owned push left current_op=Review_comments running for
+    approximately 99 minutes. *)
+let () =
+  let gen_wait_polls =
+    QCheck2.Gen.list_size
+      (QCheck2.Gen.int_range 0 40)
+      (QCheck2.Gen.oneof_list [ Poll_normal; Poll_review_comments ])
+  in
+  let prop =
+    QCheck2.Test.make
+      ~name:"PI-13b: review push timeouts release busy and converge within cap"
+      ~count:300 gen_wait_polls (fun wait_polls ->
+        let orch, pid, patches = mk_bootstrapped () in
+        let rec attempt remaining orch =
+          if
+            remaining = 0
+            || Patch_agent.needs_intervention (Orchestrator.agent orch pid)
+          then orch
+          else
+            let orch =
+              apply_command orch patches
+                (Apply_poll { patch_idx = 0; poll_kind = Poll_review_comments })
+            in
+            let a = Orchestrator.agent orch pid in
+            if a.Patch_agent.busy then orch
+            else
+              let orch =
+                Orchestrator.fire orch
+                  (Orchestrator.Respond (pid, Operation_kind.Review_comments))
+              in
+              let orch =
+                List.fold wait_polls ~init:orch ~f:(fun o poll_kind ->
+                    apply_command o patches
+                      (Apply_poll { patch_idx = 0; poll_kind }))
+              in
+              let timed_out_result =
+                Orchestrator.combine_session_and_push ~branch_changed:true
+                  ~session:Orchestrator.Session_ok
+                  ~push:(Worktree.Push_error "git push timed out")
+              in
+              let orch =
+                Orchestrator.apply_session_result orch pid timed_out_result
+              in
+              let orch =
+                Orchestrator.apply_respond_outcome orch pid
+                  Operation_kind.Review_comments Orchestrator.Respond_retry_push
+              in
+              let after = Orchestrator.agent orch pid in
+              if after.Patch_agent.busy || Option.is_some after.current_op then
+                orch
+              else attempt (remaining - 1) orch
+        in
+        let orch = attempt 3 orch in
+        let final = Orchestrator.agent orch pid in
+        (not final.Patch_agent.busy)
+        && Option.is_none final.current_op
+        && Patch_agent.needs_intervention final
+        && final.push_failure_count >= 3)
+  in
+  QCheck2.Test.check_exn prop;
+  Stdlib.print_endline "PI-13b passed"
+
 (** PI-14: Two consecutive Session_no_commits promote to needs_intervention —
     without a pending Human in the queue, the counter crossing 2 is enough to
     stop the scheduler from re-enqueueing Start. Regression for the class of bug

--- a/test/test_push_plan_integration.ml
+++ b/test/test_push_plan_integration.ml
@@ -64,6 +64,7 @@ let setup_seed_clone ~origin_dir ~managed_dir =
 
 let scenario_branch_switched env =
   let process_mgr = Eio.Stdenv.process_mgr env in
+  let clock = Eio.Stdenv.clock env in
   with_temp_dir @@ fun root ->
   let origin_dir = Stdlib.Filename.concat root "origin.git" in
   let managed_dir = Stdlib.Filename.concat root "managed" in
@@ -77,9 +78,10 @@ let scenario_branch_switched env =
   sh ~dir:managed_dir "git commit -q -m 'feat work'";
   sh ~dir:managed_dir "git checkout -q -b recovery";
   let outcome =
-    Worktree.force_push_with_lease ~process_mgr ~path:managed_dir
+    Worktree.force_push_with_lease ~clock ~process_mgr ~path:managed_dir
       ~branch:(Types.Branch.of_string "feat")
       ~base:(Types.Branch.of_string "main")
+      ()
   in
   (match outcome with
   | Worktree.Push_rejected (Push_reject_classify.Local_state_unsafe { reason })
@@ -114,6 +116,7 @@ let scenario_branch_switched env =
 
 let scenario_local_missing_remote env =
   let process_mgr = Eio.Stdenv.process_mgr env in
+  let clock = Eio.Stdenv.clock env in
   with_temp_dir @@ fun root ->
   let origin_dir = Stdlib.Filename.concat root "origin.git" in
   let managed_dir = Stdlib.Filename.concat root "managed" in
@@ -184,9 +187,10 @@ let scenario_local_missing_remote env =
   if String.equal local_feat remote_feat_sha then
     failwith "precondition: local feat was supposed to be stale";
   let outcome =
-    Worktree.force_push_with_lease ~process_mgr ~path:managed_dir
+    Worktree.force_push_with_lease ~clock ~process_mgr ~path:managed_dir
       ~branch:(Types.Branch.of_string "feat")
       ~base:(Types.Branch.of_string "main")
+      ()
   in
   (match outcome with
   | Worktree.Push_rejected (Push_reject_classify.Local_state_unsafe { reason })
@@ -225,6 +229,7 @@ let scenario_local_missing_remote env =
 
 let scenario_happy_path env =
   let process_mgr = Eio.Stdenv.process_mgr env in
+  let clock = Eio.Stdenv.clock env in
   with_temp_dir @@ fun root ->
   let origin_dir = Stdlib.Filename.concat root "origin.git" in
   let managed_dir = Stdlib.Filename.concat root "managed" in
@@ -251,10 +256,29 @@ let scenario_happy_path env =
     failwith
       (Printf.sprintf "precondition: refs/heads/feat=%s expected %s"
          feat_ref_sha local_sha);
-  let outcome =
-    Worktree.force_push_with_lease ~process_mgr ~path:managed_dir
+  (* A deadline must turn a non-returning push into data that the runner can
+     feed through [combine_session_and_push]. A zero-second deadline exercises
+     the timeout branch deterministically without depending on network timing. *)
+  let timed_out =
+    Worktree.force_push_with_lease ~timeout_seconds:0.0 ~clock ~process_mgr
+      ~path:managed_dir
       ~branch:(Types.Branch.of_string "feat")
       ~base:(Types.Branch.of_string "main")
+      ()
+  in
+  (match timed_out with
+  | Worktree.Push_error msg when String.is_substring msg ~substring:"timed out"
+    ->
+      Stdlib.print_endline "  push_timeout: OK (classified as Push_error)"
+  | other ->
+      failwith
+        (Printf.sprintf "push_timeout: expected Push_error, got %s"
+           (Worktree.show_push_result other)));
+  let outcome =
+    Worktree.force_push_with_lease ~clock ~process_mgr ~path:managed_dir
+      ~branch:(Types.Branch.of_string "feat")
+      ~base:(Types.Branch.of_string "main")
+      ()
   in
   (match outcome with
   | Worktree.Push_ok -> Stdlib.print_endline "  happy_path: OK"

--- a/test/test_worktree_missing_recovery.ml
+++ b/test/test_worktree_missing_recovery.ml
@@ -33,6 +33,7 @@ let nonexistent_path () =
 let () =
   Eio_main.run @@ fun env ->
   let process_mgr = Eio.Stdenv.process_mgr env in
+  let clock = Eio.Stdenv.clock env in
 
   (* (1) Precheck path: missing directory -> Push_worktree_missing without
      spawning git. We use a path that has never existed, so any subsequent
@@ -41,9 +42,10 @@ let () =
   assert_true "precondition: path does not exist"
     (not (Stdlib.Sys.file_exists path));
   let push_outcome =
-    Worktree.force_push_with_lease ~process_mgr ~path
+    Worktree.force_push_with_lease ~clock ~process_mgr ~path
       ~branch:(Types.Branch.of_string "feat")
       ~base:(Types.Branch.of_string "main")
+      ()
   in
   if
     not (Worktree.equal_push_result push_outcome Worktree.Push_worktree_missing)

--- a/test/test_worktree_setup_base_fetch_integration.ml
+++ b/test/test_worktree_setup_base_fetch_integration.ml
@@ -153,7 +153,9 @@ let empty_gameplan =
     [base_ref]. Returns the worktree path. *)
 let run_ensure env ~managed_dir ~project_name ~pid ~branch ~base_ref =
   let process_mgr = Eio.Stdenv.process_mgr env in
-  let module W = (val Worktree.make ~process_mgr ~repo_root:managed_dir) in
+  let clock = Eio.Stdenv.clock env in
+  let module W = (val Worktree.make ~clock ~process_mgr ~repo_root:managed_dir)
+  in
   let patch = mk_patch ~pid ~branch in
   let gameplan = { empty_gameplan with Types.Gameplan.patches = [ patch ] } in
   let module Env : Worktree_setup.ENV = struct


### PR DESCRIPTION
## Summary

- Bound supervisor-owned Git pushes with a 120-second deadline.
- Convert push timeouts into `Push_error` so the active operation releases `busy` and follows the existing retry/circuit-breaker path.
- Add randomized interleaving coverage proving review operations cannot remain busy indefinitely and persistent timeouts converge to intervention within the failure cap.

## Root cause

After an LLM session exited, Onton synchronously ran `git push --force-with-lease` before recording session completion. That subprocess had no deadline, so a hung push could leave `busy=true` and `current_op=Review_comments` indefinitely even though the agent had finished.

## Impact

A stalled push now terminates after 120 seconds, releases the current operation, and retries safely. Three consecutive failures surface `needs_intervention` instead of looping invisibly.

## Validation

- `dune build`
- `dune runtest`
- `dune fmt` / format check
- `git diff --check`
- Real-Git zero-deadline timeout classification regression
- PI-13b: 300 randomized review-poll interleavings

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/407"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786755555&installation_id=126163856&pr_number=407&repository=flowglad%2Fonton&return_to=https%3A%2F%2Fgithub.com%2Fflowglad%2Fonton%2Fpull%2F407&signature=92e2296b0c5db09fb75e4bce111ee3fdcf550ff242ba978f76213ca794000ff9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->