### PR TITLE
Fix human message delivery for starting patches

### DIFF
--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -1194,7 +1194,13 @@ let apply_start_outcome t patch_id outcome =
       (* Caller must complete explicitly after PR discovery finishes,
          so busy=true is held throughout the network call. *)
       t
-  | Start_failed -> complete t patch_id
+  | Start_failed ->
+      (* A no-PR Start may be carrying queued Human guidance. If the backend
+         never accepted the turn (for example worktree setup was refused),
+         restore that still-inflight guidance instead of clearing it. Once the
+         backend accepts the turn, Session_driver clears inflight and this is
+         equivalent to plain [complete]. *)
+      complete_failed t patch_id
 
 type respond_outcome =
   | Respond_ok

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -1009,10 +1009,10 @@ type session_result =
           surfaces for intervention. *)
 [@@deriving show, eq, sexp_of]
 
-(** Complete a failed session, restoring only still-inflight human messages to
-    the inbox. Human messages are cleared from the inflight slot as soon as the
-    backend accepts the turn, so anything remaining here was not delivered and
-    should be retried. *)
+(** Complete a failed session, restoring still-inflight human messages to the
+    inbox. PR-backed Human Respond messages leave the slot at backend
+    acceptance. Human-carrying Start messages deliberately remain until
+    successful post-PR completion, so every earlier failure restores them. *)
 let complete_failed t patch_id =
   let a = agent t patch_id in
   let inflight = a.Patch_agent.inflight_human_messages in
@@ -1027,6 +1027,10 @@ let complete_failed t patch_id =
     not (List.is_empty (agent t patch_id).Patch_agent.human_messages)
   in
   if has_messages then enqueue t patch_id Operation_kind.Human else t
+
+let complete_start_after_pr_discovery t patch_id =
+  if Patch_agent.is_pr_present (agent t patch_id) then complete t patch_id
+  else complete_failed t patch_id
 
 type force_complete_reason = Cancelled | Unexpected_exception
 [@@deriving show, eq, sexp_of]
@@ -1110,16 +1114,16 @@ let apply_session_result t patch_id result =
   | Session_push_failed reason -> (
       (* The LLM session itself ran cleanly — clear its fallback state so we
          resume the same session next iteration. The push failure does NOT
-         use [complete_failed]: the session succeeded, so any inflight human
-         messages were already delivered to the LLM and must not be restored
-         to the inbox.  Completion is deferred to [apply_respond_outcome]
-         which calls plain [complete] via [Respond_retry_push].  Using
-         [complete_failed] here caused an infinite loop: messages were
-         re-enqueued, the Human operation re-dispatched, the session
-         re-delivered the same messages, the push failed again, ad
-         infinitum — with [clear_session_fallback] preventing escalation
-         and the Human-in-queue exemption in [needs_intervention]
-         preventing the circuit breaker from firing.
+         use [complete_failed] directly. For a PR-backed Human Respond,
+         acceptance already consumed inflight messages and completion is
+         deferred to [apply_respond_outcome] via [Respond_retry_push]. For a
+         Human-carrying Start, inflight remains and the caller's
+         [Start_failed] follow-up restores it. Calling [complete_failed] here
+         caused an infinite Respond loop: messages were re-enqueued, the Human
+         operation re-dispatched, the session re-delivered the same messages,
+         the push failed again, ad infinitum — with [clear_session_fallback]
+         preventing escalation and the Human-in-queue exemption in
+         [needs_intervention] preventing the circuit breaker from firing.
 
          The [push_failure_count] counter (added in P0-B) feeds
          [needs_intervention] once it reaches 3, breaking the tight retry
@@ -1141,10 +1145,10 @@ let apply_session_result t patch_id result =
       (* The LLM session ran cleanly but left no commits on the branch (HEAD
          == base), so the supervisor skipped the push. Clear session fallback
          (the LLM itself was healthy), bump the no-commits counter (which
-         feeds [needs_intervention] at >= 2).  Like [Session_push_failed],
-         do NOT call [complete_failed] — the session succeeded and any
-         inflight human messages were delivered.  Completion is handled by
-         [apply_respond_outcome] via [Respond_retry_push]. *)
+         feeds [needs_intervention] at >= 2). Like [Session_push_failed], do NOT
+         complete here: a Respond caller uses its normal outcome transition,
+         while a Start caller uses [Start_failed], which restores retained
+         Human Start guidance. *)
       let t = clear_session_fallback t patch_id in
       update_agent t patch_id ~f:Patch_agent.increment_no_commits_push_count
   | Session_context_exhausted ->
@@ -1197,11 +1201,10 @@ let apply_start_outcome t patch_id outcome =
          so busy=true is held throughout the network call. *)
       t
   | Start_failed ->
-      (* A no-PR Start may be carrying queued Human guidance. If the backend
-         never accepted the turn (for example worktree setup was refused),
-         restore that still-inflight guidance instead of clearing it. Once the
-         backend accepts the turn, Session_driver clears inflight and this is
-         equivalent to plain [complete]. *)
+      (* A no-PR Start may be carrying queued Human guidance. Keep it
+         recoverable across every failure before successful PR association and
+         explicit completion, including accepted no-commit and push-failure
+         sessions. *)
       complete_failed t patch_id
 
 type respond_outcome =

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -484,7 +484,9 @@ let resume_message t message_id =
           then
             let op =
               match msg.action with
-              | Start _ -> None
+              | Start _ ->
+                  if List.is_empty agent.inflight_human_messages then None
+                  else Some Operation_kind.Human
               | Respond (_, kind) -> Some kind
               | Rebase _ -> Some Operation_kind.Rebase
             in

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -317,8 +317,9 @@ type start_outcome = Start_ok | Start_failed | Start_stale
 [@@deriving show, eq, sexp_of]
 
 val apply_start_outcome : t -> Patch_id.t -> start_outcome -> t
-(** Apply the outcome of a Start action fiber. [Start_failed] -> complete.
-    [Start_ok] -> identity (caller must [complete] after PR discovery).
+(** Apply the outcome of a Start action fiber. [Start_failed] ->
+    [complete_failed], restoring any Human guidance that the backend did not
+    accept. [Start_ok] -> identity (caller must [complete] after PR discovery).
     [Start_stale] -> identity. *)
 
 type respond_outcome =

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -69,6 +69,13 @@ val message_status : patch_agent_message -> message_status
 (** {2 External event application} *)
 
 val complete : t -> Patch_id.t -> t
+
+val complete_start_after_pr_discovery : t -> Patch_id.t -> t
+(** Finish a Start after its supervisor-owned PR creation/discovery step. When a
+    PR is present, completes normally and consumes any Human guidance carried by
+    the Start. When no PR was established, restores that guidance through the
+    failed-completion path before retry/intervention. *)
+
 val enqueue : t -> Patch_id.t -> Operation_kind.t -> t
 val mark_merged : t -> Patch_id.t -> t
 val remove_agent : t -> Patch_id.t -> t
@@ -158,7 +165,9 @@ val set_worktree_path : t -> Patch_id.t -> string -> t
 val set_llm_session_id : t -> Patch_id.t -> string option -> t
 
 val mark_inflight_human_messages_delivered : t -> Patch_id.t -> t
-(** Clear inflight Human messages after backend turn acceptance. See
+(** Clear inflight Human messages after backend acceptance of a PR-backed Human
+    Respond. Human-carrying Starts deliberately retain guidance until
+    {!complete_start_after_pr_discovery}. See
     {!Patch_agent.mark_inflight_human_messages_delivered}. *)
 
 val set_automerge_enabled : t -> Patch_id.t -> bool -> t
@@ -279,13 +288,13 @@ val apply_session_result : t -> Patch_id.t -> session_result -> t
     [apply_respond_outcome _ _ Respond_retry_push] (Respond path) to clear
     [busy]. This two-phase design is deliberate: the LLM session itself
     succeeded (messages were delivered; commits were made locally), so any
-    inflight human payload must be consumed by plain [complete] rather than
-    restored by [complete_failed] — the latter would re-enqueue Human and cause
-    an infinite re-delivery loop. After 2 consecutive [Session_no_commits]
-    outcomes, [needs_intervention] fires via [no_commits_push_count >= 2]. After
-    3 consecutive [Session_push_failed] outcomes (or a single one carrying a
-    permanent rejection), [needs_intervention] fires via
-    [push_failure_count >= 3] or [Given_up]. *)
+    inflight payload from a PR-backed Human Respond has already been consumed at
+    acceptance and uses plain [complete]. A Human-carrying Start deliberately
+    retains its payload and its [Start_failed] follow-up restores it. After 2
+    consecutive [Session_no_commits] outcomes, [needs_intervention] fires via
+    [no_commits_push_count >= 2]. After 3 consecutive [Session_push_failed]
+    outcomes (or a single one carrying a permanent rejection),
+    [needs_intervention] fires via [push_failure_count >= 3] or [Given_up]. *)
 
 val combine_session_and_push :
   branch_changed:bool ->
@@ -318,9 +327,10 @@ type start_outcome = Start_ok | Start_failed | Start_stale
 
 val apply_start_outcome : t -> Patch_id.t -> start_outcome -> t
 (** Apply the outcome of a Start action fiber. [Start_failed] ->
-    [complete_failed], restoring any Human guidance that the backend did not
-    accept. [Start_ok] -> identity (caller must [complete] after PR discovery).
-    [Start_stale] -> identity. *)
+    [complete_failed], restoring any Human guidance whose Start did not
+    successfully complete. [Start_ok] -> identity (caller must use
+    {!complete_start_after_pr_discovery} after PR discovery). [Start_stale] ->
+    identity. *)
 
 type respond_outcome =
   | Respond_ok

--- a/lib/runner_fiber_impl.ml
+++ b/lib/runner_fiber_impl.ml
@@ -664,48 +664,65 @@ struct
     in
     let run_llm_session ~sw ~gameplan_prompt ~patch_prompt ~kind ~patch_id
         ~prompt ~agent ~on_pr_detected ~complexity =
-      match pick_backend ~complexity with
-      | Backend_registry.Ephemeral backend, _decision ->
-          Session_driver.run ~kind ~patch_id ~prompt ~agent ~on_pr_detected
-            ~backend ~complexity
-      | Backend_registry.Long_lived backend, decision -> (
-          let patch_agent_model_result =
-            match
-              Backend_registry.resolve_model
-                ~backend:decision.Backend_routing.backend
-                ~model:decision.Backend_routing.model ~complexity
-            with
-            | Some m when not (Base.String.is_empty (Base.String.strip m)) ->
-                Ok (Base.String.strip m)
-            | Some _ | None ->
-                Error
-                  "patch-agent backend requires a concrete non-empty model \
-                   after routing"
-          in
-          match patch_agent_model_result with
-          | Error message ->
-              log_event runtime ~patch_id message;
-              (`Failed, [])
-          | Ok patch_agent_model ->
-              let session =
-                match Long_lived_sessions.find long_lived_sessions patch_id with
-                | Some session ->
-                    Session_driver.update_long_lived_session_prompts session
-                      ~gameplan_prompt ~patch_prompt;
-                    session
-                | None ->
-                    let session =
-                      Session_driver.create_long_lived_session ~backend
-                        ~provider:patch_agent_provider ~model:patch_agent_model
-                        ~effort:patch_agent_effort ~gameplan_prompt
-                        ~patch_prompt
-                    in
-                    Long_lived_sessions.register long_lived_sessions patch_id
-                      session;
-                    session
-              in
-              Session_driver.run_long_lived ~sw ~kind ~patch_id ~prompt ~agent
-                ~on_pr_detected ~session ~complexity)
+      let session_result =
+        match pick_backend ~complexity with
+        | Backend_registry.Ephemeral backend, _decision ->
+            Session_driver.run ~kind ~patch_id ~prompt ~agent ~on_pr_detected
+              ~backend ~complexity
+        | Backend_registry.Long_lived backend, decision -> (
+            let patch_agent_model_result =
+              match
+                Backend_registry.resolve_model
+                  ~backend:decision.Backend_routing.backend
+                  ~model:decision.Backend_routing.model ~complexity
+              with
+              | Some m when not (Base.String.is_empty (Base.String.strip m)) ->
+                  Ok (Base.String.strip m)
+              | Some _ | None ->
+                  Error
+                    "patch-agent backend requires a concrete non-empty model \
+                     after routing"
+            in
+            match patch_agent_model_result with
+            | Error message ->
+                log_event runtime ~patch_id message;
+                ({
+                   disposition = `Failed;
+                   tool_failures = [];
+                   turn_accepted = false;
+                 }
+                  : Session_driver.run_result)
+            | Ok patch_agent_model ->
+                let session =
+                  match
+                    Long_lived_sessions.find long_lived_sessions patch_id
+                  with
+                  | Some session ->
+                      Session_driver.update_long_lived_session_prompts session
+                        ~gameplan_prompt ~patch_prompt;
+                      session
+                  | None ->
+                      let session =
+                        Session_driver.create_long_lived_session ~backend
+                          ~provider:patch_agent_provider
+                          ~model:patch_agent_model ~effort:patch_agent_effort
+                          ~gameplan_prompt ~patch_prompt
+                      in
+                      Long_lived_sessions.register long_lived_sessions patch_id
+                        session;
+                      session
+                in
+                Session_driver.run_long_lived ~sw ~kind ~patch_id ~prompt ~agent
+                  ~on_pr_detected ~session ~complexity)
+      in
+      let disposition =
+        if
+          Patch_decision.human_delivery_unaccepted ~kind
+            ~turn_accepted:session_result.turn_accepted
+        then `Failed
+        else session_result.disposition
+      in
+      (disposition, session_result.tool_failures)
     in
     let shutdown_finished_long_lived_sessions ~sw () =
       let finished =

--- a/lib/runner_fiber_impl.ml
+++ b/lib/runner_fiber_impl.ml
@@ -662,13 +662,13 @@ struct
     let patch_agent_effort =
       Base.Option.value Env.patch_agent_effort ~default:"medium"
     in
-    let run_llm_session ~sw ~gameplan_prompt ~patch_prompt ~kind ~patch_id
-        ~prompt ~agent ~on_pr_detected ~complexity =
+    let run_llm_session ~sw ~gameplan_prompt ~patch_prompt ~kind ~delivery_mode
+        ~patch_id ~prompt ~agent ~on_pr_detected ~complexity =
       let session_result =
         match pick_backend ~complexity with
         | Backend_registry.Ephemeral backend, _decision ->
-            Session_driver.run ~kind ~patch_id ~prompt ~agent ~on_pr_detected
-              ~backend ~complexity
+            Session_driver.run ~kind ~delivery_mode ~patch_id ~prompt ~agent
+              ~on_pr_detected ~backend ~complexity
         | Backend_registry.Long_lived backend, decision -> (
             let patch_agent_model_result =
               match
@@ -712,8 +712,8 @@ struct
                         session;
                       session
                 in
-                Session_driver.run_long_lived ~sw ~kind ~patch_id ~prompt ~agent
-                  ~on_pr_detected ~session ~complexity)
+                Session_driver.run_long_lived ~sw ~kind ~delivery_mode ~patch_id
+                  ~prompt ~agent ~on_pr_detected ~session ~complexity)
       in
       let disposition =
         if
@@ -982,9 +982,10 @@ struct
                                         in
                                         let r, _tool_failures =
                                           run_llm_session ~sw ~gameplan_prompt
-                                            ~patch_prompt ~kind ~patch_id
-                                            ~prompt ~agent ~on_pr_detected
-                                            ~complexity
+                                            ~patch_prompt ~kind
+                                            ~delivery_mode:Patch_decision.Start
+                                            ~patch_id ~prompt ~agent
+                                            ~on_pr_detected ~complexity
                                         in
                                         (r
                                           :> [ `Failed
@@ -1650,8 +1651,10 @@ struct
                                             ~kind:
                                               (Some
                                                  Operation_kind.Merge_conflict)
-                                            ~patch_id ~prompt ~agent
-                                            ~on_pr_detected ~complexity
+                                            ~delivery_mode:
+                                              Patch_decision.Respond ~patch_id
+                                            ~prompt ~agent ~on_pr_detected
+                                            ~complexity
                                         in
                                         (match result with
                                         | `Ok
@@ -2373,8 +2376,10 @@ struct
                                         let result, tool_failures =
                                           run_llm_session ~sw ~gameplan_prompt
                                             ~patch_prompt ~kind:(Some kind)
-                                            ~patch_id ~prompt ~agent
-                                            ~on_pr_detected ~complexity
+                                            ~delivery_mode:
+                                              Patch_decision.Respond ~patch_id
+                                            ~prompt ~agent ~on_pr_detected
+                                            ~complexity
                                         in
                                         let result =
                                           (result

--- a/lib/runner_fiber_impl.ml
+++ b/lib/runner_fiber_impl.ml
@@ -1142,7 +1142,9 @@ struct
                                             Orchestrator.on_pr_discovery_failure
                                               orch patch_id)));
                                 Runtime.update_orchestrator runtime (fun orch ->
-                                    Orchestrator.complete orch patch_id)
+                                    Orchestrator
+                                    .complete_start_after_pr_discovery orch
+                                      patch_id)
                             | Orchestrator.Start_stale -> ())))
             | Orchestrator.Rebase (patch_id, new_base) ->
                 Some

--- a/lib/runner_fiber_impl.ml
+++ b/lib/runner_fiber_impl.ml
@@ -919,7 +919,7 @@ struct
                                             (Stdlib.Filename.concat _wt_path
                                                "AGENTS.md")
                                         in
-                                        let prompt =
+                                        let initial_prompt =
                                           Prompt.render_patch_prompt
                                             ~project_name ?agents_md
                                             ?pr_number:
@@ -927,6 +927,20 @@ struct
                                             patch gameplan
                                             ~base_branch:
                                               (Branch.to_string base_branch)
+                                        in
+                                        let prompt, kind =
+                                          match
+                                            Patch_decision.start_delivery agent
+                                          with
+                                          | Patch_decision.Start_initial ->
+                                              (initial_prompt, None)
+                                          | Patch_decision.Start_with_human
+                                              { messages } ->
+                                              ( initial_prompt ^ "\n\n"
+                                                ^ Prompt
+                                                  .render_human_message_prompt
+                                                    ~project_name messages,
+                                                Some Operation_kind.Human )
                                         in
                                         (* PR detection from stream text is a hint
                                      only — always confirmed via the GitHub
@@ -951,7 +965,7 @@ struct
                                         in
                                         let r, _tool_failures =
                                           run_llm_session ~sw ~gameplan_prompt
-                                            ~patch_prompt ~kind:None ~patch_id
+                                            ~patch_prompt ~kind ~patch_id
                                             ~prompt ~agent ~on_pr_detected
                                             ~complexity
                                         in

--- a/lib/session_driver.ml
+++ b/lib/session_driver.ml
@@ -160,7 +160,8 @@ module Make (W : Worktree.S) (Env : ENV) = struct
   module WS = Worktree_setup.Make (W) (Env)
 
   let run_with_backend ~session_mode_for_agent
-      ~(kind : Types.Operation_kind.t option) ~patch_id ~prompt
+      ~(kind : Types.Operation_kind.t option)
+      ~(delivery_mode : Patch_decision.delivery_mode) ~patch_id ~prompt
       ~(agent : Patch_agent.t) ~on_pr_detected ~backend_name ~run_backend
       ~complexity =
     let make_run_result ?(turn_accepted = false) disposition tool_failures =
@@ -320,7 +321,7 @@ module Make (W : Worktree.S) (Env : ENV) = struct
                     backend_accepted_turn := true;
                     if
                       Patch_decision.human_acceptance_delivers_messages ~agent
-                        ~kind
+                        ~delivery_mode ~kind
                     then
                       Runtime.update_orchestrator runtime (fun orch ->
                           Orchestrator.mark_inflight_human_messages_delivered
@@ -831,7 +832,8 @@ module Make (W : Worktree.S) (Env : ENV) = struct
              Session_no_commits telemetry and keeps the noop gate armed
              for the truly-idle case where the verdict does not rescue. *)
                 let no_commits_is_ok =
-                  Patch_decision.session_no_commits_is_ok ~agent ~kind
+                  Patch_decision.session_no_commits_is_ok ~agent ~delivery_mode
+                    ~kind
                 in
                 let final_session_result =
                   let combined =
@@ -879,10 +881,11 @@ module Make (W : Worktree.S) (Env : ENV) = struct
                 make_run_result ~turn_accepted:!backend_accepted_turn
                   final_user_result (List.rev !tool_failures)))
 
-  let run ~(kind : Types.Operation_kind.t option) ~patch_id ~prompt
+  let run ~(kind : Types.Operation_kind.t option)
+      ~(delivery_mode : Patch_decision.delivery_mode) ~patch_id ~prompt
       ~(agent : Patch_agent.t) ~on_pr_detected ~backend ~complexity =
-    run_with_backend ~kind ~patch_id ~prompt ~agent ~on_pr_detected
-      ~session_mode_for_agent:session_mode
+    run_with_backend ~kind ~delivery_mode ~patch_id ~prompt ~agent
+      ~on_pr_detected ~session_mode_for_agent:session_mode
       ~backend_name:backend.Llm_backend.name
       ~run_backend:backend.Llm_backend.run_streaming ~complexity
 
@@ -965,8 +968,9 @@ module Make (W : Worktree.S) (Env : ENV) = struct
         | Some handle -> session.shutdown handle);
         match handle with None -> () | Some handle -> session.shutdown handle)
 
-  let run_long_lived ~sw ~(kind : Types.Operation_kind.t option) ~patch_id
-      ~prompt ~(agent : Patch_agent.t) ~on_pr_detected ~session ~complexity =
+  let run_long_lived ~sw ~(kind : Types.Operation_kind.t option)
+      ~(delivery_mode : Patch_decision.delivery_mode) ~patch_id ~prompt
+      ~(agent : Patch_agent.t) ~on_pr_detected ~session ~complexity =
     let (Long_lived_session session) = session in
     let run_backend ~project_name ~cwd ~patch_id ~prompt ~resume_session:_
         ~session_uuid:_ ~complexity:_ ~on_event =
@@ -1054,7 +1058,8 @@ module Make (W : Worktree.S) (Env : ENV) = struct
                 session.failure_reason <- Some message;
                 failed_result message)
     in
-    run_with_backend ~kind ~patch_id ~prompt ~agent ~on_pr_detected
+    run_with_backend ~kind ~delivery_mode ~patch_id ~prompt ~agent
+      ~on_pr_detected
       ~session_mode_for_agent:(fun _ -> `Fresh)
       ~backend_name:session.name ~run_backend ~complexity
 end

--- a/lib/session_driver.ml
+++ b/lib/session_driver.ml
@@ -3,6 +3,14 @@
 
 open Base
 
+type disposition = [ `Ok | `Failed | `Retry_push | `No_commits ]
+
+type run_result = {
+  disposition : disposition;
+  tool_failures : (string * string) list;
+  turn_accepted : bool;
+}
+
 let truncate s n =
   if String.length s <= n then s else String.sub s ~pos:0 ~len:n ^ "..."
 
@@ -144,6 +152,8 @@ module type ENV = sig
 end
 
 module Make (W : Worktree.S) (Env : ENV) = struct
+  type nonrec run_result = run_result
+
   let session_mode = session_mode
   let extract_pr_number_from_text = extract_pr_number_from_text
 
@@ -153,6 +163,9 @@ module Make (W : Worktree.S) (Env : ENV) = struct
       ~(kind : Types.Operation_kind.t option) ~patch_id ~prompt
       ~(agent : Patch_agent.t) ~on_pr_detected ~backend_name ~run_backend
       ~complexity =
+    let make_run_result ?(turn_accepted = false) disposition tool_failures =
+      { disposition; tool_failures; turn_accepted }
+    in
     let runtime = Env.runtime in
     let fs = Env.fs in
     let project_name = Env.project_name in
@@ -169,7 +182,7 @@ module Make (W : Worktree.S) (Env : ENV) = struct
         Runtime.update_orchestrator runtime (fun orch ->
             Orchestrator.apply_session_result orch patch_id
               Orchestrator.Session_give_up);
-        (`Failed, [])
+        make_run_result `Failed []
     | (`Resume _ | `Fresh) as mode -> (
         let resume_session, is_fresh =
           match mode with
@@ -181,8 +194,8 @@ module Make (W : Worktree.S) (Env : ENV) = struct
             Runtime.update_orchestrator runtime (fun orch ->
                 Orchestrator.apply_session_result orch patch_id
                   Orchestrator.Session_worktree_missing);
-            (`Failed, [])
-        | Worktree_setup.Refused -> (`Failed, [])
+            make_run_result `Failed []
+        | Worktree_setup.Refused -> make_run_result `Failed []
         | Worktree_setup.Path worktree_path ->
             let cwd = Eio.Path.(fs / worktree_path) in
             let pre_session_branch_sha =
@@ -823,16 +836,7 @@ module Make (W : Worktree.S) (Env : ENV) = struct
              Session_no_commits telemetry and keeps the noop gate armed
              for the truly-idle case where the verdict does not rescue. *)
                 let no_commits_is_ok =
-                  match kind with
-                  | Some Types.Operation_kind.Human -> true
-                  | Some Types.Operation_kind.Findings -> true
-                  | Some Types.Operation_kind.Ci
-                  | Some Types.Operation_kind.Review_comments
-                  | Some Types.Operation_kind.Pr_body
-                  | Some Types.Operation_kind.Merge_conflict
-                  | Some Types.Operation_kind.Rebase
-                  | None ->
-                      false
+                  Patch_decision.session_no_commits_is_ok ~agent ~kind
                 in
                 let final_session_result =
                   let combined =
@@ -877,7 +881,8 @@ module Make (W : Worktree.S) (Env : ENV) = struct
                   ~remote_tracking_sha:push_remote_tracking_sha
                   ~base_sha:push_base_sha ~agent_before:push_agent_before
                   ~agent_after:push_agent_after;
-                (final_user_result, List.rev !tool_failures)))
+                make_run_result ~turn_accepted:!backend_accepted_turn
+                  final_user_result (List.rev !tool_failures)))
 
   let run ~(kind : Types.Operation_kind.t option) ~patch_id ~prompt
       ~(agent : Patch_agent.t) ~on_pr_detected ~backend ~complexity =

--- a/lib/session_driver.ml
+++ b/lib/session_driver.ml
@@ -318,19 +318,14 @@ module Make (W : Worktree.S) (Env : ENV) = struct
                 let mark_backend_accepted_turn () =
                   if not !backend_accepted_turn then (
                     backend_accepted_turn := true;
-                    match kind with
-                    | Some Types.Operation_kind.Human ->
-                        Runtime.update_orchestrator runtime (fun orch ->
-                            Orchestrator.mark_inflight_human_messages_delivered
-                              orch patch_id)
-                    | Some Types.Operation_kind.Ci
-                    | Some Types.Operation_kind.Review_comments
-                    | Some Types.Operation_kind.Findings
-                    | Some Types.Operation_kind.Pr_body
-                    | Some Types.Operation_kind.Merge_conflict
-                    | Some Types.Operation_kind.Rebase
-                    | None ->
-                        ())
+                    if
+                      Patch_decision.human_acceptance_delivers_messages ~agent
+                        ~kind
+                    then
+                      Runtime.update_orchestrator runtime (fun orch ->
+                          Orchestrator.mark_inflight_human_messages_delivered
+                            orch patch_id)
+                    else ())
                 in
                 let on_event (event : Types.Stream_event.t) =
                   let () =

--- a/lib/session_driver.mli
+++ b/lib/session_driver.mli
@@ -13,6 +13,17 @@
     several modules. The backend below is already abstracted; this is the single
     place where "run a session for this patch" lives. *)
 
+type disposition = [ `Ok | `Failed | `Retry_push | `No_commits ]
+
+type run_result = {
+  disposition : disposition;
+  tool_failures : (string * string) list;
+  turn_accepted : bool;
+      (** Whether the backend emitted positive evidence that it accepted the
+          turn. Callers use this to restore Human guidance when an otherwise
+          successful process exits without processing the prompt. *)
+}
+
 (** Construction-time environment for session driving. Values here are fixed for
     the lifetime of the module instance and never vary per call. *)
 module type ENV = sig
@@ -25,6 +36,8 @@ module type ENV = sig
 end
 
 module Make (_ : Worktree.S) (_ : ENV) : sig
+  type nonrec run_result = run_result
+
   val run :
     kind:Types.Operation_kind.t option ->
     patch_id:Types.Patch_id.t ->
@@ -33,13 +46,11 @@ module Make (_ : Worktree.S) (_ : ENV) : sig
     on_pr_detected:(Types.Pr_number.t -> unit) ->
     backend:Llm_backend.t ->
     complexity:int option ->
-    [ `Ok | `Failed | `Retry_push | `No_commits ] * (string * string) list
-  (** Returns the supervisor disposition and the list of [(tool_name, status)]
-      pairs for any tool calls that did not reach a [completed] state (used by
-      the Pr_body classifier to disambiguate "agent chose not to write" from
-      "Write was blocked"). Callers may also produce a [`Stale] variant from
-      pre-flight checks before invoking this function — the polymorphic-variant
-      union widens at the call site. *)
+    run_result
+  (** Returns the supervisor disposition, backend-acceptance evidence, and the
+      list of [(tool_name, status)] pairs for tool calls that did not reach a
+      [completed] state. Callers may also produce a [`Stale] variant from
+      pre-flight checks before invoking this function. *)
 
   type long_lived_session
   (** Mutable per-patch long-lived backend session state. The backend's
@@ -69,7 +80,7 @@ module Make (_ : Worktree.S) (_ : ENV) : sig
     on_pr_detected:(Types.Pr_number.t -> unit) ->
     session:long_lived_session ->
     complexity:int option ->
-    [ `Ok | `Failed | `Retry_push | `No_commits ] * (string * string) list
+    run_result
   (** Long-lived backend counterpart to {!run}. It shares the same supervisor
       bookkeeping and delivers the rendered turn over [backend.prompt] instead
       of spawning a fresh backend process. *)

--- a/lib/session_driver.mli
+++ b/lib/session_driver.mli
@@ -40,6 +40,7 @@ module Make (_ : Worktree.S) (_ : ENV) : sig
 
   val run :
     kind:Types.Operation_kind.t option ->
+    delivery_mode:Patch_decision.delivery_mode ->
     patch_id:Types.Patch_id.t ->
     prompt:string ->
     agent:Patch_agent.t ->
@@ -49,8 +50,10 @@ module Make (_ : Worktree.S) (_ : ENV) : sig
     run_result
   (** Returns the supervisor disposition, backend-acceptance evidence, and the
       list of [(tool_name, status)] pairs for tool calls that did not reach a
-      [completed] state. Callers may also produce a [`Stale] variant from
-      pre-flight checks before invoking this function. *)
+      [completed] state. [delivery_mode] records whether Start or Respond
+      initiated the turn and must remain stable across in-session PR discovery.
+      Callers may also produce a [`Stale] variant from pre-flight checks before
+      invoking this function. *)
 
   type long_lived_session
   (** Mutable per-patch long-lived backend session state. The backend's
@@ -74,6 +77,7 @@ module Make (_ : Worktree.S) (_ : ENV) : sig
   val run_long_lived :
     sw:Eio.Switch.t ->
     kind:Types.Operation_kind.t option ->
+    delivery_mode:Patch_decision.delivery_mode ->
     patch_id:Types.Patch_id.t ->
     prompt:string ->
     agent:Patch_agent.t ->

--- a/lib_core/patch_agent.ml
+++ b/lib_core/patch_agent.ml
@@ -803,7 +803,9 @@ let start t ~base_branch =
     queue;
     human_messages = (if is_human_queued then [] else t.human_messages);
     inflight_human_messages =
-      (if is_human_queued then t.human_messages else t.inflight_human_messages);
+      (if is_human_queued then
+         List.append t.human_messages t.inflight_human_messages
+       else t.inflight_human_messages);
     satisfies = true;
     base_branch = Some base_branch;
     notified_base_branch = Some base_branch;

--- a/lib_core/patch_agent.ml
+++ b/lib_core/patch_agent.ml
@@ -773,6 +773,21 @@ let mark_pr_missing t =
 let start t ~base_branch =
   if has_pr t then invalid_arg "Patch_agent.start: patch already has a PR";
   if t.busy then invalid_arg "Patch_agent.start: patch is already busy";
+  (* A no-PR patch is always dispatched through the Start action, even when a
+     human message is queued. Treat that Start as the delivery vehicle for the
+     queued Human turn: otherwise the runner renders the initial patch prompt
+     again and the Human operation can never reach [respond], whose contract
+     requires a PR. Moving the inbox to inflight gives this path the same
+     accept/restore semantics as [respond Human]. *)
+  let is_human_queued =
+    List.mem t.queue Operation_kind.Human ~equal:Operation_kind.equal
+  in
+  let queue =
+    if is_human_queued then
+      List.filter t.queue ~f:(fun k ->
+          not (Operation_kind.equal k Operation_kind.Human))
+    else t.queue
+  in
   let branch_rebased_onto =
     match worktree_state t with
     | Unmaterialized -> Some base_branch
@@ -782,9 +797,13 @@ let start t ~base_branch =
     t with
     has_session = true;
     busy = true;
-    current_op = None;
+    current_op = (if is_human_queued then Some Operation_kind.Human else None);
     current_op_state = Queued;
     current_message_id = None;
+    queue;
+    human_messages = (if is_human_queued then [] else t.human_messages);
+    inflight_human_messages =
+      (if is_human_queued then t.human_messages else t.inflight_human_messages);
     satisfies = true;
     base_branch = Some base_branch;
     notified_base_branch = Some base_branch;

--- a/lib_core/patch_agent.mli
+++ b/lib_core/patch_agent.mli
@@ -282,7 +282,10 @@ val start : t -> base_branch:Types.Branch.t -> t
     externally. Postconditions: [has_session], [busy], [satisfies],
     [base_branch = Some base_branch]. An unmaterialized start records
     [branch_rebased_onto = Some base_branch]; a materialized retry preserves the
-    existing physical rebase anchor. *)
+    existing physical rebase anchor. When [Human] is queued, Start dequeues it,
+    moves [human_messages] to [inflight_human_messages], and sets
+    [current_op = Some Human], allowing a no-PR patch to deliver human guidance
+    with the same accept/restore lifecycle as [respond Human]. *)
 
 val rebase : t -> base_branch:Types.Branch.t -> t
 (** [PatchCtx ~> Rebase] — orchestrator-executed rebase. Preconditions:

--- a/lib_core/patch_decision.ml
+++ b/lib_core/patch_decision.ml
@@ -92,6 +92,8 @@ type start_delivery =
   | Start_with_human of { messages : string list }
 [@@deriving show, eq, sexp_of, compare]
 
+type delivery_mode = Start | Respond [@@deriving show, eq, sexp_of, compare]
+
 let start_delivery (agent : Patch_agent.t) : start_delivery =
   if
     Option.equal Operation_kind.equal agent.current_op
@@ -107,20 +109,22 @@ let human_delivery_unaccepted ~(kind : Operation_kind.t option)
   (not turn_accepted)
   && Option.equal Operation_kind.equal kind (Some Operation_kind.Human)
 
-(** Backend acceptance completes delivery for a PR-backed Human Respond. A
-    Human-carrying Start retains its inflight guidance until the runner has
-    successfully associated a PR and explicitly completes the Start. *)
+(** Backend acceptance completes delivery only for a PR-backed Human Respond.
+    The explicit delivery mode prevents a Human-carrying Start from being
+    reclassified if it associates a PR while its session is still running. *)
 let human_acceptance_delivers_messages ~(agent : Patch_agent.t)
-    ~(kind : Operation_kind.t option) : bool =
+    ~(delivery_mode : delivery_mode) ~(kind : Operation_kind.t option) : bool =
   Patch_agent.is_pr_present agent
+  && equal_delivery_mode delivery_mode Respond
   && Option.equal Operation_kind.equal kind (Some Operation_kind.Human)
 
 (** Human and Findings turns may legitimately produce no commit when they are
-    responding to an existing PR. A Human-carrying Start has no PR yet and must
-    retain the ordinary Start no-commit retry/intervention semantics. *)
+    responding to an existing PR. A Human-carrying Start retains the ordinary
+    Start no-commit retry/intervention semantics even after PR association. *)
 let session_no_commits_is_ok ~(agent : Patch_agent.t)
-    ~(kind : Operation_kind.t option) : bool =
+    ~(delivery_mode : delivery_mode) ~(kind : Operation_kind.t option) : bool =
   Patch_agent.is_pr_present agent
+  && equal_delivery_mode delivery_mode Respond
   &&
   match kind with
   | Some Operation_kind.Human | Some Operation_kind.Findings -> true

--- a/lib_core/patch_decision.ml
+++ b/lib_core/patch_decision.ml
@@ -85,6 +85,20 @@ let should_clear_conflict (a : Patch_agent.t) : bool =
     || Option.equal Operation_kind.equal a.current_op
          (Some Operation_kind.Merge_conflict))
 
+(** {2 Start delivery — pre-session decision for the runner} *)
+
+type start_delivery =
+  | Start_initial
+  | Start_with_human of { messages : string list }
+[@@deriving show, eq, sexp_of, compare]
+
+let start_delivery (agent : Patch_agent.t) : start_delivery =
+  if
+    Option.equal Operation_kind.equal agent.current_op
+      (Some Operation_kind.Human)
+  then Start_with_human { messages = List.rev agent.inflight_human_messages }
+  else Start_initial
+
 (** {2 Respond delivery — pre-session decisions for the runner} *)
 
 let failure_conclusions = Ci_check.failure_conclusions

--- a/lib_core/patch_decision.ml
+++ b/lib_core/patch_decision.ml
@@ -107,6 +107,14 @@ let human_delivery_unaccepted ~(kind : Operation_kind.t option)
   (not turn_accepted)
   && Option.equal Operation_kind.equal kind (Some Operation_kind.Human)
 
+(** Backend acceptance completes delivery for a PR-backed Human Respond. A
+    Human-carrying Start retains its inflight guidance until the runner has
+    successfully associated a PR and explicitly completes the Start. *)
+let human_acceptance_delivers_messages ~(agent : Patch_agent.t)
+    ~(kind : Operation_kind.t option) : bool =
+  Patch_agent.is_pr_present agent
+  && Option.equal Operation_kind.equal kind (Some Operation_kind.Human)
+
 (** Human and Findings turns may legitimately produce no commit when they are
     responding to an existing PR. A Human-carrying Start has no PR yet and must
     retain the ordinary Start no-commit retry/intervention semantics. *)

--- a/lib_core/patch_decision.ml
+++ b/lib_core/patch_decision.ml
@@ -99,6 +99,31 @@ let start_delivery (agent : Patch_agent.t) : start_delivery =
   then Start_with_human { messages = List.rev agent.inflight_human_messages }
   else Start_initial
 
+(** A Human delivery is durable only after the backend emits evidence that it
+    accepted the turn. Other operation kinds do not use the human-message
+    inflight/restore protocol. *)
+let human_delivery_unaccepted ~(kind : Operation_kind.t option)
+    ~(turn_accepted : bool) : bool =
+  (not turn_accepted)
+  && Option.equal Operation_kind.equal kind (Some Operation_kind.Human)
+
+(** Human and Findings turns may legitimately produce no commit when they are
+    responding to an existing PR. A Human-carrying Start has no PR yet and must
+    retain the ordinary Start no-commit retry/intervention semantics. *)
+let session_no_commits_is_ok ~(agent : Patch_agent.t)
+    ~(kind : Operation_kind.t option) : bool =
+  Patch_agent.is_pr_present agent
+  &&
+  match kind with
+  | Some Operation_kind.Human | Some Operation_kind.Findings -> true
+  | Some Operation_kind.Ci
+  | Some Operation_kind.Review_comments
+  | Some Operation_kind.Pr_body
+  | Some Operation_kind.Merge_conflict
+  | Some Operation_kind.Rebase
+  | None ->
+      false
+
 (** {2 Respond delivery — pre-session decisions for the runner} *)
 
 let failure_conclusions = Ci_check.failure_conclusions

--- a/lib_core/patch_decision.mli
+++ b/lib_core/patch_decision.mli
@@ -89,6 +89,18 @@ val start_delivery : Patch_agent.t -> start_delivery
     human guidance returns it in chronological order; an ordinary Start returns
     [Start_initial]. Total for restored or partially-migrated agent states. *)
 
+val human_delivery_unaccepted :
+  kind:Types.Operation_kind.t option -> turn_accepted:bool -> bool
+(** Whether a Human delivery must be treated as failed so its still-inflight
+    guidance is restored. A backend turn is accepted only after a stream event
+    provides positive evidence that processing began. *)
+
+val session_no_commits_is_ok :
+  agent:Patch_agent.t -> kind:Types.Operation_kind.t option -> bool
+(** Whether a no-commit session is an accepted no-op. This exemption is limited
+    to Human and Findings responses on an existing PR; a Human-carrying Start
+    retains Start's no-commit retry/intervention behavior. *)
+
 (** {2 Respond delivery — pre-session decisions for the runner} *)
 
 val failure_conclusions : string list

--- a/lib_core/patch_decision.mli
+++ b/lib_core/patch_decision.mli
@@ -93,7 +93,16 @@ val human_delivery_unaccepted :
   kind:Types.Operation_kind.t option -> turn_accepted:bool -> bool
 (** Whether a Human delivery must be treated as failed so its still-inflight
     guidance is restored. A backend turn is accepted only after a stream event
-    provides positive evidence that processing began. *)
+    provides positive evidence that processing began. Human-carrying Starts
+    remain inflight even after acceptance; this predicate prevents an unaccepted
+    Start from reaching successful completion at all. *)
+
+val human_acceptance_delivers_messages :
+  agent:Patch_agent.t -> kind:Types.Operation_kind.t option -> bool
+(** Whether backend acceptance is sufficient to consume inflight Human guidance.
+    True only for PR-backed Human Respond operations. A Human-carrying Start
+    remains recoverable until its successful explicit completion after PR
+    association. *)
 
 val session_no_commits_is_ok :
   agent:Patch_agent.t -> kind:Types.Operation_kind.t option -> bool

--- a/lib_core/patch_decision.mli
+++ b/lib_core/patch_decision.mli
@@ -77,6 +77,18 @@ val should_clear_conflict : Patch_agent.t -> bool
     Merge_conflict operation is queued or in-flight, since clearing would race
     with the active resolution. *)
 
+(** {2 Start delivery — pre-session decision for the runner} *)
+
+type start_delivery =
+  | Start_initial
+  | Start_with_human of { messages : string list }
+[@@deriving show, eq, sexp_of, compare]
+
+val start_delivery : Patch_agent.t -> start_delivery
+(** Classify a fired Start action's turn payload. A Start that consumed queued
+    human guidance returns it in chronological order; an ordinary Start returns
+    [Start_initial]. Total for restored or partially-migrated agent states. *)
+
 (** {2 Respond delivery — pre-session decisions for the runner} *)
 
 val failure_conclusions : string list

--- a/lib_core/patch_decision.mli
+++ b/lib_core/patch_decision.mli
@@ -84,6 +84,10 @@ type start_delivery =
   | Start_with_human of { messages : string list }
 [@@deriving show, eq, sexp_of, compare]
 
+(** The action that initiated a backend turn. Unlike PR presence, this remains
+    stable when a Start discovers and associates its PR during the session. *)
+type delivery_mode = Start | Respond [@@deriving show, eq, sexp_of, compare]
+
 val start_delivery : Patch_agent.t -> start_delivery
 (** Classify a fired Start action's turn payload. A Start that consumed queued
     human guidance returns it in chronological order; an ordinary Start returns
@@ -98,17 +102,24 @@ val human_delivery_unaccepted :
     Start from reaching successful completion at all. *)
 
 val human_acceptance_delivers_messages :
-  agent:Patch_agent.t -> kind:Types.Operation_kind.t option -> bool
+  agent:Patch_agent.t ->
+  delivery_mode:delivery_mode ->
+  kind:Types.Operation_kind.t option ->
+  bool
 (** Whether backend acceptance is sufficient to consume inflight Human guidance.
-    True only for PR-backed Human Respond operations. A Human-carrying Start
-    remains recoverable until its successful explicit completion after PR
-    association. *)
+    True only when the initiating delivery mode is [Respond] for a PR-backed
+    Human operation. A Human-carrying [Start] remains recoverable until its
+    successful explicit completion, even if it associates a PR mid-session. *)
 
 val session_no_commits_is_ok :
-  agent:Patch_agent.t -> kind:Types.Operation_kind.t option -> bool
+  agent:Patch_agent.t ->
+  delivery_mode:delivery_mode ->
+  kind:Types.Operation_kind.t option ->
+  bool
 (** Whether a no-commit session is an accepted no-op. This exemption is limited
-    to Human and Findings responses on an existing PR; a Human-carrying Start
-    retains Start's no-commit retry/intervention behavior. *)
+    to [Respond] deliveries for Human and Findings operations on an existing PR;
+    a Human-carrying [Start] retains Start's no-commit retry/intervention
+    behavior even if it associates a PR mid-session. *)
 
 (** {2 Respond delivery — pre-session decisions for the runner} *)
 

--- a/test/test_action_outcome_properties.ml
+++ b/test/test_action_outcome_properties.ml
@@ -814,6 +814,7 @@ let () =
          let orch = Orchestrator.set_branch_blocked orch pid in
          let orch = Orchestrator.clear_branch_blocked orch pid in
          let orch = Orchestrator.clear_has_conflict orch pid in
+         let orch = Orchestrator.complete_start_after_pr_discovery orch pid in
          let orch = Orchestrator.clear_pr orch pid in
          let orch = Orchestrator.clear_session_fallback orch pid in
          let orch = Orchestrator.mark_running orch pid in

--- a/test/test_action_outcome_properties.ml
+++ b/test/test_action_outcome_properties.ml
@@ -82,6 +82,64 @@ let () =
   assert (not (Orchestrator.agent orch pid).Patch_agent.busy);
   Stdlib.print_endline "AO-1b passed"
 
+(* ========== AO-1c: accepted Human Start remains recoverable until successful
+   post-PR completion ========== *)
+
+let () =
+  let patches = mk_patches 1 in
+  let pid = pid_of_idx patches 0 in
+  let start_human () =
+    let orch = Orchestrator.create ~patches ~main_branch:main in
+    let orch = Orchestrator.send_human_message orch pid "keep this guidance" in
+    Orchestrator.fire orch (Orchestrator.Start (pid, main))
+  in
+  let failed = start_human () in
+  let before_failure = Orchestrator.agent failed pid in
+  assert (not (List.is_empty before_failure.Patch_agent.inflight_human_messages));
+  (* Backend acceptance no longer clears Human Start guidance. A clean session
+     that made no commit is still a failed Start and must restore it. *)
+  let failed =
+    Orchestrator.apply_session_result failed pid Orchestrator.Session_no_commits
+  in
+  let failed =
+    Orchestrator.apply_start_outcome failed pid Orchestrator.Start_failed
+  in
+  let after_failure = Orchestrator.agent failed pid in
+  assert (List.is_empty after_failure.Patch_agent.inflight_human_messages);
+  assert (not (List.is_empty after_failure.Patch_agent.human_messages));
+  assert (
+    List.mem after_failure.Patch_agent.queue Operation_kind.Human
+      ~equal:Operation_kind.equal);
+  (* Even a healthy backend session is not a successful Start when PR
+     association fails. The post-discovery transition restores guidance. *)
+  let discovery_failed = start_human () in
+  let discovery_failed =
+    Orchestrator.apply_session_result discovery_failed pid
+      Orchestrator.Session_ok
+  in
+  let discovery_failed =
+    Orchestrator.complete_start_after_pr_discovery discovery_failed pid
+  in
+  let after_discovery_failure = Orchestrator.agent discovery_failed pid in
+  assert (not (List.is_empty after_discovery_failure.Patch_agent.human_messages));
+  (* PR association followed by explicit completion is the only Start success
+     path that consumes the retained guidance. *)
+  let succeeded = start_human () in
+  let succeeded =
+    Orchestrator.apply_session_result succeeded pid Orchestrator.Session_ok
+  in
+  let succeeded =
+    Orchestrator.set_pr_number succeeded pid (Pr_number.of_int 1)
+  in
+  let succeeded =
+    Orchestrator.complete_start_after_pr_discovery succeeded pid
+  in
+  let after_success = Orchestrator.agent succeeded pid in
+  assert (List.is_empty after_success.Patch_agent.human_messages);
+  assert (List.is_empty after_success.Patch_agent.inflight_human_messages);
+  assert (not after_success.Patch_agent.busy);
+  Stdlib.print_endline "AO-1c passed"
+
 (* ========== AO-2: Non-stale respond outcomes produce busy=false ========== *)
 
 let () =

--- a/test/test_dependency_injection_functors.ml
+++ b/test/test_dependency_injection_functors.ml
@@ -138,7 +138,7 @@ let _check_narrowed_run :
     on_pr_detected:(Pr_number.t -> unit) ->
     backend:Llm_backend.t ->
     complexity:int option ->
-    [ `Ok | `Failed | `Retry_push | `No_commits ] * (string * string) list =
+    Session_driver.run_result =
   SD.run
 
 (* Compile-time assertion: run_long_lived accepts only per-session inputs. *)
@@ -151,7 +151,7 @@ let _check_narrowed_run_long_lived :
     on_pr_detected:(Pr_number.t -> unit) ->
     session:SD.long_lived_session ->
     complexity:int option ->
-    [ `Ok | `Failed | `Retry_push | `No_commits ] * (string * string) list =
+    Session_driver.run_result =
   SD.run_long_lived
 
 let () =
@@ -236,7 +236,7 @@ let () =
       on_pr_detected:(Pr_number.t -> unit) ->
       backend:Llm_backend.t ->
       complexity:int option ->
-      [ `Ok | `Failed | `Retry_push | `No_commits ] * (string * string) list =
+      Session_driver.run_result =
     SD.run
   in
   ignore check_narrowed_run;

--- a/test/test_dependency_injection_functors.ml
+++ b/test/test_dependency_injection_functors.ml
@@ -132,6 +132,7 @@ module SD = Session_driver.Make (Fake_worktree) (Fake_sd_env)
    and mutexes are gone from the call surface — they live in Fake_sd_env now. *)
 let _check_narrowed_run :
     kind:Operation_kind.t option ->
+    delivery_mode:Patch_decision.delivery_mode ->
     patch_id:Patch_id.t ->
     prompt:string ->
     agent:Patch_agent.t ->
@@ -145,6 +146,7 @@ let _check_narrowed_run :
 let _check_narrowed_run_long_lived :
     sw:Eio.Switch.t ->
     kind:Operation_kind.t option ->
+    delivery_mode:Patch_decision.delivery_mode ->
     patch_id:Patch_id.t ->
     prompt:string ->
     agent:Patch_agent.t ->
@@ -230,6 +232,7 @@ let () =
      and mutexes are gone from the call surface — they live in SD_Env now. *)
   let check_narrowed_run :
       kind:Operation_kind.t option ->
+      delivery_mode:Patch_decision.delivery_mode ->
       patch_id:Patch_id.t ->
       prompt:string ->
       agent:Patch_agent.t ->
@@ -295,6 +298,7 @@ let () =
   ignore
     (SD3.run
       : kind:_ ->
+        delivery_mode:_ ->
         patch_id:_ ->
         prompt:_ ->
         agent:_ ->
@@ -306,6 +310,7 @@ let () =
     (SD3.run_long_lived
       : sw:_ ->
         kind:_ ->
+        delivery_mode:_ ->
         patch_id:_ ->
         prompt:_ ->
         agent:_ ->

--- a/test/test_patch_agent.ml
+++ b/test/test_patch_agent.ml
@@ -52,6 +52,29 @@ let () =
           && List.is_empty t.human_messages
           && List.is_empty t.ci_checks && (not t.merge_ready)
           && not t.checks_passing);
+      Test.make ~name:"start consumes queued human messages into inflight"
+        Gen.(
+          triple gen_pid gen_branch
+            (list_size (int_range 1 5)
+               (string_size ~gen:printable (int_range 1 40))))
+        (fun (pid, branch, messages) ->
+          try
+            let t = create ~branch pid in
+            let t =
+              List.fold messages ~init:t ~f:(fun a message ->
+                  add_human_message a message)
+            in
+            let t = enqueue t Operation_kind.Human in
+            let t = start t ~base_branch:branch in
+            Option.equal Operation_kind.equal t.current_op
+              (Some Operation_kind.Human)
+            && List.is_empty t.human_messages
+            && List.equal String.equal t.inflight_human_messages
+                 (List.rev messages)
+            && not
+                 (List.mem t.queue Operation_kind.Human
+                    ~equal:Operation_kind.equal)
+          with _ -> false);
       (* -- enqueue is idempotent -- *)
       Test.make ~name:"enqueue is idempotent"
         Gen.(triple gen_pid gen_branch gen_op)

--- a/test/test_patch_agent.ml
+++ b/test/test_patch_agent.ml
@@ -75,6 +75,22 @@ let () =
                  (List.mem t.queue Operation_kind.Human
                     ~equal:Operation_kind.equal)
           with _ -> false);
+      Test.make
+        ~name:"start merges newly queued guidance with restored inflight"
+        Gen.(pair gen_pid gen_branch)
+        (fun (pid, branch) ->
+          try
+            let t = create ~branch pid in
+            let t = add_human_message t "older" in
+            let t = enqueue t Operation_kind.Human in
+            let t = start t ~base_branch:branch |> reset_busy in
+            let t = add_human_message t "newer" in
+            let t = enqueue t Operation_kind.Human in
+            let t = start t ~base_branch:branch in
+            List.is_empty t.human_messages
+            && List.equal String.equal t.inflight_human_messages
+                 [ "newer"; "older" ]
+          with _ -> false);
       (* -- enqueue is idempotent -- *)
       Test.make ~name:"enqueue is idempotent"
         Gen.(triple gen_pid gen_branch gen_op)

--- a/test/test_patch_controller.ml
+++ b/test/test_patch_controller.ml
@@ -513,6 +513,93 @@ let () =
                | Orchestrator.Start _ | Orchestrator.Rebase _ -> false)))
   in
 
+  let prop_starting_patch_delivers_human_guidance =
+    Test.make
+      ~name:
+        "patch_controller: needs-help no-PR patch delivers Human on next Start"
+      ~count:200
+      Gen.(
+        triple gen_patch_id gen_branch
+          (string_size ~gen:printable (int_range 1 80)))
+      (fun (pid, branch, message) ->
+        try
+          let patch = make_patch pid branch in
+          let gameplan = make_gameplan patch in
+          let orch = Orchestrator.create ~patches:[ patch ] ~main_branch:main in
+          let fail_start_without_commits orch =
+            let orch =
+              Orchestrator.fire orch (Orchestrator.Start (pid, main))
+            in
+            let orch =
+              Orchestrator.apply_session_result orch pid
+                Orchestrator.Session_no_commits
+            in
+            Orchestrator.apply_start_outcome orch pid Orchestrator.Start_failed
+          in
+          let orch =
+            fail_start_without_commits orch |> fail_start_without_commits
+          in
+          let stuck = Orchestrator.agent orch pid in
+          if not (Patch_agent.needs_intervention stuck) then false
+          else
+            let orch = Orchestrator.send_human_message orch pid message in
+            let actions =
+              Patch_controller.plan_actions orch ~patches:gameplan.patches
+            in
+            match
+              List.find actions ~f:(function
+                | Orchestrator.Start (action_pid, _) ->
+                    Patch_id.equal action_pid pid
+                | Orchestrator.Respond _ | Orchestrator.Rebase _ -> false)
+            with
+            | None -> false
+            | Some action -> (
+                let orch = Orchestrator.fire orch action in
+                let agent = Orchestrator.agent orch pid in
+                match Patch_decision.start_delivery agent with
+                | Patch_decision.Start_with_human { messages } ->
+                    List.equal String.equal messages [ message ]
+                    && Option.equal Operation_kind.equal agent.current_op
+                         (Some Operation_kind.Human)
+                    && not
+                         (List.mem agent.queue Operation_kind.Human
+                            ~equal:Operation_kind.equal)
+                | Patch_decision.Start_initial -> false)
+        with _ -> false)
+  in
+
+  let prop_failed_start_restores_undelivered_human_guidance =
+    Test.make
+      ~name:
+        "patch_controller: failed no-PR Human Start restores undelivered \
+         guidance"
+      ~count:200
+      Gen.(
+        triple gen_patch_id gen_branch
+          (string_size ~gen:printable (int_range 1 80)))
+      (fun (pid, branch, message) ->
+        try
+          let patch = make_patch pid branch in
+          let orch = Orchestrator.create ~patches:[ patch ] ~main_branch:main in
+          let orch = Orchestrator.send_human_message orch pid message in
+          let orch = Orchestrator.fire orch (Orchestrator.Start (pid, main)) in
+          let inflight = Orchestrator.agent orch pid in
+          if List.is_empty inflight.Patch_agent.inflight_human_messages then
+            false
+          else
+            let orch =
+              Orchestrator.apply_start_outcome orch pid
+                Orchestrator.Start_failed
+            in
+            let restored = Orchestrator.agent orch pid in
+            (not restored.Patch_agent.busy)
+            && List.mem restored.human_messages message ~equal:String.equal
+            && List.is_empty restored.inflight_human_messages
+            && List.mem restored.queue Operation_kind.Human
+                 ~equal:Operation_kind.equal
+        with _ -> false)
+  in
+
   let prop_reconcile_all_converges_after_acknowledged_effects =
     Test.make
       ~name:
@@ -2066,6 +2153,8 @@ let () =
       prop_reconcile_all_blocks_restart_after_intervention;
       prop_rebase_not_blocked_by_needs_intervention;
       prop_respond_still_blocked_by_needs_intervention;
+      prop_starting_patch_delivers_human_guidance;
+      prop_failed_start_restores_undelivered_human_guidance;
       prop_reconcile_all_converges_after_acknowledged_effects;
       prop_poll_to_controller_promotes_ready_after_pr_body;
       prop_poll_ci_failure_never_erases_pr_body_followup;

--- a/test/test_patch_controller_state_machine.ml
+++ b/test/test_patch_controller_state_machine.ml
@@ -126,6 +126,52 @@ let () =
         with _ -> false
         end)
   in
+  let prop_resumed_human_start_preserves_delivery_kind =
+    Test.make
+      ~name:
+        "patch_controller_state_machine: resumed Human-carrying Start keeps \
+         Human delivery kind"
+      ~count:300
+      Gen.(pair gen_patch_id gen_branch)
+      (fun (pid, branch) ->
+        begin try
+          let patch = make_patch pid branch in
+          let gameplan = make_gameplan patch in
+          let orch = Orchestrator.create ~patches:[ patch ] ~main_branch:main in
+          let orch = Orchestrator.send_human_message orch pid "guidance" in
+          let orch, _effects, messages =
+            Patch_controller.plan_tick_messages orch
+              ~project_name:"test-project" ~gameplan
+          in
+          match List.hd messages with
+          | None -> false
+          | Some msg -> (
+              let orch, action =
+                Orchestrator.accept_message orch (Orchestrator.message_id msg)
+              in
+              let is_start =
+                match action with
+                | Some (Orchestrator.Start _) -> true
+                | Some (Orchestrator.Respond _ | Orchestrator.Rebase _) | None
+                  ->
+                    false
+              in
+              let orch = Orchestrator.reset_busy orch pid in
+              let orch, resumed =
+                Orchestrator.resume_message orch (Orchestrator.message_id msg)
+              in
+              let agent = Orchestrator.agent orch pid in
+              is_start && Option.is_some resumed
+              && Option.equal Operation_kind.equal agent.current_op
+                   (Some Operation_kind.Human)
+              &&
+              match Patch_decision.start_delivery agent with
+              | Patch_decision.Start_with_human { messages } ->
+                  List.equal String.equal messages [ "guidance" ]
+              | Patch_decision.Start_initial -> false)
+        with _ -> false
+        end)
+  in
   let prop_human_after_review_completes =
     Test.make
       ~name:
@@ -522,6 +568,7 @@ let () =
     [
       prop_replay_deterministic;
       prop_resume_keeps_same_message_id;
+      prop_resumed_human_start_preserves_delivery_kind;
       prop_human_after_review_completes;
       prop_second_human_after_review;
       prop_human_messages_survive_session_failure;

--- a/test/test_patch_decision.ml
+++ b/test/test_patch_decision.ml
@@ -65,6 +65,24 @@ let () =
       Test.make ~name:"disposition: no PR -> Ready_start" gen_pid (fun pid ->
           let a = create ~branch:(Branch.of_string "b") pid in
           equal_disposition (disposition a) Ready_start);
+      Test.make
+        ~name:"start_delivery: queued human guidance survives Start firing"
+        Gen.(
+          triple gen_pid gen_branch
+            (list_size (int_range 1 5)
+               (string_size ~gen:printable (int_range 1 40))))
+        (fun (pid, branch, messages) ->
+          try
+            let a = create ~branch pid in
+            let a =
+              List.fold messages ~init:a ~f:(fun a message ->
+                  add_human_message a message)
+            in
+            let a = enqueue a Operation_kind.Human in
+            let a = start a ~base_branch:branch in
+            equal_start_delivery (start_delivery a)
+              (Start_with_human { messages })
+          with _ -> false);
       (* ---- disposition: idle (has_pr, empty queue) -> Idle ---- *)
       Test.make ~name:"disposition: has_pr, empty queue -> Idle"
         Gen.(pair gen_pid gen_branch)

--- a/test/test_patch_decision.ml
+++ b/test/test_patch_decision.ml
@@ -83,6 +83,33 @@ let () =
             equal_start_delivery (start_delivery a)
               (Start_with_human { messages })
           with _ -> false);
+      Test.make
+        ~name:"human delivery without backend acceptance must be restored"
+        Gen.bool (fun turn_accepted ->
+          Bool.equal
+            (human_delivery_unaccepted ~kind:(Some Operation_kind.Human)
+               ~turn_accepted)
+            (not turn_accepted)
+          && not
+               (human_delivery_unaccepted
+                  ~kind:(Some Operation_kind.Review_comments) ~turn_accepted));
+      Test.make ~name:"no-commit Human exemption requires an existing PR"
+        Gen.(pair gen_pid gen_branch)
+        (fun (pid, branch) ->
+          try
+            let start_agent = create ~branch pid in
+            let start_agent = add_human_message start_agent "guidance" in
+            let start_agent = enqueue start_agent Operation_kind.Human in
+            let start_agent = start start_agent ~base_branch:branch in
+            let respond_agent =
+              set_pr_number start_agent (Pr_number.of_int 1)
+            in
+            (not
+               (session_no_commits_is_ok ~agent:start_agent
+                  ~kind:(Some Operation_kind.Human)))
+            && session_no_commits_is_ok ~agent:respond_agent
+                 ~kind:(Some Operation_kind.Human)
+          with _ -> false);
       (* ---- disposition: idle (has_pr, empty queue) -> Idle ---- *)
       Test.make ~name:"disposition: has_pr, empty queue -> Idle"
         Gen.(pair gen_pid gen_branch)

--- a/test/test_patch_decision.ml
+++ b/test/test_patch_decision.ml
@@ -93,7 +93,8 @@ let () =
           && not
                (human_delivery_unaccepted
                   ~kind:(Some Operation_kind.Review_comments) ~turn_accepted));
-      Test.make ~name:"no-commit Human exemption requires an existing PR"
+      Test.make
+        ~name:"Human delivery completion requires an explicit Respond mode"
         Gen.(pair gen_pid gen_branch)
         (fun (pid, branch) ->
           try
@@ -101,19 +102,27 @@ let () =
             let start_agent = add_human_message start_agent "guidance" in
             let start_agent = enqueue start_agent Operation_kind.Human in
             let start_agent = start start_agent ~base_branch:branch in
-            let respond_agent =
+            let pr_associated_start_agent =
               set_pr_number start_agent (Pr_number.of_int 1)
             in
             (not
                (human_acceptance_delivers_messages ~agent:start_agent
-                  ~kind:(Some Operation_kind.Human)))
-            && human_acceptance_delivers_messages ~agent:respond_agent
+                  ~delivery_mode:Start ~kind:(Some Operation_kind.Human)))
+            && (not
+                  (human_acceptance_delivers_messages
+                     ~agent:pr_associated_start_agent ~delivery_mode:Start
+                     ~kind:(Some Operation_kind.Human)))
+            && human_acceptance_delivers_messages
+                 ~agent:pr_associated_start_agent ~delivery_mode:Respond
                  ~kind:(Some Operation_kind.Human)
             && (not
                   (session_no_commits_is_ok ~agent:start_agent
-                     ~kind:(Some Operation_kind.Human)))
-            && session_no_commits_is_ok ~agent:respond_agent
-                 ~kind:(Some Operation_kind.Human)
+                     ~delivery_mode:Start ~kind:(Some Operation_kind.Human)))
+            && (not
+                  (session_no_commits_is_ok ~agent:pr_associated_start_agent
+                     ~delivery_mode:Start ~kind:(Some Operation_kind.Human)))
+            && session_no_commits_is_ok ~agent:pr_associated_start_agent
+                 ~delivery_mode:Respond ~kind:(Some Operation_kind.Human)
           with _ -> false);
       (* ---- disposition: idle (has_pr, empty queue) -> Idle ---- *)
       Test.make ~name:"disposition: has_pr, empty queue -> Idle"

--- a/test/test_patch_decision.ml
+++ b/test/test_patch_decision.ml
@@ -105,8 +105,13 @@ let () =
               set_pr_number start_agent (Pr_number.of_int 1)
             in
             (not
-               (session_no_commits_is_ok ~agent:start_agent
+               (human_acceptance_delivers_messages ~agent:start_agent
                   ~kind:(Some Operation_kind.Human)))
+            && human_acceptance_delivers_messages ~agent:respond_agent
+                 ~kind:(Some Operation_kind.Human)
+            && (not
+                  (session_no_commits_is_ok ~agent:start_agent
+                     ~kind:(Some Operation_kind.Human)))
             && session_no_commits_is_ok ~agent:respond_agent
                  ~kind:(Some Operation_kind.Human)
           with _ -> false);


### PR DESCRIPTION
## What changed

- route queued human guidance through the next `Start` action when a patch still has no PR
- move that guidance through the existing inflight accept/restore lifecycle
- append the human turn after the initial patch context so it can clarify or supersede the original instructions
- restore undelivered guidance when Start fails before the backend accepts it
- add property coverage for the needs-help reproduction and pre-delivery failure path

## Root cause

The controller always selects `Start` for patches without a PR, while `Respond Human` requires a PR. As a result, queued human messages could never reach the response transition and every retry rendered only the original starting prompt.

## Impact

A human can now recover a patch stuck in `starting` / `needs-help`: the next Start delivers the human guidance instead of starving it behind repeated initial-prompt attempts.

## Validation

- `opam exec -- dune build`
- `opam exec -- dune runtest`
- `opam exec -- dune fmt`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/418"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789658848&installation_model_id=19519&pr_number=418&repository=flowglad%2Fonton&return_to=https%3A%2F%2Fgithub.com%2Fflowglad%2Fonton%2Fpull%2F418&signature=3df1f630bac530fc9c40e064e7cea6b4098dc9a6b4738655f4d827dcf4b4027e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Human guidance now remains available when sessions are interrupted, fail, or resume.
  * Guidance is restored when delivery is not accepted, preventing messages from being lost.
  * Start actions now correctly continue human-assisted workflows through pull request discovery.
  * No-commit responses are handled appropriately for eligible existing pull requests.

* **Improvements**
  * Session outcomes now provide clearer status information, including failures and whether a turn was accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->