### PR TITLE
Gate dependencies only before worktree materialization

### DIFF
--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -1103,6 +1103,7 @@ let apply_session_result t patch_id result =
       complete_failed t patch_id
   | Session_worktree_missing ->
       let t = update_agent t patch_id ~f:Patch_agent.on_pre_session_failure in
+      let t = update_agent t patch_id ~f:Patch_agent.clear_worktree_path in
       complete_failed t patch_id
   | Session_push_failed reason -> (
       (* The LLM session itself ran cleanly — clear its fallback state so we

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -416,14 +416,14 @@ let runnable_messages t =
   |> List.filter ~f:(fun msg ->
       match msg.status with
       | Pending -> (
-          (* Gate both [Start] and [Rebase] on base freshness. A [Rebase] of a
-             dependent must not run while its base is itself stale or mid-rebase
-             — otherwise it lands on a stale branch and needs a second rebase.
-             Gating it makes a fan-in/chain cascade block on its dependency
-             layers and converge bottom-up (main is always fresh), one rebase
-             per branch. The launching patch's [base_contains_merged_siblings]
-             cache supplies the sibling-containment input. [Respond] operates on
-             a worktree that already exists and is not freshness-sensitive. *)
+          (* Gate a [Start] on base freshness only when it will materialize the
+             worktree. A retry reuses an existing checkout and is no longer
+             sensitive to later base-branch state. [Rebase] always remains
+             gated: it must not run while its base is stale or mid-rebase, or it
+             would land on a stale branch and need a second rebase. The
+             launching patch's [base_contains_merged_siblings] cache supplies
+             the sibling-containment input. [Respond] also operates on an
+             existing worktree and is not freshness-sensitive. *)
           let eligibility patch_id base =
             let base_contains_merged_siblings =
               (agent t patch_id).Patch_agent.base_contains_merged_siblings
@@ -433,7 +433,10 @@ let runnable_messages t =
             | Start_eligibility.Defer _ -> false
           in
           match msg.action with
-          | Start (patch_id, base) -> eligibility patch_id base
+          | Start (patch_id, base) -> (
+              match Patch_agent.worktree_state (agent t patch_id) with
+              | Patch_agent.Unmaterialized -> eligibility patch_id base
+              | Patch_agent.Materialized _ -> true)
           | Rebase (patch_id, base) -> eligibility patch_id base
           | Respond _ -> true)
       | Acked ->

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -265,7 +265,8 @@ val apply_session_result : t -> Patch_id.t -> session_result -> t
     [Session_no_resume] -> on_session_failure (not fresh) + clear llm_session_id
     \+ complete_failed. [Session_give_up] -> set_session_failed +
     set_tried_fresh + clear llm_session_id + complete_failed.
-    [Session_worktree_missing] -> on_pre_session_failure + complete_failed.
+    [Session_worktree_missing] -> on_pre_session_failure + clear_worktree_path
+    + complete_failed.
 
     {b Deferred completion}: [Session_push_failed] and [Session_no_commits] do
     NOT complete the agent — they only adjust state ([clear_session_fallback] in

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -484,7 +484,8 @@ val apply_anchor_events :
 (** Fold {!Worktree_plan.anchor_event} observations into the agent without any
     other transition. Called by the runner Start path after executing
     {!Worktree_plan.for_start} to record the initial anchor for a
-    freshly-branched-off-dep patch, before the LLM session begins. *)
+    freshly-branched-off-dep patch, before the LLM session begins. Materialized
+    retries do not emit anchor events. *)
 
 type conflict_resolution =
   | Conflict_done

--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -461,14 +461,21 @@ let plan_action_for_patch t ~branch_map patch_id =
        is_pr_present rather than has_pr (which is true for [Missing] too). *)
     Patch_agent.is_pr_present (Orchestrator.agent t pid)
   in
+  let open_deps =
+    Graph.open_pr_deps (Orchestrator.graph t) patch_id ~has_merged
+  in
   let dependencies_allow_start =
+    List.length open_deps <= 1
+    &&
     match Patch_agent.worktree_state agent with
     | Patch_agent.Materialized _ ->
         (* Review-readiness protects the point where a dependency branch is
            cloned into a new worktree. Once that worktree exists, a failed or
            timed-out no-PR session retries in the same checkout; later CI,
            conflict, or PR-state changes on the dependency cannot make that
-           already-materialized checkout less safe to reuse. *)
+           already-materialized checkout less safe to reuse. The structural
+           cardinality guard remains because [Graph.initial_base] requires at
+           most one open dependency. *)
         true
     | Patch_agent.Unmaterialized ->
         Graph.deps_satisfied (Orchestrator.graph t) patch_id ~has_merged ~has_pr
@@ -476,9 +483,7 @@ let plan_action_for_patch t ~branch_map patch_id =
            dependency is review-ready: PR body delivered, no conflict, CI
            green. Merged deps are exempt because [open_pr_deps] filters them
            out. *)
-        && List.for_all
-             (Graph.open_pr_deps (Orchestrator.graph t) patch_id ~has_merged)
-             ~f:(fun dep -> open_dep_review_ready t dep)
+        && List.for_all open_deps ~f:(fun dep -> open_dep_review_ready t dep)
   in
   if
     (not (Patch_agent.has_pr agent))
@@ -1338,6 +1343,43 @@ let%test "plan_actions retries a materialized child without dependency gates" =
     Orchestrator.set_worktree_path t child_id "/tmp/materialized-child-worktree"
   in
   plans_child_start ~child_id ~patches t
+
+let%test "plan_actions defers a materialized child with multiple open deps" =
+  let parent_id, child_id, patches, _ = make_notes_gate_fixture () in
+  let parent_patch =
+    List.find_exn patches ~f:(fun patch ->
+        Patch_id.equal patch.Patch.id parent_id)
+  in
+  let child_patch =
+    List.find_exn patches ~f:(fun patch ->
+        Patch_id.equal patch.Patch.id child_id)
+  in
+  let sibling_id = Patch_id.of_string "sibling" in
+  let sibling_patch =
+    {
+      parent_patch with
+      id = sibling_id;
+      branch = Branch.of_string "sibling-branch";
+    }
+  in
+  let child_patch =
+    { child_patch with dependencies = [ parent_id; sibling_id ] }
+  in
+  let patches = [ parent_patch; sibling_patch; child_patch ] in
+  let start_with_pr t patch_id pr_number =
+    let t = Orchestrator.fire t (Orchestrator.Start (patch_id, main)) in
+    let t =
+      Orchestrator.set_pr_number t patch_id (Pr_number.of_int pr_number)
+    in
+    Orchestrator.complete t patch_id
+  in
+  let t = Orchestrator.create ~patches ~main_branch:main in
+  let t = start_with_pr t parent_id 41 in
+  let t = start_with_pr t sibling_id 42 in
+  let t =
+    Orchestrator.set_worktree_path t child_id "/tmp/materialized-fan-in"
+  in
+  not (plans_child_start ~child_id ~patches t)
 
 let%test "plan_actions does not gate child Start on a merged dep" =
   let parent_id, child_id, patches, t = make_notes_gate_fixture () in

--- a/lib/patch_controller.ml
+++ b/lib/patch_controller.ml
@@ -461,21 +461,31 @@ let plan_action_for_patch t ~branch_map patch_id =
        is_pr_present rather than has_pr (which is true for [Missing] too). *)
     Patch_agent.is_pr_present (Orchestrator.agent t pid)
   in
+  let dependencies_allow_start =
+    match Patch_agent.worktree_state agent with
+    | Patch_agent.Materialized _ ->
+        (* Review-readiness protects the point where a dependency branch is
+           cloned into a new worktree. Once that worktree exists, a failed or
+           timed-out no-PR session retries in the same checkout; later CI,
+           conflict, or PR-state changes on the dependency cannot make that
+           already-materialized checkout less safe to reuse. *)
+        true
+    | Patch_agent.Unmaterialized ->
+        Graph.deps_satisfied (Orchestrator.graph t) patch_id ~has_merged ~has_pr
+        (* A child may materialize its worktree only once its sole open-PR
+           dependency is review-ready: PR body delivered, no conflict, CI
+           green. Merged deps are exempt because [open_pr_deps] filters them
+           out. *)
+        && List.for_all
+             (Graph.open_pr_deps (Orchestrator.graph t) patch_id ~has_merged)
+             ~f:(fun dep -> open_dep_review_ready t dep)
+  in
   if
     (not (Patch_agent.has_pr agent))
     && (not agent.Patch_agent.busy)
     && (not agent.Patch_agent.merged)
     && (not (Patch_agent.needs_intervention agent))
-    && Graph.deps_satisfied (Orchestrator.graph t) patch_id ~has_merged ~has_pr
-    (* A child may only Start once its sole open-PR dependency is itself
-       review-ready ([open_dep_review_ready]): PR body delivered, no conflict,
-       CI green. This subsumes the older deps-notes-ready gate
-       ([pr_body_delivered] is one of its conjuncts). Merged deps are exempt:
-       [open_pr_deps] filters them out, so a human-merged parent that never
-       delivered notes can never strand its child. *)
-    && List.for_all
-         (Graph.open_pr_deps (Orchestrator.graph t) patch_id ~has_merged)
-         ~f:(fun dep -> open_dep_review_ready t dep)
+    && dependencies_allow_start
   then
     let branch_of pid =
       match Map.find branch_map pid with
@@ -1314,6 +1324,19 @@ let%test
   &&
   let t = Orchestrator.set_pr_body_delivered t parent_id true in
   let t = Orchestrator.set_checks_passing t parent_id true in
+  plans_child_start ~child_id ~patches t
+
+let%test "plan_actions retries a materialized child without dependency gates" =
+  let parent_id, child_id, patches, t = make_notes_gate_fixture () in
+  (* Exercise every dependency gate that applies to first materialization: the
+     parent has no PR, is not review-ready, and is resolving a conflict. The
+     child's existing worktree makes all of that irrelevant to retrying the
+     no-PR session in place. *)
+  let t = Orchestrator.clear_pr t parent_id in
+  let t = Orchestrator.set_has_conflict t parent_id in
+  let t =
+    Orchestrator.set_worktree_path t child_id "/tmp/materialized-child-worktree"
+  in
   plans_child_start ~child_id ~patches t
 
 let%test "plan_actions does not gate child Start on a merged dep" =

--- a/lib/runner_fiber_impl.ml
+++ b/lib/runner_fiber_impl.ml
@@ -895,7 +895,16 @@ struct
                                             ~fail_label:"start anchor capture"
                                             ~ancestor_ids
                                             (Worktree_plan.for_start
-                                               ~base:base_branch)
+                                               ~base:base_branch
+                                               ~materialized:
+                                                 (match
+                                                    Patch_agent.worktree_state
+                                                      agent
+                                                  with
+                                                 | Patch_agent.Materialized _ ->
+                                                     true
+                                                 | Patch_agent.Unmaterialized ->
+                                                     false))
                                         in
                                         (match start_anchor_events with
                                         | [] -> ()

--- a/lib_core/patch_agent.ml
+++ b/lib_core/patch_agent.ml
@@ -11,6 +11,9 @@ type session_fallback = Fresh_available | Tried_fresh | Given_up
 type op_state = Queued | Running
 [@@deriving show, eq, sexp_of, compare, yojson]
 
+type worktree_state = Unmaterialized | Materialized of string
+[@@deriving show, eq, sexp_of, compare]
+
 type t = {
   patch_id : Patch_id.t;
   branch : Branch.t;
@@ -481,6 +484,11 @@ let on_pre_session_failure t =
 
 let set_checks_passing t v = { t with checks_passing = v }
 let set_worktree_path t path = { t with worktree_path = Some path }
+
+let worktree_state t =
+  match t.worktree_path with
+  | None -> Unmaterialized
+  | Some path -> Materialized path
 
 (* Every approval precondition *except* [merge_ready] (the component-derived
    readiness, [Pr_state.merge_ready_of]). Factored out so [reconcile_automerge]

--- a/lib_core/patch_agent.ml
+++ b/lib_core/patch_agent.ml
@@ -484,6 +484,7 @@ let on_pre_session_failure t =
 
 let set_checks_passing t v = { t with checks_passing = v }
 let set_worktree_path t path = { t with worktree_path = Some path }
+let clear_worktree_path t = { t with worktree_path = None }
 
 let worktree_state t =
   match t.worktree_path with

--- a/lib_core/patch_agent.ml
+++ b/lib_core/patch_agent.ml
@@ -772,6 +772,11 @@ let mark_pr_missing t =
 let start t ~base_branch =
   if has_pr t then invalid_arg "Patch_agent.start: patch already has a PR";
   if t.busy then invalid_arg "Patch_agent.start: patch is already busy";
+  let branch_rebased_onto =
+    match worktree_state t with
+    | Unmaterialized -> Some base_branch
+    | Materialized _ -> t.branch_rebased_onto
+  in
   {
     t with
     has_session = true;
@@ -782,10 +787,10 @@ let start t ~base_branch =
     satisfies = true;
     base_branch = Some base_branch;
     notified_base_branch = Some base_branch;
-    (* The initial Start plants the branch on [base_branch]; the local branch
-       tip is literally this base's HEAD until the agent commits. Record it
-       so the drift detector knows the branch is on the right base. *)
-    branch_rebased_onto = Some base_branch;
+    (* The initial Start plants the branch on [base_branch]. A retry in an
+       existing checkout only changes the structural base supplied to the
+       session; it does not physically rebase that checkout. *)
+    branch_rebased_onto;
     ci_checks = [];
   }
 

--- a/lib_core/patch_agent.mli
+++ b/lib_core/patch_agent.mli
@@ -280,7 +280,9 @@ val start : t -> base_branch:Types.Branch.t -> t
 (** [PatchCtx ~> Start] — begin work on a patch. Preconditions (checked):
     [~has_pr], [~busy]. Caller must verify [in_gameplan] and [deps_satisfied]
     externally. Postconditions: [has_session], [busy], [satisfies],
-    [base_branch = Some base_branch]. *)
+    [base_branch = Some base_branch]. An unmaterialized start records
+    [branch_rebased_onto = Some base_branch]; a materialized retry preserves the
+    existing physical rebase anchor. *)
 
 val rebase : t -> base_branch:Types.Branch.t -> t
 (** [PatchCtx ~> Rebase] — orchestrator-executed rebase. Preconditions:

--- a/lib_core/patch_agent.mli
+++ b/lib_core/patch_agent.mli
@@ -503,6 +503,10 @@ val set_checks_passing : t -> bool -> t
 val set_worktree_path : t -> string -> t
 (** Store the resolved worktree path for this patch. *)
 
+val clear_worktree_path : t -> t
+(** Clear a worktree path that recovery has proven is no longer live. The next
+    Start is consequently treated as first materialization. *)
+
 val worktree_state : t -> worktree_state
 (** The worktree lifecycle, independent of whether the patch session is queued
     or running. Dependency readiness gates only [Unmaterialized]; a retry in

--- a/lib_core/patch_agent.mli
+++ b/lib_core/patch_agent.mli
@@ -15,6 +15,9 @@ type session_fallback = Fresh_available | Tried_fresh | Given_up
 type op_state = Queued | Running
 [@@deriving show, eq, sexp_of, compare, yojson]
 
+type worktree_state = Unmaterialized | Materialized of string
+[@@deriving show, eq, sexp_of, compare]
+
 type t = private {
   patch_id : Types.Patch_id.t;
   branch : Types.Branch.t;
@@ -497,6 +500,12 @@ val set_checks_passing : t -> bool -> t
 
 val set_worktree_path : t -> string -> t
 (** Store the resolved worktree path for this patch. *)
+
+val worktree_state : t -> worktree_state
+(** The worktree lifecycle, independent of whether the patch session is queued
+    or running. Dependency readiness gates only [Unmaterialized]; a retry in
+    [Materialized _] operates on its existing checkout and must not be re-gated
+    on later dependency state changes. *)
 
 val is_approved_modulo_merge_ready : t -> main_branch:Types.Branch.t -> bool
 (** Every approval precondition except [merge_ready]. A patch satisfying this

--- a/lib_core/worktree_plan.ml
+++ b/lib_core/worktree_plan.ml
@@ -41,13 +41,15 @@ let for_merge_conflict ~base =
     Record_anchor_on_success { slot = 0; base };
   ]
 
-let for_start ~base =
-  [
-    Ensure_worktree;
-    Fetch_origin;
-    Capture_anchor { ref_name = ref_string_of base; slot = 0 };
-    Record_anchor_on_success { slot = 0; base };
-  ]
+let for_start ~base ~materialized =
+  if materialized then [ Ensure_worktree ]
+  else
+    [
+      Ensure_worktree;
+      Fetch_origin;
+      Capture_anchor { ref_name = ref_string_of base; slot = 0 };
+      Record_anchor_on_success { slot = 0; base };
+    ]
 
 let ensures_worktree_before_fs (plan : t) =
   let rec loop ensured = function

--- a/lib_core/worktree_plan.mli
+++ b/lib_core/worktree_plan.mli
@@ -54,13 +54,15 @@ val for_merge_conflict : base:Types.Branch.t -> t
 (** Plan for the merge-conflict resolution path (post rebase-in-progress check):
     ensure the worktree, fetch, then rebase onto [origin/<base>]. *)
 
-val for_start : base:Types.Branch.t -> t
+val for_start : base:Types.Branch.t -> materialized:bool -> t
 (** Plan executed by the runner Start path BEFORE the LLM session begins: ensure
-    worktree, fetch, capture [origin/<base>]'s tip into slot 0, then record an
-    anchor referencing that SHA. Records the initial anchor for a
-    freshly-branched-off-dep patch — closing the production bug blind spot where
-    Start never wrote an anchor and the first rebase (post-squash) had nothing
-    safe to fall back to. *)
+    the worktree and, when [materialized = false], fetch, capture
+    [origin/<base>]'s tip into slot 0, then record an anchor referencing that
+    SHA. This records the initial anchor for a freshly-branched-off-dep patch —
+    closing the production bug blind spot where Start never wrote an anchor and
+    the first rebase (post-squash) had nothing safe to fall back to. A
+    materialized retry emits no anchor operations because it does not physically
+    rebase the existing checkout. *)
 
 val ensures_worktree_before_fs : t -> bool
 (** Returns [true] iff every non-{!Ensure_worktree} op is preceded by an

--- a/test/dune
+++ b/test/dune
@@ -564,6 +564,13 @@
  (ocamlc_flags (:standard -w -40-42)))
 
 (test
+ (name test_worktree_start_state_interleavings)
+ (modules test_worktree_start_state_interleavings)
+ (libraries onton onton_core onton_test_support qcheck-core qcheck-core.runner)
+ (ocamlopt_flags (:standard -w -40-42))
+ (ocamlc_flags (:standard -w -40-42)))
+
+(test
  (name test_fanin_liveness_interleavings)
  (modules test_fanin_liveness_interleavings)
  (libraries onton onton_core onton_test_support qcheck-core qcheck-core.runner)

--- a/test/test_intervention_reason.ml
+++ b/test/test_intervention_reason.ml
@@ -326,6 +326,7 @@ let () =
              (fun a -> Patch_agent.set_merge_queue_required a flag);
              (fun a -> Patch_agent.set_mergeability_unknown a flag);
              (fun a -> Patch_agent.set_worktree_path a "/tmp/wt");
+             (fun a -> Patch_agent.clear_worktree_path a);
            ]
          in
          let a =
@@ -336,6 +337,7 @@ let () =
          let _history = Patch_agent.anchor_history a in
          let _in_merge_queue = Patch_agent.in_merge_queue a in
          let _priority = Patch_agent.highest_priority a in
+         let _worktree_state = Patch_agent.worktree_state a in
          let _approved =
            Patch_agent.is_approved_modulo_merge_ready a ~main_branch:main
          in

--- a/test/test_patch_agent.ml
+++ b/test/test_patch_agent.ml
@@ -1328,6 +1328,7 @@ let () =
           ignore bump_generation;
           ignore clear_automerge_deadline;
           ignore clear_branch_blocked;
+          ignore clear_worktree_path;
           ignore clear_pr;
           ignore clear_session_fallback;
           ignore highest_priority;

--- a/test/test_stale_base_invariants.ml
+++ b/test/test_stale_base_invariants.ml
@@ -329,14 +329,21 @@ let base_is_fresh m base =
           | [ d ], Some b -> Branch.equal b (branch_of_patches m.patches d)
           | _ -> false)
 
-(** SBI: every [Start (_, base)] surfaced by [runnable_messages] has a fresh
-    [base] per [base_is_fresh]. [Enqueue_start] seeds the outbox with real
-    Pending Starts whose base varies, so this is non-vacuous. *)
-let sbi_runnable_starts_are_fresh m =
+(** SBI: every [Start (_, base)] that will materialize a worktree has a fresh
+    [base] per [base_is_fresh]. A retry with an existing worktree deliberately
+    bypasses dependency freshness because its checkout has already been cut.
+    [Enqueue_start] seeds the outbox with real Pending Starts whose base varies,
+    so this is non-vacuous. *)
+let sbi_materializing_starts_are_fresh m =
   let runnable = Orchestrator.runnable_messages m.orch in
   List.for_all runnable ~f:(fun msg ->
       match Orchestrator.message_action msg with
-      | Orchestrator.Start (_, base) -> base_is_fresh m base
+      | Orchestrator.Start (patch_id, base) -> (
+          match
+            Patch_agent.worktree_state (Orchestrator.agent m.orch patch_id)
+          with
+          | Patch_agent.Unmaterialized -> base_is_fresh m base
+          | Patch_agent.Materialized _ -> true)
       | Orchestrator.Rebase _ | Orchestrator.Respond _ -> true)
 
 (** SBI-2 (liveness): any patch deferred by the freshness gate is making
@@ -474,7 +481,9 @@ let gen_command_seq ~n_patches =
 
 let prop_sbi_holds =
   QCheck2.Test.make ~count:300
-    ~name:"SBI: every Start in runnable_messages is freshness-eligible (Allow)"
+    ~name:
+      "SBI: every materializing Start in runnable_messages is \
+       freshness-eligible"
     Gen.(
       let* n_patches = int_range 2 4 in
       let* cmds = gen_command_seq ~n_patches in
@@ -484,7 +493,7 @@ let prop_sbi_holds =
       let _final, ok =
         List.fold cmds ~init:(m, true) ~f:(fun (m, ok) cmd ->
             let m = apply_command m cmd in
-            (m, ok && sbi_runnable_starts_are_fresh m))
+            (m, ok && sbi_materializing_starts_are_fresh m))
       in
       ok)
 

--- a/test/test_worktree_missing_recovery.ml
+++ b/test/test_worktree_missing_recovery.ml
@@ -110,8 +110,13 @@ let () =
   let orch = Orchestrator.create ~patches ~main_branch:main in
   (* Drive the agent to busy without a PR (start path). *)
   let orch = Orchestrator.fire orch (Orchestrator.Start (pid, main)) in
+  let orch = Orchestrator.set_worktree_path orch pid "/tmp/deleted-worktree" in
   let agent_before = Orchestrator.agent orch pid in
   assert_true "agent_before busy" agent_before.Patch_agent.busy;
+  assert_true "agent_before materialized"
+    (Patch_agent.equal_worktree_state
+       (Patch_agent.worktree_state agent_before)
+       (Patch_agent.Materialized "/tmp/deleted-worktree"));
   let attempts_before = agent_before.Patch_agent.start_attempts_without_pr in
   let orch =
     Orchestrator.apply_session_result orch pid
@@ -119,6 +124,10 @@ let () =
   in
   let agent_after = Orchestrator.agent orch pid in
   assert_true "agent_after not busy" (not agent_after.Patch_agent.busy);
+  assert_true "agent_after unmaterialized"
+    (Patch_agent.equal_worktree_state
+       (Patch_agent.worktree_state agent_after)
+       Patch_agent.Unmaterialized);
   let attempts_after = agent_after.Patch_agent.start_attempts_without_pr in
   if not (Int.equal attempts_after (attempts_before + 1)) then
     failwith

--- a/test/test_worktree_plan.ml
+++ b/test/test_worktree_plan.ml
@@ -89,14 +89,16 @@ let () =
         gen_branch (fun base ->
           ensures_worktree_before_fs (for_merge_conflict ~base));
       Test.make ~name:"for_start: ensures worktree before any fs op" gen_branch
-        (fun base -> ensures_worktree_before_fs (for_start ~base));
+        (fun base ->
+          ensures_worktree_before_fs (for_start ~base ~materialized:false));
       Test.make ~name:"for_rebase: first op is Ensure_worktree" gen_branch
         (fun new_base -> first_op_is_ensure_worktree (for_rebase ~new_base));
       Test.make ~name:"for_merge_conflict: first op is Ensure_worktree"
         gen_branch (fun base ->
           first_op_is_ensure_worktree (for_merge_conflict ~base));
       Test.make ~name:"for_start: first op is Ensure_worktree" gen_branch
-        (fun base -> first_op_is_ensure_worktree (for_start ~base));
+        (fun base ->
+          first_op_is_ensure_worktree (for_start ~base ~materialized:false));
       Test.make ~name:"for_rebase: rebase target is origin/<new_base>"
         gen_branch (fun new_base ->
           let target =
@@ -110,7 +112,7 @@ let () =
       (* for_start has no Rebase_onto — it just captures and records. *)
       Test.make ~name:"for_start: no Rebase_onto op" gen_branch (fun base ->
           not
-            (List.exists (for_start ~base) ~f:(function
+            (List.exists (for_start ~base ~materialized:false) ~f:(function
               | Rebase_onto _ -> true
               | Ensure_worktree | Fetch_origin | Capture_anchor _
               | Record_anchor_on_success _ ->
@@ -118,11 +120,16 @@ let () =
       Test.make
         ~name:"for_start: includes Capture_anchor for origin/<base> in slot 0"
         gen_branch (fun base ->
-          plan_has_capture_for_slot (for_start ~base)
+          plan_has_capture_for_slot
+            (for_start ~base ~materialized:false)
             ("origin/" ^ Branch.to_string base)
             0);
       Test.make ~name:"for_start: includes Record_anchor_on_success for base"
-        gen_branch (fun base -> plan_has_record_for (for_start ~base) base);
+        gen_branch (fun base ->
+          plan_has_record_for (for_start ~base ~materialized:false) base);
+      Test.make ~name:"for_start: materialized retry emits no anchor operations"
+        gen_branch (fun base ->
+          equal (for_start ~base ~materialized:true) [ Ensure_worktree ]);
       Test.make ~name:"ensures_worktree_before_fs: agrees with reference"
         gen_plan (fun plan ->
           Bool.equal

--- a/test/test_worktree_start_state_interleavings.ml
+++ b/test/test_worktree_start_state_interleavings.ml
@@ -163,23 +163,21 @@ let prop_unmaterialized_gate_safety =
     ~count:500 gen_dependency_ops (fun ops ->
       try
         let patches, parent, child, orch = bootstrap () in
-        let rec loop orch = function
-          | ops -> (
-              let child_agent = Orchestrator.agent orch child in
-              let invariant =
-                Patch_agent.equal_worktree_state
-                  (Patch_agent.worktree_state child_agent)
-                  Patch_agent.Unmaterialized
-                && (dependency_materialization_ready orch parent
-                   || not (child_start_planned orch ~patches ~child))
-              in
-              invariant
-              &&
-              match ops with
-              | [] -> true
-              | op :: rest -> loop (apply_dependency_op orch parent op) rest)
+        let invariant orch =
+          let child_agent = Orchestrator.agent orch child in
+          Patch_agent.equal_worktree_state
+            (Patch_agent.worktree_state child_agent)
+            Patch_agent.Unmaterialized
+          && (dependency_materialization_ready orch parent
+             || not (child_start_planned orch ~patches ~child))
         in
-        loop orch ops
+        let rec loop orch = function
+          | [] -> true
+          | op :: rest ->
+              let orch = apply_dependency_op orch parent op in
+              invariant orch && loop orch rest
+        in
+        invariant orch && loop orch ops
       with _ -> false)
 
 (** WSI-2: once the cut exists, every dependency-state prefix still plans the

--- a/test/test_worktree_start_state_interleavings.ml
+++ b/test/test_worktree_start_state_interleavings.ml
@@ -1,0 +1,338 @@
+(* @archlint.module test
+   @archlint.domain orchestrator *)
+
+open Base
+open Onton
+open Onton_core
+open Onton_core.Types
+
+(** Worktree-start-state interleaving properties.
+
+    Patch scheduling and worktree materialization are independent state axes:
+
+    - [Unmaterialized] means the next no-PR Start will cut a new worktree, so
+      dependency availability, review-readiness, and base freshness gate it.
+    - [Materialized path] means the checkout already exists. A failed or timed-
+      out no-PR session retries in that checkout, so subsequent dependency state
+      changes cannot gate the retry.
+
+    The properties below drive the real patch controller and orchestrator over
+    arbitrary interleavings of dependency PR/CI/review/conflict/rebase/merge
+    changes and child session lifecycle changes. *)
+
+let main = Branch.of_string "main"
+let patches () = Onton_test_support.Test_generators.mk_linear_patches 2
+
+let parent_and_child patches =
+  ( Onton_test_support.Test_generators.pid_of_idx patches 0,
+    Onton_test_support.Test_generators.pid_of_idx patches 1 )
+
+let bootstrap () =
+  let patches = patches () in
+  let parent, child = parent_and_child patches in
+  let orch = Orchestrator.create ~patches ~main_branch:main in
+  let orch = Orchestrator.fire orch (Orchestrator.Start (parent, main)) in
+  let orch = Orchestrator.set_pr_number orch parent (Pr_number.of_int 1) in
+  let orch = Orchestrator.complete orch parent in
+  (patches, parent, child, orch)
+
+let child_start_action orch ~patches ~child =
+  Patch_controller.plan_actions orch ~patches
+  |> List.find ~f:(function
+    | Orchestrator.Start (patch_id, _) -> Patch_id.equal patch_id child
+    | Orchestrator.Respond _ | Orchestrator.Rebase _ -> false)
+
+let child_start_planned orch ~patches ~child =
+  Option.is_some (child_start_action orch ~patches ~child)
+
+type dependency_op =
+  | Pr_present
+  | Pr_absent
+  | Checks_passing
+  | Checks_failing
+  | Notes_delivered
+  | Notes_missing
+  | Conflict_detected
+  | Conflict_cleared
+  | Rebase_enqueued
+  | Rebase_started
+  | Rebase_finished
+  | Merged
+
+let gen_dependency_op =
+  QCheck2.Gen.oneof_list
+    [
+      Pr_present;
+      Pr_absent;
+      Checks_passing;
+      Checks_failing;
+      Notes_delivered;
+      Notes_missing;
+      Conflict_detected;
+      Conflict_cleared;
+      Rebase_enqueued;
+      Rebase_started;
+      Rebase_finished;
+      Merged;
+    ]
+
+let gen_dependency_ops =
+  QCheck2.Gen.list_size (QCheck2.Gen.int_range 0 80) gen_dependency_op
+
+let gen_materialized_path =
+  QCheck2.Gen.map
+    (fun suffix -> "/tmp/worktree-start-state-child-" ^ Int.to_string suffix)
+    QCheck2.Gen.nat_small
+
+let gen_path_and_dependency_ops =
+  QCheck2.Gen.pair gen_materialized_path gen_dependency_ops
+
+let apply_dependency_op orch parent = function
+  | Pr_present ->
+      let agent = Orchestrator.agent orch parent in
+      if agent.Patch_agent.merged || Patch_agent.has_pr agent then orch
+      else Orchestrator.set_pr_number orch parent (Pr_number.of_int 1)
+  | Pr_absent ->
+      let agent = Orchestrator.agent orch parent in
+      if
+        agent.Patch_agent.merged || agent.Patch_agent.busy
+        || not (Patch_agent.is_pr_present agent)
+      then orch
+      else Orchestrator.clear_pr orch parent
+  | Checks_passing -> Orchestrator.set_checks_passing orch parent true
+  | Checks_failing -> Orchestrator.set_checks_passing orch parent false
+  | Notes_delivered -> Orchestrator.set_pr_body_delivered orch parent true
+  | Notes_missing -> Orchestrator.set_pr_body_delivered orch parent false
+  | Conflict_detected -> Orchestrator.set_has_conflict orch parent
+  | Conflict_cleared -> Orchestrator.clear_has_conflict orch parent
+  | Rebase_enqueued ->
+      let agent = Orchestrator.agent orch parent in
+      if
+        agent.Patch_agent.merged || agent.Patch_agent.busy
+        || not (Patch_agent.is_pr_present agent)
+      then orch
+      else Orchestrator.enqueue orch parent Operation_kind.Rebase
+  | Rebase_started ->
+      let agent = Orchestrator.agent orch parent in
+      if
+        agent.Patch_agent.merged || agent.Patch_agent.busy
+        || not (Patch_agent.is_pr_present agent)
+      then orch
+      else
+        let orch = Orchestrator.enqueue orch parent Operation_kind.Rebase in
+        let agent = Orchestrator.agent orch parent in
+        if
+          Option.equal Operation_kind.equal
+            (Patch_agent.highest_priority agent)
+            (Some Operation_kind.Rebase)
+        then Orchestrator.fire orch (Orchestrator.Rebase (parent, main))
+        else orch
+  | Rebase_finished ->
+      let agent = Orchestrator.agent orch parent in
+      if
+        agent.Patch_agent.busy
+        && Option.equal Operation_kind.equal agent.Patch_agent.current_op
+             (Some Operation_kind.Rebase)
+      then Orchestrator.apply_rebase_result orch parent Worktree.Ok main |> fst
+      else orch
+  | Merged ->
+      let agent = Orchestrator.agent orch parent in
+      if agent.Patch_agent.merged then orch
+      else Orchestrator.mark_merged orch parent
+
+let dependency_materialization_ready orch parent =
+  let agent = Orchestrator.agent orch parent in
+  agent.Patch_agent.merged
+  || Patch_agent.is_pr_present agent
+     && agent.Patch_agent.pr_body_delivered
+     && (not agent.Patch_agent.has_conflict)
+     && agent.Patch_agent.checks_passing
+
+let materialized_with_same_path orch child expected_path =
+  match Patch_agent.worktree_state (Orchestrator.agent orch child) with
+  | Patch_agent.Materialized path -> String.equal path expected_path
+  | Patch_agent.Unmaterialized -> false
+
+(** WSI-1: before the cut, every prefix whose dependency is unavailable or not
+    review-ready keeps the child Start blocked. This is the safety half of the
+    state distinction. *)
+let prop_unmaterialized_gate_safety =
+  QCheck2.Test.make
+    ~name:
+      "WSI-1: Unmaterialized Start stays gated across dependency interleavings"
+    ~count:500 gen_dependency_ops (fun ops ->
+      try
+        let patches, parent, child, orch = bootstrap () in
+        let rec loop orch = function
+          | ops -> (
+              let child_agent = Orchestrator.agent orch child in
+              let invariant =
+                Patch_agent.equal_worktree_state
+                  (Patch_agent.worktree_state child_agent)
+                  Patch_agent.Unmaterialized
+                && (dependency_materialization_ready orch parent
+                   || not (child_start_planned orch ~patches ~child))
+              in
+              invariant
+              &&
+              match ops with
+              | [] -> true
+              | op :: rest -> loop (apply_dependency_op orch parent op) rest)
+        in
+        loop orch ops
+      with _ -> false)
+
+(** WSI-2: once the cut exists, every dependency-state prefix still plans the
+    child's no-PR retry. This covers CI regression, missing/changed PR state,
+    conflicts, queued/running rebases, and merge transitions in any order. *)
+let prop_materialized_retry_dependency_invariance =
+  QCheck2.Test.make
+    ~name:"WSI-2: Materialized retry ignores all later dependency interleavings"
+    ~count:500 gen_path_and_dependency_ops (fun (path, ops) ->
+      try
+        let patches, parent, child, orch = bootstrap () in
+        let orch = Orchestrator.set_worktree_path orch child path in
+        let rec loop orch = function
+          | ops -> (
+              materialized_with_same_path orch child path
+              && child_start_planned orch ~patches ~child
+              &&
+              match ops with
+              | [] -> true
+              | op :: rest -> loop (apply_dependency_op orch parent op) rest)
+        in
+        loop orch ops
+      with _ -> false)
+
+type lifecycle_op =
+  | Dependency of dependency_op
+  | Schedule_child
+  | Fail_child
+  | Complete_child
+  | Land_child_pr
+  | Clear_child_pr
+  | Send_child_message
+  | Reset_child_intervention
+
+let gen_lifecycle_op =
+  QCheck2.Gen.oneof_weighted
+    [
+      (5, QCheck2.Gen.map (fun op -> Dependency op) gen_dependency_op);
+      (1, QCheck2.Gen.return Schedule_child);
+      (1, QCheck2.Gen.return Fail_child);
+      (1, QCheck2.Gen.return Complete_child);
+      (1, QCheck2.Gen.return Land_child_pr);
+      (1, QCheck2.Gen.return Clear_child_pr);
+      (1, QCheck2.Gen.return Send_child_message);
+      (1, QCheck2.Gen.return Reset_child_intervention);
+    ]
+
+let gen_lifecycle_ops =
+  QCheck2.Gen.list_size (QCheck2.Gen.int_range 1 100) gen_lifecycle_op
+
+let gen_path_and_lifecycle_ops =
+  QCheck2.Gen.pair gen_materialized_path gen_lifecycle_ops
+
+let apply_lifecycle_op orch ~patches ~parent ~child = function
+  | Dependency op -> apply_dependency_op orch parent op
+  | Schedule_child -> (
+      match child_start_action orch ~patches ~child with
+      | Some action -> Orchestrator.fire orch action
+      | None -> orch)
+  | Fail_child ->
+      let agent = Orchestrator.agent orch child in
+      if agent.Patch_agent.busy then
+        Orchestrator.apply_session_result orch child
+          (Orchestrator.Session_failed
+             { is_fresh = true; detail = Some "interleaving timeout" })
+      else orch
+  | Complete_child ->
+      let agent = Orchestrator.agent orch child in
+      if agent.Patch_agent.busy then Orchestrator.complete orch child else orch
+  | Land_child_pr ->
+      let agent = Orchestrator.agent orch child in
+      if agent.Patch_agent.merged || Patch_agent.has_pr agent then orch
+      else
+        let orch = Orchestrator.set_pr_number orch child (Pr_number.of_int 2) in
+        if (Orchestrator.agent orch child).Patch_agent.busy then
+          Orchestrator.complete orch child
+        else orch
+  | Clear_child_pr ->
+      let agent = Orchestrator.agent orch child in
+      if agent.Patch_agent.busy || not (Patch_agent.is_pr_present agent) then
+        orch
+      else Orchestrator.clear_pr orch child
+  | Send_child_message -> Orchestrator.send_human_message orch child "continue"
+  | Reset_child_intervention -> Orchestrator.reset_intervention_state orch child
+
+(** WSI-3: materialization is sticky across both axes of the state machine.
+    Session scheduling/failure/completion, PR creation/recreation, human input,
+    intervention resets, and arbitrary dependency changes never erase or alter
+    the established checkout. *)
+let prop_materialized_state_is_sticky =
+  QCheck2.Test.make
+    ~name:
+      "WSI-3: Materialized path is sticky across full lifecycle interleavings"
+    ~count:500 gen_path_and_lifecycle_ops (fun (path, ops) ->
+      try
+        let patches, parent, child, orch = bootstrap () in
+        let orch = Orchestrator.set_worktree_path orch child path in
+        let rec loop orch = function
+          | [] -> materialized_with_same_path orch child path
+          | op :: rest ->
+              let orch = apply_lifecycle_op orch ~patches ~parent ~child op in
+              materialized_with_same_path orch child path && loop orch rest
+        in
+        loop orch ops
+      with _ -> false)
+
+(** WSI-4: the Patch 6 witness generalized over arbitrary dependency suffixes.
+    The same unsafe dependency snapshot blocks before materialization, allows a
+    Start immediately after materialization, survives a timed-out fresh session,
+    and remains retryable after every later dependency interleaving. *)
+let prop_materialization_is_the_gate_cutover =
+  QCheck2.Test.make
+    ~name:
+      "WSI-4: materialization is the one-way cutover from gated Start to retry"
+    ~count:500 gen_path_and_dependency_ops (fun (path, ops) ->
+      try
+        let patches, parent, child, orch = bootstrap () in
+        let orch = Orchestrator.clear_pr orch parent in
+        let orch = Orchestrator.set_checks_passing orch parent false in
+        let orch = Orchestrator.set_pr_body_delivered orch parent false in
+        let orch = Orchestrator.set_has_conflict orch parent in
+        if child_start_planned orch ~patches ~child then false
+        else
+          let orch = Orchestrator.set_worktree_path orch child path in
+          match child_start_action orch ~patches ~child with
+          | None -> false
+          | Some action ->
+              let orch = Orchestrator.fire orch action in
+              let orch =
+                Orchestrator.apply_session_result orch child
+                  (Orchestrator.Session_failed
+                     { is_fresh = true; detail = Some "timed out" })
+              in
+              let rec loop orch = function
+                | [] ->
+                    materialized_with_same_path orch child path
+                    && child_start_planned orch ~patches ~child
+                | op :: rest ->
+                    let orch = apply_dependency_op orch parent op in
+                    materialized_with_same_path orch child path
+                    && child_start_planned orch ~patches ~child
+                    && loop orch rest
+              in
+              loop orch ops
+      with _ -> false)
+
+let () =
+  let runner = QCheck_base_runner.run_tests_main in
+  ignore
+    (runner
+       [
+         prop_unmaterialized_gate_safety;
+         prop_materialized_retry_dependency_invariance;
+         prop_materialized_state_is_sticky;
+         prop_materialization_is_the_gate_cutover;
+       ])

--- a/test/test_worktree_start_state_interleavings.ml
+++ b/test/test_worktree_start_state_interleavings.ml
@@ -324,6 +324,41 @@ let prop_materialization_is_the_gate_cutover =
               loop orch ops
       with _ -> false)
 
+(** WSI-5: after a parent merges, the structural base for a materialized child
+    retry changes to main, but firing that retry must not claim the existing
+    checkout was physically rebased. *)
+let prop_materialized_retry_preserves_rebase_anchor =
+  QCheck2.Test.make
+    ~name:"WSI-5: materialized retry preserves the physical rebase anchor"
+    ~count:1 QCheck2.Gen.unit (fun () ->
+      try
+        let patches, parent, child, orch = bootstrap () in
+        let orch = Orchestrator.set_pr_body_delivered orch parent true in
+        let orch = Orchestrator.set_checks_passing orch parent true in
+        match child_start_action orch ~patches ~child with
+        | Some (Orchestrator.Start (_, original_base) as action) -> (
+            let orch = Orchestrator.fire orch action in
+            let orch = Orchestrator.set_worktree_path orch child "/tmp/child" in
+            let orch =
+              Orchestrator.apply_session_result orch child
+                (Orchestrator.Session_failed
+                   { is_fresh = true; detail = Some "retry after parent merge" })
+            in
+            let orch = Orchestrator.mark_merged orch parent in
+            match child_start_action orch ~patches ~child with
+            | Some (Orchestrator.Start (_, retry_base) as retry) ->
+                let orch = Orchestrator.fire orch retry in
+                let child_agent = Orchestrator.agent orch child in
+                Branch.equal retry_base main
+                && (not (Branch.equal original_base retry_base))
+                && Option.equal Branch.equal
+                     child_agent.Patch_agent.branch_rebased_onto
+                     (Some original_base)
+            | Some (Orchestrator.Respond _ | Orchestrator.Rebase _) | None ->
+                false)
+        | Some (Orchestrator.Respond _ | Orchestrator.Rebase _) | None -> false
+      with _ -> false)
+
 let () =
   let runner = QCheck_base_runner.run_tests_main in
   ignore
@@ -333,4 +368,5 @@ let () =
          prop_materialized_retry_dependency_invariance;
          prop_materialized_state_is_sticky;
          prop_materialization_is_the_gate_cutover;
+         prop_materialized_retry_preserves_rebase_anchor;
        ])


### PR DESCRIPTION
## What changed

- distinguish worktree lifecycle as `Unmaterialized` or `Materialized path`, independently of whether a session is pending or started
- apply dependency review-readiness and base-freshness gates only while the worktree is unmaterialized
- preserve rebase freshness gating
- add a regression test for retrying a materialized child when its dependency is no longer review-ready
- add randomized interleaving properties for materialization safety, retry independence, path stickiness, and timeout recovery

## Why

Review-readiness protects the moment a dependency branch is used to materialize a child worktree. Once that checkout exists, a failed or timed-out session resumes in the same worktree. Reapplying dependency gates at that point incorrectly moved the patch back to pending even though no clone or base selection would occur.

## Impact

A materialized patch with no PR can restart after a session failure regardless of later CI, conflict, PR, or rebase state changes on its dependencies. First-time materialization remains gated exactly as before.

## Validation

- `dune build`
- `dune runtest`
- `dune fmt`
- 4 QCheck interleaving properties, 500 generated sequences each
- pre-commit build, test, and format hooks

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/414"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788661074&installation_model_id=19519&pr_number=414&repository=flowglad%2Fonton&return_to=https%3A%2F%2Fgithub.com%2Fflowglad%2Fonton%2Fpull%2F414&signature=08dfa58e7c5302971dfd302635e923b0f7125468d2eb1a6a0cb2b93525e0cd69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Existing worktrees can now be restarted without being blocked by outdated base or dependency status.
  * New worktrees continue to require fresh bases and satisfied dependencies before starting.
  * Retry behavior is more reliable when related changes become unavailable or conflicted.

* **Tests**
  * Added coverage for worktree start behavior across dependency changes, failures, rebases, conflicts, merges, and retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->