### PR TITLE
Upgrade to OCaml 5.5 and Dune 3.24.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 _build/
 _opam/
+/compile_commands.json
 /tags
 /worktrees/
 .claude

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,6 +180,6 @@ sequences are covered by `test/test_rebase_state_machine.ml` (SM-1, SM-2
 - Reference specification: `../orchestrate-gameplan/spec/anton.pant`
 
 ## Stack
-- OCaml 5.5.0, dune 3.21, local opam switch
+- OCaml 5.5.0, dune 3.24.2, local opam switch
 - `open Base` in lib modules for Jane Street ppx compatibility
 - PPX: ppx_deriving (show/eq/ord), ppx_sexp_conv, ppx_compare, ppx_hash, ppx_expect, ppx_inline_test, ppx_assert

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ x86_64).
 ### Option C: From source
 
 Only needed if you want to modify onton or are on a platform without prebuilt
-binaries. Requires OCaml 5.5.0, dune 3.21, and opam:
+binaries. Requires OCaml 5.5.0, dune 3.24.2, and opam:
 
 ```sh
 git clone https://github.com/flowglad/onton.git
@@ -269,7 +269,7 @@ worth knowing about:
 
 In addition to the runtime dependencies above, building from source needs the
 OCaml toolchain listed under [Option C](#option-c-from-source): OCaml 5.5.0,
-dune 3.21, and opam. `opam install . --deps-only` installs the rest
+dune 3.24.2, and opam. `opam install . --deps-only` installs the rest
 (`base`, `eio`, `cmarkit`, `re`, `cmdliner`, `qcheck`, etc.).
 
 ## Usage

--- a/dune-project
+++ b/dune-project
@@ -1,3 +1,3 @@
-(lang dune 3.21)
+(lang dune 3.24)
 (name onton)
 (formatting (enabled_for ocaml))

--- a/dune-workspace
+++ b/dune-workspace
@@ -1,5 +1,6 @@
 (lang dune 3.24)
 (env
  (dev
+  (bin_annot true)
   (flags (:standard -w +a-44-70 -warn-error +A-44-70))
   (ocamlopt_flags (:standard -O2))))

--- a/dune-workspace
+++ b/dune-workspace
@@ -1,4 +1,4 @@
-(lang dune 3.21)
+(lang dune 3.24)
 (env
  (dev
   (flags (:standard -w +a-44-70 -warn-error +A-44-70))

--- a/lib/findings_registry.ml
+++ b/lib/findings_registry.ml
@@ -36,5 +36,5 @@ let remove_stale_for_scope t ~backend_name ~owner ~repo ~pr_number ~keep_keys =
         t.table;
       List.iter (fun key -> Hashtbl.remove t.table key) !stale)
 
-let find t ~key = with_lock t (fun () -> Hashtbl.find_opt t.table key)
+let take t ~key = with_lock t (fun () -> Hashtbl.find_and_remove t.table key)
 let forget t ~key = with_lock t (fun () -> Hashtbl.remove t.table key)

--- a/lib/findings_registry.mli
+++ b/lib/findings_registry.mli
@@ -57,8 +57,11 @@ val remove_stale_for_scope :
     backend's current unresolved findings instead of accumulating stale routes.
 *)
 
-val find : t -> key:string -> entry option
+val take : t -> key:string -> entry option
+(** Atomically return and remove the entry for [key], if present. Use this
+    before an effectful resolve operation so a later cleanup cannot remove an
+    entry concurrently refreshed by the poller. *)
 
 val forget : t -> key:string -> unit
-(** Drop the entry. Called after a resolve POST so the table doesn't grow
-    unbounded across the lifetime of the process. *)
+(** Drop the entry without returning it. Used on terminal paths that cannot or
+    should not issue a resolve request. *)

--- a/lib/findings_resolver.ml
+++ b/lib/findings_resolver.ml
@@ -117,7 +117,7 @@ let resolve_after_session ~review_clients ~log ~findings_registry ~artifact_dir
                    f.id why);
               Findings_registry.forget findings_registry ~key:f.id
           | (Some (Wontfix _) | None) as verdict -> (
-              match Findings_registry.find findings_registry ~key:f.id with
+              match Findings_registry.take findings_registry ~key:f.id with
               | None ->
                   log
                     (Printf.sprintf
@@ -140,8 +140,7 @@ let resolve_after_session ~review_clients ~log ~findings_registry ~artifact_dir
                         (Printf.sprintf
                            "Skipping resolve for finding %s — review backend \
                             %s is no longer configured"
-                           f.id backend_name);
-                      Findings_registry.forget findings_registry ~key:f.id
+                           f.id backend_name)
                   | Some
                       (module R : Review_service_client.S
                         with type error = Review_service_client.error) -> (
@@ -160,12 +159,9 @@ let resolve_after_session ~review_clients ~log ~findings_registry ~artifact_dir
                                   kind)
                                (Onton_core.Review_service.outcome_kind_to_string
                                   response.Onton_core.Review_service.outcome
-                                    .kind));
-                          Findings_registry.forget findings_registry ~key:f.id
+                                    .kind))
                       | Error err ->
                           log
                             (Printf.sprintf "Failed to resolve finding %s — %s"
-                               f.id (R.show_error err));
-                          Findings_registry.forget findings_registry ~key:f.id))
-              ))
+                               f.id (R.show_error err))))))
         delivered

--- a/lib/project_store.ml
+++ b/lib/project_store.ml
@@ -378,7 +378,7 @@ let with_temp_data_dir f =
     ~finally:(fun () ->
       (match old with
       | Some value -> Unix.putenv "ONTON_DATA_DIR" value
-      | None -> Unix.putenv "ONTON_DATA_DIR" "");
+      | None -> Unix.unsetenv "ONTON_DATA_DIR");
       try
         ignore
           (Stdlib.Sys.command
@@ -402,6 +402,33 @@ let dir_entries_for_test path =
 let json_field_for_test name = function
   | `Assoc fields -> List.Assoc.find fields name ~equal:String.equal
   | _ -> None
+
+let%test "with_temp_data_dir restores an absent environment variable" =
+  let original = Stdlib.Sys.getenv_opt "ONTON_DATA_DIR" in
+  Stdlib.Fun.protect
+    ~finally:(fun () ->
+      match original with
+      | Some value -> Unix.putenv "ONTON_DATA_DIR" value
+      | None -> Unix.unsetenv "ONTON_DATA_DIR")
+    (fun () ->
+      Unix.unsetenv "ONTON_DATA_DIR";
+      with_temp_data_dir (fun () -> ());
+      Option.is_none (Stdlib.Sys.getenv_opt "ONTON_DATA_DIR"))
+
+let%test "with_temp_data_dir restores an existing environment variable" =
+  let original = Stdlib.Sys.getenv_opt "ONTON_DATA_DIR" in
+  Stdlib.Fun.protect
+    ~finally:(fun () ->
+      match original with
+      | Some value -> Unix.putenv "ONTON_DATA_DIR" value
+      | None -> Unix.unsetenv "ONTON_DATA_DIR")
+    (fun () ->
+      Unix.putenv "ONTON_DATA_DIR" "onton-project-store-original";
+      with_temp_data_dir (fun () -> ());
+      Option.value_map
+        (Stdlib.Sys.getenv_opt "ONTON_DATA_DIR")
+        ~default:false
+        ~f:(String.equal "onton-project-store-original"))
 
 let%test "ci_check_key uses run id for CheckRuns and slug for id-less checks" =
   let run_check = ci_check_for_test ~id:123 ~name:"CI / Test Suite" () in

--- a/lib/rlimit_stubs.c
+++ b/lib/rlimit_stubs.c
@@ -18,7 +18,6 @@
 #include <sys/resource.h>
 #include <errno.h>
 #include <string.h>
-#include <stdlib.h>
 
 /* Returns (soft, hard) as an OCaml int pair. */
 CAMLprim value caml_onton_getrlimit_nofile(value unit) {
@@ -52,15 +51,6 @@ CAMLprim value caml_onton_setrlimit_nofile_soft(value v_soft) {
   }
   rl.rlim_cur = (rlim_t)Long_val(v_soft);
   if (setrlimit(RLIMIT_NOFILE, &rl) != 0) {
-    caml_failwith(strerror(errno));
-  }
-  CAMLreturn(Val_unit);
-}
-
-CAMLprim value caml_onton_unsetenv(value v_name) {
-  CAMLparam1(v_name);
-  const char *name = String_val(v_name);
-  if (unsetenv(name) != 0) {
     caml_failwith(strerror(errno));
   }
   CAMLreturn(Val_unit);

--- a/lib/session_artifacts.ml
+++ b/lib/session_artifacts.ml
@@ -137,34 +137,15 @@ let rm_rf path =
          (Printf.sprintf "rm -rf %s" (Stdlib.Filename.quote path)))
   with _ -> ()
 
-let default_data_root () =
-  match Stdlib.Sys.getenv_opt "XDG_DATA_HOME" with
-  | Some xdg -> Stdlib.Filename.concat xdg "onton"
-  | None ->
-      Stdlib.Filename.concat
-        (Stdlib.Filename.concat (Stdlib.Sys.getenv "HOME") ".local/share")
-        "onton"
-
 let with_temp_data_dir f =
   let old = Stdlib.Sys.getenv_opt "ONTON_DATA_DIR" in
-  let restore_path_when_unset =
-    match old with Some _ -> None | None -> Some (default_data_root ())
-  in
   let dir = Stdlib.Filename.temp_dir "onton-session-artifacts-" "" in
   Unix.putenv "ONTON_DATA_DIR" dir;
   Stdlib.Fun.protect
     ~finally:(fun () ->
       (match old with
       | Some value -> Unix.putenv "ONTON_DATA_DIR" value
-      | None -> (
-          match restore_path_when_unset with
-          | None -> ()
-          | Some path ->
-              (* Tests do not have an unsetenv binding. Restore the resolved
-                 default data root so later tests never inherit a deleted temp
-                 directory through ONTON_DATA_DIR. *)
-              Project_store.ensure_dir path;
-              Unix.putenv "ONTON_DATA_DIR" path));
+      | None -> Unix.unsetenv "ONTON_DATA_DIR");
       rm_rf dir)
     (fun () -> f ())
 
@@ -193,6 +174,33 @@ let spawn_finalized_event ~patch_id ~session_uuid =
   in
   Telemetry.Event.Spawn_finalized
     { patch_id; session_uuid; meta = Session_meta.yojson_of_t meta }
+
+let%test "with_temp_data_dir restores an absent environment variable" =
+  let original = Stdlib.Sys.getenv_opt "ONTON_DATA_DIR" in
+  Stdlib.Fun.protect
+    ~finally:(fun () ->
+      match original with
+      | Some value -> Unix.putenv "ONTON_DATA_DIR" value
+      | None -> Unix.unsetenv "ONTON_DATA_DIR")
+    (fun () ->
+      Unix.unsetenv "ONTON_DATA_DIR";
+      with_temp_data_dir (fun () -> ());
+      Option.is_none (Stdlib.Sys.getenv_opt "ONTON_DATA_DIR"))
+
+let%test "with_temp_data_dir restores an existing environment variable" =
+  let original = Stdlib.Sys.getenv_opt "ONTON_DATA_DIR" in
+  Stdlib.Fun.protect
+    ~finally:(fun () ->
+      match original with
+      | Some value -> Unix.putenv "ONTON_DATA_DIR" value
+      | None -> Unix.unsetenv "ONTON_DATA_DIR")
+    (fun () ->
+      Unix.putenv "ONTON_DATA_DIR" "onton-session-artifacts-original";
+      with_temp_data_dir (fun () -> ());
+      Option.value_map
+        (Stdlib.Sys.getenv_opt "ONTON_DATA_DIR")
+        ~default:false
+        ~f:(String.equal "onton-session-artifacts-original"))
 
 let%test "create+finalize writes meta.json with schema_version=1" =
   with_temp_data_dir @@ fun () ->

--- a/lib/spawn_env.ml
+++ b/lib/spawn_env.ml
@@ -3,8 +3,6 @@
 
 open Base
 
-external unsetenv_stub : string -> unit = "caml_onton_unsetenv"
-
 let patch_root ~project_dir ~patch_id =
   Stdlib.Filename.concat project_dir
     (Stdlib.Filename.concat "spawn-envs" (Types.Patch_id.to_string patch_id))
@@ -405,7 +403,7 @@ let%test "resolve_user_config_dir absolutizes relative env and HOME paths" =
   let restore_home () =
     match old_home with
     | Some home -> Unix.putenv "HOME" home
-    | None -> unsetenv_stub "HOME"
+    | None -> Unix.unsetenv "HOME"
   in
   Unix.putenv "HOME" "relative-home";
   Stdlib.Fun.protect ~finally:restore_home @@ fun () ->

--- a/lib_core/review_backend.ml
+++ b/lib_core/review_backend.ml
@@ -21,15 +21,7 @@ let string_field field json : (string, string) Result.t =
   | None -> Error (Printf.sprintf "missing required field %S" field)
   | Some _ -> Error (Printf.sprintf "%S must be a string" field)
 
-let strip_trailing_slashes s =
-  let len = String.length s in
-  let rec last i =
-    if i <= 0 then i
-    else if Char.equal (String.get s (i - 1)) '/' then last (i - 1)
-    else i
-  in
-  let l = last len in
-  if l = len then s else String.sub s ~pos:0 ~len:l
+let strip_trailing_slashes = Stdlib.String.drop_last_while (Char.equal '/')
 
 let has_authority base_url =
   match String.substr_index base_url ~pattern:"://" with

--- a/onton.opam
+++ b/onton.opam
@@ -5,7 +5,7 @@ synopsis: "OCaml orchestrator for parallel Claude Code agents"
 maintainer: ["flowglad"]
 depends: [
   "ocaml" {= "5.5.0"}
-  "dune" {>= "3.21" & < "3.22"}
+  "dune" {>= "3.24.2" & < "3.25"}
   "base" {>= "v0.17.0"}
   "eio" {>= "1.3"}
   "eio_main" {>= "1.3"}

--- a/test/dune
+++ b/test/dune
@@ -9,6 +9,13 @@
  (libraries onton unix))
 
 (test
+ (name test_findings_resolver)
+ (modules test_findings_resolver)
+ (libraries onton onton_core eio_main unix)
+ (ocamlopt_flags (:standard -w -40-42))
+ (ocamlc_flags (:standard -w -40-42)))
+
+(test
  (name test_automerge_deadline_properties)
  (modules test_automerge_deadline_properties)
  (libraries onton onton_core onton_test_support qcheck-core qcheck-core.runner)

--- a/test/test_findings_resolver.ml
+++ b/test/test_findings_resolver.ml
@@ -1,0 +1,114 @@
+(* @archlint.module test
+   @archlint.domain findings-registry *)
+
+open Onton
+open Onton_core
+
+let entry ~finding_id : Findings_registry.entry =
+  {
+    backend_name = "fake";
+    owner = "owner";
+    repo = "repo";
+    pr_number = 42;
+    finding_id;
+  }
+
+let finding ~id : Review_service.finding =
+  {
+    id;
+    github_comment_id = None;
+    posting_sha = "deadbeef";
+    path = "lib/example.ml";
+    start_line = 1;
+    end_line = 1;
+    severity = Review_service.Note;
+    body = "finding";
+    created_at = "2026-08-07T00:00:00Z";
+    outcome =
+      {
+        kind = Review_service.Outstanding;
+        detected_at = None;
+        actor = None;
+        reason = None;
+        last_reply = None;
+      };
+  }
+
+let active_registration :
+    (Findings_registry.t * string * Findings_registry.entry) option ref =
+  ref None
+
+module Fake_review_client = struct
+  type error = Review_service_client.error
+
+  let show_error = Review_service_client.show_error
+  let name = "fake"
+
+  let list_findings ~owner:_ ~repo:_ ~pr_number:_ () =
+    failwith "list_findings is not used by this test"
+
+  let mark_resolved ~owner:_ ~repo:_ ~pr_number:_ ~finding_id ~kind:_ ?actor:_
+      ?reason:_ () =
+    (match !active_registration with
+    | Some (registry, key, replacement) ->
+        Findings_registry.register registry ~key replacement
+    | None -> failwith "missing replacement registry entry");
+    let outcome : Review_service.outcome =
+      {
+        kind = Review_service.Addressed;
+        detected_at = None;
+        actor = None;
+        reason = None;
+        last_reply = None;
+      }
+    in
+    Ok ({ id = finding_id; outcome } : Review_service.resolve_response)
+end
+
+let expect_some_finding_id expected = function
+  | Some (actual : Findings_registry.entry) ->
+      if not (String.equal actual.finding_id expected) then
+        failwith
+          (Printf.sprintf "expected finding id %s, got %s" expected
+             actual.finding_id)
+  | None -> failwith (Printf.sprintf "expected registry entry %s" expected)
+
+let test_take_removes_once () =
+  let registry = Findings_registry.create () in
+  let key = "key" in
+  Findings_registry.register registry ~key (entry ~finding_id:"original");
+  Findings_registry.take registry ~key |> expect_some_finding_id "original";
+  match Findings_registry.take registry ~key with
+  | None -> ()
+  | Some _ -> failwith "take returned an entry twice"
+
+let test_resolver_preserves_concurrent_refresh () =
+  let registry = Findings_registry.create () in
+  let key =
+    Findings_registry.make_key ~backend_name:"fake" ~owner:"owner" ~repo:"repo"
+      ~pr_number:42 ~finding_id:"raw-id"
+  in
+  Findings_registry.register registry ~key (entry ~finding_id:"raw-id");
+  active_registration := Some (registry, key, entry ~finding_id:"refreshed-id");
+  Fun.protect
+    ~finally:(fun () -> active_registration := None)
+    (fun () ->
+      Findings_resolver.resolve_after_session
+        ~review_clients:
+          [
+            (module Fake_review_client : Review_service_client.S
+              with type error = Review_service_client.error);
+          ]
+        ~log:ignore ~findings_registry:registry
+        ~artifact_dir:
+          (Filename.concat
+             (Filename.get_temp_dir_name ())
+             (Printf.sprintf "onton-missing-wontfix-%d" (Unix.getpid ())))
+        ~delivered:[ finding ~id:key ]
+        ());
+  Findings_registry.take registry ~key |> expect_some_finding_id "refreshed-id"
+
+let () =
+  Eio_main.run @@ fun _env ->
+  test_take_removes_once ();
+  test_resolver_preserves_concurrent_refresh ()

--- a/test/test_git_env.ml
+++ b/test/test_git_env.ml
@@ -4,8 +4,6 @@
 open Onton
 open Onton_core
 
-external unsetenv_stub : string -> unit = "caml_onton_unsetenv"
-
 let env_list () = Git_env.clean_env () |> Array.to_list
 
 let binding name s =
@@ -29,7 +27,7 @@ let count name env = List.length (List.filter (binding name) env)
 let restore_env name old_value =
   match old_value with
   | Some value -> Unix.putenv name value
-  | None -> unsetenv_stub name
+  | None -> Unix.unsetenv name
 
 let assert_true label cond = if not cond then failwith label
 

--- a/test/test_session_driver_telemetry.ml
+++ b/test/test_session_driver_telemetry.ml
@@ -5,8 +5,6 @@ open Base
 open Onton
 open Onton_core
 
-external unsetenv : string -> unit = "caml_onton_unsetenv"
-
 let failures = ref 0
 
 let fail name msg =
@@ -62,7 +60,7 @@ let with_data_dir root f =
   Exn.protect ~f ~finally:(fun () ->
       match previous with
       | Some value -> Unix.putenv "ONTON_DATA_DIR" value
-      | None -> unsetenv "ONTON_DATA_DIR")
+      | None -> Unix.unsetenv "ONTON_DATA_DIR")
 
 let run_case ~name ~subkind ~exit_code =
   let root = temp_root () in


### PR DESCRIPTION
## Summary

- upgrade the compiler baseline to OCaml 5.5.0 and Dune 3.24.2 across opam metadata, CI, release builds, documentation, and local tooling
- adapt inline-test warning scopes for OCaml 5.5
- replace the custom `unsetenv` C stub with `Unix.unsetenv` and restore absent test environment variables correctly
- consume findings registry entries atomically with `Hashtbl.find_and_remove`, preventing a completed resolve from deleting a concurrent poller refresh
- simplify trailing-slash normalization with `String.drop_last_while`

## Why

This keeps Onton on the current OCaml toolchain and uses the new 5.5 standard-library APIs to remove custom FFI code and harden concurrent findings resolution.

## Impact

Source builds, CI, and release jobs now require OCaml 5.5.0 and Dune 3.24.2. Runtime behavior is otherwise unchanged except for correct environment restoration and safer findings registry cleanup.

## Validation

- `opam exec -- dune build`
- `opam exec -- dune runtest`
- `opam exec -- dune fmt`
- pre-commit build, test, and format checks

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/415"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788708698&installation_model_id=19519&pr_number=415&repository=flowglad%2Fonton&return_to=https%3A%2F%2Fgithub.com%2Fflowglad%2Fonton%2Fpull%2F415&signature=572b27dd70d8b36907f050a4313b1772110d9b179100610af4c94ca34ac42a28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->