### PR TITLE
Heal runtime-added patches on resume

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1057,14 +1057,16 @@ let run_main_loop (setup : runtime_setup) (cap : constructed_capabilities)
       (Persistence.save ~path:(Project_store.snapshot_path project_name) snap)
   in
   let fatal_message = ref None in
+  let fatal_reported = ref false in
   let log_fatal message =
     log_event setup.runtime message;
     if Base.Option.is_none !fatal_message then fatal_message := Some message
   in
   let report_fatal () =
-    Base.Option.iter !fatal_message ~f:(fun message ->
-        fatal_message := None;
-        Printf.eprintf "onton: %s\n%!" message)
+    if not !fatal_reported then
+      Base.Option.iter !fatal_message ~f:(fun message ->
+          fatal_reported := true;
+          Printf.eprintf "onton: %s\n%!" message)
   in
   let guard_fiber ?(quit_is_normal = false) ?(return_is_normal = false) name f
       () =

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -768,6 +768,17 @@ let setup_runtime env ~config ~gameplan ~existing_snapshot ~auto_merge =
         Printf.eprintf "Starting new project %S.\n%!" project_name;
         Runtime.create ~gameplan ~main_branch ~max_ci_failures ()
   in
+  Base.List.iter (Runtime.resume_repairs runtime) ~f:(function
+    | Resume_gameplan.Preserved_snapshot_patch patch_id ->
+        Printf.eprintf
+          "onton: restored runtime-added patch %s from snapshot.\n%!"
+          (Patch_id.to_string patch_id)
+    | Resume_gameplan.Reconstructed_missing_patch patch_id ->
+        Printf.eprintf
+          "onton: repaired runtime-added patch %s from legacy saved state; its \
+           original full description was unavailable.\n\
+           %!"
+          (Patch_id.to_string patch_id));
   (* [--auto-merge] only seeds the initial state of a fresh project. On resume,
      each patch's persisted [automerge_enabled] wins so per-patch user toggles
      are not silently re-enabled across restarts. *)
@@ -1045,9 +1056,14 @@ let run_main_loop (setup : runtime_setup) (cap : constructed_capabilities)
     ignore
       (Persistence.save ~path:(Project_store.snapshot_path project_name) snap)
   in
+  let fatal_message = ref None in
   let log_fatal message =
     log_event setup.runtime message;
-    Printf.eprintf "onton: %s\n%!" message
+    if Base.Option.is_none !fatal_message then fatal_message := Some message
+  in
+  let report_fatal () =
+    Base.Option.iter !fatal_message ~f:(fun message ->
+        Printf.eprintf "onton: %s\n%!" message)
   in
   let guard_fiber ?(quit_is_normal = false) ?(return_is_normal = false) name f
       () =
@@ -1071,6 +1087,7 @@ let run_main_loop (setup : runtime_setup) (cap : constructed_capabilities)
         :: common_fibers)
     with Supervisor_guard.Fatal_supervisor_error _ ->
       save_snapshot ();
+      report_fatal ();
       Stdlib.exit 1)
   else
     let raw_state = Term.Raw.enter () in
@@ -1096,6 +1113,7 @@ let run_main_loop (setup : runtime_setup) (cap : constructed_capabilities)
     with Supervisor_guard.Fatal_supervisor_error _ ->
       (* Fun.protect's [finally] has already restored the terminal and saved the
          runtime snapshot. *)
+      report_fatal ();
       Stdlib.exit 1
 
 (** Trailing-positional PR operations parsed from the command line. *)

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1063,6 +1063,7 @@ let run_main_loop (setup : runtime_setup) (cap : constructed_capabilities)
   in
   let report_fatal () =
     Base.Option.iter !fatal_message ~f:(fun message ->
+        fatal_message := None;
         Printf.eprintf "onton: %s\n%!" message)
   in
   let guard_fiber ?(quit_is_normal = false) ?(return_is_normal = false) name f
@@ -1084,7 +1085,8 @@ let run_main_loop (setup : runtime_setup) (cap : constructed_capabilities)
       Eio.Fiber.all
         (guard_fiber "headless" (fun () -> Fibers.Headless.run ())
         :: guard_fiber "runner" (fun () -> Fibers.Runner.run ())
-        :: common_fibers)
+        :: common_fibers);
+      report_fatal ()
     with Supervisor_guard.Fatal_supervisor_error _ ->
       save_snapshot ();
       report_fatal ();
@@ -1097,7 +1099,8 @@ let run_main_loop (setup : runtime_setup) (cap : constructed_capabilities)
           Term.Raw.clear_suspend_handlers ();
           Term.Raw.leave raw_state;
           Eio.Flow.copy_string (Tui.exit_tui ()) setup.stdout;
-          save_snapshot ())
+          save_snapshot ();
+          report_fatal ())
         (fun () ->
           Term.Raw.install_suspend_handlers raw_state;
           try

--- a/lib/runtime.ml
+++ b/lib/runtime.ml
@@ -24,16 +24,13 @@ let create ~gameplan ~(main_branch : Branch.t)
         let graph = Orchestrator.graph s.orchestrator in
         let missing_patches =
           Orchestrator.all_agents s.orchestrator
-          |> Base.List.filter_map ~f:(fun (agent : Patch_agent.t) ->
-              if Patch_agent.has_pr agent then None
-              else
-                Some
-                  Resume_gameplan.
-                    {
-                      patch_id = agent.patch_id;
-                      branch = agent.branch;
-                      dependencies = Graph.deps graph agent.patch_id;
-                    })
+          |> Base.List.map ~f:(fun (agent : Patch_agent.t) ->
+              Resume_gameplan.
+                {
+                  patch_id = agent.patch_id;
+                  branch = agent.branch;
+                  dependencies = Graph.deps graph agent.patch_id;
+                })
         in
         let reconciled =
           Resume_gameplan.reconcile ~loaded:gameplan ~persisted:s.gameplan

--- a/lib/runtime.ml
+++ b/lib/runtime.ml
@@ -10,27 +10,51 @@ type snapshot = {
   transcripts : (Patch_id.t, string) Base.Hashtbl.t;
 }
 
-type t = { mutex : Eio.Mutex.t; mutable snap : snapshot }
+type t = {
+  mutex : Eio.Mutex.t;
+  mutable snap : snapshot;
+  resume_repairs : Resume_gameplan.repair list;
+}
 
 let create ~gameplan ~(main_branch : Branch.t)
     ?(max_ci_failures = Patch_agent.default_max_ci_failures) ?snapshot () =
-  let snap =
+  let snap, resume_repairs =
     match snapshot with
     | Some s ->
+        let graph = Orchestrator.graph s.orchestrator in
+        let missing_patches =
+          Orchestrator.all_agents s.orchestrator
+          |> Base.List.filter_map ~f:(fun (agent : Patch_agent.t) ->
+              if Patch_agent.has_pr agent then None
+              else
+                Some
+                  Resume_gameplan.
+                    {
+                      patch_id = agent.patch_id;
+                      branch = agent.branch;
+                      dependencies = Graph.deps graph agent.patch_id;
+                    })
+        in
+        let reconciled =
+          Resume_gameplan.reconcile ~loaded:gameplan ~persisted:s.gameplan
+            ~missing_patches ~activity_log:s.activity_log
+        in
         let orchestrator =
           Orchestrator.set_main_branch s.orchestrator main_branch
         in
-        { s with orchestrator; gameplan }
+        ( { s with orchestrator; gameplan = reconciled.gameplan },
+          reconciled.repairs )
     | None ->
         let orchestrator =
           Orchestrator.create ~patches:gameplan.Gameplan.patches ~main_branch
         in
-        {
-          orchestrator;
-          activity_log = Activity_log.empty;
-          gameplan;
-          transcripts = Base.Hashtbl.create (module Patch_id);
-        }
+        ( {
+            orchestrator;
+            activity_log = Activity_log.empty;
+            gameplan;
+            transcripts = Base.Hashtbl.create (module Patch_id);
+          },
+          [] )
   in
   (* Config wins over whatever the snapshot (or the constructor default)
      carried: the cap is a per-project setting resolved from the CLI flag and
@@ -42,7 +66,9 @@ let create ~gameplan ~(main_branch : Branch.t)
         Orchestrator.set_max_ci_failures snap.orchestrator ~max_ci_failures;
     }
   in
-  { mutex = Eio.Mutex.create (); snap }
+  { mutex = Eio.Mutex.create (); snap; resume_repairs }
+
+let resume_repairs t = t.resume_repairs
 
 let read t f =
   Eio.Mutex.lock t.mutex;

--- a/lib/runtime.mli
+++ b/lib/runtime.mli
@@ -30,6 +30,10 @@ val create :
     is stamped onto the orchestrator (and every agent) in both the fresh and the
     restore path, so config always wins over persisted values. *)
 
+val resume_repairs : t -> Resume_gameplan.repair list
+(** Patches preserved or reconstructed while reconciling a resume snapshot with
+    the freshly loaded source gameplan. Empty for a fresh runtime. *)
+
 (** {2 Atomic read access} *)
 
 val read : t -> (snapshot -> 'a) -> 'a

--- a/lib/tui_fiber.ml
+++ b/lib/tui_fiber.ml
@@ -467,18 +467,8 @@ struct
                         input_mode := Tui_input.Normal;
                         dep_select_chosen := Set.empty (module Patch_id);
                         dep_select_cursor := 0;
-                        let deps_str =
-                          match patch.Patch.dependencies with
-                          | [] -> "no dependencies"
-                          | ds ->
-                              "depends on "
-                              ^ (List.map ds ~f:Patch_id.to_string
-                                |> String.concat ~sep:", ")
-                        in
                         log_event Env.runtime ~patch_id:patch.Patch.id
-                          (Printf.sprintf "Added patch %s (%s) — %s"
-                             (Patch_id.to_string patch.Patch.id)
-                             deps_str title)))
+                          (Resume_gameplan.added_patch_event_message patch)))
             | Term.Key.Char _ | Term.Key.Tab | Term.Key.Paste _
             | Term.Key.Backspace | Term.Key.Left | Term.Key.Right
             | Term.Key.Home | Term.Key.End | Term.Key.Page_up

--- a/lib_core/resume_gameplan.ml
+++ b/lib_core/resume_gameplan.ml
@@ -31,18 +31,71 @@ let runtime_patch_number patch_id =
 let is_runtime_patch_id patch_id =
   Option.is_some (runtime_patch_number patch_id)
 
+let canonical_runtime_branch gameplan patch_id =
+  Option.map (runtime_patch_number patch_id) ~f:(fun _ ->
+      Gameplan.branch_of_id gameplan patch_id)
+
 let ids_of_patches patches =
   List.map patches ~f:(fun patch -> patch.Patch.id)
   |> Set.of_list (module Patch_id)
 
-let dedup_known_dependencies ~known dependencies =
+let dedup_known_dependencies ~known ~patch_id dependencies =
   List.fold dependencies
     ~init:([], Set.empty (module Patch_id))
     ~f:(fun (acc, seen) dependency ->
-      if Set.mem known dependency && not (Set.mem seen dependency) then
-        (dependency :: acc, Set.add seen dependency)
+      if
+        Set.mem known dependency
+        && (not (Patch_id.equal dependency patch_id))
+        && not (Set.mem seen dependency)
+      then (dependency :: acc, Set.add seen dependency)
       else (acc, seen))
   |> fst |> List.rev
+
+let dependency_map patches =
+  List.fold patches
+    ~init:(Map.empty (module Patch_id))
+    ~f:(fun acc patch ->
+      match Map.add acc ~key:patch.Patch.id ~data:patch.dependencies with
+      | `Ok map -> map
+      | `Duplicate -> acc)
+
+let has_dependency_path dependencies ~source ~target =
+  let rec loop seen = function
+    | [] -> false
+    | patch_id :: rest ->
+        if Patch_id.equal patch_id target then true
+        else if Set.mem seen patch_id then loop seen rest
+        else
+          let seen = Set.add seen patch_id in
+          let next =
+            Option.value (Map.find dependencies patch_id) ~default:[]
+          in
+          loop seen (next @ rest)
+  in
+  loop (Set.empty (module Patch_id)) [ source ]
+
+let sanitize_dependencies ~known ~dependencies patch =
+  let dependencies =
+    dedup_known_dependencies ~known ~patch_id:patch.Patch.id patch.dependencies
+    |> List.filter ~f:(fun dependency ->
+        not
+          (has_dependency_path dependencies ~source:dependency
+             ~target:patch.Patch.id))
+  in
+  { patch with Patch.dependencies }
+
+let added_patch_event_message (patch : Patch.t) =
+  let dependencies =
+    match patch.dependencies with
+    | [] -> "no dependencies"
+    | dependencies ->
+        "depends on "
+        ^ (List.map dependencies ~f:Patch_id.to_string
+          |> String.concat ~sep:", ")
+  in
+  Printf.sprintf "Added patch %s (%s) — %s"
+    (Patch_id.to_string patch.id)
+    dependencies patch.title
 
 let parse_added_event ~patch_id message =
   let prefix =
@@ -81,69 +134,88 @@ let activity_hint activity_log patch_id =
 
 let reconstructed_patch ~gameplan ~known activity_log
     ({ patch_id; branch; dependencies } : missing_patch) =
-  if
-    (not (is_runtime_patch_id patch_id))
-    || not (Branch.equal branch (Gameplan.branch_of_id gameplan patch_id))
-  then None
-  else
-    let title, dependencies =
-      match activity_hint activity_log patch_id with
-      | Some (title, logged_dependencies) when not (String.is_empty title) ->
-          (title, logged_dependencies)
-      | Some (_, logged_dependencies) ->
-          ( "Recovered runtime patch " ^ Patch_id.to_string patch_id,
-            logged_dependencies )
-      | None ->
-          ( "Recovered runtime patch " ^ Patch_id.to_string patch_id,
-            dependencies )
-    in
-    let dependencies = dedup_known_dependencies ~known dependencies in
-    Some
-      ({
-         Patch.id = patch_id;
-         title;
-         description = title;
-         branch;
-         dependencies;
-         spec = "";
-         acceptance_criteria = [];
-         files = [];
-         classification = "";
-         changes = [];
-         test_stubs_introduced = [];
-         test_stubs_implemented = [];
-         complexity = None;
-         precedents = [];
-         required_context = [];
-       }
-        : Patch.t)
+  match canonical_runtime_branch gameplan patch_id with
+  | None -> None
+  | Some canonical_branch when not (Branch.equal branch canonical_branch) ->
+      None
+  | Some _ ->
+      let title, dependencies =
+        match activity_hint activity_log patch_id with
+        | Some (title, logged_dependencies) when not (String.is_empty title) ->
+            (title, logged_dependencies)
+        | Some (_, logged_dependencies) ->
+            ( "Recovered runtime patch " ^ Patch_id.to_string patch_id,
+              logged_dependencies )
+        | None ->
+            ( "Recovered runtime patch " ^ Patch_id.to_string patch_id,
+              dependencies )
+      in
+      let dependencies =
+        dedup_known_dependencies ~known ~patch_id dependencies
+      in
+      Some
+        ({
+           Patch.id = patch_id;
+           title;
+           description = title;
+           branch;
+           dependencies;
+           spec = "";
+           acceptance_criteria = [];
+           files = [];
+           classification = "";
+           changes = [];
+           test_stubs_introduced = [];
+           test_stubs_implemented = [];
+           complexity = None;
+           precedents = [];
+           required_context = [];
+         }
+          : Patch.t)
 
 let reconcile ~loaded ~persisted ~missing_patches ~activity_log =
   let loaded_ids = ids_of_patches loaded.Gameplan.patches in
-  let _, preserved =
-    List.fold persisted.Gameplan.patches ~init:(loaded_ids, [])
-      ~f:(fun (seen, acc) patch ->
+  let loaded_branches =
+    List.map loaded.Gameplan.patches ~f:(fun patch ->
+        Branch.to_string patch.Patch.branch)
+    |> Set.of_list (module String)
+  in
+  let _, _, preserved =
+    List.fold persisted.Gameplan.patches ~init:(loaded_ids, loaded_branches, [])
+      ~f:(fun (seen_ids, seen_branches, acc) patch ->
         if
           is_runtime_patch_id patch.Patch.id
-          && not (Set.mem seen patch.Patch.id)
-        then (Set.add seen patch.id, patch :: acc)
-        else (seen, acc))
+          && (not (Set.mem seen_ids patch.Patch.id))
+          && not (Set.mem seen_branches (Branch.to_string patch.Patch.branch))
+        then
+          ( Set.add seen_ids patch.id,
+            Set.add seen_branches (Branch.to_string patch.branch),
+            patch :: acc )
+        else (seen_ids, seen_branches, acc))
   in
   let preserved = List.rev preserved in
   let gameplan =
     { loaded with Gameplan.patches = loaded.patches @ preserved }
   in
   let known = ids_of_patches gameplan.Gameplan.patches in
-  let reconstructable, reconstructable_ids =
-    List.fold missing_patches ~init:([], known) ~f:(fun (acc, seen) missing ->
-        if
-          Set.mem seen missing.patch_id
-          || (not (is_runtime_patch_id missing.patch_id))
-          || not
-               (Branch.equal missing.branch
-                  (Gameplan.branch_of_id gameplan missing.patch_id))
-        then (acc, seen)
-        else (missing :: acc, Set.add seen missing.patch_id))
+  let known_branches =
+    List.map gameplan.Gameplan.patches ~f:(fun patch ->
+        Branch.to_string patch.Patch.branch)
+    |> Set.of_list (module String)
+  in
+  let reconstructable, reconstructable_ids, _ =
+    List.fold missing_patches ~init:([], known, known_branches)
+      ~f:(fun (acc, seen_ids, seen_branches) missing ->
+        match canonical_runtime_branch gameplan missing.patch_id with
+        | Some canonical_branch
+          when (not (Set.mem seen_ids missing.patch_id))
+               && (not
+                     (Set.mem seen_branches (Branch.to_string missing.branch)))
+               && Branch.equal missing.branch canonical_branch ->
+            ( missing :: acc,
+              Set.add seen_ids missing.patch_id,
+              Set.add seen_branches (Branch.to_string missing.branch) )
+        | Some _ | None -> (acc, seen_ids, seen_branches))
   in
   let reconstructed =
     List.rev reconstructable
@@ -154,6 +226,16 @@ let reconcile ~loaded ~persisted ~missing_patches ~activity_log =
   in
   let gameplan =
     { gameplan with Gameplan.patches = gameplan.patches @ reconstructed }
+  in
+  let known = ids_of_patches gameplan.Gameplan.patches in
+  let dependencies = dependency_map gameplan.patches in
+  let gameplan =
+    {
+      gameplan with
+      Gameplan.patches =
+        List.map gameplan.patches
+          ~f:(sanitize_dependencies ~known ~dependencies);
+    }
   in
   let repairs =
     List.map preserved ~f:(fun patch -> Preserved_snapshot_patch patch.Patch.id)

--- a/lib_core/resume_gameplan.ml
+++ b/lib_core/resume_gameplan.ml
@@ -1,0 +1,163 @@
+(* @archlint.module core
+   @archlint.domain orchestrator *)
+
+open Base
+open Types
+
+type missing_patch = {
+  patch_id : Patch_id.t;
+  branch : Branch.t;
+  dependencies : Patch_id.t list;
+}
+[@@deriving show, eq]
+
+type repair =
+  | Preserved_snapshot_patch of Patch_id.t
+  | Reconstructed_missing_patch of Patch_id.t
+[@@deriving show, eq]
+
+type result = { gameplan : Gameplan.t; repairs : repair list }
+[@@deriving show, eq]
+
+let runtime_patch_number patch_id =
+  let raw = Patch_id.to_string patch_id in
+  match String.chop_prefix raw ~prefix:"add" with
+  | None -> None
+  | Some suffix -> (
+      match Int.of_string_opt suffix with
+      | Some n when n > 0 && String.equal suffix (Int.to_string n) -> Some n
+      | Some _ | None -> None)
+
+let is_runtime_patch_id patch_id =
+  Option.is_some (runtime_patch_number patch_id)
+
+let ids_of_patches patches =
+  List.map patches ~f:(fun patch -> patch.Patch.id)
+  |> Set.of_list (module Patch_id)
+
+let dedup_known_dependencies ~known dependencies =
+  List.fold dependencies
+    ~init:([], Set.empty (module Patch_id))
+    ~f:(fun (acc, seen) dependency ->
+      if Set.mem known dependency && not (Set.mem seen dependency) then
+        (dependency :: acc, Set.add seen dependency)
+      else (acc, seen))
+  |> fst |> List.rev
+
+let parse_added_event ~patch_id message =
+  let prefix =
+    Printf.sprintf "Added patch %s (" (Patch_id.to_string patch_id)
+  in
+  match String.chop_prefix message ~prefix with
+  | None -> None
+  | Some rest -> (
+      match String.substr_index rest ~pattern:") — " with
+      | None -> None
+      | Some separator_index ->
+          let deps_text = String.prefix rest separator_index in
+          let title =
+            String.drop_prefix rest (separator_index + String.length ") — ")
+            |> String.strip
+          in
+          let dependencies =
+            if String.equal deps_text "no dependencies" then Some []
+            else
+              String.chop_prefix deps_text ~prefix:"depends on "
+              |> Option.map ~f:(fun raw ->
+                  String.split raw ~on:','
+                  |> List.map ~f:(fun dependency ->
+                      Patch_id.of_string (String.strip dependency)))
+          in
+          Option.map dependencies ~f:(fun dependencies -> (title, dependencies))
+      )
+
+let activity_hint activity_log patch_id =
+  Activity_log.recent_events activity_log ~limit:Int.max_value
+  |> List.find_map ~f:(fun event ->
+      match event.Activity_log.Event.patch_id with
+      | Some event_patch_id when Patch_id.equal event_patch_id patch_id ->
+          parse_added_event ~patch_id event.message
+      | Some _ | None -> None)
+
+let reconstructed_patch ~gameplan ~known activity_log
+    ({ patch_id; branch; dependencies } : missing_patch) =
+  if
+    (not (is_runtime_patch_id patch_id))
+    || not (Branch.equal branch (Gameplan.branch_of_id gameplan patch_id))
+  then None
+  else
+    let title, dependencies =
+      match activity_hint activity_log patch_id with
+      | Some (title, logged_dependencies) when not (String.is_empty title) ->
+          (title, logged_dependencies)
+      | Some (_, logged_dependencies) ->
+          ( "Recovered runtime patch " ^ Patch_id.to_string patch_id,
+            logged_dependencies )
+      | None ->
+          ( "Recovered runtime patch " ^ Patch_id.to_string patch_id,
+            dependencies )
+    in
+    let dependencies = dedup_known_dependencies ~known dependencies in
+    Some
+      ({
+         Patch.id = patch_id;
+         title;
+         description = title;
+         branch;
+         dependencies;
+         spec = "";
+         acceptance_criteria = [];
+         files = [];
+         classification = "";
+         changes = [];
+         test_stubs_introduced = [];
+         test_stubs_implemented = [];
+         complexity = None;
+         precedents = [];
+         required_context = [];
+       }
+        : Patch.t)
+
+let reconcile ~loaded ~persisted ~missing_patches ~activity_log =
+  let loaded_ids = ids_of_patches loaded.Gameplan.patches in
+  let _, preserved =
+    List.fold persisted.Gameplan.patches ~init:(loaded_ids, [])
+      ~f:(fun (seen, acc) patch ->
+        if
+          is_runtime_patch_id patch.Patch.id
+          && not (Set.mem seen patch.Patch.id)
+        then (Set.add seen patch.id, patch :: acc)
+        else (seen, acc))
+  in
+  let preserved = List.rev preserved in
+  let gameplan =
+    { loaded with Gameplan.patches = loaded.patches @ preserved }
+  in
+  let known = ids_of_patches gameplan.Gameplan.patches in
+  let reconstructable, reconstructable_ids =
+    List.fold missing_patches ~init:([], known) ~f:(fun (acc, seen) missing ->
+        if
+          Set.mem seen missing.patch_id
+          || (not (is_runtime_patch_id missing.patch_id))
+          || not
+               (Branch.equal missing.branch
+                  (Gameplan.branch_of_id gameplan missing.patch_id))
+        then (acc, seen)
+        else (missing :: acc, Set.add seen missing.patch_id))
+  in
+  let reconstructed =
+    List.rev reconstructable
+    |> List.filter_map
+         ~f:
+           (reconstructed_patch ~gameplan ~known:reconstructable_ids
+              activity_log)
+  in
+  let gameplan =
+    { gameplan with Gameplan.patches = gameplan.patches @ reconstructed }
+  in
+  let repairs =
+    List.map preserved ~f:(fun patch -> Preserved_snapshot_patch patch.Patch.id)
+    @ List.map reconstructed ~f:(fun patch ->
+        Reconstructed_missing_patch patch.Patch.id)
+  in
+  { gameplan; repairs }

--- a/lib_core/resume_gameplan.mli
+++ b/lib_core/resume_gameplan.mli
@@ -27,6 +27,10 @@ type repair =
 type result = { gameplan : Gameplan.t; repairs : repair list }
 [@@deriving show, eq]
 
+val added_patch_event_message : Patch.t -> string
+(** Stable activity-log encoding used by both the runtime patch producer and
+    legacy resume reconstruction. *)
+
 val reconcile :
   loaded:Gameplan.t ->
   persisted:Gameplan.t ->
@@ -42,7 +46,8 @@ val reconcile :
     {!Gameplan.branch_of_id}. The most recent matching "Added patch" activity
     event supplies its title and dependency list when available; otherwise a
     safe recovery description and the graph dependencies are used. Unknown and
-    duplicate dependencies are removed, so the returned gameplan is always
-    referentially valid.
+    duplicate, self-referential, and cyclic dependencies are removed, so the
+    returned gameplan is always referentially valid. Snapshot-only patches that
+    collide with an existing branch are skipped.
 
     The function is total and idempotent. *)

--- a/lib_core/resume_gameplan.mli
+++ b/lib_core/resume_gameplan.mli
@@ -1,0 +1,48 @@
+(* @archlint.module interface
+   @archlint.domain orchestrator *)
+
+open Types
+
+(** Pure reconciliation of the freshly loaded gameplan with state persisted in a
+    runtime snapshot.
+
+    Runtime-added planned patches use the reserved [addN] id namespace. They
+    exist only in the snapshot, so blindly replacing the snapshot gameplan with
+    the source gameplan on resume loses them while leaving their agents behind.
+    This module preserves those patches and can reconstruct legacy snapshots
+    that were already damaged by the old resume behavior. *)
+
+type missing_patch = {
+  patch_id : Patch_id.t;
+  branch : Branch.t;
+  dependencies : Patch_id.t list;
+}
+[@@deriving show, eq]
+
+type repair =
+  | Preserved_snapshot_patch of Patch_id.t
+  | Reconstructed_missing_patch of Patch_id.t
+[@@deriving show, eq]
+
+type result = { gameplan : Gameplan.t; repairs : repair list }
+[@@deriving show, eq]
+
+val reconcile :
+  loaded:Gameplan.t ->
+  persisted:Gameplan.t ->
+  missing_patches:missing_patch list ->
+  activity_log:Activity_log.t ->
+  result
+(** [reconcile] keeps [loaded] authoritative for its project metadata and all
+    patch ids it contains, then appends runtime-added [addN] patches found only
+    in [persisted].
+
+    A [missing_patch] absent from both gameplans is reconstructed only when its
+    id is a canonical runtime-added [addN] id and its branch matches
+    {!Gameplan.branch_of_id}. The most recent matching "Added patch" activity
+    event supplies its title and dependency list when available; otherwise a
+    safe recovery description and the graph dependencies are used. Unknown and
+    duplicate dependencies are removed, so the returned gameplan is always
+    referentially valid.
+
+    The function is total and idempotent. *)

--- a/test/dune
+++ b/test/dune
@@ -64,6 +64,13 @@
  (ocamlc_flags (:standard -w -40-42)))
 
 (test
+ (name test_resume_gameplan_properties)
+ (modules test_resume_gameplan_properties)
+ (libraries onton_core qcheck-core qcheck-core.runner base)
+ (ocamlopt_flags (:standard -w -40-42))
+ (ocamlc_flags (:standard -w -40-42)))
+
+(test
  (name test_patch_agent)
  (modules test_patch_agent)
  (libraries onton onton_core qcheck-core))

--- a/test/test_resume_gameplan_properties.ml
+++ b/test/test_resume_gameplan_properties.ml
@@ -161,21 +161,66 @@ let prop_reconstructs_corrupted_runtime_patch =
       | None -> false)
 
 let prop_added_patch_event_message_encodes_patch_metadata =
+  let title_part =
+    QCheck2.Gen.string_size
+      ~gen:(QCheck2.Gen.char_range 'a' 'z')
+      (QCheck2.Gen.int_range 1 32)
+  in
+  let title =
+    QCheck2.Gen.oneof
+      [
+        title_part;
+        QCheck2.Gen.map2
+          (fun left right -> left ^ ") — " ^ right)
+          title_part title_part;
+      ]
+  in
   QCheck2.Test.make
-    ~name:"added patch event encoding preserves id, dependencies, and title"
+    ~name:"added patch event encoding round-trips through resume reconstruction"
     ~count:200
-    QCheck2.Gen.(pair string (list string))
-    (fun (title, dependency_names) ->
-      let dependencies = List.map dependency_names ~f:pid in
-      let added = runtime_patch ~dependencies "add1" title in
-      let encoded_dependencies =
-        match dependency_names with
-        | [] -> "no dependencies"
-        | names -> "depends on " ^ String.concat names ~sep:", "
+    QCheck2.Gen.(pair title (list_size (int_range 0 8) (int_range 1 6)))
+    (fun (title, dependency_numbers) ->
+      let dependencies =
+        List.map dependency_numbers ~f:(fun number ->
+            pid (Int.to_string number))
       in
-      String.equal
-        (Resume_gameplan.added_patch_event_message added)
-        (Printf.sprintf "Added patch add1 (%s) — %s" encoded_dependencies title))
+      let expected_dependencies =
+        List.fold dependencies ~init:[] ~f:(fun unique dependency ->
+            if List.mem unique dependency ~equal:Patch_id.equal then unique
+            else unique @ [ dependency ])
+      in
+      let loaded =
+        gameplan
+          (List.init 6 ~f:(fun index ->
+               let id = Int.to_string (index + 1) in
+               patch id ("patch " ^ id)))
+      in
+      let patch_id = pid "add1" in
+      let added = runtime_patch ~dependencies "add1" title in
+      let activity_log =
+        Activity_log.add_event Activity_log.empty
+          (Activity_log.Event.create ~timestamp:1.0 ~patch_id
+             (Resume_gameplan.added_patch_event_message added))
+      in
+      let result =
+        reconcile ~loaded ~persisted:loaded ~activity_log
+          ~missing_patches:
+            [
+              {
+                Resume_gameplan.patch_id;
+                branch = Gameplan.branch_of_id loaded patch_id;
+                dependencies = [];
+              };
+            ]
+          ()
+      in
+      match find_patch result.gameplan patch_id with
+      | Some recovered ->
+          String.equal recovered.Patch.title title
+          && String.equal recovered.description title
+          && List.equal Patch_id.equal recovered.dependencies
+               expected_dependencies
+      | None -> false)
 
 let prop_does_not_heal_adhoc_or_noncanonical_patch =
   QCheck2.Test.make

--- a/test/test_resume_gameplan_properties.ml
+++ b/test/test_resume_gameplan_properties.ml
@@ -208,7 +208,7 @@ let prop_added_patch_event_message_encodes_patch_metadata =
             [
               {
                 Resume_gameplan.patch_id;
-                branch = Gameplan.branch_of_id loaded patch_id;
+                branch = added.branch;
                 dependencies = [];
               };
             ]

--- a/test/test_resume_gameplan_properties.ml
+++ b/test/test_resume_gameplan_properties.ml
@@ -1,0 +1,244 @@
+(* @archlint.module test
+   @archlint.domain orchestrator *)
+
+open Base
+open Onton_core
+open Types
+
+let pid = Patch_id.of_string
+
+let patch ?(dependencies = []) id title =
+  let id = pid id in
+  {
+    Patch.id;
+    title;
+    description = title ^ " description";
+    branch = Branch.of_string ("resume/patch-" ^ Patch_id.to_string id);
+    dependencies;
+    spec = "";
+    acceptance_criteria = [];
+    files = [];
+    classification = "";
+    changes = [];
+    test_stubs_introduced = [];
+    test_stubs_implemented = [];
+    complexity = None;
+    precedents = [];
+    required_context = [];
+  }
+
+let gameplan patches =
+  {
+    Gameplan.project_name = "resume";
+    repo_owner = "owner";
+    repo_name = "repo";
+    problem_statement = "problem";
+    solution_summary = "solution";
+    final_state_spec = "spec";
+    patches;
+    functional_changes = [];
+    context_resources = [];
+    reachability_traces = [];
+    current_state_analysis = "state";
+    explicit_opinions = "opinions";
+    acceptance_criteria = [];
+    open_questions = [];
+  }
+
+let runtime_patch ?(dependencies = []) id title =
+  let patch_id = pid id in
+  {
+    (patch ~dependencies id title) with
+    Patch.branch = Gameplan.branch_of_id (gameplan []) patch_id;
+  }
+
+let find_patch gameplan patch_id =
+  List.find gameplan.Gameplan.patches ~f:(fun patch ->
+      Patch_id.equal patch.Patch.id patch_id)
+
+let reconcile ?(missing_patches = []) ?(activity_log = Activity_log.empty)
+    ~loaded ~persisted () =
+  Resume_gameplan.reconcile ~loaded ~persisted ~missing_patches ~activity_log
+
+let prop_totality =
+  QCheck2.Test.make ~name:"resume gameplan reconciliation is total" ~count:500
+    QCheck2.Gen.(triple string string (list string))
+    (fun (title, message, dependency_names) ->
+      try
+        let base = patch "1" "base" in
+        let added = runtime_patch "add1" title in
+        let loaded = gameplan [ base ] in
+        let persisted = gameplan [ base; added ] in
+        let dependencies = List.map dependency_names ~f:pid in
+        let activity_log =
+          Activity_log.add_event Activity_log.empty
+            (Activity_log.Event.create ~timestamp:1.0 ~patch_id:(pid "add1")
+               message)
+        in
+        ignore
+          (reconcile ~loaded ~persisted ~activity_log
+             ~missing_patches:
+               [
+                 {
+                   Resume_gameplan.patch_id = pid "add1";
+                   branch = added.branch;
+                   dependencies;
+                 };
+               ]
+             ()
+            : Resume_gameplan.result);
+        true
+      with _ -> false)
+
+let prop_preserves_snapshot_runtime_patch_exactly =
+  QCheck2.Test.make
+    ~name:"resume preserves snapshot-only runtime patch metadata exactly"
+    ~count:200 QCheck2.Gen.string (fun description ->
+      let base = patch "1" "base" in
+      let added =
+        {
+          (runtime_patch ~dependencies:[ pid "1" ] "add1" "follow-up") with
+          Patch.description;
+        }
+      in
+      let result =
+        reconcile ~loaded:(gameplan [ base ])
+          ~persisted:(gameplan [ base; added ])
+          ()
+      in
+      match find_patch result.gameplan (pid "add1") with
+      | Some actual ->
+          Patch.equal actual added
+          && List.equal Resume_gameplan.equal_repair result.repairs
+               [ Resume_gameplan.Preserved_snapshot_patch (pid "add1") ]
+      | None -> false)
+
+let prop_loaded_patch_wins_on_collision =
+  QCheck2.Test.make ~name:"freshly loaded patch wins on id collision" ~count:1
+    QCheck2.Gen.unit (fun () ->
+      let loaded_add = runtime_patch "add1" "loaded" in
+      let stale_add = runtime_patch "add1" "stale snapshot" in
+      let result =
+        reconcile ~loaded:(gameplan [ loaded_add ])
+          ~persisted:(gameplan [ stale_add ]) ()
+      in
+      match find_patch result.gameplan (pid "add1") with
+      | Some actual ->
+          String.equal actual.Patch.title "loaded"
+          && List.is_empty result.repairs
+      | None -> false)
+
+let prop_reconstructs_corrupted_runtime_patch =
+  QCheck2.Test.make
+    ~name:"corrupted addN patch is reconstructed from activity and graph"
+    ~count:1 QCheck2.Gen.unit (fun () ->
+      let one = patch "1" "one" in
+      let two = patch "2" "two" in
+      let loaded = gameplan [ one; two ] in
+      let patch_id = pid "add1" in
+      let branch = Gameplan.branch_of_id loaded patch_id in
+      let activity_log =
+        Activity_log.add_event Activity_log.empty
+          (Activity_log.Event.create ~timestamp:2.0 ~patch_id
+             "Added patch add1 (depends on 1, 2, 2, gone) — More expressive \
+              auth composition")
+      in
+      let result =
+        reconcile ~loaded ~persisted:loaded ~activity_log
+          ~missing_patches:
+            [ { Resume_gameplan.patch_id; branch; dependencies = [ pid "1" ] } ]
+          ()
+      in
+      match find_patch result.gameplan patch_id with
+      | Some recovered ->
+          String.equal recovered.Patch.title "More expressive auth composition"
+          && String.equal recovered.description recovered.title
+          && Branch.equal recovered.branch branch
+          && List.equal Patch_id.equal recovered.dependencies
+               [ pid "1"; pid "2" ]
+          && List.equal Resume_gameplan.equal_repair result.repairs
+               [ Resume_gameplan.Reconstructed_missing_patch patch_id ]
+      | None -> false)
+
+let prop_does_not_heal_adhoc_or_noncanonical_patch =
+  QCheck2.Test.make
+    ~name:"numeric ad-hoc and noncanonical addN agents are not synthesized"
+    ~count:1 QCheck2.Gen.unit (fun () ->
+      let loaded = gameplan [ patch "1" "one" ] in
+      let result =
+        reconcile ~loaded ~persisted:loaded
+          ~missing_patches:
+            [
+              {
+                Resume_gameplan.patch_id = pid "123";
+                branch = Branch.of_string "resume/patch-123";
+                dependencies = [];
+              };
+              {
+                Resume_gameplan.patch_id = pid "add1";
+                branch = Branch.of_string "somewhere/else";
+                dependencies = [];
+              };
+            ]
+          ()
+      in
+      List.length result.gameplan.patches = 1 && List.is_empty result.repairs)
+
+let prop_reconstructed_patches_can_depend_on_each_other =
+  QCheck2.Test.make
+    ~name:"reconstructed runtime patches retain dependencies on each other"
+    ~count:1 QCheck2.Gen.unit (fun () ->
+      let loaded = gameplan [ patch "1" "one" ] in
+      let add1 = pid "add1" in
+      let add2 = pid "add2" in
+      let result =
+        reconcile ~loaded ~persisted:loaded
+          ~missing_patches:
+            [
+              {
+                Resume_gameplan.patch_id = add2;
+                branch = Gameplan.branch_of_id loaded add2;
+                dependencies = [ add1 ];
+              };
+              {
+                Resume_gameplan.patch_id = add1;
+                branch = Gameplan.branch_of_id loaded add1;
+                dependencies = [ pid "1" ];
+              };
+            ]
+          ()
+      in
+      match find_patch result.gameplan add2 with
+      | Some recovered ->
+          List.equal Patch_id.equal recovered.Patch.dependencies [ add1 ]
+      | None -> false)
+
+let prop_gameplan_reconciliation_is_idempotent =
+  QCheck2.Test.make ~name:"resume gameplan reconciliation is idempotent"
+    ~count:200 QCheck2.Gen.string (fun title ->
+      let base = patch "1" "base" in
+      let added = runtime_patch ~dependencies:[ pid "1" ] "add1" title in
+      let first =
+        reconcile ~loaded:(gameplan [ base ])
+          ~persisted:(gameplan [ base; added ])
+          ()
+      in
+      let second =
+        reconcile ~loaded:first.gameplan ~persisted:first.gameplan ()
+      in
+      Gameplan.equal first.gameplan second.gameplan)
+
+let () =
+  let tests =
+    [
+      prop_totality;
+      prop_preserves_snapshot_runtime_patch_exactly;
+      prop_loaded_patch_wins_on_collision;
+      prop_reconstructs_corrupted_runtime_patch;
+      prop_does_not_heal_adhoc_or_noncanonical_patch;
+      prop_reconstructed_patches_can_depend_on_each_other;
+      prop_gameplan_reconciliation_is_idempotent;
+    ]
+  in
+  let exit_code = QCheck_base_runner.run_tests ~verbose:true tests in
+  if exit_code <> 0 then Stdlib.exit exit_code

--- a/test/test_resume_gameplan_properties.ml
+++ b/test/test_resume_gameplan_properties.ml
@@ -213,6 +213,49 @@ let prop_reconstructed_patches_can_depend_on_each_other =
           List.equal Patch_id.equal recovered.Patch.dependencies [ add1 ]
       | None -> false)
 
+let prop_sanitizes_malformed_dependencies =
+  QCheck2.Test.make
+    ~name:"resume removes unknown, duplicate, self, and cyclic dependencies"
+    ~count:1 QCheck2.Gen.unit (fun () ->
+      let one = patch ~dependencies:[ pid "gone" ] "1" "one" in
+      let add1 =
+        runtime_patch
+          ~dependencies:[ pid "add1"; pid "1"; pid "1"; pid "add2" ]
+          "add1" "first"
+      in
+      let add2 = runtime_patch ~dependencies:[ pid "add1" ] "add2" "second" in
+      let result =
+        reconcile ~loaded:(gameplan [ one ])
+          ~persisted:(gameplan [ one; add1; add2 ])
+          ()
+      in
+      match
+        ( find_patch result.gameplan (pid "1"),
+          find_patch result.gameplan (pid "add1"),
+          find_patch result.gameplan (pid "add2") )
+      with
+      | Some one, Some add1, Some add2 ->
+          List.is_empty one.Patch.dependencies
+          && List.equal Patch_id.equal add1.dependencies [ pid "1" ]
+          && List.is_empty add2.dependencies
+      | _ -> false)
+
+let prop_rejects_duplicate_snapshot_branches =
+  QCheck2.Test.make
+    ~name:"resume rejects snapshot runtime patches with duplicate branches"
+    ~count:1 QCheck2.Gen.unit (fun () ->
+      let one = patch "1" "one" in
+      let duplicate =
+        { (runtime_patch "add1" "duplicate") with Patch.branch = one.branch }
+      in
+      let result =
+        reconcile ~loaded:(gameplan [ one ])
+          ~persisted:(gameplan [ one; duplicate ])
+          ()
+      in
+      Option.is_none (find_patch result.gameplan (pid "add1"))
+      && List.is_empty result.repairs)
+
 let prop_gameplan_reconciliation_is_idempotent =
   QCheck2.Test.make ~name:"resume gameplan reconciliation is idempotent"
     ~count:200 QCheck2.Gen.string (fun title ->
@@ -237,6 +280,8 @@ let () =
       prop_reconstructs_corrupted_runtime_patch;
       prop_does_not_heal_adhoc_or_noncanonical_patch;
       prop_reconstructed_patches_can_depend_on_each_other;
+      prop_sanitizes_malformed_dependencies;
+      prop_rejects_duplicate_snapshot_branches;
       prop_gameplan_reconciliation_is_idempotent;
     ]
   in

--- a/test/test_resume_gameplan_properties.ml
+++ b/test/test_resume_gameplan_properties.ml
@@ -160,6 +160,23 @@ let prop_reconstructs_corrupted_runtime_patch =
                [ Resume_gameplan.Reconstructed_missing_patch patch_id ]
       | None -> false)
 
+let prop_added_patch_event_message_encodes_patch_metadata =
+  QCheck2.Test.make
+    ~name:"added patch event encoding preserves id, dependencies, and title"
+    ~count:200
+    QCheck2.Gen.(pair string (list string))
+    (fun (title, dependency_names) ->
+      let dependencies = List.map dependency_names ~f:pid in
+      let added = runtime_patch ~dependencies "add1" title in
+      let encoded_dependencies =
+        match dependency_names with
+        | [] -> "no dependencies"
+        | names -> "depends on " ^ String.concat names ~sep:", "
+      in
+      String.equal
+        (Resume_gameplan.added_patch_event_message added)
+        (Printf.sprintf "Added patch add1 (%s) — %s" encoded_dependencies title))
+
 let prop_does_not_heal_adhoc_or_noncanonical_patch =
   QCheck2.Test.make
     ~name:"numeric ad-hoc and noncanonical addN agents are not synthesized"
@@ -278,6 +295,7 @@ let () =
       prop_preserves_snapshot_runtime_patch_exactly;
       prop_loaded_patch_wins_on_collision;
       prop_reconstructs_corrupted_runtime_patch;
+      prop_added_patch_event_message_encodes_patch_metadata;
       prop_does_not_heal_adhoc_or_noncanonical_patch;
       prop_reconstructed_patches_can_depend_on_each_other;
       prop_sanitizes_malformed_dependencies;

--- a/test/test_runtime_create.ml
+++ b/test/test_runtime_create.ml
@@ -82,3 +82,120 @@ let () =
   in
   assert (Branch.equal actual new_branch);
   Printf.printf "PASS: Runtime.create overrides snapshot main_branch\n"
+
+(* Regression test for runtime-added planned patches. The source gameplan is
+   intentionally stale because these patches are snapshot-only by design.
+   Resume must keep intact metadata and must also reconstruct a legacy snapshot
+   that was already saved after the stale source gameplan overwrote it. *)
+let () =
+  let open Onton_core in
+  let open Types in
+  let main_branch = Branch.of_string "main" in
+  let base_id = Patch_id.of_string "1" in
+  let added_id = Patch_id.of_string "add1" in
+  let base_patch =
+    {
+      Patch.id = base_id;
+      title = "base";
+      description = "base";
+      branch = Branch.of_string "resume/patch-1";
+      dependencies = [];
+      spec = "";
+      acceptance_criteria = [];
+      files = [];
+      classification = "";
+      changes = [];
+      test_stubs_introduced = [];
+      test_stubs_implemented = [];
+      complexity = None;
+      precedents = [];
+      required_context = [];
+    }
+  in
+  let source_gameplan =
+    {
+      Gameplan.project_name = "resume";
+      repo_owner = "";
+      repo_name = "";
+      problem_statement = "";
+      solution_summary = "";
+      final_state_spec = "";
+      patches = [ base_patch ];
+      current_state_analysis = "";
+      explicit_opinions = "";
+      acceptance_criteria = [];
+      open_questions = [];
+      functional_changes = [];
+      context_resources = [];
+      reachability_traces = [];
+    }
+  in
+  let added_patch =
+    {
+      base_patch with
+      Patch.id = added_id;
+      title = "More expressive auth composition";
+      description = "Full runtime-added patch description";
+      branch = Gameplan.branch_of_id source_gameplan added_id;
+      dependencies = [ base_id ];
+    }
+  in
+  let orchestrator =
+    Onton.Orchestrator.create ~patches:[ base_patch ] ~main_branch
+    |> fun orchestrator ->
+    Onton.Orchestrator.add_planned_patch orchestrator added_patch
+      ~deps:[ base_id ]
+  in
+  let make_snapshot ~gameplan ~activity_log =
+    {
+      Onton.Runtime.orchestrator;
+      activity_log;
+      gameplan;
+      transcripts = Base.Hashtbl.create (module Patch_id);
+    }
+  in
+  let persisted_gameplan =
+    { source_gameplan with Gameplan.patches = [ base_patch; added_patch ] }
+  in
+  let intact_runtime =
+    Onton.Runtime.create ~gameplan:source_gameplan ~main_branch
+      ~snapshot:
+        (make_snapshot ~gameplan:persisted_gameplan
+           ~activity_log:Activity_log.empty)
+      ()
+  in
+  let intact_patch =
+    Onton.Runtime.read intact_runtime (fun snapshot ->
+        Base.List.find snapshot.Onton.Runtime.gameplan.Gameplan.patches
+          ~f:(fun patch -> Patch_id.equal patch.Patch.id added_id))
+  in
+  assert (Base.Option.equal Patch.equal intact_patch (Some added_patch));
+  let activity_log =
+    Activity_log.add_event Activity_log.empty
+      (Activity_log.Event.create ~timestamp:1.0 ~patch_id:added_id
+         "Added patch add1 (depends on 1) — More expressive auth composition")
+  in
+  let repaired_runtime =
+    Onton.Runtime.create ~gameplan:source_gameplan ~main_branch
+      ~snapshot:(make_snapshot ~gameplan:source_gameplan ~activity_log)
+      ()
+  in
+  let repaired_snapshot = Onton.Runtime.read repaired_runtime Base.Fn.id in
+  let repaired_patch =
+    Base.List.find repaired_snapshot.Onton.Runtime.gameplan.Gameplan.patches
+      ~f:(fun patch -> Patch_id.equal patch.Patch.id added_id)
+  in
+  assert (Base.Option.is_some repaired_patch);
+  assert (
+    Base.List.equal Resume_gameplan.equal_repair
+      (Onton.Runtime.resume_repairs repaired_runtime)
+      [ Resume_gameplan.Reconstructed_missing_patch added_id ]);
+  assert (
+    try
+      ignore
+        (Onton.Patch_controller.plan_messages
+           repaired_snapshot.Onton.Runtime.orchestrator
+           ~patches:repaired_snapshot.Onton.Runtime.gameplan.Gameplan.patches);
+      true
+    with Invalid_argument _ -> false);
+  Printf.printf "PASS: Runtime.create heals runtime-added patches on resume\n"

--- a/test/test_runtime_create.ml
+++ b/test/test_runtime_create.ml
@@ -145,6 +145,9 @@ let () =
     |> fun orchestrator ->
     Onton.Orchestrator.add_planned_patch orchestrator added_patch
       ~deps:[ base_id ]
+    |> fun orchestrator ->
+    Onton.Orchestrator.set_pr_number orchestrator added_id
+      (Pr_number.of_int 417)
   in
   let make_snapshot ~gameplan ~activity_log =
     {
@@ -170,10 +173,16 @@ let () =
           ~f:(fun patch -> Patch_id.equal patch.Patch.id added_id))
   in
   assert (Base.Option.equal Patch.equal intact_patch (Some added_patch));
+  assert (
+    Base.List.count
+      (Onton.Runtime.read intact_runtime (fun snapshot ->
+           snapshot.Onton.Runtime.gameplan.Gameplan.patches))
+      ~f:(fun patch -> Patch_id.equal patch.Patch.id added_id)
+    = 1);
   let activity_log =
     Activity_log.add_event Activity_log.empty
       (Activity_log.Event.create ~timestamp:1.0 ~patch_id:added_id
-         "Added patch add1 (depends on 1) — More expressive auth composition")
+         (Resume_gameplan.added_patch_event_message added_patch))
   in
   let repaired_runtime =
     Onton.Runtime.create ~gameplan:source_gameplan ~main_branch
@@ -185,7 +194,11 @@ let () =
     Base.List.find repaired_snapshot.Onton.Runtime.gameplan.Gameplan.patches
       ~f:(fun patch -> Patch_id.equal patch.Patch.id added_id)
   in
-  assert (Base.Option.is_some repaired_patch);
+  let expected_repaired_patch =
+    { added_patch with Patch.description = "More expressive auth composition" }
+  in
+  assert (
+    Base.Option.equal Patch.equal repaired_patch (Some expected_repaired_patch));
   assert (
     Base.List.equal Resume_gameplan.equal_repair
       (Onton.Runtime.resume_repairs repaired_runtime)


### PR DESCRIPTION
## Summary

- Preserve snapshot-only runtime-added `addN` patches when resuming with the original source gameplan.
- Reconstruct already-corrupted runtime patch state from the canonical branch, dependency graph, and saved “Added patch” activity event.
- Keep fatal supervisor diagnostics visible by printing them after TUI terminal cleanup.
- Add pure property coverage and an end-to-end runtime resume regression.

## Root cause

Runtime-added patches are persisted only in the snapshot gameplan. On resume, `Runtime.create` replaced that persisted gameplan with the original on-disk gameplan. This removed `add1` metadata while leaving its agent in the orchestrator graph, causing `Patch_controller.reconcile_messages` to reject it as an orphan.

The supervisor printed that error before TUI cleanup, and `exit_tui` then cleared the screen, making the crash appear silent.

## Impact

Normal snapshots retain complete runtime-added patch metadata. Snapshots already damaged by the old behavior heal canonical `addN` patches and can resume instead of repeatedly crashing. Numeric ad-hoc PR agents remain outside this recovery path.

## Validation

- `dune fmt`
- `dune build`
- `dune runtest`
- Reproduced against a copy of the affected `modular-auth-recipe-toolkit` state: `add1` was reconstructed with all 13 dependencies and the TUI rendered without the invariant failure.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/417"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789656958&installation_model_id=19519&pr_number=417&repository=flowglad%2Fonton&return_to=https%3A%2F%2Fgithub.com%2Fflowglad%2Fonton%2Fpull%2F417&signature=56613a8d57a7e93b49104ace76ddefbc39559c488610f40f7c6acb35a7942630"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Runtime snapshots now preserve and restore runtime-added patches when resuming.
  * Missing eligible patches can be reconstructed from saved activity history.
  * Startup reports repaired or restored patches.

* **Bug Fixes**
  * Improved recovery from incomplete or outdated snapshots.
  * Fatal supervisor errors are now reported after shutdown, preventing duplicate or premature messages.

* **Tests**
  * Added coverage for snapshot reconciliation, patch recovery, dependencies, collisions, and repeated resumes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->