### PR TITLE
Make automerge timeout configurable

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -36,6 +36,7 @@ type run_knobs = {
   poll_interval : float;
   max_concurrency : int;
   max_ci_failures : int;
+  automerge_timeout : float option;
   headless : bool;
   patch_agent_provider : string option;
   patch_agent_effort : string option;
@@ -173,6 +174,7 @@ struct
         let repo = Env.config.github_repo
         let main_branch = Env.config.main_branch
         let max_concurrency = Env.config.max_concurrency
+        let automerge_timeout = Env.config.automerge_timeout
         let review_team = Env.config.repo_config.review_team
         let patch_agent_provider = Env.config.patch_agent_provider
         let patch_agent_effort = Env.config.patch_agent_effort
@@ -303,6 +305,7 @@ let finalize_run ~project_name ~repo_coords ~run_knobs ~backend_inputs
     poll_interval;
     max_concurrency;
     max_ci_failures;
+    automerge_timeout;
     headless;
     patch_agent_provider;
     patch_agent_effort;
@@ -313,6 +316,12 @@ let finalize_run ~project_name ~repo_coords ~run_knobs ~backend_inputs
     backend_inputs
   in
   let repo_config = load_repo_config_or_exit ~github_owner ~github_repo in
+  let automerge_timeout =
+    Option.value automerge_timeout
+      ~default:
+        (Option.value repo_config.Repo_config.automerge_timeout
+           ~default:Patch_controller.default_automerge_timeout)
+  in
   let backend, model =
     resolve_backend_model ~cli_backend ~cli_model ~stored_backend ~stored_model
       ~repo_config
@@ -321,6 +330,7 @@ let finalize_run ~project_name ~repo_coords ~run_knobs ~backend_inputs
     ~model
     ~main_branch:(Branch.to_string main_branch)
     ~poll_interval ~repo_root ~max_concurrency ~max_ci_failures
+    ~automerge_timeout
     ~url_scheme:(Option.map Managed_repo.string_of_url_scheme url_scheme)
     ();
   (* Refresh the agent-readable gameplan copy under artifacts/ so patch
@@ -340,6 +350,7 @@ let finalize_run ~project_name ~repo_coords ~run_knobs ~backend_inputs
       repo_root;
       max_concurrency;
       max_ci_failures;
+      automerge_timeout;
       headless;
       patch_agent_provider;
       patch_agent_effort;
@@ -356,7 +367,8 @@ let finalize_run ~project_name ~repo_coords ~run_knobs ~backend_inputs
       values. *)
 let resolve_config ~project ~gameplan_path ~github_token ~backend ~model
     ~main_branch ~poll_interval ~(repo_root : string option) ~max_concurrency
-    ~(max_ci_failures : int option) ~headless ~(clone_scheme : string option) =
+    ~(max_ci_failures : int option) ~(automerge_timeout : float option)
+    ~headless ~(clone_scheme : string option) =
   let clone_scheme_override =
     match clone_scheme with
     | None -> None
@@ -393,6 +405,7 @@ let resolve_config ~project ~gameplan_path ~github_token ~backend ~model
       max_ci_failures =
         Option.value max_ci_failures
           ~default:Patch_agent.default_max_ci_failures;
+      automerge_timeout;
       headless;
       patch_agent_provider;
       patch_agent_effort;
@@ -670,6 +683,10 @@ let resolve_config ~project ~gameplan_path ~github_token ~backend ~model
                       max_ci_failures =
                         Option.value max_ci_failures
                           ~default:stored.Project_store.max_ci_failures;
+                      automerge_timeout =
+                        Some
+                          (Option.value automerge_timeout
+                             ~default:stored.Project_store.automerge_timeout);
                     }
                   in
                   let backend_inputs =
@@ -1260,12 +1277,12 @@ let run_with_config ~no_lock ~auto_merge ~pr_ops (config : config) gameplan
 
 let run ~project ~gameplan_path ~github_token ~backend ~model
     ~(main_branch : Branch.t option) ~poll_interval ~(repo_root : string option)
-    ~max_concurrency ~max_ci_failures ~headless ~no_lock ~auto_merge
-    ~clone_scheme ~pr_ops =
+    ~max_concurrency ~max_ci_failures ~automerge_timeout ~headless ~no_lock
+    ~auto_merge ~clone_scheme ~pr_ops =
   match
     resolve_config ~project ~gameplan_path ~github_token ~backend ~model
       ~main_branch ~poll_interval ~repo_root ~max_concurrency ~max_ci_failures
-      ~headless ~clone_scheme
+      ~automerge_timeout ~headless ~clone_scheme
   with
   | Error errs ->
       Base.List.iter errs ~f:(fun e -> Printf.eprintf "Error: %s\n" e);
@@ -1481,6 +1498,28 @@ let max_ci_failures_arg =
            which case the flag wins and is persisted."
         ~env:(Cmd.Env.info "ONTON_MAX_CI_FAILURES"))
 
+let positive_float_arg =
+  let parse raw =
+    match Stdlib.float_of_string_opt raw with
+    | Some value when Float.is_finite value && Float.compare value 0. > 0 ->
+        Ok value
+    | Some _ | None -> Error (`Msg "expected a finite number greater than zero")
+  in
+  Cmdliner.Arg.conv (parse, Format.pp_print_float)
+
+let automerge_timeout_arg =
+  let open Cmdliner in
+  Arg.(
+    value
+    & opt (some positive_float_arg) None
+    & info [ "automerge-timeout" ] ~docv:"SECONDS"
+        ~doc:
+          "Idle time after a PR becomes eligible before automerge fires. Must \
+           be greater than zero (default: stored project value, then the \
+           repository config's automerge_timeout, then 300 seconds). The \
+           resolved value is persisted for flag-less resumes."
+        ~env:(Cmd.Env.info "ONTON_AUTOMERGE_TIMEOUT"))
+
 let headless_arg =
   let open Cmdliner in
   Arg.(
@@ -1543,8 +1582,8 @@ let auto_merge_arg =
 let main_cmd ~pr_ops =
   let open Cmdliner in
   let run_cmd project gameplan_path github_token backend model main_branch
-      poll_interval repo_root max_concurrency max_ci_failures headless
-      upload_debug no_lock prune no_refresh auto_merge clone_scheme =
+      poll_interval repo_root max_concurrency max_ci_failures automerge_timeout
+      headless upload_debug no_lock prune no_refresh auto_merge clone_scheme =
     if prune then
       Stdlib.exit
         ( Eio_main.run @@ fun env ->
@@ -1580,16 +1619,16 @@ let main_cmd ~pr_ops =
       run ~project ~gameplan_path ~github_token
         ~backend:(Base.String.strip backend)
         ~model:(Base.String.strip model) ~main_branch ~poll_interval ~repo_root
-        ~max_concurrency ~max_ci_failures ~headless ~no_lock ~auto_merge
-        ~clone_scheme ~pr_ops)
+        ~max_concurrency ~max_ci_failures ~automerge_timeout ~headless ~no_lock
+        ~auto_merge ~clone_scheme ~pr_ops)
   in
   let term =
     Term.(
       const run_cmd $ project_arg $ gameplan_path_arg $ github_token_arg
       $ backend_arg $ model_arg $ main_branch_arg $ poll_interval_arg $ repo_arg
-      $ max_concurrency_arg $ max_ci_failures_arg $ headless_arg
-      $ upload_debug_arg $ no_lock_arg $ prune_arg $ no_refresh_arg
-      $ auto_merge_arg $ clone_scheme_arg)
+      $ max_concurrency_arg $ max_ci_failures_arg $ automerge_timeout_arg
+      $ headless_arg $ upload_debug_arg $ no_lock_arg $ prune_arg
+      $ no_refresh_arg $ auto_merge_arg $ clone_scheme_arg)
   in
   let info =
     Cmd.info "onton" ~version:Version.s

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -674,7 +674,9 @@ let resolve_config ~project ~gameplan_path ~github_token ~backend ~model
                      [max_ci_failures] can distinguish "flag passed" from
                      "flag omitted" (it is optional at the CLI layer), so an
                      explicit flag overrides the stored value; otherwise the
-                     stored value wins. *)
+                     stored value wins. [automerge_timeout] keeps legacy field
+                     absence intact so [finalize_run] can apply the repository
+                     default before the built-in fallback. *)
                   let run_knobs =
                     {
                       run_knobs with
@@ -684,9 +686,9 @@ let resolve_config ~project ~gameplan_path ~github_token ~backend ~model
                         Option.value max_ci_failures
                           ~default:stored.Project_store.max_ci_failures;
                       automerge_timeout =
-                        Some
-                          (Option.value automerge_timeout
-                             ~default:stored.Project_store.automerge_timeout);
+                        (match automerge_timeout with
+                        | Some _ as timeout -> timeout
+                        | None -> stored.Project_store.automerge_timeout);
                     }
                   in
                   let backend_inputs =
@@ -1340,10 +1342,12 @@ let cli_option_takes_value (s : string) : bool =
   | None -> (
       (* Keep this in sync with Cmdliner [opt] arguments below:
          --gameplan, --token, --backend, --model, --repo, --main-branch,
-         --poll-interval, and --max-concurrency. *)
+         --poll-interval, --max-concurrency, --max-ci-failures, and
+         --automerge-timeout. *)
       match s with
       | "--gameplan" | "--token" | "--backend" | "--model" | "--repo"
-      | "--main-branch" | "--poll-interval" | "--max-concurrency" ->
+      | "--main-branch" | "--poll-interval" | "--max-concurrency"
+      | "--max-ci-failures" | "--automerge-timeout" ->
           true
       | _ -> false)
 

--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -645,7 +645,8 @@ let apply_github_effect_success t = function
   | Set_pr_base { patch_id; base; _ } ->
       Orchestrator.set_base_branch t patch_id base
 
-let automerge_idle_timeout = 300.0
+let default_automerge_timeout = 300.0
+let automerge_idle_timeout = default_automerge_timeout
 let automerge_max_failures = 3
 
 (** Pure predicate: a patch is a candidate to START a new automerge call when it
@@ -784,9 +785,9 @@ let automerge_action (agent : Patch_agent.t) ~main_branch =
   | false, Some _ -> None
   | false, None -> Some Direct_merge
 
-let apply_automerge_failure_state t ~now patch_id =
+let apply_automerge_failure_state t ~now ~automerge_timeout patch_id =
   Orchestrator.apply_automerge_failure_state t patch_id
-    ~retry_deadline:(now +. automerge_idle_timeout)
+    ~retry_deadline:(now +. automerge_timeout)
     ~max_failures:automerge_max_failures
 
 (** Reconcile the automerge deadline for every agent. Returns the updated
@@ -803,16 +804,17 @@ let apply_automerge_failure_state t ~now patch_id =
       which funnels into the non-candidate branches below (clearing any stale
       deadline). No separate early-return is needed.
     - If the patch is a candidate and has no deadline, set one at
-      [now +. automerge_idle_timeout].
+      [now +. automerge_timeout].
     - If the patch is not a candidate and has a deadline, clear it — any
       feedback resets the timer, so enabling again must wait out a fresh
-      5-minute window.
+      configured idle window.
     - If the patch is a candidate and the deadline has elapsed, mark the agent
       [automerge_inflight = true] atomically and include it in the returned
       decision list. The deadline is left in place; clearing it, clearing the
       inflight flag, and advancing the failure counter are the caller's
       responsibility via [apply_automerge_success]/[apply_automerge_failure]. *)
-let reconcile_automerge t ~now =
+let reconcile_automerge ?(automerge_timeout = default_automerge_timeout) t ~now
+    =
   let agents = Orchestrator.all_agents t in
   let main_branch = Orchestrator.main_branch t in
   List.fold agents ~init:(t, []) ~f:(fun (t, decisions) agent ->
@@ -898,7 +900,7 @@ let reconcile_automerge t ~now =
                 (Orchestrator.clear_automerge_deadline t patch_id, decisions)
             | false, None -> (t, decisions)
             | true, None ->
-                let deadline = now +. automerge_idle_timeout in
+                let deadline = now +. automerge_timeout in
                 ( Orchestrator.set_automerge_deadline t patch_id deadline,
                   decisions )
             | true, Some deadline ->
@@ -939,15 +941,16 @@ let apply_automerge_success t patch_id =
 let apply_merge_queue_entered t patch_id entry =
   Orchestrator.entered_merge_queue t patch_id entry
 
-let apply_merge_queue_dequeued t ~now patch_id =
+let apply_merge_queue_dequeued ?(automerge_timeout = default_automerge_timeout)
+    t ~now patch_id =
   let t = Orchestrator.set_merge_queue_entry t patch_id None in
   let t = Orchestrator.set_automerge_inflight t patch_id false in
   let t = Orchestrator.reset_automerge_failure_count t patch_id in
-  Orchestrator.set_automerge_deadline t patch_id (now +. automerge_idle_timeout)
+  Orchestrator.set_automerge_deadline t patch_id (now +. automerge_timeout)
 
 (** Apply the durable state change that follows a failed merge call. Clears the
     inflight flag and increments the failure counter. Pushes the deadline out by
-    [automerge_idle_timeout] so the retry is at least one idle window away — the
+    [automerge_timeout] so the retry is at least one idle window away — the
     runner may call [reconcile_and_execute_automerge] every tick (~1s), and
     without an explicit push-out a persistent GitHub failure could produce a
     burst of calls within a single poll cycle.
@@ -959,8 +962,9 @@ let apply_merge_queue_dequeued t ~now patch_id =
     - Automerge has been disabled (the user toggled it off while the merge was
       in flight): writing a deadline would contradict the disabled state and
       stick around until the next tick cleared it. *)
-let apply_automerge_failure t ~now patch_id =
-  apply_automerge_failure_state t ~now patch_id
+let apply_automerge_failure ?(automerge_timeout = default_automerge_timeout) t
+    ~now patch_id =
+  apply_automerge_failure_state t ~now ~automerge_timeout patch_id
 
 let make_orchestrator ~patch_id ~main_branch =
   let patch =
@@ -1697,6 +1701,18 @@ let%test "reconcile_automerge marks inflight when firing a decision" =
   List.length decisions = 1
   && (Orchestrator.agent t pid).Patch_agent.automerge_inflight
 
+let%test "reconcile_automerge uses configured timeout when arming" =
+  let _patch, t = make_orchestrator ~patch_id:pid ~main_branch:main in
+  let t = make_approved_agent t in
+  let now = 100.0 in
+  let automerge_timeout = 17.5 in
+  let t, decisions = reconcile_automerge ~automerge_timeout t ~now in
+  List.is_empty decisions
+  &&
+  match (Orchestrator.agent t pid).Patch_agent.automerge_deadline with
+  | Some deadline -> Float.equal deadline (now +. automerge_timeout)
+  | None -> false
+
 let%test "reconcile_automerge skips when inflight is true" =
   let _patch, t = make_orchestrator ~patch_id:pid ~main_branch:main in
   let t = make_approved_agent t in
@@ -1746,13 +1762,14 @@ let%test "apply_automerge_failure bumps deadline one idle window out" =
   let t = Orchestrator.set_automerge_deadline t pid 1.0 in
   let t = Orchestrator.set_automerge_inflight t pid true in
   let now = 1000.0 in
-  let t = apply_automerge_failure t ~now pid in
+  let automerge_timeout = 17.5 in
+  let t = apply_automerge_failure ~automerge_timeout t ~now pid in
   let a = Orchestrator.agent t pid in
   a.Patch_agent.automerge_failure_count = 1
   && (not a.Patch_agent.automerge_inflight)
   &&
   match a.Patch_agent.automerge_deadline with
-  | Some d -> Float.( = ) d (now +. automerge_idle_timeout)
+  | Some d -> Float.equal d (now +. automerge_timeout)
   | None -> false
 
 let%test "apply_automerge_failure clears deadline once cap is reached" =

--- a/lib/patch_controller.mli
+++ b/lib/patch_controller.mli
@@ -123,8 +123,11 @@ val apply_github_effect_success :
   Orchestrator.t -> github_effect -> Orchestrator.t
 (** Apply the durable state changes that follow a successful GitHub effect. *)
 
+val default_automerge_timeout : float
+(** Built-in automerge idle window in seconds (300). *)
+
 val automerge_idle_timeout : float
-(** Seconds of idle time after approval before automerge fires. *)
+(** Compatibility alias for {!default_automerge_timeout}. *)
 
 val automerge_max_failures : int
 (** Hard cap on consecutive automerge call failures per patch. Once a patch hits
@@ -188,13 +191,16 @@ val should_dequeue_merge_queue :
     same predicate as [reconcile_automerge] for its pre-flight recheck. *)
 
 val reconcile_automerge :
-  Orchestrator.t -> now:float -> Orchestrator.t * automerge_decision list
+  ?automerge_timeout:float ->
+  Orchestrator.t ->
+  now:float ->
+  Orchestrator.t * automerge_decision list
 (** Reconcile the automerge deadline for every agent and return decisions to
     merge. For each agent:
     - merged → clear any stale deadline/inflight flag (no decision).
     - [automerge_inflight] → no-op; the executor owns the deadline and inflight
       transitions via [apply_automerge_success] / [apply_automerge_failure].
-    - candidate + no deadline → set deadline at [now +. automerge_idle_timeout].
+    - candidate + no deadline → set deadline at [now +. automerge_timeout].
     - not candidate + deadline, but [automerge_transient_hold] → preserve the
       deadline unchanged and emit no decision (GitHub is recomputing
       mergeability after the base advanced; the idle window keeps counting).
@@ -231,18 +237,26 @@ val apply_merge_queue_entered :
     automerge fire. *)
 
 val apply_merge_queue_dequeued :
-  Orchestrator.t -> now:float -> Patch_id.t -> Orchestrator.t
+  ?automerge_timeout:float ->
+  Orchestrator.t ->
+  now:float ->
+  Patch_id.t ->
+  Orchestrator.t
 (** Record that an automerge dequeue request succeeded. The PR is no longer
     known to be in GitHub's merge queue, the successful GitHub call clears the
     consecutive automerge API-failure counter, and the deadline is restarted so
     a still-ready PR can be enqueued again after the idle window. *)
 
 val apply_automerge_failure :
-  Orchestrator.t -> now:float -> Patch_id.t -> Orchestrator.t
+  ?automerge_timeout:float ->
+  Orchestrator.t ->
+  now:float ->
+  Patch_id.t ->
+  Orchestrator.t
 (** Record a failed merge call: clear the inflight flag and increment the
     consecutive failure counter. Push the deadline out to
-    [now +. automerge_idle_timeout] so the retry is at least one idle window
-    away (without this bound, a persistent GitHub failure could burst many merge
+    [now +. automerge_timeout] so the retry is at least one idle window away
+    (without this bound, a persistent GitHub failure could burst many merge
     calls per poll cycle since the runner re-reconciles every tick). The
     deadline is NOT re-armed when either (a) the failure cap has now been
     reached (reconciliation will no longer issue merge calls for this patch), or

--- a/lib/project_store.ml
+++ b/lib/project_store.ml
@@ -145,10 +145,10 @@ type stored_config = {
       (* Per-project CI-failure cap (see [Patch_agent.max_ci_failures]).
          Defaulted on legacy configs predating the field; persisted so a value
          set once via --max-ci-failures survives flag-less resumes. *)
-  automerge_timeout : float;
-      [@yojson.default Patch_controller.default_automerge_timeout]
-      (* Per-project automerge idle window. Defaulted on legacy configs and
-         persisted so CLI/config choices survive flag-less resumes. *)
+  automerge_timeout : float option; [@yojson.default None]
+      (* Per-project automerge idle window. [None] preserves field absence in
+         legacy configs so flag-less resumes can consult the repository
+         default; newly resolved values are persisted as [Some]. *)
   url_scheme : string option; [@yojson.default None]
       (* Persisted transport scheme for the managed clone's [origin]. [None]
          on legacy configs predating P0-D; on the next [ensure_managed_repo]
@@ -174,7 +174,7 @@ let save_config ~project_name ~github_owner ~github_repo ~backend ~model
       repo_root;
       max_concurrency;
       max_ci_failures;
-      automerge_timeout;
+      automerge_timeout = Some automerge_timeout;
       url_scheme;
     }
   in
@@ -580,7 +580,9 @@ let%test "load_config tolerates a legacy persisted github_token" =
       Stdlib.close_out oc;
       match load_config ~project_name with
       | Ok cfg ->
-          String.equal cfg.github_owner "o" && String.equal cfg.github_repo "r"
+          String.equal cfg.github_owner "o"
+          && String.equal cfg.github_repo "r"
+          && Option.is_none cfg.automerge_timeout
       | Error _ -> false)
 
 (* The token is no longer persisted: [save_config] must not write a
@@ -602,6 +604,6 @@ let%test "save_config persists no github_token and round-trips" =
           String.equal cfg.project_name project_name
           && String.equal cfg.github_owner "o"
           && Int.equal cfg.max_ci_failures Patch_agent.default_max_ci_failures
-          && Float.equal cfg.automerge_timeout
-               Patch_controller.default_automerge_timeout
+          && Option.equal Float.equal cfg.automerge_timeout
+               (Some Patch_controller.default_automerge_timeout)
       | Error _ -> false)

--- a/lib/project_store.ml
+++ b/lib/project_store.ml
@@ -145,6 +145,10 @@ type stored_config = {
       (* Per-project CI-failure cap (see [Patch_agent.max_ci_failures]).
          Defaulted on legacy configs predating the field; persisted so a value
          set once via --max-ci-failures survives flag-less resumes. *)
+  automerge_timeout : float;
+      [@yojson.default Patch_controller.default_automerge_timeout]
+      (* Per-project automerge idle window. Defaulted on legacy configs and
+         persisted so CLI/config choices survive flag-less resumes. *)
   url_scheme : string option; [@yojson.default None]
       (* Persisted transport scheme for the managed clone's [origin]. [None]
          on legacy configs predating P0-D; on the next [ensure_managed_repo]
@@ -155,7 +159,7 @@ type stored_config = {
 
 let save_config ~project_name ~github_owner ~github_repo ~backend ~model
     ~main_branch ~poll_interval ~repo_root ~max_concurrency ~max_ci_failures
-    ?(url_scheme : string option = None) () =
+    ~automerge_timeout ?(url_scheme : string option = None) () =
   let dir = project_dir project_name in
   ensure_dir dir;
   let config =
@@ -170,6 +174,7 @@ let save_config ~project_name ~github_owner ~github_repo ~backend ~model
       repo_root;
       max_concurrency;
       max_ci_failures;
+      automerge_timeout;
       url_scheme;
     }
   in
@@ -587,7 +592,8 @@ let%test "save_config persists no github_token and round-trips" =
       save_config ~project_name ~github_owner:"o" ~github_repo:"r"
         ~backend:"claude" ~model:"sonnet" ~main_branch:"main" ~poll_interval:5.0
         ~repo_root:"/tmp/r" ~max_concurrency:4
-        ~max_ci_failures:Patch_agent.default_max_ci_failures ();
+        ~max_ci_failures:Patch_agent.default_max_ci_failures
+        ~automerge_timeout:Patch_controller.default_automerge_timeout ();
       let raw = read_file_for_test (config_path project_name) in
       (not (String.is_substring raw ~substring:"github_token"))
       &&
@@ -596,4 +602,6 @@ let%test "save_config persists no github_token and round-trips" =
           String.equal cfg.project_name project_name
           && String.equal cfg.github_owner "o"
           && Int.equal cfg.max_ci_failures Patch_agent.default_max_ci_failures
+          && Float.equal cfg.automerge_timeout
+               Patch_controller.default_automerge_timeout
       | Error _ -> false)

--- a/lib/project_store.mli
+++ b/lib/project_store.mli
@@ -54,9 +54,11 @@ type stored_config = {
           {!Patch_agent.max_ci_failures}). Defaults to
           [Patch_agent.default_max_ci_failures] on legacy configs predating the
           field. *)
-  automerge_timeout : float;
-      (** Per-project automerge idle window in seconds. Defaults to
-          {!Patch_controller.default_automerge_timeout} for legacy configs. *)
+  automerge_timeout : float option;
+      (** Persisted per-project automerge idle window in seconds. [None] on
+          legacy configs preserves field absence so resolution can fall through
+          to the repository default and then
+          {!Patch_controller.default_automerge_timeout}. *)
   url_scheme : string option;
       (** Persisted transport for the managed [origin]. [None] on legacy configs
           predating P0-D; gets auto-resolved on the next

--- a/lib/project_store.mli
+++ b/lib/project_store.mli
@@ -54,6 +54,9 @@ type stored_config = {
           {!Patch_agent.max_ci_failures}). Defaults to
           [Patch_agent.default_max_ci_failures] on legacy configs predating the
           field. *)
+  automerge_timeout : float;
+      (** Per-project automerge idle window in seconds. Defaults to
+          {!Patch_controller.default_automerge_timeout} for legacy configs. *)
   url_scheme : string option;
       (** Persisted transport for the managed [origin]. [None] on legacy configs
           predating P0-D; gets auto-resolved on the next
@@ -73,6 +76,7 @@ val save_config :
   repo_root:string ->
   max_concurrency:int ->
   max_ci_failures:int ->
+  automerge_timeout:float ->
   ?url_scheme:string option ->
   unit ->
   unit

--- a/lib/resolved_config.ml
+++ b/lib/resolved_config.ml
@@ -77,10 +77,6 @@ let validate_resolved_config ~project_name ~backend ~github_token ~github_owner
         ( max_ci_failures < 1,
           Printf.sprintf "--max-ci-failures must be >= 1 (got %d)"
             max_ci_failures );
-        ( (not (Float.is_finite automerge_timeout))
-          || Float.compare automerge_timeout 0. <= 0,
-          Printf.sprintf "--automerge-timeout must be finite and > 0 (got %g)"
-            automerge_timeout );
         ( (match patch_agent_provider with
           | Some provider ->
               not
@@ -101,6 +97,13 @@ let validate_resolved_config ~project_name ~backend ~github_token ~github_owner
             (String.concat ", " known_patch_agent_efforts) );
       ]
       ~f:(fun (cond, msg) -> if cond then Some msg else None)
+  in
+  let errors =
+    match
+      Resolved_config_validation.automerge_timeout_error automerge_timeout
+    with
+    | None -> errors
+    | Some error -> errors @ [ error ]
   in
   match errors with [] -> Ok () | errs -> Error errs
 

--- a/lib/resolved_config.ml
+++ b/lib/resolved_config.ml
@@ -15,6 +15,7 @@ type config = {
   repo_root : string;
   max_concurrency : int;
   max_ci_failures : int;
+  automerge_timeout : float;
   headless : bool;
   patch_agent_provider : string option;
   patch_agent_effort : string option;
@@ -34,6 +35,7 @@ type t = {
   repo_root : string;
   max_concurrency : int;
   max_ci_failures : int;
+  automerge_timeout : float;
   headless : bool;
   patch_agent_provider : string option;
   patch_agent_effort : string option;
@@ -49,7 +51,7 @@ let known_patch_agent_efforts = [ "low"; "medium"; "high" ]
 
 let validate_resolved_config ~project_name ~backend ~github_token ~github_owner
     ~github_repo ~main_branch ~poll_interval ~max_concurrency ~max_ci_failures
-    ~patch_agent_provider ~patch_agent_effort =
+    ~automerge_timeout ~patch_agent_provider ~patch_agent_effort =
   let errors =
     Base.List.filter_map
       [
@@ -75,6 +77,10 @@ let validate_resolved_config ~project_name ~backend ~github_token ~github_owner
         ( max_ci_failures < 1,
           Printf.sprintf "--max-ci-failures must be >= 1 (got %d)"
             max_ci_failures );
+        ( (not (Float.is_finite automerge_timeout))
+          || Float.compare automerge_timeout 0. <= 0,
+          Printf.sprintf "--automerge-timeout must be finite and > 0 (got %g)"
+            automerge_timeout );
         ( (match patch_agent_provider with
           | Some provider ->
               not
@@ -107,6 +113,7 @@ let of_config (config : config) =
       ~poll_interval:config.poll_interval
       ~max_concurrency:config.max_concurrency
       ~max_ci_failures:config.max_ci_failures
+      ~automerge_timeout:config.automerge_timeout
       ~patch_agent_provider:config.patch_agent_provider
       ~patch_agent_effort:config.patch_agent_effort
   with
@@ -125,6 +132,7 @@ let of_config (config : config) =
           repo_root = config.repo_root;
           max_concurrency = config.max_concurrency;
           max_ci_failures = config.max_ci_failures;
+          automerge_timeout = config.automerge_timeout;
           headless = config.headless;
           patch_agent_provider = config.patch_agent_provider;
           patch_agent_effort = config.patch_agent_effort;

--- a/lib/resolved_config.mli
+++ b/lib/resolved_config.mli
@@ -15,6 +15,7 @@ type config = {
   repo_root : string;
   max_concurrency : int;
   max_ci_failures : int;
+  automerge_timeout : float;
       (** Per-project cap on consecutive CI-failure responses per patch (see
           {!Onton_core.Patch_agent.max_ci_failures}). Resolved from
           [--max-ci-failures] / stored project config / built-in default. *)
@@ -41,6 +42,7 @@ type t = {
   repo_root : string;
   max_concurrency : int;
   max_ci_failures : int;
+  automerge_timeout : float;
   headless : bool;
   patch_agent_provider : string option;
   patch_agent_effort : string option;

--- a/lib/resolved_config.mli
+++ b/lib/resolved_config.mli
@@ -15,10 +15,13 @@ type config = {
   repo_root : string;
   max_concurrency : int;
   max_ci_failures : int;
-  automerge_timeout : float;
       (** Per-project cap on consecutive CI-failure responses per patch (see
           {!Onton_core.Patch_agent.max_ci_failures}). Resolved from
           [--max-ci-failures] / stored project config / built-in default. *)
+  automerge_timeout : float;
+      (** Automerge idle window in seconds. Must be finite and greater than
+          zero. Resolved from [--automerge-timeout], persisted project config,
+          repository config, or the built-in default, in that order. *)
   headless : bool;
   patch_agent_provider : string option;
   patch_agent_effort : string option;

--- a/lib/resolved_config.mli
+++ b/lib/resolved_config.mli
@@ -20,8 +20,9 @@ type config = {
           [--max-ci-failures] / stored project config / built-in default. *)
   automerge_timeout : float;
       (** Automerge idle window in seconds. Must be finite and greater than
-          zero. Resolved from [--automerge-timeout], persisted project config,
-          repository config, or the built-in default, in that order. *)
+          zero. Resolved from [--automerge-timeout] / [ONTON_AUTOMERGE_TIMEOUT],
+          persisted project config, repository config, or the built-in default,
+          in that order. *)
   headless : bool;
   patch_agent_provider : string option;
   patch_agent_effort : string option;

--- a/lib/runner_fiber.mli
+++ b/lib/runner_fiber.mli
@@ -11,6 +11,7 @@ module Runner_env : sig
     val repo : string
     val main_branch : Branch.t
     val max_concurrency : int
+    val automerge_timeout : float
     val review_team : string option
     val patch_agent_provider : string option
     val patch_agent_effort : string option

--- a/lib/runner_fiber_impl.ml
+++ b/lib/runner_fiber_impl.ml
@@ -19,6 +19,7 @@ module Runner_env = struct
     val repo : string
     val main_branch : Branch.t
     val max_concurrency : int
+    val automerge_timeout : float
     val review_team : string option
     val patch_agent_provider : string option
     val patch_agent_effort : string option
@@ -126,15 +127,16 @@ struct
   (** Reconcile per-patch automerge deadlines. For each deadline that has
       elapsed, merge the PR on GitHub and mark the patch merged on success. On
       failure the failure counter is incremented and the deadline pushed out by
-      a fresh idle window, so the retry is at least 5 minutes out regardless of
-      how often the runner tick fires. Retries continue until the consecutive
-      failure cap is reached, at which point reconciliation stops issuing merge
-      calls until the user toggles automerge off/on. *)
+      a fresh configured idle window regardless of how often the runner tick
+      fires. Retries continue until the consecutive failure cap is reached, at
+      which point reconciliation stops issuing merge calls until the user
+      toggles automerge off/on. *)
   let reconcile_and_execute_automerge ~runtime =
     let now = Unix.gettimeofday () in
     let decisions =
       Runtime.update_orchestrator_returning runtime (fun orch ->
-          Patch_controller.reconcile_automerge orch ~now)
+          Patch_controller.reconcile_automerge
+            ~automerge_timeout:Env.automerge_timeout orch ~now)
     in
     (* Dispatch concurrently with a bounded fiber pool. A slow merge call can
      take up to GitHub's request timeout (~30s), so serial iteration would
@@ -146,7 +148,7 @@ struct
      intentional: bounded concurrency avoids a thundering herd against GitHub
      rate limits and keeps exactly one automerge fiber alive on the switch
      (the runner loop is already decoupled — it does not wait on this). The
-     1s cadence is not load-bearing either: deadlines fire on 5-minute idle
+     1s cadence is not load-bearing either: deadlines fire on configured idle
      windows, and [automerge_inflight] already prevents double-claiming. *)
     Eio.Fiber.List.iter ~max_fibers:4
       (fun Patch_controller.
@@ -185,7 +187,7 @@ struct
                   Orchestrator.set_automerge_inflight orch patch_id false
                 in
                 Orchestrator.set_automerge_deadline orch patch_id
-                  (now_ts +. Patch_controller.automerge_idle_timeout)))
+                  (now_ts +. Env.automerge_timeout)))
         in
         let apply_failure () =
           inflight_cleared := true;
@@ -194,6 +196,7 @@ struct
              the failure count or applying the retry/cap deadline rules. *)
           Runtime.update_orchestrator runtime (fun orch ->
               Patch_controller.apply_automerge_failure orch
+                ~automerge_timeout:Env.automerge_timeout
                 ~now:(Unix.gettimeofday ()) patch_id)
         in
         let record_enqueued_and_clear_inflight entry =
@@ -300,6 +303,7 @@ struct
                         inflight_cleared := true;
                         Runtime.update_orchestrator runtime (fun orch ->
                             Patch_controller.apply_merge_queue_dequeued orch
+                              ~automerge_timeout:Env.automerge_timeout
                               ~now:(Unix.gettimeofday ()) patch_id);
                         log_event runtime ~patch_id
                           (Printf.sprintf

--- a/lib/runner_fiber_impl.mli
+++ b/lib/runner_fiber_impl.mli
@@ -11,6 +11,7 @@ module Runner_env : sig
     val repo : string
     val main_branch : Branch.t
     val max_concurrency : int
+    val automerge_timeout : float
     val review_team : string option
     val patch_agent_provider : string option
     val patch_agent_effort : string option

--- a/lib/tui.ml
+++ b/lib/tui.ml
@@ -1191,7 +1191,7 @@ let render_manage_overlay ~width ~height ~automerge_enabled ~needs_intervention
       (Printf.sprintf " Manage Patch  %s" dismiss)
   in
   let automerge_label =
-    Printf.sprintf "    a   %s automerge (5-minute idle timer after approval)"
+    Printf.sprintf "    a   %s automerge (idle timer after approval)"
       (if automerge_enabled then "Disable" else "Enable")
   in
   let automerge_item =

--- a/lib_core/patch_agent.mli
+++ b/lib_core/patch_agent.mli
@@ -581,9 +581,9 @@ val set_automerge_enabled : t -> bool -> t
     a fresh timer. Calling with the current value is a no-op — the failure
     count, inflight flag, and [automerge_deadline] are NOT reset in that case.
     If the preserved deadline has already elapsed, the next reconcile tick will
-    fire immediately rather than waiting [automerge_idle_timeout]; callers that
-    need a fresh timer must call [clear_automerge_deadline] explicitly after
-    this function. *)
+    fire immediately rather than waiting the configured automerge timeout;
+    callers that need a fresh timer must call [clear_automerge_deadline]
+    explicitly after this function. *)
 
 val set_automerge_deadline : t -> float -> t
 (** Record the Unix timestamp at which the supervisor should merge this patch if

--- a/lib_core/repo_config.ml
+++ b/lib_core/repo_config.ml
@@ -8,6 +8,7 @@ type route = { backend : string; model : string option }
 type t = {
   default_backend : string option;
   default_model : string option;
+  automerge_timeout : float option;
   review_team : string option;
   complexity_routes : (int * route) list;
   review_backends : Review_backend.t list;
@@ -17,6 +18,7 @@ let empty =
   {
     default_backend = None;
     default_model = None;
+    automerge_timeout = None;
     review_team = None;
     complexity_routes = [];
     review_backends = [];
@@ -103,6 +105,17 @@ let parse_routing ~known_backends (json : Yojson.Safe.t) :
 
 let default_known_review_kinds = [ "review-service" ]
 
+let parse_automerge_timeout (json : Yojson.Safe.t) =
+  match Json.field "automerge_timeout" json with
+  | None -> Ok None
+  | Some (`Int seconds) when seconds > 0 -> Ok (Some (Float.of_int seconds))
+  | Some (`Float seconds) when Float.is_finite seconds && Float.(seconds > 0.)
+    ->
+      Ok (Some seconds)
+  | Some (`Int _ | `Float _) ->
+      Error "automerge_timeout must be a finite number greater than zero"
+  | Some _ -> Error "automerge_timeout must be a number of seconds"
+
 let parse_default ~known_backends (json : Yojson.Safe.t) :
     (string option * string option, string) Result.t =
   match json with
@@ -161,22 +174,25 @@ let parse_string ~known_backends
             | Some (`String s) -> Ok (Some (String.strip s))
             | Some _ -> Error "review_team must be a string"
           in
-          Result.bind (parse_default ~known_backends default_json)
-            ~f:(fun (default_backend, default_model) ->
-              Result.bind review_team_result ~f:(fun review_team ->
-                  Result.bind (parse_routing ~known_backends routing)
-                    ~f:(fun routes ->
-                      Result.map
-                        (Review_backend.parse_array
-                           ~known_kinds:known_review_kinds review_backends_json)
-                        ~f:(fun review_backends ->
-                          {
-                            default_backend;
-                            default_model;
-                            review_team;
-                            complexity_routes = routes;
-                            review_backends;
-                          }))))
+          Result.bind (parse_automerge_timeout json)
+            ~f:(fun automerge_timeout ->
+              Result.bind (parse_default ~known_backends default_json)
+                ~f:(fun (default_backend, default_model) ->
+                  Result.bind review_team_result ~f:(fun review_team ->
+                      Result.bind (parse_routing ~known_backends routing)
+                        ~f:(fun routes ->
+                          Result.map
+                            (Review_backend.parse_array
+                               ~known_kinds:known_review_kinds
+                               review_backends_json) ~f:(fun review_backends ->
+                              {
+                                default_backend;
+                                default_model;
+                                automerge_timeout;
+                                review_team;
+                                complexity_routes = routes;
+                                review_backends;
+                              })))))
       | _ -> Error "config.json: top-level value must be an object")
 
 let load ~config_dir ~known_backends ?known_review_kinds () =
@@ -206,6 +222,27 @@ let%test "parse_string: missing routing -> empty" =
   match parse_string ~known_backends:[ "claude" ] "{}" with
   | Ok t -> List.is_empty t.complexity_routes
   | Error _ -> false
+
+let%test "parse_string: automerge_timeout parses" =
+  match
+    parse_string ~known_backends:[ "claude" ] {|{"automerge_timeout":12.5}|}
+  with
+  | Ok t -> Option.equal Float.equal t.automerge_timeout (Some 12.5)
+  | Error _ -> false
+
+let%test "parse_string: non-positive automerge_timeout rejected" =
+  match
+    parse_string ~known_backends:[ "claude" ] {|{"automerge_timeout":0}|}
+  with
+  | Error msg -> String.is_substring msg ~substring:"greater than zero"
+  | Ok _ -> false
+
+let%test "parse_string: non-number automerge_timeout rejected" =
+  match
+    parse_string ~known_backends:[ "claude" ] {|{"automerge_timeout":"fast"}|}
+  with
+  | Error msg -> String.is_substring msg ~substring:"number of seconds"
+  | Ok _ -> false
 
 let%test "parse_string: unknown top-level keys are ignored (forward compat)" =
   let raw = {|{"futureKey":{"foo":"bar"}}|} in

--- a/lib_core/repo_config.mli
+++ b/lib_core/repo_config.mli
@@ -41,7 +41,9 @@ type t = {
           [Some other] pins a specific model. [None] means "not configured". *)
   automerge_timeout : float option;
       (** Top-level [automerge_timeout] in seconds. Must be finite and greater
-          than zero. [None] falls through to the built-in 300-second default. *)
+          than zero. Resolution uses a CLI override, then a persisted project
+          value, then this repository value; [None] falls through to the
+          built-in 300-second default. *)
   review_team : string option;
       (** Top-level [review_team] slug from the config file. [None] keeps the
           review-request feature disabled for this repo. *)

--- a/lib_core/repo_config.mli
+++ b/lib_core/repo_config.mli
@@ -5,7 +5,9 @@
     [~/.config/onton/<owner>/<repo>/config.json] (the same directory layout the
     [User_config] hook lives in — see [User_config.config_dir]).
 
-    Carries three sections:
+    Carries repository-level defaults and three sections:
+    - [automerge_timeout] — the default idle window in seconds before an
+      eligible PR is automatically merged.
     - [default] — a per-repo default [(backend, model)] pair that mirrors the
       [--backend] / [--model] CLI flags. Either field may be omitted. Slots into
       the resolution chain below [Project_store] (stored values from previous
@@ -37,6 +39,9 @@ type t = {
       (** Top-level [default.model] from the config file. [Some "auto"] (case-
           insensitive) activates [routing] in the same way as [--model auto].
           [Some other] pins a specific model. [None] means "not configured". *)
+  automerge_timeout : float option;
+      (** Top-level [automerge_timeout] in seconds. Must be finite and greater
+          than zero. [None] falls through to the built-in 300-second default. *)
   review_team : string option;
       (** Top-level [review_team] slug from the config file. [None] keeps the
           review-request feature disabled for this repo. *)
@@ -52,6 +57,14 @@ type t = {
 
 val empty : t
 (** Returned when [config.json] is absent — the no-op config. *)
+
+val parse_string :
+  known_backends:string list ->
+  ?known_review_kinds:string list ->
+  string ->
+  (t, string) Stdlib.Result.t
+(** Parse and validate repository configuration without performing I/O. Never
+    raises for malformed input; schema failures are returned as [Error]. *)
 
 val load :
   config_dir:string ->
@@ -77,6 +90,7 @@ val load :
           "backend": "codex",
           "model":   "auto"
         },
+        "automerge_timeout": 300,
         "routing": {
           "1": { "backend": "claude", "model": "haiku" },
           "2": { "backend": "codex",  "model": "gpt-5.6-terra" },

--- a/lib_core/resolved_config_validation.ml
+++ b/lib_core/resolved_config_validation.ml
@@ -1,0 +1,12 @@
+(* @archlint.module core
+   @archlint.domain resolved-config *)
+
+let automerge_timeout_error automerge_timeout =
+  if
+    (not (Float.is_finite automerge_timeout))
+    || Float.compare automerge_timeout 0. <= 0
+  then
+    Some
+      (Printf.sprintf "--automerge-timeout must be finite and > 0 (got %g)"
+         automerge_timeout)
+  else None

--- a/lib_core/resolved_config_validation.mli
+++ b/lib_core/resolved_config_validation.mli
@@ -1,0 +1,6 @@
+(* @archlint.module interface
+   @archlint.domain resolved-config *)
+
+val automerge_timeout_error : float -> string option
+(** Return the validation error for an automerge idle window, or [None] when the
+    value is finite and greater than zero. Total for every float. *)

--- a/test/dune
+++ b/test/dune
@@ -16,6 +16,13 @@
  (ocamlc_flags (:standard -w -40-42)))
 
 (test
+ (name test_repo_config_properties)
+ (modules test_repo_config_properties)
+ (libraries onton_core qcheck-core qcheck-core.runner)
+ (ocamlopt_flags (:standard -w -40-42))
+ (ocamlc_flags (:standard -w -40-42)))
+
+(test
  (name test_comment_responses_properties)
  (modules test_comment_responses_properties)
  (libraries onton_core qcheck-core qcheck-core.runner base)

--- a/test/dune
+++ b/test/dune
@@ -23,6 +23,13 @@
  (ocamlc_flags (:standard -w -40-42)))
 
 (test
+ (name test_resolved_config_validation_properties)
+ (modules test_resolved_config_validation_properties)
+ (libraries onton_core qcheck-core qcheck-core.runner)
+ (ocamlopt_flags (:standard -w -40-42))
+ (ocamlc_flags (:standard -w -40-42)))
+
+(test
  (name test_comment_responses_properties)
  (modules test_comment_responses_properties)
  (libraries onton_core qcheck-core qcheck-core.runner base)

--- a/test/test_action_outcome_properties.ml
+++ b/test/test_action_outcome_properties.ml
@@ -898,7 +898,7 @@ let () =
            && (match after_dequeued.Patch_agent.automerge_deadline with
              | Some deadline ->
                  Float.( = ) deadline
-                   (dequeue_now +. Patch_controller.automerge_idle_timeout)
+                   (dequeue_now +. Patch_controller.default_automerge_timeout)
              | None -> false)
            && Patch_controller.should_dequeue_merge_queue stuck_agent
                 ~main_branch:main ~entry_id:stuck_entry.Pr_state.id

--- a/test/test_automerge_deadline_properties.ml
+++ b/test/test_automerge_deadline_properties.ml
@@ -34,7 +34,7 @@ open Onton_core.Types
 
 let main = Branch.of_string "main"
 let other_branch = Branch.of_string "release"
-let timeout = Patch_controller.automerge_idle_timeout
+let timeout = Patch_controller.default_automerge_timeout
 let max_failures = Patch_controller.automerge_max_failures
 
 (* -- Helpers -- *)

--- a/test/test_patch_controller.ml
+++ b/test/test_patch_controller.ml
@@ -1626,7 +1626,11 @@ let () =
         let now = 1000.0 in
         let orch = make_orch patch agent in
         let orch = Orchestrator.set_automerge_inflight orch pid true in
-        let orch = Patch_controller.apply_merge_queue_dequeued orch ~now pid in
+        let automerge_timeout = 17.5 in
+        let orch =
+          Patch_controller.apply_merge_queue_dequeued ~automerge_timeout orch
+            ~now pid
+        in
         let agent = Orchestrator.agent orch pid in
         Option.is_none agent.merge_queue_entry
         && agent.merge_queue_required
@@ -1634,8 +1638,7 @@ let () =
         && agent.automerge_failure_count = 0
         &&
         match agent.automerge_deadline with
-        | Some deadline ->
-            Float.( = ) deadline (now +. Patch_controller.automerge_idle_timeout)
+        | Some deadline -> Float.equal deadline (now +. automerge_timeout)
         | None -> false)
   in
 

--- a/test/test_repo_config_properties.ml
+++ b/test/test_repo_config_properties.ml
@@ -1,0 +1,33 @@
+(* @archlint.module test
+   @archlint.domain repo-config *)
+
+open Onton_core
+
+let known_backends = [ "claude"; "codex" ]
+
+let parse_is_total =
+  QCheck2.Test.make ~name:"repo config parsing is total" ~count:1000
+    QCheck2.Gen.string (fun raw ->
+      try
+        ignore (Repo_config.parse_string ~known_backends raw);
+        true
+      with _ -> false)
+
+let positive_automerge_timeout_round_trips =
+  QCheck2.Test.make
+    ~name:"positive finite automerge timeouts parse without changing value"
+    ~count:500
+    QCheck2.Gen.(float_range 0.001 10000.)
+    (fun timeout ->
+      try
+        let raw = Printf.sprintf {|{"automerge_timeout":%.17g}|} timeout in
+        match Repo_config.parse_string ~known_backends raw with
+        | Ok config ->
+            Option.equal Float.equal config.Repo_config.automerge_timeout
+              (Some timeout)
+        | Error _ -> false
+      with _ -> false)
+
+let () =
+  QCheck2.Test.check_exn parse_is_total;
+  QCheck2.Test.check_exn positive_automerge_timeout_round_trips

--- a/test/test_repo_config_properties.ml
+++ b/test/test_repo_config_properties.ml
@@ -5,6 +5,18 @@ open Onton_core
 
 let known_backends = [ "claude"; "codex" ]
 
+let parse_timeout timeout =
+  let raw = Printf.sprintf {|{"automerge_timeout":%.17g}|} timeout in
+  match Repo_config.parse_string ~known_backends raw with
+  | Ok config -> Ok config.Repo_config.automerge_timeout
+  | Error error -> Error error
+
+let equal_parse_result left right =
+  match (left, right) with
+  | Ok left, Ok right -> Option.equal Float.equal left right
+  | Error left, Error right -> String.equal left right
+  | Ok _, Error _ | Error _, Ok _ -> false
+
 let parse_is_total =
   QCheck2.Test.make ~name:"repo config parsing is total" ~count:1000
     QCheck2.Gen.string (fun raw ->
@@ -19,15 +31,44 @@ let positive_automerge_timeout_round_trips =
     ~count:500
     QCheck2.Gen.(float_range 0.001 10000.)
     (fun timeout ->
-      try
-        let raw = Printf.sprintf {|{"automerge_timeout":%.17g}|} timeout in
-        match Repo_config.parse_string ~known_backends raw with
-        | Ok config ->
-            Option.equal Float.equal config.Repo_config.automerge_timeout
-              (Some timeout)
-        | Error _ -> false
-      with _ -> false)
+      match parse_timeout timeout with
+      | Ok parsed -> Option.equal Float.equal parsed (Some timeout)
+      | Error _ -> false)
+
+let automerge_timeout_boundaries =
+  QCheck2.Test.make
+    ~name:
+      "automerge timeout enforces zero, negative, near-zero, and finite \
+       boundaries" ~count:1 QCheck2.Gen.unit (fun () ->
+      let rejected_numbers = [ 0.; -0.; -1.; -1e-300 ] in
+      let rejected_raw = [ "NaN"; "Infinity"; "-Infinity"; "1e999" ] in
+      let rejects_number timeout = Result.is_error (parse_timeout timeout) in
+      let rejects_raw timeout =
+        Result.is_error
+          (Repo_config.parse_string ~known_backends
+             (Printf.sprintf {|{"automerge_timeout":%s}|} timeout))
+      in
+      let near_zero = Float.next_after 0. Float.infinity in
+      List.for_all rejects_number rejected_numbers
+      && List.for_all rejects_raw rejected_raw
+      &&
+      match parse_timeout near_zero with
+      | Ok parsed -> Option.equal Float.equal parsed (Some near_zero)
+      | Error _ -> false)
+
+let repeated_parse_order_independent =
+  QCheck2.Test.make ~name:"repeated repo config parses are order independent"
+    ~count:300
+    QCheck2.Gen.(list_size (int_range 0 40) (float_range 0.001 10000.))
+    (fun timeouts ->
+      let forward = List.map parse_timeout timeouts in
+      let reverse_then_restore =
+        List.rev (List.map parse_timeout (List.rev timeouts))
+      in
+      List.equal equal_parse_result forward reverse_then_restore)
 
 let () =
   QCheck2.Test.check_exn parse_is_total;
-  QCheck2.Test.check_exn positive_automerge_timeout_round_trips
+  QCheck2.Test.check_exn positive_automerge_timeout_round_trips;
+  QCheck2.Test.check_exn automerge_timeout_boundaries;
+  QCheck2.Test.check_exn repeated_parse_order_independent

--- a/test/test_resolved_config_properties.ml
+++ b/test/test_resolved_config_properties.ml
@@ -19,6 +19,8 @@ let valid_config ~max_concurrency ~max_ci_failures : Resolved_config.config =
     Resolved_config.repo_root = ".";
     Resolved_config.max_concurrency;
     Resolved_config.max_ci_failures;
+    Resolved_config.automerge_timeout =
+      Patch_controller.default_automerge_timeout;
     Resolved_config.headless = true;
     Resolved_config.patch_agent_provider = None;
     Resolved_config.patch_agent_effort = None;
@@ -51,6 +53,39 @@ let max_ci_failures_must_be_positive =
       | Ok _ -> false
       | Error errors -> List.length errors >= 1)
 
+let automerge_timeout_must_be_positive =
+  QCheck2.Test.make
+    ~name:"resolved config rejects non-positive automerge timeout" ~count:200
+    QCheck2.Gen.(float_range (-100.) 0.)
+    (fun automerge_timeout ->
+      let config =
+        {
+          (valid_config ~max_concurrency:1
+             ~max_ci_failures:Patch_agent.default_max_ci_failures)
+          with
+          Resolved_config.automerge_timeout;
+        }
+      in
+      match Resolved_config.of_config config with
+      | Ok _ -> false
+      | Error errors -> List.length errors >= 1)
+
+let non_finite_automerge_timeout_is_rejected () =
+  List.for_all
+    (fun automerge_timeout ->
+      let config =
+        {
+          (valid_config ~max_concurrency:1
+             ~max_ci_failures:Patch_agent.default_max_ci_failures)
+          with
+          Resolved_config.automerge_timeout;
+        }
+      in
+      Result.is_error (Resolved_config.of_config config))
+    [ Float.nan; Float.infinity; Float.neg_infinity ]
+
 let () =
   QCheck2.Test.check_exn max_concurrency_must_be_positive;
-  QCheck2.Test.check_exn max_ci_failures_must_be_positive
+  QCheck2.Test.check_exn max_ci_failures_must_be_positive;
+  QCheck2.Test.check_exn automerge_timeout_must_be_positive;
+  assert (non_finite_automerge_timeout_is_rejected ())

--- a/test/test_resolved_config_properties.ml
+++ b/test/test_resolved_config_properties.ml
@@ -84,8 +84,76 @@ let non_finite_automerge_timeout_is_rejected () =
       Result.is_error (Resolved_config.of_config config))
     [ Float.nan; Float.infinity; Float.neg_infinity ]
 
+let positive_automerge_timeout_is_preserved =
+  QCheck2.Test.make
+    ~name:"resolved config preserves valid automerge timeout values" ~count:500
+    QCheck2.Gen.(float_range 0.001 10000.)
+    (fun automerge_timeout ->
+      let config =
+        {
+          (valid_config ~max_concurrency:1
+             ~max_ci_failures:Patch_agent.default_max_ci_failures)
+          with
+          Resolved_config.automerge_timeout;
+        }
+      in
+      match Resolved_config.of_config config with
+      | Ok resolved ->
+          Float.equal resolved.Resolved_config.automerge_timeout
+            automerge_timeout
+      | Error _ -> false)
+
+let automerge_timeout_resolution_is_total =
+  QCheck2.Test.make ~name:"resolved config timeout validation is total"
+    ~count:1000 QCheck2.Gen.float (fun automerge_timeout ->
+      try
+        let config =
+          {
+            (valid_config ~max_concurrency:1
+               ~max_ci_failures:Patch_agent.default_max_ci_failures)
+            with
+            Resolved_config.automerge_timeout;
+          }
+        in
+        ignore (Resolved_config.of_config config);
+        true
+      with _ -> false)
+
+let repeated_resolution_order_independent =
+  QCheck2.Test.make
+    ~name:"repeated resolved config decisions are order independent" ~count:300
+    QCheck2.Gen.(list_size (int_range 0 40) (float_range 0.001 10000.))
+    (fun timeouts ->
+      let resolve automerge_timeout =
+        let config =
+          {
+            (valid_config ~max_concurrency:1
+               ~max_ci_failures:Patch_agent.default_max_ci_failures)
+            with
+            Resolved_config.automerge_timeout;
+          }
+        in
+        match Resolved_config.of_config config with
+        | Ok resolved -> Ok resolved.Resolved_config.automerge_timeout
+        | Error errors -> Error errors
+      in
+      let equal_result left right =
+        match (left, right) with
+        | Ok left, Ok right -> Float.equal left right
+        | Error left, Error right -> List.equal String.equal left right
+        | Ok _, Error _ | Error _, Ok _ -> false
+      in
+      let forward = List.map resolve timeouts in
+      let reverse_then_restore =
+        List.rev (List.map resolve (List.rev timeouts))
+      in
+      List.equal equal_result forward reverse_then_restore)
+
 let () =
   QCheck2.Test.check_exn max_concurrency_must_be_positive;
   QCheck2.Test.check_exn max_ci_failures_must_be_positive;
   QCheck2.Test.check_exn automerge_timeout_must_be_positive;
-  assert (non_finite_automerge_timeout_is_rejected ())
+  assert (non_finite_automerge_timeout_is_rejected ());
+  QCheck2.Test.check_exn positive_automerge_timeout_is_preserved;
+  QCheck2.Test.check_exn automerge_timeout_resolution_is_total;
+  QCheck2.Test.check_exn repeated_resolution_order_independent

--- a/test/test_resolved_config_validation_properties.ml
+++ b/test/test_resolved_config_validation_properties.ml
@@ -1,0 +1,55 @@
+(* @archlint.module test
+   @archlint.domain resolved-config *)
+
+open Onton_core
+
+let validation_is_total =
+  QCheck2.Test.make ~name:"automerge timeout validation is total" ~count:1000
+    QCheck2.Gen.float (fun timeout ->
+      try
+        ignore (Resolved_config_validation.automerge_timeout_error timeout);
+        true
+      with _ -> false)
+
+let validation_matches_contract =
+  QCheck2.Test.make
+    ~name:"automerge timeout validation accepts exactly positive finite values"
+    ~count:1000 QCheck2.Gen.float (fun timeout ->
+      let expected = Float.is_finite timeout && Float.compare timeout 0. > 0 in
+      Bool.equal expected
+        (Option.is_none
+           (Resolved_config_validation.automerge_timeout_error timeout)))
+
+let boundary_values_match_contract =
+  QCheck2.Test.make ~name:"automerge timeout validation handles boundaries"
+    ~count:1 QCheck2.Gen.unit (fun () ->
+      let invalid =
+        [ 0.; -0.; -1.; Float.nan; Float.infinity; Float.neg_infinity ]
+      in
+      let near_zero = Float.next_after 0. Float.infinity in
+      List.for_all
+        (fun timeout ->
+          Option.is_some
+            (Resolved_config_validation.automerge_timeout_error timeout))
+        invalid
+      && Option.is_none
+           (Resolved_config_validation.automerge_timeout_error near_zero))
+
+let repeated_validation_is_order_independent =
+  QCheck2.Test.make
+    ~name:"repeated automerge timeout validation is order independent"
+    ~count:300
+    QCheck2.Gen.(list_size (int_range 0 40) float)
+    (fun timeouts ->
+      let validate = Resolved_config_validation.automerge_timeout_error in
+      let forward = List.map validate timeouts in
+      let reverse_then_restore =
+        List.rev (List.map validate (List.rev timeouts))
+      in
+      List.equal (Option.equal String.equal) forward reverse_then_restore)
+
+let () =
+  QCheck2.Test.check_exn validation_is_total;
+  QCheck2.Test.check_exn validation_matches_contract;
+  QCheck2.Test.check_exn boundary_values_match_contract;
+  QCheck2.Test.check_exn repeated_validation_is_order_independent

--- a/test/test_resolved_config_validation_properties.ml
+++ b/test/test_resolved_config_validation_properties.ml
@@ -35,21 +35,26 @@ let boundary_values_match_contract =
       && Option.is_none
            (Resolved_config_validation.automerge_timeout_error near_zero))
 
-let repeated_validation_is_order_independent =
+let repeated_validation_matches_contract =
   QCheck2.Test.make
-    ~name:"repeated automerge timeout validation is order independent"
+    ~name:"repeated automerge timeout validation preserves the contract"
     ~count:300
-    QCheck2.Gen.(list_size (int_range 0 40) float)
+    QCheck2.Gen.(list_size (int_range 1 40) float)
     (fun timeouts ->
       let validate = Resolved_config_validation.automerge_timeout_error in
-      let forward = List.map validate timeouts in
-      let reverse_then_restore =
-        List.rev (List.map validate (List.rev timeouts))
-      in
-      List.equal (Option.equal String.equal) forward reverse_then_restore)
+      List.for_all
+        (fun timeout ->
+          let first = validate timeout in
+          let second = validate timeout in
+          let should_error =
+            (not (Float.is_finite timeout)) || Float.compare timeout 0. <= 0
+          in
+          Option.equal String.equal first second
+          && Bool.equal should_error (Option.is_some first))
+        timeouts)
 
 let () =
   QCheck2.Test.check_exn validation_is_total;
   QCheck2.Test.check_exn validation_matches_contract;
   QCheck2.Test.check_exn boundary_values_match_contract;
-  QCheck2.Test.check_exn repeated_validation_is_order_independent
+  QCheck2.Test.check_exn repeated_validation_matches_contract


### PR DESCRIPTION
## Summary

- add `--automerge-timeout SECONDS` and `ONTON_AUTOMERGE_TIMEOUT` overrides
- support a top-level `"automerge_timeout"` default in the per-repository Onton config
- persist the resolved timeout in project config so flag-less resumes retain it
- thread the configured value through initial deadlines, retries, merge-queue dequeue timing, and executor catch-up windows

Resolution precedence is CLI/environment override → stored project value → repository config → the existing 300-second built-in default.

Example repository config:

```json
{
  "automerge_timeout": 120
}
```

Values must be finite and greater than zero.

## User impact

Teams can shorten or lengthen the automerge idle window without rebuilding Onton, either for a single invocation or as a repository-wide default.

## Validation

- `dune fmt`
- `dune build`
- `dune runtest`
- CLI help inspection for `--automerge-timeout`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/412"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788216441&installation_model_id=19519&pr_number=412&repository=flowglad%2Fonton&return_to=https%3A%2F%2Fgithub.com%2Fflowglad%2Fonton%2Fpull%2F412&signature=1d908d31ada8d4141c8617ff4d2f5267a8e2316f6c5f93895bf68becf3f62415"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable automerge idle timeouts through command-line, environment, project, and repository settings.
  * Settings are persisted and retained when resuming runs unless explicitly overridden.
  * Automerge retries, reconciliation, and queue transitions now honor the configured timeout.

* **Bug Fixes**
  * Invalid timeout values, including zero, negative, non-numeric, or non-finite values, are rejected.

* **Documentation**
  * Updated interface text to describe the configurable idle timer after approval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->