### PR TITLE
Treat closed PRs as terminal during prune

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1514,10 +1514,10 @@ let prune_arg =
         ~doc:
           "Remove every stored project whose gameplan patches are all terminal \
            (merged or closed). Skips projects whose lock is held by a live \
-           onton process. By default, each project's non-terminal patches are \
-           reconciled with the forge first (one PR-state query per patch) so \
-           out-of-band merges and closures are detected; pass --no-refresh to \
-           skip the network step.")
+           onton process. By default, each stored PR for a non-merged agent is \
+           reconciled with the forge first (one PR-state query per eligible \
+           PR) so out-of-band merges and closures are detected; pass \
+           --no-refresh to skip the network step.")
 
 let no_refresh_arg =
   let open Cmdliner in

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1512,11 +1512,12 @@ let prune_arg =
     value & flag
     & info [ "prune" ]
         ~doc:
-          "Remove every stored project whose gameplan patches are all merged. \
-           Skips projects whose lock is held by a live onton process. By \
-           default, each project's non-terminal patches are reconciled with \
-           the forge first (one PR-state query per patch) so out-of-band \
-           merges are detected; pass --no-refresh to skip the network step.")
+          "Remove every stored project whose gameplan patches are all terminal \
+           (merged or closed). Skips projects whose lock is held by a live \
+           onton process. By default, each project's non-terminal patches are \
+           reconciled with the forge first (one PR-state query per patch) so \
+           out-of-band merges and closures are detected; pass --no-refresh to \
+           skip the network step.")
 
 let no_refresh_arg =
   let open Cmdliner in

--- a/lib/prune_runner.ml
+++ b/lib/prune_runner.ml
@@ -5,8 +5,8 @@ open Base
 open Types
 
 type prune_status =
-  | All_merged
-  | Not_merged
+  | All_terminal
+  | Not_terminal
   | No_patches
   | No_snapshot
   | Load_error of string
@@ -14,6 +14,7 @@ type prune_status =
 type refresh_summary = {
   attempted : int;
   newly_merged : int;
+  closed : int;
   errors : int;
   skipped_reason : string option;
       (** When the project was eligible for refresh but it was skipped (e.g.
@@ -45,14 +46,12 @@ let rec remove_path path =
       try Stdlib.Sys.remove path with Sys_error _ -> ())
 
 (** Build the list of (patch_id, pr_number) pairs that can be reconciled with
-    the forge: agent stored as not-merged AND has a PR number on file. *)
+    the forge: agent stored as not-merged AND has a PR number on file. Both
+    present and missing PRs are included: a missing PR may be a closed PR, which
+    is terminal for pruning. *)
 let refresh_candidates (agents : Patch_agent.t Map.M(Patch_id).t) =
   Map.fold agents ~init:[] ~f:(fun ~key:patch_id ~data:agent acc ->
       if agent.Patch_agent.merged then acc
-        (* Skip Missing: the PR is gone from the forge, so refreshing it would
-           404. Wait for an explicit Rediscover_pr to bring it back to Present
-           or for the operator to remove it. *)
-      else if not (Patch_agent.is_pr_present agent) then acc
       else
         match Patch_agent.pr_number agent with
         | None -> acc
@@ -60,8 +59,8 @@ let refresh_candidates (agents : Patch_agent.t Map.M(Patch_id).t) =
 
 (** Refresh [agents] by querying the forge for every non-terminal patch with a
     recorded PR number. Returns the (possibly updated) agents map and a
-    [refresh_summary]. Forge errors are tolerated — the corresponding agent is
-    left untouched, classification proceeds with its stored [merged] flag. *)
+    [refresh_summary], plus patch IDs whose PRs are closed. Forge errors are
+    tolerated — the corresponding agent is left untouched and non-terminal. *)
 let refresh_agents_from_forge
     ~(make_forge :
        owner:string ->
@@ -73,7 +72,14 @@ let refresh_agents_from_forge
   let candidates = refresh_candidates agents in
   if List.is_empty candidates then
     ( agents,
-      { attempted = 0; newly_merged = 0; errors = 0; skipped_reason = None } )
+      [],
+      {
+        attempted = 0;
+        newly_merged = 0;
+        closed = 0;
+        errors = 0;
+        skipped_reason = None;
+      } )
   else
     match
       make_forge ~owner:cfg.github_owner ~repo:cfg.github_repo
@@ -81,9 +87,11 @@ let refresh_agents_from_forge
     with
     | None ->
         ( agents,
+          [],
           {
             attempted = 0;
             newly_merged = 0;
+            closed = 0;
             errors = 0;
             skipped_reason =
               Some
@@ -106,12 +114,14 @@ let refresh_agents_from_forge
             candidates
         in
         let attempted = List.length results in
-        let agents, newly_merged, errors =
-          List.fold results ~init:(agents, 0, 0)
+        let agents, closed_patch_ids, newly_merged, errors =
+          List.fold results ~init:(agents, [], 0, 0)
             ~f:(fun
-                (agents, merged_count, errs) (patch_id, _pr_number, result) ->
+                (agents, closed_ids, merged_count, errs)
+                (patch_id, _pr_number, result)
+              ->
               match result with
-              | Error _ -> (agents, merged_count, errs + 1)
+              | Error _ -> (agents, closed_ids, merged_count, errs + 1)
               | Ok pr_state ->
                   if Pr_state.merged pr_state then
                     let agents =
@@ -126,10 +136,20 @@ let refresh_agents_from_forge
                                  (Patch_agent.mark_merged agent)
                                  pr_state.Pr_state.merge_commit_sha))
                     in
-                    (agents, merged_count + 1, errs)
-                  else (agents, merged_count, errs))
+                    (agents, closed_ids, merged_count + 1, errs)
+                  else if Pr_state.closed pr_state then
+                    (agents, patch_id :: closed_ids, merged_count, errs)
+                  else (agents, closed_ids, merged_count, errs))
         in
-        (agents, { attempted; newly_merged; errors; skipped_reason = None })
+        ( agents,
+          closed_patch_ids,
+          {
+            attempted;
+            newly_merged;
+            closed = List.length closed_patch_ids;
+            errors;
+            skipped_reason = None;
+          } )
 
 let format_refresh_summary (s : refresh_summary) =
   let pr_word n = if n = 1 then "PR" else "PRs" in
@@ -145,6 +165,8 @@ let format_refresh_summary (s : refresh_summary) =
           ]
           @ (if s.newly_merged > 0 then
                [ Stdlib.Printf.sprintf "%d newly merged" s.newly_merged ]
+             else [])
+          @ (if s.closed > 0 then [ Stdlib.Printf.sprintf "%d closed" s.closed ]
              else [])
           @
           if s.errors > 0 then
@@ -165,29 +187,33 @@ let classify_project ~make_forge ~refresh ~slug =
     | Ok snap ->
         let agents = Orchestrator.agents_map snap.Runtime.orchestrator in
         let patches = snap.Runtime.gameplan.Gameplan.patches in
-        let agents, refresh_summary =
-          if not refresh then (agents, None)
+        let agents, closed_patch_ids, refresh_summary =
+          if not refresh then (agents, [], None)
           else
             match Project_store.load_config ~project_name:slug with
             | Error _ ->
                 ( agents,
+                  [],
                   Some
                     {
                       attempted = 0;
                       newly_merged = 0;
+                      closed = 0;
                       errors = 0;
                       skipped_reason = Some "stored config unreadable";
                     } )
             | Ok cfg ->
-                let agents, summary =
+                let agents, closed_patch_ids, summary =
                   refresh_agents_from_forge ~make_forge ~cfg ~agents
                 in
-                (agents, Some summary)
+                (agents, closed_patch_ids, Some summary)
         in
         let status =
-          match Prune_decision.classify_snapshot ~patches ~agents with
-          | Prune_decision.All_merged -> All_merged
-          | Prune_decision.Not_merged -> Not_merged
+          match
+            Prune_decision.classify_snapshot ~patches ~agents ~closed_patch_ids
+          with
+          | Prune_decision.All_terminal -> All_terminal
+          | Prune_decision.Not_terminal -> Not_terminal
           | Prune_decision.No_patches -> No_patches
         in
         (status, refresh_summary)
@@ -275,8 +301,9 @@ let run_prune ~net ~clock ~github_token ~refresh () =
                          classify_project ~make_forge ~refresh ~slug
                        in
                        (match status with
-                       | All_merged -> remove_path project_dir
-                       | Not_merged | No_patches | No_snapshot | Load_error _ ->
+                       | All_terminal -> remove_path project_dir
+                       | Not_terminal | No_patches | No_snapshot | Load_error _
+                         ->
                            ());
                        (status, refresh_summary)))
               with
@@ -287,7 +314,7 @@ let run_prune ~net ~clock ~github_token ~refresh () =
                 errors :=
                   (project_name, Stdlib.Printf.sprintf "prune failed: %s" msg)
                   :: !errors
-            | Ok (All_merged, refresh_summary) -> (
+            | Ok (All_terminal, refresh_summary) -> (
                 try
                   let refresh_note =
                     Option.bind refresh_summary ~f:format_refresh_summary
@@ -297,7 +324,7 @@ let run_prune ~net ~clock ~github_token ~refresh () =
                     :: !removed
                 with exn ->
                   errors := (project_name, Exn.to_string exn) :: !errors)
-            | Ok (Not_merged, refresh_summary) ->
+            | Ok (Not_terminal, refresh_summary) ->
                 kept :=
                   ( project_name,
                     kept_reason ~base:"has unmerged patches" ~refresh_summary )

--- a/lib/prune_runner.ml
+++ b/lib/prune_runner.ml
@@ -327,7 +327,8 @@ let run_prune ~net ~clock ~github_token ~refresh () =
             | Ok (Not_terminal, refresh_summary) ->
                 kept :=
                   ( project_name,
-                    kept_reason ~base:"has unmerged patches" ~refresh_summary )
+                    kept_reason ~base:"has non-terminal patches"
+                      ~refresh_summary )
                   :: !kept
             | Ok (No_patches, _) ->
                 kept := (project_name, "gameplan has no patches") :: !kept

--- a/lib/prune_runner.mli
+++ b/lib/prune_runner.mli
@@ -8,7 +8,8 @@ val run_prune :
   refresh:bool ->
   unit ->
   int
-(** Remove stored projects whose gameplan patches are all merged.
+(** Remove stored projects whose gameplan patches are all terminal (merged or
+    closed).
 
     When [refresh] is [true], every project with at least one non-terminal patch
     (i.e. an agent with [merged = false] and a recorded PR number) is reconciled

--- a/lib_core/prune_decision.ml
+++ b/lib_core/prune_decision.ml
@@ -4,17 +4,19 @@
 open Base
 open Types
 
-type project_status = All_merged | Not_merged | No_patches
+type project_status = All_terminal | Not_terminal | No_patches
 [@@deriving show, eq, sexp_of, compare]
 
 let classify_snapshot ~(patches : Patch.t list)
-    ~(agents : Patch_agent.t Map.M(Patch_id).t) =
+    ~(agents : Patch_agent.t Map.M(Patch_id).t) ~closed_patch_ids =
   if List.is_empty patches then No_patches
   else
-    let all_merged =
+    let all_terminal =
       List.for_all patches ~f:(fun (p : Patch.t) ->
           match Map.find agents p.Patch.id with
-          | Some agent -> agent.Patch_agent.merged
+          | Some agent ->
+              agent.Patch_agent.merged
+              || List.mem closed_patch_ids p.Patch.id ~equal:Patch_id.equal
           | None -> false)
     in
-    if all_merged then All_merged else Not_merged
+    if all_terminal then All_terminal else Not_terminal

--- a/lib_core/prune_decision.ml
+++ b/lib_core/prune_decision.ml
@@ -11,12 +11,12 @@ let classify_snapshot ~(patches : Patch.t list)
     ~(agents : Patch_agent.t Map.M(Patch_id).t) ~closed_patch_ids =
   if List.is_empty patches then No_patches
   else
+    let closed_patch_ids = Set.of_list (module Patch_id) closed_patch_ids in
     let all_terminal =
       List.for_all patches ~f:(fun (p : Patch.t) ->
           match Map.find agents p.Patch.id with
           | Some agent ->
-              agent.Patch_agent.merged
-              || List.mem closed_patch_ids p.Patch.id ~equal:Patch_id.equal
+              agent.Patch_agent.merged || Set.mem closed_patch_ids p.Patch.id
           | None -> false)
     in
     if all_terminal then All_terminal else Not_terminal

--- a/lib_core/prune_decision.mli
+++ b/lib_core/prune_decision.mli
@@ -8,15 +8,17 @@ open Types
     for reading snapshots and locks; this module only classifies already-decoded
     snapshot data. *)
 
-type project_status = All_merged | Not_merged | No_patches
+type project_status = All_terminal | Not_terminal | No_patches
 [@@deriving show, eq, sexp_of, compare]
 
 val classify_snapshot :
   patches:Patch.t list ->
   agents:Patch_agent.t Map.M(Patch_id).t ->
+  closed_patch_ids:Patch_id.t list ->
   project_status
 (** Classify a decoded project snapshot for pruning.
 
-    A project is [All_merged] only when the gameplan has at least one patch and
-    every gameplan patch has a corresponding merged agent. Missing agents count
-    as [Not_merged]. *)
+    A project is [All_terminal] only when the gameplan has at least one patch
+    and every gameplan patch has a corresponding agent that is either merged in
+    the snapshot or whose PR was observed closed during the prune refresh.
+    Missing agents count as [Not_terminal]. *)

--- a/test/test_prune_decision_properties.ml
+++ b/test/test_prune_decision_properties.ml
@@ -50,8 +50,9 @@ let gen_patches_flags_and_extra =
     int_range 0 10 >>= fun extra_count ->
     return (patches, flags, List.init extra_count ~f:(fun i -> patch (100 + i))))
 
-let classify patches agents =
+let classify ?(closed_patch_ids = []) patches agents =
   Prune_decision.classify_snapshot ~patches ~agents:(agents_map agents)
+    ~closed_patch_ids
 
 let () =
   let open QCheck2 in
@@ -77,23 +78,24 @@ let () =
   in
   let prop_all_merged_iff_all_present_merged =
     Test.make
-      ~name:"prune non-empty is All_merged iff every patch agent is merged"
+      ~name:"prune non-empty is All_terminal iff every patch agent is merged"
       ~count:1000 gen_patches_and_flags (fun (patches, flags) ->
         let agents =
           List.map2_exn patches flags ~f:(fun p merged ->
               agent_for_patch ~merged p)
         in
         let status = classify patches agents in
-        let expected_all_merged =
+        let expected_all_terminal =
           (not (List.is_empty patches)) && List.for_all flags ~f:(fun x -> x)
         in
         Bool.equal
-          (Prune_decision.equal_project_status status Prune_decision.All_merged)
-          expected_all_merged)
+          (Prune_decision.equal_project_status status
+             Prune_decision.All_terminal)
+          expected_all_terminal)
   in
   let prop_missing_agent_not_merged =
     Test.make
-      ~name:"prune missing gameplan agent is Not_merged for non-empty patches"
+      ~name:"prune missing gameplan agent is Not_terminal for non-empty patches"
       ~count:500
       Gen.(map (fun n -> List.init n ~f:patch) (int_range 1 20))
       (fun patches ->
@@ -103,7 +105,7 @@ let () =
           | _ :: rest -> List.map rest ~f:(agent_for_patch ~merged:true)
         in
         Prune_decision.equal_project_status (classify patches agents)
-          Prune_decision.Not_merged)
+          Prune_decision.Not_terminal)
   in
   let prop_irrelevant_agents_do_not_change =
     Test.make ~name:"prune ignores agents outside the gameplan" ~count:1000
@@ -136,12 +138,40 @@ let () =
         let p = patch 1 in
         let patches = [ p; { p with title = "duplicate id" } ] in
         let expected =
-          if merged then Prune_decision.All_merged
-          else Prune_decision.Not_merged
+          if merged then Prune_decision.All_terminal
+          else Prune_decision.Not_terminal
         in
         Prune_decision.equal_project_status
           (classify patches [ agent_for_patch ~merged p ])
           expected)
+  in
+  let prop_closed_prs_are_terminal =
+    Test.make ~name:"prune closed PRs are terminal alongside merged PRs"
+      ~count:1000 gen_patches_and_flags (fun (patches, merged_flags) ->
+        let agents =
+          List.map2_exn patches merged_flags ~f:(fun p merged ->
+              agent_for_patch ~merged p)
+        in
+        let closed_patch_ids =
+          List.filter_map (List.zip_exn patches merged_flags)
+            ~f:(fun (p, merged) -> if merged then None else Some p.Patch.id)
+        in
+        let expected =
+          if List.is_empty patches then Prune_decision.No_patches
+          else Prune_decision.All_terminal
+        in
+        Prune_decision.equal_project_status
+          (classify ~closed_patch_ids patches agents)
+          expected)
+  in
+  let prop_closed_without_agent_is_not_terminal =
+    Test.make
+      ~name:"prune closed PR id without a corresponding agent is not terminal"
+      ~count:200 Gen.unit (fun () ->
+        let p = patch 1 in
+        Prune_decision.equal_project_status
+          (classify ~closed_patch_ids:[ p.Patch.id ] [ p ] [])
+          Prune_decision.Not_terminal)
   in
   let suite =
     [
@@ -152,6 +182,8 @@ let () =
       prop_irrelevant_agents_do_not_change;
       prop_patch_order_invariant;
       prop_duplicate_patch_ids_follow_same_agent;
+      prop_closed_prs_are_terminal;
+      prop_closed_without_agent_is_not_terminal;
     ]
   in
   let errcode = QCheck_base_runner.run_tests ~verbose:true suite in

--- a/test/test_prune_decision_properties.ml
+++ b/test/test_prune_decision_properties.ml
@@ -148,21 +148,23 @@ let () =
   let prop_closed_prs_are_terminal =
     Test.make ~name:"prune closed PRs are terminal alongside merged PRs"
       ~count:1000 gen_patches_and_flags (fun (patches, merged_flags) ->
-        let agents =
-          List.map2_exn patches merged_flags ~f:(fun p merged ->
-              agent_for_patch ~merged p)
-        in
-        let closed_patch_ids =
-          List.filter_map (List.zip_exn patches merged_flags)
-            ~f:(fun (p, merged) -> if merged then None else Some p.Patch.id)
-        in
-        let expected =
-          if List.is_empty patches then Prune_decision.No_patches
-          else Prune_decision.All_terminal
-        in
-        Prune_decision.equal_project_status
-          (classify ~closed_patch_ids patches agents)
-          expected)
+        try
+          let agents =
+            List.map2_exn patches merged_flags ~f:(fun p merged ->
+                agent_for_patch ~merged p)
+          in
+          let closed_patch_ids =
+            List.filter_map (List.zip_exn patches merged_flags)
+              ~f:(fun (p, merged) -> if merged then None else Some p.Patch.id)
+          in
+          let expected =
+            if List.is_empty patches then Prune_decision.No_patches
+            else Prune_decision.All_terminal
+          in
+          Prune_decision.equal_project_status
+            (classify ~closed_patch_ids patches agents)
+            expected
+        with _ -> false)
   in
   let prop_closed_without_agent_is_not_terminal =
     Test.make


### PR DESCRIPTION
## Summary

- Treat closed pull requests as terminal during `--prune`, alongside merged pull requests.
- Refresh missing-but-numbered pull requests so out-of-band closures can be detected.
- Report closed pull requests separately in prune refresh summaries and update CLI documentation.
- Add property coverage for merged/closed terminal combinations and missing-agent safety.

## Root cause

Prune refresh queried GitHub for non-merged pull requests but discarded the `Closed` result. Classification only inspected the persisted `merged` flag, so projects whose pull requests had been closed were incorrectly retained as having unmerged patches.

## Impact

Running `--prune` now removes a stored project once every gameplan patch has a merged or closed pull request. Open pull requests, missing agents, forge errors, and patches without pull requests remain non-terminal.

## Validation

- `dune build`
- `dune runtest`
- `dune fmt` / pre-commit format check
- `git diff --check`
- Focused prune property suite (9 tests)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/409"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787312725&installation_model_id=19519&pr_number=409&repository=flowglad%2Fonton&return_to=https%3A%2F%2Fgithub.com%2Fflowglad%2Fonton%2Fpull%2F409&signature=196ab80708f687a34df6657055b0d8c3e3bd0a19967343eec0c88a663ae2c121"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pruning now removes stored projects when all gameplan patches are terminal—either merged or closed.
  * Closed pull requests are detected during refresh and included in pruning decisions.
  * Refresh summaries now report closed pull requests when applicable.

* **Documentation**
  * Updated command-line help and pruning documentation to describe the expanded terminal-state behavior.

* **Tests**
  * Added coverage for closed pull requests and terminal-state classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->