### PR TITLE
Defer CI reruns until workflows complete

### DIFF
--- a/lib/github.ml
+++ b/lib/github.ml
@@ -1107,6 +1107,12 @@ let job_log_timeout = 60.0
     fiber indefinitely — which is how the poll loop wedged in production. *)
 let default_timeout = 30.0
 
+(** Overall budget for waiting for an in-progress Actions run to finish before
+    requesting its failed-job rerun. This is deliberately separate from the
+    per-request timeout: workflows commonly run for several minutes, while an
+    individual GitHub API request should still fail quickly if it is wedged. *)
+let workflow_completion_poll_timeout = 30.0 *. 60.0
+
 (** Internal: execute an HTTP request against api.github.com. Returns the raw
     response body on 2xx, [Http_error] otherwise. *)
 let meth_to_string = function
@@ -1325,7 +1331,6 @@ let rerun_failed_jobs_for_check ~net ~clock ?timeout t
         Printf.sprintf "/repos/%s/%s/actions/runs/%d/rerun-failed-jobs" t.owner
           t.repo run_id
       in
-      let polling_timeout = Option.value timeout ~default:default_timeout in
       let rec wait_until_complete () =
         match request ~net ~clock ?timeout t ~meth:`GET ~path:run_path () with
         | Error _ as error -> error
@@ -1361,7 +1366,7 @@ let rerun_failed_jobs_for_check ~net ~clock ?timeout t
             Error error
       in
       match
-        Eio.Time.with_timeout clock polling_timeout (fun () ->
+        Eio.Time.with_timeout clock workflow_completion_poll_timeout (fun () ->
             Ok (wait_until_complete ()))
       with
       | Ok (Ok ()) -> request_rerun ()
@@ -1369,7 +1374,11 @@ let rerun_failed_jobs_for_check ~net ~clock ?timeout t
       | Error `Timeout ->
           Error
             (Timeout
-               { meth = "GET"; path = run_path; seconds = polling_timeout }))
+               {
+                 meth = "GET";
+                 path = run_path;
+                 seconds = workflow_completion_poll_timeout;
+               }))
 
 let check_repo_access_internal ~net ~clock ?timeout t =
   let path = Printf.sprintf "/repos/%s/%s" t.owner t.repo in

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -1061,20 +1061,7 @@ let parse_actions_jobs_response body =
           |> List.filter ~f:Types.Ci_check.is_failure
           |> Result.return)
 
-let parse_actions_run_id_from_url url =
-  let marker = "/actions/runs/" in
-  match String.substr_index url ~pattern:marker with
-  | None -> None
-  | Some pos ->
-      let start = pos + String.length marker in
-      let rest = String.drop_prefix url start in
-      let len =
-        match String.findi rest ~f:(fun _ ch -> not (Char.is_digit ch)) with
-        | None -> String.length rest
-        | Some (idx, _) -> idx
-      in
-      let id = String.prefix rest len in
-      if String.is_empty id then None else Int.of_string_opt id
+let parse_actions_run_id_from_url = Ci_rerun_decision.workflow_run_id_from_url
 
 let digest_annotation_of_check_annotation (a : check_annotation) :
     Ci_log_digest.annotation =
@@ -1331,12 +1318,48 @@ let rerun_failed_jobs_for_check ~net ~clock ?timeout t
                rerun"
               check.name))
   | Some run_id ->
-      let path =
+      let run_path =
+        Printf.sprintf "/repos/%s/%s/actions/runs/%d" t.owner t.repo run_id
+      in
+      let rerun_path =
         Printf.sprintf "/repos/%s/%s/actions/runs/%d/rerun-failed-jobs" t.owner
           t.repo run_id
       in
-      Result.map (request ~net ~clock ?timeout t ~meth:`POST ~path ())
-        ~f:(fun _ -> ())
+      let rec wait_until_complete () =
+        match request ~net ~clock ?timeout t ~meth:`GET ~path:run_path () with
+        | Error _ as error -> error
+        | Ok body -> (
+            match Ci_rerun_decision.workflow_status_of_response body with
+            | Completed -> request_rerun ()
+            | Pending ->
+                Eio.Time.sleep clock 10.0;
+                wait_until_complete ()
+            | Malformed ->
+                Error
+                  (Json_parse_error
+                     (Printf.sprintf
+                        "workflow run %d response has no valid status" run_id)))
+      and request_rerun () =
+        match
+          request ~net ~clock ?timeout t ~meth:`POST ~path:rerun_path ()
+        with
+        | Ok _ -> Ok ()
+        | Error (Http_error ({ status = 403; body; _ } as http_error)) ->
+            if
+              response_error_message_contains body
+                ~substring:"workflow is already running"
+            then
+              (* Another actor won the small race between our completed-status
+                 GET and POST. The desired rerun is already in progress. *)
+              Ok ()
+            else Error (Http_error http_error)
+        | Error (Http_error _ as error) -> Error error
+        | Error
+            (( Json_parse_error _ | Graphql_error _ | Timeout _
+             | Transport_error _ ) as error) ->
+            Error error
+      in
+      wait_until_complete ()
 
 let check_repo_access_internal ~net ~clock ?timeout t =
   let path = Printf.sprintf "/repos/%s/%s" t.owner t.repo in

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -1317,7 +1317,7 @@ let rerun_failed_jobs_for_check ~net ~clock ?timeout t
               "check %S has no GitHub Actions workflow run URL; refusing full \
                rerun"
               check.name))
-  | Some run_id ->
+  | Some run_id -> (
       let run_path =
         Printf.sprintf "/repos/%s/%s/actions/runs/%d" t.owner t.repo run_id
       in
@@ -1325,16 +1325,17 @@ let rerun_failed_jobs_for_check ~net ~clock ?timeout t
         Printf.sprintf "/repos/%s/%s/actions/runs/%d/rerun-failed-jobs" t.owner
           t.repo run_id
       in
+      let polling_timeout = Option.value timeout ~default:default_timeout in
       let rec wait_until_complete () =
         match request ~net ~clock ?timeout t ~meth:`GET ~path:run_path () with
         | Error _ as error -> error
         | Ok body -> (
             match Ci_rerun_decision.workflow_status_of_response body with
-            | Completed -> request_rerun ()
-            | Pending ->
+            | Ci_rerun_decision.Completed -> Ok ()
+            | Ci_rerun_decision.Pending ->
                 Eio.Time.sleep clock 10.0;
                 wait_until_complete ()
-            | Malformed ->
+            | Ci_rerun_decision.Malformed ->
                 Error
                   (Json_parse_error
                      (Printf.sprintf
@@ -1359,7 +1360,16 @@ let rerun_failed_jobs_for_check ~net ~clock ?timeout t
              | Transport_error _ ) as error) ->
             Error error
       in
-      wait_until_complete ()
+      match
+        Eio.Time.with_timeout clock polling_timeout (fun () ->
+            Ok (wait_until_complete ()))
+      with
+      | Ok (Ok ()) -> request_rerun ()
+      | Ok (Error _ as error) -> error
+      | Error `Timeout ->
+          Error
+            (Timeout
+               { meth = "GET"; path = run_path; seconds = polling_timeout }))
 
 let check_repo_access_internal ~net ~clock ?timeout t =
   let path = Printf.sprintf "/repos/%s/%s" t.owner t.repo in

--- a/lib/runner_fiber_impl.ml
+++ b/lib/runner_fiber_impl.ml
@@ -2613,6 +2613,11 @@ struct
                                           | Patch_decision.Ci_payload
                                               { failed_checks } ->
                                               if session_no_commits then
+                                                let failed_checks =
+                                                  Ci_rerun_decision
+                                                  .unique_workflow_checks
+                                                    failed_checks
+                                                in
                                                 let rerun_results =
                                                   Base.List.map failed_checks
                                                     ~f:(fun check ->

--- a/lib_core/ci_rerun_decision.ml
+++ b/lib_core/ci_rerun_decision.ml
@@ -12,13 +12,14 @@ let workflow_run_id_from_url url =
   | Some pos ->
       let start = pos + String.length marker in
       let rest = String.drop_prefix url start in
-      let len =
+      let id =
         match String.findi rest ~f:(fun _ ch -> not (Char.is_digit ch)) with
-        | None -> String.length rest
-        | Some (idx, _) -> idx
+        | None -> Some rest
+        | Some (idx, ('/' | '?' | '#')) -> Some (String.prefix rest idx)
+        | Some _ -> None
       in
-      let id = String.prefix rest len in
-      if String.is_empty id then None else Int.of_string_opt id
+      Option.bind id ~f:(fun id ->
+          if String.is_empty id then None else Int.of_string_opt id)
 
 let unique_workflow_checks checks =
   let _, rev_checks =

--- a/lib_core/ci_rerun_decision.ml
+++ b/lib_core/ci_rerun_decision.ml
@@ -1,0 +1,45 @@
+(* @archlint.module core
+   @archlint.domain ci-rerun *)
+
+open Base
+
+type workflow_status = Completed | Pending | Malformed [@@deriving show, eq]
+
+let workflow_run_id_from_url url =
+  let marker = "/actions/runs/" in
+  match String.substr_index url ~pattern:marker with
+  | None -> None
+  | Some pos ->
+      let start = pos + String.length marker in
+      let rest = String.drop_prefix url start in
+      let len =
+        match String.findi rest ~f:(fun _ ch -> not (Char.is_digit ch)) with
+        | None -> String.length rest
+        | Some (idx, _) -> idx
+      in
+      let id = String.prefix rest len in
+      if String.is_empty id then None else Int.of_string_opt id
+
+let unique_workflow_checks checks =
+  let _, rev_checks =
+    List.fold checks
+      ~init:(Set.empty (module Int), [])
+      ~f:(fun (seen, acc) (check : Types.Ci_check.t) ->
+        let run_id =
+          Option.bind check.details_url ~f:workflow_run_id_from_url
+        in
+        match run_id with
+        | Some id when Set.mem seen id -> (seen, acc)
+        | Some id -> (Set.add seen id, check :: acc)
+        | None -> (seen, check :: acc))
+  in
+  List.rev rev_checks
+
+let workflow_status_of_response body =
+  match try Some (Yojson.Safe.from_string body) with _ -> None with
+  | None -> Malformed
+  | Some json -> (
+      match Json.string_field "status" json with
+      | Some "completed" -> Completed
+      | Some _ -> Pending
+      | None -> Malformed)

--- a/lib_core/ci_rerun_decision.mli
+++ b/lib_core/ci_rerun_decision.mli
@@ -1,0 +1,21 @@
+(* @archlint.module core
+   @archlint.domain ci-rerun *)
+
+(** Pure decisions used when requesting GitHub Actions failed-job reruns. *)
+
+type workflow_status = Completed | Pending | Malformed [@@deriving show, eq]
+
+val workflow_run_id_from_url : string -> int option
+(** Extract the numeric run id after [/actions/runs/] from a check URL. Returns
+    [None] for missing, empty, non-numeric, or overflowing ids. *)
+
+val unique_workflow_checks : Types.Ci_check.t list -> Types.Ci_check.t list
+(** Keep the first check for each identifiable workflow run, preserving input
+    order. Checks without an identifiable run are retained so the handler can
+    report their individual errors instead of silently dropping them. *)
+
+val workflow_status_of_response : string -> workflow_status
+(** Decode [GET /actions/runs/:id]. [Completed] is returned only for
+    [{"status":"completed"}], any other string status is [Pending], and
+    malformed JSON or a missing/non-string status is [Malformed]. Never raises.
+*)

--- a/test/dune
+++ b/test/dune
@@ -59,6 +59,13 @@
  (libraries onton onton_core base yojson))
 
 (test
+ (name test_ci_rerun_decision_properties)
+ (modules test_ci_rerun_decision_properties)
+ (libraries onton_core qcheck-core qcheck-core.runner base)
+ (ocamlopt_flags (:standard -w -40-42))
+ (ocamlc_flags (:standard -w -40-42)))
+
+(test
  (name test_json)
  (modules test_json)
  (libraries onton_core base yojson ppx_yojson_conv_lib))

--- a/test/dune
+++ b/test/dune
@@ -61,9 +61,7 @@
 (test
  (name test_ci_rerun_decision_properties)
  (modules test_ci_rerun_decision_properties)
- (libraries onton_core qcheck-core qcheck-core.runner base)
- (ocamlopt_flags (:standard -w -40-42))
- (ocamlc_flags (:standard -w -40-42)))
+ (libraries onton_core qcheck-core qcheck-core.runner base))
 
 (test
  (name test_json)

--- a/test/test_ci_rerun_decision_properties.ml
+++ b/test/test_ci_rerun_decision_properties.ml
@@ -40,31 +40,26 @@ let gen_check =
 let gen_checks = QCheck2.Gen.list_size (QCheck2.Gen.int_range 0 40) gen_check
 
 let run_id (check : Ci_check.t) =
-  Option.bind check.details_url ~f:Ci_rerun_decision.workflow_run_id_from_url
+  Option.bind check.Ci_check.details_url
+    ~f:Ci_rerun_decision.workflow_run_id_from_url
 
 let prop_url_parser_total =
   QCheck2.Test.make ~name:"workflow run URL parser is total" ~count:2_000
     gen_text (fun value ->
-      try
-        let _ = Ci_rerun_decision.workflow_run_id_from_url value in
-        true
-      with _ -> false)
+      let _ = Ci_rerun_decision.workflow_run_id_from_url value in
+      true)
 
 let prop_status_parser_total =
   QCheck2.Test.make ~name:"workflow status response parser is total"
     ~count:2_000 gen_text (fun value ->
-      try
-        let _ = Ci_rerun_decision.workflow_status_of_response value in
-        true
-      with _ -> false)
+      let _ = Ci_rerun_decision.workflow_status_of_response value in
+      true)
 
 let prop_dedupe_total =
   QCheck2.Test.make ~name:"workflow check dedupe is total" ~count:1_000
     gen_checks (fun checks ->
-      try
-        let _ = Ci_rerun_decision.unique_workflow_checks checks in
-        true
-      with _ -> false)
+      let _ = Ci_rerun_decision.unique_workflow_checks checks in
+      true)
 
 let prop_dedupe_idempotent =
   QCheck2.Test.make ~name:"workflow check dedupe is idempotent" ~count:1_000
@@ -72,6 +67,46 @@ let prop_dedupe_idempotent =
       let once = Ci_rerun_decision.unique_workflow_checks checks in
       let twice = Ci_rerun_decision.unique_workflow_checks once in
       List.equal Ci_check.equal once twice)
+
+let gen_interleaved_run_ids =
+  QCheck2.Gen.list_size
+    (QCheck2.Gen.int_range 0 80)
+    QCheck2.Gen.(option (int_range 0 8))
+
+let check_of_run_id index run_id =
+  Ci_check.
+    {
+      name = Printf.sprintf "check-%d" index;
+      conclusion = "failure";
+      details_url =
+        Option.map run_id ~f:(fun id ->
+            Printf.sprintf "https://github.com/o/r/actions/runs/%d/job/%d" id
+              index);
+      description = None;
+      started_at = None;
+      id = None;
+    }
+
+let prop_dedupe_interleavings =
+  QCheck2.Test.make
+    ~name:"dedupe preserves first checks and order across interleavings"
+    ~count:1_000 gen_interleaved_run_ids (fun run_ids ->
+      let checks = List.mapi run_ids ~f:check_of_run_id in
+      let expected =
+        List.filter_mapi checks ~f:(fun index check ->
+            match run_id check with
+            | None -> Some check
+            | Some id ->
+                let appeared_earlier =
+                  List.take checks index
+                  |> List.exists ~f:(fun earlier ->
+                      Option.equal Int.equal (run_id earlier) (Some id))
+                in
+                if appeared_earlier then None else Some check)
+      in
+      List.equal Ci_check.equal
+        (Ci_rerun_decision.unique_workflow_checks checks)
+        expected)
 
 let prop_identifiable_runs_unique =
   QCheck2.Test.make
@@ -101,17 +136,17 @@ let prop_status_boundaries =
       Ci_rerun_decision.equal_workflow_status
         (Ci_rerun_decision.workflow_status_of_response
            {|{"status":"completed"}|})
-        Completed
+        Ci_rerun_decision.Completed
       && Ci_rerun_decision.equal_workflow_status
            (Ci_rerun_decision.workflow_status_of_response
               {|{"status":"in_progress"}|})
-           Pending
+           Ci_rerun_decision.Pending
       && Ci_rerun_decision.equal_workflow_status
            (Ci_rerun_decision.workflow_status_of_response {|{"status":null}|})
-           Malformed
+           Ci_rerun_decision.Malformed
       && Ci_rerun_decision.equal_workflow_status
            (Ci_rerun_decision.workflow_status_of_response "not-json")
-           Malformed)
+           Ci_rerun_decision.Malformed)
 
 let prop_url_boundaries =
   QCheck2.Test.make ~name:"workflow run URL boundaries" ~count:1
@@ -120,12 +155,30 @@ let prop_url_boundaries =
         (Ci_rerun_decision.workflow_run_id_from_url
            "https://github.com/o/r/actions/runs/42/job/7")
         (Some 42)
+      && Option.equal Int.equal
+           (Ci_rerun_decision.workflow_run_id_from_url
+              "https://github.com/o/r/actions/runs/42?attempt=2")
+           (Some 42)
+      && Option.equal Int.equal
+           (Ci_rerun_decision.workflow_run_id_from_url
+              "https://github.com/o/r/actions/runs/42#details")
+           (Some 42)
+      && Option.equal Int.equal
+           (Ci_rerun_decision.workflow_run_id_from_url
+              "https://github.com/o/r/actions/runs/42")
+           (Some 42)
       && Option.is_none
            (Ci_rerun_decision.workflow_run_id_from_url
               "https://github.com/o/r/actions/runs/")
       && Option.is_none
            (Ci_rerun_decision.workflow_run_id_from_url
-              "https://github.com/o/r/actions/runs/not-a-number/job/7"))
+              "https://github.com/o/r/actions/runs/not-a-number/job/7")
+      && Option.is_none
+           (Ci_rerun_decision.workflow_run_id_from_url
+              "https://github.com/o/r/actions/runs/42x")
+      && Option.is_none
+           (Ci_rerun_decision.workflow_run_id_from_url
+              ("https://github.com/o/r/actions/runs/" ^ String.make 128 '9')))
 
 let () =
   QCheck_base_runner.run_tests_main
@@ -134,6 +187,7 @@ let () =
       prop_status_parser_total;
       prop_dedupe_total;
       prop_dedupe_idempotent;
+      prop_dedupe_interleavings;
       prop_identifiable_runs_unique;
       prop_unidentifiable_checks_retained;
       prop_status_boundaries;

--- a/test/test_ci_rerun_decision_properties.ml
+++ b/test/test_ci_rerun_decision_properties.ml
@@ -1,0 +1,141 @@
+(* @archlint.module test
+   @archlint.domain ci-rerun *)
+
+open Base
+open Onton_core
+open Onton_core.Types
+
+let gen_text = QCheck2.Gen.string_size (QCheck2.Gen.int_range 0 80)
+
+let gen_details_url =
+  let open QCheck2.Gen in
+  oneof_weighted
+    [
+      (2, return None);
+      ( 5,
+        map
+          (fun id ->
+            Some
+              (Printf.sprintf "https://github.com/o/r/actions/runs/%d/job/123"
+                 id))
+          (int_range 0 12) );
+      (3, map (fun value -> Some value) gen_text);
+    ]
+
+let gen_check =
+  let open QCheck2.Gen in
+  let* name = gen_text in
+  let* details_url = gen_details_url in
+  return
+    Ci_check.
+      {
+        name;
+        conclusion = "failure";
+        details_url;
+        description = None;
+        started_at = None;
+        id = None;
+      }
+
+let gen_checks = QCheck2.Gen.list_size (QCheck2.Gen.int_range 0 40) gen_check
+
+let run_id (check : Ci_check.t) =
+  Option.bind check.details_url ~f:Ci_rerun_decision.workflow_run_id_from_url
+
+let prop_url_parser_total =
+  QCheck2.Test.make ~name:"workflow run URL parser is total" ~count:2_000
+    gen_text (fun value ->
+      try
+        let _ = Ci_rerun_decision.workflow_run_id_from_url value in
+        true
+      with _ -> false)
+
+let prop_status_parser_total =
+  QCheck2.Test.make ~name:"workflow status response parser is total"
+    ~count:2_000 gen_text (fun value ->
+      try
+        let _ = Ci_rerun_decision.workflow_status_of_response value in
+        true
+      with _ -> false)
+
+let prop_dedupe_total =
+  QCheck2.Test.make ~name:"workflow check dedupe is total" ~count:1_000
+    gen_checks (fun checks ->
+      try
+        let _ = Ci_rerun_decision.unique_workflow_checks checks in
+        true
+      with _ -> false)
+
+let prop_dedupe_idempotent =
+  QCheck2.Test.make ~name:"workflow check dedupe is idempotent" ~count:1_000
+    gen_checks (fun checks ->
+      let once = Ci_rerun_decision.unique_workflow_checks checks in
+      let twice = Ci_rerun_decision.unique_workflow_checks once in
+      List.equal Ci_check.equal once twice)
+
+let prop_identifiable_runs_unique =
+  QCheck2.Test.make
+    ~name:"at most one rerun request is planned for each workflow run"
+    ~count:1_000 gen_checks (fun checks ->
+      let ids =
+        Ci_rerun_decision.unique_workflow_checks checks
+        |> List.filter_map ~f:run_id
+      in
+      let unique_ids = Set.of_list (module Int) ids in
+      List.length ids = Set.length unique_ids)
+
+let prop_unidentifiable_checks_retained =
+  QCheck2.Test.make
+    ~name:"checks without workflow identities are retained for error reporting"
+    ~count:1_000 gen_checks (fun checks ->
+      let count_unidentified values =
+        List.count values ~f:(fun check -> Option.is_none (run_id check))
+      in
+      Int.equal
+        (count_unidentified checks)
+        (count_unidentified (Ci_rerun_decision.unique_workflow_checks checks)))
+
+let prop_status_boundaries =
+  QCheck2.Test.make ~name:"only a completed workflow status permits a rerun"
+    ~count:1 QCheck2.Gen.unit (fun () ->
+      Ci_rerun_decision.equal_workflow_status
+        (Ci_rerun_decision.workflow_status_of_response
+           {|{"status":"completed"}|})
+        Completed
+      && Ci_rerun_decision.equal_workflow_status
+           (Ci_rerun_decision.workflow_status_of_response
+              {|{"status":"in_progress"}|})
+           Pending
+      && Ci_rerun_decision.equal_workflow_status
+           (Ci_rerun_decision.workflow_status_of_response {|{"status":null}|})
+           Malformed
+      && Ci_rerun_decision.equal_workflow_status
+           (Ci_rerun_decision.workflow_status_of_response "not-json")
+           Malformed)
+
+let prop_url_boundaries =
+  QCheck2.Test.make ~name:"workflow run URL boundaries" ~count:1
+    QCheck2.Gen.unit (fun () ->
+      Option.equal Int.equal
+        (Ci_rerun_decision.workflow_run_id_from_url
+           "https://github.com/o/r/actions/runs/42/job/7")
+        (Some 42)
+      && Option.is_none
+           (Ci_rerun_decision.workflow_run_id_from_url
+              "https://github.com/o/r/actions/runs/")
+      && Option.is_none
+           (Ci_rerun_decision.workflow_run_id_from_url
+              "https://github.com/o/r/actions/runs/not-a-number/job/7"))
+
+let () =
+  QCheck_base_runner.run_tests_main
+    [
+      prop_url_parser_total;
+      prop_status_parser_total;
+      prop_dedupe_total;
+      prop_dedupe_idempotent;
+      prop_identifiable_runs_unique;
+      prop_unidentifiable_checks_retained;
+      prop_status_boundaries;
+      prop_url_boundaries;
+    ]


### PR DESCRIPTION
## Summary

- poll a GitHub Actions workflow run until it completes before requesting a failed-job rerun
- deduplicate failed checks so each workflow run receives only one rerun request
- treat an already-running rerun won by another actor as success
- add pure property coverage for status decoding, workflow URL parsing, and deduplication

## Testing

- `dune build`
- `dune runtest`
- `dune fmt`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/419"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789752360&installation_model_id=19519&pr_number=419&repository=flowglad%2Fonton&return_to=https%3A%2F%2Fgithub.com%2Fflowglad%2Fonton%2Fpull%2F419&signature=41ded9ed0251080c6b386b8356959610103b1934625a51eab9fe4079d995cbb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved rerunning of failed CI jobs by waiting for workflow runs to finish before submitting rerun requests.
  - Prevented duplicate rerun requests for checks tied to the same workflow run.
  - Treats already-running workflows as successful rerun requests while preserving other error reporting.
  - Improved handling of incomplete, malformed, or unrecognized workflow responses without unexpected failures.

- **Tests**
  - Added coverage for workflow status handling, URL parsing, deduplication, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->