### PR TITLE
Inject repository context into ad-hoc prompts

### DIFF
--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -573,21 +573,20 @@ let render_patch_layer_of_gameplan ~project_name ?pr_number (patch : Patch.t)
     ~ancestors:(ancestor_patches gameplan patch)
     ~base_branch ()
 
-(* When all of [patch], [gameplan], [base_branch] are supplied, returns
-   the gameplan+patch prefix; otherwise returns the empty string. Used by
-   the layered turn-prompt composers to support callers that don't have a
-   gameplan-defined patch in scope (e.g. ad-hoc PRs). *)
+(* Compose the stable context that precedes a turn prompt. Repository
+   conventions are independent of whether the patch came from a gameplan, so
+   retain [AGENTS.md] for ad-hoc PRs even when there is no gameplan+patch prefix
+   to render. *)
 let layered_prefix ~project_name ?pr_number ?patch ?gameplan ?base_branch
     ?agents_md () =
+  let repo_context = agents_md_section agents_md in
   match (patch, gameplan, base_branch) with
   | Some p, Some g, Some b ->
       render_gameplan_layer ~project_name g
-      ^ (match agents_md with
-        | Some content -> agents_md_section (Some content)
-        | None -> "")
+      ^ repo_context
       ^ render_patch_layer_of_gameplan ~project_name ?pr_number p g
           ~base_branch:b
-  | _ -> ""
+  | _ -> repo_context
 
 let render_turn_layer_start ~(project_name : string) : string =
   let vars = [ ("project_name", project_name) ] in
@@ -1800,6 +1799,24 @@ let%test "agents_md section normalizes trailing newline spacing" =
   String.equal
     (agents_md_section (Some "Rule one.\n"))
     "## Project Conventions (AGENTS.md)\n\nRule one.\n\n"
+
+let%test "ad-hoc turn prompts retain agents_md context" =
+  let agents_md = "Run every build with stdin closed." in
+  let expected_prefix = agents_md_section (Some agents_md) in
+  let ci_prompt =
+    render_ci_failure_unknown_prompt ~project_name:"adhoc" ~agents_md ()
+  in
+  let review_prompt =
+    render_review_prompt ~project_name:"adhoc" ~agents_md
+      ~artifact_dir:"/tmp/comment-responses" []
+  in
+  let conflict_prompt =
+    render_merge_conflict_prompt ~project_name:"adhoc" ~agents_md
+      ~base_branch:"main" ()
+  in
+  String.is_prefix ci_prompt ~prefix:expected_prefix
+  && String.is_prefix review_prompt ~prefix:expected_prefix
+  && String.is_prefix conflict_prompt ~prefix:expected_prefix
 
 (* === Three-layer invariants ===
 

--- a/lib/prompt.ml
+++ b/lib/prompt.ml
@@ -1810,12 +1810,17 @@ let%test "ad-hoc turn prompts retain agents_md context" =
     render_review_prompt ~project_name:"adhoc" ~agents_md
       ~artifact_dir:"/tmp/comment-responses" []
   in
+  let findings_prompt =
+    render_findings_prompt ~project_name:"adhoc" ~agents_md
+      ~artifact_dir:"/tmp/findings-wontfix" []
+  in
   let conflict_prompt =
     render_merge_conflict_prompt ~project_name:"adhoc" ~agents_md
       ~base_branch:"main" ()
   in
   String.is_prefix ci_prompt ~prefix:expected_prefix
   && String.is_prefix review_prompt ~prefix:expected_prefix
+  && String.is_prefix findings_prompt ~prefix:expected_prefix
   && String.is_prefix conflict_prompt ~prefix:expected_prefix
 
 (* === Three-layer invariants ===

--- a/lib/prompt.mli
+++ b/lib/prompt.mli
@@ -119,10 +119,11 @@ val render_turn_layer_merge_conflict :
 
 (** {1 Composed prompts}
 
-    Each public render below is the composition of the three layers. Follow-up
-    renders accept the layer inputs as optional — when a caller has no
-    gameplan-defined patch in scope (e.g. ad-hoc PRs), the layered prefix is
-    omitted and only the turn layer is emitted. *)
+    Each public render below is the composition of the three layers plus the
+    repository's optional [AGENTS.md] context. Follow-up renders accept the
+    gameplan layer inputs as optional: when a caller has no gameplan-defined
+    patch in scope (e.g. ad-hoc PRs), the gameplan and patch layers are omitted,
+    but [AGENTS.md] is still retained before the turn layer. *)
 
 val render_patch_prompt :
   project_name:string ->

--- a/lib/prompt.mli
+++ b/lib/prompt.mli
@@ -119,7 +119,7 @@ val render_turn_layer_merge_conflict :
 
 (** {1 Composed prompts}
 
-    Each public render below is the composition of the three layers plus the
+    Each layered public render below composes the three layers plus the
     repository's optional [AGENTS.md] context. Follow-up renders accept the
     gameplan layer inputs as optional: when a caller has no gameplan-defined
     patch in scope (e.g. ad-hoc PRs), the gameplan and patch layers are omitted,


### PR DESCRIPTION
## Summary

- preserve repository AGENTS.md context when a patch has no gameplan entry
- apply the shared context prefix to ad-hoc CI, review, findings, and merge-conflict turns
- add regression coverage for ad-hoc prompt composition

## Verification

- dune build
- dune runtest
- dune fmt / pre-commit format check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowglad/codesmith/onton/pr/421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790516873&installation_model_id=19519&pr_number=421&repository=flowglad%2Fonton&return_to=https%3A%2F%2Fgithub.com%2Fflowglad%2Fonton%2Fpull%2F421&signature=7bc65ee45a3535ee495f93d1982f98fc3e7476498ea436a3b79281e3aad84f12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Repository conventions from `AGENTS.md` are now included in all applicable prompts, including ad-hoc pull requests.
  * Prompts without a gameplan or patch context now retain repository guidance instead of omitting it.

* **Documentation**
  * Clarified how repository conventions and optional gameplan and patch context are included in composed prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->