### PR TITLE
Package setsid helper in releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,8 @@ jobs:
           mkdir -p _dist/bin
           cp _build/default/bin/main.exe _dist/bin/onton
           cp _build/default/bin/setsid_exec/main.exe _dist/bin/onton-setsid-exec
+          test -x _dist/bin/onton
+          test -x _dist/bin/onton-setsid-exec
           tar czf onton-${{ matrix.arch }}-apple-darwin.tar.gz \
             -C _dist/bin onton onton-setsid-exec
           test "$(tar tzf onton-${{ matrix.arch }}-apple-darwin.tar.gz | sort | tr '\n' ' ')" = \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,13 +60,17 @@ jobs:
         run: opam install . --deps-only --with-test -y
 
       - name: Build
-        run: opam exec -- dune build bin/main.exe
+        run: opam exec -- dune build bin/main.exe bin/setsid_exec/main.exe
 
       - name: Package binary
         run: |
           mkdir -p _dist/bin
           cp _build/default/bin/main.exe _dist/bin/onton
-          tar czf onton-${{ matrix.arch }}-apple-darwin.tar.gz -C _dist/bin onton
+          cp _build/default/bin/setsid_exec/main.exe _dist/bin/onton-setsid-exec
+          tar czf onton-${{ matrix.arch }}-apple-darwin.tar.gz \
+            -C _dist/bin onton onton-setsid-exec
+          test "$(tar tzf onton-${{ matrix.arch }}-apple-darwin.tar.gz | sort | tr '\n' ' ')" = \
+            "onton onton-setsid-exec "
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:

--- a/Formula/onton.rb.template
+++ b/Formula/onton.rb.template
@@ -20,7 +20,7 @@ class Onton < Formula
   depends_on "gmp"
 
   def install
-    bin.install "onton"
+    bin.install "onton", "onton-setsid-exec"
     # Rewrite CI's hardcoded libgmp path to this machine's Homebrew prefix
     old_path = Utils.popen_read("otool", "-L", bin/"onton")
       .lines.find { |l| l.include?("libgmp") }&.strip&.split&.first
@@ -32,5 +32,6 @@ class Onton < Formula
 
   test do
     assert_match "onton", shell_output("#{bin}/onton --version 2>&1", 0)
+    assert_predicate bin/"onton-setsid-exec", :executable?
   end
 end


### PR DESCRIPTION
## Summary

- build `bin/setsid_exec/main.exe` in the macOS release workflow
- package it beside `onton` as `onton-setsid-exec`
- install both executables from the generated Homebrew formula
- verify the release archive contents and helper executable bit

## Why

Onton already resolves `onton-setsid-exec` beside the main executable and uses it to isolate worker process groups. Release archives currently contain only `onton`, so installed releases silently fall back to launching without process-group isolation and worker grandchildren can reparent to PID 1 during teardown.

This keeps existing runtime behavior and interfaces intact while making release installations include the helper the runtime already expects.

## Validation

- `opam exec -- dune clean`
- `opam exec -- dune build`
- `opam exec -- dune build @install`
- `opam exec -- dune runtest`
- `opam exec -- dune build @fmt`
- `ruby -c Formula/onton.rb.template`
- release-shaped tarball contains exactly `onton` and `onton-setsid-exec`
- packaged `onton-setsid-exec` is executable

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/413"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788391571&installation_model_id=19519&pr_number=413&repository=flowglad%2Fonton&return_to=https%3A%2F%2Fgithub.com%2Fflowglad%2Fonton%2Fpull%2F413&signature=9b235134028e6804d315b4b36bdd62d2b9d21acf5acd970501954cc8fe680cd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * macOS release archives now include the `onton-setsid-exec` helper alongside the main `onton` executable.
  * Package installation now provides both executables.
  * Added validation to confirm release archives contain the expected files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->