### PR TITLE
Require precedent research before implementation

### DIFF
--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -117,11 +117,25 @@ let format_precedents (ps : Precedent.t list) : string =
     in
     "\n\
      ## Established Precedents\n\n\
-     This patch should adopt the following proven techniques rather than \
-     rolling its own. Read the references when you need detail on the API \
-     shape or invariants they impose. Each entry names a library, algorithm, \
-     pattern, paper, RFC, doc, or blog post; the trailing sentence explains \
-     how it applies to this specific patch.\n\n" ^ body ^ "\n"
+     This patch must be grounded in the established precedents below. Treat \
+     reviewing them as required research, not optional background reading. Web \
+     research is part of this task when a source is external.\n\n\
+     **Before making code changes:**\n\n\
+     1. Retrieve and read every listed reference. Follow the canonical URL \
+     when one is provided. When an entry names a paper, RFC, standard, \
+     library, pattern, documentation set, or other external source without a \
+     URL, use web search or the available research tools to locate an \
+     authoritative primary source.\n\
+     2. Identify the concrete API shape, algorithm steps, invariants, and \
+     tradeoffs that apply to this patch. Do not rely only on the title or the \
+     summary below.\n\
+     3. Apply those findings to the implementation. If a source cannot be \
+     retrieved, is ambiguous, or conflicts with the codebase or gameplan, do \
+     not silently substitute recollection: record the limitation and your \
+     resolution in the implementation notes.\n\n\
+     Only begin implementation after completing this review. Each entry's \
+     trailing sentence explains how the source applies to this specific \
+     patch.\n\n" ^ body ^ "\n"
 
 let format_context_resources (resources : Context_resource.t list) : string =
   if List.is_empty resources then ""
@@ -2075,6 +2089,14 @@ let%test
       ~base_branch:"main" ()
   in
   String.is_substring rendered ~substring:"## Established Precedents"
+  && String.is_substring rendered
+       ~substring:"Treat reviewing them as required research"
+  && String.is_substring rendered
+       ~substring:"Retrieve and read every listed reference"
+  && String.is_substring rendered
+       ~substring:"use web search or the available research tools"
+  && String.is_substring rendered
+       ~substring:"Only begin implementation after completing this review"
   && String.is_substring rendered ~substring:"**[library] Bindlib**"
   && String.is_substring rendered
        ~substring:"https://github.com/rlepigre/ocaml-bindlib"


### PR DESCRIPTION
## Summary

- make precedent review a mandatory pre-implementation research step
- instruct patch agents to retrieve canonical sources or use web research tools to locate authoritative primary sources
- require agents to extract applicable APIs, algorithms, invariants, and tradeoffs before coding
- add regression assertions for the strengthened prompt language

## Why

The existing prompt told patch agents to read precedents only when they needed more detail. That made source review effectively optional, even when a patch cited research literature, standards, or external documentation. This change makes the intended workflow explicit and prevents agents from silently substituting memory for the cited material.

## Impact

Patch agents receiving established precedents will research and read them before implementation, document inaccessible or conflicting sources, and ground their changes in the cited prior art.

## Validation

- `dune build`
- `dune runtest`
- `dune build @fmt`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/408"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787261204&installation_model_id=19519&pr_number=408&repository=flowglad%2Fonton&return_to=https%3A%2F%2Fgithub.com%2Fflowglad%2Fonton%2Fpull%2F408&signature=bf2fc152798144d6db4f72423fab6bc0a7cba7c4d8fc756fdafca7549e3f7ed1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->