### PR TITLE
Add configurable reasoning effort routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,11 +521,12 @@ write a per-repo config at
 {
   "default": {
     "backend": "codex",
-    "model":   "auto"
+    "model":   "auto",
+    "effort":  "medium"
   },
   "routing": {
-    "1": { "backend": "claude", "model": "haiku"   },
-    "3": { "backend": "codex",  "model": "gpt-5.6-sol" }
+    "1": { "backend": "claude", "model": "haiku", "effort": "default" },
+    "3": { "backend": "codex",  "model": "gpt-5.6-sol", "effort": "xhigh" }
   }
 }
 ```
@@ -539,11 +540,18 @@ Resolution order, evaluated per field independently:
 
 `model: "auto"` from any source — the CLI flag or `default.model` —
 activates the `routing` map: each patch's complexity (1/2/3) picks its
-own `(backend, model)`, falling back to the effective backend's hardcoded
-ladder for tiers with no entry. Both subfields of `default` are
-optional; pin just `backend`, just `model`, or both. Run
+own `(backend, model, effort)`, falling back to the effective backend's
+hardcoded model ladder for tiers with no entry. All three fields of `default`
+are optional; pin any combination. Run
 `onton-check-repo-config <owner> <repo>` to verify how a `config.json`
 parses.
+
+`effort` is optional in both `default` and each route. A route with no effort
+inherits `default.effort`; the literal `"default"` explicitly lets the selected
+model use its provider default. Codex supports `minimal`, `low`, `medium`,
+`high`, and `xhigh`; Claude supports `low`, `medium`, `high`, `xhigh`, and
+`max`. Onton rejects effort overrides for other backends and values unsupported
+by the selected provider.
 
 For Codex, the built-in ladder maps complexity 1/2/3 to `gpt-5.6-luna`,
 `gpt-5.6-terra`, and `gpt-5.6-sol`. Missing or out-of-range complexity

--- a/bin/check_repo_config.ml
+++ b/bin/check_repo_config.ml
@@ -22,6 +22,7 @@ let () =
           let show_opt = function Some s -> s | None -> "(unset)" in
           Printf.printf "default.backend   : %s\n" (show_opt c.default_backend);
           Printf.printf "default.model     : %s\n" (show_opt c.default_model);
+          Printf.printf "default.effort    : %s\n" (show_opt c.default_effort);
           Printf.printf "complexity_routes : %d entries\n"
             (List.length c.complexity_routes);
           Printf.printf "review_backends   : %d entries\n"

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -865,11 +865,11 @@ let construct_capabilities ~net (setup : runtime_setup) =
       ~timeout:session_timeout ~setsid_exec
   in
   let pick_backend ~complexity =
-    let ({ Backend_routing.backend; model } as decision) =
+    let ({ Backend_routing.backend; model; effort } as decision) =
       Backend_routing.decide ~repo_config ~default_backend:backend
         ~effective_model:effective_model_opt ~complexity
     in
-    (Backend_registry.get registry ~backend ~model, decision)
+    (Backend_registry.get registry ~backend ~model ~effort, decision)
   in
   let backend_name = function
     | Backend_registry.Ephemeral backend -> backend.Llm_backend.name

--- a/lib/backend_preflight.ml
+++ b/lib/backend_preflight.ml
@@ -87,29 +87,19 @@ let validate ?getenv_opt ?is_executable ~default_backend ~effective_model
         | Ok () -> None
         | Error msg -> Some msg)
   in
-  let complexities =
-    if Backend_routing.is_auto_model effective_model then
-      [ None; Some 1; Some 2; Some 3 ]
-    else [ None ]
-  in
   let effort_errors =
-    List.filter_map complexities ~f:(fun complexity ->
-        let { Backend_routing.backend; effort; _ } =
-          Backend_routing.decide ~repo_config ~default_backend ~effective_model
-            ~complexity
-        in
-        match effort with
-        | None -> None
-        | Some level when Backend_routing.effort_is_supported ~backend level ->
-            None
-        | Some level ->
-            Some
-              (Printf.sprintf
-                 "backend %S does not support reasoning effort %S for \
-                  complexity %s"
-                 backend level
-                 (Option.value_map complexity ~default:"default"
-                    ~f:Int.to_string)))
+    Backend_routing.unsupported_efforts ~repo_config ~default_backend
+      ~effective_model
+    |> List.map
+         ~f:(fun
+             ({ unsupported_backend; unsupported_level; unsupported_complexity } :
+               Backend_routing.unsupported_effort)
+           ->
+           Printf.sprintf
+             "backend %S does not support reasoning effort %S for complexity %s"
+             unsupported_backend unsupported_level
+             (Option.value_map unsupported_complexity ~default:"default"
+                ~f:Int.to_string))
   in
   let errors =
     executable_errors @ effort_errors

--- a/lib/backend_preflight.ml
+++ b/lib/backend_preflight.ml
@@ -81,11 +81,39 @@ let validate ?getenv_opt ?is_executable ~default_backend ~effective_model
   let backends =
     selected_backends ~default_backend ~effective_model ~repo_config
   in
-  let errors =
+  let executable_errors =
     List.filter_map backends ~f:(fun backend ->
         match check_backend ?getenv_opt ?is_executable backend with
         | Ok () -> None
         | Error msg -> Some msg)
+  in
+  let complexities =
+    if Backend_routing.is_auto_model effective_model then
+      [ None; Some 1; Some 2; Some 3 ]
+    else [ None ]
+  in
+  let effort_errors =
+    List.filter_map complexities ~f:(fun complexity ->
+        let { Backend_routing.backend; effort; _ } =
+          Backend_routing.decide ~repo_config ~default_backend ~effective_model
+            ~complexity
+        in
+        match effort with
+        | None -> None
+        | Some level when Backend_routing.effort_is_supported ~backend level ->
+            None
+        | Some level ->
+            Some
+              (Printf.sprintf
+                 "backend %S does not support reasoning effort %S for \
+                  complexity %s"
+                 backend level
+                 (Option.value_map complexity ~default:"default"
+                    ~f:Int.to_string)))
+  in
+  let errors =
+    executable_errors @ effort_errors
+    |> List.dedup_and_sort ~compare:String.compare
   in
   match errors with [] -> Ok () | _ :: _ -> Error errors
 
@@ -93,7 +121,8 @@ let%test "selected_backends ignores routes unless effective model is auto" =
   let repo_config =
     {
       Repo_config.empty with
-      complexity_routes = [ (1, { backend = "codex"; model = None }) ];
+      complexity_routes =
+        [ (1, { backend = "codex"; model = None; effort = Inherit }) ];
     }
   in
   List.equal String.equal
@@ -107,8 +136,8 @@ let%test "selected_backends includes routes for auto effective model" =
       Repo_config.empty with
       complexity_routes =
         [
-          (1, { backend = "codex"; model = None });
-          (2, { backend = "claude"; model = Some "sonnet" });
+          (1, { backend = "codex"; model = None; effort = Inherit });
+          (2, { backend = "claude"; model = Some "sonnet"; effort = Inherit });
         ];
     }
   in
@@ -129,3 +158,33 @@ let%test "validate reports missing backend executable" =
       String.is_substring msg ~substring:"codex"
       && String.is_substring msg ~substring:"not found or is not executable"
   | Ok () | Error _ -> false
+
+let%test "validate rejects provider-incompatible reasoning effort" =
+  let repo_config = { Repo_config.empty with default_effort = Some "max" } in
+  match
+    validate
+      ~getenv_opt:(fun _ -> Some "/bin")
+      ~is_executable:(fun _ -> true)
+      ~default_backend:"codex" ~effective_model:None ~repo_config ()
+  with
+  | Error [ msg ] ->
+      String.is_substring msg ~substring:"codex"
+      && String.is_substring msg ~substring:"max"
+  | Ok () | Error _ -> false
+
+let%test "validate accepts supported route reasoning efforts" =
+  let repo_config =
+    {
+      Repo_config.empty with
+      complexity_routes =
+        [
+          (1, { backend = "codex"; model = None; effort = Level "minimal" });
+          (2, { backend = "claude"; model = None; effort = Level "max" });
+        ];
+    }
+  in
+  Result.is_ok
+    (validate
+       ~getenv_opt:(fun _ -> Some "/bin")
+       ~is_executable:(fun _ -> true)
+       ~default_backend:"codex" ~effective_model:(Some "auto") ~repo_config ())

--- a/lib/backend_registry.ml
+++ b/lib/backend_registry.ml
@@ -4,8 +4,9 @@
 open Base
 
 type t = {
-  factory : backend:string -> model:string option -> kind;
-  cache : (string * string option, kind) Hashtbl.t;
+  factory :
+    backend:string -> model:string option -> effort:string option -> kind;
+  cache : (string * string option * string option, kind) Hashtbl.t;
 }
 
 and kind = Ephemeral of Llm_backend.t | Long_lived of Llm_backend_long_lived.t
@@ -24,17 +25,19 @@ let display_name_of_claude_model = function
   | None -> "Claude"
 
 let make_factory ~(process_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t) ~clock
-    ~timeout ~setsid_exec : backend:string -> model:string option -> kind =
- fun ~backend ~model ->
+    ~timeout ~setsid_exec :
+    backend:string -> model:string option -> effort:string option -> kind =
+ fun ~backend ~model ~effort ->
   match backend with
   | "claude" ->
       Ephemeral
         (Claude_backend.create
            ~name:(display_name_of_claude_model model)
-           ~model ~process_mgr ~clock ~timeout ~setsid_exec)
+           ~model ~effort ~process_mgr ~clock ~timeout ~setsid_exec)
   | "codex" ->
       Ephemeral
-        (Codex_backend.create ~model ~process_mgr ~clock ~timeout ~setsid_exec)
+        (Codex_backend.create ~model ~effort ~process_mgr ~clock ~timeout
+           ~setsid_exec)
   | "opencode" ->
       Ephemeral
         (Opencode_backend.create ~model ~process_mgr ~clock ~timeout
@@ -81,12 +84,12 @@ let resolve_model ~backend ~model ~complexity =
   | "patch-agent", None -> auto_model ~backend ~complexity
   | _ -> model
 
-let get t ~backend ~model =
-  let key = (backend, model) in
+let get t ~backend ~model ~effort =
+  let key = (backend, model, effort) in
   match Hashtbl.find t.cache key with
   | Some b -> b
   | None ->
-      let b = t.factory ~backend ~model in
+      let b = t.factory ~backend ~model ~effort in
       (* [set] (not [add_exn]): the runner forks one daemon fiber per patch
          action, so two fibers may both miss [find] and race to insert the
          same key. Constructing a duplicate backend is harmless — they hold

--- a/lib/backend_registry.mli
+++ b/lib/backend_registry.mli
@@ -1,15 +1,14 @@
 (* @archlint.module interface
    @archlint.domain backend-registry *)
 
-(** Lazy cache of backend instances keyed by [(backend_name, model)].
+(** Lazy cache of backend instances keyed by [(backend_name, model, effort)].
 
-    A run can route different patches to different backends (see
-    [Repo_config.modelRouting]), so we may need several distinct [Llm_backend.t]
-    values during a single session — one per unique [(backend, model)] tuple
-    referenced by either the CLI flags or the routing map. Constructing them
-    eagerly would be wasteful when the routing only uses one or two; the
-    registry builds each on first lookup and caches it for the rest of the run.
-*)
+    A run can route different patches to different backends, so we may need
+    several distinct [Llm_backend.t] values during a single session — one per
+    unique [(backend, model, effort)] tuple referenced by either the CLI flags
+    or the routing map. Constructing them eagerly would be wasteful when the
+    routing only uses one or two; the registry builds each on first lookup and
+    caches it for the rest of the run. *)
 
 type t
 
@@ -27,10 +26,11 @@ val create :
     backends. The Eio capabilities and per-session [timeout] are baked into the
     closure so callers don't re-thread them on every [get]. *)
 
-val get : t -> backend:string -> model:string option -> kind
-(** Return the cached backend for [(backend, model)], constructing it on first
-    request. Raises [Invalid_argument] for unrecognised backend names — callers
-    are expected to validate against the known list before asking. *)
+val get :
+  t -> backend:string -> model:string option -> effort:string option -> kind
+(** Return the cached backend for [(backend, model, effort)], constructing it on
+    first request. Raises [Invalid_argument] for unrecognised backend names —
+    callers are expected to validate against the known list before asking. *)
 
 val auto_model : backend:string -> complexity:int option -> string option
 (** Look up the named backend's hardcoded complexity → model ladder — the model

--- a/lib/claude_backend.ml
+++ b/lib/claude_backend.ml
@@ -1,7 +1,7 @@
 (* @archlint.module core
    @archlint.domain claude-backend *)
 
-let create ~name ~model ~process_mgr ~clock ~timeout ~setsid_exec :
+let create ~name ~model ~effort ~process_mgr ~clock ~timeout ~setsid_exec :
     Llm_backend.t =
   {
     name;
@@ -15,7 +15,7 @@ let create ~name ~model ~process_mgr ~clock ~timeout ~setsid_exec :
         ~complexity
         ~on_event
       ->
-        Claude_runner.run_streaming ~model ~process_mgr ~clock ~timeout
+        Claude_runner.run_streaming ~model ~effort ~process_mgr ~clock ~timeout
           ~setsid_exec ~project_name ~cwd ~patch_id ~prompt ~resume_session
           ~session_uuid ~complexity ~on_event);
   }

--- a/lib/claude_backend.mli
+++ b/lib/claude_backend.mli
@@ -4,6 +4,7 @@
 val create :
   name:string ->
   model:string option ->
+  effort:string option ->
   process_mgr:_ Eio.Process.mgr ->
   clock:_ Eio.Time.clock ->
   timeout:float ->
@@ -11,7 +12,9 @@ val create :
   Llm_backend.t
 (** Create an LLM backend that uses the Claude CLI. [model], when provided, is
     passed via [--model]; [None] (or empty) lets the Claude CLI pick its own
-    default. [timeout] is the maximum session duration in seconds before the
-    process is killed. [setsid_exec], when [Some path], routes the subprocess
-    through the [onton-setsid-exec] shim so it leads its own process group and
-    the whole tree can be reaped on teardown. *)
+    default. [effort], when provided, is passed via [--effort]; [None] lets the
+    Claude CLI use the selected model's default. [timeout] is the maximum
+    session duration in seconds before the process is killed. [setsid_exec],
+    when [Some path], routes the subprocess through the [onton-setsid-exec] shim
+    so it leads its own process group and the whole tree can be reaped on
+    teardown. *)

--- a/lib/claude_runner.ml
+++ b/lib/claude_runner.ml
@@ -15,14 +15,14 @@ let parse_stream_event = Claude_event_parser.parse_stream_event
 let parse_stream_events = Claude_event_parser.parse_stream_events
 let warn_to_stderr msg = Stdio.eprintf "%s\n" msg
 
-let build_args ~getenv_opt ~model ~complexity ~prompt ~resume_session =
-  Claude_event_parser.build_args ~getenv_opt ~warn:warn_to_stderr ~model
+let build_args ~getenv_opt ~model ~effort ~complexity ~prompt ~resume_session =
+  Claude_event_parser.build_args ~getenv_opt ~warn:warn_to_stderr ~model ~effort
     ~complexity ~prompt ~resume_session
 
-let build_stream_args ~getenv_opt ~model ~complexity ~prompt ~minted_session_id
-    ~resume_session =
+let build_stream_args ~getenv_opt ~model ~effort ~complexity ~prompt
+    ~minted_session_id ~resume_session =
   Claude_event_parser.build_stream_args ~getenv_opt ~warn:warn_to_stderr ~model
-    ~complexity ~prompt ~minted_session_id ~resume_session
+    ~effort ~complexity ~prompt ~minted_session_id ~resume_session
 
 let prepare_minted_session_id_with_env ~getenv_opt ~patch_id ~resume_session =
   ignore (patch_id : Types.Patch_id.t);
@@ -42,11 +42,12 @@ let prepare_minted_session_id_with_env ~getenv_opt ~patch_id ~resume_session =
 let prepare_minted_session_id =
   prepare_minted_session_id_with_env ~getenv_opt:Stdlib.Sys.getenv_opt
 
-let run ~model ~process_mgr ~cwd ~patch_id ~prompt ~resume_session ~complexity =
+let run ~model ~effort ~process_mgr ~cwd ~patch_id ~prompt ~resume_session
+    ~complexity =
   ignore (patch_id : Types.Patch_id.t);
   let args =
-    build_args ~getenv_opt:Stdlib.Sys.getenv_opt ~model ~complexity ~prompt
-      ~resume_session
+    build_args ~getenv_opt:Stdlib.Sys.getenv_opt ~model ~effort ~complexity
+      ~prompt ~resume_session
   in
   let stdout_content, stderr_content, exit_code =
     Eio.Switch.run @@ fun sw ->
@@ -101,8 +102,9 @@ let run ~model ~process_mgr ~cwd ~patch_id ~prompt ~resume_session ~complexity =
     timed_out = false;
   }
 
-let run_streaming ~model ~process_mgr ~clock ~timeout ~setsid_exec ~project_name
-    ~cwd ~patch_id ~prompt ~resume_session ~session_uuid ~complexity ~on_event =
+let run_streaming ~model ~effort ~process_mgr ~clock ~timeout ~setsid_exec
+    ~project_name ~cwd ~patch_id ~prompt ~resume_session ~session_uuid
+    ~complexity ~on_event =
   let model = Llm_backend.resolve_auto_model ~model ~complexity ~auto_model in
   let env =
     Spawn_env.merge_env ~base_env:(Unix.environment ())
@@ -120,8 +122,8 @@ let run_streaming ~model ~process_mgr ~clock ~timeout ~setsid_exec ~project_name
       }
   | Ok minted_session_id ->
       let args =
-        build_stream_args ~getenv_opt:Stdlib.Sys.getenv_opt ~model ~complexity
-          ~prompt ~minted_session_id ~resume_session
+        build_stream_args ~getenv_opt:Stdlib.Sys.getenv_opt ~model ~effort
+          ~complexity ~prompt ~minted_session_id ~resume_session
       in
       let process_line line =
         let trimmed = strip_ansi (String.strip line) in

--- a/lib/claude_runner.mli
+++ b/lib/claude_runner.mli
@@ -19,6 +19,7 @@ open Base
 
 val run :
   model:string option ->
+  effort:string option ->
   process_mgr:_ Eio.Process.mgr ->
   cwd:Eio.Fs.dir_ty Eio.Path.t ->
   patch_id:Types.Patch_id.t ->
@@ -47,6 +48,7 @@ val auto_model : complexity:int option -> string option
 
 val run_streaming :
   model:string option ->
+  effort:string option ->
   process_mgr:_ Eio.Process.mgr ->
   clock:_ Eio.Time.clock ->
   timeout:float ->
@@ -80,6 +82,7 @@ val strip_ansi : string -> string
 val build_args :
   getenv_opt:(string -> string option) ->
   model:string option ->
+  effort:string option ->
   complexity:int option ->
   prompt:string ->
   resume_session:string option ->
@@ -89,6 +92,7 @@ val build_args :
 val build_stream_args :
   getenv_opt:(string -> string option) ->
   model:string option ->
+  effort:string option ->
   complexity:int option ->
   prompt:string ->
   minted_session_id:string option ->

--- a/lib/codex_backend.ml
+++ b/lib/codex_backend.ml
@@ -43,11 +43,12 @@ let budget_cap_nano_usd_from_env () =
           Some (Int64.of_float (Float.round_nearest (cap *. 1_000_000_000.0)))
       | Some _ | None -> None)
 
-let run_streaming ~model ~process_mgr ~clock ~timeout ~setsid_exec ~project_name
-    ~cwd ~patch_id ~prompt ~resume_session ~session_uuid ~complexity ~on_event =
+let run_streaming ~model ~effort ~process_mgr ~clock ~timeout ~setsid_exec
+    ~project_name ~cwd ~patch_id ~prompt ~resume_session ~session_uuid
+    ~complexity ~on_event =
   let model = Llm_backend.resolve_auto_model ~model ~complexity ~auto_model in
   let cwd_path = snd cwd in
-  let args = build_args ~model ~cwd_path ~prompt ~resume_session in
+  let args = build_args ~model ~effort ~cwd_path ~prompt ~resume_session in
   let env =
     Spawn_env.merge_env ~base_env:(Unix.environment ())
       ~overrides:
@@ -78,7 +79,8 @@ let run_streaming ~model ~process_mgr ~clock ~timeout ~setsid_exec ~project_name
     run_once ())
   else result
 
-let create ~model ~process_mgr ~clock ~timeout ~setsid_exec : Llm_backend.t =
+let create ~model ~effort ~process_mgr ~clock ~timeout ~setsid_exec :
+    Llm_backend.t =
   {
     name = "Codex";
     run_streaming =
@@ -91,7 +93,7 @@ let create ~model ~process_mgr ~clock ~timeout ~setsid_exec : Llm_backend.t =
         ~complexity
         ~on_event
       ->
-        run_streaming ~model ~process_mgr ~clock ~timeout ~setsid_exec ~cwd
-          ~project_name ~patch_id ~prompt ~resume_session ~session_uuid
+        run_streaming ~model ~effort ~process_mgr ~clock ~timeout ~setsid_exec
+          ~cwd ~project_name ~patch_id ~prompt ~resume_session ~session_uuid
           ~complexity ~on_event);
   }

--- a/lib/codex_backend.mli
+++ b/lib/codex_backend.mli
@@ -3,6 +3,7 @@
 
 val create :
   model:string option ->
+  effort:string option ->
   process_mgr:_ Eio.Process.mgr ->
   clock:_ Eio.Time.clock ->
   timeout:float ->
@@ -10,9 +11,10 @@ val create :
   Llm_backend.t
 (** Create an LLM backend that uses the Codex CLI. [model], when provided, is
     passed to [codex exec] via the [-m] flag; [None] (or empty) lets the Codex
-    CLI pick its own default. [timeout] is the maximum session duration in
-    seconds before the process is killed. See {!Claude_backend.create} for
-    [setsid_exec] semantics. *)
+    CLI pick its own default. [effort], when provided, is passed as Codex's
+    [model_reasoning_effort] config override. [timeout] is the maximum session
+    duration in seconds before the process is killed. See
+    {!Claude_backend.create} for [setsid_exec] semantics. *)
 
 val parse_event : string -> Types.Stream_event.t list
 (** Parse a single NDJSON line from Codex's JSON output. Exposed for testing. *)

--- a/lib/tui.ml
+++ b/lib/tui.ml
@@ -401,7 +401,7 @@ let patch_view_of_agent (agent : Patch_agent.t)
   let patch_id = agent.patch_id in
   let patch_opt = Map.find patches_by_id patch_id in
   let complexity = Option.bind patch_opt ~f:(fun p -> p.Patch.complexity) in
-  let { Backend_routing.backend = backend_name; model } =
+  let { Backend_routing.backend = backend_name; model; effort = _ } =
     resolve_routing ~complexity
   in
   let title =

--- a/lib_core/backend_routing.ml
+++ b/lib_core/backend_routing.ml
@@ -3,11 +3,27 @@
 
 open Base
 
-type decision = { backend : string; model : string option }
+type decision = {
+  backend : string;
+  model : string option;
+  effort : string option;
+}
 
 let is_auto_model = function
   | Some s -> String.equal (String.lowercase s) "auto"
   | None -> false
+
+let effort_is_supported ~backend effort =
+  match backend with
+  | "codex" ->
+      List.mem
+        [ "minimal"; "low"; "medium"; "high"; "xhigh" ]
+        effort ~equal:String.equal
+  | "claude" ->
+      List.mem
+        [ "low"; "medium"; "high"; "xhigh"; "max" ]
+        effort ~equal:String.equal
+  | _ -> false
 
 let first_nonempty (xs : string list) ~default =
   match List.find xs ~f:(fun s -> not (String.is_empty (String.strip s))) with
@@ -35,16 +51,31 @@ let resolve_pair ~cli_backend ~cli_model ~stored_backend ~stored_model
 let decide ~(repo_config : Repo_config.t) ~default_backend ~effective_model
     ~complexity : decision =
   if not (is_auto_model effective_model) then
-    { backend = default_backend; model = effective_model }
+    {
+      backend = default_backend;
+      model = effective_model;
+      effort = repo_config.default_effort;
+    }
   else
     match Repo_config.route_for_complexity repo_config ~complexity with
-    | Some { Repo_config.backend; model } -> { backend; model }
+    | Some { Repo_config.backend; model; effort } ->
+        let effort =
+          match effort with
+          | Repo_config.Inherit -> repo_config.default_effort
+          | Repo_config.Provider_default -> None
+          | Repo_config.Level level -> Some level
+        in
+        { backend; model; effort }
     | None ->
         (* Canonicalise the auto sentinel to lowercase so e.g. [--model AUTO]
            and [--model auto] hit the same [Backend_registry] cache key
-           ([(backend, model)]). [resolve_auto_model] downstream lowercases
-           anyway, so observable behaviour is unchanged. *)
-        { backend = default_backend; model = Some "auto" }
+           ([(backend, model, effort)]). [resolve_auto_model] downstream
+           lowercases anyway, so observable behaviour is unchanged. *)
+        {
+          backend = default_backend;
+          model = Some "auto";
+          effort = repo_config.default_effort;
+        }
 
 let resolve_auto (dec : decision) ~auto_model ~complexity : decision =
   if is_auto_model dec.model then { dec with model = auto_model ~complexity }
@@ -52,28 +83,55 @@ let resolve_auto (dec : decision) ~auto_model ~complexity : decision =
 
 let%test "resolve_auto: replaces 'auto' with auto_model result" =
   let auto_model ~complexity:_ = Some "resolved" in
-  let dec = { backend = "claude"; model = Some "auto" } in
+  let dec = { backend = "claude"; model = Some "auto"; effort = None } in
   let out = resolve_auto dec ~auto_model ~complexity:(Some 1) in
   Option.equal String.equal out.model (Some "resolved")
   && String.equal out.backend "claude"
 
 let%test "resolve_auto: case-insensitive on AUTO" =
   let auto_model ~complexity:_ = Some "resolved" in
-  let dec = { backend = "codex"; model = Some "AUTO" } in
+  let dec = { backend = "codex"; model = Some "AUTO"; effort = None } in
   let out = resolve_auto dec ~auto_model ~complexity:None in
   Option.equal String.equal out.model (Some "resolved")
 
 let%test "resolve_auto: leaves explicit model unchanged" =
   let auto_model ~complexity:_ = Some "resolved" in
-  let dec = { backend = "claude"; model = Some "sonnet" } in
+  let dec = { backend = "claude"; model = Some "sonnet"; effort = None } in
   let out = resolve_auto dec ~auto_model ~complexity:(Some 2) in
   Option.equal String.equal out.model (Some "sonnet")
 
 let%test "resolve_auto: leaves None unchanged" =
   let auto_model ~complexity:_ = Some "resolved" in
-  let dec = { backend = "claude"; model = None } in
+  let dec = { backend = "claude"; model = None; effort = None } in
   let out = resolve_auto dec ~auto_model ~complexity:(Some 2) in
   Option.is_none out.model
+
+let%test "decide: route effort inherits, clears, or overrides default" =
+  let route effort = { Repo_config.backend = "codex"; model = None; effort } in
+  let decide effort =
+    decide
+      ~repo_config:
+        {
+          Repo_config.empty with
+          default_effort = Some "high";
+          complexity_routes = [ (1, route effort) ];
+        }
+      ~default_backend:"codex" ~effective_model:(Some "auto")
+      ~complexity:(Some 1)
+    |> fun d -> d.effort
+  in
+  Option.equal String.equal (decide Repo_config.Inherit) (Some "high")
+  && Option.is_none (decide Repo_config.Provider_default)
+  && Option.equal String.equal
+       (decide (Repo_config.Level "xhigh"))
+       (Some "xhigh")
+
+let%test "effort_is_supported is provider-specific" =
+  effort_is_supported ~backend:"codex" "minimal"
+  && (not (effort_is_supported ~backend:"claude" "minimal"))
+  && effort_is_supported ~backend:"claude" "max"
+  && (not (effort_is_supported ~backend:"codex" "max"))
+  && not (effort_is_supported ~backend:"gemini" "high")
 
 (* [resolve_pair] tests. *)
 

--- a/lib_core/backend_routing.ml
+++ b/lib_core/backend_routing.ml
@@ -13,17 +13,7 @@ let is_auto_model = function
   | Some s -> String.equal (String.lowercase s) "auto"
   | None -> false
 
-let effort_is_supported ~backend effort =
-  match backend with
-  | "codex" ->
-      List.mem
-        [ "minimal"; "low"; "medium"; "high"; "xhigh" ]
-        effort ~equal:String.equal
-  | "claude" ->
-      List.mem
-        [ "low"; "medium"; "high"; "xhigh"; "max" ]
-        effort ~equal:String.equal
-  | _ -> false
+let effort_is_supported = Repo_config.effort_is_supported
 
 let first_nonempty (xs : string list) ~default =
   match List.find xs ~f:(fun s -> not (String.is_empty (String.strip s))) with
@@ -76,6 +66,37 @@ let decide ~(repo_config : Repo_config.t) ~default_backend ~effective_model
           model = Some "auto";
           effort = repo_config.default_effort;
         }
+
+type unsupported_effort = {
+  unsupported_backend : string;
+  unsupported_level : string;
+  unsupported_complexity : int option;
+}
+
+let unsupported_efforts ~(repo_config : Repo_config.t) ~default_backend
+    ~effective_model =
+  let complexities =
+    if is_auto_model effective_model then
+      None
+      :: List.map repo_config.complexity_routes ~f:(fun (complexity, _) ->
+          Some complexity)
+      |> List.dedup_and_sort ~compare:(Option.compare Int.compare)
+    else [ None ]
+  in
+  List.filter_map complexities ~f:(fun complexity ->
+      let ({ backend; effort; _ } : decision) =
+        decide ~repo_config ~default_backend ~effective_model ~complexity
+      in
+      match effort with
+      | None -> None
+      | Some effort when effort_is_supported ~backend effort -> None
+      | Some effort ->
+          Some
+            {
+              unsupported_backend = backend;
+              unsupported_level = effort;
+              unsupported_complexity = complexity;
+            })
 
 let resolve_auto (dec : decision) ~auto_model ~complexity : decision =
   if is_auto_model dec.model then { dec with model = auto_model ~complexity }
@@ -132,6 +153,31 @@ let%test "effort_is_supported is provider-specific" =
   && effort_is_supported ~backend:"claude" "max"
   && (not (effort_is_supported ~backend:"codex" "max"))
   && not (effort_is_supported ~backend:"gemini" "high")
+
+let%test "unsupported_efforts checks configured route keys" =
+  let repo_config =
+    {
+      Repo_config.empty with
+      complexity_routes =
+        [
+          (4, { backend = "codex"; model = None; effort = Level "max" });
+          (9, { backend = "claude"; model = None; effort = Level "max" });
+        ];
+    }
+  in
+  match
+    unsupported_efforts ~repo_config ~default_backend:"codex"
+      ~effective_model:(Some "auto")
+  with
+  | [
+   {
+     unsupported_backend = "codex";
+     unsupported_level = "max";
+     unsupported_complexity = Some 4;
+   };
+  ] ->
+      true
+  | _ -> false
 
 (* [resolve_pair] tests. *)
 

--- a/lib_core/backend_routing.mli
+++ b/lib_core/backend_routing.mli
@@ -1,8 +1,8 @@
 (* @archlint.module interface
    @archlint.domain backend-routing *)
 
-(** Pure decision: which [(backend, model)] tuple should drive a given patch's
-    session?
+(** Pure decision: which [(backend, model, effort)] tuple should drive a given
+    patch's session?
 
     Combines four inputs into one tuple, with no IO, no Eio capabilities, and no
     global state — so the decision is fully testable as a property function. The
@@ -15,6 +15,9 @@ type decision = {
       (** [Some "auto"] (case-insensitive) signals the per-backend hardcoded
           complexity → model ladder; [Some other] is an explicit model name;
           [None] drops [--model] from the CLI invocation entirely. *)
+  effort : string option;
+      (** Concrete provider reasoning effort. [None] omits the effort override
+          and lets the selected model use its own default. *)
 }
 
 val decide :
@@ -29,18 +32,19 @@ val decide :
 
     + If [effective_model] is not the literal ["auto"] (case-insensitive), the
       effective pair wins for the whole run: result is
-      [{ backend = default_backend; model = effective_model }]. The routing map
-      is ignored. This preserves the "explicit override" escape hatch.
+      [{ backend = default_backend; model = effective_model; effort = ... }].
+      The routing map is ignored. This preserves the "explicit override" escape
+      hatch.
     + If [effective_model] is ["auto"] (case-insensitive) AND [Repo_config] has
       a route for this complexity: the route wins —
-      [{ backend = route.backend; model = route.model }]. This is the only case
-      where the routing map takes effect.
+      [{ backend = route.backend; model = route.model; effort = ... }]. This is
+      the only case where the routing map takes effect.
     + Otherwise ([effective_model] is ["auto"] but no route applies — typically
       because [complexity = None], or the route map has no entry for this
       complexity): result is
-      [{ backend = default_backend; model = effective_model }]. The downstream
-      backend will see [Some "auto"] and apply its own hardcoded ladder via
-      [Llm_backend.resolve_auto_model].
+      [{ backend = default_backend; model = effective_model; effort = ... }].
+      The downstream backend will see [Some "auto"] and apply its own hardcoded
+      ladder via [Llm_backend.resolve_auto_model].
 
     The function never raises and is total over all inputs. *)
 
@@ -69,6 +73,11 @@ val is_auto_model : string option -> bool
 (** [is_auto_model m] returns [true] iff [m] is [Some s] where [s]
     case-insensitively equals ["auto"]. Exposed for tests and call sites that
     need to gate other behavior on the same predicate. *)
+
+val effort_is_supported : backend:string -> string -> bool
+(** Whether [backend] supports the concrete reasoning-effort value. Only the
+    native Claude and Codex backends accept effort overrides; unsupported
+    backends and unknown levels return [false]. *)
 
 val resolve_auto :
   decision ->

--- a/lib_core/backend_routing.mli
+++ b/lib_core/backend_routing.mli
@@ -42,8 +42,8 @@ val decide :
     + Otherwise ([effective_model] is ["auto"] but no route applies — typically
       because [complexity = None], or the route map has no entry for this
       complexity): result is
-      [{ backend = default_backend; model = effective_model; effort = ... }].
-      The downstream backend will see [Some "auto"] and apply its own hardcoded
+      [{ backend = default_backend; model = Some "auto"; effort = ... }]. The
+      downstream backend will see [Some "auto"] and apply its own hardcoded
       ladder via [Llm_backend.resolve_auto_model].
 
     The function never raises and is total over all inputs. *)
@@ -78,6 +78,23 @@ val effort_is_supported : backend:string -> string -> bool
 (** Whether [backend] supports the concrete reasoning-effort value. Only the
     native Claude and Codex backends accept effort overrides; unsupported
     backends and unknown levels return [false]. *)
+
+type unsupported_effort = {
+  unsupported_backend : string;
+  unsupported_level : string;
+  unsupported_complexity : int option;
+}
+(** An effort override that is not supported by the selected backend at a
+    particular complexity. [None] denotes the default/fallback decision. *)
+
+val unsupported_efforts :
+  repo_config:Repo_config.t ->
+  default_backend:string ->
+  effective_model:string option ->
+  unsupported_effort list
+(** Enumerate unsupported effective effort overrides. When routing is active,
+    checks the default/fallback decision and every configured route key; when
+    routing is inactive, checks only the effective default decision. *)
 
 val resolve_auto :
   decision ->

--- a/lib_core/claude_event_parser.ml
+++ b/lib_core/claude_event_parser.ml
@@ -53,6 +53,10 @@ let model_args = function
   | Some m when not (String.is_empty m) -> [ "--model"; m ]
   | _ -> []
 
+let effort_args = function
+  | Some e when not (String.is_empty e) -> [ "--effort"; e ]
+  | _ -> []
+
 let max_turns_for ~complexity =
   match complexity with Some 1 -> 50 | Some 2 -> 100 | _ -> 200
 
@@ -93,7 +97,8 @@ let bare_args ~getenv_opt =
   | Some k when not (String.is_empty (String.strip k)) -> [ "--bare" ]
   | _ -> []
 
-let build_args ~getenv_opt ~warn ~model ~complexity ~prompt ~resume_session =
+let build_args ~getenv_opt ~warn ~model ~effort ~complexity ~prompt
+    ~resume_session =
   let base = [ "claude" ] in
   let prompt_args = [ "-p"; prompt; "--output-format"; "text" ] in
   let session_args =
@@ -109,9 +114,10 @@ let build_args ~getenv_opt ~warn ~model ~complexity ~prompt ~resume_session =
     @ budget_cap_args ~getenv_opt ~warn ()
     @ bare_args ~getenv_opt
   in
-  base @ model_args model @ prompt_args @ session_args @ flags
+  base @ model_args model @ effort_args effort @ prompt_args @ session_args
+  @ flags
 
-let build_stream_args ~getenv_opt ~warn ~model ~complexity ~prompt
+let build_stream_args ~getenv_opt ~warn ~model ~effort ~complexity ~prompt
     ~minted_session_id ~resume_session =
   (match (minted_session_id, resume_session) with
   | Some _, Some _ ->
@@ -141,8 +147,8 @@ let build_stream_args ~getenv_opt ~warn ~model ~complexity ~prompt
     @ budget_cap_args ~getenv_opt ~warn ()
     @ bare_args ~getenv_opt
   in
-  base @ model_args model @ minted_session_args @ prompt_args @ session_args
-  @ flags
+  base @ model_args model @ effort_args effort @ minted_session_args
+  @ prompt_args @ session_args @ flags
 
 (** Find the first '\{' in [s] and return the substring starting there. Defense
     against any leading garbage in a stream-json line. *)
@@ -337,7 +343,7 @@ let%test "max_turns_for: None -> 200" =
 let%test "build_args fresh (no resume, with model)" =
   let args =
     build_args ~getenv_opt:with_api_key ~warn:ignore_warn ~model:(Some "sonnet")
-      ~complexity:(Some 2) ~prompt:"do stuff" ~resume_session:None
+      ~effort:None ~complexity:(Some 2) ~prompt:"do stuff" ~resume_session:None
   in
   List.equal String.equal args
     [
@@ -358,7 +364,7 @@ let%test "build_args fresh (no resume, with model)" =
 let%test "build_args fresh (no resume, no model)" =
   let args =
     build_args ~getenv_opt:with_api_key ~warn:ignore_warn ~model:None
-      ~complexity:(Some 1) ~prompt:"do stuff" ~resume_session:None
+      ~effort:None ~complexity:(Some 1) ~prompt:"do stuff" ~resume_session:None
   in
   List.equal String.equal args
     [
@@ -374,10 +380,23 @@ let%test "build_args fresh (no resume, no model)" =
       "--bare";
     ]
 
+let%test "build_args includes configured effort" =
+  let args =
+    build_args ~getenv_opt:with_api_key ~warn:ignore_warn ~model:(Some "opus")
+      ~effort:(Some "xhigh") ~complexity:(Some 3) ~prompt:"do stuff"
+      ~resume_session:None
+  in
+  match
+    List.drop_while args ~f:(fun arg -> not (String.equal arg "--effort"))
+  with
+  | "--effort" :: "xhigh" :: _ -> true
+  | _ -> false
+
 let%test "build_args with resume session" =
   let args =
     build_args ~getenv_opt:with_api_key ~warn:ignore_warn ~model:(Some "opus")
-      ~complexity:(Some 3) ~prompt:"do stuff" ~resume_session:(Some "abc-123")
+      ~effort:None ~complexity:(Some 3) ~prompt:"do stuff"
+      ~resume_session:(Some "abc-123")
   in
   List.equal String.equal args
     [
@@ -399,21 +418,21 @@ let%test "build_args with resume session" =
 
 let%test "build_args includes --exclude-dynamic-system-prompt-sections" =
   let args =
-    build_args ~getenv_opt:no_env ~warn:ignore_warn ~model:None ~complexity:None
-      ~prompt:"do stuff" ~resume_session:None
+    build_args ~getenv_opt:no_env ~warn:ignore_warn ~model:None ~effort:None
+      ~complexity:None ~prompt:"do stuff" ~resume_session:None
   in
   List.mem args "--exclude-dynamic-system-prompt-sections" ~equal:String.equal
 
 let%test "build_args includes --bare when ANTHROPIC_API_KEY is set" =
   List.mem
     (build_args ~getenv_opt:with_api_key ~warn:ignore_warn ~model:None
-       ~complexity:None ~prompt:"do stuff" ~resume_session:None)
+       ~effort:None ~complexity:None ~prompt:"do stuff" ~resume_session:None)
     "--bare" ~equal:String.equal
 
 let%test "build_args omits --bare without ANTHROPIC_API_KEY (OAuth path)" =
   not
     (List.mem
-       (build_args ~getenv_opt:no_env ~warn:ignore_warn ~model:None
+       (build_args ~getenv_opt:no_env ~warn:ignore_warn ~model:None ~effort:None
           ~complexity:None ~prompt:"do stuff" ~resume_session:None)
        "--bare" ~equal:String.equal)
 
@@ -421,15 +440,15 @@ let%test "build_args omits --bare when ANTHROPIC_API_KEY is empty/whitespace" =
   let getenv_opt = function "ANTHROPIC_API_KEY" -> Some "   " | _ -> None in
   not
     (List.mem
-       (build_args ~getenv_opt ~warn:ignore_warn ~model:None ~complexity:None
-          ~prompt:"do stuff" ~resume_session:None)
+       (build_args ~getenv_opt ~warn:ignore_warn ~model:None ~effort:None
+          ~complexity:None ~prompt:"do stuff" ~resume_session:None)
        "--bare" ~equal:String.equal)
 
 let%test "build_stream_args fresh (no resume, with model)" =
   let args =
     build_stream_args ~getenv_opt:with_api_key ~warn:ignore_warn
-      ~model:(Some "sonnet") ~complexity:(Some 2) ~prompt:"do stuff"
-      ~minted_session_id:None ~resume_session:None
+      ~model:(Some "sonnet") ~effort:None ~complexity:(Some 2)
+      ~prompt:"do stuff" ~minted_session_id:None ~resume_session:None
   in
   List.equal String.equal args
     [
@@ -451,7 +470,7 @@ let%test "build_stream_args fresh (no resume, with model)" =
 let%test "build_stream_args fresh (no resume, no model)" =
   let args =
     build_stream_args ~getenv_opt:with_api_key ~warn:ignore_warn ~model:None
-      ~complexity:None ~prompt:"do stuff" ~minted_session_id:None
+      ~effort:None ~complexity:None ~prompt:"do stuff" ~minted_session_id:None
       ~resume_session:None
   in
   List.equal String.equal args
@@ -472,7 +491,7 @@ let%test "build_stream_args fresh (no resume, no model)" =
 let%test "build_stream_args with resume session" =
   let args =
     build_stream_args ~getenv_opt:with_api_key ~warn:ignore_warn
-      ~model:(Some "opus") ~complexity:(Some 1) ~prompt:"do stuff"
+      ~model:(Some "opus") ~effort:None ~complexity:(Some 1) ~prompt:"do stuff"
       ~minted_session_id:None ~resume_session:(Some "abc-123")
   in
   List.equal String.equal args
@@ -497,7 +516,7 @@ let%test "build_stream_args with resume session" =
 let%test "build_stream_args includes --exclude-dynamic-system-prompt-sections" =
   let args =
     build_stream_args ~getenv_opt:no_env ~warn:ignore_warn ~model:None
-      ~complexity:None ~prompt:"do stuff" ~minted_session_id:None
+      ~effort:None ~complexity:None ~prompt:"do stuff" ~minted_session_id:None
       ~resume_session:None
   in
   List.mem args "--exclude-dynamic-system-prompt-sections" ~equal:String.equal
@@ -505,7 +524,7 @@ let%test "build_stream_args includes --exclude-dynamic-system-prompt-sections" =
 let%test "build_stream_args emits --session-id when minted_session_id is Some" =
   let args =
     build_stream_args ~getenv_opt:with_api_key ~warn:ignore_warn
-      ~model:(Some "sonnet") ~complexity:None ~prompt:"do stuff"
+      ~model:(Some "sonnet") ~effort:None ~complexity:None ~prompt:"do stuff"
       ~minted_session_id:(Some "123e4567-e89b-42d3-a456-426614174000")
       ~resume_session:None
   in
@@ -531,8 +550,8 @@ let%test "build_stream_args emits --session-id when minted_session_id is Some" =
 let%test "build_stream_args rejects session-id plus resume together" =
   match
     build_stream_args ~getenv_opt:no_env ~warn:ignore_warn ~model:None
-      ~complexity:None ~prompt:"do stuff" ~minted_session_id:(Some "minted")
-      ~resume_session:(Some "resume")
+      ~effort:None ~complexity:None ~prompt:"do stuff"
+      ~minted_session_id:(Some "minted") ~resume_session:(Some "resume")
   with
   | _ -> false
   | exception Invalid_argument _ -> true
@@ -540,7 +559,7 @@ let%test "build_stream_args rejects session-id plus resume together" =
 let%test "build_stream_args includes --bare when ANTHROPIC_API_KEY is set" =
   List.mem
     (build_stream_args ~getenv_opt:with_api_key ~warn:ignore_warn ~model:None
-       ~complexity:None ~prompt:"do stuff" ~minted_session_id:None
+       ~effort:None ~complexity:None ~prompt:"do stuff" ~minted_session_id:None
        ~resume_session:None)
     "--bare" ~equal:String.equal
 
@@ -549,8 +568,8 @@ let%test "build_stream_args omits --bare without ANTHROPIC_API_KEY (OAuth path)"
   not
     (List.mem
        (build_stream_args ~getenv_opt:no_env ~warn:ignore_warn ~model:None
-          ~complexity:None ~prompt:"do stuff" ~minted_session_id:None
-          ~resume_session:None)
+          ~effort:None ~complexity:None ~prompt:"do stuff"
+          ~minted_session_id:None ~resume_session:None)
        "--bare" ~equal:String.equal)
 
 let%test
@@ -562,7 +581,7 @@ let%test
   in
   let args =
     build_stream_args ~getenv_opt ~warn:ignore_warn ~model:(Some "sonnet")
-      ~complexity:None ~prompt:"do stuff" ~minted_session_id:None
+      ~effort:None ~complexity:None ~prompt:"do stuff" ~minted_session_id:None
       ~resume_session:None
   in
   List.equal String.equal args

--- a/lib_core/codex_event_parser.ml
+++ b/lib_core/codex_event_parser.ml
@@ -104,13 +104,19 @@ let parse_event_with_cost_tracking ~model ~budget_cap_nano_usd ~cost_state line
           ([ Types.Stream_event.Error msg ], cost_state)
       | _ -> ([], cost_state))
 
-let build_args ~model ~cwd_path ~prompt ~resume_session =
+let build_args ~model ~effort ~cwd_path ~prompt ~resume_session =
   let model_args =
     match model with
     | Some m when not (String.is_empty m) -> [ "-m"; m ]
     | _ -> []
   in
-  let global = [ "codex"; "-C"; cwd_path ] in
+  let effort_args =
+    match effort with
+    | Some e when not (String.is_empty e) ->
+        [ "-c"; Printf.sprintf "model_reasoning_effort=%S" e ]
+    | _ -> []
+  in
+  let global = [ "codex"; "-C"; cwd_path ] @ effort_args in
   let trailing = [ "--dangerously-bypass-approvals-and-sandbox" ] in
   match resume_session with
   | Some session_id ->
@@ -154,7 +160,7 @@ let%test "auto_model: missing or invalid complexity -> Sol" =
 
 let%test "build_args fresh (no resume, no model)" =
   let args =
-    build_args ~model:None ~cwd_path:"/tmp/work" ~prompt:"do stuff"
+    build_args ~model:None ~effort:None ~cwd_path:"/tmp/work" ~prompt:"do stuff"
       ~resume_session:None
   in
   List.equal String.equal args
@@ -170,7 +176,7 @@ let%test "build_args fresh (no resume, no model)" =
 
 let%test "build_args fresh with model" =
   let args =
-    build_args ~model:(Some "gpt-5-mini") ~cwd_path:"/tmp/work"
+    build_args ~model:(Some "gpt-5-mini") ~effort:None ~cwd_path:"/tmp/work"
       ~prompt:"do stuff" ~resume_session:None
   in
   List.equal String.equal args
@@ -186,9 +192,29 @@ let%test "build_args fresh with model" =
       "--dangerously-bypass-approvals-and-sandbox";
     ]
 
+let%test "build_args adds a model_reasoning_effort override" =
+  let args =
+    build_args ~model:(Some "gpt-5.6-luna") ~effort:(Some "xhigh")
+      ~cwd_path:"/tmp/work" ~prompt:"do stuff" ~resume_session:None
+  in
+  List.equal String.equal args
+    [
+      "codex";
+      "-C";
+      "/tmp/work";
+      "-c";
+      "model_reasoning_effort=\"xhigh\"";
+      "exec";
+      "do stuff";
+      "--json";
+      "-m";
+      "gpt-5.6-luna";
+      "--dangerously-bypass-approvals-and-sandbox";
+    ]
+
 let%test "build_args with resume session passes prompt and bypass flag" =
   let args =
-    build_args ~model:None ~cwd_path:"/tmp/work" ~prompt:"do stuff"
+    build_args ~model:None ~effort:None ~cwd_path:"/tmp/work" ~prompt:"do stuff"
       ~resume_session:(Some "sess-1")
   in
   List.equal String.equal args
@@ -206,7 +232,7 @@ let%test "build_args with resume session passes prompt and bypass flag" =
 
 let%test "build_args with resume session and model" =
   let args =
-    build_args ~model:(Some "gpt-5-mini") ~cwd_path:"/tmp/work"
+    build_args ~model:(Some "gpt-5-mini") ~effort:None ~cwd_path:"/tmp/work"
       ~prompt:"do stuff" ~resume_session:(Some "sess-1")
   in
   List.equal String.equal args

--- a/lib_core/repo_config.ml
+++ b/lib_core/repo_config.ml
@@ -3,11 +3,18 @@
 
 open Base
 
-type route = { backend : string; model : string option }
+type effort_override = Inherit | Provider_default | Level of string
+
+type route = {
+  backend : string;
+  model : string option;
+  effort : effort_override;
+}
 
 type t = {
   default_backend : string option;
   default_model : string option;
+  default_effort : string option;
   automerge_timeout : float option;
   review_team : string option;
   complexity_routes : (int * route) list;
@@ -18,6 +25,7 @@ let empty =
   {
     default_backend = None;
     default_model = None;
+    default_effort = None;
     automerge_timeout = None;
     review_team = None;
     complexity_routes = [];
@@ -25,6 +33,17 @@ let empty =
   }
 
 let config_path ~config_dir = Stdlib.Filename.concat config_dir "config.json"
+let known_efforts = [ "minimal"; "low"; "medium"; "high"; "xhigh"; "max" ]
+
+let parse_effort_string ~path value =
+  let value = String.lowercase (String.strip value) in
+  if String.is_empty value then Error (path ^ " must not be empty")
+  else if String.equal value "default" then Ok None
+  else if List.mem known_efforts value ~equal:String.equal then Ok (Some value)
+  else
+    Error
+      (Printf.sprintf "%s must be one of: default, %s" path
+         (String.concat ~sep:", " known_efforts))
 
 let parse_route ~known_backends ~complexity (json : Yojson.Safe.t) :
     (route, string) Result.t =
@@ -49,26 +68,44 @@ let parse_route ~known_backends ~complexity (json : Yojson.Safe.t) :
               (Printf.sprintf "routing.%d.model must be a string when present"
                  complexity)
       in
+      let effort_result =
+        match Json.field "effort" json with
+        | None -> Ok Inherit
+        | Some (`String s) ->
+            Result.map
+              (parse_effort_string
+                 ~path:(Printf.sprintf "routing.%d.effort" complexity)
+                 s)
+              ~f:(function
+                | None -> Provider_default | Some effort -> Level effort)
+        | Some _ ->
+            Error
+              (Printf.sprintf "routing.%d.effort must be a string when present"
+                 complexity)
+      in
       Result.bind backend_result ~f:(fun backend ->
           Result.bind model_result ~f:(fun model ->
-              match backend with
-              | None ->
-                  Error
-                    (Printf.sprintf
-                       "routing.%d: missing required string field \"backend\""
-                       complexity)
-              | Some name
-                when not (List.mem known_backends name ~equal:String.equal) ->
-                  Error
-                    (Printf.sprintf
-                       "routing.%d.backend = %S is not a known backend \
-                        (expected one of: %s)"
-                       complexity name
-                       (String.concat ~sep:", " known_backends))
-              | Some name -> Ok { backend = name; model }))
+              Result.bind effort_result ~f:(fun effort ->
+                  match backend with
+                  | None ->
+                      Error
+                        (Printf.sprintf
+                           "routing.%d: missing required string field \
+                            \"backend\""
+                           complexity)
+                  | Some name
+                    when not (List.mem known_backends name ~equal:String.equal)
+                    ->
+                      Error
+                        (Printf.sprintf
+                           "routing.%d.backend = %S is not a known backend \
+                            (expected one of: %s)"
+                           complexity name
+                           (String.concat ~sep:", " known_backends))
+                  | Some name -> Ok { backend = name; model; effort })))
   | _ ->
       Error
-        (Printf.sprintf "routing.%d must be an object {backend, model}"
+        (Printf.sprintf "routing.%d must be an object {backend, model, effort}"
            complexity)
 
 let parse_routing ~known_backends (json : Yojson.Safe.t) :
@@ -100,8 +137,8 @@ let parse_routing ~known_backends (json : Yojson.Safe.t) :
       |> Result.map ~f:List.rev
   | _ ->
       Error
-        ("routing must be an object mapping complexity -> {backend, model};"
-       ^ " got " ^ Yojson.Safe.to_string json)
+        ("routing must be an object mapping complexity -> {backend, model, \
+          effort};" ^ " got " ^ Yojson.Safe.to_string json)
 
 let default_known_review_kinds = [ "review-service" ]
 
@@ -117,9 +154,9 @@ let parse_automerge_timeout (json : Yojson.Safe.t) =
   | Some _ -> Error "automerge_timeout must be a number of seconds"
 
 let parse_default ~known_backends (json : Yojson.Safe.t) :
-    (string option * string option, string) Result.t =
+    (string option * string option * string option, string) Result.t =
   match json with
-  | `Null -> Ok (None, None)
+  | `Null -> Ok (None, None, None)
   | `Assoc _ ->
       let backend_result =
         match Json.field "backend" json with
@@ -145,9 +182,16 @@ let parse_default ~known_backends (json : Yojson.Safe.t) :
         | Some (`String s) -> Ok (Some (String.strip s))
         | Some _ -> Error "default.model must be a string when present"
       in
+      let effort_result =
+        match Json.field "effort" json with
+        | None -> Ok None
+        | Some (`String s) -> parse_effort_string ~path:"default.effort" s
+        | Some _ -> Error "default.effort must be a string when present"
+      in
       Result.bind backend_result ~f:(fun b ->
-          Result.map model_result ~f:(fun m -> (b, m)))
-  | _ -> Error "default must be an object {backend, model}"
+          Result.bind model_result ~f:(fun m ->
+              Result.map effort_result ~f:(fun e -> (b, m, e))))
+  | _ -> Error "default must be an object {backend, model, effort}"
 
 let parse_string ~known_backends
     ?(known_review_kinds = default_known_review_kinds) (raw : string) :
@@ -177,7 +221,7 @@ let parse_string ~known_backends
           Result.bind (parse_automerge_timeout json)
             ~f:(fun automerge_timeout ->
               Result.bind (parse_default ~known_backends default_json)
-                ~f:(fun (default_backend, default_model) ->
+                ~f:(fun (default_backend, default_model, default_effort) ->
                   Result.bind review_team_result ~f:(fun review_team ->
                       Result.bind (parse_routing ~known_backends routing)
                         ~f:(fun routes ->
@@ -188,6 +232,7 @@ let parse_string ~known_backends
                               {
                                 default_backend;
                                 default_model;
+                                default_effort;
                                 automerge_timeout;
                                 review_team;
                                 complexity_routes = routes;
@@ -261,11 +306,11 @@ let%test "parse_string: full routing parses" =
       let r2 = route_for_complexity t ~complexity:(Some 2) in
       Option.is_none r2
       && (match r1 with
-        | Some { backend = "claude"; model = Some "haiku" } -> true
+        | Some { backend = "claude"; model = Some "haiku"; _ } -> true
         | _ -> false)
       &&
       match r3 with
-      | Some { backend = "codex"; model = Some "gpt-5.5" } -> true
+      | Some { backend = "codex"; model = Some "gpt-5.5"; _ } -> true
       | _ -> false)
   | Error _ -> false
 
@@ -274,9 +319,38 @@ let%test "parse_string: model omitted -> None" =
   match parse_string ~known_backends:[ "claude" ] raw with
   | Ok t -> (
       match route_for_complexity t ~complexity:(Some 2) with
-      | Some { backend = "claude"; model = None } -> true
+      | Some { backend = "claude"; model = None; _ } -> true
       | _ -> false)
   | Error _ -> false
+
+let%test "parse_string: effort supports inherit, default, and explicit level" =
+  let raw =
+    {|{"default":{"effort":" HIGH "},"routing":{"1":{"backend":"codex"},"2":{"backend":"codex","effort":"default"},"3":{"backend":"codex","effort":"xhigh"}}}|}
+  in
+  match parse_string ~known_backends:[ "codex" ] raw with
+  | Error _ -> false
+  | Ok t -> (
+      let effort_at complexity =
+        route_for_complexity t ~complexity:(Some complexity)
+        |> Option.map ~f:(fun route -> route.effort)
+      in
+      Option.equal String.equal t.default_effort (Some "high")
+      && (match effort_at 1 with
+        | Some Inherit -> true
+        | Some Provider_default | Some (Level _) | None -> false)
+      && (match effort_at 2 with
+        | Some Provider_default -> true
+        | Some Inherit | Some (Level _) | None -> false)
+      &&
+      match effort_at 3 with
+      | Some (Level "xhigh") -> true
+      | Some (Level _) | Some Inherit | Some Provider_default | None -> false)
+
+let%test "parse_string: invalid effort rejected" =
+  let raw = {|{"routing":{"1":{"backend":"codex","effort":"extreme"}}}|} in
+  match parse_string ~known_backends:[ "codex" ] raw with
+  | Error msg -> String.is_substring msg ~substring:"routing.1.effort"
+  | Ok _ -> false
 
 let%test "parse_string: unknown backend rejected" =
   let raw = {|{"routing":{"1":{"backend":"made-up"}}}|} in
@@ -332,7 +406,7 @@ let%test "parse_string: model whitespace is trimmed" =
   match parse_string ~known_backends:[ "claude" ] raw with
   | Ok t -> (
       match route_for_complexity t ~complexity:(Some 1) with
-      | Some { backend = "claude"; model = Some "haiku" } -> true
+      | Some { backend = "claude"; model = Some "haiku"; _ } -> true
       | _ -> false)
   | Error _ -> false
 
@@ -472,7 +546,7 @@ let%test "parse_string: default coexists with routing" =
       && Option.equal String.equal t.default_model (Some "auto")
       &&
       match t.complexity_routes with
-      | [ (1, { backend = "claude"; model = Some "haiku" }) ] -> true
+      | [ (1, { backend = "claude"; model = Some "haiku"; _ }) ] -> true
       | _ -> false)
   | Error _ -> false
 

--- a/lib_core/repo_config.ml
+++ b/lib_core/repo_config.ml
@@ -33,7 +33,24 @@ let empty =
   }
 
 let config_path ~config_dir = Stdlib.Filename.concat config_dir "config.json"
-let known_efforts = [ "minimal"; "low"; "medium"; "high"; "xhigh"; "max" ]
+
+let effort_support =
+  [
+    ("codex", [ "minimal"; "low"; "medium"; "high"; "xhigh" ]);
+    ("claude", [ "low"; "medium"; "high"; "xhigh"; "max" ]);
+  ]
+
+let supported_efforts ~backend =
+  Option.value
+    (List.Assoc.find effort_support backend ~equal:String.equal)
+    ~default:[]
+
+let effort_is_supported ~backend effort =
+  List.mem (supported_efforts ~backend) effort ~equal:String.equal
+
+let known_efforts =
+  List.concat_map effort_support ~f:snd
+  |> List.stable_dedup ~compare:String.compare
 
 let parse_effort_string ~path value =
   let value = String.lowercase (String.strip value) in
@@ -71,6 +88,7 @@ let parse_route ~known_backends ~complexity (json : Yojson.Safe.t) :
       let effort_result =
         match Json.field "effort" json with
         | None -> Ok Inherit
+        | Some (`String s) when String.is_empty (String.strip s) -> Ok Inherit
         | Some (`String s) ->
             Result.map
               (parse_effort_string
@@ -185,6 +203,7 @@ let parse_default ~known_backends (json : Yojson.Safe.t) :
       let effort_result =
         match Json.field "effort" json with
         | None -> Ok None
+        | Some (`String s) when String.is_empty (String.strip s) -> Ok None
         | Some (`String s) -> parse_effort_string ~path:"default.effort" s
         | Some _ -> Error "default.effort must be a string when present"
       in
@@ -351,6 +370,19 @@ let%test "parse_string: invalid effort rejected" =
   match parse_string ~known_backends:[ "codex" ] raw with
   | Error msg -> String.is_substring msg ~substring:"routing.1.effort"
   | Ok _ -> false
+
+let%test "parse_string: blank effort is treated as unset" =
+  let raw =
+    {|{"default":{"effort":"  \t"},"routing":{"1":{"backend":"codex","effort":" \n "}}}|}
+  in
+  match parse_string ~known_backends:[ "codex" ] raw with
+  | Error _ -> false
+  | Ok t -> (
+      Option.is_none t.default_effort
+      &&
+      match route_for_complexity t ~complexity:(Some 1) with
+      | Some { effort = Inherit; _ } -> true
+      | Some { effort = Provider_default | Level _; _ } | None -> false)
 
 let%test "parse_string: unknown backend rejected" =
   let raw = {|{"routing":{"1":{"backend":"made-up"}}}|} in

--- a/lib_core/repo_config.mli
+++ b/lib_core/repo_config.mli
@@ -76,6 +76,11 @@ val parse_string :
 (** Parse and validate repository configuration without performing I/O. Never
     raises for malformed input; schema failures are returned as [Error]. *)
 
+val effort_is_supported : backend:string -> string -> bool
+(** Whether the named backend supports a concrete reasoning-effort level. This
+    is also the source of truth for the effort values accepted by the
+    configuration parser. *)
+
 val load :
   config_dir:string ->
   known_backends:string list ->

--- a/lib_core/repo_config.mli
+++ b/lib_core/repo_config.mli
@@ -8,18 +8,20 @@
     Carries repository-level defaults and three sections:
     - [automerge_timeout] — the default idle window in seconds before an
       eligible PR is automatically merged.
-    - [default] — a per-repo default [(backend, model)] pair that mirrors the
-      [--backend] / [--model] CLI flags. Either field may be omitted. Slots into
-      the resolution chain below [Project_store] (stored values from previous
-      runs) but above the hard-coded built-in default.
+    - [default] — per-repo defaults for backend, model, and reasoning effort.
+      Each field may be omitted. Backend and model slot into the resolution
+      chain below [Project_store] (stored values from previous runs) but above
+      the hard-coded built-in default.
     - [routing] — a per-patch override that binds each complexity tier (1/2/3)
-      to a [(backend, model)] tuple. Fires when the effective model (CLI or
-      [default.model]) is the literal ["auto"] (case-insensitive). Otherwise the
-      effective pair drives the whole run.
+      to a [(backend, model, effort)] tuple. Fires when the effective model (CLI
+      or [default.model]) is the literal ["auto"] (case-insensitive). Otherwise
+      the effective pair drives the whole run.
     - [reviewBackends] — additional review sources to poll alongside the forge.
 
     Unknown top-level keys are ignored so the file can grow with new sections
     (e.g. timeouts, hook overrides) without breaking older binaries. *)
+
+type effort_override = Inherit | Provider_default | Level of string
 
 type route = {
   backend : string;
@@ -27,6 +29,9 @@ type route = {
   model : string option;
       (** Model passed to that backend. [None] leaves [--model] off and lets the
           backend's own default apply. *)
+  effort : effort_override;
+      (** Route-level reasoning effort. Missing values inherit the top-level
+          default; [Provider_default] explicitly omits the provider flag. *)
 }
 
 type t = {
@@ -39,6 +44,9 @@ type t = {
       (** Top-level [default.model] from the config file. [Some "auto"] (case-
           insensitive) activates [routing] in the same way as [--model auto].
           [Some other] pins a specific model. [None] means "not configured". *)
+  default_effort : string option;
+      (** Top-level [default.effort]. [None] lets the selected provider use its
+          own reasoning-effort default. *)
   automerge_timeout : float option;
       (** Top-level [automerge_timeout] in seconds. Must be finite and greater
           than zero. Resolution uses a CLI override, then a persisted project
@@ -90,19 +98,22 @@ val load :
       {
         "default": {
           "backend": "codex",
-          "model":   "auto"
+          "model":   "auto",
+          "effort":  "medium"
         },
         "automerge_timeout": 300,
         "routing": {
-          "1": { "backend": "claude", "model": "haiku" },
-          "2": { "backend": "codex",  "model": "gpt-5.6-terra" },
-          "3": { "backend": "claude", "model": "opus" }
+          "1": { "backend": "claude", "model": "haiku", "effort": "default" },
+          "2": { "backend": "codex",  "model": "gpt-5.6-terra", "effort": "high" },
+          "3": { "backend": "claude", "model": "opus", "effort": "xhigh" }
         }
       }
     ]}
     Inside [routing.<n>], [backend] is required and [model] is optional. Inside
-    [default], both [backend] and [model] are optional. Top-level extra keys are
-    ignored so the file can grow without breaking older binaries. *)
+    [default], [backend], [model], and [effort] are optional. A missing route
+    effort inherits [default.effort]; ["default"] explicitly omits the provider
+    flag. Top-level extra keys are ignored so the file can grow without breaking
+    older binaries. *)
 
 val route_for_complexity : t -> complexity:int option -> route option
 (** Look up the override for a given patch complexity. [None] when the patch has

--- a/test/test_backend_event_parser_properties.ml
+++ b/test/test_backend_event_parser_properties.ml
@@ -25,8 +25,8 @@ let codex_build_args_preserve_prompt =
   QCheck2.Test.make ~name:"codex build_args preserve prompt" ~count:200
     QCheck2.Gen.string_small (fun prompt ->
       let args =
-        Codex_event_parser.build_args ~model:None ~cwd_path:"/tmp/work" ~prompt
-          ~resume_session:None
+        Codex_event_parser.build_args ~model:None ~effort:None
+          ~cwd_path:"/tmp/work" ~prompt ~resume_session:None
       in
       List.mem prompt args)
 

--- a/test/test_backend_parser_totality.ml
+++ b/test/test_backend_parser_totality.ml
@@ -209,8 +209,8 @@ let claude_build_args_carry_prompt =
     (fun (prompt, resume_session) ->
       let args =
         Claude_event_parser.build_args ~getenv_opt:Claude_event_parser.no_env
-          ~warn:Claude_event_parser.ignore_warn ~model:None ~complexity:None
-          ~prompt ~resume_session
+          ~warn:Claude_event_parser.ignore_warn ~model:None ~effort:None
+          ~complexity:None ~prompt ~resume_session
       in
       List.mem args prompt ~equal:String.equal
       &&
@@ -225,8 +225,8 @@ let claude_build_stream_args_carry_prompt =
       let args =
         Claude_event_parser.build_stream_args
           ~getenv_opt:Claude_event_parser.no_env
-          ~warn:Claude_event_parser.ignore_warn ~model:None ~complexity:None
-          ~prompt ~minted_session_id:None ~resume_session:None
+          ~warn:Claude_event_parser.ignore_warn ~model:None ~effort:None
+          ~complexity:None ~prompt ~minted_session_id:None ~resume_session:None
       in
       List.mem args prompt ~equal:String.equal)
 

--- a/test/test_backend_parser_totality.ml
+++ b/test/test_backend_parser_totality.ml
@@ -145,6 +145,18 @@ let claude_model_args_round_trips =
           List.equal String.equal args [ "--model"; m ]
       | _ -> List.is_empty args)
 
+(* [effort_args] emits ["--effort"; e] for a non-empty effort and []
+   otherwise. *)
+let claude_effort_args_round_trips =
+  QCheck2.Test.make ~name:"claude effort_args wraps non-empty effort" ~count:200
+    QCheck2.Gen.(option string_small)
+    (fun effort ->
+      let args = Claude_event_parser.effort_args effort in
+      match effort with
+      | Some e when not (String.is_empty e) ->
+          List.equal String.equal args [ "--effort"; e ]
+      | _ -> List.is_empty args)
+
 (* Build an env oracle from the generated [api_key]: it answers
    [ANTHROPIC_API_KEY] with the generated value (and [None] for everything
    else). [bare_args] emits [--bare] iff that value is non-blank. The constant
@@ -269,6 +281,7 @@ let claude_public_surface_is_linked =
       ignore Claude_event_parser.budget_cap_args;
       ignore Claude_event_parser.build_args;
       ignore Claude_event_parser.build_stream_args;
+      ignore Claude_event_parser.effort_args;
       ignore Claude_event_parser.find_json_start;
       ignore Claude_event_parser.ignore_warn;
       ignore Claude_event_parser.max_turns_for;
@@ -313,6 +326,7 @@ let () =
       claude_auto_model_is_total;
       claude_max_turns_for_is_positive;
       claude_model_args_round_trips;
+      claude_effort_args_round_trips;
       claude_bare_args_tracks_api_key;
       claude_budget_cap_args_tracks_env;
       claude_build_args_carry_prompt;

--- a/test/test_backend_routing.ml
+++ b/test/test_backend_routing.ml
@@ -108,6 +108,41 @@ let pp_decision (d : Backend_routing.decision) =
     | Some s -> Printf.sprintf "Some %S" s
     | None -> "None")
 
+let equal_unsupported_effort (a : Backend_routing.unsupported_effort)
+    (b : Backend_routing.unsupported_effort) =
+  String.equal a.unsupported_backend b.unsupported_backend
+  && String.equal a.unsupported_level b.unsupported_level
+  && Option.equal Int.equal a.unsupported_complexity b.unsupported_complexity
+
+let expected_unsupported_efforts ~(repo_config : Repo_config.t) ~default_backend
+    ~effective_model =
+  let complexities =
+    if Backend_routing.is_auto_model effective_model then
+      None
+      :: List.map repo_config.complexity_routes ~f:(fun (complexity, _) ->
+          Some complexity)
+      |> List.dedup_and_sort ~compare:(Option.compare Int.compare)
+    else [ None ]
+  in
+  List.filter_map complexities ~f:(fun complexity ->
+      let decision =
+        Backend_routing.decide ~repo_config ~default_backend ~effective_model
+          ~complexity
+      in
+      match decision.effort with
+      | None -> None
+      | Some level
+        when Backend_routing.effort_is_supported ~backend:decision.backend level
+        ->
+          None
+      | Some level ->
+          Some
+            {
+              Backend_routing.unsupported_backend = decision.backend;
+              unsupported_level = level;
+              unsupported_complexity = complexity;
+            })
+
 let effort_support_matches_provider_contract =
   let gen_query =
     QCheck2.Gen.(
@@ -363,36 +398,24 @@ let () =
         && Option.equal String.equal resolved.model (Some explicit))
   in
 
-  let prop_unsupported_efforts_are_sound_and_total =
+  let prop_unsupported_efforts_are_complete_sound_and_total =
     Test.make
       ~name:
-        "unsupported_efforts: total and every issue matches the effective \
-         decision"
+        "unsupported_efforts: complete, sound, and total over effective \
+         decisions"
       ~count:1000
       (Gen.tup3 gen_repo_config gen_backend_name gen_effective_model)
       (fun (repo_config, default_backend, effective_model) ->
         try
-          Backend_routing.unsupported_efforts ~repo_config ~default_backend
-            ~effective_model
-          |> List.for_all
-               ~f:(fun
-                   ({
-                      unsupported_backend;
-                      unsupported_level;
-                      unsupported_complexity;
-                    } :
-                     Backend_routing.unsupported_effort)
-                 ->
-                 let decision =
-                   Backend_routing.decide ~repo_config ~default_backend
-                     ~effective_model ~complexity:unsupported_complexity
-                 in
-                 String.equal decision.backend unsupported_backend
-                 && Option.equal String.equal decision.effort
-                      (Some unsupported_level)
-                 && not
-                      (Backend_routing.effort_is_supported
-                         ~backend:unsupported_backend unsupported_level))
+          let expected =
+            expected_unsupported_efforts ~repo_config ~default_backend
+              ~effective_model
+          in
+          let actual =
+            Backend_routing.unsupported_efforts ~repo_config ~default_backend
+              ~effective_model
+          in
+          List.equal equal_unsupported_effort actual expected
         with _ -> false)
   in
 
@@ -421,7 +444,7 @@ let () =
       prop_resolve_pair_total_non_empty_backend;
       prop_resolve_auto_inlines_auto;
       prop_resolve_auto_leaves_explicit;
-      prop_unsupported_efforts_are_sound_and_total;
+      prop_unsupported_efforts_are_complete_sound_and_total;
       effort_support_matches_provider_contract;
       prop_public_surface_is_linked;
     ]

--- a/test/test_backend_routing.ml
+++ b/test/test_backend_routing.ml
@@ -88,6 +88,45 @@ let pp_decision (d : Backend_routing.decision) =
     | Some s -> Printf.sprintf "Some %S" s
     | None -> "None")
 
+let effort_support_matches_provider_contract =
+  let gen_query =
+    QCheck2.Gen.(
+      oneof
+        [
+          pair string string;
+          pair
+            (oneof_list [ "codex"; "claude"; "gemini" ])
+            (oneof_list
+               [
+                 "minimal";
+                 "low";
+                 "medium";
+                 "high";
+                 "xhigh";
+                 "max";
+                 "default";
+                 "HIGH";
+                 "";
+               ]);
+        ])
+  in
+  QCheck2.Test.make
+    ~name:"effort_is_supported: matches the exact provider contracts"
+    ~count:1000 gen_query (fun (backend, effort) ->
+      let expected =
+        match backend with
+        | "codex" ->
+            List.mem
+              [ "minimal"; "low"; "medium"; "high"; "xhigh" ]
+              effort ~equal:String.equal
+        | "claude" ->
+            List.mem
+              [ "low"; "medium"; "high"; "xhigh"; "max" ]
+              effort ~equal:String.equal
+        | _ -> false
+      in
+      Bool.equal (Backend_routing.effort_is_supported ~backend effort) expected)
+
 let () =
   let open QCheck2 in
   let prop_explicit_model_passes_through =
@@ -307,6 +346,7 @@ let () =
   let prop_public_surface_is_linked =
     Test.make ~name:"backend routing public surface is linked" Gen.unit
       (fun () ->
+        ignore Backend_routing.effort_is_supported;
         ignore Backend_routing.resolve_auto;
         ignore Backend_routing.resolve_pair;
         true)
@@ -327,6 +367,7 @@ let () =
       prop_resolve_pair_total_non_empty_backend;
       prop_resolve_auto_inlines_auto;
       prop_resolve_auto_leaves_explicit;
+      effort_support_matches_provider_contract;
       prop_public_surface_is_linked;
     ]
   in

--- a/test/test_backend_routing.ml
+++ b/test/test_backend_routing.ml
@@ -39,6 +39,10 @@ let gen_non_auto_cli_model : string option QCheck2.Gen.t =
 let gen_auto_variant : string QCheck2.Gen.t =
   QCheck2.Gen.oneof_list [ "auto"; "AUTO"; "Auto"; "aUTo"; "auTO" ]
 
+let gen_effective_model : string option QCheck2.Gen.t =
+  QCheck2.Gen.oneof
+    [ gen_non_auto_cli_model; QCheck2.Gen.map Option.some gen_auto_variant ]
+
 let gen_complexity : int option QCheck2.Gen.t =
   let open QCheck2.Gen in
   oneof
@@ -62,11 +66,24 @@ let gen_route_model : string option QCheck2.Gen.t =
            ]);
     ]
 
+let gen_effort : string QCheck2.Gen.t =
+  QCheck2.Gen.oneof_list
+    [ "minimal"; "low"; "medium"; "high"; "xhigh"; "max"; "extreme" ]
+
+let gen_effort_override : Repo_config.effort_override QCheck2.Gen.t =
+  QCheck2.Gen.oneof
+    [
+      QCheck2.Gen.return Repo_config.Inherit;
+      QCheck2.Gen.return Repo_config.Provider_default;
+      QCheck2.Gen.map (fun effort -> Repo_config.Level effort) gen_effort;
+    ]
+
 let gen_route : Repo_config.route QCheck2.Gen.t =
   let open QCheck2.Gen in
   let* backend = gen_backend_name in
   let* model = gen_route_model in
-  return { Repo_config.backend; model; effort = Inherit }
+  let* effort = gen_effort_override in
+  return { Repo_config.backend; model; effort }
 
 (* Generate a repo config with a random subset of complexity tiers populated.
    The empty config (no routes) is one possible value. *)
@@ -78,8 +95,11 @@ let gen_repo_config : Repo_config.t QCheck2.Gen.t =
     return (List.dedup_and_sort sub ~compare:Int.compare)
   in
   let* routes = list_size (return (List.length keys)) gen_route in
+  let* default_effort =
+    oneof [ return None; map (fun effort -> Some effort) gen_effort ]
+  in
   let complexity_routes = List.zip_exn keys routes in
-  return { Repo_config.empty with complexity_routes }
+  return { Repo_config.empty with default_effort; complexity_routes }
 
 let pp_decision (d : Backend_routing.decision) =
   Printf.sprintf "{ backend = %s; model = %s; effort = %s }" d.backend
@@ -343,10 +363,44 @@ let () =
         && Option.equal String.equal resolved.model (Some explicit))
   in
 
+  let prop_unsupported_efforts_are_sound_and_total =
+    Test.make
+      ~name:
+        "unsupported_efforts: total and every issue matches the effective \
+         decision"
+      ~count:1000
+      (Gen.tup3 gen_repo_config gen_backend_name gen_effective_model)
+      (fun (repo_config, default_backend, effective_model) ->
+        try
+          Backend_routing.unsupported_efforts ~repo_config ~default_backend
+            ~effective_model
+          |> List.for_all
+               ~f:(fun
+                   ({
+                      unsupported_backend;
+                      unsupported_level;
+                      unsupported_complexity;
+                    } :
+                     Backend_routing.unsupported_effort)
+                 ->
+                 let decision =
+                   Backend_routing.decide ~repo_config ~default_backend
+                     ~effective_model ~complexity:unsupported_complexity
+                 in
+                 String.equal decision.backend unsupported_backend
+                 && Option.equal String.equal decision.effort
+                      (Some unsupported_level)
+                 && not
+                      (Backend_routing.effort_is_supported
+                         ~backend:unsupported_backend unsupported_level))
+        with _ -> false)
+  in
+
   let prop_public_surface_is_linked =
     Test.make ~name:"backend routing public surface is linked" Gen.unit
       (fun () ->
         ignore Backend_routing.effort_is_supported;
+        ignore Backend_routing.unsupported_efforts;
         ignore Backend_routing.resolve_auto;
         ignore Backend_routing.resolve_pair;
         true)
@@ -367,6 +421,7 @@ let () =
       prop_resolve_pair_total_non_empty_backend;
       prop_resolve_auto_inlines_auto;
       prop_resolve_auto_leaves_explicit;
+      prop_unsupported_efforts_are_sound_and_total;
       effort_support_matches_provider_contract;
       prop_public_surface_is_linked;
     ]

--- a/test/test_backend_routing.ml
+++ b/test/test_backend_routing.ml
@@ -66,7 +66,7 @@ let gen_route : Repo_config.route QCheck2.Gen.t =
   let open QCheck2.Gen in
   let* backend = gen_backend_name in
   let* model = gen_route_model in
-  return { Repo_config.backend; model }
+  return { Repo_config.backend; model; effort = Inherit }
 
 (* Generate a repo config with a random subset of complexity tiers populated.
    The empty config (no routes) is one possible value. *)
@@ -82,8 +82,11 @@ let gen_repo_config : Repo_config.t QCheck2.Gen.t =
   return { Repo_config.empty with complexity_routes }
 
 let pp_decision (d : Backend_routing.decision) =
-  Printf.sprintf "{ backend = %s; model = %s }" d.backend
+  Printf.sprintf "{ backend = %s; model = %s; effort = %s }" d.backend
     (match d.model with Some s -> Printf.sprintf "Some %S" s | None -> "None")
+    (match d.effort with
+    | Some s -> Printf.sprintf "Some %S" s
+    | None -> "None")
 
 let () =
   let open QCheck2 in
@@ -271,7 +274,9 @@ let () =
       ~name:"resolve_auto: Some \"auto\" model is replaced by auto_model result"
       ~count:500 (Gen.tup3 gen_backend_name gen_route_model gen_complexity)
       (fun (backend, auto_result, complexity) ->
-        let decision = { Backend_routing.backend; model = Some "auto" } in
+        let decision =
+          { Backend_routing.backend; model = Some "auto"; effort = None }
+        in
         let resolved =
           Backend_routing.resolve_auto decision
             ~auto_model:(fun ~complexity:_ -> auto_result)
@@ -287,7 +292,9 @@ let () =
          (Gen.oneof_list [ "opus"; "sonnet"; "gpt-5.5" ])
          gen_complexity)
       (fun (backend, explicit, complexity) ->
-        let decision = { Backend_routing.backend; model = Some explicit } in
+        let decision =
+          { Backend_routing.backend; model = Some explicit; effort = None }
+        in
         let resolved =
           Backend_routing.resolve_auto decision
             ~auto_model:(fun ~complexity:_ -> Some "SHOULD-NOT-APPEAR")

--- a/test/test_claude_backend_properties.ml
+++ b/test/test_claude_backend_properties.ml
@@ -10,7 +10,7 @@ let create_preserves_generated_name =
     ~count:50 QCheck2.Gen.string_small (fun name ->
       Eio_main.run @@ fun env ->
       let backend =
-        Claude_backend.create ~name ~model:None
+        Claude_backend.create ~name ~model:None ~effort:None
           ~process_mgr:(Eio.Stdenv.process_mgr env)
           ~clock:(Eio.Stdenv.clock env) ~timeout:1.0 ~setsid_exec:None
       in

--- a/test/test_intervention_reason.ml
+++ b/test/test_intervention_reason.ml
@@ -162,7 +162,7 @@ let () =
   let views =
     Tui.views_of_orchestrator ~orchestrator ~gameplan ~activity:[]
       ~resolve_routing:(fun ~complexity:_ ->
-        { Backend_routing.backend = "claude"; model = None })
+        { Backend_routing.backend = "claude"; model = None; effort = None })
       ()
   in
   match views with


### PR DESCRIPTION
## Summary

- add optional `effort` settings to per-repo defaults and complexity routes
- support inherited, provider-default, and explicit effort semantics
- pass resolved effort to Codex as `model_reasoning_effort` and Claude as `--effort`
- reject unsupported backend/effort combinations during preflight
- document the configuration and extend routing, parser, and backend tests

## Why

Onton could route patches by backend and model, but could not tune reasoning effort by patch complexity. This enables configurations such as Luna/default for easy patches, Luna/high for medium patches, and Luna/xhigh for difficult patches.

## Configuration example

```json
{
  "default": {
    "backend": "codex",
    "model": "auto"
  },
  "routing": {
    "1": { "backend": "codex", "model": "gpt-5.6-luna", "effort": "default" },
    "2": { "backend": "codex", "model": "gpt-5.6-luna", "effort": "high" },
    "3": { "backend": "codex", "model": "gpt-5.6-luna", "effort": "xhigh" }
  }
}
```

A missing route effort inherits `default.effort`; `"default"` explicitly lets the selected provider/model choose its own effort.

## Validation

- `opam exec -- dune fmt`
- `opam exec -- dune build`
- `opam exec -- dune runtest`
- `opam exec -- dune build @fmt`
- verified installed Codex and Claude CLIs accept the emitted effort arguments

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/411"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788213964&installation_model_id=19519&pr_number=411&repository=flowglad%2Fonton&return_to=https%3A%2F%2Fgithub.com%2Fflowglad%2Fonton%2Fpull%2F411&signature=c391d935f3615d0e2c415ba4a0f174f366acebdf50cfbaa447f9f8fca9a096c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable reasoning-effort settings for repository defaults and individual routing entries.
  * Effort values now flow through backend selection and execution for Codex and Claude.
  * Added support for inherited, provider-default, and explicitly selected effort levels.
* **Bug Fixes**
  * Invalid backend and effort combinations are now detected with clear validation errors.
  * Backend configurations with different effort settings are handled independently.
* **Documentation**
  * Updated configuration examples and documented supported effort values for Codex and Claude.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->